### PR TITLE
Reset prefetchCache when reloading a route.

### DIFF
--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -24,23 +24,21 @@ class Messenger {
     this._resetCache()
   }
 
-  sendPromise (payload) {
+  send (payload) {
     return new Promise((resolve, reject) => {
-      this.send(payload, (err) => {
+      if (this.serviceWorkerState === 'REGISTERED') {
+        this._send(payload, handleCallback)
+      } else {
+        this.serviceWorkerReadyCallbacks.push(() => {
+          this._send(payload, handleCallback)
+        })
+      }
+
+      function handleCallback (err) {
         if (err) return reject(err)
         return resolve()
-      })
+      }
     })
-  }
-
-  send (payload, cb) {
-    if (this.serviceWorkerState === 'REGISTERED') {
-      this._send(payload, cb)
-    } else {
-      this.serviceWorkerReadyCallbacks.push(() => {
-        this._send(payload, cb)
-      })
-    }
   }
 
   _send (payload, cb = () => {}) {
@@ -125,7 +123,7 @@ export async function prefetch (href) {
   const url = getPrefetchUrl(href)
   if (PREFETCHED_URLS[url]) return
 
-  await messenger.sendPromise({ action: 'ADD_URL', url: url })
+  await messenger.send({ action: 'ADD_URL', url: url })
   PREFETCHED_URLS[url] = true
 }
 

--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -116,6 +116,17 @@ export function prefetch (href) {
   PREFETCHED_URLS[url] = true
 }
 
+export function resetPrefetchCache () {
+  return new Promise((resolve, reject) => {
+    if (!messenger) return resolve()
+
+    messenger._resetCache((err) => {
+      if (err) return reject(err)
+      return resolve()
+    })
+  })
+}
+
 export default class LinkPrefetch extends React.Component {
   render () {
     const { href } = this.props

--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -24,6 +24,15 @@ class Messenger {
     this._resetCache()
   }
 
+  sendPromise (payload) {
+    return new Promise((resolve, reject) => {
+      this.send(payload, (err) => {
+        if (err) return reject(err)
+        return resolve()
+      })
+    })
+  }
+
   send (payload, cb) {
     if (this.serviceWorkerState === 'REGISTERED') {
       this._send(payload, cb)
@@ -99,32 +108,33 @@ if (hasServiceWorkerSupport()) {
   messenger = new Messenger()
 }
 
-export function prefetch (href) {
+function getPrefetchUrl (href) {
+  let { pathname } = urlParse(href)
+  const url = `/_next/pages${pathname}`
+
+  return url
+}
+
+export async function prefetch (href) {
   if (!hasServiceWorkerSupport()) return
   if (!isLocal(href)) return
 
   // Register the service worker if it's not.
   messenger.ensureInitialized()
 
-  let { pathname } = urlParse(href)
-  // Add support for the index page
-
-  const url = `/_next/pages${pathname}`
+  const url = getPrefetchUrl(href)
   if (PREFETCHED_URLS[url]) return
 
-  messenger.send({ action: 'ADD_URL', url: url })
+  await messenger.sendPromise({ action: 'ADD_URL', url: url })
   PREFETCHED_URLS[url] = true
 }
 
-export function resetPrefetchCache () {
-  return new Promise((resolve, reject) => {
-    if (!messenger) return resolve()
+export async function reloadIfPrefetched (href) {
+  const url = getPrefetchUrl(href)
+  if (!PREFETCHED_URLS[url]) return
 
-    messenger._resetCache((err) => {
-      if (err) return reject(err)
-      return resolve()
-    })
-  })
+  delete PREFETCHED_URLS[url]
+  await prefetch(href)
 }
 
 export default class LinkPrefetch extends React.Component {

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -2,7 +2,7 @@ import { parse, format } from 'url'
 import evalScript from '../eval-script'
 import shallowEquals from '../shallow-equals'
 import { EventEmitter } from 'events'
-import { resetPrefetchCache } from '../prefetch'
+import { reloadIfPrefetched } from '../prefetch'
 
 export default class Router extends EventEmitter {
   constructor (pathname, query, { Component, ErrorComponent, ctx } = {}) {
@@ -77,8 +77,8 @@ export default class Router extends EventEmitter {
   }
 
   async reload (route) {
-    await resetPrefetchCache()
     delete this.components[route]
+    await reloadIfPrefetched(route)
 
     if (route !== this.route) return
 

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -2,6 +2,7 @@ import { parse, format } from 'url'
 import evalScript from '../eval-script'
 import shallowEquals from '../shallow-equals'
 import { EventEmitter } from 'events'
+import { resetPrefetchCache } from '../prefetch'
 
 export default class Router extends EventEmitter {
   constructor (pathname, query, { Component, ErrorComponent, ctx } = {}) {
@@ -76,6 +77,7 @@ export default class Router extends EventEmitter {
   }
 
   async reload (route) {
+    await resetPrefetchCache()
     delete this.components[route]
 
     if (route !== this.route) return


### PR DESCRIPTION
Fixes #616 

If there's a HMR reload event, we'll prefetch again if the route is registered for prefetching.