### PR TITLE
Babelrc false babelrc

### DIFF
--- a/examples/.babelrc
+++ b/examples/.babelrc
@@ -1,3 +1,3 @@
 {
-    "presets": ["../babel"]
+  "babelrc": false
 }

--- a/server/build/babel/find-config.js
+++ b/server/build/babel/find-config.js
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import buildConfigChain from 'babel-core/lib/transformation/file/options/build-config-chain'
 
-export default function findBabelConfigLocation (dir) {
+export default function findBabelConfig (dir) {
   // We need to provide a location of a filename inside the `dir`.
   // For the name of the file, we could be provide anything.
   const filename = join(dir, 'filename.js')
@@ -12,5 +12,5 @@ export default function findBabelConfigLocation (dir) {
   // That's the config we are passing as the "options" below
   const configList = buildConfigChain(options).filter(i => i.loc !== 'base')
 
-  return configList[0] ? configList[0].loc : null
+  return configList[0]
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -10,7 +10,7 @@ import WatchPagesPlugin from './plugins/watch-pages-plugin'
 import JsonPagesPlugin from './plugins/json-pages-plugin'
 import getConfig from '../config'
 import * as babelCore from 'babel-core'
-import findBabelConfigLocation from './babel/find-config-location'
+import findBabelConfig from './babel/find-config'
 
 const documentPage = join('pages', '_document.js')
 const defaultPages = [
@@ -114,14 +114,22 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     presets: []
   }
 
-  const configLocation = findBabelConfigLocation(dir)
-  if (configLocation) {
+  const externalBabelConfig = findBabelConfig(dir)
+  if (externalBabelConfig) {
     console.log(`> Using external babel configuration`)
-    console.log(`> location: "${configLocation}"`)
-    mainBabelOptions.babelrc = true
+    console.log(`> location: "${externalBabelConfig.loc}"`)
+    // It's possible to turn off babelrc support via babelrc itself.
+    // In that case, we should add our default preset.
+    // That's why we need to do this.
+    const { options } = externalBabelConfig
+    mainBabelOptions.babelrc = options.babelrc === false ? options.babelrc : true
   } else {
-    mainBabelOptions.presets.push(require.resolve('./babel/preset'))
     mainBabelOptions.babelrc = false
+  }
+
+  // Add our default preset if the no "babelrc" found.
+  if (!mainBabelOptions.babelrc) {
+    mainBabelOptions.presets.push(require.resolve('./babel/preset'))
   }
 
   const rules = (dev ? [{

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -122,7 +122,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     // In that case, we should add our default preset.
     // That's why we need to do this.
     const { options } = externalBabelConfig
-    mainBabelOptions.babelrc = options.babelrc === false ? options.babelrc : true
+    mainBabelOptions.babelrc = options.babelrc !== false
   } else {
     mainBabelOptions.babelrc = false
   }


### PR DESCRIPTION
Also fixes https://github.com/zeit/next.js/issues/1089

It's possible to disable babelrc via a `.babelrc` config. In that case, we need to add our default preset.

With this PR we handle that case. 

This also helps us with the examples. So, we can have a `.babelrc` file in the `examples` directory with this:

```json
{
  "babelrc": false
}
```