### PR TITLE
Return a promise from request handler so Hapi lifecycle can complete

### DIFF
--- a/examples/custom-server-hapi/next-wrapper.js
+++ b/examples/custom-server-hapi/next-wrapper.js
@@ -2,7 +2,12 @@ const pathWrapper = (app, pathName, opts) => ({ raw, query }, hapiReply) =>
 app.renderToHTML(raw.req, raw.res, pathName, query, opts)
 .then(hapiReply)
 
-const defaultHandlerWrapper = app => ({ raw, url }, hapiReply) =>
-app.run(raw.req, raw.res, url)
-
+const defaultHandlerWrapper = app => {
+  const handler = app.getRequestHandler()
+  return ({ raw, url }, hapiReply) =>
+    handler(raw.req, raw.res, url)
+      .then(() => {
+        hapiReply.close(false)
+      })
+}
 module.exports = { pathWrapper, defaultHandlerWrapper }

--- a/examples/custom-server-hapi/package.json
+++ b/examples/custom-server-hapi/package.json
@@ -8,6 +8,8 @@
     "hapi": "^16.1.0",
     "next": "^2.0.0-beta",
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "good": "^7.1.0",
+    "good-console": "^6.2.0"
   }
 }

--- a/examples/custom-server-hapi/server.js
+++ b/examples/custom-server-hapi/server.js
@@ -1,37 +1,54 @@
 const next = require('next')
 const Hapi = require('hapi')
+const Good = require('good')
 const { pathWrapper, defaultHandlerWrapper } = require('./next-wrapper')
 
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const server = new Hapi.Server()
 
+// add request logging (optional)
+const pluginOptions = [
+  {
+    register: Good,
+    options: {
+      reporters: {
+        console: [{
+          module: 'good-console'
+        }, 'stdout']
+      }
+    }
+  }
+]
+
 app.prepare()
 .then(() => {
   server.connection({ port: 3000 })
+  server.register(pluginOptions)
+  .then(() => {
+    server.route({
+      method: 'GET',
+      path: '/a',
+      handler: pathWrapper(app, '/a')
+    })
 
-  server.route({
-    method: 'GET',
-    path: '/a',
-    handler: pathWrapper(app, '/a')
-  })
+    server.route({
+      method: 'GET',
+      path: '/b',
+      handler: pathWrapper(app, '/b')
+    })
 
-  server.route({
-    method: 'GET',
-    path: '/b',
-    handler: pathWrapper(app, '/b')
-  })
+    server.route({
+      method: 'GET',
+      path: '/{p*}', /* catch all route */
+      handler: defaultHandlerWrapper(app)
+    })
 
-  server.route({
-    method: 'GET',
-    path: '/{p*}', /* catch all route */
-    handler: defaultHandlerWrapper(app)
-  })
-
-  server.start().catch(error => {
-    console.log('Error starting server')
-    console.log(error)
-  }).then(() => {
-    console.log('> Ready on http://localhost:3000')
+    server.start().catch(error => {
+      console.log('Error starting server')
+      console.log(error)
+    }).then(() => {
+      console.log('> Ready on http://localhost:3000')
+    })
   })
 })

--- a/server/index.js
+++ b/server/index.js
@@ -42,7 +42,7 @@ export default class Server {
         throw new Error('Please provide a parsed url to `handle` as third parameter. See https://github.com/zeit/next.js#custom-server-and-routing for an example.')
       }
 
-      this.run(req, res, parsedUrl)
+      return this.run(req, res, parsedUrl)
       .catch((err) => {
         if (!this.quiet) console.error(err)
         res.statusCode = 500
@@ -252,7 +252,7 @@ export default class Server {
   }
 
   async serveStaticWithGzip (req, res, path) {
-    this._serveStatic(req, res, () => {
+    await this._serveStatic(req, res, () => {
       return serveStaticWithGzip(req, res, path)
     })
   }


### PR DESCRIPTION
Addresses #1062.  Previously when using the defaultHandlerWrapper Hapi would never be advised the request had been completing.

This required changes to the core server/index.js:

1. Returning a promise from the request handler returned by getRequestHandler (so we can know when processing has completed)
2. Having serveStaticWithGzip await the call to render.serveStaticWithGzip (Otherwise the promise above returns before processing is complete)

There are a few other async methods in server/index.js that seem to me like they are missing await on the async methods they call (e.g. renderToHTML calling this.renderErrorToHTML, render404 calling this.renderError), but I haven't hit an issue with them so far and wasn't sure if there was something I'm missing.

Minimal logging was added to the custom server Hapi example, as otherwise problems with the Hapi custom server integration tend to get eaten.

