### PR TITLE
fix link for environments without synthetic events

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -12,7 +12,7 @@ export default class Link extends Component {
 
   linkClicked (e) {
     if (e.target.nodeName === 'A' &&
-      (e.metaKey || e.ctrlKey || e.shiftKey || e.nativeEvent.which === 2)) {
+      (e.metaKey || e.ctrlKey || e.shiftKey || (e.nativeEvent && e.nativeEvent.which === 2))) {
       // ignore click for new tab / new window behavior
       return
     }


### PR DESCRIPTION
just a quick additional check to make sure we don't throw when synthetic events don't exist.