### PR TITLE
Check for .json file extension before JSON parse. Was throwing when r…

### DIFF
--- a/server/build/plugins/json-pages-plugin.js
+++ b/server/build/plugins/json-pages-plugin.js
@@ -3,7 +3,7 @@ export default class JsonPagesPlugin {
     compiler.plugin('after-compile', (compilation, callback) => {
       const pages = Object
         .keys(compilation.assets)
-        .filter((filename) => /^bundles\/pages.*\.js$/.test(filename))
+        .filter((filename) => /^bundles[/\\]pages.*\.js$/.test(filename))
 
       pages.forEach((pageName) => {
         const page = compilation.assets[pageName]

--- a/server/read-page.js
+++ b/server/read-page.js
@@ -12,11 +12,15 @@ async function readPage (path) {
     return cache[f]
   }
 
-  const source = await fs.readFile(f, 'utf8')
-  const { component } = JSON.parse(source)
+  let content = await fs.readFile(f, 'utf8')
 
-  cache[f] = component
-  return component
+  if (f.slice(-5) === '.json') {
+    const { component } = JSON.parse(content)
+    content = component
+  }
+
+  cache[f] = content
+  return content
 }
 
 export default readPage


### PR DESCRIPTION
…eading js files. Related to #597