### PR TITLE
Add default utf-8 charset.

### DIFF
--- a/lib/head.js
+++ b/lib/head.js
@@ -11,6 +11,10 @@ class Head extends React.Component {
   }
 }
 
+export function defaultHead () {
+  return [<meta charSet='utf-8' className='next-head' />]
+}
+
 function reduceComponents (components) {
   return components
   .map((c) => c.props.children)
@@ -18,6 +22,7 @@ function reduceComponents (components) {
   .map((children) => React.Children.toArray(children))
   .reduce((a, b) => a.concat(b), [])
   .reverse()
+  .concat(...defaultHead())
   .filter(unique())
   .reverse()
   .map((c) => {

--- a/server/render.js
+++ b/server/render.js
@@ -8,7 +8,7 @@ import read from './read'
 import getConfig from './config'
 import Router from '../lib/router'
 import Document from '../lib/document'
-import Head from '../lib/head'
+import Head, {defaultHead} from '../lib/head'
 import App from '../lib/app'
 
 export async function render (url, ctx = {}, {
@@ -33,7 +33,7 @@ export async function render (url, ctx = {}, {
     return (staticMarkup ? renderToStaticMarkup : renderToString)(app)
   })
 
-  const head = Head.rewind() || []
+  const head = Head.rewind() || defaultHead()
   const config = await getConfig(dir)
 
   const doc = createElement(Document, {

--- a/test/fixtures/basic/pages/head.js
+++ b/test/fixtures/basic/pages/head.js
@@ -4,6 +4,7 @@ import Head from 'next/head'
 
 export default () => <div>
   <Head>
+    <meta charSet='iso-8859-5' />
     <meta content='my meta' />
   </Head>
   <h1>I can haz meta tags</h1>

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ test.before(() => build(dir))
 
 test(async t => {
   const html = await render('/stateless')
+  t.true(html.includes('<meta charset="utf-8" class="next-head"/>'))
   t.true(html.includes('<h1>My component!</h1>'))
 })
 
@@ -25,6 +26,7 @@ test(async t => {
 
 test(async t => {
   const html = await (render('/head'))
+  t.true(html.includes('<meta charset="iso-8859-5" class="next-head"/>'))
   t.true(html.includes('<meta content="my meta" class="next-head"/>'))
   t.true(html.includes('<div><h1>I can haz meta tags</h1></div>'))
 })


### PR DESCRIPTION
Closes #237.

Sets UTF-8 as the default charset for pages without a `<Head>` or with a `<Head>` but no `<meta charSet>`.

If  `<Head>` has a `<meta charSet>` tag, that value will override the default.

Thanks for next! 😄