### PR TITLE
Don't delete `.next` folder before a replacement is built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.log
 
 # other
 .next
+.next-*
 
 # coverage
 .nyc_output

--- a/server/build/clean.js
+++ b/server/build/clean.js
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import del from 'del'
 
-export default function clean (dir) {
-  return del(resolve(dir, '.next'))
+export default function clean (dir, folderName = '.next') {
+  return del(resolve(dir, folderName))
 }

--- a/server/build/gzip.js
+++ b/server/build/gzip.js
@@ -3,8 +3,8 @@ import path from 'path'
 import zlib from 'zlib'
 import glob from 'glob-promise'
 
-export default async function gzipAssets (dir) {
-  const nextDir = path.resolve(dir, '.next')
+export default async function gzipAssets (dir, buildFolder = '.next') {
+  const nextDir = path.resolve(dir, buildFolder)
 
   const coreAssets = [
     path.join(nextDir, 'commons.js'),

--- a/server/build/replace.js
+++ b/server/build/replace.js
@@ -1,0 +1,18 @@
+import fs from 'fs'
+import path from 'path'
+import uuid from 'uuid'
+
+export default function replaceCurrentBuild (dir, buildFolder, distFolder) {
+  const distDir = path.resolve(dir, distFolder)
+  const buildDir = path.resolve(dir, buildFolder)
+  const oldDir = path.resolve(dir, `.next-${uuid.v4()}`)
+
+  return new Promise((resolve, reject) => {
+    fs.rename(distDir, oldDir, () => {
+      fs.rename(buildDir, distDir, (err) => {
+        if (err) return reject(err)
+        resolve(oldDir)
+      })
+    })
+  })
+}

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -23,7 +23,7 @@ const interpolateNames = new Map(defaultPages.map((p) => {
   return [join(nextPagesDir, p), `dist/pages/${p}`]
 }))
 
-export default async function createCompiler (dir, { dev = false, quiet = false } = {}) {
+export default async function createCompiler (dir, buildFolder, { dev = false, quiet = false } = {}) {
   dir = resolve(dir)
   const config = getConfig(dir)
   const defaultEntries = dev
@@ -228,7 +228,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false 
     context: dir,
     entry,
     output: {
-      path: join(dir, '.next'),
+      path: join(dir, buildFolder || '.next'),
       filename: '[name]',
       libraryTarget: 'commonjs2',
       publicPath: '/_webpack/',

--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -35,7 +35,7 @@ export default class HotReloader {
 
   async start () {
     const [compiler] = await Promise.all([
-      webpack(this.dir, { dev: true, quiet: this.quiet }),
+      webpack(this.dir, null, { dev: true, quiet: this.quiet }),
       clean(this.dir)
     ])
 


### PR DESCRIPTION
Solves https://github.com/zeit/next.js/issues/1135. 

On build, sequentially: 
1. Leaves the current state `.next` as is
2. Builds the new state into a random `.next-6c15581c-e852-...`
3. Renames the old state `.next` to a random `.next-5c523d99-4375-...`
4. Renames the new state `.next-6c15581c-e852-...` to `.next`, efficiently replacing the current state
5. Removes the old state `.next-5c523d99-4375-...`
6. *(This is where you'd restart the `next.js` process)*

On deploy (using eg. `pm2`), this led my current app to have, a total down time of virtually nothing, instead of being down for several minutes.

The problem was, in the current state of `next.js`, that the entire `.next` directory suddenly disappeared when my `next.js` process was still running and using the files in it, which made it crash and display **`Internal Server Error`** (the `_error.js` disappeared, too...).

With this solution, there's virtually no down time when deploying.