### PR TITLE
Add cross browser stacktrace

### DIFF
--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ansiHTML from 'ansi-html'
 import Head from './head'
 
-export default ({ err, err: { name, message, stack, module } }) => (
+export default ({ err, err: { name, message, module } }) => (
   <div style={styles.errorDebug}>
     <Head>
       <meta name='viewport' content='width=device-width, initial-scale=1.0' />

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ansiHTML from 'ansi-html'
 import Head from './head'
 
-export default ({ err: { name, message, stack, module } }) => (
+export default ({ err, err: { name, message, stack, module } }) => (
   <div style={styles.errorDebug}>
     <Head>
       <meta name='viewport' content='width=device-width, initial-scale=1.0' />
@@ -11,8 +11,17 @@ export default ({ err: { name, message, stack, module } }) => (
     {
       name === 'ModuleBuildError'
       ? <pre style={styles.message} dangerouslySetInnerHTML={{ __html: ansiHTML(encodeHtml(message)) }} />
-      : <pre style={styles.message}>{stack}</pre>
+      : <StackTrace error={err} />
     }
+  </div>
+)
+
+const StackTrace = ({ error: { name, message, stack } }) => (
+  <div>
+    <div style={styles.heading}>{name && message && `${name}: ${message}`}</div>
+    <pre style={styles.message}>
+      {stack}
+    </pre>
   </div>
 )
 


### PR DESCRIPTION
Fixes #756

So, in the end it turns out that `stack` in chrome has `name` and `message` included in the `stack`. Safari doesn't have this, which is why you'd only see the trace and not the error message. I added a heading (same styling as the other heading) which displays the `name` + `message` either way, so we don't have to do browser sniffing.