### PR TITLE
Add `next build` and `next start` to the first How to use sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ and add a script to your package.json like this:
 ```json
 {
   "scripts": {
-    "dev": "next"
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
   }
 }
 ```


### PR DESCRIPTION
Now the build and start scripts are hidden way down the readme in the "Production use" section.
It seems to be a common pitfall to miss the production setup section and users end up trying to use the dev version in prod.

This PR adds the `build` and `start` scripts to the first "How to use" sample.