### PR TITLE
chore: add test coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": [
+    "transform-async-to-generator",
+    "transform-object-rest-spread",
+    "transform-class-properties",
+    "transform-runtime"
+  ],
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ npm-debug.log
 
 # other
 .next
+
+# coverage
+.nyc_output
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
 cache:
   directories:
     - node_modules
+after_script: npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img width="112" alt="screen shot 2016-10-25 at 2 37 27 pm" src="https://cloud.githubusercontent.com/assets/13041/19686250/971bf7f8-9ac0-11e6-975c-188defd82df1.png">
 
 [![Build Status](https://travis-ci.org/zeit/next.js.svg?branch=master)](https://travis-ci.org/zeit/next.js)
+[![Coverage Status](https://coveralls.io/repos/zeit/next.js/badge.svg?branch=master)](https://coveralls.io/r/zeit/next.js?branch=master)
+
 [![Slack Channel](https://zeit-slackin.now.sh/badge.svg)](https://zeit.chat)
 
 Next.js is a minimalistic framework for server-rendered React applications.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ const benchmark = require('gulp-benchmark')
 const sequence = require('run-sequence')
 const webpack = require('webpack-stream')
 const del = require('del')
+const processEnv = require('gulp-process-env')
 
 const babelOptions = JSON.parse(fs.readFileSync('.babelrc', 'utf-8'))
 
@@ -134,12 +135,14 @@ gulp.task('build-client', ['compile-lib', 'compile-client'], () => {
 })
 
 gulp.task('test', () => {
-  process.env.NODE_ENV = 'test'
+  const env = processEnv({NODE_ENV: 'test'})
   return gulp.src('test/**/**.test.js')
+  .pipe(env)
   .pipe(ava({
     verbose: true,
     nyc: true
   }))
+  .pipe(env.restore())
 })
 
 gulp.task('bench', ['compile', 'copy', 'compile-bench', 'copy-bench-fixtures'], () => {

--- a/lib/document.js
+++ b/lib/document.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import htmlescape from 'htmlescape'
-import pkg from '../../package.json'
+import readPkgUp from 'read-pkg-up'
+
+const pkg = readPkgUp.sync({normalize: false}).pkg
 
 export default ({ head, css, html, data, dev, staticMarkup, cdn }) => {
   return <html>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "nyc": {
     "require": [
-      "babel-register"
+      "babel-core/register"
     ],
     "exclude": [
       "gulpfile.js",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "gulp-benchmark": "1.1.1",
     "gulp-cached": "1.1.1",
     "gulp-notify": "2.2.0",
+    "gulp-process-env": "0.0.2",
     "husky": "0.11.9",
     "nyc": "9.0.1",
     "run-sequence": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "build": "gulp",
     "pretest": "npm run lint",
     "test": "gulp test",
-    "lint": "standard && standard bin/*",
     "html-report": "nyc report --reporter=html",
+    "ava": "cross-env NODE_ENV=test nyc ava --verbose",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "lint": "standard && standard bin/*",
     "prepublish": "gulp release",
     "precommit": "npm run lint"
   },
@@ -42,7 +43,7 @@
       "**/examples/**",
       "**/bench/**"
     ],
-    "all": true,
+    "all": false,
     "sourceMap": false,
     "instrument": false
   },
@@ -101,6 +102,7 @@
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "benchmark": "2.1.1",
     "coveralls": "2.11.15",
+    "cross-env": "^3.1.3",
     "gulp": "3.9.1",
     "gulp-ava": "0.15.0",
     "gulp-babel": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,35 @@
   },
   "scripts": {
     "build": "gulp",
-    "test": "npm run lint && gulp test",
+    "pretest": "npm run lint",
+    "test": "gulp test",
     "lint": "standard && standard bin/*",
+    "html-report": "nyc report --reporter=html",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "prepublish": "gulp release",
     "precommit": "npm run lint"
   },
-  "ava": {
-    "babel": {}
+  "nyc": {
+    "require": [
+      "babel-register"
+    ],
+    "exclude": [
+      "gulpfile.js",
+      "css.js",
+      "link.js",
+      "head.js",
+      "client/**",
+      "**/pages/**",
+      "**/coverage/**",
+      "**/client/**",
+      "**/test/**",
+      "**/dist/**",
+      "**/examples/**",
+      "**/bench/**"
+    ],
+    "all": true,
+    "sourceMap": false,
+    "instrument": false
   },
   "standard": {
     "parser": "babel-eslint"
@@ -54,11 +76,14 @@
     "react": "15.4.0",
     "react-dom": "15.4.0",
     "react-hot-loader": "3.0.0-beta.6",
+    "read-pkg-up": "2.0.0",
     "send": "0.14.1",
+    "sockjs-client": "1.1.1",
     "strip-ansi": "3.0.1",
     "url": "0.11.0",
     "webpack": "1.13.3",
     "webpack-dev-server": "1.16.2",
+<<<<<<< HEAD
     "sockjs-client": "1.1.1",
     "write-file-webpack-plugin": "3.4.2"
   },
@@ -67,6 +92,15 @@
     "babel-eslint": "7.1.1",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "benchmark": "2.1.2",
+    "write-file-webpack-plugin": "3.3.0"
+  },
+  "devDependencies": {
+    "ava": "0.16.0",
+    "babel-eslint": "7.0.0",
+    "babel-plugin-istanbul": "3.0.0",
+    "babel-plugin-transform-remove-strict-mode": "0.0.2",
+    "benchmark": "2.1.1",
+    "coveralls": "2.11.15",
     "gulp": "3.9.1",
     "gulp-ava": "0.15.0",
     "gulp-babel": "6.1.2",
@@ -74,6 +108,7 @@
     "gulp-cached": "1.1.1",
     "gulp-notify": "2.2.0",
     "husky": "0.11.9",
+    "nyc": "9.0.1",
     "run-sequence": "1.2.2",
     "standard": "8.5.0",
     "webpack-stream": "3.2.0"

--- a/package.json
+++ b/package.json
@@ -84,8 +84,6 @@
     "url": "0.11.0",
     "webpack": "1.13.3",
     "webpack-dev-server": "1.16.2",
-<<<<<<< HEAD
-    "sockjs-client": "1.1.1",
     "write-file-webpack-plugin": "3.4.2"
   },
   "devDependencies": {
@@ -93,16 +91,8 @@
     "babel-eslint": "7.1.1",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "benchmark": "2.1.2",
-    "write-file-webpack-plugin": "3.3.0"
-  },
-  "devDependencies": {
-    "ava": "0.16.0",
-    "babel-eslint": "7.0.0",
-    "babel-plugin-istanbul": "3.0.0",
-    "babel-plugin-transform-remove-strict-mode": "0.0.2",
-    "benchmark": "2.1.1",
     "coveralls": "2.11.15",
-    "cross-env": "^3.1.3",
+    "cross-env": "3.1.3",
     "gulp": "3.9.1",
     "gulp-ava": "0.15.0",
     "gulp-babel": "6.1.2",
@@ -111,7 +101,7 @@
     "gulp-notify": "2.2.0",
     "gulp-process-env": "0.0.2",
     "husky": "0.11.9",
-    "nyc": "9.0.1",
+    "nyc": "10.0.0",
     "run-sequence": "1.2.2",
     "standard": "8.5.0",
     "webpack-stream": "3.2.0"

--- a/test/fixtures/basic/pages/head.js
+++ b/test/fixtures/basic/pages/head.js
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import Head from 'next/head'
 

--- a/test/fixtures/basic/pages/link.js
+++ b/test/fixtures/basic/pages/link.js
@@ -1,0 +1,5 @@
+import React from 'react'
+import Link from 'next/link'
+export default () => (
+  <div>Hello World. <Link href='/about'>About</Link></div>
+)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -7,33 +7,38 @@ const dir = join(__dirname, 'fixtures', 'basic')
 
 test.before(() => build(dir))
 
-test(async t => {
+test('renders a stateless component', async t => {
   const html = await render('/stateless')
   t.true(html.includes('<meta charset="utf-8" class="next-head"/>'))
   t.true(html.includes('<h1>My component!</h1>'))
 })
 
-test(async t => {
-  const html = await render('/css')
-  t.true(html.includes('.css-im3wl1'))
-  t.true(html.includes('<div class="css-im3wl1">This is red</div>'))
-})
-
-test(async t => {
+test('renders a stateful component', async t => {
   const html = await render('/stateful')
   t.true(html.includes('<div><p>The answer is 42</p></div>'))
 })
 
-test(async t => {
+test('header helper renders header information', async t => {
   const html = await (render('/head'))
   t.true(html.includes('<meta charset="iso-8859-5" class="next-head"/>'))
   t.true(html.includes('<meta content="my meta" class="next-head"/>'))
   t.true(html.includes('<div><h1>I can haz meta tags</h1></div>'))
 })
 
-test(async t => {
+test('css helper renders styles', async t => {
+  const html = await render('/css')
+  t.true(html.includes('.css-im3wl1'))
+  t.true(html.includes('<div class="css-im3wl1">This is red</div>'))
+})
+
+test('renders properties populated asynchronously', async t => {
   const html = await render('/async-props')
   t.true(html.includes('<p>Diego Milito</p>'))
+})
+
+test('renders a link component', async t => {
+  const html = await render('/link')
+  t.true(html.includes('<a href="/about">About</a>'))
 })
 
 function render (url, ctx) {

--- a/test/lib/shallow-equals.test.js
+++ b/test/lib/shallow-equals.test.js
@@ -1,0 +1,39 @@
+import test from 'ava'
+import shallowEquals from '../../lib/shallow-equals'
+
+test('returns true if all key/value pairs match', t => {
+  t.true(shallowEquals({
+    a: 1,
+    b: 2,
+    c: 99
+  }, {
+    a: 1,
+    b: 2,
+    c: 99
+  }))
+})
+
+test('returns false if any key/value pair is different', t => {
+  t.false(shallowEquals({
+    a: 1,
+    b: 2,
+    c: 99
+  }, {
+    a: 1,
+    b: 2,
+    c: 99,
+    d: 33
+  }))
+})
+
+test('returns false if nested objects are contained', t => {
+  t.false(shallowEquals({
+    a: 1,
+    b: 2,
+    c: {}
+  }, {
+    a: 1,
+    b: 2,
+    c: {}
+  }))
+})


### PR DESCRIPTION
Adds test coverage using `nyc` and `babel-plugin-istanbul`, see #244

<img width="770" alt="screen shot 2016-11-15 at 12 35 24 am" src="https://cloud.githubusercontent.com/assets/194609/20298547/6c28ad46-aacb-11e6-8b8f-904e4b706008.png">

## a few notes about this pull request

* I've switched to using `babel-core/register`, which is easier to wire up with `babel-plugin-istanbul`.
* I've moved babel settings into `.babelrc`, and in turn load these in `gulpfile.js`; both `babel-register`, and the build process need these same settings, and it seemed worthwhile to consolidate them.
* I've introduced a few more dependencies:
  * `coveralls`: used to pipe lcov report to coveralls.io.
  * `read-pkg-up`: used to load the parent package.json (this is necessary because in test files are under `lib/`, but after building they are located in `dist/lib`.
  * `babel-plugin-istanbul`: istanbul plugin for instrumenting test coverage (only run when env is `test`).
  * `nyc`: command line tool for instrumenting tests, outputting reports, etc.
  * `cross-env`: pass environment to a script in a way that works on Windows.
* I added a couple more tests, mainly to ensure that coverage was being computed accurately.

## enabling coverage badge

To get the coverage bade working, someone with admin access to this repo will need to enable this project on https://coveralls.io/
