### PR TITLE
Add Polling for Bash on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "glamor": "2.18.2",
     "glob-promise": "2.0.0",
     "htmlescape": "1.1.1",
+    "is-windows-bash": "1.0.1",
     "json-loader": "0.5.4",
     "loader-utils": "0.2.16",
     "minimist": "1.2.0",

--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -1,6 +1,7 @@
 import { join, relative, sep } from 'path'
 import webpackDevMiddleware from 'webpack-dev-middleware'
 import webpackHotMiddleware from 'webpack-hot-middleware'
+import isWindowsBash from 'is-windows-bash'
 import webpack from './build/webpack'
 import read from './read'
 
@@ -106,6 +107,14 @@ export default class HotReloader {
       this.prevChunkHashes = chunkHashes
     })
 
+    const windowsSettings = isWindowsBash() ? {
+      lazy: false,
+      watchOptions: {
+        aggregateTimeout: 300,
+        poll: true
+      }
+    } : {}
+
     this.webpackDevMiddleware = webpackDevMiddleware(compiler, {
       publicPath: '/_webpack/',
       noInfo: true,
@@ -124,7 +133,8 @@ export default class HotReloader {
         timings: false,
         version: false,
         warnings: false
-      }
+      },
+      ...windowsSettings
     })
 
     this.webpackHotMiddleware = webpackHotMiddleware(compiler, { log: false })


### PR DESCRIPTION
[Per an official source](https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364), reading the `/proc/version` file and searching for 'Microsoft' is currently the best way to detect if a user is running Bash on Windows. [I wrote a small package](https://github.com/IanMitchell/is-windows-bash) that checks to see if the user is on Linux and Bash, and if they are will read that file to check if it's a Windows environment. If it is, I add polling to the webpack dev server.

First time doing something like this, so if I've gone about this the wrong way completely a course adjustment would be much appreciated 😄 

Fixes #166 

