### PR TITLE
Fix for #204

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -184,7 +184,12 @@ export default async function createCompiler (dir, { hotReload = false, dev = fa
         [require.resolve('../../lib/link')]: 'next/link',
         [require.resolve('../../lib/prefetch')]: 'next/prefetch',
         [require.resolve('../../lib/css')]: 'next/css',
-        [require.resolve('../../lib/head')]: 'next/head'
+        [require.resolve('../../lib/head')]: 'next/head',
+        // React addons ask for React like this.
+        // That causes webpack to push react into the app's bundle.
+        // This fix simply prevents that and ask to use React from the next-bundle
+        './React': 'react',
+        './ReactDOM': 'react-dom'
       }
     ],
     resolve: {


### PR DESCRIPTION
Fixes #204

React addons require React in a special way.
That causes Webpack to push React into the app's bundle.
This fix adds new externals entries to prevent that.