### PR TITLE
Handle undefined assets when combining.

### DIFF
--- a/server/build/plugins/combine-assets-plugin.js
+++ b/server/build/plugins/combine-assets-plugin.js
@@ -11,7 +11,10 @@ export default class CombineAssetsPlugin {
     compiler.plugin('after-compile', (compilation, callback) => {
       let newSource = ''
       this.input.forEach((name) => {
-        newSource += `${compilation.assets[name].source()}\n`
+        const asset = compilation.assets[name]
+        if (!asset) return
+
+        newSource += `${asset.source()}\n`
         delete compilation.assets[name]
       })
 


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/1547

It's possible for `common.js` to be empty in certain cases.
So, we need to handle it.