### PR TITLE
Find custom babel config location properly.

### DIFF
--- a/examples/.babelrc
+++ b/examples/.babelrc
@@ -1,2 +1,3 @@
 {
+    "presets": ["../babel"]
 }

--- a/server/build/babel/find-config-location.js
+++ b/server/build/babel/find-config-location.js
@@ -1,0 +1,16 @@
+import { join } from 'path'
+import buildConfigChain from 'babel-core/lib/transformation/file/options/build-config-chain'
+
+export default function findBabelConfigLocation (dir) {
+  // We need to provide a location of a filename inside the `dir`.
+  // For the name of the file, we could be provide anything.
+  const filename = join(dir, 'filename.js')
+  const options = { babelrc: true, filename }
+
+  // First We need to build the config chain.
+  // Then we need to remove the config item with the location as "base".
+  // That's the config we are passing as the "options" below
+  const configList = buildConfigChain(options).filter(i => i.loc !== 'base')
+
+  return configList[0] ? configList[0].loc : null
+}

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -1,6 +1,5 @@
 import { resolve, join } from 'path'
 import { createHash } from 'crypto'
-import { existsSync } from 'fs'
 import webpack from 'webpack'
 import glob from 'glob-promise'
 import WriteFilePlugin from 'write-file-webpack-plugin'
@@ -11,6 +10,7 @@ import WatchPagesPlugin from './plugins/watch-pages-plugin'
 import JsonPagesPlugin from './plugins/json-pages-plugin'
 import getConfig from '../config'
 import * as babelCore from 'babel-core'
+import findBabelConfigLocation from './babel/find-config-location'
 
 const documentPage = join('pages', '_document.js')
 const defaultPages = [
@@ -115,9 +115,10 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     presets: []
   }
 
-  const hasBabelRc = existsSync(join(dir, '.babelrc'))
-  if (hasBabelRc) {
-    console.log('> Using .babelrc defined in your app root')
+  const configLocation = findBabelConfigLocation(dir)
+  if (configLocation) {
+    console.log(`> Using external babel configuration`)
+    console.log(`> location: "${configLocation}"`)
   } else {
     mainBabelOptions.presets.push(require.resolve('./babel/preset'))
   }

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    // To let test apps(and Jest) to use Next's babel preset
+    "../babel",
+    // To transpile import statements into commonjs.
+    // That's because Jest(runs in Node.js) don't know how to handle them.
+    "es2015"
+   ]
+}


### PR DESCRIPTION
Earlier we simply check for the `.bablerc` file in the dir.
But the actual logic is much complex.

Now we are using the babel's actual logic to find the custom config location.