### PR TITLE
Allow for custom route in pushTo and replaceTo methods

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -67,9 +67,19 @@ function propsToState (props) {
     pathname: router.pathname,
     back: () => router.back(),
     push: (url) => router.push(route, url),
-    pushTo: (url) => router.push(null, url),
+    pushTo: (href, as) => {
+      const pushRoute = as ? href : null
+      const pushUrl = as || href
+
+      return router.push(pushRoute, pushUrl)
+    },
     replace: (url) => router.replace(route, url),
-    replaceTo: (url) => router.replace(null, url)
+    replaceTo: (href, as) => {
+      const replaceRoute = as ? href : null
+      const replaceUrl = as || href
+
+      return router.replace(replaceRoute, replaceUrl)
+    }
   }
 
   return {


### PR DESCRIPTION
https://github.com/zeit/next.js/pull/310 allows us to do things like `<Link href='/blog?id=first' as='/blog/first'>`. It would be useful to be able to do the same with `pushTo` (e.g. `pushTo('/blog?id=first', '/blog/first')` and `replaceTo`, respectively.

This PR would change both methods to mirror the login of the `Link` component: https://github.com/zeit/next.js/blob/master/lib/link.js#L29-L30