### PR TITLE
Avoid autoscrolling anchored URLs

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -14,7 +14,7 @@ export default class Link extends Component {
       return
     }
 
-    const { href, scroll, as } = this.props
+    const { href, as } = this.props
 
     if (!isLocal(href)) {
       // ignore click if it's outside our scope
@@ -25,6 +25,10 @@ export default class Link extends Component {
 
     const route = as ? href : null
     const url = as || href
+
+    //  avoid scroll for urls with anchor refs
+    let { scroll } = this.props
+    if (url.indexOf('#') > -1) scroll = false
 
     // straight up redirect
     Router.push(route, url)

--- a/lib/link.js
+++ b/lib/link.js
@@ -28,7 +28,9 @@ export default class Link extends Component {
 
     //  avoid scroll for urls with anchor refs
     let { scroll } = this.props
-    if (url.indexOf('#') > -1) scroll = false
+    if (url.indexOf('#') > -1 && !scroll) {
+      scroll = false
+    }
 
     // straight up redirect
     Router.push(route, url)

--- a/lib/link.js
+++ b/lib/link.js
@@ -28,8 +28,8 @@ export default class Link extends Component {
 
     //  avoid scroll for urls with anchor refs
     let { scroll } = this.props
-    if (url.indexOf('#') > -1 && !scroll) {
-      scroll = false
+    if (scroll == null) {
+      scroll = url.indexOf('#') < 0
     }
 
     // straight up redirect


### PR DESCRIPTION
#### Issue https://github.com/zeit/next.js/issues/442

### Description
Unexpected scrolling when including element IDs in Link URLs (ex `/#id`. This unexpected behavoir is caused by the line:
`if (scroll !== false) window.scrollTo(0, 0)`

### Solution
By forcing `scroll={false}` when the `url` contains `#`. We will avoid the forced scroll done by the line above for users that are passing element Ids.