### PR TITLE
Updated Typescript example and config files

### DIFF
--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -9,11 +9,6 @@ npm run dev  # to compile TypeScript files and to run next.js
 
 Output JS files are aside the related TypeScript ones.  
 
-## To fix  
-In tsconfig.json the options `jsx="react"` compiles JSX syntax into nested React.createElement calls.  
-This solution doesn't work well with some Next.js features like `next/head` or `next/link`.  
-The workaround is to create JS files that just return the mentioned module and require them from TSX files.  
-Like  
 
 ```js
 import Link from 'next/link'

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -6,8 +6,10 @@
     "next": "latest"
   },
   "devDependencies": {
-    "@types/react": "^15.0.1",
+    "@types/react": "^15.0.21",
     "concurrently": "^3.1.0",
-    "typescript": "^2.1.5"
+    "typescript": "2.2.1",
+    "react":"latest",
+    "react-dom":"latest"
   }
 }

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -3,13 +3,13 @@
     "dev": "concurrently \"tsc --watch\" next"
   },
   "dependencies": {
-    "next": "latest"
+    "next": "2.0.1"
   },
   "devDependencies": {
     "@types/react": "^15.0.21",
     "concurrently": "^3.1.0",
     "typescript": "2.2.1",
-    "react":"latest",
-    "react-dom":"latest"
+    "react": "15.4.2",
+    "react-dom": "15.4.2"
   }
 }

--- a/examples/with-typescript/pages/index.tsx
+++ b/examples/with-typescript/pages/index.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react'
+import Link from 'next/link'
 import MyComponent from '../components/MyComponent'
-
-export default () => 
+export default () =>
   <div>
-    <h1>Hello world</h1>
+    <p>Hello there</p>
     <MyComponent />
+    <Link prefetch href='/pagewithasync'><a>Reactpage</a></Link>
   </div>

--- a/examples/with-typescript/pages/index.tsx
+++ b/examples/with-typescript/pages/index.tsx
@@ -1,8 +1,9 @@
+import * as React from 'react'
 import Link from 'next/link'
 import MyComponent from '../components/MyComponent'
 export default () =>
   <div>
     <p>Hello there</p>
     <MyComponent />
-    <Link prefetch href='/pagewithasync'><a>Reactpage</a></Link>
+    <div>Click <Link prefetch href={{ pathname: 'pagewithasync' }}><a>Reactpage</a></Link> </div>
   </div>

--- a/examples/with-typescript/pages/pagewithasync.tsx
+++ b/examples/with-typescript/pages/pagewithasync.tsx
@@ -1,26 +1,26 @@
 import * as React from 'react'
 import 'isomorphic-fetch'
-interface pagesProps {
+
+interface IPageProps {
   stars: number
 }
-interface pageState {
+
+interface IPageState {
   clicked: boolean
 }
-export default class extends React.Component<pagesProps, pageState> {
+
+export default class extends React.Component<IPageProps, IPageState> {
   static async getInitialProps() {
     const res = await fetch('https://api.github.com/repos/zeit/next.js');
     const data = await res.json();
     return { stars: data.stargazers_count }
   }
-  constructor() {
-    super();
-    this.state = { clicked: false }
-  }
-  click() {
+  public state: { clicked: false }
+  private click = () => {
     this.setState({ clicked: true })
   }
   render() {
-    return <div onClick={this.click.bind(this)}>
+    return <div onClick={this.click}>
       <h1>Next has {this.props.stars} stars</h1>
       <span>{this.state.clicked ? 'clicked' : 'please click'}</span>
     </div>

--- a/examples/with-typescript/pages/pagewithasync.tsx
+++ b/examples/with-typescript/pages/pagewithasync.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import 'isomorphic-fetch'
+interface pagesProps {
+  stars: number
+}
+interface pageState {
+  clicked: boolean
+}
+export default class extends React.Component<pagesProps, pageState> {
+  static async getInitialProps() {
+    const res = await fetch('https://api.github.com/repos/zeit/next.js');
+    const data = await res.json();
+    return { stars: data.stargazers_count }
+  }
+  constructor() {
+    super();
+    this.state = { clicked: false }
+  }
+  click() {
+    this.setState({ clicked: true })
+  }
+  render() {
+    return <div onClick={this.click.bind(this)}>
+      <h1>Next has {this.props.stars} stars</h1>
+      <span>{this.state.clicked ? 'clicked' : 'please click'}</span>
+    </div>
+  }
+}

--- a/examples/with-typescript/tsconfig.json
+++ b/examples/with-typescript/tsconfig.json
@@ -1,8 +1,12 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2015",
-        "jsx": "react",
-        "allowJs": true
+        "module": "es2015",
+        "target": "es2017",
+        "jsx": "react-native",
+        "moduleResolution": "node",
+        "lib": [
+            "dom",
+            "es2017"
+        ]
     }
 }


### PR DESCRIPTION
I added props and state to the example the way Typescript recommends
https://www.typescriptlang.org/docs/handbook/react-&-webpack.html

I updated tsconfig so the compiled code becomes what Zeit suggest at (e.g. async await)
https://zeit.co/blog/next

This way Typescript does it thing (intellisense, warnings at compiletime and removes declarations) and Zeit does the rest. (in the old example Typescript compiled to js and not jsx)

Advantages:

- Removable - Typescript is just a layer.
- Stackoverflow - you can post the JS code (which now looks good)
- Issues - if you have an issue you need to post here on GH you would either have to post Typescript code or ugly JS code (compiled) Helpers could (rightly) say perhaps it is the Typescript to JS compilation that goes wrong.
- Better use of Zeit servers capabilites. If they support async await why would we want Typescript to polyfill them. Therefore the goal should be to compile to es2017 and let Zeit do their thing.

The updates to the tsconfig are all necessary to achieve this.
