### PR TITLE
webpack: load modules from NODE_PATH too

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -152,7 +152,7 @@ export default async function createCompiler (dir, { hotReload = false } = {}) {
       root: [
         nodeModulesDir,
         join(dir, 'node_modules')
-      ]
+      ].concat((process.env.NODE_PATH || '').split(';'))
     },
     resolveLoader: {
       root: [

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -152,7 +152,10 @@ export default async function createCompiler (dir, { hotReload = false } = {}) {
       root: [
         nodeModulesDir,
         join(dir, 'node_modules')
-      ].concat((process.env.NODE_PATH || '').split(';'))
+      ].concat(
+        (process.env.NODE_PATH || '')
+        .split(process.platform === 'win32' ? ';' : ':')
+      )
     },
     resolveLoader: {
       root: [


### PR DESCRIPTION
support:

```sh
$ NODE_PATH=/my_node_modules next

# need to set NODE_PATH on both `build` and `start`
$ NODE_PATH=/my_node_modules next build
$ NODE_PATH=/my_node_modules next start
```