### PR TITLE
Use react-hot-loader/webpack

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -87,6 +87,10 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
       join(dir, 'pages'),
       nextPagesDir
     ]
+  }, {
+    test: /\.js$/,
+    loader: 'react-hot-loader/webpack',
+    exclude: /node_modules/
   }] : [])
   .concat([{
     test: /\.json$/,


### PR DESCRIPTION
It seems this is required to detect unexported components according to the description of https://github.com/gaearon/react-hot-boilerplate/pull/61.