### PR TITLE
Revert "Dont' override glamor methods, use a new object instead (#754)"

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -1,7 +1,5 @@
 import { deprecated } from './utils'
-import glamor from 'glamor'
-
-const css = Object.assign({}, glamor)
+const css = require('glamor')
 
 for (const [k, v] of Object.entries(css)) {
   if (typeof v === 'function') {


### PR DESCRIPTION
This reverts commit 86516629cf95c482336b77ad5e13151e19b34832.