### PR TITLE
Expose the Router.changeState to change the state directly.

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -14,7 +14,7 @@ const SingletonRouter = {
 
 // Create public properties and methods of the router in the SingletonRouter
 const propertyFields = ['components', 'pathname', 'route', 'query']
-const coreMethodFields = ['push', 'replace', 'reload', 'back', 'prefetch']
+const coreMethodFields = ['push', 'replace', 'reload', 'back', 'prefetch', 'changeState']
 const routerEvents = ['routeChangeStart', 'routeChangeComplete', 'routeChangeError']
 
 propertyFields.forEach((field) => {

--- a/readme.md
+++ b/readme.md
@@ -297,8 +297,9 @@ Above `Router` object comes with the following API:
 - `query` - `Object` with the parsed query string. Defaults to `{}`
 - `push(url, as=url)` - performs a `pushState` call with the given url
 - `replace(url, as=url)` - performs a `replaceState` call with the given url
+- `changeState(method, url, as=url)` - change the `history.state` directly. value for `method` should be either `pushState` or `replaceState`.
 
-The second `as` parameter for `push` and `replace` is an optional _decoration_ of the URL. Useful if you configured custom routes on the server.
+The `as` parameter for `push`, `replace` and `changeState` is an optional _decoration_ of the URL. Useful if you configured custom routes on the server.
 
 _Note: in order to programmatically change the route without triggering navigation and component-fetching, use `props.url.push` and `props.url.replace` within a component_
 


### PR DESCRIPTION
This is way to change the `history.state` directly. Basically, you can use this instead of `history.replaceState`  or `history.replaceState`

Examples:

```js
import Router from 'next/router'

Router.changeState('replaceState', '/page', '/masked/url')
Router.changeState('replaceState', '/page', '/page#hash-change')
```