### PR TITLE
Add child function support to Link

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -49,15 +49,15 @@ export default class Link extends Component {
   }
 
   render () {
+    if (typeof this.props.children == 'function') {
+      return this.props.children({
+        as: this.props.as,
+        href: this.props.href,
+        onClick: this.linkClicked
+      })
+    }
+
     const children = Children.map(this.props.children, (child) => {
-      if (typeof child == 'function') {
-        return child({
-            as: this.props.as,
-            href: this.props.href,
-            onClick: this.linkClicked
-        })  
-      }
-      
       const props = {
         onClick: this.linkClicked
       }

--- a/lib/link.js
+++ b/lib/link.js
@@ -49,7 +49,7 @@ export default class Link extends Component {
   }
 
   render () {
-    if (typeof this.props.children == 'function') {
+    if (typeof this.props.children === 'function') {
       return this.props.children({
         as: this.props.as,
         href: this.props.href,

--- a/lib/link.js
+++ b/lib/link.js
@@ -10,7 +10,8 @@ export default class Link extends Component {
   static propTypes = {
     children: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.element
+      PropTypes.element,
+      PropTypes.func
     ]).isRequired
   }
 
@@ -49,6 +50,14 @@ export default class Link extends Component {
 
   render () {
     const children = Children.map(this.props.children, (child) => {
+      if (typeof child == function) {
+        return child({
+            as: this.props.as,
+            href: this.props.href,
+            onClick: this.linkClicked
+        })  
+      }
+      
       const props = {
         onClick: this.linkClicked
       }

--- a/lib/link.js
+++ b/lib/link.js
@@ -50,7 +50,7 @@ export default class Link extends Component {
 
   render () {
     const children = Children.map(this.props.children, (child) => {
-      if (typeof child == function) {
+      if (typeof child == 'function') {
         return child({
             as: this.props.as,
             href: this.props.href,


### PR DESCRIPTION
In my project, I'm using React Bootstrap for style/UI components. In my header, I use the NavItem component. But, that component is not aware of the Next.js router, which results in a server roundtrip for every click.

To fix this, I borrowed a concept from React Router and added support for child functions to Link. Here is how I use it in my project:

```
<Link href='/'>{ ({href, onClick}) =>
  <NavItem eventKey={1} href={href} onClick={onClick}>Index</NavItem>
}</Link>
```

This allows me to inject the onClick from my router-aware Link to my non-router-aware NavItem.

Hope it's helpful.