### PR TITLE
Fix handling finished response

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,7 +46,7 @@ export async function loadGetInitialProps (Component, ctx) {
   if (!Component.getInitialProps) return {}
 
   const props = await Component.getInitialProps(ctx)
-  if (!props) {
+  if (!props && (!ctx.res || !ctx.res.finished)) {
     const compName = Component.displayName || Component.name
     const message = `"${compName}.getInitialProps()" should resolve to an object. But found "${props}" instead.`
     throw new Error(message)

--- a/server/render.js
+++ b/server/render.js
@@ -83,6 +83,8 @@ async function doRender (req, res, pathname, query, {
 
   const docProps = await loadGetInitialProps(Document, { ...ctx, renderPage })
 
+  if (res.finished) return
+
   const doc = createElement(Document, {
     __NEXT_DATA__: {
       component,


### PR DESCRIPTION
- allows to not return `props` if response is already finished on `getInititlProps`
- check `res.finished` on `getInitialProps` of `Document`
 