### PR TITLE
Remove line break between badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/zeit/next.js.svg?branch=master)](https://travis-ci.org/zeit/next.js)
 [![Coverage Status](https://coveralls.io/repos/zeit/next.js/badge.svg?branch=master)](https://coveralls.io/r/zeit/next.js?branch=master)
-
 [![Slack Channel](https://zeit-slackin.now.sh/badge.svg)](https://zeit.chat)
 
 Next.js is a minimalistic framework for server-rendered React applications.


### PR DESCRIPTION
Fixes this README display issue:

<img width="273" alt="screen shot 2016-12-02 at 15 27 36" src="https://cloud.githubusercontent.com/assets/4217871/20835549/e777d8f6-b8a3-11e6-9924-06f3040e4f19.png">
