### PR TITLE
Mobx leaks memory on server side

### DIFF
--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -2,9 +2,9 @@
   "name": "with-mobx",
   "version": "1.0.0",
   "scripts": {
-    "dev": "next",
+    "dev": "node server.js",
     "build": "next build",
-    "start": "next start"
+    "start": "NODE_ENV=production node server.js"
   },
   "dependencies": {
     "mobx": "^2.7.0",

--- a/examples/with-mobx/server.js
+++ b/examples/with-mobx/server.js
@@ -1,0 +1,20 @@
+const dev = process.env.NODE_ENV !== 'production';
+
+const { createServer } = require('http');
+const { parse } = require('url');
+const next = require('next');
+const mobxReact = require('mobx-react');
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+mobxReact.useStaticRendering(true);
+
+app.prepare().then(() => {
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(3000, err => {
+    if (err) throw err;
+    console.log('> Ready on http://localhost:3000');
+  });
+});

--- a/examples/with-mobx/server.js
+++ b/examples/with-mobx/server.js
@@ -1,20 +1,20 @@
-const dev = process.env.NODE_ENV !== 'production';
+const dev = process.env.NODE_ENV !== 'production'
 
-const { createServer } = require('http');
-const { parse } = require('url');
-const next = require('next');
-const mobxReact = require('mobx-react');
-const app = next({ dev });
-const handle = app.getRequestHandler();
+const { createServer } = require('http')
+const { parse } = require('url')
+const next = require('next')
+const mobxReact = require('mobx-react')
+const app = next({ dev })
+const handle = app.getRequestHandler()
 
-mobxReact.useStaticRendering(true);
+mobxReact.useStaticRendering(true)
 
 app.prepare().then(() => {
   createServer((req, res) => {
-    const parsedUrl = parse(req.url, true);
-    handle(req, res, parsedUrl);
+    const parsedUrl = parse(req.url, true)
+    handle(req, res, parsedUrl)
   }).listen(3000, err => {
-    if (err) throw err;
-    console.log('> Ready on http://localhost:3000');
-  });
-});
+    if (err) throw err
+    console.log('> Ready on http://localhost:3000')
+  })
+})


### PR DESCRIPTION
Current example of mobx observer usage leaks memory on server side, https://github.com/mobxjs/mobx-react/issues/140
In order to fix this server side render needs to configure / use the static rendering

This PR fixes it.