### PR TITLE
catch-all routing with an _all.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Each top-level component receives a `url` property with the following API:
 - `pushTo(url)` - performs a `pushState` call that renders the new `url`. This is equivalent to following a `<Link>`
 - `replaceTo(url)` - performs a `replaceState` call that renders the new `url`
 
+If you are building an application which requires a catch-all route (for example, `/users/4`), you can define a `_all.js` file in the `./pages/user` folder.  Any un-matched route under the "user" route will be sent to this page.
+
 ### Error handling
 
 404 or 500 errors are handled both client and server side by a default component `error.js`. If you wish to override it, define a `_error.js`:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Each top-level component receives a `url` property with the following API:
 - `pushTo(url)` - performs a `pushState` call that renders the new `url`. This is equivalent to following a `<Link>`
 - `replaceTo(url)` - performs a `replaceState` call that renders the new `url`
 
-If you are building an application which requires a catch-all route (for example, `/users/4`), you can define a `_all.js` file in the `./pages/user` folder.  Any un-matched route under the "user" route will be sent to this page.
+If you are building an application which requires a catch-all route (for example, `/user/4`), you can define a `_all.js` file in the `./pages/user` folder.  Any un-matched route under the "user" route will be sent to this page.
 
 ### Error handling
 

--- a/examples/matched-routes/pages/index.js
+++ b/examples/matched-routes/pages/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <h1>A list of Users</h1>
+    <p><em>All using the same react page template...</em></p>
+    <ul>
+      <li><Link href='/user/1'>User 1</Link></li>
+      <li><Link href='/user/2'>User 2</Link></li>
+      <li><Link href='/user/3'>User 3</Link></li>
+    </ul>
+  </div>
+)

--- a/examples/matched-routes/pages/user/_all.js
+++ b/examples/matched-routes/pages/user/_all.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react'
+import Link from 'next/link'
+
+export default class CatchAll extends Component {
+  constructor (props) {
+    super(props)
+
+    let routeParts = this.props.url.pathname.split('/')
+    this.state = { user_id: parseInt(routeParts[(routeParts.length - 1)]) }
+  }
+
+  render () {
+    return <div>
+      <p>user_id: {this.state.user_id}</p>
+      <Link href={'/'}>Back</Link>
+    </div>
+  }
+}

--- a/examples/matched-routes/pages/user/_all.js
+++ b/examples/matched-routes/pages/user/_all.js
@@ -5,8 +5,7 @@ export default class CatchAll extends Component {
   constructor (props) {
     super(props)
 
-    let routeParts = this.props.url.pathname.split('/')
-    this.state = { user_id: parseInt(routeParts[(routeParts.length - 1)]) }
+    this.state = { user_id: parseInt(this.props.url.pathname.split('/').pop()) }
   }
 
   render () {

--- a/server/resolve.js
+++ b/server/resolve.js
@@ -25,12 +25,17 @@ export function resolveFromList (id, files) {
 function getPaths (id) {
   const i = sep === '/' ? id : id.replace(/\//g, sep)
 
+  let parts = i.split(sep)
+  if (parts.length > 0) parts.pop()
+  const catchAll = parts.join(sep) + sep + '_all.js'
+
   if (i.slice(-3) === '.js') return [i]
   if (i[i.length - 1] === sep) return [i + 'index.js']
 
   return [
     i + '.js',
-    join(i, 'index.js')
+    join(i, 'index.js'),
+    catchAll
   ]
 }
 

--- a/test/fixtures/basic/pages/catch-all/_all.js
+++ b/test/fixtures/basic/pages/catch-all/_all.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react'
+
+export default class CatchAll extends Component {
+  constructor (props) {
+    super(props)
+
+    let routeParts = this.props.url.pathname.split('/')
+    this.state = { user_id: parseInt(routeParts[(routeParts.length - 1)]) }
+  }
+
+  render () {
+    return <div>
+      <p>user id: {this.state.user_id}</p>
+    </div>
+  }
+}

--- a/test/fixtures/basic/pages/catch-all/_all.js
+++ b/test/fixtures/basic/pages/catch-all/_all.js
@@ -4,8 +4,7 @@ export default class CatchAll extends Component {
   constructor (props) {
     super(props)
 
-    let routeParts = this.props.url.pathname.split('/')
-    this.state = { user_id: parseInt(routeParts[(routeParts.length - 1)]) }
+    this.state = { user_id: parseInt(this.props.url.pathname.split('/').pop()) }
   }
 
   render () {

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,11 @@ test(async t => {
   t.true(html.includes('<p>Diego Milito</p>'))
 })
 
+test(async t => {
+  const html = await render('/catch-all/4')
+  t.true(html.includes('<p>user id: 4</p>'))
+})
+
 function render (url, ctx) {
   return _render(url, ctx, { dir, staticMarkup: true })
 }


### PR DESCRIPTION
Part of the solve for https://github.com/zeit/next.js/issues/25
re: https://github.com/zeit/next.js/issues/25#issuecomment-258660345

From the README update:

> If you are building an application which requires a catch-all route (for example, `/user/4`), you can define a `_all.js` file in the `./pages/user` folder.  Any un-matched route under the "user" route will be sent to this page.
