### PR TITLE
Add app's node_modules dir to resolveLoaders.

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -47,7 +47,8 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     interpolateNames.set(path, `dist/pages/${p}`)
   }
 
-  const nodeModulesDir = join(__dirname, '..', '..', '..', 'node_modules')
+  const nextNodeModulesDir = join(__dirname, '..', '..', '..', 'node_modules')
+  const appNodeModulesDir = join(dir, 'node_modules')
   const minChunks = pages.filter((p) => p !== documentPage).length
 
   const plugins = [
@@ -184,8 +185,8 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     },
     resolve: {
       modules: [
-        nodeModulesDir,
-        join(dir, 'node_modules')
+        nextNodeModulesDir,
+        appNodeModulesDir
       ].concat(
         (process.env.NODE_PATH || '')
         .split(process.platform === 'win32' ? ';' : ':')
@@ -194,7 +195,8 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     },
     resolveLoader: {
       modules: [
-        nodeModulesDir,
+        nextNodeModulesDir,
+        appNodeModulesDir,
         join(__dirname, 'loaders')
       ]
     },


### PR DESCRIPTION
Fixes #581 

Otherwise, webpack will throw an error saying
it couldn't find entries.
That's because it couldn't find babel-loader and
other loaders installed into app's node_modules dir.