### PR TITLE
Fix links in FAQ: syntactic features

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -280,7 +280,7 @@ While these are tractable for CSS itself, we don’t need to duplicate the effor
 
 We track V8. Since V8 has wide support for ES6 and `async` and `await`, we transpile those. Since V8 doesn’t support class decorators, we don’t transpile those.
 
-See [this](link to default babel config we use) and [this](link to issue that tracks the ability to change babel options)
+See [this](https://github.com/zeit/next.js/blob/master/gulpfile.js#L11) and [this](https://github.com/zeit/next.js/issues/26)
 
 </details>
 


### PR DESCRIPTION
It seems like the two links in the syntactic features section of the FAQ were both placeholder text which I'm guessing should go to the two places that I linked based on what the placeholder text says but I could be wrong.
