### PR TITLE
support className prop in next/link

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -11,6 +11,7 @@ export default class Link extends Component {
   }
 
   static propTypes = {
+    className: PropTypes.string,
     prefetch: PropTypes.bool,
     children: PropTypes.oneOfType([
       PropTypes.element,
@@ -103,7 +104,7 @@ export default class Link extends Component {
   }
 
   render () {
-    let { children } = this.props
+    let { children, className } = this.props
     let { href, as } = this
     // Deprecated. Warning shown by propType check. If the childen provided is a string (<Link>example</Link>) we wrap it in an <a> tag
     if (typeof children === 'string') {
@@ -113,6 +114,7 @@ export default class Link extends Component {
     // This will return the first child, if multiple are provided it will throw an error
     const child = Children.only(children)
     const props = {
+      className,
       onClick: this.linkClicked
     }
 


### PR DESCRIPTION
Currently the `className` prop when passed to next/link is dropped. This will at least allow it to be targetable/styled by class.