### PR TITLE
chore: switch existing tests to new next-test-helper library

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "gulp-notify": "2.2.0",
     "husky": "0.12.0",
     "jest": "^18.0.0",
+    "next-test-helper": "^1.0.6",
     "nyc": "^10.0.0",
     "run-sequence": "1.2.2",
     "standard": "8.6.0",


### PR DESCRIPTION
switches next.js itself to using the new test helping library `next-test-helper` that we've been working on.

follows on from: https://github.com/zeit/next.js/pull/461