### PR TITLE
Remove `developers` from LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Zeit, Inc. developers 
+Copyright (c) 2016 Zeit, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
@leo I contemplated this one, but the word `developers` doesn't make sense in the context of the copyright and license so I think we should remove it.