### PR TITLE
Add support to transpile import/export syntax

### DIFF
--- a/examples/with-jest/.babelrc
+++ b/examples/with-jest/.babelrc
@@ -1,3 +1,15 @@
 {
-    "presets": ["next/babel"]
+  "env": {
+    "development": {
+      "presets": ["next/babel"]
+    },
+    "production": {
+      "presets": ["next/babel"]
+    },
+    "test": {
+      // next/babel does not transpile import/export syntax.
+      // So, using es2015 in the beginning will fix that.
+      "presets": ["es2015", "next/babel"]
+    }
+  }
 }

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -15,9 +15,8 @@
     "babel-jest": "^18.0.0",
     "enzyme": "^2.5.1",
     "jest-cli": "^18.0.0",
-    "react": "^15.3.2",
-    "react-addons-test-utils": "^15.3.2",
-    "react-dom": "^15.3.2",
-    "react-test-renderer": "^15.4.1"
+    "react-addons-test-utils": "^15.4.2",
+    "babel-preset-es2015": "^6.22.0",
+    "react-test-renderer": "^15.4.2"
   }
 }


### PR DESCRIPTION
Ref: https://github.com/zeit/next.js/issues/1037

next/babel doesn't transpile import/export.
So, we need to do it explicitly, but only for test env.