### PR TITLE
Add more Glamor help to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,22 @@ That means pages never load unnecessary code!
 
 ### CSS
 
-We use [glamor](https://github.com/threepointone/glamor) to provide a great built-in solution for CSS isolation and modularization without trading off any CSS features
+We use [glamor](https://github.com/threepointone/glamor) to provide a great built-in solution for CSS isolation and modularization without trading off any CSS features.
+
+Glamor's [HowTo](https://github.com/threepointone/glamor/blob/master/docs/howto.md) shows converting various CSS use cases to Glamor. See Glamor's [API docs](https://github.com/threepointone/glamor/blob/master/docs/api.md) for more details.
 
 ```jsx
 import React from 'react'
-import css from 'next/css'
+import css, {insertRule} from 'next/css'
 
 export default () => (
   <div className={style}>
     Hello world
   </div>
 )
+
+// Global CSS rule
+insertRule("html, body { margin: 0; padding: 0; }")
 
 const style = css({
   background: 'red',


### PR DESCRIPTION
This adds information I had to search for and experiment with, being new to Glamor.

I think adding the `insertRule` import is useful to show you can access all of Glamor's API from `'next/css'`. It also answers the common question we've been getting of "How do I add global styles?"
