### PR TITLE
Updated readme to reflect proper name of url.pathname property

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Client-side routing behaves exactly like the native UA:
 
 Each top-level component receives a `url` property with the following API:
 
-- `path` - `String` of the current path excluding the query string
+- `pathname` - `String` of the current path excluding the query string
 - `query` - `Object` with the parsed query string. Defaults to `{}`
 - `push(url)` - performs a `pushState` call associated with the current component
 - `replace(url)` - performs a `replaceState` call associated with the current component


### PR DESCRIPTION
The README said that `url` had a `path` property, but it is actually coming back as `pathname` 
