### PR TITLE
Run tests sequentially in the CI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "testonly": "cross-env NODE_PATH=test/lib jest \\.test.js",
     "posttestonly": "fly posttest",
     "pretest": "npm run lint && cross-env NODE_ENV=test-build npm run release",
-    "test": "npm run testonly -- --coverage --forceExit",
+    "test": "npm run testonly -- --coverage --forceExit --runInBand",
     "coveralls": "nyc --instrument=false --source-map=false report --temp-directory=./coverage --reporter=text-lcov | coveralls",
     "lint": "standard 'bin/*' 'client/**/*.js' 'examples/**/*.js' 'lib/**/*.js' 'pages/**/*.js' 'server/**/*.js' 'test/**/*.js'",
     "prepublish": "npm run release",


### PR DESCRIPTION
This potentially avoids timeout errors in the CI.