### PR TITLE
Handle accept headers totally inside Next.js

### DIFF
--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const next = require('next')
-const accepts = require('accepts')
 
 const app = next({ dir: '.', dev: true })
 const handle = app.getRequestHandler()
@@ -8,15 +7,6 @@ const handle = app.getRequestHandler()
 app.prepare()
 .then(() => {
   const server = express()
-
-  server.use((req, res, next) => {
-    const accept = accepts(req)
-    const type = accept.type(['json', 'html'])
-    if (type === 'json') {
-      return handle(req, res)
-    }
-    next()
-  })
 
   server.get('/a', (req, res) => {
     return app.render(req, res, '/b', req.query)

--- a/examples/custom-server/server.js
+++ b/examples/custom-server/server.js
@@ -1,7 +1,6 @@
 const { createServer } = require('http')
 const { parse } = require('url')
 const next = require('next')
-const accepts = require('accepts')
 
 const app = next({ dev: true })
 const handle = app.getRequestHandler()
@@ -9,13 +8,6 @@ const handle = app.getRequestHandler()
 app.prepare()
 .then(() => {
   createServer((req, res) => {
-    const accept = accepts(req)
-    const type = accept.type(['json', 'html'])
-    if (type === 'json') {
-      handle(req, res)
-      return
-    }
-
     const { pathname, query } = parse(req.url, true)
 
     if (pathname === '/a') {

--- a/examples/parameterized-routing/server.js
+++ b/examples/parameterized-routing/server.js
@@ -1,7 +1,6 @@
 const { createServer } = require('http')
 const { parse } = require('url')
 const next = require('next')
-const accepts = require('accepts')
 const pathMatch = require('path-match')
 
 const app = next({ dev: true })
@@ -12,13 +11,6 @@ const match = route('/blog/:id')
 app.prepare()
 .then(() => {
   createServer((req, res) => {
-    const accept = accepts(req)
-    const type = accept.type(['json', 'html'])
-    if (type === 'json') {
-      handle(req, res)
-      return
-    }
-
     const { pathname } = parse(req.url)
     const params = match(pathname)
     if (params === false) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -166,7 +166,8 @@ export default class Router {
           if (xhr.abort) xhr.abort()
         }
 
-        const xhr = loadComponent(route, (err, data) => {
+        const url = `/_next/pages${route}`
+        const xhr = loadComponent(url, (err, data) => {
           if (err) return reject(err)
           resolve({
             Component: data.Component,

--- a/server/index.js
+++ b/server/index.js
@@ -62,12 +62,7 @@ export default class Server {
 
     this.router.get('/:path*', async (req, res) => {
       const { pathname, query } = parse(req.url, true)
-      const accept = accepts(req)
-      if (accept.type(['json', 'html']) === 'json') {
-        await this.renderJSON(res, pathname)
-      } else {
-        await this.render(req, res, pathname, query)
-      }
+      await this.render(req, res, pathname, query)
     })
   }
 
@@ -95,9 +90,17 @@ export default class Server {
     }
   }
 
-  async render (req, res, pathname, query) {
-    const html = await this.renderToHTML(req, res, pathname, query)
-    sendHTML(res, html)
+  async render (req, res, pathname, query, use) {
+    const accept = accepts(req)
+    if (accept.type(['json', 'html']) === 'json') {
+      // When we are asking for the page json, we always need to give
+      // the real pathname. But not the pathname user provided.
+      const { pathname: realPathname } = parse(req.url)
+      await this.renderJSON(res, realPathname)
+    } else {
+      const html = await this.renderToHTML(req, res, pathname, query)
+      sendHTML(res, html)
+    }
   }
 
   async renderToHTML (req, res, pathname, query) {
@@ -216,4 +219,3 @@ export default class Server {
     if (p) return errors.get(p)[0]
   }
 }
-

--- a/server/index.js
+++ b/server/index.js
@@ -50,8 +50,8 @@ export default class Server {
     })
 
     this.router.get('/_next/pages/:path*', async (req, res, params) => {
-      const path = params.path || ['']
-      const pathname = `/${path[0]}`
+      const paths = params.path || []
+      const pathname = `/${paths.join('/')}`
       await this.renderJSON(res, pathname)
     })
 


### PR DESCRIPTION
Now user doesn't need to handle accept headers anymore. So the code looks like this:

```js
const express = require('express')
const next = require('next')

const app = next({ dir: '.', dev: true })
const handle = app.getRequestHandler()

app.prepare()
  .then(() => {
    const server = express()

    server.get('/a', (req, res) => {
      return app.render(req, res, '/b', req.query)
    })

    server.get('/b', (req, res) => {
      return app.render(req, res, '/a', req.query)
    })

    server.get('*', (req, res) => {
      return handle(req, res)
    })

    server.listen(3000, (err) => {
      if (err) throw err
      console.log('> Ready on http://localhost:3000')
    })
  })
```

So now users doesn't need to know anything about accept headers and routing looks so simple.