### PR TITLE
Add `next export` for static builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ npm-debug.log
 # coverage
 .nyc_output
 coverage
+
+# osx
+.DS_Store

--- a/bin/next
+++ b/bin/next
@@ -21,6 +21,7 @@ const commands = new Set([
   'init',
   'build',
   'start',
+  'export',
   defaultCommand
 ])
 

--- a/bin/next-export
+++ b/bin/next-export
@@ -29,7 +29,7 @@ if (argv.help) {
     If no directory is provided, <dir> will be <root>/build.
 
     <root> represents where the compiled <dir> folder should go.
-    If no directory is provided, .next will be created in the current directory.
+    If no directory is provided, <root> will be the current directory.
   `)
   process.exit(0)
 }

--- a/bin/next-export
+++ b/bin/next-export
@@ -39,7 +39,7 @@ const dir = resolve(root, argv._[0] || 'build')
 
 // Check if pages dir exists and warn if not
 if (!existsSync(root)) {
-  printAndExit(`> No such directory exists as the project root: ${dir}`)
+  printAndExit(`> No such directory exists as the project root: ${root}`)
 }
 
 if (!existsSync(join(root, 'pages'))) {

--- a/bin/next-export
+++ b/bin/next-export
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { resolve, join } from 'path'
+import { existsSync } from 'fs'
+import parseArgs from 'minimist'
+import Build from '../server/build'
+import Export from '../server/export'
+import { printAndExit } from '../lib/utils'
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+
+const argv = parseArgs(process.argv.slice(2), {
+  alias: {
+    h: 'help',
+    r: 'root'
+  },
+  boolean: ['h']
+})
+
+if (argv.help) {
+  console.log(`
+    Description
+      Compiles and exports the application to a static website
+
+    Usage
+      $ next export <dir>
+      $ next export --root <root> <dir>
+
+    <dir> represents where the static directory will go.
+    If no directory is provided, <dir> will be <root>/build.
+
+    <root> represents where the compiled <dir> folder should go.
+    If no directory is provided, .next will be created in the current directory.
+  `)
+  process.exit(0)
+}
+
+const root = resolve(argv['root'] || '.')
+const dir = resolve(root, argv._[0] || 'build')
+
+// Check if pages dir exists and warn if not
+if (!existsSync(root)) {
+  printAndExit(`> No such directory exists as the project root: ${dir}`)
+}
+
+if (!existsSync(join(root, 'pages'))) {
+  if (existsSync(join(root, '..', 'pages'))) {
+    printAndExit('> No `pages` directory found. Did you mean to run `next` in the parent (`../`) directory?')
+  }
+
+  printAndExit('> Couldn\'t find a `pages` directory. Please create one under the project root')
+}
+
+Build(root)
+.then(() => Export({ dir, root }))
+.catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/bin/next-export
+++ b/bin/next-export
@@ -11,7 +11,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
     h: 'help',
-    r: 'root'
+    o: 'out'
   },
   boolean: ['h']
 })
@@ -23,35 +23,35 @@ if (argv.help) {
 
     Usage
       $ next export <dir>
-      $ next export --root <root> <dir>
+      $ next export --out <out> <dir>
 
-    <dir> represents where the static directory will go.
-    If no directory is provided, <dir> will be <root>/build.
+    <dir> represents where the compiled folder should go.
+    If no directory is provided, <dir> will be the current directory.
 
-    <root> represents where the compiled <dir> folder should go.
-    If no directory is provided, <root> will be the current directory.
+    <out> represents where the static directory will go.
+    If no directory is provided, <out> will be <dir>/site.
   `)
   process.exit(0)
 }
 
-const root = resolve(argv['root'] || '.')
-const dir = resolve(root, argv._[0] || 'build')
+const dir = resolve(argv._[0] || '.')
+const out = resolve(dir, argv['out'] || 'site')
 
 // Check if pages dir exists and warn if not
-if (!existsSync(root)) {
-  printAndExit(`> No such directory exists as the project root: ${root}`)
+if (!existsSync(dir)) {
+  printAndExit(`> No such directory exists as the project root: ${dir}`)
 }
 
-if (!existsSync(join(root, 'pages'))) {
-  if (existsSync(join(root, '..', 'pages'))) {
+if (!existsSync(join(dir, 'pages'))) {
+  if (existsSync(join(dir, '..', 'pages'))) {
     printAndExit('> No `pages` directory found. Did you mean to run `next` in the parent (`../`) directory?')
   }
 
   printAndExit('> Couldn\'t find a `pages` directory. Please create one under the project root')
 }
 
-Build(root)
-.then(() => Export({ dir, root }))
+Build(dir)
+.then(() => Export({ dir, out }))
 .catch((err) => {
   console.error(err)
   process.exit(1)

--- a/client/index.js
+++ b/client/index.js
@@ -18,6 +18,7 @@ if (!window.Promise) {
 
 const {
   __NEXT_DATA__: {
+    exported,
     component,
     errorComponent,
     props,
@@ -35,7 +36,11 @@ let lastAppProps
 export const router = createRouter(pathname, query, getURL(), {
   Component,
   ErrorComponent,
-  err
+  err,
+  formatURL: exported && function (buildId, route) {
+    route = route && route.replace(/\/$/, '')
+    return route + '/index.json'
+  }
 })
 
 const headManager = new HeadManager()

--- a/client/index.js
+++ b/client/index.js
@@ -80,6 +80,9 @@ async function doRender ({ Component, props, hash, err, emitter }) {
     // fetch props if ErrorComponent was replaced with a page component by HMR
     const { pathname, query } = router
     props = await loadGetInitialProps(Component, { err, pathname, query })
+  } else if (exported) {
+    const { pathname, query } = router
+    props = await loadGetInitialProps(Component, { err, pathname, query })
   }
 
   if (emitter) {

--- a/client/index.js
+++ b/client/index.js
@@ -80,7 +80,7 @@ async function doRender ({ Component, props, hash, err, emitter }) {
     // fetch props if ErrorComponent was replaced with a page component by HMR
     const { pathname, query } = router
     props = await loadGetInitialProps(Component, { err, pathname, query })
-  } else if (exported) {
+  } else if (exported && !lastAppProps) {
     const { pathname, query } = router
     props = await loadGetInitialProps(Component, { err, pathname, query })
   }

--- a/client/index.js
+++ b/client/index.js
@@ -38,8 +38,7 @@ export const router = createRouter(pathname, query, getURL(), {
   ErrorComponent,
   err,
   formatURL: exported && function (buildId, route) {
-    route = route && route.replace(/\/$/, '')
-    return route + '/index.json'
+    return route ? route.replace(/\/$/, '') + '/index.json' : '/index.json'
   }
 })
 

--- a/client/index.js
+++ b/client/index.js
@@ -6,6 +6,7 @@ import { createRouter } from '../lib/router'
 import App from '../lib/app'
 import evalScript from '../lib/eval-script'
 import { loadGetInitialProps, getURL } from '../lib/utils'
+import querystring from 'querystring'
 
 // Polyfill Promise globally
 // This is needed because Webpack2's dynamic loading(common chunks) code
@@ -80,7 +81,8 @@ async function doRender ({ Component, props, hash, err, emitter }) {
     const { pathname, query } = router
     props = await loadGetInitialProps(Component, { err, pathname, query })
   } else if (exported && !lastAppProps) {
-    const { pathname, query } = router
+    const { pathname } = router
+    const query = querystring.parse(window.location.search.slice(1))
     props = await loadGetInitialProps(Component, { err, pathname, query })
   }
 

--- a/examples/static-export/pages/about.js
+++ b/examples/static-export/pages/about.js
@@ -7,17 +7,13 @@ export default class About extends Component {
     this.state = {}
   }
 
-  static async getInitialProps ({ build }) {
-    // this will get triggered on export!
-    // useful for pulling in markdown files
-    // during the build and doing other
-    // custom logic
-    if (build) return {}
+  static async getInitialProps (ctx) {
+    console.log('loading about!', ctx)
+    return {}
+  }
 
-    // Errors during the build will halt the build
-    // Errors on the client-side will get routed to "An unexpected error has occurred."
-    // throw new Error("can't build on client-side!")
-
+  static async getBuildProps (ctx) {
+    console.log('build props', ctx)
     return {}
   }
 

--- a/examples/static-export/pages/about.js
+++ b/examples/static-export/pages/about.js
@@ -1,0 +1,18 @@
+import { Component } from 'react'
+import Router from 'next/router'
+
+export default class About extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {}
+  }
+
+  render () {
+    return (
+      <div>
+        <h2>About Me</h2>
+        <a onClick={() => Router.push('/')}>Go Back to Index</a>
+      </div>
+    )
+  }
+}

--- a/examples/static-export/pages/about.js
+++ b/examples/static-export/pages/about.js
@@ -7,6 +7,20 @@ export default class About extends Component {
     this.state = {}
   }
 
+  static async getInitialProps ({ build }) {
+    // this will get triggered on export!
+    // useful for pulling in markdown files
+    // during the build and doing other
+    // custom logic
+    if (build) return {}
+
+    // Errors during the build will halt the build
+    // Errors on the client-side will get routed to "An unexpected error has occurred."
+    // throw new Error("can't build on client-side!")
+
+    return {}
+  }
+
   render () {
     return (
       <div>

--- a/examples/static-export/pages/about.js
+++ b/examples/static-export/pages/about.js
@@ -12,7 +12,7 @@ export default class About extends Component {
     return {}
   }
 
-  static async getBuildProps (ctx) {
+  static async getStaticInitialProps (ctx) {
     console.log('build props', ctx)
     return {}
   }

--- a/examples/static-export/pages/index.js
+++ b/examples/static-export/pages/index.js
@@ -1,0 +1,37 @@
+import { Component } from 'react'
+import Button from '../ui/button'
+import Link from 'next/link'
+
+export default class Index extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      answer: ''
+    }
+  }
+
+  static async getInitialProps ({ pathname }) {
+    return {
+      title: 'Hello Static Stack!'
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        <h2>{this.props.title}</h2>
+        <Link href='/about'><a>Learn more about me</a></Link>
+        <br />
+        <br />
+        <Button onClick={() => this.setState({ answer: 'yes.' })}>
+          Did Rehydration Work?
+        </Button>
+        <br />
+        <br />
+        <div>{this.state.answer}</div>
+        <br />
+        <Link href='/movies'><a>Check out the movies</a></Link>
+      </div>
+    )
+  }
+}

--- a/examples/static-export/pages/index.js
+++ b/examples/static-export/pages/index.js
@@ -31,6 +31,7 @@ export default class Index extends Component {
         <div>{this.state.answer}</div>
         <br />
         <Link href='/movies'><a>Check out the movies</a></Link>
+        <a onClick={() => (document.location.pathname = '/about')}>Go to my about page</a>
       </div>
     )
   }

--- a/examples/static-export/pages/movies/index.js
+++ b/examples/static-export/pages/movies/index.js
@@ -1,0 +1,19 @@
+
+import { Component } from 'react'
+import Link from 'next/link'
+
+export default class Movies extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {}
+  }
+
+  render (props) {
+    return (
+      <div>
+        <h2>Some of my favorite movies</h2>
+        <Link href='/'><a>Go Back to Index</a></Link>
+      </div>
+    )
+  }
+}

--- a/examples/static-export/ui/button.js
+++ b/examples/static-export/ui/button.js
@@ -1,0 +1,3 @@
+export default ({ onClick, children }) => (
+  <button onClick={onClick}>{children}</button>
+)

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -10,7 +10,7 @@ import { _notifyBuildIdMismatch } from './'
 const webpackModule = module
 
 export default class Router {
-  constructor (pathname, query, as, { Component, ErrorComponent, err } = {}) {
+  constructor (pathname, query, as, { Component, ErrorComponent, err, formatURL } = {}) {
     // represents the current component key
     this.route = toRoute(pathname)
 
@@ -22,6 +22,7 @@ export default class Router {
 
     // Handling Router Events
     this.events = mitt()
+    this.formatURL = formatURL || this.formatURL
 
     this.prefetchQueue = new PQueue({ concurrency: 2 })
     this.ErrorComponent = ErrorComponent
@@ -333,10 +334,14 @@ export default class Router {
     return promise
   }
 
+  formatURL (buildId, route) {
+    return `/_next/${encodeURIComponent(buildId)}/pages${route}`
+  }
+
   doFetchRoute (route) {
     const { buildId } = window.__NEXT_DATA__
-    const url = `/_next/${encodeURIComponent(buildId)}/pages${route}`
-
+    const url = this.formatURL(buildId, route)
+    console.log('fetching url', url)
     return fetch(url, {
       method: 'GET',
       credentials: 'same-origin',

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -341,7 +341,6 @@ export default class Router {
   doFetchRoute (route) {
     const { buildId } = window.__NEXT_DATA__
     const url = this.formatURL(buildId, route)
-    console.log('fetching url', url)
     return fetch(url, {
       method: 'GET',
       credentials: 'same-origin',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,13 +54,13 @@ export async function loadGetInitialProps (Component, ctx) {
   return props
 }
 
-export async function loadGetBuildProps (Component, ctx) {
-  if (!Component.getBuildProps) return {}
+export async function loadGetStaticInitialProps (Component, ctx) {
+  if (!Component.getStaticInitialProps) return {}
 
-  const props = await Component.getBuildProps(ctx)
+  const props = await Component.getStaticInitialProps(ctx)
   if (!props) {
     const compName = Component.displayName || Component.name
-    const message = `"${compName}.getBuildProps()" should resolve to an object. But found "${props}" instead.`
+    const message = `"${compName}.getStaticInitialProps()" should resolve to an object. But found "${props}" instead.`
     throw new Error(message)
   }
   return props

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,6 +54,18 @@ export async function loadGetInitialProps (Component, ctx) {
   return props
 }
 
+export async function loadGetBuildProps (Component, ctx) {
+  if (!Component.getBuildProps) return {}
+
+  const props = await Component.getBuildProps(ctx)
+  if (!props) {
+    const compName = Component.displayName || Component.name
+    const message = `"${compName}.getBuildProps()" should resolve to an object. But found "${props}" instead.`
+    throw new Error(message)
+  }
+  return props
+}
+
 export function getLocationOrigin () {
   const { protocol, hostname, port } = window.location
   return `${protocol}//${hostname}${port ? ':' + port : ''}`

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "cross-spawn": "5.1.0",
     "del": "2.2.2",
     "friendly-errors-webpack-plugin": "1.5.0",
+    "fs-promise": "2.0.2",
     "glob-promise": "3.1.0",
     "htmlescape": "1.1.1",
     "http-status": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "mz": "2.6.0",
     "path-match": "1.2.4",
     "pkg-up": "1.0.0",
+    "querystring": "^0.2.0",
     "react-hot-loader": "3.0.0-beta.6",
     "send": "0.15.1",
     "source-map-support": "0.4.14",

--- a/server/document.js
+++ b/server/document.js
@@ -61,13 +61,13 @@ export class NextScript extends Component {
 
   getChunkScript (filename, additionalProps = {}) {
     const { __NEXT_DATA__ } = this.context._documentProps
-    let { buildStats } = __NEXT_DATA__
+    let { buildStats, exported } = __NEXT_DATA__
     const hash = buildStats ? buildStats[filename].hash : '-'
 
     return (
       <script
         type='text/javascript'
-        src={`/_next/${hash}/${filename}`}
+        src={exported ? `/${filename}` : `/_next/${hash}/${filename}`}
         {...additionalProps}
       />
     )

--- a/server/export.js
+++ b/server/export.js
@@ -45,7 +45,7 @@
      const pageName = getPageName(pageDir, page)
      const Component = require(page).default
      const query = {}
-     const ctx = { pathname, query, export: true }
+     const ctx = { pathname, query, build: true }
      const bundlePath = await resolve(join(nextPath, 'bundles', 'pages', pageName))
 
      const [

--- a/server/export.js
+++ b/server/export.js
@@ -4,7 +4,7 @@
 
  import { join, basename, dirname, extname, relative, resolve as pathResolve } from 'path'
  import { renderToString, renderToStaticMarkup } from 'react-dom/server'
- import { loadGetInitialProps } from '../lib/utils'
+ import { loadGetBuildProps } from '../lib/utils'
  import Head, { defaultHead } from '../lib/head'
  import { Router } from '../lib/router'
  import { createElement } from 'react'
@@ -53,7 +53,7 @@
       component,
       errorComponent
     ] = await Promise.all([
-      loadGetInitialProps(Component, ctx),
+      loadGetBuildProps(Component, ctx),
       readPage(bundlePath),
       readPage(join(nextPath, 'bundles', 'pages', '_error'))
     ])
@@ -79,7 +79,7 @@
        return { html, head }
      }
 
-     const docProps = await loadGetInitialProps(Document, Object.assign(ctx, { renderPage }))
+     const docProps = await loadGetBuildProps(Document, Object.assign(ctx, { renderPage }))
      const doc = createElement(Document, Object.assign({
        __NEXT_DATA__: {
          component: component,

--- a/server/export.js
+++ b/server/export.js
@@ -4,7 +4,7 @@
 
 import { join, basename, dirname, extname, relative, resolve as pathResolve } from 'path'
 import { renderToString, renderToStaticMarkup } from 'react-dom/server'
-import { loadGetBuildProps } from '../lib/utils'
+import { loadGetStaticInitialProps } from '../lib/utils'
 import Head, { defaultHead } from '../lib/head'
 import { Router } from '../lib/router'
 import { createElement } from 'react'
@@ -53,7 +53,7 @@ export default async function Export ({
       component,
       errorComponent
     ] = await Promise.all([
-      loadGetBuildProps(Component, ctx),
+      loadGetStaticInitialProps(Component, ctx),
       readPage(bundlePath),
       readPage(join(nextPath, 'bundles', 'pages', '_error'))
     ])
@@ -79,7 +79,7 @@ export default async function Export ({
       return { html, head }
     }
 
-    const docProps = await loadGetBuildProps(Document, Object.assign(ctx, { renderPage }))
+    const docProps = await loadGetStaticInitialProps(Document, Object.assign(ctx, { renderPage }))
     const doc = createElement(Document, Object.assign({
       __NEXT_DATA__: {
         component: component,

--- a/server/export.js
+++ b/server/export.js
@@ -21,13 +21,13 @@
 
  export default async function Export ({
   staticMarkup = false,
-  root = process.cwd(),
-  dir = 'build',
+  dir = process.cwd(),
+  out = 'site',
   dev = false
 } = {}) {
-   const nextPath = join(root, '.next')
+   const nextPath = join(dir, '.next')
    const pageDir = join(nextPath, 'dist', 'pages')
-   const exportPath = pathResolve(root, dir)
+   const exportPath = pathResolve(dir, out)
 
    let pages = await glob(join(pageDir, '**', '*.js'))
    pages = pages.filter(page => basename(page)[0] !== '_')
@@ -45,7 +45,7 @@
      const pageName = getPageName(pageDir, page)
      const Component = require(page).default
      const query = {}
-     const ctx = { pathname, query, build: true }
+     const ctx = { pathname, query }
      const bundlePath = await resolve(join(nextPath, 'bundles', 'pages', pageName))
 
      const [
@@ -110,7 +110,7 @@
    }))
 
    // copy over the static/
-   await fs.copy(join(root, 'static'), join(exportPath, 'static'))
+   await fs.copy(join(dir, 'static'), join(exportPath, 'static'))
  }
 
 // Turn the path into a route

--- a/server/export.js
+++ b/server/export.js
@@ -2,53 +2,53 @@
  * Module dependencies
  */
 
- import { join, basename, dirname, extname, relative, resolve as pathResolve } from 'path'
- import { renderToString, renderToStaticMarkup } from 'react-dom/server'
- import { loadGetBuildProps } from '../lib/utils'
- import Head, { defaultHead } from '../lib/head'
- import { Router } from '../lib/router'
- import { createElement } from 'react'
- import readPage from './read-page'
- import glob from 'glob-promise'
- import mkdir from 'mkdirp-then'
- import resolve from './resolve'
- import App from '../lib/app'
- import fs from 'fs-promise'
+import { join, basename, dirname, extname, relative, resolve as pathResolve } from 'path'
+import { renderToString, renderToStaticMarkup } from 'react-dom/server'
+import { loadGetBuildProps } from '../lib/utils'
+import Head, { defaultHead } from '../lib/head'
+import { Router } from '../lib/router'
+import { createElement } from 'react'
+import readPage from './read-page'
+import glob from 'glob-promise'
+import mkdir from 'mkdirp-then'
+import resolve from './resolve'
+import App from '../lib/app'
+import fs from 'fs-promise'
 
 /**
  * Export to Static HTML
  */
 
- export default async function Export ({
+export default async function Export ({
   staticMarkup = false,
   dir = process.cwd(),
   out = 'site',
   dev = false
 } = {}) {
-   const nextPath = join(dir, '.next')
-   const pageDir = join(nextPath, 'dist', 'pages')
-   const exportPath = pathResolve(dir, out)
+  const nextPath = join(dir, '.next')
+  const pageDir = join(nextPath, 'dist', 'pages')
+  const exportPath = pathResolve(dir, out)
 
-   let pages = await glob(join(pageDir, '**', '*.js'))
-   pages = pages.filter(page => basename(page)[0] !== '_')
+  let pages = await glob(join(pageDir, '**', '*.js'))
+  pages = pages.filter(page => basename(page)[0] !== '_')
 
   // load the top-level document
-   const Document = require(join(nextPath, 'dist', 'pages', '_document.js')).default
-   await mkdir(exportPath)
+  const Document = require(join(nextPath, 'dist', 'pages', '_document.js')).default
+  await mkdir(exportPath)
 
   // copy over the common bundle
-   await fs.copy(join(nextPath, 'app.js'), join(exportPath, 'app.js'))
+  await fs.copy(join(nextPath, 'app.js'), join(exportPath, 'app.js'))
 
   // build all the pages
-   await Promise.all(pages.map(async (page) => {
-     const pathname = toRoute(pageDir, page)
-     const pageName = getPageName(pageDir, page)
-     const Component = require(page).default
-     const query = {}
-     const ctx = { pathname, query }
-     const bundlePath = await resolve(join(nextPath, 'bundles', 'pages', pageName))
+  await Promise.all(pages.map(async (page) => {
+    const pathname = toRoute(pageDir, page)
+    const pageName = getPageName(pageDir, page)
+    const Component = require(page).default
+    const query = {}
+    const ctx = { pathname, query }
+    const bundlePath = await resolve(join(nextPath, 'bundles', 'pages', pageName))
 
-     const [
+    const [
       props,
       component,
       errorComponent
@@ -58,60 +58,60 @@
       readPage(join(nextPath, 'bundles', 'pages', '_error'))
     ])
 
-     const renderPage = () => {
-       const app = createElement(App, {
-         Component,
-         props,
+    const renderPage = () => {
+      const app = createElement(App, {
+        Component,
+        props,
         // TODO: figure out if err is relevant with `next build`
         // err: dev ? err : null,
-         router: new Router(pathname, query)
-       })
+        router: new Router(pathname, query)
+      })
 
-       const render = staticMarkup ? renderToStaticMarkup : renderToString
+      const render = staticMarkup ? renderToStaticMarkup : renderToString
 
-       let html
-       let head
-       try {
-         html = render(app)
-       } finally {
-         head = Head.rewind() || defaultHead()
-       }
-       return { html, head }
-     }
+      let html
+      let head
+      try {
+        html = render(app)
+      } finally {
+        head = Head.rewind() || defaultHead()
+      }
+      return { html, head }
+    }
 
-     const docProps = await loadGetBuildProps(Document, Object.assign(ctx, { renderPage }))
-     const doc = createElement(Document, Object.assign({
-       __NEXT_DATA__: {
-         component: component,
-         errorComponent,
-         props,
-         pathname,
-         query,
+    const docProps = await loadGetBuildProps(Document, Object.assign(ctx, { renderPage }))
+    const doc = createElement(Document, Object.assign({
+      __NEXT_DATA__: {
+        component: component,
+        errorComponent,
+        props,
+        pathname,
+        query,
         // TODO: figure out if we need/want build stats when we export
         // buildId,
         // buildStats,
-         exported: true
+        exported: true
         // TODO: needed for static builds?
         // err: (err && dev) ? errorToJSON(err) : null
-       },
-       dev,
-       staticMarkup
-     }, docProps))
+      },
+      dev,
+      staticMarkup
+    }, docProps))
 
-     const html = '<!DOCTYPE html>' + renderToStaticMarkup(doc)
+    const html = '<!DOCTYPE html>' + renderToStaticMarkup(doc)
 
     // write files
-     const htmlPath = join(exportPath, pathname)
-     await mkdir(htmlPath)
-     await fs.writeFile(join(htmlPath, 'index.html'), html)
+    const htmlPath = join(exportPath, pathname)
+    await mkdir(htmlPath)
+    await fs.writeFile(join(htmlPath, 'index.html'), html)
 
     // copy component bundle over
-     await fs.copy(bundlePath, join(htmlPath, 'index.json'))
-   }))
+    await fs.copy(bundlePath, join(htmlPath, 'index.json'))
+  }))
 
    // copy over the static/
-   await fs.copy(join(dir, 'static'), join(exportPath, 'static'))
- }
+  await fs.copy(join(dir, 'static'), join(exportPath, 'static'))
+}
 
 // Turn the path into a route
 //
@@ -119,24 +119,30 @@
 //  - index.js        => /
 //  - about.js        => /about
 //  - movies/index.js => /movies
- function toRoute (pageDir, entry) {
-   const page = '/' + relative(pageDir, entry)
-   const base = basename(page, extname(page))
-   if (base === 'index') {
-     const dir = dirname(page)
-     return dir === '/' ? '/' : dir
-   } else {
-     return '/' + base
-   }
- }
+function toRoute (pageDir, entry) {
+  const page = '/' + relative(pageDir, entry)
+  const base = basename(page, extname(page))
+  if (base === 'index') {
+    const dir = dirname(page)
+    return dir === '/' ? '/' : dir
+  } else {
+    return '/' + base
+  }
+}
 
- function getPageName (pageDir, entry) {
-   const page = '/' + relative(pageDir, entry)
-   const base = basename(page, extname(page))
-   if (base === 'index') {
-     const dir = basename(dirname(page))
-     return dir === '' ? 'index' : dir
-   } else {
-     return base
-   }
- }
+// Get the page name
+//
+// e.g.
+//  - index.js        => index
+//  - about.js        => about
+//  - movies/index.js => movies
+function getPageName (pageDir, entry) {
+  const page = '/' + relative(pageDir, entry)
+  const base = basename(page, extname(page))
+  if (base === 'index') {
+    const dir = basename(dirname(page))
+    return dir === '' ? 'index' : dir
+  } else {
+    return base
+  }
+}

--- a/server/export.js
+++ b/server/export.js
@@ -108,6 +108,9 @@
     // copy component bundle over
      await fs.copy(bundlePath, join(htmlPath, 'index.json'))
    }))
+
+   // copy over the static/
+   await fs.copy(join(root, 'static'), join(exportPath, 'static'))
  }
 
 // Turn the path into a route

--- a/server/export.js
+++ b/server/export.js
@@ -1,0 +1,139 @@
+/*
+ * Module dependencies
+ */
+
+ import { join, basename, dirname, extname, relative, resolve as pathResolve } from 'path'
+ import { renderToString, renderToStaticMarkup } from 'react-dom/server'
+ import { loadGetInitialProps } from '../lib/utils'
+ import Head, { defaultHead } from '../lib/head'
+ import { Router } from '../lib/router'
+ import { createElement } from 'react'
+ import readPage from './read-page'
+ import glob from 'glob-promise'
+ import mkdir from 'mkdirp-then'
+ import resolve from './resolve'
+ import App from '../lib/app'
+ import fs from 'fs-promise'
+
+/**
+ * Export to Static HTML
+ */
+
+ export default async function Export ({
+  staticMarkup = false,
+  root = process.cwd(),
+  dir = 'build',
+  dev = false
+} = {}) {
+   const nextPath = join(root, '.next')
+   const pageDir = join(nextPath, 'dist', 'pages')
+   const exportPath = pathResolve(root, dir)
+
+   let pages = await glob(join(pageDir, '**', '*.js'))
+   pages = pages.filter(page => basename(page)[0] !== '_')
+
+  // load the top-level document
+   const Document = require(join(nextPath, 'dist', 'pages', '_document.js')).default
+   await mkdir(exportPath)
+
+  // copy over the common bundle
+   await fs.copy(join(nextPath, 'app.js'), join(exportPath, 'app.js'))
+
+  // build all the pages
+   await Promise.all(pages.map(async (page) => {
+     const pathname = toRoute(pageDir, page)
+     const pageName = getPageName(pageDir, page)
+     const Component = require(page).default
+     const query = {}
+     const ctx = { pathname, query, export: true }
+     const bundlePath = await resolve(join(nextPath, 'bundles', 'pages', pageName))
+
+     const [
+      props,
+      component,
+      errorComponent
+    ] = await Promise.all([
+      loadGetInitialProps(Component, ctx),
+      readPage(bundlePath),
+      readPage(join(nextPath, 'bundles', 'pages', '_error'))
+    ])
+
+     const renderPage = () => {
+       const app = createElement(App, {
+         Component,
+         props,
+        // TODO: figure out if err is relevant with `next build`
+        // err: dev ? err : null,
+         router: new Router(pathname, query)
+       })
+
+       const render = staticMarkup ? renderToStaticMarkup : renderToString
+
+       let html
+       let head
+       try {
+         html = render(app)
+       } finally {
+         head = Head.rewind() || defaultHead()
+       }
+       return { html, head }
+     }
+
+     const docProps = await loadGetInitialProps(Document, Object.assign(ctx, { renderPage }))
+     const doc = createElement(Document, Object.assign({
+       __NEXT_DATA__: {
+         component: component,
+         errorComponent,
+         props,
+         pathname,
+         query,
+        // TODO: figure out if we need/want build stats when we export
+        // buildId,
+        // buildStats,
+         exported: true
+        // TODO: needed for static builds?
+        // err: (err && dev) ? errorToJSON(err) : null
+       },
+       dev,
+       staticMarkup
+     }, docProps))
+
+     const html = '<!DOCTYPE html>' + renderToStaticMarkup(doc)
+
+    // write files
+     const htmlPath = join(exportPath, pathname)
+     await mkdir(htmlPath)
+     await fs.writeFile(join(htmlPath, 'index.html'), html)
+
+    // copy component bundle over
+     await fs.copy(bundlePath, join(htmlPath, 'index.json'))
+   }))
+ }
+
+// Turn the path into a route
+//
+// e.g.
+//  - index.js        => /
+//  - about.js        => /about
+//  - movies/index.js => /movies
+ function toRoute (pageDir, entry) {
+   const page = '/' + relative(pageDir, entry)
+   const base = basename(page, extname(page))
+   if (base === 'index') {
+     const dir = dirname(page)
+     return dir === '/' ? '/' : dir
+   } else {
+     return '/' + base
+   }
+ }
+
+ function getPageName (pageDir, entry) {
+   const page = '/' + relative(pageDir, entry)
+   const base = basename(page, extname(page))
+   if (base === 'index') {
+     const dir = basename(dirname(page))
+     return dir === '' ? 'index' : dir
+   } else {
+     return base
+   }
+ }


### PR DESCRIPTION
This PR adds support for a `next export -o <out> <dir>` command and closes #604. This PR is a *non-breaking* change and intentionally makes very few changes to the existing codebase. 

The way it works is it first performs a `next build` and then takes that output and turns it into a self-executing static bundle. The lifecycle hooks in a static build are a bit different than a dynamic build:

- During the export, next will call each page's `getStaticInitialProps()` static method if they have one. This will enable things like pulling in and compiling markdown files *at build time*. Any errors that happen here will halt the build. The reason to go with `getStaticInitialProps()` as opposed to `getInitialProps({ build: true })` is that `getStaticInitialProps()` won't break any existing next.js plugins (ex. https://github.com/matthewmueller/next-cookies/blob/master/index.js#L20-L28) and can be treated as a progressive enhancement.
- The client will always call `getInitialProps()` *on page load*. This is a bit different because in the dynamic build, the server will call `getInitialProps()`, but since we don't have control over the server in static builds, we'll call it here. This is where you'll load user data.

I made 4 changes to the existing codebase:

- `__NEXT_DATA__` will now receive `{ exported: true }` so it can adjust the way the router fetches new pages.
- `Document` now knows about `{ exported: true }` to adjust the location of the `app.js` common bundle.
- Using the `{ exported: true }` from `__NEXT_DATA__`, we also trigger `getInitialProps` on page load before rehydrating (as mentioned above).
- Add an `export` command in `bin/next`

There was a lot of discussion in #604 about custom routing. I decided **not** to include custom routing in this PR because most static file servers support redirects and by using the `as` parameter in `<Link as={as} />` and `Router.push(url, as)`, you can support dynamic routes like `/blog/:slug`.

Wasn't sure how to setup the test environment for this project, but happy to add tests once the implementation is settled on.

Note that there's a couple `TODO`s in `server/export.js`. Please have a look as I wasn't sure if those pieces are relevant for production or if they're just used in development.

Let me know what you think and if there's anything I can do to improve this PR!

