### PR TITLE
before sending html, check if response is still open

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -190,7 +190,9 @@ export default class Server {
 }
 
 function sendHTML (res, html) {
-  res.setHeader('Content-Type', 'text/html')
-  res.setHeader('Content-Length', Buffer.byteLength(html))
-  res.end(html)
+  if (!res.finished) {
+    res.setHeader('Content-Type', 'text/html')
+    res.setHeader('Content-Length', Buffer.byteLength(html))
+    res.end(html)
+  }
 }


### PR DESCRIPTION
current with `next` if you try something like this: 

```js
export default class Foo extends React.Component {

  static getInitialProps ({ req, res }) {

   // manually override server side react rendering 
    if (req) {
        res.end('my hijacked response!');
        return {}
    }
    return {}
  }

  render() {
    return <h1> Hi </h1>
  }
}
```

next will attempt to write rendered html to the now closed http response which results in a "can't set headers after they've been sent" error.

This PR checks to see if the response is still open before sending html, allowing for more adhoc hijacking of the request in `getInitialProps`
