### PR TITLE
next init: Create supplied directory if it does not exist.

### DIFF
--- a/bin/next-init
+++ b/bin/next-init
@@ -2,6 +2,7 @@
 import { resolve, join, basename } from 'path'
 import parseArgs from 'minimist'
 import { exists, writeFile, mkdir } from 'mz/fs'
+import mkdirp from 'mkdirp-then'
 
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
@@ -20,7 +21,7 @@ if (basename(dir) === 'pages') {
 exists(dir)
 .then(async present => {
   if (!present) {
-    await mkdir(dir)
+    await mkdirp(dir)
   }
 
   if (!await exists(join(dir, 'package.json'))) {

--- a/bin/next-init
+++ b/bin/next-init
@@ -17,9 +17,13 @@ if (basename(dir) === 'pages') {
   process.exit(1)
 }
 
-exists(join(dir, 'package.json'))
+exists(dir)
 .then(async present => {
   if (!present) {
+    await mkdir(dir)
+  }
+
+  if (!await exists(join(dir, 'package.json'))) {
     await writeFile(join(dir, 'package.json'), basePackage.replace(/my-app/g, basename(dir)))
   }
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "json-loader": "0.5.4",
     "loader-utils": "0.2.16",
     "minimist": "1.2.0",
+    "mkdirp-then": "1.2.0",
     "mz": "2.4.0",
     "path-match": "1.2.4",
     "react": "15.3.2",


### PR DESCRIPTION
Currently, when running `next init some-directory`, if `some-directory` does not yet exist the command will exit with a nasty looking error (see below).

This PR creates the supplied directory if it does not exist, preventing the error.

```
next init some-directory
{ Error: ENOENT: no such file or directory, open '/Users/timoxley/Projects/tests/some-directory/package.json'
    at Error (native)
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/timoxley/Projects/tests/some-directory/package.json' }
```
