### PR TITLE
Complete hapi lifecycle for defaultHandlerWrapper, and include loggin…

### DIFF
--- a/examples/custom-server-hapi/next-wrapper.js
+++ b/examples/custom-server-hapi/next-wrapper.js
@@ -4,5 +4,6 @@ app.renderToHTML(raw.req, raw.res, pathName, query, opts)
 
 const defaultHandlerWrapper = app => ({ raw, url }, hapiReply) =>
 app.run(raw.req, raw.res, url)
+.then(hapiReply)
 
 module.exports = { pathWrapper, defaultHandlerWrapper }

--- a/examples/custom-server-hapi/package.json
+++ b/examples/custom-server-hapi/package.json
@@ -8,6 +8,9 @@
     "hapi": "^16.1.0",
     "next": "^2.0.0-beta",
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "good": "^7.1.0",
+    "good-console": "^6.2.0",
+    "good-squeeze": "^5.0.1"
   }
 }

--- a/examples/custom-server-hapi/server.js
+++ b/examples/custom-server-hapi/server.js
@@ -1,37 +1,61 @@
 const next = require('next')
 const Hapi = require('hapi')
+const Good = require('good');
 const { pathWrapper, defaultHandlerWrapper } = require('./next-wrapper')
 
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const server = new Hapi.Server()
 
+// add request logging (optional)
+const pluginOptions = [
+  {
+    register: Good,
+    options: {
+      reporters: {
+        console: [{
+          module: 'good-squeeze',
+          name: 'Squeeze',
+          args: [{
+            response: '*',
+            log: '*'
+          }]
+        }, {
+          module: 'good-console'
+        }, 'stdout']
+      }
+    }
+  }
+]
+
 app.prepare()
 .then(() => {
   server.connection({ port: 3000 })
+  server.register(pluginOptions)
+  .then(() => {
+    server.route({
+      method: 'GET',
+      path: '/a',
+      handler: pathWrapper(app, '/a')
+    })
 
-  server.route({
-    method: 'GET',
-    path: '/a',
-    handler: pathWrapper(app, '/a')
-  })
+    server.route({
+      method: 'GET',
+      path: '/b',
+      handler: pathWrapper(app, '/b')
+    })
 
-  server.route({
-    method: 'GET',
-    path: '/b',
-    handler: pathWrapper(app, '/b')
-  })
+    server.route({
+      method: 'GET',
+      path: '/{p*}', /* catch all route */
+      handler: defaultHandlerWrapper(app)
+    })
 
-  server.route({
-    method: 'GET',
-    path: '/{p*}', /* catch all route */
-    handler: defaultHandlerWrapper(app)
-  })
-
-  server.start().catch(error => {
-    console.log('Error starting server')
-    console.log(error)
-  }).then(() => {
-    console.log('> Ready on http://localhost:3000')
+    server.start().catch(error => {
+      console.log('Error starting server')
+      console.log(error)
+    }).then(() => {
+      console.log('> Ready on http://localhost:3000')
+    })
   })
 })


### PR DESCRIPTION
Addresses #1062

hapiReply must be called after app.run so that Hapi knows the request has completed.

Logging was added as this is how I noticed the problem and verified the fix.  Can be removed if it overcomplicates the example.