### PR TITLE
Don't process.exit(null) when e.g `next build` is `SIGKILL`ed

### DIFF
--- a/bin/next
+++ b/bin/next
@@ -46,7 +46,19 @@ const bin = join(__dirname, 'next-' + cmd)
 
 const startProcess = () => {
   const proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] })
-  proc.on('close', (code) => process.exit(code))
+  proc.on('close', (code, signal) => {
+    if (code !== null) {
+      process.exit(code)
+    }
+    if (signal) {
+      if (signal === 'SIGKILL') {
+        process.exit(137)
+      }
+      console.log(`got signal ${signal}, exitting`)
+      process.exit(1)
+    }
+    process.exit(0)
+  })
   proc.on('error', (err) => {
     console.error(err)
     process.exit(1)


### PR DESCRIPTION
I came across this while debugging issues, where `next build` would silently fail when running out of memory and being OOM killed.

Turns out that `spwan`ed process that receives `SIGKILL`  has exit code reported as `null` and the signal name contains the name of the signal...

Huge thanks for @matheuss for help with testing out the fix