### PR TITLE
[dont merge] fix duplicate React with DedupePlugin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,6 +82,7 @@ gulp.task('build-dev-client', ['compile-lib', 'compile-client'], () => {
   .pipe(webpack({
     quiet: true,
     output: { filename: 'next-dev.bundle.js', libraryTarget: 'var', library: 'require' },
+    plugins: [new webpack.webpack.optimize.DedupePlugin()],
     module: {
       loaders: [
         {
@@ -108,6 +109,7 @@ gulp.task('build-client', ['compile-lib', 'compile-client'], () => {
     quiet: true,
     output: { filename: 'next.bundle.js', libraryTarget: 'var', library: 'require' },
     plugins: [
+      new webpack.webpack.optimize.DedupePlugin(),
       new webpack.webpack.DefinePlugin({
         'process.env': {
           NODE_ENV: JSON.stringify('production')

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -36,6 +36,7 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
   const nodeModulesDir = join(__dirname, '..', '..', '..', 'node_modules')
 
   const plugins = [
+    new webpack.optimize.DedupePlugin(),
     new WriteFilePlugin({
       exitOnErrors: false,
       log: false,


### PR DESCRIPTION
React was included twice in the `client.js` file
And also in the `__NEXT_DATA__` server injected data

this should save a bunch of bytes and headaches :)

related to #394 