### PR TITLE
Fire the route cancelled error right away.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -70,10 +70,10 @@ export default class Router extends EventEmitter {
       return
     }
 
-    this.abortComponentLoad()
-
     const { url, as } = e.state
     const { pathname, query } = parse(url, true)
+
+    this.abortComponentLoad(as)
 
     if (!this.urlIsNew(pathname, query)) {
       this.emit('routeChangeStart', as)
@@ -91,7 +91,6 @@ export default class Router extends EventEmitter {
     } = await this.getRouteInfo(route, pathname, query, as)
 
     if (error && error.cancelled) {
-      this.emit('routeChangeError', error, as)
       return
     }
 
@@ -132,7 +131,6 @@ export default class Router extends EventEmitter {
     } = await this.getRouteInfo(route, pathname, query, url)
 
     if (error && error.cancelled) {
-      this.emit('routeChangeError', error, url)
       return
     }
 
@@ -159,7 +157,7 @@ export default class Router extends EventEmitter {
   }
 
   async change (method, url, as) {
-    this.abortComponentLoad()
+    this.abortComponentLoad(as)
     const { pathname, query } = parse(url, true)
 
     // If asked to change the current URL we should reload the current page
@@ -178,7 +176,6 @@ export default class Router extends EventEmitter {
     } = await this.getRouteInfo(route, pathname, query, as)
 
     if (error && error.cancelled) {
-      this.emit('routeChangeError', error, as)
       return false
     }
 
@@ -331,7 +328,8 @@ export default class Router extends EventEmitter {
     })
   }
 
-  abortComponentLoad () {
+  abortComponentLoad (as) {
+    this.emit('routeChangeError', new Error('Route Cancelled'), as)
     if (this.componentLoadCancel) {
       this.componentLoadCancel()
       this.componentLoadCancel = null


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/1310

Earlier it wait until the JSON page is fetched.
But that's wrong and it affects when using libs like NProgress.