### PR TITLE
fix: expose babel presets for upstream libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "zeit/next.js",
   "files": [
     "dist",
+    "babel.js",
     "link.js",
     "css.js",
     "head.js",


### PR DESCRIPTION
It would be nice to be able to do this:

```json
{
  "presets": ["next/babel"]
}
```

currently you need to do this:

```json
{
  "presets": ["next/dist/server/build/babel/preset"]
}
```