### PR TITLE
Add SSR caching example to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ export default ({ url }) => (
     <li><a href="./examples/custom-server">Basic custom server</a></li>
     <li><a href="./examples/custom-server-express">Express integration</a></li>
     <li><a href="./examples/parameterized-routing">Parameterized routing</a></li>
+    <li><a href="./examples/ssr-caching">SSR caching</a></li>
   </ul>
 </details></p>
 


### PR DESCRIPTION
I didn't see the examples section in the README when I was creating the example.