### PR TITLE
update example with correct syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ export default class Error extends React.Component {
         this.props.statusCode
         ? `An error ${this.props.statusCode} occurred on server`
         : 'An error occurred on client'
-      ]</p>
+      }</p>
     )
   }
 }


### PR DESCRIPTION
- [x] was using `]` instead of `}`