### PR TITLE
Properly handle hash URL changes.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -34,11 +34,18 @@ export default class Router extends EventEmitter {
   }
 
   async onPopState (e) {
-    // Older versions of safari and chrome tend to fire popstate event at the
-    // page load.
-    // We should not complete that event and the following check will fix it.
-    // Fixes:
     if (!e.state) {
+      // We get state as undefined for two reasons.
+      //  1. With older safari (< 8) and older chrome (< 34)
+      //  2. When the URL changed with #
+      //
+      // In the both cases, we don't need to proceed and change the route.
+      // (as it's already changed)
+      // But we can simply replace the state with the new changes.
+      // Actually, for (1) we don't need to nothing. But it's hard to detect that event.
+      // So, doing the following for (1) does no harm.
+      const { pathname, query } = this
+      this.replace(format({ pathname, query }), getURL())
       return
     }
 
@@ -276,7 +283,8 @@ export default class Router extends EventEmitter {
 }
 
 function getURL () {
-  return window.location.pathname + (window.location.search || '') + (window.location.hash || '')
+  const { href, origin } = window.location
+  return href.replace(new RegExp(origin), '')
 }
 
 function toRoute (path) {

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -284,7 +284,7 @@ export default class Router extends EventEmitter {
 
 function getURL () {
   const { href, origin } = window.location
-  return href.replace(new RegExp(`^${origin}`), '')
+  return href.substring(origin.length)
 }
 
 function toRoute (path) {

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -284,7 +284,7 @@ export default class Router extends EventEmitter {
 
 function getURL () {
   const { href, origin } = window.location
-  return href.replace(new RegExp(origin), '')
+  return href.replace(new RegExp(`^${origin}`), '')
 }
 
 function toRoute (path) {


### PR DESCRIPTION
This handle handle two special `popstate` events.
In those events,  We get state as undefined for two reasons.

1. With older safari (< 8) and older chrome (< 34)
2. When the URL changed with #

In the both cases, we don't need to proceed and change the route.
(as it's already changed)

But we can simply replace the state with the new changes.
Actually, for (1) we don't need to nothing. But it's hard to detect that event.
So, doing the following for (1) does no harm.