### PR TITLE
Add support for Webpack 2's tree-shaking

### DIFF
--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -3,7 +3,7 @@ const babelRuntimePath = require.resolve('babel-runtime/package')
 
 module.exports = {
   presets: [
-    require.resolve('babel-preset-es2015'),
+    [require.resolve('babel-preset-es2015'), { modules: false }],
     require.resolve('babel-preset-react')
   ],
   plugins: [

--- a/server/build/loaders/emit-file-loader.js
+++ b/server/build/loaders/emit-file-loader.js
@@ -1,4 +1,5 @@
 import loaderUtils from 'loader-utils'
+import { transform } from 'babel-core'
 
 module.exports = function (content, sourceMap) {
   this.cacheable()
@@ -10,7 +11,14 @@ module.exports = function (content, sourceMap) {
   const opts = { context, content, regExp }
   const interpolatedName = loaderUtils.interpolateName(this, name, opts)
 
-  this.emitFile(interpolatedName, content, sourceMap)
+  const transpiled = transform(content, {
+    presets: [
+      'es2015'
+    ],
+    sourceMaps: 'both',
+    inputSourceMap: sourceMap
+  })
 
-  this.callback(null, content, sourceMap)
+  this.emitFile(interpolatedName, transpiled.code, transpiled.map)
+  this.callback(null, transpiled.code, transpiled.map)
 }

--- a/server/build/loaders/emit-file-loader.js
+++ b/server/build/loaders/emit-file-loader.js
@@ -1,6 +1,6 @@
 import loaderUtils from 'loader-utils'
 
-module.exports = function (content, sourceMap, options) {
+module.exports = function (content, sourceMap) {
   this.cacheable()
 
   const query = loaderUtils.parseQuery(this.query)

--- a/server/build/loaders/emit-file-loader.js
+++ b/server/build/loaders/emit-file-loader.js
@@ -1,7 +1,6 @@
 import loaderUtils from 'loader-utils'
-import { transform } from 'babel-core'
 
-module.exports = function (content, sourceMap) {
+module.exports = function (content, sourceMap, options) {
   this.cacheable()
 
   const query = loaderUtils.parseQuery(this.query)
@@ -11,14 +10,15 @@ module.exports = function (content, sourceMap) {
   const opts = { context, content, regExp }
   const interpolatedName = loaderUtils.interpolateName(this, name, opts)
 
-  const transpiled = transform(content, {
-    presets: [
-      'es2015'
-    ],
-    sourceMaps: process.env.NODE_ENV === 'production' ? false : 'both',
-    inputSourceMap: sourceMap
-  })
+  const emit = (code, map) => {
+    this.emitFile(interpolatedName, code, map)
+    this.callback(null, code, map)
+  }
 
-  this.emitFile(interpolatedName, transpiled.code, transpiled.map)
-  this.callback(null, transpiled.code, transpiled.map)
+  if (query.transform) {
+    const transformed = query.transform({ content, sourceMap })
+    return emit(transformed.content, transformed.sourceMap)
+  }
+
+  return emit(content, sourceMap)
 }

--- a/server/build/loaders/emit-file-loader.js
+++ b/server/build/loaders/emit-file-loader.js
@@ -15,7 +15,7 @@ module.exports = function (content, sourceMap) {
     presets: [
       'es2015'
     ],
-    sourceMaps: 'both',
+    sourceMaps: process.env.NODE_ENV === 'production' ? false : 'both',
     inputSourceMap: sourceMap
   })
 

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -147,9 +147,8 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     options: {
       name: 'dist/[path][name].[ext]',
       // By default, our babel config does not transpile ES2015 module syntax because
-      // webpack knows how to handle them.
-      // But Node.js doesn't know handle them.
-      // So, we have to transpile them here.
+      // webpack knows how to handle them. (That's how it can do tree-shaking)
+      // But Node.js doesn't know how to handle them. So, we have to transpile them here.
       transform ({ content, sourceMap }) {
         const transpiled = babelCore.transform(content, {
           presets: ['es2015'],

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -152,7 +152,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
       transform ({ content, sourceMap }) {
         const transpiled = babelCore.transform(content, {
           presets: ['es2015'],
-          sourceMaps: process.env.NODE_ENV === 'production' ? false : 'both',
+          sourceMaps: dev ? 'both' : false,
           inputSourceMap: sourceMap
         })
 

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -10,6 +10,7 @@ import UnlinkFilePlugin from './plugins/unlink-file-plugin'
 import WatchPagesPlugin from './plugins/watch-pages-plugin'
 import JsonPagesPlugin from './plugins/json-pages-plugin'
 import getConfig from '../config'
+import * as babelCore from 'babel-core'
 
 const documentPage = join('pages', '_document.js')
 const defaultPages = [
@@ -144,7 +145,23 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
       return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
     },
     options: {
-      name: 'dist/[path][name].[ext]'
+      name: 'dist/[path][name].[ext]',
+      // By default, our babel config does not transpile ES2015 module syntax because
+      // webpack knows how to handle them.
+      // But Node.js doesn't know handle them.
+      // So, we have to transpile them here.
+      transform ({ content, sourceMap }) {
+        const transpiled = babelCore.transform(content, {
+          presets: ['es2015'],
+          sourceMaps: process.env.NODE_ENV === 'production' ? false : 'both',
+          inputSourceMap: sourceMap
+        })
+
+        return {
+          content: transpiled.code,
+          sourceMap: transpiled.map
+        }
+      }
     }
   }, {
     loader: 'babel-loader',


### PR DESCRIPTION
With this PR we'll let webpack2 to handle ES2015 module system. Then only it can do tree shaking.

Since Node.js can't do that, we need to transpile
ES2015 module system in the emit-file-loader.