### PR TITLE
[WIP] Make the on-demand-entries opt-in

### DIFF
--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -149,17 +149,20 @@ export default class HotReloader {
     })
 
     this.webpackHotMiddleware = webpackHotMiddleware(compiler, { log: false })
-    this.onDemandEntries = onDemandEntryHandler(this.webpackDevMiddleware, compiler, {
-      dir: this.dir,
-      dev: true,
-      ...this.config.onDemandEntries
-    })
 
     this.middlewares = [
       this.webpackDevMiddleware,
-      this.webpackHotMiddleware,
-      this.onDemandEntries.middleware()
+      this.webpackHotMiddleware
     ]
+
+    if (this.config.onDemandEntries) {
+      this.onDemandEntries = onDemandEntryHandler(this.webpackDevMiddleware, compiler, {
+        dir: this.dir,
+        dev: true,
+        ...this.config.onDemandEntries
+      })
+      this.middlewares.push(this.onDemandEntries.middleware())
+    }
   }
 
   waitUntilValid () {
@@ -196,7 +199,9 @@ export default class HotReloader {
   }
 
   ensurePage (page) {
-    return this.onDemandEntries.ensurePage(page)
+    if (this.onDemandEntries) {
+      return this.onDemandEntries.ensurePage(page)
+    }
   }
 }
 


### PR DESCRIPTION
Due to this: https://github.com/zeit/next.js/issues/1296

The slowness of the ^^^ mentioned app due to the use of heavy NPM modules. (Most probably). Once we introduce the static build, that won't be a problem.

Just for now, I think it's better to make "on-demand-entries" opt-in.