### PR TITLE
Expose css, link, and head in package.

### DIFF
--- a/css.js
+++ b/css.js
@@ -1,0 +1,1 @@
+require('./dist/lib/css');

--- a/css.js
+++ b/css.js
@@ -1,1 +1,1 @@
-require('./dist/lib/css');
+module.exports = require('./dist/lib/css')

--- a/head.js
+++ b/head.js
@@ -1,0 +1,1 @@
+require('./dist/lib/head');

--- a/head.js
+++ b/head.js
@@ -1,1 +1,1 @@
-require('./dist/lib/head');
+module.exports = require('./dist/lib/head')

--- a/link.js
+++ b/link.js
@@ -1,0 +1,1 @@
+require('./dist/lib/link');

--- a/link.js
+++ b/link.js
@@ -1,1 +1,1 @@
-require('./dist/lib/link');
+module.exports = require('./dist/lib/link')

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "license": "MIT",
   "repository": "zeit/next.js",
   "files": [
-    "dist"
+    "dist",
+    "link.js",
+    "css.js",
+    "head.js"
   ],
   "bin": {
     "next": "./dist/bin/next"


### PR DESCRIPTION
This is a fix for #113.  It exposes the css, link, and head modules from `dist/lib` in the top-level package so that next client code run by a test runner or analyzed by a linter can still access those packages through the same syntax.  E.g. `import Head from 'next/head'` will now work from both a test runner and in `next` internally.

@nkzawa I'm assuming this is what you meant when you said "I think it'd be nice to put files like next/head.js (no gulp tasks)."  Please correct me if I'm wrong.

And thanks for the awesome project!  :)
