### PR TITLE
Changing prepublish to pre-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "gulp",
     "test": "npm run lint && gulp test",
     "lint": "standard && standard bin/*",
-    "prepublish": "gulp release",
+    "pre-publish": "gulp release",
     "precommit": "npm run lint"
   },
   "ava": {


### PR DESCRIPTION
When I run `npm install`, it also runs `gulp release` (logs here - [travis build 7.1](https://travis-ci.org/zeit/next.js/jobs/173652108#L167))

This is because `npm install` runs `prepublish` by default. This is raised as an [issue with npm here](https://github.com/npm/npm/issues/3059)

For next.js, this might be a [feature not a bug](https://github.com/npm/npm/issues/3059#issuecomment-12282746). However, if the intention is to check if the repo is setup correctly, then `npm test` would be a better command to run using a `postinstall` script.

My assumption is this is an unintentional side effect. @nkzawa, Correct me if I'm wrong.

Changing it to ~prepublish~ `pre-publish` seems to be the convention.