### PR TITLE
Add a global Promise polyfill.

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -7,6 +7,15 @@ import App from '../lib/app'
 import evalScript from '../lib/eval-script'
 import { loadGetInitialProps, getURL } from '../lib/utils'
 
+// Polyfill Promise globally
+// This is needed because Webpack2's dynamic loading(common chunks) code
+// depends on Promise.
+// So, we need to polyfill it.
+// See: https://github.com/webpack/webpack/issues/4254
+if (!window.Promise) {
+  window.Promise = Promise
+}
+
 const {
   __NEXT_DATA__: {
     component,

--- a/client/next.js
+++ b/client/next.js
@@ -1,12 +1,3 @@
 import next from './'
 
-// Polyfill Promise globally
-// This is needed because Webpack2's dynamic loading(common chunks) code
-// depends on Promise.
-// So, we need to polyfill it.
-// See: https://github.com/webpack/webpack/issues/4254
-if (!window.Promise) {
-  window.Promise = Promise
-}
-
 next()

--- a/client/next.js
+++ b/client/next.js
@@ -1,3 +1,12 @@
 import next from './'
 
+// Polyfill Promise globally
+// This is needed because Webpack2's dynamic loading(common chunks) code
+// depends on Promise.
+// So, we need to polyfill it.
+// See: https://github.com/webpack/webpack/issues/4254
+if (!window.Promise) {
+  window.Promise = Promise
+}
+
 next()


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/975

This is needed because Webpack2's dynamic loading(common chunks) code
depends on Promise.
So, we need to polyfill it.
See: https://github.com/webpack/webpack/issues/4254