### PR TITLE
Fix loader-utils spelling in code

### DIFF
--- a/server/build/loaders/emit-file-loader.js
+++ b/server/build/loaders/emit-file-loader.js
@@ -1,14 +1,14 @@
-import loaderUrils from 'loader-utils'
+import loaderUtils from 'loader-utils'
 
 module.exports = function (content) {
   this.cacheable()
 
-  const query = loaderUrils.parseQuery(this.query)
+  const query = loaderUtils.parseQuery(this.query)
   const name = query.name || '[hash].[ext]'
   const context = query.context || this.options.context
   const regExp = query.regExp
   const opts = { context, content, regExp }
-  const interpolatedName = loaderUrils.interpolateName(this, name, opts)
+  const interpolatedName = loaderUtils.interpolateName(this, name, opts)
 
   this.emitFile(interpolatedName, content)
 


### PR DESCRIPTION
I noticed a little _spelling_ mistake in the codebase.

Even though this spelling mistake would not affect how things work, I still think it would be nice to correct it.