### PR TITLE
Add Ready component to handle loading across pages.

### DIFF
--- a/lib/ready.js
+++ b/lib/ready.js
@@ -1,0 +1,54 @@
+import React, { Component, PropTypes } from 'react'
+
+const DefaultLoadingHandler = () => (<p>Loading...</p>)
+const DefaultErrorHandler = ({ error }) => (
+  <pre>
+    <code style={{ color: 'red' }}>{error.stack}</code>
+  </pre>
+)
+
+export default class Ready extends Component {
+  static contextTypes = {
+    router: PropTypes.object
+  }
+
+  static propTypes = {
+    children: PropTypes.node
+  }
+
+  constructor (...args) {
+    super(...args)
+    this.state = {}
+  }
+
+  componentDidMount () {
+    const { router } = this.context
+    this.removeOnReadyCallback = router.onReady((readyData) => {
+      this.setState({ readyData })
+    })
+  }
+
+  componentWillUnmount () {
+    this.removeOnReadyCallback()
+  }
+
+  render () {
+    const {
+      children,
+      loadingHandler: LoadingHandler = DefaultLoadingHandler,
+      errorHandler: ErrorHandler = DefaultErrorHandler
+    } = this.props
+    const { readyData } = this.state
+
+    // no ready data means initially. We simply load children
+    if (!readyData) return children
+
+    // this is the loading state and we need to render the loading screen
+    if (readyData.loading) return (<LoadingHandler />)
+
+    // handle errors
+    if (readyData.error) return (<ErrorHandler error={readyData.error} />)
+
+    return children
+  }
+}

--- a/lib/router.js
+++ b/lib/router.js
@@ -18,6 +18,9 @@ export default class Router {
     this.componentLoadCancel = null
     this.onPopState = this.onPopState.bind(this)
 
+    // notify the ready state
+    this.readyCallbacks = new Set()
+
     if (typeof window !== 'undefined') {
       window.addEventListener('popstate', this.onPopState)
     }
@@ -101,12 +104,17 @@ export default class Router {
     let data
     let props
     try {
+      this.fireReadyEvents({ loading: true })
+
       data = await this.fetchComponent(route)
       const ctx = { ...data.ctx, pathname, query }
       props = await this.getInitialProps(data.Component, ctx)
-    } catch (err) {
-      if (err.cancelled) return false
-      throw err
+
+      this.fireReadyEvents({ loading: false })
+    } catch (error) {
+      if (error.cancelled) return false
+      this.fireReadyEvents({ error })
+      throw error
     }
 
     if (getURL() !== url) {
@@ -197,6 +205,15 @@ export default class Router {
   subscribe (fn) {
     this.subscriptions.add(fn)
     return () => this.subscriptions.delete(fn)
+  }
+
+  onReady (fn) {
+    this.readyCallbacks.add(fn)
+    return () => this.readyCallbacks.delete(fn)
+  }
+
+  fireReadyEvents (data) {
+    this.readyCallbacks.forEach((fn) => fn(data))
   }
 }
 

--- a/ready.js
+++ b/ready.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/lib/ready')


### PR DESCRIPTION
Fixes #238 

Basically this allows us to show a loading screen when switching between pages.
Here's how to use this:

```jsx
import React from 'react';
import Ready from 'next/ready';
import Header from '../components/header.js';

const Loading = () => (<p>It's coming...</p>);

export default () => (
  <div>
    <Header />
    <Ready loadingHandler={Loading}>
      <p>Hello Next!</p>
    </Ready>
  </div>
);
```
