### PR TITLE
Adding an example for universal custom routing

### DIFF
--- a/examples/custom-universal-routing/components/link.js
+++ b/examples/custom-universal-routing/components/link.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import NextLink from 'next/link'
+import {customRoutes} from '../next.config'
+
+function matchInternal (route) {
+  const match = customRoutes.find((element) => {
+    return route.match(element.test)
+  })
+
+  return match ? match.routeTo : false
+}
+
+export default class Link extends React.Component {
+  render () {
+    const internalRoute = matchInternal(this.props.href)
+
+    return <NextLink href={internalRoute} as={this.props.href}>
+      {this.props.children}
+    </NextLink>
+  }
+}

--- a/examples/custom-universal-routing/next.config.js
+++ b/examples/custom-universal-routing/next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  customRoutes: [{
+    test: /^\/$/,
+    routeTo: '/foo'
+  }, {
+    test: /^\/about(\/?)$/,
+    routeTo: '/bar'
+  }]
+}

--- a/examples/custom-universal-routing/package.json
+++ b/examples/custom-universal-routing/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "next": "^2.0.0-beta"
+  }
+}

--- a/examples/custom-universal-routing/pages/bar.js
+++ b/examples/custom-universal-routing/pages/bar.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import Link from '../components/link'
+
+export default class Bar extends React.Component {
+  render () {
+    return <div>
+      <h1>About (Bar Template)</h1>
+      <div>Click <Link href='/'><a>here</a></Link> to go back home.</div>
+    </div>
+  }
+}

--- a/examples/custom-universal-routing/pages/foo.js
+++ b/examples/custom-universal-routing/pages/foo.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import Link from '../components/link'
+
+export default class Foo extends React.Component {
+  render () {
+    return <div>
+      <h1>Home (Foo Template)</h1>
+      <div>Click <Link href='/about'><a>here</a></Link> to see the about page.</div>
+    </div>
+  }
+}

--- a/examples/custom-universal-routing/server.js
+++ b/examples/custom-universal-routing/server.js
@@ -1,0 +1,30 @@
+const { createServer } = require('http')
+const { parse } = require('url')
+
+const next = require('next')
+const nextConfig = require('./next.config')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare()
+  .then(() => {
+    createServer((req, res) => {
+      const { pathname, query } = parse(req.url, true)
+
+      const match = nextConfig.customRoutes.find((definition) => {
+        return pathname.match(definition.test)
+      })
+
+      if (match) {
+        app.render(req, res, match.routeTo, query)
+      } else {
+        handle(req, res)
+      }
+    })
+    .listen(3000, (err) => {
+      if (err) throw err
+      console.log('> Ready on http://localhost:3000')
+    })
+  })


### PR DESCRIPTION
Howdy! I was looking through the examples for a custom `server.js`, and they all worked well enough on the server-side. I did notice that they stop working on the client-side unless you use the `href` and `as` attributes in conjunction on your `Link` components, effectively duplicating your routing logic wherever you have a `Link`.

I can't find it at the moment, but in another issue @rauchg (or perhaps another of the maintainers) +1'd the concept of making a custom component to handle the route matching, referencing some shared configuration, which works like a charm for us. I didn't see a complete example of universal route matching in `./examples`, so I thought I'd add one.

Hopefully this isn't duplicative from another example! Thanks so much to the team — this project has been an amazing leg up for us! Hoping to get some of our production code moved over to Next soon!