### PR TITLE
Fix error fonts

### DIFF
--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -41,7 +41,7 @@ const styles = {
 
   message: {
     fontFamily: '"SF Mono", "Roboto Mono", "Fira Mono", consolas, menlo-regular, monospace',
-    fontSize: '10px',
+    fontSize: '14px',
     color: '#fbe7f1',
     margin: 0,
     whiteSpace: 'pre-wrap',
@@ -50,7 +50,7 @@ const styles = {
 
   heading: {
     fontFamily: '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
-    fontSize: '13px',
+    fontSize: '16px',
     fontWeight: 'bold',
     color: '#ff84bf',
     marginBottom: '20px'

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -40,7 +40,7 @@ const styles = {
   },
 
   message: {
-    fontFamily: '"SF Mono", "Roboto Mono", "Fira Mono", menlo-regular, monospace',
+    fontFamily: '"SF Mono", "Roboto Mono", "Fira Mono", consolas, menlo-regular, monospace',
     fontSize: '10px',
     color: '#fbe7f1',
     margin: 0,


### PR DESCRIPTION
## Add "consolas" for windows, and fix too small font size in non-retina displays.

### Before
![image](https://cloud.githubusercontent.com/assets/15059605/22152444/f0f5b458-df5d-11e6-89de-81a4e8a94d0e.png)

### After
![image](https://cloud.githubusercontent.com/assets/15059605/22152474/19461dee-df5e-11e6-96a6-e25cf7b34f51.png)

