### PR TITLE
Fix .baberc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": ["latest", "react"],
   "plugins": [
-    "transform-async-to-generator",
     "transform-object-rest-spread",
     "transform-class-properties",
     "transform-runtime"


### PR DESCRIPTION
We don't have `preset-es2015` as a dependency anymore, and it'd make sense to use `preset-latest` for compiling next.js too.

Related https://github.com/zeit/next.js/pull/1027