### PR TITLE
Add NODE_PATH support for resolveLoaders as well.

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -103,6 +103,11 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     )
   }
 
+  const nodePathList = (process.env.NODE_PATH || '')
+    .split(process.platform === 'win32' ? ';' : ':')
+    .filter((p) => !!p)
+    .map((p) => join(p))
+
   const mainBabelOptions = {
     babelrc: true,
     cacheDirectory: true,
@@ -185,18 +190,16 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     resolve: {
       modules: [
         nextNodeModulesDir,
-        'node_modules'
-      ].concat(
-        (process.env.NODE_PATH || '')
-        .split(process.platform === 'win32' ? ';' : ':')
-        .filter((p) => !!p)
-      )
+        'node_modules',
+        ...nodePathList
+      ]
     },
     resolveLoader: {
       modules: [
         nextNodeModulesDir,
         'node_modules',
-        join(__dirname, 'loaders')
+        join(__dirname, 'loaders'),
+        ...nodePathList
       ]
     },
     plugins,

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -106,7 +106,6 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
   const nodePathList = (process.env.NODE_PATH || '')
     .split(process.platform === 'win32' ? ';' : ':')
     .filter((p) => !!p)
-    .map((p) => join(p))
 
   const mainBabelOptions = {
     babelrc: true,


### PR DESCRIPTION
Related to: https://github.com/zeit/next.js/issues/699

If we do support this, we could easily fix #699 by setting a `NODE_PATH`.