### PR TITLE
Add return true to prefetch

### DIFF
--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -106,14 +106,16 @@ export function prefetch (href) {
   // Register the service worker if it's not.
   messenger.ensureInitialized()
 
-  let { pathname } = urlParse(href)
+  const { pathname } = urlParse(href)
   // Add support for the index page
 
   const url = `/_next/pages${pathname}`
-  if (PREFETCHED_URLS[url]) return
+  if (PREFETCHED_URLS[url]) return true
 
   messenger.send({ action: 'ADD_URL', url: url })
   PREFETCHED_URLS[url] = true
+
+  return true
 }
 
 export default class LinkPrefetch extends React.Component {


### PR DESCRIPTION
Fixes '#540'

This avoids unintended bugs because you'd expect the function to return something instead of 'void'