### PR TITLE
Fix status messages on error

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import HTTPStatus from 'http-status'
 import Head from './head'
 
 export default class Error extends React.Component {
@@ -9,9 +10,7 @@ export default class Error extends React.Component {
 
   render () {
     const { statusCode } = this.props
-    const title = statusCode === 404
-      ? 'This page could not be found'
-      : (statusCode ? 'Internal Server Error' : 'An unexpected error has occurred')
+    const title = HTTPStatus[statusCode] || 'An unexpected error has occurred'
 
     return <div style={styles.error}>
       <Head>

--- a/lib/error.js
+++ b/lib/error.js
@@ -10,7 +10,9 @@ export default class Error extends React.Component {
 
   render () {
     const { statusCode } = this.props
-    const title = HTTPStatus[statusCode] || 'An unexpected error has occurred'
+    const title = statusCode === 404
+      ? 'This page could not be found'
+      : HTTPStatus[statusCode] || 'An unexpected error has occurred'
 
     return <div style={styles.error}>
       <Head>

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "glamor": "2.20.23",
     "glob-promise": "3.1.0",
     "htmlescape": "1.1.1",
+    "http-status": "1.0.1",
     "is-windows-bash": "1.0.3",
     "json-loader": "0.5.4",
     "loader-utils": "0.2.16",


### PR DESCRIPTION
This PR fixes that `Internal Server Error` is shown even when `statusCode` is 403, for example. 