### PR TITLE
Examples: Update Inferno & Preact

### DIFF
--- a/examples/using-inferno/package.json
+++ b/examples/using-inferno/package.json
@@ -7,13 +7,11 @@
     "start": "NODE_ENV=production node server.js"
   },
   "dependencies": {
-    "inferno": "^1.0.7",
-    "inferno-compat": "^1.0.7",
-    "inferno-server": "^1.3.0-rc.9",
+    "inferno": "^1.4.0",
+    "inferno-compat": "^1.4.0",
+    "inferno-server": "^1.4.0",
     "module-alias": "^2.0.0",
-    "next": "^2.0.0-beta",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "next": "^2.0.0-beta"
   },
   "author": "",
   "license": "MIT"

--- a/examples/using-preact/next.config.js
+++ b/examples/using-preact/next.config.js
@@ -11,10 +11,6 @@ module.exports = {
       'react-dom': 'preact-compat/dist/preact-compat'
     }
 
-    // Disable uglify. This has been fixed in https://github.com/developit/preact-compat/issues/155.
-    // Can be removed once there is a new preact-compat release.
-    config.plugins = config.plugins.filter((plugin) => (plugin.constructor.name !== 'UglifyJsPlugin'))
-
     return config
   }
 }

--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world",
+  "name": "using-preact",
   "version": "1.0.0",
   "scripts": {
     "dev": "node server.js",
@@ -9,15 +9,9 @@
   "dependencies": {
     "module-alias": "^2.0.0",
     "next": "^2.0.0-beta",
-    "preact": "^7.1.0",
-    "preact-compat": "^3.9.4",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "preact": "^7.2.0",
+    "preact-compat": "^3.14.0"
   },
   "author": "",
-  "license": "ISC",
-  "devDependencies": {
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0"
-  }
+  "license": "ISC"
 }


### PR DESCRIPTION
Bumped dependencies & removed irrelevant lines from each `package.json`. Also re-enabled UglifyJS for Preact.

Current benchmarks on my machine (continuing from [here](https://github.com/zeit/next.js/pull/1346#issuecomment-284147574)):

```
Preact:

Concurrency Level:      10
Time taken for tests:   1.452 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      13470000 bytes
HTML transferred:       13310000 bytes
Requests per second:    688.81 [#/sec] (mean)
Time per request:       14.518 [ms] (mean)
Time per request:       1.452 [ms] (mean, across all concurrent requests)
Transfer rate:          9060.82 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       3
Processing:    10   14   2.8     14      26
Waiting:       10   14   2.8     14      26
Total:         10   14   2.8     14      26

Percentage of the requests served within a certain time (ms)
  50%     14
  66%     15
  75%     15
  80%     16
  90%     19
  95%     21
  98%     23
  99%     24
 100%     26 (longest request)


Inferno:

Concurrency Level:      10
Time taken for tests:   1.524 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      13490000 bytes
HTML transferred:       13330000 bytes
Requests per second:    656.13 [#/sec] (mean)
Time per request:       15.241 [ms] (mean)
Time per request:       1.524 [ms] (mean, across all concurrent requests)
Transfer rate:          8643.76 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    10   15   2.7     14      28
Waiting:       10   15   2.7     14      28
Total:         10   15   2.7     15      28

Percentage of the requests served within a certain time (ms)
  50%     15
  66%     16
  75%     16
  80%     17
  90%     19
  95%     20
  98%     24
  99%     26
 100%     28 (longest request)
```

> **Note:** Each result is the final set after 5 immediate repeats. 