### PR TITLE
Use -apply-system font on error page

### DIFF
--- a/pages/_error.js
+++ b/pages/_error.js
@@ -31,7 +31,7 @@ const styles = {
     left: 0,
     right: 0,
     position: 'absolute',
-    fontFamily: '"SF UI Text", "Helvetica Neue", "Lucida Grande"',
+    fontFamily: '-apple-system, "SF UI Text", "Helvetica Neue", "Lucida Grande", sans-serif',
     textAlign: 'center',
     paddingTop: '20%'
   }),


### PR DESCRIPTION
The CSS rule on the error page doesn't work and the text on the page isn't rendered in SF UI Text. If we want to use SF on the error page, then, at least in Safari, we can use `-apply-system` as the font family.

I also added a fallback to sans-serif, just to be explicit.
