### PR TITLE
Update system font stacks on error pages

### DIFF
--- a/pages/_error-debug.js
+++ b/pages/_error-debug.js
@@ -40,14 +40,14 @@ const styles = {
   }),
 
   message: style({
-    fontFamily: 'menlo-regular',
+    fontFamily: '"SF Mono", "Roboto Mono", "Fira Mono", menlo-regular, monospace',
     fontSize: '10px',
     color: '#fff',
     margin: 0
   }),
 
   heading: style({
-    fontFamily: 'sans-serif',
+    fontFamily: '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
     fontSize: '13px',
     fontWeight: 'bold',
     color: '#ff90c6',

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -31,7 +31,7 @@ const styles = {
     left: 0,
     right: 0,
     position: 'absolute',
-    fontFamily: '-apple-system, "SF UI Text", "Helvetica Neue", "Lucida Grande", sans-serif',
+    fontFamily: '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
     textAlign: 'center',
     paddingTop: '20%'
   }),


### PR DESCRIPTION
This PR is follow-up on #140.

It adds a more verbose system font stack for the two error pages, making use of higher quality system fonts where available. (For example, using `BlinkMacSystemFont` to render SF within Chrome on macOS, and better system fonts for other operating systems.)

💅 Fancy! 💅
