### PR TITLE
Disable informational console logging

### DIFF
--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -1,4 +1,4 @@
-import webpackHotMiddlewareClient from 'webpack-hot-middleware/client?overlay=false&reload=true'
+import webpackHotMiddlewareClient from 'webpack-hot-middleware/client?overlay=false&reload=true&noInfo=true'
 import Router from '../lib/router'
 
 const handlers = {


### PR DESCRIPTION
I have a suggestion for a less 'messy' dev experience.
Maybe it's possible to disable all the **informational** console logging of ```webpack-hot-middleware```?

Instead of having this every time, with every refresh: 
<img width="1436" alt="screen shot 2017-02-20 at 19 21 13" src="https://cloud.githubusercontent.com/assets/23201486/23140630/efddcc00-f7b2-11e6-993b-cd4ec972b55b.png">

It would look like this, cleaner: 
<img width="1437" alt="screen shot 2017-02-20 at 19 21 50" src="https://cloud.githubusercontent.com/assets/23201486/23140635/f68f84b2-f7b2-11e6-98be-5f13d64d97d7.png">

Warnings and errors will still be shown, just not all the console logging.
<img width="1439" alt="screen shot 2017-02-20 at 19 22 38" src="https://cloud.githubusercontent.com/assets/23201486/23140639/f97e9a8c-f7b2-11e6-95a9-53d3413ece12.png">
