### PR TITLE
update styletron example to support multiple stylesheets

### DIFF
--- a/examples/with-styletron/pages/_document.js
+++ b/examples/with-styletron/pages/_document.js
@@ -5,8 +5,8 @@ export default class MyDocument extends Document {
   static getInitialProps ({ renderPage }) {
     const page = renderPage()
     const styletron = flush()
-    const css = styletron ? styletron.getCss() : null
-    return { ...page, css }
+    const stylesheets = styletron ? styletron.getStylesheets() : []
+    return { ...page, stylesheets }
   }
 
   render () {
@@ -14,7 +14,14 @@ export default class MyDocument extends Document {
       <html>
         <Head>
           <title>My page</title>
-          <style className='_styletron_hydrate_' dangerouslySetInnerHTML={{ __html: this.props.css }} />
+          {this.props.stylesheets.map((sheet, i) => (
+            <style
+              className="_styletron_hydrate_"
+              dangerouslySetInnerHTML={{ __html: sheet.css }}
+              media={sheet.media || ''}
+              key={i}
+            />
+          ))}
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
Looking at the styletron docs for [`getCss`](http://styletron.js.org/StyletronServer.html#getCss) it's recommended that you use [`getStylesheets`](http://styletron.js.org/StyletronServer.html#getStylesheets) for hydrating server-rendered styles. This becomes important when you have media queries. Styletron creates separate style tags for each media query, so client-side and server-side rendering won't match the single set of styles returned by `getCss`.