### PR TITLE
Explain where & when getInitialProps executes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ export default class extends React.Component {
 
 Notice that to load data when the page loads, we use `getInitialProps` which is an [`async`](https://zeit.co/blog/async-and-await) static method. It can asynchronously fetch anything that resolves to a JavaScript plain `Object`, which populates `props`.
 
+For the initial page load, `getInitialProps` will execute on the server only. `getInitialProps` will only be executed on the client when navigating to a different route via the `props.url.pushTo` API.
+
 ### Routing
 
 Client-side transitions between routes are enabled via a `<Link>` component


### PR DESCRIPTION
This behaviour was surprising, I'd assumed `getInitialProps` would execute in both environments, though I assume the intention is that this prevents double-handling.

Related https://github.com/zeit/next.js/issues/183