### PR TITLE
Fix styled-components server-render example

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -4,7 +4,9 @@ import styleSheet from 'styled-components/lib/models/StyleSheet'
 export default class MyDocument extends Document {
   static async getInitialProps ({ renderPage }) {
     const page = renderPage()
-    const styles = styleSheet.rules().map(rule => rule.cssText).join('\n')
+    const styles = (
+      <style dangerouslySetInnerHTML={{ __html: styleSheet.rules().map(rule => rule.cssText).join('\n') }} />
+    )
     return { ...page, styles }
   }
 


### PR DESCRIPTION
This fix the issue I reported here #1381.

To use the `styles` prop in the `getInitialProps` of `pages/_document.js` you need to return a React element instead of a string.