### PR TITLE
Ensure bin files are linted. Fix lint issue in bin/next-init.

### DIFF
--- a/bin/next-init
+++ b/bin/next-init
@@ -50,7 +50,7 @@ const basePackage = `{
   }
 }`
 
-const basePage =`
+const basePage = `
 import React from 'react'
 export default () => <p>Hello, world</p>
 `

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "scripts": {
     "build": "gulp",
-    "test": "standard && gulp test",
-    "lint": "standard",
+    "test": "npm run lint && gulp test",
+    "lint": "standard && standard bin/*",
     "prepublish": "gulp release",
     "precommit": "npm run lint"
   },


### PR DESCRIPTION
Currently `standard` is not linting `next`'s `bin/*` files. Noticed as my in-editor linter picked up a minor whitespace issue in `bin/next-init`, but `npm run lint` did not.

Since these files don't have any extension, `standard` ignores them. I did not see any means to have `standard` lint these files without explicitly passing them as parameters, hence this ugly `&&` fix.

I looked into `eslint` & `standard` config options however I couldn't see any that work around this, perhaps I need to look harder. `standard` would still ignore the files even after explicitly adding each `bin/*` file in an `"include"` in the package.json standard config. I believe this is a limitation of `eslint`, rather than of `standard`. Another option could be to add a `.js` extension to these files, but I can't make that call.
