### PR TITLE
Fixed hapi example

### DIFF
--- a/examples/custom-server-hapi/next-wrapper.js
+++ b/examples/custom-server-hapi/next-wrapper.js
@@ -1,34 +1,8 @@
-const { Readable } = require('stream')
+const pathWrapper = (app, pathName, opts) => ({ raw, query }, hapiReply) =>
+app.renderToHTML(raw.req, raw.res, pathName, query, opts)
+.then(hapiReply)
 
-function pathWrapper (app, pathName, opts) {
-  return function (hapiRequest, hapiReply) {
-    return new Promise((resolve, reject) => {
-      app.render(hapiRequest.raw.req, hapiRequest.raw.res, pathName, hapiRequest.query, opts)
-        .catch(error => {
-          reject(error)
-        })
-        .then(() => {
-          return hapiReply(new Readable().wrap(hapiRequest.raw.res))
-        })
-    })
-  }
-}
+const defaultHandlerWrapper = app => ({ raw }, hapiReply) =>
+app.run(raw.req, raw.res)
 
-function defaultHandlerWrapper (app) {
-  return function (hapiRequest, hapiReply) {
-    return new Promise((resolve, reject) => {
-      app.run(hapiRequest.raw.req, hapiRequest.raw.res)
-        .catch(error => {
-          reject(error)
-        })
-        .then(() => {
-          return hapiReply(new Readable().wrap(hapiRequest.raw.res))
-        })
-    })
-  }
-}
-
-module.exports = {
-  pathWrapper,
-  defaultHandlerWrapper
-}
+module.exports = { pathWrapper, defaultHandlerWrapper }


### PR DESCRIPTION
The example was using `app.render` which returns the html back to the client and then using the hapi `reply` function that was rendering again. Now We are using `renderToHTML` and using hapi's `reply` to get back the content to the user