### PR TITLE
Use service-worker to fetch only JSON pages.

### DIFF
--- a/client/next-prefetcher.js
+++ b/client/next-prefetcher.js
@@ -17,7 +17,7 @@ self.addEventListener('activate', (e) => {
 
 self.addEventListener('fetch', (e) => {
   // bypass all requests except JSON pages.
-  if (!(/_next\/[\w-]*\/pages/.test(e.request.url))) return
+  if (!(/\/_next\/[^/]+\/pages\//.test(e.request.url))) return
 
   e.respondWith(getResponse(e.request))
 })

--- a/client/next-prefetcher.js
+++ b/client/next-prefetcher.js
@@ -16,12 +16,8 @@ self.addEventListener('activate', (e) => {
 })
 
 self.addEventListener('fetch', (e) => {
-  const h = e.request.headers
-  const accept = h.getAll ? h.getAll('accept') : h.get('accept').split(',')
-  for (const a of accept) {
-    // bypass Server Sent Events
-    if (a === 'text/event-stream') return
-  }
+  // bypass all requests except JSON pages.
+  if (!(/_next\/[\w-]*\/pages/.test(e.request.url))) return
 
   e.respondWith(getResponse(e.request))
 })


### PR DESCRIPTION
We simply don't need to proxy other requests through service workers.
That's might cause some latency issues.