### PR TITLE
Add a way to disable running service workers.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -10,6 +10,16 @@ import { loadGetInitialProps, getLocationOrigin } from '../utils'
 // Add "fetch" polyfill for older browsers
 if (typeof window !== 'undefined') {
   require('whatwg-fetch')
+  // Unregister if there's an exisiting service worker.
+  // This is because we ship a service worker in previous version.
+  // We don't use it and having a already running worker might cause issues.
+  // (We can remove this in future releases)
+  navigator.serviceWorker.getRegistrations()
+    .then((registrations) => {
+      for (let registration of registrations) {
+        registration.unregister()
+      }
+    })
 }
 
 export default class Router extends EventEmitter {


### PR DESCRIPTION
This is because we ship a service worker in previous version.
We don't use it and having a already running worker might cause issues.
(We can remove this in future releases)