### PR TITLE
Use ErrorDebug component on error of react-hot-loader

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -22,7 +22,7 @@ export default class App extends Component {
 
     return <div>
       <Container {...containerProps} />
-      {ErrorDebug && err ? <ErrorDebug err={err} /> : null}
+      {ErrorDebug && err ? <ErrorDebug error={err} /> : null}
     </div>
   }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -40,7 +40,7 @@ class Container extends Component {
 
     // includes AppContainer which bypasses shouldComponentUpdate method
     // https://github.com/gaearon/react-hot-loader/issues/442
-    return <AppContainer>
+    return <AppContainer errorReporter={ErrorDebug}>
       <Component {...props} url={url} />
     </AppContainer>
   }

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ansiHTML from 'ansi-html'
 import Head from './head'
 
-export default ({ err, err: { name, message, module } }) => (
+export default ({ error, error: { name, message, module } }) => (
   <div style={styles.errorDebug}>
     <Head>
       <meta name='viewport' content='width=device-width, initial-scale=1.0' />
@@ -11,7 +11,7 @@ export default ({ err, err: { name, message, module } }) => (
     {
       name === 'ModuleBuildError'
       ? <pre style={styles.message} dangerouslySetInnerHTML={{ __html: ansiHTML(encodeHtml(message)) }} />
-      : <StackTrace error={err} />
+      : <StackTrace error={error} />
     }
   </div>
 )


### PR DESCRIPTION
`react-hot-loader` renders [redbox](https://github.com/commissure/redbox-react) as default when an error occurs, but we'd like to use our `ErrorDebug` component for this purpose.

https://github.com/gaearon/react-hot-loader/blob/next/docs/TipsAndTricks.md