### PR TITLE
Handles the initial popstate event of older version of Safari

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -34,9 +34,17 @@ export default class Router extends EventEmitter {
   }
 
   async onPopState (e) {
+    // Older versions of safari and chrome tend to fire popstate event at the
+    // page load.
+    // We should not complete that event and the following check will fix it.
+    // Fixes:
+    if (!e.state) {
+      return
+    }
+
     this.abortComponentLoad()
 
-    const { url = getURL(), as = url } = e.state || {}
+    const { url, as } = e.state
     const { pathname, query } = parse(url, true)
 
     if (!this.urlIsNew(pathname, query)) {


### PR DESCRIPTION
Fixes #868 

This happens because the older safari (< 10) and chrome (< 34) tend to [emit a popstate](https://developer.mozilla.org/en-US/docs/Web/Events/popstate) event on the page load. 

The issue comes when there's a custom route. With [this change](https://github.com/zeit/next.js/compare/43e2707e5dcb961189e2ddab3492c2ce8360758d...45bc4fe46550c8085f90173275dcbd57fb2f9acb#diff-ccd76929358a61054445c927c7746ef4R36) it'll try to set the `href` as the current URL and fetch the JSON page.
But there's no such page and server will emit a 404.