### PR TITLE
Exploration of different config + expose webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ Note: we recommend putting `.next` in `.npmignore` or `.gitignore`. Otherwise, u
 ## Configuration
 
 While Next.js aims to work without any configuration, sometimes there is a need to add custom behaviour.
-You can define custom configuration in the configuration file called `next.config.js`, this file is stored in the root of the project. An example of a configuration
-looks like this:
+You can define custom configuration in a file called `next.config.js` in the project root directory.
+An example of a configuration looks like this:
 
 ```javascript
 // next.config.js
@@ -307,14 +307,13 @@ An example of this is using `eslint-loader` to lint the files before compiling. 
 ```javascript
 module.exports = {
   webpack: (webpackConfig, { hotReload, dev }) => {
-    const newConfig = { ...webpackConfig }
-    newConfig.module.preLoaders.push({ test: /\.js$/, loader: 'eslint-loader' })
-    return newConfig
+    webpackConfig.module.preLoaders.push({ test: /\.js$/, loader: 'eslint-loader' })
+    return webpackConfig
   }
 }
 ```
 
-As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js and `options`, which
+As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js, and `options`, which
 contains `hotReload` (`true` if hotReload is on) and `dev` (`true` if dev environment). The config you return is the config used by Next.js.
 You can also return a `Promise` which will be resolved first.
 
@@ -327,23 +326,21 @@ const I18nPlugin = require('i18n-webpack-plugin');
 
 module.exports = {
   webpack: (webpackConfig, { hotReload, dev }) => {
-    const newConfig = { ...webpackConfig }
     // Read image files:
-    newConfig.module.loaders.push({
+    webpackConfig.module.loaders.push({
       test: /\.png$/,
       loader: 'file'
     })
 
     // Adding a plugin
-    newConfig.plugins.push(new I18nPlugin())
+    webpackConfig.plugins.push(new I18nPlugin())
 
     // Or adding an alias
-    newConfig.resolve.alias = {
-      ...newConfig.resolve.alias,
-      src: './src'
-    }
+    // Create webpackConfig.resolve.alias if it doesn't exist yet:
+    webpackConfig.resolve.alias = webpackConfig.resolve.alias || {}
+    webpackConfig.resolve.alias.src = './src'
 
-    return newConfig
+    return webpackConfig
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ module.exports = {
 
 As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js and `options`, which
 contains `hotReload` (`true` if hotReload is on) and `dev` (`true` if dev environment). The config you return is the config used by Next.js.
+You can also return a `Promise` which will be resolved first.
 
 _NOTE: Use this option with care, because you can potentially break the existing webpack build configuration by using this option._
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ An example of this is using `eslint-loader` to lint the files before compiling. 
 
 ```javascript
 module.exports = {
-  webpack: (webpackConfig, hotReload) => {
+  webpack: (webpackConfig, { hotReload, dev }) => {
     const newConfig = { ...webpackConfig }
     newConfig.module.preLoaders.push({ test: /\.js$/, loader: 'eslint-loader' })
     return newConfig
@@ -314,8 +314,8 @@ module.exports = {
 }
 ```
 
-As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js and `hotReload`, which
-is `true` if hot reloading is enabled. The config you return is the config used by Next.js.
+As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js and `options`, which
+contains `hotReload` (`true` if hotReload is on) and `dev` (`true` if dev environment). The config you return is the config used by Next.js.
 
 _NOTE: Use this option with care, because you can potentially break the existing webpack build configuration by using this option._
 
@@ -325,7 +325,7 @@ These are some more examples:
 const I18nPlugin = require('i18n-webpack-plugin');
 
 module.exports = {
-  webpack: (webpackConfig, hotReload) => {
+  webpack: (webpackConfig, { hotReload, dev }) => {
     const newConfig = { ...webpackConfig }
     // Read image files:
     newConfig.module.loaders.push({

--- a/README.md
+++ b/README.md
@@ -285,6 +285,68 @@ Then run `now` and enjoy!
 
 Note: we recommend putting `.next` in `.npmignore` or `.gitignore`. Otherwise, use `files` or `now.files` to opt-into a whitelist of files you want to deploy (and obviously exclude `.next`)
 
+## Configuration
+
+While Next.js aims to work without any configuration, sometimes there is a need to add custom behaviour.
+You can define custom configuration in the configuration file called `next.config.js`, this file is stored in the root of the project. An example of a configuration
+looks like this:
+
+```javascript
+// next.config.js
+module.exports = {
+  cdn: true
+}
+```
+
+### Customizing webpack config
+
+Sometimes the user needs to have custom configuration for webpack to add a specific behaviour in the build process.
+An example of this is using `eslint-loader` to lint the files before compiling. This can be done by defining 
+`webpack` in the config.
+
+```javascript
+module.exports = {
+  webpack: (webpackConfig, hotReload) => {
+    const newConfig = { ...webpackConfig }
+    newConfig.module.preLoaders.push({ test: /\.js$/, loader: 'eslint-loader' })
+    return newConfig
+  }
+}
+```
+
+As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js and `hotReload`, which
+is `true` if hot reloading is enabled. The config you return is the config used by Next.js.
+
+_NOTE: Use this option with care, because you can potentially break the existing webpack build configuration by using this option._
+
+These are some more examples:
+
+```javascript
+const I18nPlugin = require('i18n-webpack-plugin');
+
+module.exports = {
+  webpack: (webpackConfig, hotReload) => {
+    const newConfig = { ...webpackConfig }
+    // Read image files:
+    newConfig.module.loaders.push({
+      test: /\.png$/,
+      loader: 'file'
+    })
+
+    // Adding a plugin
+    newConfig.plugins.push(new I18nPlugin())
+
+    // Or adding an alias
+    newConfig.resolve.alias = {
+      ...newConfig.resolve.alias,
+      src: './src'
+    }
+
+    return newConfig
+  }
+}
+```
+
 ## FAQ
 
 <details>
@@ -423,7 +485,7 @@ For this reason we want to promote a situation where users can share the cache f
 
 We are committed to providing a great uptime and levels of security for our CDN. Even so, we also **automatically fall back** if the CDN script fails to load [with a simple trick](http://www.hanselman.com/blog/CDNsFailButYourScriptsDontHaveToFallbackFromCDNToLocalJQuery.aspx).
 
-To turn the CDN off, just set `{ “next”: { “cdn”: false } }` in `package.json`.
+To turn the CDN off, just set `module.exports = { cdn: false }` in `next.config.js`.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -306,15 +306,15 @@ An example of this is using `eslint-loader` to lint the files before compiling. 
 
 ```javascript
 module.exports = {
-  webpack: (webpackConfig, { hotReload, dev }) => {
+  webpack: (webpackConfig, { dev }) => {
     webpackConfig.module.preLoaders.push({ test: /\.js$/, loader: 'eslint-loader' })
     return webpackConfig
   }
 }
 ```
 
-As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js, and `options`, which
-contains `hotReload` (`true` if hotReload is on) and `dev` (`true` if dev environment). The config you return is the config used by Next.js.
+As you can see you need to provide a function which has two parameters `webpackConfig`, which is the config used by Next.js, and `options`, which contains
+`dev` (`true` if dev environment). The config you return is the config used by Next.js.
 You can also return a `Promise` which will be resolved first.
 
 _NOTE: Use this option with care, because you can potentially break the existing webpack build configuration by using this option._
@@ -325,7 +325,7 @@ These are some more examples:
 const I18nPlugin = require('i18n-webpack-plugin');
 
 module.exports = {
-  webpack: (webpackConfig, { hotReload, dev }) => {
+  webpack: (webpackConfig, { dev }) => {
     // Read image files:
     webpackConfig.module.loaders.push({
       test: /\.png$/,

--- a/bin/next
+++ b/bin/next
@@ -2,6 +2,7 @@
 
 import { join } from 'path'
 import { spawn } from 'cross-spawn'
+import { watchFile } from 'fs'
 
 const defaultCommand = 'dev'
 const commands = new Set([
@@ -23,9 +24,21 @@ if (commands.has(cmd)) {
 
 const bin = join(__dirname, 'next-' + cmd)
 
-const proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] })
-proc.on('close', (code) => process.exit(code))
-proc.on('error', (err) => {
-  console.error(err)
-  process.exit(1)
-})
+const startProcess = () => {
+  const proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] })
+  proc.on('error', (err) => {
+    console.error(err)
+    process.exit(1)
+  })
+  return proc
+}
+
+let proc = startProcess()
+
+if (cmd === 'dev') {
+  watchFile(join(process.cwd(), 'next.config.js'), () => {
+    console.log('\n> Found a change in next.config.js, restarting the server...')
+    proc.kill()
+    proc = startProcess()
+  })
+}

--- a/bin/next
+++ b/bin/next
@@ -26,6 +26,7 @@ const bin = join(__dirname, 'next-' + cmd)
 
 const startProcess = () => {
   const proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] })
+  proc.on('close', (code) => process.exit(code))
   proc.on('error', (err) => {
     console.error(err)
     process.exit(1)
@@ -36,9 +37,13 @@ const startProcess = () => {
 let proc = startProcess()
 
 if (cmd === 'dev') {
-  watchFile(join(process.cwd(), 'next.config.js'), () => {
-    console.log('\n> Found a change in next.config.js, restarting the server...')
-    proc.kill()
-    proc = startProcess()
+  watchFile(join(process.cwd(), 'next.config.js'), (cur) => {
+    if (cur.size > 0) {
+      console.log('\n> Found a change in next.config.js, restarting the server...')
+      // Don't listen to 'close' now since otherwise parent gets killed by listener
+      proc.removeAllListeners('close')
+      proc.kill()
+      proc = startProcess()
+    }
   })
 }

--- a/bin/next
+++ b/bin/next
@@ -37,8 +37,8 @@ const startProcess = () => {
 let proc = startProcess()
 
 if (cmd === 'dev') {
-  watchFile(join(process.cwd(), 'next.config.js'), (cur) => {
-    if (cur.size > 0) {
+  watchFile(join(process.cwd(), 'next.config.js'), (cur, prev) => {
+    if (cur.size > 0 || prev.size > 0) {
       console.log('\n> Found a change in next.config.js, restarting the server...')
       // Don't listen to 'close' now since otherwise parent gets killed by listener
       proc.removeAllListeners('close')

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -167,7 +167,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
     [errorDebugPath, 'dist/pages/_error-debug.js']
   ])
 
-  const webpackConfig = webpack({
+  let webpackConfig = {
     context: dir,
     entry,
     output: {
@@ -207,11 +207,11 @@ export default async function createCompiler (dir, { dev = false } = {}) {
     customInterpolateName: function (url, name, opts) {
       return interpolateNames.get(this.resourcePath) || url
     }
-  })
+  }
   const config = getConfig(dir)
   if (config.webpack) {
     console.log('> Using Webpack config function defined in next.config.js.')
-    return await config.webpack(webpackConfig, { hotReload, dev })
+    webpackConfig = await config.webpack(webpackConfig, { hotReload, dev })
   }
-  return webpackConfig
+  return webpack(webpackConfig)
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -208,7 +208,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
       return interpolateNames.get(this.resourcePath) || url
     }
   })
-  const config = await getConfig(dir)
+  const config = getConfig(dir)
   const userWebpackConfig = config.webpack(webpackConfig, hotReload)
   return userWebpackConfig
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -211,7 +211,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
   const config = getConfig(dir)
   if (config.webpack) {
     console.log('> Using Webpack config function defined in next.config.js.')
-    webpackConfig = await config.webpack(webpackConfig, { hotReload, dev })
+    webpackConfig = await config.webpack(webpackConfig, { dev })
   }
   return webpack(webpackConfig)
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -209,6 +209,9 @@ export default async function createCompiler (dir, { dev = false } = {}) {
     }
   })
   const config = getConfig(dir)
-  const userWebpackConfig = config.webpack(webpackConfig, hotReload)
-  return userWebpackConfig
+  if (config.webpack) {
+    console.log('Using Webpack config function defined in next.config.js.')
+    return config.webpack(webpackConfig, hotReload)
+  }
+  return webpackConfig
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -9,6 +9,7 @@ import WatchPagesPlugin from './plugins/watch-pages-plugin'
 import WatchRemoveEventPlugin from './plugins/watch-remove-event-plugin'
 import DynamicEntryPlugin from './plugins/dynamic-entry-plugin'
 import DetachPlugin from './plugins/detach-plugin'
+import getConfig from '../config'
 
 export default async function createCompiler (dir, { dev = false } = {}) {
   dir = resolve(dir)
@@ -166,7 +167,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
     [errorDebugPath, 'dist/pages/_error-debug.js']
   ])
 
-  return webpack({
+  const webpackConfig = webpack({
     context: dir,
     entry,
     output: {
@@ -207,4 +208,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
       return interpolateNames.get(this.resourcePath) || url
     }
   })
+  const config = await getConfig(dir)
+  const userWebpackConfig = config.webpack(webpackConfig)
+  return userWebpackConfig
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -211,7 +211,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
   const config = getConfig(dir)
   if (config.webpack) {
     console.log('> Using Webpack config function defined in next.config.js.')
-    return config.webpack(webpackConfig, { hotReload, dev })
+    return await config.webpack(webpackConfig, { hotReload, dev })
   }
   return webpackConfig
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -209,6 +209,6 @@ export default async function createCompiler (dir, { dev = false } = {}) {
     }
   })
   const config = await getConfig(dir)
-  const userWebpackConfig = config.webpack(webpackConfig)
+  const userWebpackConfig = config.webpack(webpackConfig, hotReload)
   return userWebpackConfig
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -211,7 +211,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
   const config = getConfig(dir)
   if (config.webpack) {
     console.log('> Using Webpack config function defined in next.config.js.')
-    return config.webpack(webpackConfig, hotReload)
+    return config.webpack(webpackConfig, { hotReload, dev })
   }
   return webpackConfig
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -210,7 +210,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
   })
   const config = getConfig(dir)
   if (config.webpack) {
-    console.log('Using Webpack config function defined in next.config.js.')
+    console.log('> Using Webpack config function defined in next.config.js.')
     return config.webpack(webpackConfig, hotReload)
   }
   return webpackConfig

--- a/server/config.js
+++ b/server/config.js
@@ -1,5 +1,4 @@
 import { join } from 'path'
-import { readFile } from 'mz/fs'
 
 const cache = new Map()
 
@@ -13,21 +12,21 @@ export default function getConfig (dir) {
 }
 
 async function loadConfig (dir) {
-  const path = join(dir, 'package.json')
+  const path = join(dir, 'next.config.js')
 
-  let data
+  let module
   try {
-    data = await readFile(path, 'utf8')
+    module = require(path)
   } catch (err) {
-    if (err.code === 'ENOENT') {
-      data = '{}'
+    if (err.code === 'MODULE_NOT_FOUND') {
+      module = {}
     } else {
       throw err
     }
   }
 
   // no try-cache, it must be a valid json
-  const config = JSON.parse(data).next || {}
+  const config = module.default || module || {}
 
   return Object.assign({}, defaultConfig, config)
 }

--- a/server/config.js
+++ b/server/config.js
@@ -14,7 +14,7 @@ export default function getConfig (dir) {
   return cache.get(dir)
 }
 
-async function loadConfig (dir) {
+function loadConfig (dir) {
   const path = join(dir, 'next.config.js')
 
   let module

--- a/server/config.js
+++ b/server/config.js
@@ -2,7 +2,10 @@ import { join } from 'path'
 
 const cache = new Map()
 
-const defaultConfig = {}
+const defaultConfig = {
+  cdn: true,
+  webpack: (cfg) => cfg
+}
 
 export default function getConfig (dir) {
   if (!cache.has(dir)) {

--- a/server/config.js
+++ b/server/config.js
@@ -34,7 +34,7 @@ function loadConfig (dir) {
   }
 
   if (packageConfig) {
-    console.warn("You're using package.json as source of config for next.js. Please use next.config.js instead.")
+    console.warn("WARNING: You're using package.json as source of config for next.js. Please use next.config.js instead.")
   }
 
   return Object.assign({}, defaultConfig, userConfig, packageConfig || {})

--- a/server/config.js
+++ b/server/config.js
@@ -34,7 +34,7 @@ function loadConfig (dir) {
   }
 
   if (packageConfig) {
-    console.warn("WARNING: You're using package.json as source of config for next.js. Please use next.config.js instead.")
+    console.warn("> [warn] You're using package.json as source of config for next.js. Use next.config.js instead.")
   }
 
   return Object.assign({}, defaultConfig, userConfig, packageConfig || {})

--- a/server/config.js
+++ b/server/config.js
@@ -4,7 +4,7 @@ const cache = new Map()
 
 const defaultConfig = {
   cdn: true,
-  webpack: (cfg) => cfg
+  webpack: (cfg, hotReload) => cfg
 }
 
 export default function getConfig (dir) {

--- a/server/config.js
+++ b/server/config.js
@@ -4,7 +4,6 @@ import { existsSync } from 'fs'
 const cache = new Map()
 
 const defaultConfig = {
-  cdn: true,
   webpack: null
 }
 
@@ -17,10 +16,8 @@ export default function getConfig (dir) {
 
 function loadConfig (dir) {
   const path = join(dir, 'next.config.js')
-  const packagePath = join(dir, 'package.json')
 
   let userConfig = {}
-  let packageConfig = null
 
   const userHasConfig = existsSync(path)
   if (userHasConfig) {
@@ -28,14 +25,5 @@ function loadConfig (dir) {
     userConfig = userConfigModule.default || userConfigModule
   }
 
-  const userHasPackageConfig = existsSync(packagePath)
-  if (userHasPackageConfig) {
-    packageConfig = require(packagePath).next
-  }
-
-  if (packageConfig) {
-    console.warn("> [warn] You're using package.json as source of config for next.js. Use next.config.js instead.")
-  }
-
-  return Object.assign({}, defaultConfig, userConfig, packageConfig || {})
+  return Object.assign({}, defaultConfig, userConfig)
 }

--- a/server/config.js
+++ b/server/config.js
@@ -25,7 +25,6 @@ async function loadConfig (dir) {
     }
   }
 
-  // no try-cache, it must be a valid json
   const config = module.default || module || {}
 
   return Object.assign({}, defaultConfig, config)

--- a/server/render.js
+++ b/server/render.js
@@ -67,6 +67,7 @@ async function doRender (req, res, pathname, query, {
   }
 
   const docProps = await Document.getInitialProps({ ...ctx, renderPage })
+  const config = getConfig(dir)
 
   const doc = createElement(Document, {
     __NEXT_DATA__: {

--- a/server/render.js
+++ b/server/render.js
@@ -67,7 +67,6 @@ async function doRender (req, res, pathname, query, {
   }
 
   const docProps = await Document.getInitialProps({ ...ctx, renderPage })
-  const config = getConfig(dir)
 
   const doc = createElement(Document, {
     __NEXT_DATA__: {


### PR DESCRIPTION
We currently use `package.json` for our configuration. I think we should move away from using `package.json` and use something like `next.config.js` since it gives us more power than JSON.

An example is the issue for custom Webpack support: https://github.com/zeit/next.js/issues/40.
With a config like this you could do this for example:

```js
// next.config.js

export default {
  webpack: (webpackConfig) => {
    const newConfig = { ...webpackConfig };
    newConfig.module.preloaders.push({ test: /\.js$/, loader: 'eslint-loader' });
    return newConfig;
  },
  cdn: false
}
```

Which is in my opinion better than creating a new file for webpack since this is more centralised. This does however still give users the option to use different files, for the webpack example:

```js
// next.config.js

export default {
  webpack: require('./webpack').default,
  cdn: false
}
```

These are just my thoughts, I found out that I needed a sort of config file in `.js` when starting a PR for this project. Very curious what others think of this 😄.