### PR TITLE
Build on tmp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ npm-debug.log
 
 # other
 .next
-.next-*
 
 # coverage
 .nyc_output

--- a/server/build/clean.js
+++ b/server/build/clean.js
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import del from 'del'
 
-export default function clean (dir, folderName = '.next') {
-  return del(resolve(dir, folderName))
+export default function clean (dir) {
+  return del(resolve(dir, '.next'))
 }

--- a/server/build/gzip.js
+++ b/server/build/gzip.js
@@ -3,8 +3,8 @@ import path from 'path'
 import zlib from 'zlib'
 import glob from 'glob-promise'
 
-export default async function gzipAssets (dir, buildFolder = '.next') {
-  const nextDir = path.resolve(dir, buildFolder)
+export default async function gzipAssets (dir) {
+  const nextDir = path.resolve(dir, '.next')
 
   const coreAssets = [
     path.join(nextDir, 'commons.js'),

--- a/server/build/index.js
+++ b/server/build/index.js
@@ -1,22 +1,29 @@
+import { tmpdir } from 'os'
+import { join } from 'path'
 import fs from 'mz/fs'
 import uuid from 'uuid'
-import path from 'path'
+import del from 'del'
 import webpack from './webpack'
-import clean from './clean'
 import gzipAssets from './gzip'
 import replaceCurrentBuild from './replace'
 
 export default async function build (dir) {
-  const distFolder = '.next'
-  const buildFolder = `.next-${uuid.v4()}`
-  const compiler = await webpack(dir, buildFolder)
+  const buildDir = join(tmpdir(), uuid.v4())
+  const compiler = await webpack(dir, { buildDir })
 
-  await runCompiler(compiler)
-  const oldFolder = await replaceCurrentBuild(dir, buildFolder, distFolder)
-  await gzipAssets(dir, distFolder)
-  await writeBuildId(dir, distFolder)
+  try {
+    await runCompiler(compiler)
+    await gzipAssets(buildDir)
+    await writeBuildId(buildDir)
+  } catch (err) {
+    console.error(`> Failed to build on ${buildDir}`)
+    throw err
+  }
 
-  clean(dir, oldFolder)
+  await replaceCurrentBuild(dir, buildDir)
+
+  // no need to wait
+  del(buildDir)
 }
 
 function runCompiler (compiler) {
@@ -37,8 +44,8 @@ function runCompiler (compiler) {
   })
 }
 
-async function writeBuildId (dir, distFolder) {
-  const buildIdPath = path.resolve(dir, distFolder, 'BUILD_ID')
+async function writeBuildId (dir) {
+  const buildIdPath = join(dir, '.next', 'BUILD_ID')
   const buildId = uuid.v4()
   await fs.writeFile(buildIdPath, buildId, 'utf8')
 }

--- a/server/build/replace.js
+++ b/server/build/replace.js
@@ -1,18 +1,16 @@
-import fs from 'fs'
-import path from 'path'
-import uuid from 'uuid'
+import { rename } from 'mz/fs'
+import { join } from 'path'
 
-export default function replaceCurrentBuild (dir, buildFolder, distFolder) {
-  const distDir = path.resolve(dir, distFolder)
-  const buildDir = path.resolve(dir, buildFolder)
-  const oldDir = path.resolve(dir, `.next-${uuid.v4()}`)
+export default async function replaceCurrentBuild (dir, buildDir) {
+  const _dir = join(dir, '.next')
+  const _buildDir = join(buildDir, '.next')
+  const oldDir = join(buildDir, '.next.old')
 
-  return new Promise((resolve, reject) => {
-    fs.rename(distDir, oldDir, () => {
-      fs.rename(buildDir, distDir, (err) => {
-        if (err) return reject(err)
-        resolve(oldDir)
-      })
-    })
-  })
+  try {
+    await rename(_dir, oldDir)
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err
+  }
+  await rename(_buildDir, _dir)
+  return oldDir
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -23,7 +23,7 @@ const interpolateNames = new Map(defaultPages.map((p) => {
   return [join(nextPagesDir, p), `dist/pages/${p}`]
 }))
 
-export default async function createCompiler (dir, buildFolder, { dev = false, quiet = false } = {}) {
+export default async function createCompiler (dir, { dev = false, quiet = false, buildDir } = {}) {
   dir = resolve(dir)
   const config = getConfig(dir)
   const defaultEntries = dev
@@ -228,7 +228,7 @@ export default async function createCompiler (dir, buildFolder, { dev = false, q
     context: dir,
     entry,
     output: {
-      path: join(dir, buildFolder || '.next'),
+      path: join(buildDir || dir, '.next'),
       filename: '[name]',
       libraryTarget: 'commonjs2',
       publicPath: '/_webpack/',

--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -35,7 +35,7 @@ export default class HotReloader {
 
   async start () {
     const [compiler] = await Promise.all([
-      webpack(this.dir, null, { dev: true, quiet: this.quiet }),
+      webpack(this.dir, { dev: true, quiet: this.quiet }),
       clean(this.dir)
     ])
 


### PR DESCRIPTION
- builds on `tmpdir` so that failed build directories don't remain on app folder.
- swap directory when all builds including `gzipAssets` and `writeBuildId` have finished

Related https://github.com/zeit/next.js/pull/1139