### PR TITLE
Allow overriding the Server module with a subclass

### DIFF
--- a/bin/next-dev
+++ b/bin/next-dev
@@ -3,9 +3,11 @@ import 'source-map-support/register'
 import { resolve, join } from 'path'
 import parseArgs from 'minimist'
 import { existsSync, readFileSync } from 'fs'
-import Server from '../server'
+import getConfig from '../server/config'
 import { printAndExit } from '../lib/utils'
 import pkgUp from 'pkg-up'
+
+const { Server } = getConfig(process.cwd())
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 

--- a/bin/next-start
+++ b/bin/next-start
@@ -2,8 +2,10 @@
 
 import { resolve } from 'path'
 import parseArgs from 'minimist'
-import Server from '../server'
+import getConfig from '../server/config'
 import { existsSync } from 'fs'
+
+const { Server } = getConfig(process.cwd())
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 

--- a/examples/server-subclass/README.md
+++ b/examples/server-subclass/README.md
@@ -1,0 +1,32 @@
+
+# Server subclass example
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/server-subclass
+cd server-subclass
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+Next provides 2 main ways to run the server - either using the built-in http handling provided by `server/index.js`, or by [running your own custom server](https://github.com/zeit/next.js#custom-server-and-routing). This approach is between the all-or-nothing approaches, allowing you to override server methods without losing all of the dev tooling provided by the `next` command.
+
+This example shows you how you could replace the http server (and add custom routes) while still running your application with `next dev` or `next start`.
+
+Note that because the server.js uses async/await, this example only runs in node.js >= 7.6.

--- a/examples/server-subclass/next.config.js
+++ b/examples/server-subclass/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  Server: require('./server')
+}

--- a/examples/server-subclass/package.json
+++ b/examples/server-subclass/package.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^2.0.0-beta",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
+  },
+  "engines" : { "node" : ">=7.6" }
+}

--- a/examples/server-subclass/pages/index.js
+++ b/examples/server-subclass/pages/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import Link from 'next/link'
+
+export default () => (
+  <ul>
+    <li><Link href='/things?id=1' as='/things/1'><a>Thing 1</a></Link></li>
+  </ul>
+)

--- a/examples/server-subclass/pages/things.js
+++ b/examples/server-subclass/pages/things.js
@@ -1,0 +1,17 @@
+import { Component } from 'react'
+import Link from 'next/link'
+
+export default class Things extends Component {
+  render () {
+    const id = parseInt(this.props.url.query.id, 10)
+    const nextThing = id + 1
+    return (
+      <div>
+        <h2>Welcome to Thing {id}</h2>
+        <Link href={`/things?id=${nextThing}`} as={`/things/${nextThing}`}>
+          <a>Thing {nextThing}</a>
+        </Link>
+      </div>
+    )
+  }
+}

--- a/examples/server-subclass/server.js
+++ b/examples/server-subclass/server.js
@@ -1,0 +1,38 @@
+const { createServer } = require('http')
+const Server = require('next/server')
+
+const thingsPattern = /^\/things\/?(.*)/
+
+class MyServer extends Server {
+  constructor () {
+    super(...arguments)
+    // you can override properties for instance
+    this.quiet = false
+  }
+  // override the start method to provide a custom server
+  async start (port, hostname) {
+    await this.prepare()
+    const handle = this.getRequestHandler()
+    this.http = createServer((req, res) => {
+      // custom route matching - in this case, we convert URLs from parameterized to query based
+      const matches = req.url.match(thingsPattern)
+      if (matches) {
+        req.query.path = matches[1].split('/')
+        req.url = '/things'
+        this.render(req, res, req.url, req.query)
+      } else {
+        // fallback to default handling
+        handle(req, res)
+      }
+    })
+    // this is just copied from next's server/index.js
+    await new Promise((resolve, reject) => {
+      // This code catches EADDRINUSE error if the port is already in use
+      this.http.on('error', reject)
+      this.http.on('listening', () => resolve())
+      this.http.listen(port, hostname)
+    })
+  }
+}
+
+module.exports = MyServer

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "document.js",
     "prefetch.js",
     "router.js",
-    "error.js"
+    "error.js",
+    "server.js"
   ],
   "bin": {
     "next": "./dist/bin/next"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/server').default

--- a/server/config.js
+++ b/server/config.js
@@ -1,11 +1,13 @@
 import { join } from 'path'
 import { existsSync } from 'fs'
+import Server from './index'
 
 const cache = new Map()
 
 const defaultConfig = {
   webpack: null,
-  poweredByHeader: true
+  poweredByHeader: true,
+  Server
 }
 
 export default function getConfig (dir) {


### PR DESCRIPTION
- add a new config option, `Server` - which can be provided a subclass of next/server to modify server functionality (such as routing)
- add the ability to `require('next/server')` for server subclasses
- add an example of usage

**background/comments**

I have been enjoying most of working with next.js, but found that the lack of a clear way to add parameterized routes was my biggest pain point in getting started and staying productive with the framework.

This PR is an attempt to provide an extension point so that we can customize server behavior without having to toss out the advantages of running via `next dev|start`. I've provided a patch that only adds a few lines of code, and an example of how one might take advantage of the new functionality to simplify parameterized routing.

To me, this is probably the biggest pain point in next, so even if this PR doesn't land, I'd love to chat about the willingness of the zeit team to explore adding params to the core API, or if extension points like this are the right path forward.

Thanks a bunch for the excellent lib, this is one of the closest projects I've seen to achieving the SSR holy grail.