### PR TITLE
'#21' - Add Identity-based idempotency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ export default () => (
 )
 ```
 
-To avoid duplicate tags in your head you can use the `key` property, which will make sure the tag is only rendered once:
+To avoid duplicate tags in your `<head>` you can use the `key` property, which will make sure the tag is only rendered once:
 
 ```jsx
 import Head from 'next/head'

--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ export default () => (
 )
 ```
 
+To avoid duplicate tags in your head you can use the `key` property, which will make sure the tag is only rendered once:
+
+```jsx
+import Head from 'next/head'
+export default () => (
+  <div>
+    <Head>
+      <title>My page title</title>
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" key="viewport" />
+    </Head>
+    <Head>
+      <meta name="viewport" content="initial-scale=1.2, width=device-width" key="viewport" />
+    </Head>
+    <p>Hello world!</p>
+  </div>
+)
+```
+
+In this case only the second `<meta name="viewport" />` is rendered.
+
 _Note: The contents of `<head>` get cleared upon unmounting the component, so make sure each page completely defines what it needs in `<head>`, without making assumptions about what other pages added_
 
 ### Fetching data and component lifecycle

--- a/client/head-manager.js
+++ b/client/head-manager.js
@@ -11,6 +11,7 @@ const DOMAttributeNames = {
 export default class HeadManager {
   constructor () {
     this.updatePromise = null
+    this.unique = new Map()
   }
 
   updateHead (head) {
@@ -26,6 +27,22 @@ export default class HeadManager {
     const tags = {}
     head.forEach((h) => {
       const components = tags[h.type] || []
+
+      if (h.key) {
+        if (this.unique.has(h.key)) {
+          const c = this.unique.get(h.key)
+
+          if (components.indexOf(c) === -1) {
+            components.push(c)
+            tags[h.type] = components
+
+            return
+          }
+        }
+
+        this.unique.set(h.key, h)
+      }
+
       components.push(h)
       tags[h.type] = components
     })

--- a/client/head-manager.js
+++ b/client/head-manager.js
@@ -11,7 +11,6 @@ const DOMAttributeNames = {
 export default class HeadManager {
   constructor () {
     this.updatePromise = null
-    this.unique = new Map()
   }
 
   updateHead (head) {
@@ -27,22 +26,6 @@ export default class HeadManager {
     const tags = {}
     head.forEach((h) => {
       const components = tags[h.type] || []
-
-      if (h.key) {
-        if (this.unique.has(h.key)) {
-          const c = this.unique.get(h.key)
-
-          if (components.indexOf(c) === -1) {
-            components.push(c)
-            tags[h.type] = components
-
-            return
-          }
-        }
-
-        this.unique.set(h.key, h)
-      }
-
       components.push(h)
       tags[h.type] = components
     })

--- a/lib/head.js
+++ b/lib/head.js
@@ -49,9 +49,16 @@ const METATYPES = ['name', 'httpEquiv', 'charSet', 'itemProp']
 function unique () {
   const tags = new Set()
   const metaTypes = new Set()
+  const keys = new Set()
   const metaCategories = {}
 
   return (h) => {
+    if (h.key) {
+      if (keys.has(h.key)) return false
+      keys.add(h.key)
+      return true
+    }
+
     switch (h.type) {
       case 'title':
       case 'base':


### PR DESCRIPTION
This fixes #21.

Note:
Due to this reverse() https://github.com/zeit/next.js/blob/master/lib/head.js#L24 the last `key` is used instead of the first. I don't know if this is an issue.

Usage:
```
<Head>
  <link rel="stylesheet" href="/abc.css" key="test" />
  <link rel="stylesheet" href="/def.css" key="test" />
</Head>
```

Will only render `<link rel="stylesheet" href="/def.css" key="test" />`. When rendering new pages it checks if the key was already set. If so it will not remove the current `key="test"` and discard the new `key="test"`. `key` is used by React for the same kind of functionality. So it seems the best possible prop to use. Though I'm open to changing it to `id`