### PR TITLE
Unregister old serviceworker code

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -7,6 +7,24 @@ import { loadGetInitialProps, getLocationOrigin } from '../utils'
 import { _notifyBuildIdMismatch } from './'
 import fetch from 'unfetch'
 
+if (typeof window !== 'undefined' && typeof navigator.serviceWorker !== 'undefined') {
+  navigator.serviceWorker.getRegistrations()
+    .then(registrations => {
+      registrations.forEach(registration => {
+        if (!registration.active) {
+          return
+        }
+
+        if (registration.active.scriptURL.indexOf('_next-prefetcher.js') === -1) {
+          return
+        }
+
+        console.warn(`Unregistered deprecated 'next/prefetch' ServiceWorker. See https://github.com/zeit/next.js#prefetching-pages`)
+        registration.unregister()
+      })
+    })
+}
+
 export default class Router extends EventEmitter {
   constructor (pathname, query, { Component, ErrorComponent, err } = {}) {
     super()


### PR DESCRIPTION
Bring back https://github.com/zeit/next.js/commit/1b9e8771ec569def1773040b68f404c2cbc9484e with a check for the prefetch serviceworker + if serviceWorkers are supported by the browser

Fixes #1205