### PR TITLE
Make styled-jsx optional.

### DIFF
--- a/examples/with-styled-jsx-postcss/.babelrc
+++ b/examples/with-styled-jsx-postcss/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "next/babel"
+    ["next/babel", { styledJsx: false }]
   ],
   "plugins": [
     "styled-jsx-postcss/babel"

--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -1,18 +1,17 @@
 const babelRuntimePath = require.resolve('babel-runtime/package')
   .replace(/[\\/]package\.json$/, '')
 
-module.exports = {
-  presets: [
-    [require.resolve('babel-preset-es2015'), { modules: false }],
-    require.resolve('babel-preset-react')
-  ],
-  plugins: [
+export default function preset (ctx, options = {}) {
+  const {
+    styledJsx = true
+  } = options
+
+  const plugins = [
     require.resolve('babel-plugin-react-require'),
     require.resolve('babel-plugin-transform-async-to-generator'),
     require.resolve('babel-plugin-transform-object-rest-spread'),
     require.resolve('babel-plugin-transform-class-properties'),
     require.resolve('babel-plugin-transform-runtime'),
-    require.resolve('styled-jsx/babel'),
     [
       require.resolve('babel-plugin-module-resolver'),
       {
@@ -31,4 +30,16 @@ module.exports = {
       }
     ]
   ]
+
+  if (styledJsx) {
+    plugins.push(require.resolve('styled-jsx/babel'))
+  }
+
+  return {
+    presets: [
+      [require.resolve('babel-preset-es2015'), { modules: false }],
+      require.resolve('babel-preset-react')
+    ],
+    plugins
+  }
 }


### PR DESCRIPTION
This fixes #964 
This is to support plugins like `styled-jsx-postcss`

But I'd like to solve this from `styled-jsx` end. `styled-jsx` should parse the content only once.
Even it's included multiple times.

Since this works earlier, I think something got changed recently related to this in the `styled-jsx` side.
cc @rauchg @nkzawa @giuseppeg 

