### PR TITLE
Fix getInitialProps called on client on first load

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -32,6 +32,9 @@ export default class Router {
     const as = getURL()
     const { url = as } = e.state || {}
     const { pathname, query } = parse(url, true)
+
+    if (!this.urlIsNew(pathname, query)) return
+
     const route = toRoute(pathname)
 
     Promise.resolve()
@@ -113,6 +116,12 @@ export default class Router {
 
   async change (method, url, as) {
     const { pathname, query } = parse(url, true)
+
+    if (!this.urlIsNew(pathname, query)) {
+      changeState()
+      return true
+    }
+
     const route = toRoute(pathname)
 
     this.abortComponentLoad()
@@ -135,9 +144,7 @@ export default class Router {
       console.error(err)
     }
 
-    if (method !== 'pushState' || getURL() !== as) {
-      window.history[method]({ url }, null, as)
-    }
+    changeState()
 
     this.route = route
     this.set(pathname, query, { ...data, props })
@@ -145,14 +152,18 @@ export default class Router {
     if (_err) throw _err
 
     return true
+
+    function changeState () {
+      if (method !== 'pushState' || getURL() !== as) {
+        window.history[method]({ url }, null, as)
+      }
+    }
   }
 
   set (pathname, query, data) {
-    if (this.urlIsNew(pathname, query)) {
-      this.pathname = pathname
-      this.query = query
-      this.notify(data)
-    }
+    this.pathname = pathname
+    this.query = query
+    this.notify(data)
   }
 
   urlIsNew (pathname, query) {


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/570

Additionally, this fixes `getInitialProps` is called even if only hash of url was changed.