### PR TITLE
Allow the pages directory to be in node_modules

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -113,7 +113,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
     loader: 'babel',
     include: [dir, nextPagesDir],
     exclude (str) {
-      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
+      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0 && str.indexOf(dir) !== 0
     },
     query: {
       presets: ['es2015', 'react'],


### PR DESCRIPTION
Our use case is that we have a module `@org/client` that has all our pages in them, and we would like to use this as our pages directory. This change allows babel to transpile the es6 code from the pages dir into es5 for the bundle. 

Without this change. I receive the following error:

```
{ Error: bundles/pages/index.js from UglifyJs
SyntaxError: Unexpected token: punc ()) [bundles/pages/index.js:89,20]
...
```

----

See this discussion for the errors I was having: https://zeit-community.slack.com/archives/next/p1480537539002428