### PR TITLE
Updated typescript example to newest Typescript and e

### DIFF
--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -1,22 +1,12 @@
-# TypeScript Next.js example  
-This is a really simple project that show the usage of Next.js with TypeScript.  
+# TypeScript Next.js example
 
-## How to use it?  
+This is a really simple project that show the usage of Next.js with TypeScript. 
+It has example for interaces and with Visual Studio Code (and other editors) it will you give you autocomplete on the properties of the properties on the props of the RegionParagraph Component (it knows this.props.data.name is a string)
+
+## How to use it?
+
 ```
 npm install  # to install dependencies
-npm run dev  # to compile TypeScript files and to run next.js  
-```  
-
-Output JS files are aside the related TypeScript ones.  
-
-## To fix  
-In tsconfig.json the options `jsx="react"` compiles JSX syntax into nested React.createElement calls.  
-This solution doesn't work well with some Next.js features like `next/head` or `next/link`.  
-The workaround is to create JS files that just return the mentioned module and require them from TSX files.  
-Like  
-
-```js
-import Link from 'next/link'
-
-export default Link
+npm run dev  # to compile TypeScript files and to run next.js 
+edit the files in the typescript library and the js files in pages and components will update 
 ```

--- a/examples/with-typescript/components/MyComponent.tsx
+++ b/examples/with-typescript/components/MyComponent.tsx
@@ -1,6 +1,0 @@
-import * as React from 'react'
-
-export default () =>
-  <div>
-    <p>This is my component</p>
-  </div>

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -3,11 +3,13 @@
     "dev": "concurrently \"tsc --watch\" next"
   },
   "dependencies": {
-    "next": "latest"
+    "next": "2.0.1",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
   },
   "devDependencies": {
-    "@types/react": "^15.0.1",
-    "concurrently": "^3.1.0",
-    "typescript": "^2.1.5"
+    "@types/react": "^15.0.21",
+    "concurrently": "^3.4.0",
+    "typescript": "^2.2.2"
   }
 }

--- a/examples/with-typescript/pages/index.tsx
+++ b/examples/with-typescript/pages/index.tsx
@@ -1,8 +1,0 @@
-import * as React from 'react'
-import MyComponent from '../components/MyComponent'
-
-export default () => 
-  <div>
-    <h1>Hello world</h1>
-    <MyComponent />
-  </div>

--- a/examples/with-typescript/tsconfig.json
+++ b/examples/with-typescript/tsconfig.json
@@ -1,8 +1,13 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2015",
-        "jsx": "react",
-        "allowJs": true
-    }
+        "jsx": "react-native",
+        "outDir": "",
+        "target": "es6",
+        "module": "es2015",
+        "moduleResolution": "node",
+        "strictNullChecks": true
+    },
+    "include": [
+        "typescript/**/*"
+    ]
 }

--- a/examples/with-typescript/typescript/components/RegionParagraph.tsx
+++ b/examples/with-typescript/typescript/components/RegionParagraph.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+export default class extends React.Component<RegionParagraphProps, null> {
+    getVisitString() {
+        if (typeof this.props.data.visitInfo == 'number')
+            return 'Visited this fine country in the summer of ' + this.props.data.visitInfo;
+        else
+            //auto complete for Date object because if visitInfo is not a number it must be a date
+            return 'Visited this fine country on the ' + this.props.data.visitInfo.getDate() + '. '
+    }
+    render() {
+        return <p>
+            {this.props.data.name + ': ' + this.getVisitString()}
+        </p>
+    }
+}

--- a/examples/with-typescript/typescript/definitions/projektdefinitions.ts
+++ b/examples/with-typescript/typescript/definitions/projektdefinitions.ts
@@ -1,0 +1,10 @@
+interface RegionInfo {
+    name: string;
+    visitInfo: Date | number;
+}
+interface RegionParagraphProps {
+    data: RegionInfo;
+}
+interface indexState {
+    regionData: Array<RegionInfo>;
+}

--- a/examples/with-typescript/typescript/pages/index.tsx
+++ b/examples/with-typescript/typescript/pages/index.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import RegionParagraph from '../components/RegionParagraph'
+import Head from 'next/head'
+//If your editor supports it you can go to definition on indexState
+export default class extends React.Component<{}, indexState> {
+  constructor() {
+    super();
+    this.state = {
+      //try adding to this array - you will get autocomplete 
+      //and warning if you miss a property
+      regionData: [
+        { name: 'UK', visitInfo: 98 },
+        { name: 'China', visitInfo: new Date(2012, 5, 5) }
+      ]
+    }
+  }
+  render() {
+    return <div>
+      <Head>
+        <title>Yo!</title>
+      </Head>
+      <h1>Hello world</h1>
+      {this.state.regionData.map(rD =>
+        // if you don't have a data property you will get a warning
+        <RegionParagraph
+          key={rD.name}
+          data={rD} />)
+      }
+    </div >
+  }
+}


### PR DESCRIPTION
In typescript 2.2 it is now possible to compile to js. This example does that and makes it easy to abandon typescript at anytime. 
Typescript files in typescript library and otherwise the project looks like 'normal' next project.
Added example with props and state interfaces.

PS: This is my very first github pull request - please let me know if I missed something.
