### PR TITLE
Fix koa-404 issue by adding res.statusCode to 200

### DIFF
--- a/examples/custom-server-koa/server.js
+++ b/examples/custom-server-koa/server.js
@@ -26,6 +26,13 @@ app.prepare()
     this.respond = false
   })
 
+  server.use(function *(next) {
+    // Koa doesn't seems to set the default statusCode.
+    // So, this middleware does that
+    this.res.statusCode = 200
+    yield next
+  })
+
   server.use(router.routes())
   server.listen(3000, (err) => {
     if (err) throw err


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/677

Seems like koa doesn't set the default status code. So, we need to do it explicitly. 