### PR TITLE
Revert "Update cross-env to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "cheerio": "0.22.0",
     "chromedriver": "2.26.1",
     "coveralls": "2.11.16",
-    "cross-env": "3.2.0",
+    "cross-env": "3.1.4",
     "fly": "2.0.5",
     "fly-babel": "2.1.1",
     "fly-clear": "1.0.1",


### PR DESCRIPTION
Reverts zeit/next.js#1348

Due to some errors on travis which caused by this module.