### PR TITLE
Shallow routing changes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import { AppContainer } from 'react-hot-loader'
 import shallowEquals from './shallow-equals'
+import { warn } from './utils'
 
 const ErrorDebug = process.env.NODE_ENV === 'production'
   ? null : require('./error-debug').default
@@ -65,6 +66,32 @@ class Container extends Component {
 function createUrl (router) {
   return {
     query: router.query,
-    pathname: router.pathname
+    pathname: router.pathname,
+    back: () => {
+      warn(`Warning: 'url.back()' is deprecated. Use "window.history.back()"`)
+      router.back()
+    },
+    push: (url, as) => {
+      warn(`Warning: 'url.push()' is deprecated. Use "next/router" APIs.`)
+      return router.push(url, as)
+    },
+    pushTo: (href, as) => {
+      warn(`Warning: 'url.pushTo()' is deprecated. Use "next/router" APIs.`)
+      const pushRoute = as ? href : null
+      const pushUrl = as || href
+
+      return router.push(pushRoute, pushUrl)
+    },
+    replace: (url, as) => {
+      warn(`Warning: 'url.replace()' is deprecated. Use "next/router" APIs.`)
+      return router.replace(url, as)
+    },
+    replaceTo: (href, as) => {
+      warn(`Warning: 'url.replaceTo()' is deprecated. Use "next/router" APIs.`)
+      const replaceRoute = as ? href : null
+      const replaceUrl = as || href
+
+      return router.replace(replaceRoute, replaceUrl)
+    }
   }
 }

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -181,7 +181,7 @@ export default (context, render) => {
     })
 
     describe('with shallow routing', () => {
-      it('should not update the url without running getInitialProps', async () => {
+      it('should update the url without running getInitialProps', async () => {
         const browser = await webdriver(context.appPort, '/nav/shallow-routing')
         const counter = await browser
           .elementByCss('#increase').click()
@@ -196,7 +196,7 @@ export default (context, render) => {
         await browser.close()
       })
 
-      it('should handle back button and should not run getInitialProps', async () => {
+      it('should handle the back button and should not run getInitialProps', async () => {
         const browser = await webdriver(context.appPort, '/nav/shallow-routing')
         let counter = await browser
           .elementByCss('#increase').click()


### PR DESCRIPTION
Fixes some typos and added back the original `props.url` API. (With warnings)