### PR TITLE
Add X-Powered-By header.

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -4,7 +4,8 @@ import { existsSync } from 'fs'
 const cache = new Map()
 
 const defaultConfig = {
-  webpack: null
+  webpack: null,
+  poweredByHeader: true
 }
 
 export default function getConfig (dir) {

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,9 @@ import {
 import Router from './router'
 import HotReloader from './hot-reloader'
 import { resolveFromList } from './resolve'
+import getConfig from './config'
+// We need to go up one more level since we are in the `dist` directory
+import pkg from '../../package'
 
 export default class Server {
   constructor ({ dir = '.', dev = false, staticMarkup = false, quiet = false } = {}) {
@@ -22,6 +25,7 @@ export default class Server {
     this.router = new Router()
     this.hotReloader = dev ? new HotReloader(this.dir) : null
     this.http = null
+    this.config = getConfig(dir)
 
     this.defineRoutes()
   }
@@ -111,6 +115,9 @@ export default class Server {
   }
 
   async render (req, res, pathname, query) {
+    if (this.config.poweredByHeader) {
+      res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
+    }
     const html = await this.renderToHTML(req, res, pathname, query)
     sendHTML(res, html)
   }

--- a/server/render.js
+++ b/server/render.js
@@ -6,6 +6,8 @@ import read from './read'
 import Router from '../lib/router'
 import Head, { defaultHead } from '../lib/head'
 import App from '../lib/app'
+// We need to go up one more level since we are in the `dist` directory
+import pkg from '../../package'
 
 export async function render (req, res, pathname, query, opts) {
   const html = await renderToHTML(req, res, pathname, opts)
@@ -102,6 +104,7 @@ export async function renderErrorJSON (err, res, { dir = process.cwd(), dev = fa
 export function sendHTML (res, html) {
   res.setHeader('Content-Type', 'text/html')
   res.setHeader('Content-Length', Buffer.byteLength(html))
+  res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
   res.end(html)
 }
 

--- a/server/render.js
+++ b/server/render.js
@@ -6,8 +6,6 @@ import read from './read'
 import Router from '../lib/router'
 import Head, { defaultHead } from '../lib/head'
 import App from '../lib/app'
-// We need to go up one more level since we are in the `dist` directory
-import pkg from '../../package'
 
 export async function render (req, res, pathname, query, opts) {
   const html = await renderToHTML(req, res, pathname, opts)
@@ -104,7 +102,6 @@ export async function renderErrorJSON (err, res, { dir = process.cwd(), dev = fa
 export function sendHTML (res, html) {
   res.setHeader('Content-Type', 'text/html')
   res.setHeader('Content-Length', Buffer.byteLength(html))
-  res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
   res.end(html)
 }
 


### PR DESCRIPTION
See:

```
sh-3.2$ curl -v http://localhost:3000
* Rebuilt URL to: http://localhost:3000/
*   Trying ::1...
* Connected to localhost (::1) port 3000 (#0)
> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.49.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/html
< Content-Length: 3172
-------------------------------
< X-Powered-By: Next.js 1.2.3
-------------------------------
< Date: Sat, 17 Dec 2016 11:38:52 GMT
< Connection: keep-alive
```