### PR TITLE
Handle buildId mismatch properly

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,4 +1,4 @@
-/* global location */
+/* global window, location */
 import _Router from './router'
 import url from 'url'
 import UUID from 'uuid'
@@ -83,6 +83,7 @@ export const Router = _Router
 // persist the browser state.
 const onBeforeReloadHooks = []
 export function _reload () {
+  console.log('XXXX', 'reloadd....')
   const parsedUrl = url.parse(location.href, true)
   const reloadKey = UUID.v4()
   parsedUrl.query.__reloadKey = reloadKey
@@ -97,6 +98,8 @@ export function _reload () {
 Object.defineProperty(SingletonRouter, 'onBeforeReload', {
   get () { return () => {} },
   set (fn) {
+    if (typeof window === 'undefined') return
+
     onBeforeReloadHooks.push(fn)
   }
 })
@@ -104,6 +107,8 @@ Object.defineProperty(SingletonRouter, 'onBeforeReload', {
 Object.defineProperty(SingletonRouter, 'onAfterReload', {
   get () { return () => {} },
   set (fn) {
+    if (typeof window === 'undefined') return
+
     const parsedUrl = url.parse(location.href, true)
     if (!parsedUrl.query.__reloadKey) return
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -82,8 +82,7 @@ export const Router = _Router
 // Add a functionality to reload the current page while providing a way to
 // persist the browser state.
 const onBeforeReloadHooks = []
-export function _reload () {
-  console.log('XXXX', 'reloadd....')
+export function _forceReload () {
   const parsedUrl = url.parse(location.href, true)
   const reloadKey = UUID.v4()
   parsedUrl.query.__reloadKey = reloadKey

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,5 +1,7 @@
 /* global location */
 import _Router from './router'
+import url from 'url'
+import UUID from 'uuid'
 
 const SingletonRouter = {
   router: null, // holds the actual router instance
@@ -77,7 +79,34 @@ export const createRouter = function (...args) {
 // Export the actual Router class, which is usually used inside the server
 export const Router = _Router
 
-// Reload the current page
+// Add a functionality to reload the current page while providing a way to
+// persist the browser state.
+const onBeforeReloadHooks = []
 export function _reload () {
-  location.reload()
+  const parsedUrl = url.parse(location.href, true)
+  const reloadKey = UUID.v4()
+  parsedUrl.query.__reloadKey = reloadKey
+
+  onBeforeReloadHooks.forEach((hook) => hook(reloadKey))
+
+  delete parsedUrl.search
+  const reloadUrl = url.format(parsedUrl)
+  location.href = reloadUrl
 }
+
+Object.defineProperty(SingletonRouter, 'onBeforeReload', {
+  get () { return () => {} },
+  set (fn) {
+    onBeforeReloadHooks.push(fn)
+  }
+})
+
+Object.defineProperty(SingletonRouter, 'onAfterReload', {
+  get () { return () => {} },
+  set (fn) {
+    const parsedUrl = url.parse(location.href, true)
+    if (!parsedUrl.query.__reloadKey) return
+
+    fn(parsedUrl.query.__reloadKey)
+  }
+})

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,3 +1,4 @@
+/* global location */
 import _Router from './router'
 
 const SingletonRouter = {
@@ -75,3 +76,8 @@ export const createRouter = function (...args) {
 
 // Export the actual Router class, which is usually used inside the server
 export const Router = _Router
+
+// Reload the current page
+export function _reload () {
+  location.reload()
+}

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -6,7 +6,7 @@ import evalScript from '../eval-script'
 import shallowEquals from '../shallow-equals'
 import PQueue from '../p-queue'
 import { loadGetInitialProps, getLocationOrigin } from '../utils'
-import { _reload } from './'
+import { _forceReload } from './'
 
 // Add "fetch" polyfill for older browsers
 if (typeof window !== 'undefined') {
@@ -243,7 +243,7 @@ export default class Router extends EventEmitter {
     const jsonData = await jsonPageRes.json()
 
     if (jsonData.buildIdMismatch) {
-      _reload()
+      _forceReload()
       throw new Error('Reloading due to buildId mismatch')
     }
 

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -6,6 +6,7 @@ import evalScript from '../eval-script'
 import shallowEquals from '../shallow-equals'
 import PQueue from '../p-queue'
 import { loadGetInitialProps, getLocationOrigin } from '../utils'
+import { _reload } from './'
 
 // Add "fetch" polyfill for older browsers
 if (typeof window !== 'undefined') {
@@ -240,6 +241,12 @@ export default class Router extends EventEmitter {
 
     const jsonPageRes = await this.fetchRoute(route)
     const jsonData = await jsonPageRes.json()
+
+    if (jsonData.buildIdMismatch) {
+      _reload()
+      throw new Error('Reloading due to buildId mismatch')
+    }
+
     const newData = {
       ...loadComponent(jsonData),
       jsonPageRes

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ _**NOTE! the README on the `master` branch might not match that of the [latest s
     - [With `<Link>`](#with-link)
     - [Imperatively](#imperatively)
       - [Router Events](#router-events)
+      - [Reload Hooks](#reload-hooks)
   - [Prefetching Pages](#prefetching-pages)
     - [With `<Link>`](#with-link-1)
     - [Imperatively](#imperatively-1)
@@ -334,6 +335,27 @@ Router.onRouteChangeError = (err, url) => {
   if (err.cancelled) {
     console.log(`Route to ${url} was cancelled!`)
   }
+}
+```
+
+##### Reload Hooks
+
+Between new deployments, Next.js might reload your app when you are navigating pages. With that, your app's client side state might get destroyed. In that case, you can use our reload hooks to restore that state after the reload.
+
+Let's assume our client side state stored in a variable called `state`. Then this is how we use reload hooks to restore the state .
+
+```js
+let state = {}
+
+Router.onBeforeReload = function (key) {
+  localStorage.setItem(key, JSON.stringify(state))
+}
+
+Router.onAfterReload = function (key) {
+  const data = (localStorage.getItem(key))
+  if (!data) return
+
+  const state = JSON.parse(data)
 }
 ```
 

--- a/server/index.js
+++ b/server/index.js
@@ -81,13 +81,21 @@ export default class Server {
       },
 
       '/_next/:buildId/main.js': async (req, res, params) => {
-        this.handleBuildId(params.buildId, res)
+        if (!this.handleBuildId(params.buildId, res)) {
+          reloadTheBrowser(res)
+          return
+        }
+
         const p = join(this.dir, '.next/main.js')
         await this.serveStatic(req, res, p)
       },
 
       '/_next/:buildId/commons.js': async (req, res, params) => {
-        this.handleBuildId(params.buildId, res)
+        if (!this.handleBuildId(params.buildId, res)) {
+          reloadTheBrowser(res)
+          return
+        }
+
         const p = join(this.dir, '.next/commons.js')
         await this.serveStatic(req, res, p)
       },
@@ -301,4 +309,9 @@ export default class Server {
     const p = resolveFromList(id, errors.keys())
     if (p) return errors.get(p)[0]
   }
+}
+
+function reloadTheBrowser (res) {
+  res.setHeader('Content-Type', 'text/javascript')
+  res.end('location.reload()')
 }

--- a/test/integration/basic/pages/force-reload.js
+++ b/test/integration/basic/pages/force-reload.js
@@ -1,0 +1,33 @@
+/* global localStorage */
+import React, { Component } from 'react'
+import Router, { _reload } from 'next/router'
+
+let counter = 0
+
+export default class extends Component {
+
+  increase () {
+    counter++
+    this.forceUpdate()
+  }
+
+  render () {
+    return (
+      <div className='force-reload'>
+        <div id='counter'>
+          Counter: {counter}
+        </div>
+        <button id='increase' onClick={() => this.increase()}>Increase</button>
+        <button id='reload' onClick={() => _reload()}>Reload</button>
+      </div>
+    )
+  }
+}
+
+Router.onBeforeReload = function (key) {
+  localStorage.setItem(key, counter)
+}
+
+Router.onAfterReload = function (key) {
+  counter = parseInt(localStorage.getItem(key))
+}

--- a/test/integration/basic/pages/force-reload.js
+++ b/test/integration/basic/pages/force-reload.js
@@ -1,6 +1,6 @@
 /* global localStorage */
 import React, { Component } from 'react'
-import Router, { _reload } from 'next/router'
+import Router, { _forceReload } from 'next/router'
 
 let counter = 0
 
@@ -18,7 +18,7 @@ export default class extends Component {
           Counter: {counter}
         </div>
         <button id='increase' onClick={() => this.increase()}>Increase</button>
-        <button id='reload' onClick={() => _reload()}>Reload</button>
+        <button id='reload' onClick={() => _forceReload()}>Reload</button>
       </div>
     )
   }

--- a/test/integration/basic/test/misc.js
+++ b/test/integration/basic/test/misc.js
@@ -1,6 +1,7 @@
 /* global describe, test, expect */
+import webdriver from 'next-webdriver'
 
-export default function ({ app }) {
+export default function (context) {
   describe('Misc', () => {
     test('finishes response', async () => {
       const res = {
@@ -9,8 +10,25 @@ export default function ({ app }) {
           this.finished = true
         }
       }
-      const html = await app.renderToHTML({}, res, '/finish-response', {})
+      const html = await context.app.renderToHTML({}, res, '/finish-response', {})
       expect(html).toBeFalsy()
+    })
+
+    test('should allow to persist while force reload', async () => {
+      const browser = await webdriver(context.appPort, '/force-reload')
+      const countText = await browser
+        .elementByCss('#increase').click()
+        .elementByCss('#increase').click()
+        .elementByCss('#counter').text()
+
+      expect(countText).toBe('Counter: 2')
+
+      await browser.elementByCss('#reload').click()
+
+      const newCountText = await browser.elementByCss('#counter').text()
+      expect(newCountText).toBe(countText)
+
+      await browser.close()
     })
   })
 }


### PR DESCRIPTION
Related to https://github.com/zeit/next.js/issues/786

In this case, we'll do a reload when we detect a buildId mismatch.
With the reload, it'll load the newest version of the app.

With this reload, it might destroy the app's state. So, we've a way to restore the state.

Let's assume our client side state stored in a variable called `state`. Then this is how we use reload hooks to restore the state .

```js
let state = {}

Router.onBeforeReload = function (key) {
  localStorage.setItem(key, JSON.stringify(state))
}

Router.onAfterReload = function (key) {
  const data = (localStorage.getItem(key))
  if (!data) return

  const state = JSON.parse(data)
}
```