### PR TITLE
expose new setHeaders API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -122,8 +122,8 @@ export default class Server {
     // since it can be used on getInitialProps
     res.statusCode = statusCode
 
-    const html = await render(url, ctx, { dir, dev })
-    sendHTML(res, html)
+    const rendered = await render(url, ctx, { dir, dev })
+    sendHTML(res, rendered.html, rendered.headers)
   }
 
   async renderJSON (req, res) {
@@ -214,8 +214,17 @@ export default class Server {
   }
 }
 
-function sendHTML (res, html) {
+function sendHTML (res, html, headers) {
   res.setHeader('Content-Type', 'text/html')
   res.setHeader('Content-Length', Buffer.byteLength(html))
+  if (headers) {
+    Object.keys(headers).forEach((item) => {
+      if (item !== 'Status Code') {
+        res.setHeader(item, headers[item])
+      } else if (item === 'Status Code') {
+        res.statusCode = headers[item]
+      }
+    })
+  }
   res.end(html)
 }

--- a/server/render.js
+++ b/server/render.js
@@ -22,10 +22,12 @@ export async function render (url, ctx = {}, {
 
   const [
     props,
+    headers,
     component,
     errorComponent
   ] = await Promise.all([
     Component.getInitialProps ? Component.getInitialProps(ctx) : {},
+    Component.setHeaders ? Component.setHeaders(ctx) : { 'X-Powered-By': 'next.js' },
     read(join(dir, '.next', 'bundles', 'pages', path)),
     read(join(dir, '.next', 'bundles', 'pages', dev ? '_error-debug' : '_error'))
   ])
@@ -59,7 +61,10 @@ export async function render (url, ctx = {}, {
     cdn: config.cdn
   })
 
-  return '<!DOCTYPE html>' + renderToStaticMarkup(doc)
+  return {
+    html: '<!DOCTYPE html>' + renderToStaticMarkup(doc),
+    headers: headers
+  }
 }
 
 export async function renderJSON (url, { dir = process.cwd() } = {}) {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -14,37 +14,37 @@ describe('integration tests', () => {
   beforeAll(() => build(dir))
 
   test('renders a stateless component', async () => {
-    const html = await render('/stateless')
-    expect(html.includes('<meta charset="utf-8" class="next-head"/>')).toBeTruthy()
-    expect(html.includes('<h1>My component!</h1>')).toBeTruthy()
+    const response = await render('/stateless')
+    expect(response.html.includes('<meta charset="utf-8" class="next-head"/>')).toBeTruthy()
+    expect(response.html.includes('<h1>My component!</h1>')).toBeTruthy()
   })
 
   test('renders a stateful component', async () => {
-    const html = await render('/stateful')
-    expect(html.includes('<div><p>The answer is 42</p></div>')).toBeTruthy()
+    const response = await render('/stateful')
+    expect(response.html.includes('<div><p>The answer is 42</p></div>')).toBeTruthy()
   })
 
   test('header helper renders header information', async () => {
-    const html = await (render('/head'))
-    expect(html.includes('<meta charset="iso-8859-5" class="next-head"/>')).toBeTruthy()
-    expect(html.includes('<meta content="my meta" class="next-head"/>')).toBeTruthy()
-    expect(html.includes('<div><h1>I can haz meta tags</h1></div>')).toBeTruthy()
+    const response = await (render('/head'))
+    expect(response.html.includes('<meta charset="iso-8859-5" class="next-head"/>')).toBeTruthy()
+    expect(response.html.includes('<meta content="my meta" class="next-head"/>')).toBeTruthy()
+    expect(response.html.includes('<div><h1>I can haz meta tags</h1></div>')).toBeTruthy()
   })
 
   test('css helper renders styles', async () => {
-    const html = await render('/css')
-    expect(/\.css-\w+/.test(html)).toBeTruthy()
-    expect(/<div class="css-\w+">This is red<\/div>/.test(html)).toBeTruthy()
+    const response = await render('/css')
+    expect(/\.css-\w+/.test(response.html)).toBeTruthy()
+    expect(/<div class="css-\w+">This is red<\/div>/.test(response.html)).toBeTruthy()
   })
 
   test('renders properties populated asynchronously', async () => {
-    const html = await render('/async-props')
-    expect(html.includes('<p>Diego Milito</p>')).toBeTruthy()
+    const response = await render('/async-props')
+    expect(response.html.includes('<p>Diego Milito</p>')).toBeTruthy()
   })
 
   test('renders a link component', async () => {
-    const html = await render('/link')
-    expect(html.includes('<a href="/about">About</a>')).toBeTruthy()
+    const response = await render('/link')
+    expect(response.html.includes('<a href="/about">About</a>')).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
This allows someone to set the response headers of the page. For example, they can perform a server side redirect:

```js
static async setHeaders({ req }) {
  return {
    'Status Code': 302,
    Location: 'http://www.example.com/',
  };
}
```

Where 'Status Code' is a special key that doesn't actually set anything in the header, but actually performs `res.statusCode = 302` that's exposed on the [send](https://github.com/pillarjs/send) library.