### PR TITLE
fix: cmd+click Links

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -25,7 +25,7 @@ export default class Link extends Component {
   }
 
   linkClicked (e) {
-    if (e.target.nodeName === 'A' &&
+    if (e.currentTarget.nodeName === 'A' &&
       (e.metaKey || e.ctrlKey || e.shiftKey || (e.nativeEvent && e.nativeEvent.which === 2))) {
       // ignore click for new tab / new window behavior
       return


### PR DESCRIPTION
If an anchor tag wraps a DOM element, the click target will be the nested element, not the anchor. This is an issue when the **Link** component is checking for modifier keys, i.e. cmd + click to open a new tab.

To fix, check `currentTarget` instead.
