### PR TITLE
[WIP] Add support for babel-preset-env.

### DIFF
--- a/client/patch-react.js
+++ b/client/patch-react.js
@@ -6,6 +6,9 @@ import React from 'react'
 let patched = false
 
 export default (handleError = () => {}) => {
+  // Temporarly stop patching React to support native class syntax for React
+  if (React) return
+
   if (patched) {
     throw new Error('React is already monkeypatched')
   }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-plugin-transform-react-jsx-source": "6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "0.3.2",
     "babel-plugin-transform-runtime": "6.22.0",
-    "babel-preset-latest": "6.22.0",
+    "babel-preset-env": "1.2.1",
     "babel-preset-react": "6.23.0",
     "babel-runtime": "6.23.0",
     "case-sensitive-paths-webpack-plugin": "1.1.4",

--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -13,8 +13,11 @@ const plugins = envPlugins[process.env.NODE_ENV] || []
 
 module.exports = {
   presets: [
-    [require.resolve('babel-preset-latest'), {
-      'es2015': { modules: false }
+    [require.resolve('babel-preset-env'), {
+      modules: false,
+      targets: {
+        browsers: ['last 2 Chrome versions']
+      }
     }],
     require.resolve('babel-preset-react')
   ],

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -190,13 +190,19 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
         const transpiled = babelCore.transform(content, {
           babelrc: false,
           sourceMaps: dev ? 'both' : false,
+          presets: [
+            [require.resolve('babel-preset-env'), {
+              targets: {
+                node: 'current'
+              }
+            }]
+          ],
           // Here we need to resolve all modules to the absolute paths.
           // Earlier we did it with the babel-preset.
           // But since we don't transpile ES2015 in the preset this is not resolving.
           // That's why we need to do it here.
           // See more: https://github.com/zeit/next.js/issues/951
           plugins: [
-            [require.resolve('babel-plugin-transform-es2015-modules-commonjs')],
             [
               require.resolve('babel-plugin-module-resolver'),
               {


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/1335

The goal of this PR is to reduce the bundle size and the re-build time.
But we can't see those benefits right away.

### Why?

* Due to the use of `env` preset,  we have to do two(2) babel transformation for both webpack and node (SSR).
* Size of the bundle (main.js) won't decrease because source-maps is the main reason for the big bundle.