### PR TITLE
Fix broken projects because of missing json-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "glamor": "2.17.10",
     "glob-promise": "1.0.6",
     "htmlescape": "1.1.1",
+    "json-loader": "0.5.4",
     "loader-utils": "0.2.16",
     "minimist": "1.2.0",
     "mz": "2.4.0",


### PR DESCRIPTION
I ran into this problem when trying to use [prisimic.io](https://github.com/prismicio/javascript-kit) with `next.js` where I get this error:

```
ERROR in ./~/prismic.io/lib/requests.js
Module not found: Error: Cannot resolve module 'json-loader' in /Users/b/c/thefaithnet/node_modules/prismic.io/lib
 @ ./~/prismic.io/lib/requests.js 111:16-42 148:16-42
```

The [offending line of code in prismic.io](https://github.com/prismicio/javascript-kit/blob/master/lib/requests.js#L111) is this:

``` js
var pjson = require('../package.json');
```

I only get this error after installing `next`.

This happens because `next` is set to use `json-loader` in [server/build/webpack.js](https://github.com/zeit/next.js/blob/ca161c375f22c71549849595b68f3e43eda94a89/server/build/webpack.js#L144), but `next` doesn't have the `json-loader` dependency defined.

This PR adds `json-loader` as a dependency.

My current workaround is to add `json-loader` as a dependency to my project.
