### PR TITLE
[example] Progressive rendered application

### DIFF
--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -32,3 +32,5 @@ This example features:
 
 * An app with a component that must only be rendered in the client
 * A loading component that will be displayed before rendering the client-only component
+
+**Example**: https://progressive-render-raceuevkqw.now.sh/

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -1,0 +1,34 @@
+# Example app implementing progressive server-side render
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/progressive-render
+cd progressive-render
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+Some times you want to **not** server render some parts of your application. That can be third party components without server render compatibility or just because that content isn't enough important for the user (eg. below the fold content).
+
+In that cases you can use `react-no-ssr` to wrap that client-only components and avoid server rendering it at all and then do the render in the client after the application has loaded.
+
+This example features:
+
+* An app with a component that must only be rendered in the client
+* A loading component that will be displayed before rendering the client-only component

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -26,7 +26,7 @@ now
 
 Sometimes you want to **not** server render some parts of your application. That can be third party components without server render compatibility, components that depends on `window` and other only browsers APIs or just because that content isn't enough important for the user (eg. below the fold content).
 
-In that cases you can use `react-no-ssr` to wrap that client-only components and avoid server rendering it at all and then do the render in the client after the application has loaded.
+In that case you can wrap the component in `react-no-ssr` which will only render the component client-side.
 
 This example features:
 

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -24,7 +24,7 @@ now
 
 ## The idea behind the example
 
-Sometimes you want to **not** server render some parts of your application. That can be third party components without server render compatibility, components that depends on `window` and other only browsers APIs or just because that content isn't enough important for the user (eg. below the fold content).
+Sometimes you want to **not** server render some parts of your application. That can be third party components without server render capabilities, components that depends on `window` and other browser only APIs or just because that content isn't important enough for the user (eg. below the fold content).
 
 In that case you can wrap the component in `react-no-ssr` which will only render the component client-side.
 

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -24,7 +24,7 @@ now
 
 ## The idea behind the example
 
-Sometimes you want to **not** server render some parts of your application. That can be third party components without server render compatibility or just because that content isn't enough important for the user (eg. below the fold content).
+Sometimes you want to **not** server render some parts of your application. That can be third party components without server render compatibility, components that depends on `window` and other only browsers APIs or just because that content isn't enough important for the user (eg. below the fold content).
 
 In that cases you can use `react-no-ssr` to wrap that client-only components and avoid server rendering it at all and then do the render in the client after the application has loaded.
 

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -24,7 +24,7 @@ now
 
 ## The idea behind the example
 
-Some times you want to **not** server render some parts of your application. That can be third party components without server render compatibility or just because that content isn't enough important for the user (eg. below the fold content).
+Sometimes you want to **not** server render some parts of your application. That can be third party components without server render compatibility or just because that content isn't enough important for the user (eg. below the fold content).
 
 In that cases you can use `react-no-ssr` to wrap that client-only components and avoid server rendering it at all and then do the render in the client after the application has loaded.
 

--- a/examples/progressive-render/components/Loading.js
+++ b/examples/progressive-render/components/Loading.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+
+export default () => (
+  <div>
+    <h3>Loading...</h3>
+    <style jsx>{`
+      div {
+        align-items: center;
+        display: flex;
+        height: 50vh;
+        justify-content: center;
+      }
+    `}</style>
+  </div>
+)

--- a/examples/progressive-render/components/Loading.js
+++ b/examples/progressive-render/components/Loading.js
@@ -1,6 +1,5 @@
 import React from 'react'
 
-
 export default () => (
   <div>
     <h3>Loading...</h3>

--- a/examples/progressive-render/package.json
+++ b/examples/progressive-render/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "progressive-render",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^2.0.0-beta",
+    "react-no-ssr": "1.1.0"
+  }
+}

--- a/examples/progressive-render/package.json
+++ b/examples/progressive-render/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^2.0.0-beta",
+    "next": "latest",
     "react-no-ssr": "1.1.0"
   }
 }

--- a/examples/progressive-render/pages/index.js
+++ b/examples/progressive-render/pages/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import NoSSR from 'react-no-ssr'
 import Loading from '../components/Loading'
 
-
 export default () => (
   <main>
     <section>

--- a/examples/progressive-render/pages/index.js
+++ b/examples/progressive-render/pages/index.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import NoSSR from 'react-no-ssr'
+import Loading from '../components/Loading'
+
+
+export default () => (
+  <main>
+    <section>
+      <h1>
+        This section is server-side rendered.
+      </h1>
+    </section>
+
+    <NoSSR onSSR={<Loading />}>
+      <section>
+        <h2>
+          This section is <em>only</em> client-side rendered.
+        </h2>
+      </section>
+    </NoSSR>
+
+    <style jsx>{`
+      section {
+        align-items: center;
+        display: flex;
+        height: 50vh;
+        justify-content: center;
+      }
+    `}</style>
+  </main>
+)


### PR DESCRIPTION
Sometimes you don't want to render the whole page in the server. Maybe you want to only server render above the fold content, SEO related content or you can be using third-party client-only components that cannot be server rendered at all.

This example show how you can wrap any component using [`react-no-ssr`](https://github.com/kadirahq/react-no-ssr) to only render them in the client.

Using this technique you can reduce the server render time, the TTFB and TTI reducing the amount of HTML generated in the server. An explanation of how Netflix benefited from using this technique: http://techblog.netflix.com/2015/08/making-netflixcom-faster.html

> I chose react-no-ssr above Electrode [above-the-fold-only-server-render](https://github.com/electrode-io/above-the-fold-only-server-render) because you don't need to set anything in the context, it just works.