### PR TITLE
next init: Inherit project name from current directory

### DIFF
--- a/bin/next-init
+++ b/bin/next-init
@@ -20,7 +20,7 @@ exists(join(dir, 'package.json'))
   }
 
   if (!present) {
-    await writeFile(join(dir, 'package.json'), basePackage)
+    await writeFile(join(dir, 'package.json'), basePackage.replace(/my-app/g, basename(dir)))
   }
 
   if (!await exists(join(dir, 'static'))) {


### PR DESCRIPTION
Currently `next init` always produces a `package.json` with the same name "my-app".

This PR changes next init to sets the package name to the same name where `next init` is run from. This is one of the minor conveniences offered by `npm init`.

```
mkdir some-project
cd some-project
next init
```
#### After

Note the name is inherited from the directory you run `next init` from.

``` json
{
  "name": "some-project",
  "description": "some-project",
  "dependencies": {
    "next": "latest"
  },
  "scripts": {
    "dev": "next",
    "build": "next build",
    "start": "next start"
  }
}
```
#### Before

Note the "my-app" default no matter what directory you're running `init` in:

``` json
{
  "name": "my-app",
  "description": "my app",
  "dependencies": {
    "next": "latest"
  },
  "scripts": {
    "dev": "next",
    "build": "next build",
    "start": "next start"
  }
}
```
