### PR TITLE
Ping to on-demand-entries on every page change.

### DIFF
--- a/client/on-demand-entries-client.js
+++ b/client/on-demand-entries-client.js
@@ -3,6 +3,12 @@
 import Router from '../lib/router'
 import fetch from 'unfetch'
 
+const originalRouteChangeComplete = Router.onRouteChangeComplete
+Router.onRouteChangeComplete = (...args) => {
+  if (originalRouteChangeComplete) originalRouteChangeComplete(...args)
+  ping()
+}
+
 async function ping () {
   try {
     const url = `/_next/on-demand-entries-ping?page=${Router.pathname}`


### PR DESCRIPTION
This will prevent disposing the page after viewing it.
Otherwise, it'll possible to dispose the page even we load the page on the client.