### PR TITLE
Support relative urls on Link component

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -1,3 +1,4 @@
+import { resolve } from 'url'
 import React, { Component, Children, PropTypes } from 'react'
 import Router from './router'
 
@@ -21,12 +22,16 @@ export default class Link extends Component {
       return
     }
 
-    const { href, as = href } = this.props
+    let { href, as } = this.props
 
     if (!isLocal(href)) {
       // ignore click if it's outside our scope
       return
     }
+
+    const { pathname } = window.location
+    href = resolve(pathname, href)
+    as = as ? resolve(pathname, as) : href
 
     e.preventDefault()
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -79,6 +79,6 @@ export default class Link extends Component {
 
 export function isLocal (href) {
   const origin = window.location.origin
-  return !/^https?:\/\//.test(href) ||
+  return !/^(https?:)?\/\//.test(href) ||
     origin === href.substr(0, origin.length)
 }

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -32,7 +32,7 @@ export default class Router extends EventEmitter {
   async onPopState (e) {
     this.abortComponentLoad()
 
-    const { url, as } = e.state
+    const { url = getURL(), as = url } = e.state || {}
     const { pathname, query } = parse(url, true)
 
     if (!this.urlIsNew(pathname, query)) {


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/573, https://github.com/zeit/next.js/issues/602

- support relative paths (`./path` and `#id`)
- support protocol-relative urls (`//zeit.co/path`)
- fix error for clicking anchor tag `TypeError: Cannot read property 'url' of null`