### PR TITLE
chore: switch from ava to jest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,10 +5,5 @@
     "transform-object-rest-spread",
     "transform-class-properties",
     "transform-runtime"
-  ],
-  "env": {
-    "test": {
-      "plugins": ["istanbul"]
-    }
-  }
+  ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,12 +3,11 @@ const gulp = require('gulp')
 const babel = require('gulp-babel')
 const cache = require('gulp-cached')
 const notify_ = require('gulp-notify')
-const ava = require('gulp-ava')
 const benchmark = require('gulp-benchmark')
 const sequence = require('run-sequence')
 const webpack = require('webpack-stream')
 const del = require('del')
-const processEnv = require('gulp-process-env')
+const jest = require('gulp-jest')
 
 const babelOptions = JSON.parse(fs.readFileSync('.babelrc', 'utf-8'))
 
@@ -135,14 +134,18 @@ gulp.task('build-client', ['compile-lib', 'compile-client'], () => {
 })
 
 gulp.task('test', () => {
-  const env = processEnv({NODE_ENV: 'test'})
-  return gulp.src('test/**/**.test.js')
-  .pipe(env)
-  .pipe(ava({
+  return gulp.src('./test')
+  .pipe(jest.default({
+    coverage: true,
     verbose: true,
-    nyc: true
+    config: {
+      rootDir: './test',
+      testEnvironment: 'node',
+      coveragePathIgnorePatterns: [
+        'test/.*'
+      ]
+    }
   }))
-  .pipe(env.restore())
 })
 
 gulp.task('bench', ['compile', 'copy', 'compile-bench', 'copy-bench-fixtures'], () => {

--- a/package.json
+++ b/package.json
@@ -18,34 +18,12 @@
     "build": "gulp",
     "pretest": "npm run lint",
     "test": "gulp test",
-    "html-report": "nyc report --reporter=html",
-    "ava": "cross-env NODE_ENV=test nyc ava --verbose",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "html-report": "nyc report --temp-directory=./coverage --reporter=html",
+    "jest": "jest --coverage",
+    "coveralls": "nyc report --temp-directory=./coverage --reporter=text-lcov | coveralls",
     "lint": "standard && standard bin/*",
     "prepublish": "gulp release",
     "precommit": "npm run lint"
-  },
-  "nyc": {
-    "require": [
-      "babel-core/register"
-    ],
-    "exclude": [
-      "gulpfile.js",
-      "css.js",
-      "link.js",
-      "head.js",
-      "client/**",
-      "**/pages/**",
-      "**/coverage/**",
-      "**/client/**",
-      "**/test/**",
-      "**/dist/**",
-      "**/examples/**",
-      "**/bench/**"
-    ],
-    "all": false,
-    "sourceMap": false,
-    "instrument": false
   },
   "standard": {
     "parser": "babel-eslint"
@@ -92,24 +70,24 @@
     "write-file-webpack-plugin": "3.4.2"
   },
   "devDependencies": {
-    "ava": "0.17.0",
     "babel-eslint": "7.1.1",
-    "babel-plugin-istanbul": "3.0.0",
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "benchmark": "2.1.2",
     "coveralls": "2.11.15",
-    "cross-env": "3.1.3",
     "gulp": "3.9.1",
-    "gulp-ava": "0.15.0",
     "gulp-babel": "6.1.2",
     "gulp-benchmark": "1.1.1",
     "gulp-cached": "1.1.1",
+    "gulp-jest": "^0.6.0",
     "gulp-notify": "2.2.0",
-    "gulp-process-env": "0.0.2",
     "husky": "0.11.9",
-    "nyc": "10.0.0",
+    "jest": "^17.0.3",
+    "nyc": "^10.0.0",
     "run-sequence": "1.2.2",
     "standard": "8.6.0",
     "webpack-stream": "3.2.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,44 +1,51 @@
-import test from 'ava'
-import { join } from 'path'
+/* global expect, jasmine, describe, test, beforeAll */
+
+'use strict'
+
 import build from '../server/build'
+import { join } from 'path'
 import { render as _render } from '../server/render'
 
 const dir = join(__dirname, 'fixtures', 'basic')
 
-test.before(() => build(dir))
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
 
-test('renders a stateless component', async t => {
-  const html = await render('/stateless')
-  t.true(html.includes('<meta charset="utf-8" class="next-head"/>'))
-  t.true(html.includes('<h1>My component!</h1>'))
-})
+describe('integration tests', () => {
+  beforeAll(() => build(dir))
 
-test('renders a stateful component', async t => {
-  const html = await render('/stateful')
-  t.true(html.includes('<div><p>The answer is 42</p></div>'))
-})
+  test('renders a stateless component', async () => {
+    const html = await render('/stateless')
+    expect(html.includes('<meta charset="utf-8" class="next-head"/>')).toBeTruthy()
+    expect(html.includes('<h1>My component!</h1>')).toBeTruthy()
+  })
 
-test('header helper renders header information', async t => {
-  const html = await (render('/head'))
-  t.true(html.includes('<meta charset="iso-8859-5" class="next-head"/>'))
-  t.true(html.includes('<meta content="my meta" class="next-head"/>'))
-  t.true(html.includes('<div><h1>I can haz meta tags</h1></div>'))
-})
+  test('renders a stateful component', async () => {
+    const html = await render('/stateful')
+    expect(html.includes('<div><p>The answer is 42</p></div>')).toBeTruthy()
+  })
 
-test('css helper renders styles', async t => {
-  const html = await render('/css')
-  t.regex(html, /\.css-\w+/)
-  t.regex(html, /<div class="css-\w+">This is red<\/div>/)
-})
+  test('header helper renders header information', async () => {
+    const html = await (render('/head'))
+    expect(html.includes('<meta charset="iso-8859-5" class="next-head"/>')).toBeTruthy()
+    expect(html.includes('<meta content="my meta" class="next-head"/>')).toBeTruthy()
+    expect(html.includes('<div><h1>I can haz meta tags</h1></div>')).toBeTruthy()
+  })
 
-test('renders properties populated asynchronously', async t => {
-  const html = await render('/async-props')
-  t.true(html.includes('<p>Diego Milito</p>'))
-})
+  test('css helper renders styles', async () => {
+    const html = await render('/css')
+    expect(/\.css-\w+/.test(html)).toBeTruthy()
+    expect(/<div class="css-\w+">This is red<\/div>/.test(html)).toBeTruthy()
+  })
 
-test('renders a link component', async t => {
-  const html = await render('/link')
-  t.true(html.includes('<a href="/about">About</a>'))
+  test('renders properties populated asynchronously', async () => {
+    const html = await render('/async-props')
+    expect(html.includes('<p>Diego Milito</p>')).toBeTruthy()
+  })
+
+  test('renders a link component', async () => {
+    const html = await render('/link')
+    expect(html.includes('<a href="/about">About</a>')).toBeTruthy()
+  })
 })
 
 function render (url, ctx) {

--- a/test/lib/shallow-equals.test.js
+++ b/test/lib/shallow-equals.test.js
@@ -1,39 +1,44 @@
-import test from 'ava'
+/* global expect, describe, test */
+
+'use strict'
+
 import shallowEquals from '../../lib/shallow-equals'
 
-test('returns true if all key/value pairs match', t => {
-  t.true(shallowEquals({
-    a: 1,
-    b: 2,
-    c: 99
-  }, {
-    a: 1,
-    b: 2,
-    c: 99
-  }))
-})
+describe('shallow-equals', () => {
+  test('returns true if all key/value pairs match', () => {
+    expect(shallowEquals({
+      a: 1,
+      b: 2,
+      c: 99
+    }, {
+      a: 1,
+      b: 2,
+      c: 99
+    })).toBeTruthy()
+  })
 
-test('returns false if any key/value pair is different', t => {
-  t.false(shallowEquals({
-    a: 1,
-    b: 2,
-    c: 99
-  }, {
-    a: 1,
-    b: 2,
-    c: 99,
-    d: 33
-  }))
-})
+  test('returns false if any key/value pair is different', () => {
+    expect(shallowEquals({
+      a: 1,
+      b: 2,
+      c: 99
+    }, {
+      a: 1,
+      b: 2,
+      c: 99,
+      d: 33
+    })).toBeFalsy()
+  })
 
-test('returns false if nested objects are contained', t => {
-  t.false(shallowEquals({
-    a: 1,
-    b: 2,
-    c: {}
-  }, {
-    a: 1,
-    b: 2,
-    c: {}
-  }))
+  test('returns false if nested objects are contained', () => {
+    expect(shallowEquals({
+      a: 1,
+      b: 2,
+      c: {}
+    }, {
+      a: 1,
+      b: 2,
+      c: {}
+    })).toBeFalsy()
+  })
 })


### PR DESCRIPTION
## What Is This?

This pull requests switches the existing test-suite + test-coverage over to using jest.

fixes: #278 

## Future Work

Currently `testEnvironment` is set to `node`. Jest's default setting of `jsdom` interferes with `render`, throwing the following error:

```js
if (SideEffect.canUseDOM) {
          throw new Error('You may only call rewind() on the server. Call peek() to read the current state.')
 }
```

It would be nice to expose a way to more easily globally configure `canUseDOM`, so that tests can be written that take advantage of the jsdom mocking.

CC: @sedubois, @rauchg