### PR TITLE
Make routing documentation more coherent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -359,7 +359,7 @@ Router.onAppUpdated = (nextUrl) => {
   </ul>
 </details></p>
 
-Shallow routig allows you to change the URL without running `getInitialProps`. You'll receive the updated `pathname` and the `query` via the `url` prop of the same page that's loaded, without losing state.
+Shallow routing allows you to change the URL without running `getInitialProps`. You'll receive the updated `pathname` and the `query` via the `url` prop of the same page that's loaded, without losing state.
 
 You can do this by invoking either `Router.push` or `Router.replace` with `shallow: true` option. Here's an example:
 

--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ _Note: `getInitialProps` can **not** be used in children components. Only in `pa
 </details></p>
 
 Client-side routing behaves exactly like the browser:
+
 1. The component is fetched
 2. If it defines `getInitialProps`, data is fetched. If an error occurs, `_error.js` is rendered
 3. After 1 and 2 complete, `pushState` is performed and the new component rendered


### PR DESCRIPTION
- add missing documentation (e.g `as` is undocumented in declarative <Link>)
- remove documentation redundancies
- hide away the inline examples in "details" snippet

The improvements are not perfect, but if they are good enough, suggest to merge and refine in later PR.

- [ ] update TOC (how?)