### PR TITLE
Fix webpack cache

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -175,6 +175,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
       filename: '[name]',
       libraryTarget: 'commonjs2',
       publicPath: '/_webpack/',
+      strictModuleExceptionHandling: true,
       devtoolModuleFilenameTemplate ({ resourcePath }) {
         const hash = createHash('sha1')
         hash.update(Date.now() + '')


### PR DESCRIPTION
This PR fixes runtime error is not properly rendered on client transitions in a certain case.
Without the `strictModuleExceptionHandling` option, webpack sets an empty object to module cache when a module threw an error.
