### PR TITLE
Add warning about module.exports use

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,31 @@ module.exports = {
 }
 ```
 
+#### Default Babel configuration
+Next.js uses Babel6 out of the box, which doesn't support default `module.exports`.
+##### Invalid:
+```js
+import React from 'react':
+//  bad import
+const Link = require('next/link').default;
+
+//  bad export
+module.exports = () => (
+  <Link href='/'>Invalid</Link>
+)
+```
+##### Valid:
+```js
+import React from 'react';
+//  good import
+import Link from 'next/link';
+
+//  good export
+export default () => (
+  <Link href='/'>Valid</Link>
+)
+```
+
 ## Production deployment
 
 To deploy, instead of running `next`, you probably want to build ahead of time. Therefore, building and starting are separate commands:

--- a/README.md
+++ b/README.md
@@ -481,7 +481,6 @@ module.exports = {
 Next.js uses Babel6 out of the box, which doesn't support default `module.exports`.
 ##### Invalid:
 ```js
-import React from 'react':
 //  bad import
 const Link = require('next/link').default;
 
@@ -492,7 +491,6 @@ module.exports = () => (
 ```
 ##### Valid:
 ```js
-import React from 'react';
 //  good import
 import Link from 'next/link';
 


### PR DESCRIPTION
Issue https://github.com/zeit/next.js/issues/252

This is adding a warning to the readme on using default `module.exports` to the readme, which Babel6 no longer supports.