### PR TITLE
Freezing version for standard in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "gulp-notify": "2.2.0",
     "husky": "0.11.9",
     "run-sequence": "1.2.2",
-    "standard": "^8.4.0",
+    "standard": "8.4.0",
     "webpack-stream": "3.2.0"
   }
 }


### PR DESCRIPTION
Added in https://github.com/zeit/next.js/pull/27.
Removed `^`

@nkzawa One more 😄 
