### PR TITLE
Set the default minChunks values to the length of pages.

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -44,7 +44,8 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
     }),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'commons',
-      filename: 'commons.js'
+      filename: 'commons.js',
+      minChunks: pages.length
     })
   ]
 


### PR DESCRIPTION
Earlier it was for all length of entry points.
But we add two more entry points for errors.
Because of that, moving common modules to `commons.js` won't work.

Thanks @benhjames for his research on this.