### PR TITLE
Show deprecate url.pushTo and url.replaceTo warnings only on dev.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { AppContainer } from 'react-hot-loader'
+import { warn } from './utils'
 
 export default class App extends Component {
   static childContextTypes = {
@@ -67,7 +68,7 @@ function propsToState (props) {
     back: () => router.back(),
     push: (url, as) => router.push(url, as),
     pushTo: (href, as) => {
-      console.warn(`Warning: 'url.pushTo()' is deprecated. Please use 'url.push()' instead.`)
+      warn(`Warning: 'url.pushTo()' is deprecated. Please use 'url.push()' instead.`)
       const pushRoute = as ? href : null
       const pushUrl = as || href
 
@@ -75,7 +76,7 @@ function propsToState (props) {
     },
     replace: (url, as) => router.replace(url, as),
     replaceTo: (href, as) => {
-      console.warn(`Warning: 'url.replaceTo()' is deprecated. Please use 'url.replace()' instead.`)
+      warn(`Warning: 'url.replaceTo()' is deprecated. Please use 'url.replace()' instead.`)
       const replaceRoute = as ? href : null
       const replaceUrl = as || href
 

--- a/lib/css.js
+++ b/lib/css.js
@@ -1,8 +1,7 @@
+import { warn } from './utils'
 const css = require('glamor')
 
-if (process.env.NODE_ENV !== 'production') {
-  console.error('Warning: \'next/css\' is deprecated. Please use styled-jsx syntax instead.')
-}
+warn('Warning: \'next/css\' is deprecated. Please use styled-jsx syntax instead.')
 
 /**
  * Expose style as default and the whole object as properties

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,5 @@
+export function warn (message) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(message)
+  }
+}


### PR DESCRIPTION
In order to warn the user, now we are using a warn function
which is located in the `lib/utils` module.