### PR TITLE
Added travis file + fixed sockjs dependency on npm 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+os:
+ - osx
+ - linux
 node_js:
   - "node"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-os:
- - osx
- - linux
 node_js:
   - "node"
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "6"
-  - "5"
   - "4"
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "5"
+  - "4"
+cache:
+  directories:
+    - node_modules

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "write-file-webpack-plugin": "3.3.0"
   },
   "devDependencies": {
+    "ava": "0.16.0",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "benchmark": "2.1.1",
@@ -83,6 +84,7 @@
     "gulp-notify": "2.2.0",
     "husky": "0.11.9",
     "run-sequence": "1.2.2",
+    "sockjs-client": "1.1.1",
     "standard": "8.4.0",
     "webpack-stream": "3.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "url": "0.11.0",
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.2",
+    "sockjs-client": "1.1.1",
     "write-file-webpack-plugin": "3.3.0"
   },
   "devDependencies": {
@@ -83,7 +84,6 @@
     "gulp-notify": "2.2.0",
     "husky": "0.11.9",
     "run-sequence": "1.2.2",
-    "sockjs-client": "1.1.1",
     "standard": "8.4.0",
     "webpack-stream": "3.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "write-file-webpack-plugin": "3.3.0"
   },
   "devDependencies": {
-    "ava": "0.16.0",
     "babel-eslint": "7.0.0",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "benchmark": "2.1.1",


### PR DESCRIPTION
There is no need for adding `scripts` in the travis file, it will run `npm install` and `npm test` by default.

```yml
language: node_js
```

Node versions: `[current, 6, 4]` based on [Node LTS plan](https://github.com/nodejs/LTS)

```yml
node_js:
  - "node"
  - "6"
  - "4"
```

Caching `node_modules` for faster builds

```yml
cache:
  directories:
    - node_modules
```

Link to results - https://travis-ci.org/siddharthkp/next.js/jobs/173480820

---

On [client/webpack-dev-client/socket.js#L1](https://github.com/zeit/next.js/blob/master/client/webpack-dev-client/socket.js#L1), there is

```js
import SockJS from 'sockjs-client'
```
`sockjs-client` is not declared as a dependency in `package.json`. `webpack-dev-server` however, has `sockjs-client` as a dependency.

On npm 3.x, this piece of code works because of the flat structure of `node_modules`

But on npm 2.x, it breaks because the correct path is `webpack-dev-server/node_modules/sockjs-client` To fix this, added `sockjs-client` to `dependencies`.

<details>
  <summary>Build step was failing on npm 2.x</summary>

link to travis - https://travis-ci.org/siddharthkp/next.js/builds/173474914

```
stream.js:74
      throw er; // Unhandled stream error in pipe.
      ^
Error: ./dist/client/webpack-dev-client/socket.js
Module not found: Error: Cannot resolve module 'sockjs-client' in /Users/travis/build/siddharthkp/next.js/dist/client/webpack-dev-client
resolve module sockjs-client in /Users/travis/build/siddharthkp/next.js/dist/client/webpack-dev-client
  looking for modules in /Users/travis/build/siddharthkp/next.js/node_modules
    /Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client doesn't exist (module as directory)
    resolve 'file' sockjs-client in /Users/travis/build/siddharthkp/next.js/node_modules
      resolve file
        /Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client doesn't exist
        /Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.webpack.js doesn't exist
        /Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.web.js doesn't exist
        /Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.js doesn't exist
        /Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.json doesn't exist
[/Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client]
[/Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client]
[/Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.webpack.js]
[/Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.web.js]
[/Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.js]
[/Users/travis/build/siddharthkp/next.js/node_modules/sockjs-client.json]
 @ ./dist/client/webpack-dev-client/socket.js 8:20-44
```
</details>