### PR TITLE
Remove default next pages compilation from the main babel-loader.

### DIFF
--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -27,7 +27,8 @@ module.exports = {
           'next/head': require.resolve('../../../lib/head'),
           'next/document': require.resolve('../../../server/document'),
           'next/router': require.resolve('../../../lib/router'),
-          'styled-jsx/style': require.resolve('styled-jsx/style')
+          'styled-jsx/style': require.resolve('styled-jsx/style'),
+          'ansi-html': require.resolve('ansi-html')
         }
       }
     ]

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -143,28 +143,21 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
   }, {
     loader: 'babel-loader',
     include: nextPagesDir,
-    options: {
+    exclude (str) {
+      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
+    },
+    query: {
       babelrc: false,
       cacheDirectory: true,
       sourceMaps: dev ? 'both' : false,
-      plugins: [
-        [
-          require.resolve('babel-plugin-module-resolver'),
-          {
-            alias: {
-              'ansi-html': require.resolve('ansi-html'),
-              'styled-jsx/style': require.resolve('styled-jsx/style')
-            }
-          }
-        ]
-      ]
+      presets: [require.resolve('./babel/preset')]
     }
   }, {
     test: /\.js(\?[^?]*)?$/,
     loader: 'babel-loader',
-    include: [dir, nextPagesDir],
+    include: [dir],
     exclude (str) {
-      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
+      return /node_modules/.test(str)
     },
     query: mainBabelOptions
   }])

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -146,7 +146,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     exclude (str) {
       return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
     },
-    query: {
+    options: {
       babelrc: false,
       cacheDirectory: true,
       sourceMaps: dev ? 'both' : false,
@@ -159,7 +159,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     exclude (str) {
       return /node_modules/.test(str)
     },
-    query: mainBabelOptions
+    options: mainBabelOptions
   }])
 
   let webpackConfig = {


### PR DESCRIPTION
Fixes: https://github.com/zeit/next.js/issues/715

This will fix the issue when the user ignore node_modules
via our .babelrc option.