### PR TITLE
Passing props through Link element

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -5,10 +5,6 @@ export default class Link extends Component {
     router: PropTypes.object
   }
 
-  constructor (props) {
-    super(props)
-  }
-
   linkClicked (e) {
     if (e.target.nodeName === 'A' &&
       (e.metaKey || e.ctrlKey || e.shiftKey || e.nativeEvent.which === 2)) {

--- a/lib/link.js
+++ b/lib/link.js
@@ -7,7 +7,6 @@ export default class Link extends Component {
 
   constructor (props) {
     super(props)
-    this.linkClicked = this.linkClicked.bind(this)
   }
 
   linkClicked (e) {
@@ -40,7 +39,8 @@ export default class Link extends Component {
   render () {
     const children = Children.map(this.props.children, (child) => {
       const props = {
-        onClick: this.linkClicked
+        ...this.props,
+        onClick: (e) => this.linkClicked(e)
       }
 
       const isAnchor = child && child.type === 'a'


### PR DESCRIPTION
Will enable styles, classNames, and other props to be included on the resulting element.

Currently, I'm unable to pass a class onto Link elements and therefore can't customize the styling of a link.