### PR TITLE
Ensure not to render ErrorDebug on production

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -65,7 +65,7 @@ async function doRender (req, res, pathname, query, {
     const app = createElement(App, {
       Component,
       props,
-      err,
+      err: dev ? err : null,
       router: new Router(pathname, query)
     })
 


### PR DESCRIPTION
This PR fixes that the red debug error screen can be shown when you run `next start` without `NODE_ENV=production`.