### PR TITLE
Transform es2015 modules if our babel preset runs outside of Next.js

### DIFF
--- a/examples/with-jest/.babelrc
+++ b/examples/with-jest/.babelrc
@@ -1,15 +1,5 @@
 {
-  "env": {
-    "development": {
-      "presets": ["next/babel"]
-    },
-    "production": {
-      "presets": ["next/babel"]
-    },
-    "test": {
-      // next/babel does not transpile import/export syntax.
-      // So, using es2015 in the beginning will fix that.
-      "presets": ["es2015", "next/babel"]
-    }
-  }
+  "presets": [
+    "next/babel"
+  ]
 }

--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -7,10 +7,21 @@ const productionPlugins = isProduction ? [
   require.resolve('babel-plugin-transform-react-remove-prop-types')
 ] : []
 
+const es2015Config = {}
+
+// Do not transform ES2015 modules if we are inside Next.js
+// That's because webpack2 knows how to handle it.
+// (And that's how it can do code splitting)
+//
+// But in other environements like Jest, we should transform it.
+if (process.env.INSIDE_NEXT) {
+  es2015Config.modules = false
+}
+
 module.exports = {
   presets: [
     [require.resolve('babel-preset-latest'), {
-      'es2015': { modules: false }
+      'es2015': es2015Config
     }],
     require.resolve('babel-preset-react')
   ],

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -12,6 +12,10 @@ import getConfig from '../config'
 import * as babelCore from 'babel-core'
 import findBabelConfigLocation from './babel/find-config-location'
 
+// Mark whether we are inside Next.js
+// So, our babel preset could do some Next.js specific configurations
+process.env.INSIDE_NEXT = 1
+
 const documentPage = join('pages', '_document.js')
 const defaultPages = [
   '_error.js',


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/1042

Usually `next/babel` is used outside of Next.js. That's why basically we exposed it.
But it cause a lot of issues lately because, we don't transform ES2015 modules.

This causes issues when used with Jest and with cases like #1042 

So, with this PR we changed our preset to transform ES2015 everywhere except inside Next.js.

