### PR TITLE
Do not patch prototypes with render exposed only as a getter.

### DIFF
--- a/client/patch-react.js
+++ b/client/patch-react.js
@@ -112,15 +112,8 @@ function wrap (fn, around) {
 }
 
 function canOverrideRender (prototype) {
-  const original = prototype.render
-  let overridable = true
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, 'render')
+  if (!descriptor) return true
 
-  try {
-    prototype.render = 'Something'
-    prototype.render = original
-  } catch (ex) {
-    overridable = false
-  }
-
-  return overridable
+  return descriptor.writable
 }


### PR DESCRIPTION
Fixes #880

We could expect to have React components with their render method defined only as a getter. 
In that case, we can't override it.

In those cases, we need to do it at runtime. This PR does that.