### PR TITLE
Add isServer prop to getInitialProps

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -190,6 +190,8 @@ export default class Router {
     const cancel = () => { cancelled = true }
     this.componentLoadCancel = cancel
 
+    ctx.isServer = false;
+
     const props = await (Component.getInitialProps ? Component.getInitialProps(ctx) : {})
 
     if (cancel === this.componentLoadCancel) {

--- a/server/render.js
+++ b/server/render.js
@@ -40,7 +40,7 @@ async function doRender (req, res, pathname, query, {
   ])
   Component = Component.default || Component
   Document = Document.default || Document
-  const ctx = { err, req, res, pathname, query }
+  const ctx = { err, req, res, pathname, query, isServer: true }
 
   const [
     props,


### PR DESCRIPTION
It would be nice to have a slightly more clear argument to tell you whether you're rendering from the client-side or server-side.

```js
export default class extends React.Component {
  static getInitialProps ({ isServer }) {
    return isServer ? {...} : {...};
  }
  render () {...}
}
```

Opening this up to see how you feel about it.