### PR TITLE
Remove Service Worker unregister code.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -9,25 +9,6 @@ import { _notifyBuildIdMismatch } from './'
 
 const webpackModule = module
 
-if (typeof window !== 'undefined' && typeof navigator.serviceWorker !== 'undefined') {
-  navigator.serviceWorker.getRegistrations()
-    .then(registrations => {
-      registrations.forEach(registration => {
-        if (!registration.active) {
-          return
-        }
-
-        if (registration.active.scriptURL.indexOf('_next-prefetcher.js') === -1) {
-          return
-        }
-
-        console.warn(`Unregistered deprecated 'next/prefetch' ServiceWorker. See https://github.com/zeit/next.js#prefetching-pages`)
-        registration.unregister()
-      })
-    })
-    .catch(() => {})
-}
-
 export default class Router {
   constructor (pathname, query, as, { Component, ErrorComponent, err } = {}) {
     // represents the current component key


### PR DESCRIPTION
We don't need to do it now. Because, any running service workers
might have stopped by now.