### PR TITLE
Check if BUILD_ID is available before starting

### DIFF
--- a/bin/next-start
+++ b/bin/next-start
@@ -57,3 +57,4 @@ srv.start(argv.port)
   console.error(err)
   process.exit(1)
 })
+

--- a/bin/next-start
+++ b/bin/next-start
@@ -42,8 +42,8 @@ const dir = resolve(argv._[0] || '.')
 
 const srv = new Server({ dir })
 
-if (!existsSync(resolve(dir, '.next'))) {
-  console.error(`> Could not find the '.next' directory! Try building your app with 'next build' before starting the server.`)
+if (!existsSync(resolve(dir, '.next', 'BUILD_ID'))) {
+  console.error(`> Could not find a valid build in the '.next' directory! Try building your app with 'next build' before starting the server.`)
   process.exit(1)
 }
 
@@ -57,4 +57,3 @@ srv.start(argv.port)
   console.error(err)
   process.exit(1)
 })
-


### PR DESCRIPTION
Fixes #300 

Added a check for `BUILD_ID` since it's only there after running `next build`.