### PR TITLE
Fix recent issues with release 1.2.1

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -122,7 +122,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
     loader: 'babel',
     include: [dir, nextPagesDir],
     exclude (str) {
-      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0 && str.indexOf(dir) !== 0
+      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
     },
     query: {
       sourceMaps: dev ? 'both' : false,


### PR DESCRIPTION
Revert "Allow the pages directory to be in node_modules (#318)"
This reverts commit a13c6ccb1182af32923e587a0d86f2eacac0e022.

Fixes this issue:

![screen shot 2016-12-02 at 1 10 19 pm](https://cloud.githubusercontent.com/assets/50838/20826712/f0fd9e94-b892-11e6-8806-dcb5785f5578.png)

I assume a13c6ccb1182af32923e587a0d86f2eacac0e022 will ask babel to lookup the code inside node_modules or something similar.

