### PR TITLE
Handle pages with no default export and show an error.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -19,6 +19,11 @@ export default class App extends Component {
   render () {
     const { Component, props, hash, err, router } = this.props
     const url = createUrl(router)
+    // If there no component exported we can't proceed.
+    // We'll tackle that here.
+    if (typeof Component !== 'function') {
+      throw new Error(`The default export is not a React Component in page: "${url.pathname}"`)
+    }
     const containerProps = { Component, props, hash, router, url }
 
     return <div>

--- a/test/integration/basic/pages/no-default-export.js
+++ b/test/integration/basic/pages/no-default-export.js
@@ -1,0 +1,1 @@
+export default {}

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -58,6 +58,12 @@ export default function ({ app }, suiteName, render) {
       expect(html.includes('Zeit')).toBeTruthy()
     })
 
+    test('default export is not a React Component', async () => {
+      const $ = await get$('/no-default-export')
+      const pre = $('pre')
+      expect(pre.text()).toMatch(/The default export is not a React Component/)
+    })
+
     test('error', async () => {
       const $ = await get$('/error')
       expect($('pre').text()).toMatch(/This is an expected error/)


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/1462

That error is meaningful and easy to find the issue.