### PR TITLE
[examples/parameterized-routing]: fix npm script in install section of README

### DIFF
--- a/examples/parameterized-routing/README.md
+++ b/examples/parameterized-routing/README.md
@@ -14,7 +14,7 @@ Install it and run:
 
 ```bash
 npm install
-npm run dev
+npm start
 ```
 
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))


### PR DESCRIPTION
Updated README to reflect the npm script present in package.json i.e package.json has only `start` script but no `dev` script.