### PR TITLE
Pass `webpack` into `webpack()` fn in next.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ app.prepare().then(() => {
 ```
 
 The `next` API is as follows:
-- `next(path: string, opts: object)` - `path` is 
+- `next(path: string, opts: object)` - `path` is
 - `next(opts: object)`
 
 Supported options:
@@ -397,8 +397,13 @@ The following example shows how you can use [`react-svg-loader`](https://github.
 
 ```js
 module.exports = {
-  webpack: (cfg, { dev }) => {
+  webpack: (cfg, { webpack, dev }) => {
     cfg.module.rules.push({ test: /\.svg$/, loader: 'babel!react-svg' })
+    cfg.plugins.push(
+        new webpack.DefinePlugin({
+        'process.env.CUSTOM_VALUE': JSON.stringify(process.env.CUSTOM_VALUE),
+      })
+    )
     return cfg
   }
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -189,7 +189,7 @@ export default async function createCompiler (dir, { dev = false } = {}) {
   const config = getConfig(dir)
   if (config.webpack) {
     console.log('> Using Webpack config function defined in next.config.js.')
-    webpackConfig = await config.webpack(webpackConfig, { dev })
+    webpackConfig = await config.webpack(webpackConfig, { webpack, dev })
   }
   return webpack(webpackConfig)
 }


### PR DESCRIPTION
This passes a refernce to the `webpack` module into a custom `webpack()` function defined in `next.config.js`.

A user wanting to add something like a custom `DefinePlugin` entry might have a `next.config.js` file that looks like this:

```js
module.exports = {
  webpack: (cfg) => {
    cfg.plugins.push(
      new webpack.DefinePlugin({
        'process.env.CUSTOM_VALUE': JSON.stringify(process.env.CUSTOM_VALUE),
      })
    );

    return cfg;
  },
};
```

The problem is they need access to the `webpack` module. They might think to `require('webpack')` in their `next.config.js`, but then they might feel obligated to add `webpack` to their `package.json`. Instead, it might be simpler to just pass a reference to the `webpack` to their config like this:

```js
module.exports = {
  webpack: (cfg, {webpack}) => {
    // ...
  },
};
```

Curious what folks think about this. Maybe someone is worried that the user would try to call the `webpack()` module ref and kick off the build?