### PR TITLE
Fix hot reloading sub-components

### DIFF
--- a/server/build/loaders/hot-self-accept-loader.js
+++ b/server/build/loaders/hot-self-accept-loader.js
@@ -6,23 +6,28 @@ module.exports = function (content, sourceMap) {
   const route = getRoute(this)
 
   this.callback(null, `${content}
-    if (module.hot) {
+    (function (Component, route) {
+      if (!module.hot) return
+      if (!__resourceQuery) return
+
+      var qs = require('querystring')
+      var params = qs.parse(__resourceQuery.slice(1))
+      if (params.entry == null) return
+
       module.hot.accept()
+      Component.__route = route
 
-      var Component = module.exports.default || module.exports
-      Component.__route = ${JSON.stringify(route)}
+      if (module.hot.status() === 'idle') return
 
-      if (module.hot.status() !== 'idle') {
-        var components = next.router.components
-        for (var r in components) {
-          if (!components.hasOwnProperty(r)) continue
+      var components = next.router.components
+      for (var r in components) {
+        if (!components.hasOwnProperty(r)) continue
 
-          if (components[r].Component.__route === ${JSON.stringify(route)}) {
-            next.router.update(r, Component)
-          }
+        if (components[r].Component.__route === route) {
+          next.router.update(r, Component)
         }
       }
-    }
+    })(module.exports.default || module.exports, ${JSON.stringify(route)})
   `, sourceMap)
 }
 

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -18,7 +18,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
   const entry = {}
   const defaultEntries = hotReload ? ['next/dist/client/webpack-hot-middleware-client'] : []
   for (const p of pages) {
-    entry[join('bundles', p)] = defaultEntries.concat(['./' + p])
+    entry[join('bundles', p)] = defaultEntries.concat([`./${p}?entry`])
   }
 
   const nextPagesDir = join(__dirname, '..', '..', 'pages')
@@ -26,7 +26,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
   const errorEntry = join('bundles', 'pages', '_error.js')
   const defaultErrorPath = join(nextPagesDir, '_error.js')
   if (!entry[errorEntry]) {
-    entry[errorEntry] = defaultEntries.concat([defaultErrorPath])
+    entry[errorEntry] = defaultEntries.concat([defaultErrorPath + '?entry'])
   }
 
   const errorDebugEntry = join('bundles', 'pages', '_error-debug.js')
@@ -78,14 +78,14 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
   .replace(/[\\/]package\.json$/, '')
 
   const loaders = (hotReload ? [{
-    test: /\.js$/,
+    test: /\.js(\?[^?]*)?$/,
     loader: 'hot-self-accept-loader',
     include: [
       join(dir, 'pages'),
       nextPagesDir
     ]
   }, {
-    test: /\.js$/,
+    test: /\.js(\?[^?]*)?$/,
     loader: 'react-hot-loader/webpack',
     exclude: /node_modules/
   }] : [])
@@ -93,7 +93,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
     test: /\.json$/,
     loader: 'json-loader'
   }, {
-    test: /\.(js|json)$/,
+    test: /\.(js|json)(\?[^?]*)?$/,
     loader: 'emit-file-loader',
     include: [dir, nextPagesDir],
     exclude (str) {
@@ -119,7 +119,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
       ]
     }
   }, {
-    test: /\.js$/,
+    test: /\.js(\?[^?]*)?$/,
     loader: 'babel',
     include: [dir, nextPagesDir],
     exclude (str) {


### PR DESCRIPTION
fix #294. 

This PR excludes subcomponents not to call `module.hot.accept()`. 