### PR TITLE
Fix "EXDEV: cross-device link not permitted" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "loader-utils": "0.2.16",
     "minimist": "1.2.0",
     "mkdirp-then": "1.2.0",
+    "mv": "^2.1.1",
     "mz": "2.6.0",
     "path-match": "1.2.4",
     "pkg-up": "1.0.0",

--- a/server/build/replace.js
+++ b/server/build/replace.js
@@ -15,7 +15,7 @@ export default async function replaceCurrentBuild (dir, buildDir) {
   return oldDir
 }
 
-function move(from, to) {
+function move (from, to) {
   return new Promise((resolve, reject) =>
-    mv(from, to, err => err && reject(err) || resolve()));
+    mv(from, to, err => err && reject(err) || resolve()))
 }

--- a/server/build/replace.js
+++ b/server/build/replace.js
@@ -17,5 +17,5 @@ export default async function replaceCurrentBuild (dir, buildDir) {
 
 function move (from, to) {
   return new Promise((resolve, reject) =>
-    mv(from, to, err => err && reject(err) || resolve()))
+    mv(from, to, err => err ? reject(err) : resolve()))
 }

--- a/server/build/replace.js
+++ b/server/build/replace.js
@@ -1,4 +1,4 @@
-import { rename } from 'mz/fs'
+import mv from 'mv'
 import { join } from 'path'
 
 export default async function replaceCurrentBuild (dir, buildDir) {
@@ -7,10 +7,15 @@ export default async function replaceCurrentBuild (dir, buildDir) {
   const oldDir = join(buildDir, '.next.old')
 
   try {
-    await rename(_dir, oldDir)
+    await move(_dir, oldDir)
   } catch (err) {
     if (err.code !== 'ENOENT') throw err
   }
-  await rename(_buildDir, _dir)
+  await move(_buildDir, _dir)
   return oldDir
+}
+
+function move(from, to) {
+  return new Promise((resolve, reject) =>
+    mv(from, to, err => err && reject(err) || resolve()));
 }


### PR DESCRIPTION
It looks like this error was introduced in PR #1150. I'm currently developing on Windows from a `D:\` drive, while my temp directory is on `C:\`.  It turns out that Node cannot do cross-device renames so a module, called `mv`, was created for that very purpose. I swapped in this module in place of `rename` from `mz/fs` and I'm now able to build.

Here are some references I came across while debugging this:
https://github.com/facebook/nuclide/pull/94
http://stackoverflow.com/q/37153666
http://stackoverflow.com/q/12196163