### PR TITLE
examples/nested-components: use an apostrophe rather than a prime

### DIFF
--- a/examples/nested-components/pages/index.js
+++ b/examples/nested-components/pages/index.js
@@ -19,7 +19,7 @@ export default () => (
     <hr />
 
     <Post title='The final blog post'>
-      <P>C'est fin</P>
+      <P>C’est fin</P>
     </Post>
 
     <style jsx>{`


### PR DESCRIPTION
This is just my OCD, but this file is much easier on the eyes when apostrophes are used rather than primes. It's also proper, as the [prime](https://en.wikipedia.org/wiki/Prime_(symbol)) is used in mathematics, not written English.