### PR TITLE
Add custom-server-express example

### DIFF
--- a/examples/custom-server-express/package.json
+++ b/examples/custom-server-express/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "accepts": "1.3.3",
+    "express": "^4.14.0",
+    "next": "*"
+  }
+}

--- a/examples/custom-server-express/pages/a.js
+++ b/examples/custom-server-express/pages/a.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default () => <div>a</div>

--- a/examples/custom-server-express/pages/b.js
+++ b/examples/custom-server-express/pages/b.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default () => <div>b</div>

--- a/examples/custom-server-express/pages/index.js
+++ b/examples/custom-server-express/pages/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import Link from 'next/link'
+
+export default () => (
+  <ul>
+    <li><Link href='/b' as='/a'><a>a</a></Link></li>
+    <li><Link href='/a' as='/b'><a>b</a></Link></li>
+  </ul>
+)

--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -1,0 +1,37 @@
+const express = require('express')
+const next = require('next')
+const accepts = require('accepts')
+
+const app = next('.', { dev: true })
+const handle = app.getRequestHandler()
+
+app.prepare()
+.then(() => {
+  const server = express()
+
+  server.use((req, res, next) => {
+    const accept = accepts(req)
+    const type = accept.type(['json', 'html'])
+    if (type === 'json') {
+      return handle(req, res)
+    }
+    next()
+  })
+
+  server.get('/a', (req, res, next) => {
+    return app.render(req, res, '/b', req.query)
+  })
+
+  server.get('/b', (req, res, next) => {
+    return app.render(req, res, '/a', req.query)
+  })
+
+  server.get('*', (req, res, next) => {
+    return handle(req, res)
+  })
+
+  server.listen(3000, (err) => {
+    if (err) throw err
+    console.log('> Ready on http://localhost:3000')
+  })
+})

--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -2,7 +2,7 @@ const express = require('express')
 const next = require('next')
 const accepts = require('accepts')
 
-const app = next('.', { dev: true })
+const app = next({ dir: '.', dev: true })
 const handle = app.getRequestHandler()
 
 app.prepare()

--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -18,15 +18,15 @@ app.prepare()
     next()
   })
 
-  server.get('/a', (req, res, next) => {
+  server.get('/a', (req, res) => {
     return app.render(req, res, '/b', req.query)
   })
 
-  server.get('/b', (req, res, next) => {
+  server.get('/b', (req, res) => {
     return app.render(req, res, '/a', req.query)
   })
 
-  server.get('*', (req, res, next) => {
+  server.get('*', (req, res) => {
     return handle(req, res)
   })
 


### PR DESCRIPTION
I think the custom server example is fine, but it still took me a several minutes to setup express. 

Adding this should help clarify a common use case and more importantly, demonstrate that migrating to next isn't too tough.