### PR TITLE
Wait until webpack updates before eval the JSON page.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -7,6 +7,8 @@ import PQueue from '../p-queue'
 import { loadGetInitialProps, getURL } from '../utils'
 import { _notifyBuildIdMismatch } from './'
 
+const webpackModule = module
+
 if (typeof window !== 'undefined' && typeof navigator.serviceWorker !== 'undefined') {
   navigator.serviceWorker.getRegistrations()
     .then(registrations => {
@@ -296,7 +298,7 @@ export default class Router {
     }
 
     const newData = {
-      ...loadComponent(jsonData),
+      ...await loadComponent(jsonData),
       jsonPageRes
     }
 
@@ -378,7 +380,19 @@ function toRoute (path) {
   return path.replace(/\/$/, '') || '/'
 }
 
-function loadComponent (jsonData) {
+async function loadComponent (jsonData) {
+  if (webpackModule && webpackModule.hot && webpackModule.hot.status() !== 'idle') {
+    await new Promise((resolve) => {
+      const check = (status) => {
+        if (status === 'idle') {
+          webpackModule.hot.removeStatusHandler(check)
+          resolve()
+        }
+      }
+      webpackModule.hot.status(check)
+    })
+  }
+
   const module = evalScript(jsonData.component)
   const Component = module.default || module
 


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/1510

Here's the scenario.

* We've a page called `two` and it uses a NPM module called 'abc'.
* Currently, we are in the page `one` and our vendor file doesn't have `abc`.
* So, now we are navigating to page `two` via client side.
* First webpack builds the `two` page and create the JSON page.
* It also adds `abc` to the vendor chunk and send a notification to the browser.
* In the meantime, we'll also receives the JSON page and we eval it.

There could be race condition between webpack updates `abc` module in the client and executing the JSON page. 

Ideally JSON page should eval after webpack received `abc` NPM module into the vendor chunk.

**This PR does that.**