### PR TITLE
Fix reloading the page when there's an HMR

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -85,6 +85,10 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
       name: 'commons',
       filename: 'commons.js',
       minChunks (module, count) {
+        // In the dev we use on-deman-entries.
+        // So, it makes no sense to use commonChunks with that.
+        if (dev) return false
+
         // NOTE: it depends on the fact that the entry funtion is always called
         // before applying CommonsChunkPlugin
         return count >= minChunks


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/zeit/next.js/issues/1296#issuecomment-282861492

We do this by disabling the CommonChunksPlugin's use in the dev.
With the on-demand-entires, this makes no sense.