### PR TITLE
Add a class to the error-debug screen

### DIFF
--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -3,7 +3,7 @@ import ansiHTML from 'ansi-html'
 import Head from './head'
 
 export default ({ error, error: { name, message, module } }) => (
-  <div style={styles.errorDebug}>
+  <div style={styles.errorDebug} className="__next-error-debug">
     <Head>
       <meta name='viewport' content='width=device-width, initial-scale=1.0' />
     </Head>


### PR DESCRIPTION
This allows developers to easily target the div and take actions on it (override styles, for example).