### PR TITLE
next init: create package.json with empty description

### DIFF
--- a/bin/next-init
+++ b/bin/next-init
@@ -39,7 +39,7 @@ exists(join(dir, 'package.json'))
 
 const basePackage = `{
   "name": "my-app",
-  "description": "my app",
+  "description": "",
   "dependencies": {
     "next": "latest"
   },


### PR DESCRIPTION
Minor, but IMO this is cleaner.
