### PR TITLE
Fix client error modal not showing in dev (HMR)

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -52,18 +52,18 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
     // managing pages.
     if (dev) {
       for (const p of devPages) {
-        entries[join('bundles', p)] = `./${p}?entry`
+        entries[join('bundles', p)] = [`./${p}?entry`]
       }
     } else {
       for (const p of pages) {
-        entries[join('bundles', p)] = `./${p}?entry`
+        entries[join('bundles', p)] = [`./${p}?entry`]
       }
     }
 
     for (const p of defaultPages) {
       const entryName = join('bundles', 'pages', p)
       if (!entries[entryName]) {
-        entries[entryName] = [...defaultEntries, join(nextPagesDir, p) + '?entry']
+        entries[entryName] = [join(nextPagesDir, p) + '?entry']
       }
     }
 

--- a/server/on-demand-entry-handler.js
+++ b/server/on-demand-entry-handler.js
@@ -71,7 +71,7 @@ export default function onDemandEntryHandler (devMiddleware, compiler, {
       const pathname = await resolvePath(pagePath)
       const name = join('bundles', pathname.substring(dir.length))
 
-      const entry = `${pathname}?entry`
+      const entry = [`${pathname}?entry`]
 
       await new Promise((resolve, reject) => {
         const entryInfo = entries[page]

--- a/test/integration/basic/pages/hmr/about.js
+++ b/test/integration/basic/pages/hmr/about.js
@@ -1,0 +1,7 @@
+export default () => (
+  <div className='hmr-about-page'>
+    <p>
+      This is the about page.
+    </p>
+  </div>
+)

--- a/test/integration/basic/test/hmr.js
+++ b/test/integration/basic/test/hmr.js
@@ -1,0 +1,40 @@
+/* global describe, it, expect */
+import webdriver from 'next-webdriver'
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+export default (context, render) => {
+  describe('Hot Module Reloading', () => {
+    describe('syntax error', () => {
+      it('should detect the error and recover', async () => {
+        const browser = await webdriver(context.appPort, '/hmr/about')
+        const text = await browser
+          .elementByCss('p').text()
+        expect(text).toBe('This is the about page.')
+
+        const aboutPagePath = join(__dirname, '../', 'pages', 'hmr', 'about.js')
+
+        const originalContent = readFileSync(aboutPagePath, 'utf8')
+        const erroredContent = originalContent.replace('</div>', 'div')
+
+        // change the content
+        writeFileSync(aboutPagePath, erroredContent, 'utf8')
+
+        const errorMessage = await browser
+          .waitForElementByCss('pre')
+          .elementByCss('pre').text()
+        expect(errorMessage.includes('SyntaxError: Unterminated JSX contents')).toBeTruthy()
+
+        // add the original content
+        writeFileSync(aboutPagePath, originalContent, 'utf8')
+
+        const newContent = await browser
+          .waitForElementByCss('.hmr-about-page')
+          .elementByCss('p').text()
+        expect(newContent).toBe('This is the about page.')
+
+        browser.close()
+      })
+    })
+  })
+}

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -14,6 +14,7 @@ import xPoweredBy from './xpowered-by'
 import rendering from './rendering'
 import misc from './misc'
 import clientNavigation from './client-navigation'
+import hmr from './hmr'
 
 const context = {}
 context.app = nextServer({
@@ -57,4 +58,5 @@ describe('Basic Features', () => {
   xPoweredBy(context)
   misc(context)
   clientNavigation(context, (p, q) => renderViaHTTP(context.appPort, p, q))
+  hmr(context, (p, q) => renderViaHTTP(context.appPort, p, q))
 })


### PR DESCRIPTION
We normal show a error modal when there's an error on the code. (Detected via webpack HMR)
But this didn't work with beta.37

So, this PR fixes that.

In order to prevent future issues like this, now we've a test case too.