### PR TITLE
Add next.js flowtype definition to with-flow example

### DIFF
--- a/examples/with-flow/.flowconfig
+++ b/examples/with-flow/.flowconfig
@@ -3,5 +3,6 @@
 [include]
 
 [libs]
+types/
 
 [options]

--- a/examples/with-flow/types/next.js.flow
+++ b/examples/with-flow/types/next.js.flow
@@ -1,0 +1,41 @@
+declare module "next" {
+  declare type NextApp = {
+    prepare(): Promise<void>;
+  };
+  declare module.exports: (...opts: any) => NextApp
+}
+
+declare module "next/head" {
+  declare module.exports: Class<React$Component<void, any, any>>;
+}
+
+declare module "next/link" {
+  declare module.exports: Class<React$Component<void, {href: string}, any>>;
+}
+
+declare module "next/prefetch" {
+  declare module.exports: Class<React$Component<void, {href: string, prefetch?: boolean}, any>>;
+}
+
+declare module "next/router" {
+  declare module.exports: {
+    route: string;
+    pathname: string;
+    query: Object;
+    onRouteChangeStart: ?((url: string) => void);
+    onRouteChangeComplete: ?((url: string) => void);
+    onRouteChangeError: ?((err: Error & {cancelled: boolean}, url: string) => void);
+    push(url: string, as: ?string): void;
+    replace(url: string, as: ?string): void;
+  };
+}
+
+declare module "next/document" {
+  declare export var Head: Class<React$Component<void, any, any>>;
+  declare export var Main: Class<React$Component<void, any, any>>;
+  declare export var NextScript: Class<React$Component<void, any, any>>;
+  declare export default Class<React$Component<void, any, any>> & {
+    getInitialProps: (ctx: any) => Promise<any>;
+    renderPage(cb: Function): void;
+  };
+}

--- a/examples/with-flow/types/next.js.flow
+++ b/examples/with-flow/types/next.js.flow
@@ -1,6 +1,13 @@
+/* @flow */
+
 declare module "next" {
   declare type NextApp = {
     prepare(): Promise<void>;
+    getRequestHandler(): any;
+    render(req: any, res: any, pathname: string, query: any): any;
+    renderToHTML(req: any, res: any, pathname: string, query: string): string;
+    renderError(err: Error, req: any, res: any, pathname: any, query: any): any;
+    renderErrorToHTML(err: Error, req: any, res: any, pathname: string, query: any): string;
   };
   declare module.exports: (...opts: any) => NextApp
 }
@@ -35,7 +42,7 @@ declare module "next/document" {
   declare export var Main: Class<React$Component<void, any, any>>;
   declare export var NextScript: Class<React$Component<void, any, any>>;
   declare export default Class<React$Component<void, any, any>> & {
-    getInitialProps: (ctx: any) => Promise<any>;
+    getInitialProps: (ctx: {pathname: string, query: any, req?: any, res?: any, xhr?: any, err?: any}) => Promise<any>;
     renderPage(cb: Function): void;
   };
 }

--- a/examples/with-flow/types/next.js.flow
+++ b/examples/with-flow/types/next.js.flow
@@ -21,7 +21,9 @@ declare module "next/link" {
 }
 
 declare module "next/prefetch" {
-  declare module.exports: Class<React$Component<void, {href: string, prefetch?: boolean}, any>>;
+  declare export var prefetch: (url: string) => any;
+  declare export var reloadIfPrefetched: any;
+  declare export default Class<React$Component<void, {href: string, prefetch?: boolean}, any>>;
 }
 
 declare module "next/router" {

--- a/examples/with-flow/types/next.js.flow
+++ b/examples/with-flow/types/next.js.flow
@@ -34,8 +34,8 @@ declare module "next/router" {
     onRouteChangeStart: ?((url: string) => void);
     onRouteChangeComplete: ?((url: string) => void);
     onRouteChangeError: ?((err: Error & {cancelled: boolean}, url: string) => void);
-    push(url: string, as: ?string): void;
-    replace(url: string, as: ?string): void;
+    push(url: string, as: ?string): Promise<boolean>;
+    replace(url: string, as: ?string): Promise<boolean>;
   };
 }
 


### PR DESCRIPTION
I added flow definiton file for example. (I wrote for my own next.js research)
Maybe next.js API is not stable yet, so I am not going to request that this definition becomes official type definition.

This will be help only for flowtype users now.

## Example

```js
  <Link href={1}><a>Contact</a></Link>
```

```
⋊> ~/p/n/e/with-flow on master ⨯ flow                                                                                                  19:31:36
components/layout.js:24
 24:         <Link href={1}><a>Contact</a></Link>
             ^^^^^^^^^^^^^^^ React element `Link`
 24:         <Link href={1}><a>Contact</a></Link>
                         ^ number. This type is incompatible with
 23:   declare module.exports: Class<React$Component<void, {href: string}, any>>;
                                                                  ^^^^^^ string. See lib: types/next.js.flow:23


Found 1 error
```