### PR TITLE
Fix reading incorrect package.json

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -2,7 +2,10 @@ import React from 'react'
 import htmlescape from 'htmlescape'
 import readPkgUp from 'read-pkg-up'
 
-const pkg = readPkgUp.sync({normalize: false}).pkg
+const { pkg } = readPkgUp.sync({
+  cwd: __dirname,
+  normalize: false
+})
 
 export default ({ head, css, html, data, dev, staticMarkup, cdn }) => {
   return <html>


### PR DESCRIPTION
It reads package.json of application if you didn't set `cwd`.
This causes apps can't load the client file from cdn.