### PR TITLE
Make sure routes are always lowercase

### DIFF
--- a/server/build/loaders/emit-file-loader.js
+++ b/server/build/loaders/emit-file-loader.js
@@ -8,8 +8,7 @@ module.exports = function (content, sourceMap) {
   const context = query.context || this.options.context
   const regExp = query.regExp
   const opts = { context, content, regExp }
-  const interpolatedName = loaderUtils.interpolateName(this, name, opts)
-
+  const interpolatedName = loaderUtils.interpolateName(this, name, opts).toLowerCase()
   const emit = (code, map) => {
     this.emitFile(interpolatedName, code, map)
     this.callback(null, code, map)

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -41,7 +41,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
 
     const pages = await glob('pages/**/*.js', { cwd: dir })
     for (const p of pages) {
-      entries[join('bundles', p)] = [...defaultEntries, `./${p}?entry`]
+      entries[join('bundles', p.toLowerCase())] = [...defaultEntries, `./${p}?entry`]
     }
 
     for (const p of defaultPages) {


### PR DESCRIPTION
Fixes #139. I like the idea of only having lower cased routes, even if the file has a different casing. Also, we might want to do a 301 redirect from the url with uppercasing to the lowercase version.

cc @sedubois