### PR TITLE
Add support for parameterized routing. Refs #59, #91

### DIFF
--- a/client/next.js
+++ b/client/next.js
@@ -7,13 +7,13 @@ import DefaultApp from '../lib/app'
 import evalScript from '../lib/eval-script'
 
 const {
-  __NEXT_DATA__: { app, component, props, ids, err }
+  __NEXT_DATA__: { app, component, props, ids, err, params }
 } = window
 
 const App = app ? evalScript(app).default : DefaultApp
 const Component = evalScript(component).default
 
-export const router = new Router(window.location.href, { Component, ctx: { err } })
+export const router = new Router(window.location.href, { Component, ctx: { err, params } })
 
 const headManager = new HeadManager()
 const container = document.getElementById('__next')

--- a/lib/router.js
+++ b/lib/router.js
@@ -145,7 +145,7 @@ export default class Router {
           if (err) return reject(err)
           resolve({
             Component: data.Component,
-            ctx: { xhr, err: data.err }
+            ctx: { xhr, err: data.err, params: data.params }
           })
         })
       })
@@ -220,7 +220,7 @@ function loadComponent (url, fn) {
     }
 
     const Component = module.default || module
-    fn(null, { Component, err: data.err })
+    fn(null, { Component, err: data.err, params: data.params })
   })
 }
 

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -10,7 +10,7 @@ import DynamicEntryPlugin from './plugins/dynamic-entry-plugin'
 export default async function createCompiler (dir, { hotReload = false } = {}) {
   dir = resolve(dir)
 
-  const pages = await glob('pages/**/*.js', { cwd: dir })
+  const pages = await glob('{pages,routes}/**/*.js', { cwd: dir })
 
   const entry = {}
   const defaultEntries = hotReload ? ['webpack/hot/dev-server'] : []

--- a/server/index.js
+++ b/server/index.js
@@ -40,6 +40,19 @@ export default class Server {
   }
 
   defineRoutes () {
+    const pkg = require(`${process.cwd()}/package`)
+    const routes = pkg.next.routes
+
+    if (pkg.next.routes) {
+      Object.keys(routes).forEach(path => {
+        const resolvedPath = routes[path]
+        this.router.get(path, async (req, res, params) => {
+          req.url = resolvedPath
+          await this.render(req, res, params)
+        })
+      })
+    }
+
     this.router.get('/_next/:path+', async (req, res, params) => {
       const p = join(__dirname, '..', 'client', ...(params.path || []))
       await this.serveStatic(req, res, p)
@@ -68,9 +81,9 @@ export default class Server {
     }
   }
 
-  async render (req, res) {
+  async render (req, res, params) {
     const { dir, dev } = this
-    const ctx = { req, res }
+    const ctx = { req, res, params }
     const opts = { dir, dev }
 
     let html

--- a/server/index.js
+++ b/server/index.js
@@ -120,9 +120,9 @@ export default class Server {
     sendHTML(res, html)
   }
 
-  async renderJSON (req, res) {
+  async renderJSON (req, res, params) {
     const { dir } = this
-    const opts = { dir }
+    const opts = { dir, params }
 
     let json
 

--- a/server/index.js
+++ b/server/index.js
@@ -53,11 +53,11 @@ export default class Server {
           const routesBundle = join(this.dir, '.next', 'bundles', 'routes')
           const relFile = relative(pagesBundle, join(routesBundle, route.file))
 
-          this.router.get(`${route.path}+.json`, async (req, res, params) => {
+          this.router.get(`${route.path}.json`, async (req, res, params) => {
             await this.renderJSON({ ...req, url: relFile }, res, params)
           })
 
-          this.router.get(`${route.path}*`, async (req, res, params) => {
+          this.router.get(`${route.path}`, async (req, res, params) => {
             await this.render({ ...req, url: relFile }, res, params)
           })
         }

--- a/server/render.js
+++ b/server/render.js
@@ -52,10 +52,10 @@ export async function render (url, ctx = {}, {
   return '<!DOCTYPE html>' + renderToStaticMarkup(doc)
 }
 
-export async function renderJSON (url, { dir = process.cwd() } = {}) {
+export async function renderJSON (url, { params, dir = process.cwd() } = {}) {
   const path = getPath(url)
   const component = await read(join(dir, '.next', 'bundles', 'pages', path))
-  return { component }
+  return { component, params }
 }
 
 export function errorToJSON (err) {

--- a/server/render.js
+++ b/server/render.js
@@ -42,7 +42,8 @@ export async function render (url, ctx = {}, {
       component,
       props,
       ids: ids,
-      err: ctx.err ? errorToJSON(ctx.err) : null
+      err: ctx.err ? errorToJSON(ctx.err) : null,
+      params: ctx.params
     },
     hotReload: false,
     dev,

--- a/test/fixtures/basic/routes/stateful.js
+++ b/test/fixtures/basic/routes/stateful.js
@@ -1,0 +1,14 @@
+
+import React, { Component } from 'react'
+
+export default class Statefull extends Component {
+  static getInitialProps (ctx) {
+    return ctx
+  }
+
+  render () {
+    return <div>
+      <p>The route parameter `id` is {this.props.params.id}</p>
+    </div>
+  }
+}

--- a/test/fixtures/basic/routes/stateless.js
+++ b/test/fixtures/basic/routes/stateless.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default () => <h1>My routed component!</h1>

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,18 @@ test(async t => {
   t.true(html.includes('<p>Diego Milito</p>'))
 })
 
+test(async t => {
+  const html = await render('../routes/stateless')
+  t.true(html.includes('<h1>My routed component!</h1>'))
+})
+
+test(async t => {
+  const html = await render('../routes/stateful', {
+    params: { id: 'test' }
+  })
+  t.true(html.includes('<div><p>The route parameter `id` is test</p></div>'))
+})
+
 function render (url, ctx) {
   return _render(url, ctx, { dir, staticMarkup: true })
 }


### PR DESCRIPTION
Pulls routes from `next.config.js`:

``` javascript
// next.config.js

exports.routes = [
  { path: '/posts/:id', file: 'posts/post' }
]
```

```
pages\
    index.js
routes\
    posts\
        post.js
```

Routes defined this way are resolved to the `routes` directory rather than `pages` to avoid conflicts and ensure existing functionality remains intact. Additionally, a parameters map is passed to each of the components via `ctx`.
