### PR TITLE
Changes hard-coded module aliases to be relative

### DIFF
--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -1,5 +1,4 @@
-const babelRuntimePath = require.resolve('babel-runtime/package')
-  .replace(/[\\/]package\.json$/, '')
+const relativeResolve = require('../root-module-relative-path').default(require)
 
 const envPlugins = {
   'development': [
@@ -30,14 +29,14 @@ module.exports = {
       require.resolve('babel-plugin-module-resolver'),
       {
         alias: {
-          'babel-runtime': babelRuntimePath,
-          'next/link': require.resolve('../../../lib/link'),
-          'next/prefetch': require.resolve('../../../lib/prefetch'),
-          'next/css': require.resolve('../../../lib/css'),
-          'next/head': require.resolve('../../../lib/head'),
-          'next/document': require.resolve('../../../server/document'),
-          'next/router': require.resolve('../../../lib/router'),
-          'next/error': require.resolve('../../../lib/error')
+          'babel-runtime': relativeResolve('babel-runtime/package'),
+          'next/link': relativeResolve('../../../lib/link'),
+          'next/prefetch': relativeResolve('../../../lib/prefetch'),
+          'next/css': relativeResolve('../../../lib/css'),
+          'next/head': relativeResolve('../../../lib/head'),
+          'next/document': relativeResolve('../../../server/document'),
+          'next/router': relativeResolve('../../../lib/router'),
+          'next/error': relativeResolve('../../../lib/error')
         }
       }
     ]

--- a/server/build/root-module-relative-path.js
+++ b/server/build/root-module-relative-path.js
@@ -1,0 +1,24 @@
+// Next.js needs to use module.resolve to generate paths to modules it includes,
+// but those paths need to be relative to something so that they're portable
+// across directories and machines.
+//
+// This function returns paths relative to the top-level 'node_modules'
+// directory found in the path. If none is found, returns the complete path.
+
+const RELATIVE_START = 'node_modules/'
+
+// Pass in the module's `require` object since it's module-specific.
+export default (moduleRequire) => (path) => {
+  // package.json removed because babel-runtime is resolved as
+  // "babel-runtime/package"
+  const absolutePath = moduleRequire.resolve(path)
+    .replace(/[\\/]package\.json$/, '')
+
+  const relativeStartIndex = absolutePath.indexOf(RELATIVE_START)
+
+  if (relativeStartIndex === -1) {
+    return absolutePath
+  }
+
+  return absolutePath.substring(relativeStartIndex + RELATIVE_START.length)
+}

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -11,6 +11,7 @@ import JsonPagesPlugin from './plugins/json-pages-plugin'
 import getConfig from '../config'
 import * as babelCore from 'babel-core'
 import findBabelConfig from './babel/find-config'
+import rootModuleRelativePath from './root-module-relative-path'
 
 const documentPage = join('pages', '_document.js')
 const defaultPages = [
@@ -22,6 +23,8 @@ const nextNodeModulesDir = join(__dirname, '..', '..', '..', 'node_modules')
 const interpolateNames = new Map(defaultPages.map((p) => {
   return [join(nextPagesDir, p), `dist/pages/${p}`]
 }))
+
+const relativeResolve = rootModuleRelativePath(require)
 
 export default async function createCompiler (dir, { dev = false, quiet = false, buildDir } = {}) {
   dir = resolve(dir)
@@ -164,8 +167,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
         if (!(/\.js$/.test(interpolatedName))) {
           return { content, sourceMap }
         }
-        const babelRuntimePath = require.resolve('babel-runtime/package')
-          .replace(/[\\/]package\.json$/, '')
+
         const transpiled = babelCore.transform(content, {
           babelrc: false,
           sourceMaps: dev ? 'both' : false,
@@ -180,15 +182,15 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
               require.resolve('babel-plugin-module-resolver'),
               {
                 alias: {
-                  'babel-runtime': babelRuntimePath,
-                  'next/link': require.resolve('../../lib/link'),
-                  'next/prefetch': require.resolve('../../lib/prefetch'),
-                  'next/css': require.resolve('../../lib/css'),
-                  'next/head': require.resolve('../../lib/head'),
-                  'next/document': require.resolve('../../server/document'),
-                  'next/router': require.resolve('../../lib/router'),
-                  'next/error': require.resolve('../../lib/error'),
-                  'styled-jsx/style': require.resolve('styled-jsx/style')
+                  'babel-runtime': relativeResolve('babel-runtime/package'),
+                  'next/link': relativeResolve('../../lib/link'),
+                  'next/prefetch': relativeResolve('../../lib/prefetch'),
+                  'next/css': relativeResolve('../../lib/css'),
+                  'next/head': relativeResolve('../../lib/head'),
+                  'next/document': relativeResolve('../../server/document'),
+                  'next/router': relativeResolve('../../lib/router'),
+                  'next/error': relativeResolve('../../lib/error'),
+                  'styled-jsx/style': relativeResolve('styled-jsx/style')
                 }
               }
             ]


### PR DESCRIPTION
Without this, modules built with Babel or Webpack would have hard-coded absolute paths
all the way back to the root of the filesystem. This prevented compilation and running
on different machines or even from different directories on the same machine.

With this change, paths are hard-coded to the top-most `node_modules` directory found,
which should make them portable relative to the app.

Fixes #1160