### PR TITLE
expose webpack config

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -107,7 +107,7 @@ export default async function createCompiler (dir, { hotReload = false } = {}) {
     [errorDebugPath, 'dist/pages/_error-debug.js']
   ])
 
-  return webpack({
+  const config = {
     context: dir,
     entry,
     output: {
@@ -148,5 +148,13 @@ export default async function createCompiler (dir, { hotReload = false } = {}) {
     customInterpolateName: function (url, name, opts) {
       return interpolateNames.get(this.resourcePath) || url
     }
-  })
+  }
+  try {
+    require(join(dir, 'webpack.js'))(config, hotReload)
+  } catch (e) {
+    if (e.code != "MODULE_NOT_FOUND") {
+      throw(e)
+    }
+  }
+  return webpack(config)
 }


### PR DESCRIPTION
My attempt to implement #40. I think it's the simplest possible solution.

To customize config user have to create webpack.js in project root and export function that adjusts config as needed.

```js
module.exports = (config, hotReload) => {
  if (hotReload) {
    const babelLoader = config.module.loaders.find(({loader}) => loader === 'babel')
    babelLoader.query.plugins.push(require.resolve('babel-plugin-styled-components-named'))
  }
  // Style loader not works for some reason, but it should be configured similar to this:
  config.resolveLoader.root.push(require('path').join(__dirname, 'node_modules'))
  config.module.preLoaders.push({ test: /\.css$/, loader: "style!css" })
}
``` 