### PR TITLE
Add cli usage information

### DIFF
--- a/bin/next
+++ b/bin/next
@@ -5,14 +5,28 @@ import { spawn } from 'cross-spawn'
 
 const defaultCommand = 'dev'
 const commands = new Set([
-  defaultCommand,
   'init',
   'build',
-  'start'
+  'start',
+  defaultCommand
 ])
 
 let cmd = process.argv[2]
 let args
+
+if (cmd === '--help' || cmd === '-h') {
+  console.log(`
+    Usage
+      $ next <command>
+
+    Available commands
+      ${Array.from(commands).join(', ')}
+
+    For more information run a command with the --help flag
+      $ next init --help
+  `)
+  process.exit(0)
+}
 
 if (commands.has(cmd)) {
   args = process.argv.slice(3)

--- a/bin/next
+++ b/bin/next
@@ -14,7 +14,7 @@ const commands = new Set([
 let cmd = process.argv[2]
 let args
 
-if (cmd === '--help' || cmd === '-h') {
+if (new Set(['--help', '-h']).has(cmd)) {
   console.log(`
     Usage
       $ next <command>

--- a/bin/next-build
+++ b/bin/next-build
@@ -17,9 +17,9 @@ if (argv.help) {
       Compiles the application for production deployment
 
     Usage
-      $ next build <directory>
+      $ next build <dir>
 
-    <directory> represents where the compiled .next folder should go.
+    <dir> represents where the compiled .next folder should go.
     If no directory is provided, .next will be created in the current directory
   `)
   process.exit(0)

--- a/bin/next-build
+++ b/bin/next-build
@@ -11,6 +11,17 @@ const argv = parseArgs(process.argv.slice(2), {
   boolean: ['h']
 })
 
+if (argv.help) {
+  console.log(`
+    Description
+      Compiles the application for production deployment
+
+    Usage
+      $ next build
+  `)
+  process.exit(0)
+}
+
 const dir = resolve(argv._[0] || '.')
 
 build(dir)

--- a/bin/next-build
+++ b/bin/next-build
@@ -17,7 +17,10 @@ if (argv.help) {
       Compiles the application for production deployment
 
     Usage
-      $ next build
+      $ next build <directory>
+
+    <directory> represents where the compiled .next folder should go.
+    If no directory is provided, .next will be created in the current directory
   `)
   process.exit(0)
 }

--- a/bin/next-dev
+++ b/bin/next-dev
@@ -23,7 +23,10 @@ if (argv.help) {
       reporting, etc)
 
     Usage
-      $ next dev -p <port number>
+      $ next dev <directory> -p <port number>
+
+    <directory> represents where the compiled .next folder should go.
+    If no directory is provided, .next will be created in the current directory
 
     Options
       --port, -p      A port number on which to start the application

--- a/bin/next-dev
+++ b/bin/next-dev
@@ -16,6 +16,22 @@ const argv = parseArgs(process.argv.slice(2), {
   }
 })
 
+if (argv.help) {
+  console.log(`
+    Description
+      Starts the application in development mode (hot-code reloading, error
+      reporting, etc)
+
+    Usage
+      $ next dev -p <port number>
+
+    Options
+      --port, -p      A port number on which to start the application
+      --help, -p      Displays this message
+  `)
+  process.exit(0)
+}
+
 const dir = resolve(argv._[0] || '.')
 
 const srv = new Server({ dir, dev: true })

--- a/bin/next-dev
+++ b/bin/next-dev
@@ -23,9 +23,9 @@ if (argv.help) {
       reporting, etc)
 
     Usage
-      $ next dev <directory> -p <port number>
+      $ next dev <dir> -p <port number>
 
-    <directory> represents where the compiled .next folder should go.
+    <dir> represents where the compiled .next folder should go.
     If no directory is provided, .next will be created in the current directory
 
     Options

--- a/bin/next-init
+++ b/bin/next-init
@@ -17,9 +17,9 @@ if (argv.help) {
       Scaffolds a simple project structure to get started quickly
 
     Usage
-      $ next init <directory>
+      $ next init <dir>
 
-      If no directory is providing the current directory will be used.
+      If no directory is provided the current directory will be used.
 
     Options
       --help, -p      Displays this message

--- a/bin/next-init
+++ b/bin/next-init
@@ -13,10 +13,16 @@ const argv = parseArgs(process.argv.slice(2), {
 
 if (argv.help) {
   console.log(`
-    Usage:
+    Description
+      Scaffolds a simple project structure to get started quickly
+
+    Usage
       $ next init <directory>
 
-      Directory defaults to current directory ('.')
+      If no directory is providing the current directory will be used.
+
+    Options
+      --help, -p      Displays this message
   `)
 
   process.exit(0)

--- a/bin/next-init
+++ b/bin/next-init
@@ -11,6 +11,17 @@ const argv = parseArgs(process.argv.slice(2), {
   boolean: ['h']
 })
 
+if (argv.help) {
+  console.log(`
+    Usage:
+      $ next init <directory>
+
+      Directory defaults to current directory ('.')
+  `)
+
+  process.exit(0)
+}
+
 const dir = resolve(argv._[0] || '.')
 
 if (basename(dir) === 'pages') {

--- a/bin/next-start
+++ b/bin/next-start
@@ -22,9 +22,9 @@ if (argv.help) {
       The application should be compiled with \`next build\` first.
 
     Usage
-      $ next start <directory> -p <port>
+      $ next start <dir> -p <port>
 
-    <directory> is the directory that contains the compiled .next folder
+    <dir> is the directory that contains the compiled .next folder
     created by running \`next build\`.
     If no directory is provided, the current directory will be assumed.
 

--- a/bin/next-start
+++ b/bin/next-start
@@ -15,6 +15,22 @@ const argv = parseArgs(process.argv.slice(2), {
   }
 })
 
+if (argv.help) {
+  console.log(`
+    Description
+      Starts the application in production mode.
+      The application should be compiled with \`next build\` first.
+
+    Usage
+      $ next start -p <port>
+
+    Options
+      --port, -p      A port number on which to start the application
+      --help, -p      Displays this message
+  `)
+  process.exit(0)
+}
+
 const dir = resolve(argv._[0] || '.')
 
 const srv = new Server({ dir })

--- a/bin/next-start
+++ b/bin/next-start
@@ -22,7 +22,11 @@ if (argv.help) {
       The application should be compiled with \`next build\` first.
 
     Usage
-      $ next start -p <port>
+      $ next start <directory> -p <port>
+
+    <directory> is the directory that contains the compiled .next folder
+    created by running \`next build\`.
+    If no directory is provided, the current directory will be assumed.
 
     Options
       --port, -p      A port number on which to start the application


### PR DESCRIPTION
Adds usage information to the CLI (#80) for `next` as well as sub-commands (`next dev --help`, etc).

If the messages need wordsmithing or if some other way makes more sense, just let me know 😃 

```
❯ next --help

    Usage
      $ next <command>

    Available commands
      init, build, start, dev

    For more information run a command with the --help flag
      $ next init --help
  
 ```

```
❯ next dev --help

    Description
      Starts the application in development mode (hot-code reloading, error
      reporting, etc)

    Usage
      $ next dev <dir> -p <port number>

    <dir> represents where the compiled .next folder should go.
    If no directory is provided, .next will be created in the current directory

    Options
      --port, -p      A port number on which to start the application
      --help, -p      Displays this message
```