### PR TITLE
Fix issue #85

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -31,6 +31,9 @@ export default async function createCompiler (dir, { hotReload = false } = {}) {
   const nodeModulesDir = join(__dirname, '..', '..', '..', 'node_modules')
 
   const plugins = [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    }),
     new WriteFilePlugin({
       exitOnErrors: false,
       log: false,


### PR DESCRIPTION
This pull request fixes #85

> You are currently using minified code outside of NODE_ENV === 'production'. This means that you are running a slower development build of Redux. You can use loose-envify (https://github.com/zertosh/loose-envify) for browserify or DefinePlugin for webpack (http://stackoverflow.com/questions/30030031) to ensure you have the correct code for your production build.

By setting `NODE_ENV` to `production` for production bundling process.
