### PR TITLE
Send credentials when fetching new route

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -343,6 +343,7 @@ export default class Router extends EventEmitter {
 
     return fetch(url, {
       method: 'GET',
+      credentials: 'same-origin',
       headers: { 'Accept': 'application/json' }
     })
   }


### PR DESCRIPTION
Currently if one is running a Next.js app protected by http basic auth, client side navigation fails with an unexpected error.

The reason is when fetching a new route via fetch on the client side, no credentials are sent along and the request fails with 401 Unauthorized.

I think it's safe to set `credentials` to `same-origin` in this case. This also matches the default behaviour of `XMLHttpRequest` which is used by `unfetch` when ponyfilling.

There is another fetch call in `client/on-demand-entries-client.js` that might need to be set to `same-origin`. But as it's dev only, it isn't strictly necessary.