### PR TITLE
Added missing readme and references in main readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ export default () => (
 
 #### Built-in CSS support
 
+<details>
+  <summary><b>Examples</b></summary>
+  - [Basic css](./examples/basic-css)
+</details>
+
 We bundle [styled-jsx](https://github.com/zeit/styled-jsx) to provide support for isolated scoped CSS. The aim is to support "shadow CSS" resembling of Web Components, which unfortunately [do not support server-rendering and are JS-only](https://github.com/w3c/webcomponents/issues/71).
 
 ```jsx
@@ -85,8 +90,6 @@ export default () => (
   </div>
 )
 ```
-
-See the [full example project](./examples/basic-css).
 
 #### CSS-in-JS
 
@@ -112,6 +115,11 @@ export default () => (
 
 ### Populating `<head>`
 
+<details>
+  <summary><b>Examples</b></summary>
+  - [Head elements](./examples/head-elements)
+</details>
+
 We expose a built-in component for appending elements to the `<head>` of the page.
 
 ```jsx
@@ -128,8 +136,6 @@ export default () => (
 ```
 
 _Note: The contents of `<head>` get cleared upon unmounting the component, so make sure each page completely defines what it needs in `<head>`, without making assumptions about what other pages added_
-
-See the [full example project](./examples/head-elements) using custom head elements.
 
 ### Fetching data and component lifecycle
 
@@ -166,6 +172,11 @@ For the initial page load, `getInitialProps` will execute on the server only. `g
 
 ### Routing
 
+<details>
+  <summary><b>Examples</b></summary>
+  - [Basic routing](./examples/using-routing)
+</details>
+
 #### With `<Link>`
 
 Client-side transitions between routes can be enabled via a `<Link>` component. Consider these two pages:
@@ -200,8 +211,6 @@ Each top-level component receives a `url` property with the following API:
 
 The second `as` parameter for `push` and `replace` is an optional _decoration_ of the URL. Useful if you configured custom routes on the server.
 
-See the [basic routing example](./examples/using-router).
-
 #### Imperatively
 
 You can also do client-side page transitions using the `next/router`
@@ -227,6 +236,11 @@ The second `as` parameter for `push` and `replace` is an optional _decoration_ o
 _Note: in order to programmatically change the route without triggering navigation and component-fetching, use `props.url.push` and `props.url.replace` within a component_
 
 ### Prefetching Pages
+
+<details>
+  <summary><b>Examples</b></summary>
+  - [Prefetching](./examples/with-prefetching)
+</details>
 
 Next.js exposes a module that configures a `ServiceWorker` automatically to prefetch pages: `next/prefetch`.
 
@@ -256,8 +270,6 @@ When this higher-level `<Link>` component is first used, the `ServiceWorker` get
 <Link href='/contact' prefetch={false}>Home</Link>
 ```
 
-See the [prefetching example](./examples/with-prefetching).
-
 #### Imperatively
 
 Most needs are addressed by `<Link />`, but we also expose an imperative API for advanced usage:
@@ -278,6 +290,13 @@ export default ({ url }) => (
 ```
 
 ### Custom server and routing
+
+<details>
+  <summary><b>Examples</b></summary>
+  - [Basic custom server](./examples/custom-server)
+  - [Express integration](./examples/custom-server-express)
+  - [Parameterized routing](./examples/parameterized-routing)
+</details>
 
 Typically you start your next server with `next start`. It's possible, however, to start a server 100% programmatically in order to customize routes, use route patterns, etc
 
@@ -319,11 +338,12 @@ Supported options:
 - `dir` (`string`) where the Next project is located - default `'.'`
 - `quiet` (`bool`) Display error messages with server information - default `false`
 
-See the [basic custom server](./examples/custom-server), the
-[express integration](./examples/custom-server-express) or the
-[parametrized routes](./examples/parameterized-routing).
-
 ### Custom `<Document>`
+
+<details>
+  <summary><b>Examples</b></summary>
+  - [Styled components custom document](./examples/with-styled-components)
+</details>
 
 Pages in `Next.js` skip the definition of the surrounding document's markup. For example, you never include `<html>`, `<body>`, etc. But we still make it possible to override that:
 
@@ -357,10 +377,6 @@ The `ctx` object is equivalent to the one received in all [`getInitialProps`](#f
 
 - `renderPage` (`Function`) a callback that executes the actual React rendering logic (synchronously). It's useful to decorate this function in order to support server-rendering wrappers like Aphrodite's [`renderStatic`](https://github.com/Khan/aphrodite#server-side-rendering)
 
-The [styled components example](./examples/with-styled-components) showcase how
-to extend the `<Document>` to allow server side styles with you favorite styling
-library.
-
 ### Custom error handling
 
 404 or 500 errors are handled both client and server side by a default component `error.js`. If you wish to override it, define a `_error.js`:
@@ -386,6 +402,11 @@ export default class Error extends React.Component {
 ```
 
 ### Custom configuration
+
+<details>
+  <summary><b>Examples</b></summary>
+  - [Custom babel configuration](./examples/with-custom-babel-config)
+</details>
 
 For custom advanced behavior of Next.js, you can create a `next.config.js` in the root of your project directory (next to `pages/` and `package.json`).
 
@@ -418,8 +439,6 @@ module.exports = {
   }
 }
 ```
-
-Check the [custom babel config example](./examples/with-custom-babel-config).
 
 ### Customizing babel config
 
@@ -561,7 +580,7 @@ It’s up to you. `getInitialProps` is an `async` function (or a regular functio
 <details>
 <summary>Can I use it with Redux?</summary>
 
-Yes! Here's an [example](https://github.com/zeit/next.js/wiki/Redux-example)
+Yes! Here's an [example](./examples/with-redux)
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ export default () => (
 )
 ```
 
+See the [full example project](./examples-basic-css)
+
 #### CSS-in-JS
 
 It's possible to use any existing CSS-in-JS solution. The simplest one is inline styles:
@@ -97,6 +99,8 @@ export default () => (
 ```
 
 To use more sophisticated CSS-in-JS solutions, you typically have to implement style flushing for server-side rendering. We enable this by allowing you to define your own [custom `<Document>`](#user-content-custom-document) component that wraps each page
+
+See the [full example project](./examples-basic-css) using styled-components.
 
 ### Static file serving (e.g.: images)
 
@@ -126,6 +130,8 @@ export default () => (
 ```
 
 _Note: The contents of `<head>` get cleared upon unmounting the component, so make sure each page completely defines what it needs in `<head>`, without making assumptions about what other pages added_
+
+See the [full example project](./head-elements) using custom head elements.
 
 ### Fetching data and component lifecycle
 
@@ -196,6 +202,8 @@ Each top-level component receives a `url` property with the following API:
 
 The second `as` parameter for `push` and `replace` is an optional _decoration_ of the URL. Useful if you configured custom routes on the server.
 
+See the [basic routing example](./examples/using-router)
+
 #### Imperatively
 
 You can also do client-side page transitions using the `next/router`
@@ -249,6 +257,8 @@ When this higher-level `<Link>` component is first used, the `ServiceWorker` get
 ```jsx
 <Link href='/contact' prefetch={false}>Home</Link>
 ```
+
+See the [prefetching example](./examples/with-prefetching)
 
 #### Imperatively
 
@@ -311,6 +321,10 @@ Supported options:
 - `dir` (`string`) where the Next project is located - default `'.'`
 - `quiet` (`bool`) Display error messages with server information - default `false`
 
+See the [basic custom server](./examples/custom-server), the
+[express integration](./examples/custom-server-express) or the
+[parametrized routes](./examples/parametrized-routing)
+
 ### Custom `<Document>`
 
 Pages in `Next.js` skip the definition of the surrounding document's markup. For example, you never include `<html>`, `<body>`, etc. But we still make it possible to override that:
@@ -344,6 +358,10 @@ export default class MyDocument extends Document {
 The `ctx` object is equivalent to the one received in all [`getInitialProps`](#fetching-data-and-component-lifecycle) hooks, with one addition:
 
 - `renderPage` (`Function`) a callback that executes the actual React rendering logic (synchronously). It's useful to decorate this function in order to support server-rendering wrappers like Aphrodite's [`renderStatic`](https://github.com/Khan/aphrodite#server-side-rendering)
+
+The [styled components example](./examples/with-styled-components) showcase how
+to extend the `<Document>` to allow server side styles with you favorite styling
+library.
 
 ### Custom error handling
 
@@ -402,6 +420,8 @@ module.exports = {
   }
 }
 ```
+
+Check the [custom babel config example](./examples/with-custom-babel-config).
 
 ### Customizing babel config
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export default () => (
 )
 ```
 
-See the [full example project](./examples-basic-css)
+See the [full example project](./examples/basic-css).
 
 #### CSS-in-JS
 
@@ -99,8 +99,6 @@ export default () => (
 ```
 
 To use more sophisticated CSS-in-JS solutions, you typically have to implement style flushing for server-side rendering. We enable this by allowing you to define your own [custom `<Document>`](#user-content-custom-document) component that wraps each page
-
-See the [full example project](./examples-basic-css) using styled-components.
 
 ### Static file serving (e.g.: images)
 
@@ -131,7 +129,7 @@ export default () => (
 
 _Note: The contents of `<head>` get cleared upon unmounting the component, so make sure each page completely defines what it needs in `<head>`, without making assumptions about what other pages added_
 
-See the [full example project](./head-elements) using custom head elements.
+See the [full example project](./examples/head-elements) using custom head elements.
 
 ### Fetching data and component lifecycle
 
@@ -202,7 +200,7 @@ Each top-level component receives a `url` property with the following API:
 
 The second `as` parameter for `push` and `replace` is an optional _decoration_ of the URL. Useful if you configured custom routes on the server.
 
-See the [basic routing example](./examples/using-router)
+See the [basic routing example](./examples/using-router).
 
 #### Imperatively
 
@@ -258,7 +256,7 @@ When this higher-level `<Link>` component is first used, the `ServiceWorker` get
 <Link href='/contact' prefetch={false}>Home</Link>
 ```
 
-See the [prefetching example](./examples/with-prefetching)
+See the [prefetching example](./examples/with-prefetching).
 
 #### Imperatively
 
@@ -323,7 +321,7 @@ Supported options:
 
 See the [basic custom server](./examples/custom-server), the
 [express integration](./examples/custom-server-express) or the
-[parametrized routes](./examples/parametrized-routing)
+[parametrized routes](./examples/parameterized-routing).
 
 ### Custom `<Document>`
 

--- a/examples/with-jest/README.md
+++ b/examples/with-jest/README.md
@@ -1,0 +1,35 @@
+# Example app with jest tests
+
+## How to use
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-jest
+cd with-jest
+```
+
+or clone the repo:
+
+```bash
+git clone https://github.com/zeit/next.js.git --depth=1
+cd next.js/examples/with-jest
+```
+
+Install the dependencies:
+
+```bash
+npm install
+```
+
+Run the tests:
+
+```bash
+npm test
+```
+
+## The idea behind the example
+
+This example features:
+
+* An app with jest tests


### PR DESCRIPTION
Fixing the `Add missing READMEs in examples/ and link to them throughout the README` section on #409