### PR TITLE
[WIP] Add an example with page loading indicator

### DIFF
--- a/examples/with-loading/README.md
+++ b/examples/with-loading/README.md
@@ -1,0 +1,22 @@
+# Example app with page loading indicator
+
+This example features:
+
+* An app with two pages which uses a common [Header](./components/Header.js) component for navigation links.
+* Customized version of [Link](./components/MyLink.js) which implements a loading indicator for client side navigations.
+* Uses [nprogress](https://github.com/rstacruz/nprogress) as the loading indicator.
+
+## How to run it
+
+To run it:
+
+```sh
+npm install
+npm run dev
+```
+
+To deploy it, install [now](https://zeit.co/now) and run:
+
+```sh
+now
+```

--- a/examples/with-loading/components/Header.js
+++ b/examples/with-loading/components/Header.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import Head from 'next/head'
+import MyLink from './MyLink'
+
+export default () => (
+  <div style={{ marginBottom: 20 }}>
+    <Head>
+      {/* Import CSS for nprogress */}
+      <link rel='stylesheet' type='text/css' href='http://ricostacruz.com/nprogress/nprogress.css' />
+    </Head>
+
+    <MyLink href='/'>
+      Home
+    </MyLink> |
+    <MyLink href='/about'>
+      About
+    </MyLink>
+  </div>
+)

--- a/examples/with-loading/components/Header.js
+++ b/examples/with-loading/components/Header.js
@@ -6,7 +6,7 @@ export default () => (
   <div style={{ marginBottom: 20 }}>
     <Head>
       {/* Import CSS for nprogress */}
-      <link rel='stylesheet' type='text/css' href='http://ricostacruz.com/nprogress/nprogress.css' />
+      <link rel='stylesheet' type='text/css' href='/static/nprogress.css' />
     </Head>
 
     <MyLink href='/'>

--- a/examples/with-loading/components/MyLink.js
+++ b/examples/with-loading/components/MyLink.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import Link from 'next/link'
+import NProgress from 'nprogress'
+
+export default (props) => (
+  <Link
+    {...props}
+    onStart={() => NProgress.start()}
+    onComplete={() => NProgress.done()}
+  />
+)

--- a/examples/with-loading/package.json
+++ b/examples/with-loading/package.json
@@ -3,11 +3,12 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "dev": "../../dist/bin/next"
+    "dev": "next"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "nprogress": "^0.2.0"
+    "nprogress": "^0.2.0",
+    "next": "*"
   }
 }

--- a/examples/with-loading/package.json
+++ b/examples/with-loading/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "with-loading",
+  "version": "0.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "../../dist/bin/next"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "nprogress": "^0.2.0"
+  }
+}

--- a/examples/with-loading/pages/about.js
+++ b/examples/with-loading/pages/about.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import Header from '../components/Header'
 
 export default class About extends Component {
-  // Add some delay to the loading page
+  // Add some delay
   static getInitialProps () {
     return new Promise((resolve) => {
       setTimeout(resolve, 500)

--- a/examples/with-loading/pages/about.js
+++ b/examples/with-loading/pages/about.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react'
+import Header from '../components/header.js'
+
+export default class About extends Component {
+  // Add some delay to the loading page
+  static getInitialProps () {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 500)
+    })
+  }
+
+  render () {
+    return (
+      <div>
+        <Header />
+        <p>This is about Next!</p>
+      </div>
+    )
+  }
+}

--- a/examples/with-loading/pages/about.js
+++ b/examples/with-loading/pages/about.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import Header from '../components/header.js'
+import Header from '../components/Header'
 
 export default class About extends Component {
   // Add some delay to the loading page

--- a/examples/with-loading/pages/index.js
+++ b/examples/with-loading/pages/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Header from '../components/header.js'
+import Header from '../components/Header'
 
 export default () => (
   <div>

--- a/examples/with-loading/pages/index.js
+++ b/examples/with-loading/pages/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import Header from '../components/header.js'
+
+export default () => (
+  <div>
+    <Header />
+    <p>Hello Next!</p>
+  </div>
+)

--- a/examples/with-loading/static/nprogress.css
+++ b/examples/with-loading/static/nprogress.css
@@ -1,0 +1,73 @@
+/* Make clicks pass-through */
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: #29d;
+
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 2px;
+}
+
+/* Fancy blur effect */
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px #29d, 0 0 5px #29d;
+  opacity: 1.0;
+
+  -webkit-transform: rotate(3deg) translate(0px, -4px);
+      -ms-transform: rotate(3deg) translate(0px, -4px);
+          transform: rotate(3deg) translate(0px, -4px);
+}
+
+/* Remove these to get rid of the spinner */
+#nprogress .spinner {
+  display: block;
+  position: fixed;
+  z-index: 1031;
+  top: 15px;
+  right: 15px;
+}
+
+#nprogress .spinner-icon {
+  width: 18px;
+  height: 18px;
+  box-sizing: border-box;
+
+  border: solid 2px transparent;
+  border-top-color: #29d;
+  border-left-color: #29d;
+  border-radius: 50%;
+
+  -webkit-animation: nprogress-spinner 400ms linear infinite;
+          animation: nprogress-spinner 400ms linear infinite;
+}
+
+.nprogress-custom-parent {
+  overflow: hidden;
+  position: relative;
+}
+
+.nprogress-custom-parent #nprogress .spinner,
+.nprogress-custom-parent #nprogress .bar {
+  position: absolute;
+}
+
+@-webkit-keyframes nprogress-spinner {
+  0%   { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+@keyframes nprogress-spinner {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/lib/link.js
+++ b/lib/link.js
@@ -26,15 +26,22 @@ export default class Link extends Component {
 
     e.preventDefault()
 
+    // getting navigation event props.
+    const {
+      onStart = () => null,
+      onComplete = () => null,
+      onError = () => null
+    } = this.props
+
     // straight up redirect
+    onStart()
     this.context.router.push(null, href)
     .then((success) => {
+      onComplete(success)
       if (!success) return
       if (scroll !== false) window.scrollTo(0, 0)
     })
-    .catch((err) => {
-      if (this.props.onError) this.props.onError(err)
-    })
+    .catch(onError)
   }
 
   render () {


### PR DESCRIPTION
Check this:

![r2pljyyswi](https://cloud.githubusercontent.com/assets/50838/20251019/74d325c4-aa3b-11e6-9c74-d0039a78ef2f.gif)

<br/>
In order to do this, I have to introduce two new events to the `<Link/>`. They are:

* onStart - when the page navigation starts
* onComplete - when the page navigation completes

#### Why not using onClick instead of onStart?

onClick gets called even any clicks including external navigations. That's why we need this event.