### PR TITLE
Using styled-jsx for with-jest example

### DIFF
--- a/examples/with-jest/__tests__/__snapshots__/index.test.js.snap
+++ b/examples/with-jest/__tests__/__snapshots__/index.test.js.snap
@@ -1,6 +1,8 @@
 exports[`With Snapshot Testing App shows "Hello world!" 1`] = `
-<div>
-  <p>
+<div
+  data-jsx={2648947580}>
+  <p
+    data-jsx={2648947580}>
     Hello World!
   </p>
 </div>

--- a/examples/with-jest/pages/index.js
+++ b/examples/with-jest/pages/index.js
@@ -1,5 +1,10 @@
 export default () => (
   <div>
+    <style jsx>{`
+      p {
+        color: red;
+      }
+    `}</style>
     <p>Hello World!</p>
   </div>
 )


### PR DESCRIPTION
Now we use styled-jsx in the with-jest example.
Also updated the related snapshot.