### PR TITLE
Update with-prefetching example's next version

### DIFF
--- a/examples/with-prefetching/package.json
+++ b/examples/with-prefetching/package.json
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "*"
+    "next": "^2.0.0-beta"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
Use ^2.0.0-beta as the version for with-prefetching example.
Fixes https://github.com/zeit/next.js/issues/454#issuecomment-269139543