### PR TITLE
Get rid of res.clone()

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -288,7 +288,14 @@ export default class Router {
     }
 
     const jsonPageRes = await this.fetchRoute(route)
-    const jsonData = await jsonPageRes.json()
+    let jsonData
+    // We can call .json() only once for a response.
+    // That's why we need to keep a copy of data if we already parsed it.
+    if (jsonPageRes.data) {
+      jsonData = jsonPageRes.data
+    } else {
+      jsonData = jsonPageRes.data = await jsonPageRes.json()
+    }
 
     if (jsonData.buildIdMismatch) {
       _notifyBuildIdMismatch(as)
@@ -336,16 +343,13 @@ export default class Router {
     return props
   }
 
-  async fetchRoute (route) {
+  fetchRoute (route) {
     let promise = this.fetchingRoutes[route]
     if (!promise) {
       promise = this.fetchingRoutes[route] = this.doFetchRoute(route)
     }
 
-    const res = await promise
-    // We need to clone this to prevent reading the body twice
-    // Because it's possible only once to read res.json() or a similar method.
-    return res.clone()
+    return promise
   }
 
   doFetchRoute (route) {


### PR DESCRIPTION
Usually res.clone() should work. But it's not working with the laster Safari (10.1)
It throws the following error when there's prefetching is enabled.

![screen shot 2017-03-30 at 7 29 59 pm](https://cloud.githubusercontent.com/assets/50838/24507863/4a5609ba-157f-11e7-8e8e-966e36e7bdd4.png)

So, it simply broke page navigation.

Now, we do not invoke `res.clone()` anymore.