### PR TITLE
[WIP] Only watch config file that exists on the level of source files

### DIFF
--- a/bin/next
+++ b/bin/next
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { spawn } from 'cross-spawn'
 import { watchFile } from 'fs'
 import pkg from '../../package.json'
+import getConfig from '../server/config'
 
 if (pkg.peerDependencies) {
   Object.keys(pkg.peerDependencies).forEach(dependency => {
@@ -78,9 +79,10 @@ const startProcess = () => {
 }
 
 let proc = startProcess()
+const { pagesDirectory = resolve(process.cwd(), 'pages') } = getConfig(process.cwd())
 
 if (cmd === 'dev') {
-  watchFile(join(process.cwd(), 'next.config.js'), (cur, prev) => {
+  watchFile(`${resolve(pagesDirectory, '..')}/next.config.js`, (cur, prev) => {
     if (cur.size > 0 || prev.size > 0) {
       console.log('\n> Found a change in next.config.js, restarting the server...')
       // Don't listen to 'close' now since otherwise parent gets killed by listener


### PR DESCRIPTION
This addresses https://github.com/zeit/next.js/issues/1486.

Will now only watch a `next.config.js` that is on the level of the source files (adjacent to where `/pages` ([or however named](https://github.com/zeit/next.js/pull/936)) lives).

WIP tag because the second requirement in the issue:  "[that we watch] on a lower level than the source files" is unclear.

@leo, does this imply that all directories "on a lower level" should be traversed for `next.config.js`?
