### PR TITLE
docs: don't blow away existing query string

### DIFF
--- a/examples/parameterized-routing/server.js
+++ b/examples/parameterized-routing/server.js
@@ -18,7 +18,6 @@ app.prepare()
       handle(req, res)
       return
     }
-  
     // assigning `query` into the params means that we still
     // get the query string passed to our application
     // i.e. /blog/foo?show-comments=true

--- a/examples/parameterized-routing/server.js
+++ b/examples/parameterized-routing/server.js
@@ -12,14 +12,17 @@ const match = route('/blog/:id')
 app.prepare()
 .then(() => {
   createServer((req, res) => {
-    const { pathname } = parse(req.url)
+    const { pathname, query } = parse(req.url, true)
     const params = match(pathname)
     if (params === false) {
       handle(req, res)
       return
     }
-
-    app.render(req, res, '/blog', params)
+  
+    // assigning `query` into the params means that we still
+    // get the query string passed to our application
+    // i.e. /blog/foo?show-comments=true
+    app.render(req, res, '/blog', Object.assign(params, query))
   })
   .listen(3000, (err) => {
     if (err) throw err


### PR DESCRIPTION
See comments in diff - I ran across this and it took me a while to work out why my client side code worked, but the server didn't. It was because I didn't realise that `.render`'s 3rd arg was the query object, so it was losing the _actual_ query string.