### PR TITLE
Remove strict-mode from the eval-script.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,7 @@ gulp.task('compile-client', () => {
 gulp.task('remove-strict-mode', ['compile-lib'], () => {
   return gulp.src('dist/lib/eval-script.js')
   .pipe(babel({
+    babelrc: false,
     plugins: ['babel-plugin-transform-remove-strict-mode']
   }))
   .pipe(gulp.dest('dist/lib'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,8 @@ gulp.task('compile', [
   'compile-bin',
   'compile-lib',
   'compile-server',
-  'compile-client'
+  'compile-client',
+  'remove-strict-mode'
 ])
 
 gulp.task('compile-bin', () => {
@@ -48,6 +49,15 @@ gulp.task('compile-client', () => {
   .pipe(babel(babelOptions))
   .pipe(gulp.dest('dist/client'))
   .pipe(notify('Compiled client files'))
+})
+
+gulp.task('remove-strict-mode', ['compile-lib'], () => {
+  return gulp.src('dist/lib/eval-script.js')
+  .pipe(babel({
+    plugins: ['babel-plugin-transform-remove-strict-mode']
+  }))
+  .pipe(gulp.dest('dist/lib'))
+  .pipe(notify('Completed removing strict mode for eval script'))
 })
 
 gulp.task('copy', ['copy-pages'])

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "babel-eslint": "7.1.1",
-    "babel-plugin-transform-remove-strict-mode": "^0.0.2",
+    "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "babel-preset-env": "1.1.4",
     "benchmark": "2.1.3",
     "coveralls": "2.11.15",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "babel-eslint": "7.1.1",
+    "babel-plugin-transform-remove-strict-mode": "^0.0.2",
     "babel-preset-env": "1.1.4",
     "benchmark": "2.1.3",
     "coveralls": "2.11.15",


### PR DESCRIPTION
Potential fix for https://github.com/zeit/next.js/issues/489
This allow pages to parse/execute properly.