### PR TITLE
examples/with-redux: remove global store

### DIFF
--- a/examples/with-redux/store.js
+++ b/examples/with-redux/store.js
@@ -12,13 +12,15 @@ export const startClock = () => dispatch => {
   return setInterval(() => dispatch({ type: 'TICK', light: true, ts: Date.now() }), 800)
 }
 
+let store = null
+
 export const initStore = (reducer, initialState, isServer) => {
   if (isServer && typeof window === 'undefined') {
     return createStore(reducer, initialState, applyMiddleware(thunkMiddleware))
   } else {
-    if (!window.store) {
-      window.store = createStore(reducer, initialState, applyMiddleware(thunkMiddleware))
+    if (!store) {
+      store = createStore(reducer, initialState, applyMiddleware(thunkMiddleware))
     }
-    return window.store
+    return store
   }
 }


### PR DESCRIPTION
This patch removes the global `store` on the client. IMO this example should avoid polluting the global namespace when simple scoping tricks can solve the problem equally as well.