### PR TITLE
next init: Exit non-zero when refusing to run in 'pages' dir.

### DIFF
--- a/bin/next-init
+++ b/bin/next-init
@@ -12,13 +12,13 @@ const argv = parseArgs(process.argv.slice(2), {
 
 const dir = resolve(argv._[0] || '.')
 
+if (basename(dir) === 'pages') {
+  console.warn('Your root directory is named "pages". This looks suspicious. You probably want to go one directory up.')
+  process.exit(1)
+}
+
 exists(join(dir, 'package.json'))
 .then(async present => {
-  if (basename(dir) === 'pages') {
-    console.warn('Your root directory is named "pages". This looks suspicious. You probably want to go one directory up.')
-    return
-  }
-
   if (!present) {
     await writeFile(join(dir, 'package.json'), basePackage.replace(/my-app/g, basename(dir)))
   }


### PR DESCRIPTION
Should only exit `0` if the command was successful. The command refusing to execute should be considered a failure.

Also, this condition can be detected synchronously, no need to wait on the async existence check.
