### PR TITLE
Fix userAgent reference in getInitialProps example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ import React from 'react'
 export default class extends React.Component {
   static async getInitialProps ({ req }) {
     return req
-      ? { userAgent: req.headers.userAgent }
+      ? { userAgent: req.headers['user-agent'] }
       : { userAgent: navigator.userAgent }
   }
   render () {


### PR DESCRIPTION
The getInitialProps example references `req.header.userAgent`, which does not exist. `req.headers['user-agent']` does.
