### PR TITLE
Remove babelrc from preact example doc

### DIFF
--- a/examples/using-preact/README.md
+++ b/examples/using-preact/README.md
@@ -29,5 +29,4 @@ This example uses [Preact](https://github.com/developit/preact) instead of React
 
 Here's how we did it:
 
-* Create `.babelrc` file with es2015 and react presets. This allow us to get rid of the hard coded React dependency for core Next.js modules.
 * Use `next.config.js` to customize our webpack config to support [preact-compat](https://github.com/developit/preact-compat)


### PR DESCRIPTION
The mentioned .babelrc usage is not needed for using preact with Next anymore. The actual code change was merged in (#1194)