### PR TITLE
Add auth example

### DIFF
--- a/examples/with-auth/AUTHENTICATION.md
+++ b/examples/with-auth/AUTHENTICATION.md
@@ -1,0 +1,79 @@
+# Authentication
+
+To use oAuth you need to configure environment variables with ID and secret and configure the service accordingly.
+
+This example comes pre-configured to handle Facebook, Google and Twitter oAuth if you provide the `ID` and `secret` for the service using environment variables.
+
+If you want to add new oAuth providers (for example GitHub), you will need to:
+
+* Add the oAuth provider configuration in `./routes/passport-strategies.js`
+* Add a field to your User model (in `./index.js`) with the name of the provider
+* Configure the service to point to your website (as in the examples below)
+* Specify the environment variables at run time
+
+## Configuring your account
+
+These guides are approximate as exactly how to configure oAuth varies for each provider and tends to change when they update their developer portals.
+
+Twitter's oAuth implementation is the easiest to configure, so you may want to start with that one.
+
+### Twitter
+
+Environment variables:
+
+* TWITTER_KEY
+* TWITTER_SECRET
+
+Configuration steps:
+
+1. Sign in at [https://dev.twitter.com](https://dev.twitter.com/)
+2. From the profile picture dropdown menu select **My Applications**
+3. Click **Create a new application**
+4. Enter your application name, website and description
+5. For **Callback URL**: `http://your-server.example.com/auth/oauth/twitter/callback`
+6. Go to **Settings** tab
+7. Under *Application Type* select **Read and Write** access
+8. Check the box **Allow this application to be used to Sign in with Twitter**
+9. Click **Update this Twitter's applications settings**
+10. Specify *Consumer Key* as the **TWITTER_KEY** Config Variable
+11. Specify *Consumer Secret* as the **TWITTER_SECRET** Config Variable
+
+### Facebook Login
+
+Environment variables:
+
+* FACEBOOK_ID
+* FACEBOOK_SECRET
+
+Configuration steps:
+
+1. Go to [Facebook Developers](https://developers.facebook.com/)
+2. Click **Apps > Create a New App** in the navigation bar
+3. Enter *Display Name*, then choose a category, then click **Create app**
+5. Specify *App ID* as the **FACEBOOK_ID** Config Variable
+6. Specify *App Secret* as the **FACEBOOK_SECRET** Config Variable
+7. Click on *Settings* on the sidebar, then click **+ Add Platform**
+8. Select **Website**
+9. Enable 'Client OAuth Login' and 'Web OAuth Login'
+10. list`http://your-server.example.com/auth/oauth/facebook/callback` under 'Valid OAuth redirect URIs'
+11. List your sites domain under 'domains'
+
+### Google+
+
+Environment variables:
+
+* GOOGLE_ID
+* GOOGLE_SECRET
+
+Configuration steps:
+
+1. Visit [Google Cloud Console](https://cloud.google.com/console/project)
+2. Click the **CREATE PROJECT** button, enter a *Project Name* and click **CREATE**
+3. Then select *APIs* then *Credentials*
+4. Select **Create new oAuth Client ID** and enter the following:
+ - **Application Type**: Web Application
+ - **Authorized Javascript origins**: `http://your-server.example.com/`
+ - **Authorized redirect URI**: `http://your-server.example.com/auth/oauth/google/callback`
+5. Specify *Client ID* as the **GOOGLE_ID** Config Variable
+6. Specify *Client Secret* as the **GOOGLE_SECRET** Config Variable
+7. Enable Google+ on the project - if you don't, sign in with Google+ will fail!

--- a/examples/with-auth/README.md
+++ b/examples/with-auth/README.md
@@ -1,0 +1,31 @@
+# Authentication example
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-auth
+cd with-auth
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example includes session support (with CSRF and XSS protection), email based sign-in sytem and integrates with [Passport](http://passportjs.org/) to support signing in with Facebook, Google, Twitter and other sites that support oAuth.
+
+All functionality works on both client and server side - including without JavaScript support in the browser.
+
+Please read [authentication](./AUTHENTICATION.md) to configure oAuth. And have a look at `./index.js` for server / database settings.

--- a/examples/with-auth/components/logout-button.js
+++ b/examples/with-auth/components/logout-button.js
@@ -1,0 +1,26 @@
+/* global window */
+import React from 'react'
+import Session from './session'
+
+async function logout (event) {
+  event.preventDefault()
+
+  const session = new Session()
+  await session.signout()
+
+  // @FIXME next/router not working reliably  so using window.location
+  window.location = '/'
+}
+
+export default ({ session, children }) => {
+  if (!session || !session.user) {
+    return false
+  }
+
+  return (
+    <form id='signout' method='post' action='/auth/signout' onSubmit={logout}>
+      <input name='_csrf' type='hidden' value={session.csrfToken} />
+      <button type='submit'>{children}</button>
+    </form>
+  )
+}

--- a/examples/with-auth/components/restricted.js
+++ b/examples/with-auth/components/restricted.js
@@ -1,0 +1,19 @@
+import Link from 'next/prefetch'
+import withSession from './with-session'
+
+const Unauthorized = () => (
+  <div>
+    <h1>Unauthorized</h1>
+    <p>You are not authorized to view this page.</p>
+    <p><Link href='/auth/signin'><a>Please log in</a></Link></p>
+    <p><Link href='/'><a>Back to homepage</a></Link></p>
+  </div>
+)
+
+export default (Component) => {
+  const checkAuth = (props) => {
+    return props.isLoggedIn ? <Component {...props} /> : <Unauthorized />
+  }
+
+  return withSession(checkAuth)
+}

--- a/examples/with-auth/components/session.js
+++ b/examples/with-auth/components/session.js
@@ -1,0 +1,204 @@
+/**
+ * A class to handle signing in and out and caching session data in sessionStore
+ *
+ * Note: We usewindow.XMLHttpRequest() here rather than fetch because fetch() uses
+ * Service Workers and they cannot share cookies with the browser session
+ * yet (!) so if we tried to get or pass the CSRF token it would mismatch.
+ */
+export default class Session {
+  constructor ({req} = {}) {
+    this._session = {}
+    this._user = {}
+    try {
+      if (req) {
+        // If running on server we can access the server side environment
+        this._session = {
+          csrfToken: req.connection._httpMessage.locals._csrf
+        }
+        // If the session is associated with a user add user object to session
+        if (req.user) {
+          this._session.user = req.user
+        }
+
+        return
+      }
+
+      // If running on client, attempt to load session from localStorage
+      this._session = this._getLocalStore('session')
+    } catch (err) {
+      // Handle if error reading from localStorage or server state is safe to
+      // ignore (will just cause session data to be fetched by ajax)
+    }
+  }
+
+  static async getCsrfToken () {
+    return new Promise((resolve, reject) => {
+      if (typeof window === 'undefined') {
+        return reject(Error('This method should only be called on the client'))
+      }
+
+      let xhr = new window.XMLHttpRequest()
+      xhr.open('GET', '/auth/csrf', true)
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === 4) {
+          if (xhr.status === 200) {
+            const responseJson = JSON.parse(xhr.responseText)
+            resolve(responseJson.csrfToken)
+          } else {
+            reject(Error('Unexpected response when trying to get CSRF token'))
+          }
+        }
+      }
+      xhr.onerror = () => {
+        reject(Error('XMLHttpRequest error: Unable to get CSRF token'))
+      }
+      xhr.send()
+    })
+  }
+
+  // We can't do async requests in the constructor so access is via asyc method
+  // This allows us to use XMLHttpRequest when running on the client to fetch it
+  // Note: We use XMLHttpRequest instead of fetch so auth cookies are passed
+  async getSession (forceUpdate) {
+    // If running on the server, return session as will be loaded in constructor
+    if (typeof window === 'undefined') {
+      return new Promise(resolve => {
+        resolve(this._session)
+      })
+    }
+
+    // If force update is set, clear data from store
+    if (forceUpdate === true) {
+      this._removeLocalStore('session')
+    }
+
+    // Attempt to load session data from sessionStore on every call
+    this._session = this._getLocalStore('session')
+
+    // If session data exists, has not expired AND forceUpdate is not set then
+    // return the stored session we already have.
+    if (this._session && Object.keys(this._session).length > 0 && this._session.expires && this._session.expires > Date.now()) {
+      return new Promise(resolve => {
+        resolve(this._session)
+      })
+    }
+
+    // If we don't have session data, or it's expired, or forceUpdate is set
+    // to true then revalidate it by fetching it again from the server.
+    return new Promise((resolve, reject) => {
+      let xhr = new window.XMLHttpRequest()
+      xhr.open('GET', '/auth/session', true)
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === 4) {
+          if (xhr.status === 200) {
+            // Update session with session info
+            this._session = JSON.parse(xhr.responseText)
+
+            // Set a value we will use to check this client should silently
+            // revalidate based on the value of clientMaxAge set by the server
+            this._session.expires = Date.now() + this._session.clientMaxAge
+
+            // Save changes to session
+            this._saveLocalStore('session', this._session)
+
+            resolve(this._session)
+          } else {
+            reject(Error('XMLHttpRequest failed: Unable to get session'))
+          }
+        }
+      }
+      xhr.onerror = () => {
+        reject(Error('XMLHttpRequest error: Unable to get session'))
+      }
+      xhr.send()
+    })
+  }
+
+  signin (email) {
+    // Sign in to the server
+    return new Promise(async (resolve, reject) => {
+      if (typeof window === 'undefined') {
+        return reject(Error('This method should only be called on the client'))
+      }
+
+      // Make sure we have session in memory
+      this._session = await this.getSession()
+
+      // Make sure we have the latest CSRF Token in our session
+      this._session.csrfToken = await Session.getCsrfToken()
+
+      let xhr = new window.XMLHttpRequest()
+      xhr.open('POST', '/auth/email/signin', true)
+      xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === 4) {
+          if (xhr.status !== 200) {
+            return reject(Error('XMLHttpRequest error: Error while attempting to signin'))
+          }
+
+          return resolve(true)
+        }
+      }
+      xhr.onerror = () => {
+        return reject(Error('XMLHttpRequest error: Unable to signin'))
+      }
+      xhr.send('_csrf=' + encodeURIComponent(this._session.csrfToken) + '&' +
+                'email=' + encodeURIComponent(email))
+    })
+  }
+
+  signout () {
+    // Signout from the server
+    return new Promise(async (resolve, reject) => {
+      if (typeof window === 'undefined') {
+        return reject(Error('This method should only be called on the client'))
+      }
+
+      let xhr = new window.XMLHttpRequest()
+      xhr.open('POST', '/auth/signout', true)
+      xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded')
+      xhr.onreadystatechange = async() => {
+        if (xhr.readyState === 4) {
+          // @TODO We aren't checking for success, just completion
+
+          // Update local session data
+          this._session = await this.getSession(true)
+
+          resolve(true)
+        }
+      }
+      xhr.onerror = () => {
+        reject(Error('XMLHttpRequest error: Unable to signout'))
+      }
+      xhr.send('_csrf=' + encodeURIComponent(this._session.csrfToken))
+    })
+  }
+
+  // The Web Storage API is widely supported, but not always available (e.g.
+  // it can be restricted in private browsing mode, triggering an exception).
+  // We handle that silently by just returning null here.
+  _getLocalStore (name) {
+    try {
+      return JSON.parse(window.localStorage.getItem(name))
+    } catch (err) {
+      return null
+    }
+  }
+  _saveLocalStore (name, data) {
+    try {
+      window.localStorage.setItem(name, JSON.stringify(data))
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+  _removeLocalStore (name) {
+    try {
+      window.localStorage.removeItem(name)
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+
+}

--- a/examples/with-auth/components/with-session.js
+++ b/examples/with-auth/components/with-session.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import Session from './session'
+
+export default (Component) => class extends React.Component {
+  static async getInitialProps (ctx) {
+    const session = new Session({ req: ctx.req })
+
+    let initialProps = {}
+    if (Component.getInitialProps) {
+      initialProps = Component.getInitialProps({ ...ctx, session })
+    }
+
+    const sessionData = await session.getSession()
+    console.log(sessionData)
+    let isLoggedIn = false
+    if (sessionData.user && sessionData.user.id) {
+      isLoggedIn = true
+    }
+
+    return {session: sessionData, isLoggedIn, ...initialProps}
+  }
+
+  render () {
+    return <Component {...this.props} />
+  }
+}

--- a/examples/with-auth/index.js
+++ b/examples/with-auth/index.js
@@ -1,0 +1,95 @@
+// Configure a database to store user profiles and email sign in tokens
+// Database connection string for ORM (e.g. MongoDB/Amazon Redshift/SQL DB…)
+// By default it uses SQL Lite to create a DB in /tmp/nextjs-auth.db
+process.env.DB_CONNECTION_STRING = process.env.DB_CONNECTION_STRING || 'sqlite:///tmp/nextjs-auth.db'
+
+// Secret used to encrypt session data stored on the server
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'change-me'
+
+const express = require('express')
+const next = require('next')
+const orm = require('orm')
+const auth = require('./routes/auth')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({
+  dir: '.',
+  dev
+})
+
+const handle = app.getRequestHandler()
+
+app.prepare()
+.then(() => {
+  // Get instance of Express server
+  const server = express()
+
+  // Set it up the database (used to store user info and email sign in tokens)
+  return new Promise((resolve, reject) => {
+    // Before we can set up authentication routes we need to set up a database
+    orm.connect(process.env.DB_CONNECTION_STRING, function (err, db) {
+      if (err) {
+        return reject(err)
+      }
+
+      // Define our user object
+      // * If adding a new oauth provider, add a field to store account id
+      // * Tokens are single use but don't expire & we don't save verified date
+      db.define('user', {
+        name: {type: 'text'},
+        email: {type: 'text', unique: true},
+        token: {type: 'text', unique: true},
+        verified: {type: 'boolean', defaultValue: false},
+        facebook: {type: 'text'},
+        google: {type: 'text'},
+        twitter: {type: 'text'}
+      })
+
+      // Creates require tables/collections on DB
+      // Note: If you add fields to am object this won't do that for you, it
+      // only creates tables/collections if they are not there - you still need
+      // to handle database schema changes yourself.
+      db.sync(function (err) {
+        if (err) {
+          return reject(err)
+        }
+        return resolve({ db, server })
+      })
+    })
+  })
+})
+.then(({ server, db }) => {
+  // Once DB is available, setup sessions and routes for authentication
+  auth.configure({
+    app: app,
+    server: server,
+    user: db.models.user,
+    secret: process.env.SESSION_SECRET,
+    mailserver: {
+      // nodemailer settings
+    }
+  })
+
+  // Default catch-all handler to allow Next.js to handle all other routes
+  server.all('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  // Set vary header (good practice)
+  // Note: This overrides any existing 'Vary' header but is okay in this app
+  server.use(function (req, res, next) {
+    res.setHeader('Vary', 'Accept-Encoding')
+    next()
+  })
+
+  server.listen(process.env.PORT || 3000, err => {
+    if (err) {
+      throw err
+    }
+    console.log('> Ready on http://localhost:' + process.env.PORT)
+  })
+})
+.catch(err => {
+  console.log('An error occurred, unable to start the server')
+  console.log(err)
+})

--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "with-auth",
+  "version": "1.0.0",
+  "dependencies": {
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "express-session": "^1.14.2",
+    "isomorphic-fetch": "^2.2.1",
+    "lusca": "^1.4.1",
+    "next": "^2.0.0-beta.23",
+    "nodemailer": "^2.7.0",
+    "orm": "^3.2.3",
+    "passport": "^0.3.2",
+    "passport-facebook": "^2.1.1",
+    "passport-google-oauth": "^1.0.0",
+    "passport-twitter": "^1.0.4",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "session-file-store": "^1.0.0",
+    "sqlite3": "^3.1.8",
+    "uuid": "^3.0.1"
+  },
+  "scripts": {
+    "dev": "node index.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node index.js"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/with-auth/pages/auth/check-email.js
+++ b/examples/with-auth/pages/auth/check-email.js
@@ -1,0 +1,6 @@
+export default () => (
+  <div>
+    <h2>Check your email</h2>
+    <p>You have been sent an email with a link you can use to sign in.</p>
+  </div>
+)

--- a/examples/with-auth/pages/auth/error.js
+++ b/examples/with-auth/pages/auth/error.js
@@ -1,0 +1,9 @@
+import Link from 'next/prefetch'
+
+export default () => (
+  <div>
+    <h2>Unable to sign in</h2>
+    <p>The link you tried to use to sign in was not valid.</p>
+    <p><Link href='/auth/signin'><a>Request a new one to sign in.</a></Link></p>
+  </div>
+)

--- a/examples/with-auth/pages/auth/not-configured.js
+++ b/examples/with-auth/pages/auth/not-configured.js
@@ -1,0 +1,10 @@
+import Link from 'next/prefetch'
+
+export default () => (
+  <div>
+    <h2>Not configured</h2>
+    <p>This oAuth provider has not been configured.</p>
+    <p>Check the readme for instructions on how to configure oAuth providers</p>
+    <p><Link href='/auth/signin'><a>Sign in via email</a></Link></p>
+  </div>
+)

--- a/examples/with-auth/pages/auth/signin.js
+++ b/examples/with-auth/pages/auth/signin.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import withSession from '../../components/with-session'
+import Session from '../../components/session'
+
+class SignIn extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      email: ''
+    }
+    this.handleSubmit = this.handleSubmit.bind(this)
+    this.handleEmailChange = this.handleEmailChange.bind(this)
+  }
+
+  handleEmailChange (event) {
+    this.setState({email: event.target.value.trim()})
+  }
+
+  async handleSubmit (event) {
+    event.preventDefault()
+
+    const session = new Session()
+    session.signin(this.state.email)
+    .then(() => {
+      this.props.url.push('/auth/check-email')
+    })
+    .catch(err => {
+      // @FIXME Handle error
+      console.log(err)
+    })
+  }
+
+  render () {
+    let signinForm = <div />
+    if (!this.props.session.user) {
+      signinForm = (
+        <div>
+          <form id='signin' method='post' action='/auth/email/signin' onSubmit={this.handleSubmit}>
+            <input name='_csrf' type='hidden' value={this.props.session.csrfToken} />
+            <h3>Sign in with email</h3>
+            <p>
+              <label htmlFor='email'>Email address</label><br />
+              <input name='email' type='text' placeholder='j.smith@example.com' id='email' value={this.state.email} onChange={this.handleEmailChange} />
+            </p>
+            <p>
+              <button id='submitButton' type='submit'>Sign in</button>
+            </p>
+          </form>
+          <h3>Sign in with oAuth</h3>
+          <p><a className='button button-oauth button-facebook' href='/auth/oauth/facebook'>Sign in with Facebook</a></p>
+          <p><a className='button button-oauth button-google' href='/auth/oauth/google'>Sign in with Google</a></p>
+          <p><a className='button button-oauth button-twitter' href='/auth/oauth/twitter'>Sign in with Twitter</a></p>
+        </div>
+      )
+    }
+
+    return (
+      <div>
+        <h2>Authentication</h2>
+        {signinForm}
+        <h3>How it works</h3>
+        <p>
+          This project includes a passwordless, email based authentication system, that uses
+          one time use tokens sent out via email. Recipients follow the links in the emails to sign in.
+        </p>
+        <p>
+          Cross Site Request Forgery (CSRF) protection is added to all post requests,
+          session data on the server is encrypted and and session tokens are only stored HTTP Only cookies
+          on the client as protection against Cross Site Scripting (XSS) attacks.
+        </p>
+        <p>
+          This project also integrates with Passport to allow signing in with Facebook, Google, Twitter and other sites that support oAuth.
+        </p>
+        <h3>Exending the authentication system</h3>
+        <p>
+          By default, user data is persisted on the server in SQL Lite as this requires no configuration,
+          but this can be easily changed to another database - including MongoDB, MySQL, PostgreSQL, Amazon Redshift and others
+          by setting the DB_CONNECTION_STRING environment variable accordingly.
+        </p>
+        <p>
+          For larger sites, a fully decoupled authentication system, running on a seperate backend,
+          will be easier to scale and maintain, but this example shows how you can easily add
+          authentication to any Next.js 2.0 project.
+        </p>
+        <p>
+          To use the oAuth sign in options, you will need to create your own account with each provider and configure each one for your site.
+          This can be a slightly cumbersome process that is hard to debug. See AUTHENTICATION.md for a step-by-step guide.
+        </p>
+        <p>
+          If you aren&#39;t receiving emails when trying to sign in via email, try using another email address or
+          configuring the mailserver option inside of index.js at the example root. Some email providers block email from
+          unverified mail servers.
+        </p>
+      </div>
+    )
+  }
+}
+
+// withSession can only be used on top level components (routes inside the pages directory)
+export default withSession(SignIn)

--- a/examples/with-auth/pages/auth/success.js
+++ b/examples/with-auth/pages/auth/success.js
@@ -1,0 +1,22 @@
+import Link from 'next/prefetch'
+import React from 'react'
+import Session from '../../components/session'
+
+export default class extends React.Component {
+  async componentDidMount () {
+    const session = new Session()
+    await session.getSession(true)
+    this.props.url.push('/')
+  }
+
+  render () {
+    return (
+      <div>
+        <div style={{textAlign: 'center'}}>
+          <p>You are now signed in.</p>
+          <p><Link href='/'><a>Continue</a></Link></p>
+        </div>
+      </div>
+    )
+  }
+}

--- a/examples/with-auth/pages/index.js
+++ b/examples/with-auth/pages/index.js
@@ -1,0 +1,23 @@
+import Link from 'next/prefetch'
+import React from 'react'
+import withSession from '../components/with-session'
+import LogoutButton from '../components/logout-button'
+
+const Index = ({ session, isLoggedIn }) => {
+  return (
+    <div>
+      <h1>Welcome to the Next.js auth example</h1>
+      {!isLoggedIn && <p><Link href='/auth/signin'><a>Login</a></Link></p>}
+      {isLoggedIn && (
+        <div>
+          <p>Welcome back {session.user.email}</p>
+          <LogoutButton session={session}>Log out</LogoutButton>
+        </div>
+      )}
+      <p><Link href='/restricted-page'><a>Restricted page</a></Link></p>
+    </div>
+  )
+}
+
+// withSession can only be used on top level components (routes inside the pages directory)
+export default withSession(Index)

--- a/examples/with-auth/pages/restricted-page.js
+++ b/examples/with-auth/pages/restricted-page.js
@@ -1,0 +1,13 @@
+import Link from 'next/prefetch'
+import restricted from '../components/restricted'
+
+const RestrictedPage = () => (
+  <div>
+    <h1>Restricted page</h1>
+    <p>This page is restricted to the public. Since you&#39;re logged in you see this message.</p>
+    <Link href='/'><a>Back to homepage</a></Link>
+  </div>
+)
+
+// restricted can only be used on top level components (routes inside the pages directory)
+export default restricted(RestrictedPage)

--- a/examples/with-auth/routes/auth.js
+++ b/examples/with-auth/routes/auth.js
@@ -1,0 +1,202 @@
+/**
+ * Add routes for authentication
+ *
+ * Also sets up dependancies for authentication:
+ * - Adds sessions support to Express (with HTTP only cookies for security)
+ * - Configures session store (defaults to a flat file store in /tmp/sessions)
+ * - Adds protection for Cross Site Request Forgery attacks to all POST requests
+ *
+ * Normally some of this logic might be elsewhere (like server.js) but for the
+ * purposes of this example all server logic related to authentication is here.
+ */
+'use strict'
+
+const bodyParser = require('body-parser')
+const session = require('express-session')
+const FileStore = require('session-file-store')(session)
+const nodemailer = require('nodemailer')
+const csrf = require('lusca').csrf()
+const uuid = require('uuid/v4')
+const passportStrategies = require('./passport-strategies')
+
+exports.configure = ({
+    app = null, // Next.js App
+    server = null, // Express Server
+    user: User = null, // User model
+    // URL base path for authentication routes
+    path = '/auth',
+    // Directory in ./pages/ where auth pages can be found
+    pages = 'auth',
+    // Secret used to encrypt session data on the server
+    secret = 'change-me',
+    // Sessions store for express-session (defaults to /tmp/sessions file store)
+    store = new FileStore({path: '/tmp/sessions', secret: secret}),
+    // Max session age in ms (default is 4 weeks)
+    // NB: With 'rolling: true' passed to session() the session expiry time will
+    // be reset every time a user visits the site again before it expires.
+    maxAge = 60000 * 60 * 24 * 7 * 4,
+    // How often the client should revalidate the session in ms (default 60s)
+    // Does not impact the session life on the server, but causes the client to
+    // always refetch session info after N seconds has elapsed since last
+    // checked. Sensible values are between 0 (always check the server) and a
+    // few minutes.
+    clientMaxAge = 60000,
+    // URL of the server (e.g. 'http://www.example.com'). Used when sending
+    // sign in links in emails. Autodetects to hostname if null.
+    serverUrl = null,
+    // Mailserver configuration for nodemailer (defaults to localhost if null)
+    mailserver = null
+  } = {}) => {
+  if (app === null) {
+    throw new Error('app option must be a next server instance')
+  }
+
+  if (server === null) {
+    throw new Error('server option must be an express server instance')
+  }
+
+  if (User === null) {
+    throw new Error('user option must be a User model')
+  }
+
+  // Load body parser to handle POST requests
+  server.use(bodyParser.json())
+  server.use(bodyParser.urlencoded({extended: true}))
+
+  // Configure sessions
+  server.use(session({
+    secret: secret,
+    store: store,
+    resave: false,
+    rolling: true,
+    saveUninitialized: true,
+    httpOnly: true,
+    cookie: {
+      maxAge: maxAge
+    }
+  }))
+
+  // Add CSRF to all POST requests
+  // (If you want to add exceptions to paths you can do that here)
+  server.use((req, res, next) => {
+    csrf(req, res, next)
+  })
+
+  // With sessions connfigured (& before routes) we need to configure Passport
+  // and trigger passport.initialize() before we add any routes
+  passportStrategies.configure({
+    app: app,
+    server: server,
+    user: User
+  })
+
+  // Add route to get CSRF token via AJAX
+  server.get(path + '/csrf', (req, res) => {
+    return res.json({csrfToken: res.locals._csrf})
+  })
+
+  // Return session info
+  server.get(path + '/session', (req, res) => {
+    let session = {
+      clientMaxAge: clientMaxAge,
+      csrfToken: res.locals._csrf
+    }
+
+    // Add user object to session if logged in
+    if (req.user) {
+      session.user = req.user
+    }
+
+    return res.json(session)
+  })
+
+  // On post request, redirect to page with instrutions to check email for link
+  server.post(path + '/email/signin', (req, res) => {
+    const email = req.body.email || null
+
+    if (!email || email.trim() === '') {
+      return app.render(req, res, pages + '/signin', req.params)
+    }
+
+    const token = uuid()
+    const verificationUrl = (serverUrl || 'http://' + req.headers.host) + path + '/email/signin/' + token
+
+    // Create verification token save it to database
+    // @FIXME Improve error handling
+    User.one({email: email}, function (err, user) {
+      if (err) {
+        throw err
+      }
+      if (user) {
+        user.token = token
+        user.save(function (err) {
+          if (err) {
+            throw err
+          }
+        })
+      } else {
+        User.create({email: email, token: token}, function (err) {
+          if (err) {
+            throw err
+          }
+
+          nodemailer
+          .createTransport(mailserver)
+          .sendMail({
+            to: email,
+            from: 'postmaster@sandboxb3cba664ae634d608111fbf42667bd74.mailgun.org',
+            subject: 'Sign in link',
+            text: 'Use the link below to sign in:\n\n' + verificationUrl + '\n\n'
+          }, function (err) {
+            // @TODO Handle errors
+            if (err) {
+              console.log('Generated sign in link ' + verificationUrl + ' for ' + email)
+              console.log('Error sending email to ' + email, err)
+            }
+          })
+        })
+      }
+    })
+
+    return app.render(req, res, pages + '/check-email', req.params)
+  })
+
+  server.get(path + '/email/signin/:token', (req, res) => {
+    if (!req.params.token) {
+      return res.redirect(path + '/signin')
+    }
+
+    // Look up user by token
+    User.one({token: req.params.token}, function (err, user) {
+      if (err) {
+        return res.redirect(path + '/error')
+      }
+      if (user) {
+        // Reset token and mark as verified
+        user.token = null
+        user.verified = true
+        user.save(function (err) {
+          // @TODO Improve error handling
+          if (err) {
+            return res.redirect(path + '/error')
+          }
+          // Having validated to the token, we log the user with Passport
+          req.logIn(user, function (err) {
+            if (err) {
+              return res.redirect(path + '/error')
+            }
+            return res.redirect(path + '/success')
+          })
+        })
+      } else {
+        return res.redirect(path + '/error')
+      }
+    })
+  })
+
+  server.post(path + '/signout', (req, res) => {
+    // Log user out by disassociating their account from the session
+    req.logout()
+    res.redirect('/')
+  })
+}

--- a/examples/with-auth/routes/passport-strategies.js
+++ b/examples/with-auth/routes/passport-strategies.js
@@ -1,0 +1,204 @@
+/**
+ * Configure Passport Strategies
+ */
+'use strict'
+
+const passport = require('passport')
+
+exports.configure = ({
+    app = null, // Next.js App
+    server = null, // Express Server
+    user: User = null, // User model
+    path = '/auth' // URL base path for authentication routes
+  } = {}) => {
+  if (app === null) {
+    throw new Error('app option must be a next server instance')
+  }
+
+  if (server === null) {
+    throw new Error('server option must be an express server instance')
+  }
+
+  if (User === null) {
+    throw new Error('user option must be a User model')
+  }
+
+  // Tell Passport how to seralize/deseralize user accounts
+  passport.serializeUser(function (user, done) {
+    done(null, user.id)
+  })
+
+  passport.deserializeUser(function (id, done) {
+    User.get(id, function (err, user) {
+      // Note: We don't return all user profile fields to the client, just ones
+      // that are whitelisted here to limit the amount of users' data we expose.
+      done(err, {
+        id: user.id,
+        name: user.name,
+        email: user.email
+      })
+    })
+  })
+
+  let providers = []
+
+  // IMPORTANT! If you add a provider, be sure to add a property to the User
+  // model with the name of the provider or you won't be able to log in!
+
+  if (process.env.FACEBOOK_ID && process.env.FACEBOOK_SECRET) {
+    providers.push({
+      provider: 'facebook',
+      Strategy: require('passport-facebook').Strategy,
+      strategyOptions: {
+        clientID: process.env.FACEBOOK_ID,
+        clientSecret: process.env.FACEBOOK_SECRET
+      },
+      scope: ['email', 'user_location'],
+      getUserFromProfile (profile) {
+        return {
+          id: profile.id,
+          name: profile.displayName,
+          email: profile._json.email
+        }
+      }
+    })
+  }
+
+  if (process.env.GOOGLE_ID && process.env.GOOGLE_SECRET) {
+    providers.push({
+      provider: 'google',
+      Strategy: require('passport-google-oauth').OAuth2Strategy,
+      strategyOptions: {
+        clientID: process.env.GOOGLE_ID,
+        clientSecret: process.env.GOOGLE_SECRET
+      },
+      scope: 'profile email',
+      getUserFromProfile (profile) {
+        return {
+          id: profile.id,
+          name: profile.displayName,
+          email: profile.emails[0].value
+        }
+      }
+    })
+  }
+
+  if (process.env.TWITTER_KEY && process.env.TWITTER_SECRET) {
+    providers.push({
+      provider: 'twitter',
+      Strategy: require('passport-twitter').Strategy,
+      strategyOptions: {
+        consumerKey: process.env.TWITTER_KEY,
+        consumerSecret: process.env.TWITTER_SECRET
+      },
+      scope: null,
+      getUserFromProfile (profile) {
+        return {
+          id: profile.id,
+          name: profile.displayName,
+          email: profile.username + '@twitter'
+        }
+      }
+    })
+  }
+
+  // Define a Passport strategy for provider
+  providers.forEach(({provider, Strategy, strategyOptions, getUserFromProfile}) => {
+    strategyOptions.callbackURL = path + '/oauth/' + provider + '/callback'
+    strategyOptions.passReqToCallback = true
+
+    passport.use(new Strategy(strategyOptions, (req, accessToken, refreshToken, profile, done) => {
+      try {
+        // Normalise the provider specific profile into a User object
+        profile = getUserFromProfile(profile)
+
+        // See if we have this oAuth account in the database associated with a user
+        User.one({[provider]: profile.id}, function (err, user) {
+          if (err) {
+            return done(err)
+          }
+
+          if (req.user) {
+            // If the current session is signed in
+
+            // If the oAuth account is not linked to another account, link it and exit
+            if (!user) {
+              return User.get(req.user.id, function (err, user) {
+                if (err) {
+                  return done(err)
+                }
+                user.name = user.name || profile.name
+                user[provider] = profile.id
+                user.save(function (err) {
+                  return done(err, user)
+                })
+              })
+            }
+
+            // If oAuth account already linked to the current user, just exit
+            if (req.user.id === user.id) {
+              return done(null, user)
+            }
+
+            // If the oAuth account is already linked to different account, exit with error
+            if (req.user.id !== user.id) {
+              return done(new Error('This account is already associated with another login.'))
+            }
+          } else {
+            // If the current session is not signed in
+
+            // If we have the oAuth account in the db then let them sign in as that user
+            if (user) {
+              return done(null, user)
+            }
+
+            // If we don't have the oAuth account in the db, check to see if an account with the
+            // same email address as the one associated with their oAuth acccount exists in the db
+            return User.one({email: profile.email}, function (err, user) {
+              if (err) {
+                return done(err)
+              }
+              // If we already have an account associated with that email address in the databases, the user
+              // should sign in with that account instead (to prevent them creating two accounts by mistake)
+              // Note: Automatically linking them here could expose a potential security exploit allowing someone
+              // to create an account for another users email address in advance then hijack it, so don't do that.
+              if (user) {
+                return done(new Error('There is already an account associated with the same email address.'))
+              }
+
+              // If account does not exist, create one for them and sign the user in
+              User.create({name: profile.name, email: profile.email, [provider]: profile.id}, function (err, user) {
+                if (err) {
+                  return done(err)
+                }
+                return done(null, user)
+              })
+            })
+          }
+        })
+      } catch (err) {
+        done(err)
+      }
+    }))
+  })
+
+  // Initialise Passport
+  server.use(passport.initialize())
+  server.use(passport.session())
+
+  // Add routes for provider
+  providers.forEach(({provider, scope}) => {
+    server.get(path + '/oauth/' + provider, passport.authenticate(provider, {scope: scope}))
+    server.get(path + '/oauth/' + provider + '/callback', passport.authenticate(provider, {failureRedirect: path + '/signin'}), function (req, res) {
+      // Redirect to the sign in success, page which will force the client to update it's cache
+      res.redirect(path + '/success')
+    })
+  })
+
+  // A catch all for providers that are not configured
+  server.get(path + '/oauth/:provider', function (req, res) {
+    res.redirect(path + '/not-configured')
+  })
+
+  return passport
+}


### PR DESCRIPTION
Fixes #153

Implements the auth parts of https://github.com/iaincollins/nextjs-starter with a few differences in the client side code. In the original nextjs-starter all pages extended from a page component. I changed this to a higher order component. Added another higher order component to restrict pages, cleaned up the docs, cleaned up the code to fit `standard` and finally removed all unnecessary code.