### PR TITLE
Load script with the defer attribute

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -65,7 +65,7 @@ export class NextScript extends Component {
     const hash = buildStats ? buildStats[filename].hash : '-'
 
     return (
-      <script type='text/javascript' src={`/_next/${hash}/${filename}`} />
+      <script type='text/javascript' src={`/_next/${hash}/${filename}`} defer />
     )
   }
 


### PR DESCRIPTION
Ref https://github.com/zeit/next.js/issues/1436

This will allow us to execute our core scripts after the first render.
This has issues with IE9. Since we don't support IE9 this won't be a problem.