### PR TITLE
Init next.js even after dom is loaded.

### DIFF
--- a/client/next.js
+++ b/client/next.js
@@ -1,6 +1,7 @@
 import { createElement } from 'react'
 import { render } from 'react-dom'
 import HeadManager from './head-manager'
+import domready from 'domready'
 import { rehydrate } from '../lib/css'
 import Router from '../lib/router'
 import App from '../lib/app'
@@ -10,7 +11,7 @@ const {
   __NEXT_DATA__: { component, errorComponent, props, ids, err }
 } = window
 
-document.addEventListener('DOMContentLoaded', () => {
+domready(() => {
   const Component = evalScript(component).default
   const ErrorComponent = evalScript(errorComponent).default
 

--- a/examples/shared-modules/package.json
+++ b/examples/shared-modules/package.json
@@ -14,6 +14,6 @@
   "author": "",
   "license": "ISC",
   "next": {
-    "cdn": false
+    "cdn": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-runtime": "6.18.0",
     "cross-spawn": "5.0.1",
     "del": "2.2.2",
+    "domready": "1.0.8",
     "friendly-errors-webpack-plugin": "1.1.1",
     "glamor": "2.20.8",
     "glob-promise": "2.0.0",


### PR DESCRIPTION
**This is critical as currently with v1.2.x next.js won't work at all. (It only does SSR)**

Earlier we add a event to init next.js when dom has loaded.
But if at that time dom is already loaded, next.js won't get init ever.
Now we are using domready NPM module which handle these for us.