### PR TITLE
Add the system-ui font family

### DIFF
--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -50,7 +50,7 @@ const styles = {
   },
 
   heading: {
-    fontFamily: '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
+    fontFamily: '-apple-system, system-ui, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
     fontSize: '15px',
     fontWeight: 'bold',
     color: '#febfdd',


### PR DESCRIPTION
Rationale: the -apple-system and BlinkMacSystemFont aliases work only in Mac OS; there appears to be an emerging standard, however, to make this functionality work across the board. The new name is system-ui, and it resolves e.g. to Segoe UI on Windows, Roboto on Android, and so on.

See here: https://www.chromestatus.com/feature/5640395337760768

This is also incidentally consistent with the Bootstrap CSS framework: https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss#L247