### PR TITLE
Add Router.subscribe

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -7,7 +7,7 @@ const SingletonRouter = {}
 
 // Create public properties and methods of the router in the SingletonRouter
 const propertyFields = ['components', 'pathname', 'route', 'query']
-const methodFields = ['push', 'replace', 'reload', 'back']
+const methodFields = ['push', 'replace', 'reload', 'back', 'subscribe']
 
 propertyFields.forEach((field) => {
   // Here we need to use Object.defineProperty because, we need to return


### PR DESCRIPTION
Adds the `subscribe` method to the public facing Router API. I think this is useful for a variety of reasons, but a personal example - I'm using [Prism](http://prismjs.com/) as a code highlighter. It works great on the first page load, but doesn't have a way of responding to client-side page changes. With this change, I'm able to write something like

```javascript
  componentDidMount() {
    Router.subscribe(() => Prism.highlightAll())
  }
```