### PR TITLE
Prevent prefetcher from making identical requests.

### DIFF
--- a/lib/prefetch.js
+++ b/lib/prefetch.js
@@ -121,10 +121,11 @@ export async function prefetch (href) {
   messenger.ensureInitialized()
 
   const url = getPrefetchUrl(href)
-  if (PREFETCHED_URLS[url]) return
+  if (!PREFETCHED_URLS[url]) {
+    PREFETCHED_URLS[url] = messenger.send({ action: 'ADD_URL', url: url })
+  }
 
-  await messenger.send({ action: 'ADD_URL', url: url })
-  PREFETCHED_URLS[url] = true
+  return PREFETCHED_URLS[url]
 }
 
 export async function reloadIfPrefetched (href) {


### PR DESCRIPTION
Modify `prefetch` so that it stores the promises returned by `Messenger.send` in the request cache, and returns values from there for subsequent calls to `prefetch` with the same parameters.

Fixes #664