### PR TITLE
Render styled-jsx in _document example

### DIFF
--- a/examples/with-cxs/pages/_document.js
+++ b/examples/with-cxs/pages/_document.js
@@ -4,7 +4,7 @@ import cxs from 'cxs'
 export default class MyDocument extends Document {
   static async getInitialProps ({ renderPage }) {
     const page = renderPage()
-    let style = cxs.getCss()
+    const style = cxs.getCss()
     return { ...page, style }
   }
 

--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -4,8 +4,8 @@ import styleSheet from 'styled-components/lib/models/StyleSheet'
 export default class MyDocument extends Document {
   static async getInitialProps ({ renderPage }) {
     const page = renderPage()
-    const style = styleSheet.rules().map(rule => rule.cssText).join('\n')
-    return { ...page, style }
+    const styles = styleSheet.rules().map(rule => rule.cssText).join('\n')
+    return { ...page, styles }
   }
 
   render () {
@@ -13,7 +13,6 @@ export default class MyDocument extends Document {
       <html>
         <Head>
           <title>My page</title>
-          <style dangerouslySetInnerHTML={{ __html: this.props.style }} />
         </Head>
         <body>
           <Main />

--- a/readme.md
+++ b/readme.md
@@ -473,11 +473,13 @@ Pages in `Next.js` skip the definition of the surrounding document's markup. For
 ```jsx
 // ./pages/_document.js
 import Document, { Head, Main, NextScript } from 'next/document'
+import flush from 'styled-jsx/server'
 
 export default class MyDocument extends Document {
-  static async getInitialProps (ctx) {
-    const props = await Document.getInitialProps(ctx)
-    return { ...props, customValue: 'hi there!' }
+  static getInitialProps ({ renderPage }) {
+    const {html, head} = renderPage()
+    const styles = flush()
+    return { html, head, styles }
   }
 
   render () {


### PR DESCRIPTION
Fixes #1236

The reason we have to do this is that when provided `_document` will override our `Document` class. `_document` will extend our `Document` class. But given that we override `getInitialProps` in `_document` we have to copy over its contents, including styled-jsx. Otherwise they are not server-rendered which will cause the FOUC mentioned in #1236.
