### PR TITLE
Resolve preset es2015 from next directory

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -156,7 +156,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
         }
 
         const transpiled = babelCore.transform(content, {
-          presets: ['es2015'],
+          presets: [require.resolve('babel-preset-es2015')],
           sourceMaps: dev ? 'both' : false,
           inputSourceMap: sourceMap
         })


### PR DESCRIPTION
Caused an error:

```
ERROR  Failed to compile with 5 errors

 error  in ./pages/b.js?entry

Module build failed: Error: Couldn't find preset "es2015" relative to directory "examples/custom-server"
```