### PR TITLE
Add react-require to avoid importing React 

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-generator": "6.19.0",
     "babel-loader": "6.2.8",
     "babel-plugin-module-resolver": "2.3.0",
+    "babel-plugin-react-require": "^3.0.0",
     "babel-plugin-transform-async-to-generator": "6.16.0",
     "babel-plugin-transform-class-properties": "6.19.0",
     "babel-plugin-transform-object-rest-spread": "6.19.0",

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -114,6 +114,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
     query: {
       presets: ['es2015', 'react'],
       plugins: [
+        require.resolve('babel-plugin-react-require'),
         require.resolve('babel-plugin-transform-async-to-generator'),
         require.resolve('babel-plugin-transform-object-rest-spread'),
         require.resolve('babel-plugin-transform-class-properties'),


### PR DESCRIPTION
This PR will allow a component to work without importing React each time, as discussed in https://github.com/zeit/next.js/issues/285

`component.js`

before:
```javascript
import React from 'react'

export default () => <div>My component</div>
```
after:
```javascript
export default () => <div>My component</div>
```