### PR TITLE
Ensure NODE_ENV is production when deploying on Now

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,8 +587,8 @@ For example, to deploy with [`now`](https://zeit.co/now) a `package.json` like f
   },
   "scripts": {
     "dev": "next",
-    "build": "next build",
-    "start": "next start"
+    "build": "NODE_ENV=production next build",
+    "start": "NODE_ENV=production next start"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Supported options:
 - `dir` (`string`) where the Next project is located - default `'.'`
 - `quiet` (`bool`) Hide error messages containing server information - default `false`
 
-Then, change your `build` script to `NODE_ENV=production node server.js`.
+Then, change your `start` script to `NODE_ENV=production node server.js`.
 
 ### Custom `<Document>`
 

--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ Supported options:
 - `dir` (`string`) where the Next project is located - default `'.'`
 - `quiet` (`bool`) Hide error messages containing server information - default `false`
 
+Then, change your `build` script to `NODE_ENV=production node server.js`.
+
 ### Custom `<Document>`
 
 <p><details>
@@ -587,8 +589,8 @@ For example, to deploy with [`now`](https://zeit.co/now) a `package.json` like f
   },
   "scripts": {
     "dev": "next",
-    "build": "NODE_ENV=production next build",
-    "start": "NODE_ENV=production next start"
+    "build": "next build",
+    "start": "next start"
   }
 }
 ```


### PR DESCRIPTION
As @matheuss pointed out in the #now Slack channel, NODE_ENV should probably be set explicitly for deploying on Now.

This example code uses `next build` which implicitly doesn't create a dev server (AFAIK), so it works as it is, but it gives the impression that you could just switch `"build": "next build"` with `"build": "node server.js"` when going for a custom server. But probably (based on the example in same README), you'll declare the server as `const app = next({ dev: process.env.NODE_ENV !== 'production' });`, meaning that unless NODE_ENV is explicitly set, the deployment will fail (because `dev` will be `true`, and thus will try to write to the `.next` directory which isn't writable on Now (`EACCES: permission denied, rmdir '/home/nowuser/src/.next'`).

So I thought it'd be better to educate people that they should set NODE_ENV somehow.