### PR TITLE
Some changes to better support parameterized urls

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -190,7 +190,7 @@ export default class Router {
       }
 
       const { Component, err, jsonPageRes } = routeInfo
-      const ctx = { err, pathname, query, jsonPageRes }
+      const ctx = { err, pathname: as || pathname, query, jsonPageRes }
       routeInfo.props = await this.getInitialProps(Component, ctx)
 
       this.components[route] = routeInfo
@@ -201,7 +201,7 @@ export default class Router {
 
       const Component = this.ErrorComponent
       routeInfo = { Component, err }
-      const ctx = { err, pathname, query }
+      const ctx = { err, pathname: as || pathname, query }
       routeInfo.props = await this.getInitialProps(Component, ctx)
 
       routeInfo.error = err

--- a/server/index.js
+++ b/server/index.js
@@ -180,15 +180,15 @@ export default class Server {
     }
   }
 
-  async render (req, res, pathname, query) {
+  async render (req, res, pathname, query, renderOpts) {
     if (this.config.poweredByHeader) {
       res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
     }
-    const html = await this.renderToHTML(req, res, pathname, query)
+    const html = await this.renderToHTML(req, res, pathname, query, renderOpts)
     return sendHTML(res, html, req.method)
   }
 
-  async renderToHTML (req, res, pathname, query) {
+  async renderToHTML (req, res, pathname, query, renderOpts) {
     if (this.dev) {
       const compilationErr = this.getCompilationError(pathname)
       if (compilationErr) {
@@ -198,7 +198,7 @@ export default class Server {
     }
 
     try {
-      return await renderToHTML(req, res, pathname, query, this.renderOpts)
+      return await renderToHTML(req, res, pathname, query, Object.assign({}, this.renderOpts, renderOpts))
     } catch (err) {
       if (err.code === 'ENOENT') {
         res.statusCode = 404


### PR DESCRIPTION
I've been following [this](https://github.com/zeit/next.js/pull/913) but I actually don't think it's possible with the current API get get parameters routing working with universal rendering (although I'm very happy to be wrong!).

I think these changes will allow it though:

* Allow `renderOptions` to be passed to the `render` method on the server - this means you can specify the `page` option
* Use 'as' for 'pathname' on the client if present so component gets the true pathname and can parse out parameters in `getInitialProps`.

In general it seems to me that extracting dynamic parts of the url would need to happen in `getInitialProps` as that happens on both client and server, probably using some shareable route config.

Here is a super simple example of what I mean, but if it would help I could create a sample app somewhere.

**routes.js**
```js
const route = require('path-match')();

module.exports = [
    {
        match: route('/posts/:slug/'),
        page: '/posts',
    },
    {
        match: route('/'),
        page: '/index',
    },
];
```

**server.js**
```js
const route = require('../routes');

// in a request
const {pathname, query} = parse(req.url, true);

for (const {match, page} of routes) {
    const params = match(pathname);

    if (params !== false) {
        app.render(req, res, pathname, query, {
            page,
        });
        return;
    }

}

// fall back to next routing
handle(req, res);
```

**pages/posts.js**
```js
import Link from 'next/link'
import routes from '../routes';

export default class extends React.Component {

    static getInitialProps (args) {
        const route = routes.find(route => route.page === 'products');
        const params = route.match(args.pathname);
        return {
            slug: params.slug,
        };
    }

    render () {
        return (
            <div>
                Blog post with slug {this.props.slug}
            </div>
        );
    }
}
```


