### PR TITLE
Fixed a typo and Emphasized parts requiring beta^2.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -280,13 +280,13 @@ The second `as` parameter for `push` and `replace` is an optional _decoration_ o
   </ul>
 </details></p>
 
-The component `<Link>` can also receive an URL object and it will automatically format it to create the URL string.
+The component `<Link>` can also receive an URL object and it will automatically format it to create the URL string. _(^2.0.0-beta only)_
 
 ```jsx
 // pages/index.js
 import Link from 'next/link'
 export default () => (
-  <div>Click <Link href={{ pathname: 'about', query: { name: 'Zeit' }}}<a>here</a></Link> to read more</div>
+  <div>Click <Link href={{ pathname: 'about', query: { name: 'Zeit' }}}><a>here</a></Link> to read more</div>
 )
 ```
 
@@ -312,7 +312,7 @@ export default () => (
   </ul>
 </details></p>
 
-You can also do client-side page transitions using the `next/router`
+You can also do client-side page transitions using the `next/router` _(^2.0.0-beta only)_
 
 ```jsx
 import Router from 'next/router'
@@ -335,7 +335,7 @@ The second `as` parameter for `push` and `replace` is an optional _decoration_ o
 _Note: in order to programmatically change the route without triggering navigation and component-fetching, use `props.url.push` and `props.url.replace` within a component_
 
 ##### With URL object
-You can use an URL object the same way you use it in a `<Link>` component to `push` and `replace` an url.
+You can use an URL object the same way you use it in a `<Link>` component to `push` and `replace` an url. _(^2.0.0-beta only)_
 
 ```jsx
 import Router from 'next/router'


### PR DESCRIPTION
Fixed a typo in the example regarding URL objects in a Link's href. Added emphasis to points where the documentation requires ^2.0 and does not work in the current stable build