### PR TITLE
Fire the route cancel event only when needed.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -329,8 +329,8 @@ export default class Router extends EventEmitter {
   }
 
   abortComponentLoad (as) {
-    this.emit('routeChangeError', new Error('Route Cancelled'), as)
     if (this.componentLoadCancel) {
+      this.emit('routeChangeError', new Error('Route Cancelled'), as)
       this.componentLoadCancel()
       this.componentLoadCancel = null
     }


### PR DESCRIPTION
Earlier we do it for every route change.