### PR TITLE
Add passHref Prop

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -95,7 +95,7 @@ export default class Link extends Component {
     }
 
     // If child is an <a> tag and doesn't have a href attribute we specify it so that repetition is not needed by the user
-    if (child.type === 'a' && !('href' in child.props)) {
+    if ((child.type === 'a' && !('href' in child.props)) || this.props.passHref) {
       props.href = this.props.as || this.props.href
     }
 


### PR DESCRIPTION
This is in response to https://github.com/zeit/next.js/issues/1271 to add in the ability to force `passHref` when you may have an anchor element below but wrapped as a component or otherwise.