### PR TITLE
Add some good defaults to code-splitting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Next.js is a minimalistic framework for server-rendered React applications.
   - [Custom configuration](#custom-configuration)
   - [Customizing webpack config](#customizing-webpack-config)
   - [Customizing babel config](#customizing-babel-config)
+  - [Customizing code splitting](#customizing-code-splitting)
 - [Production deployment](#production-deployment)
 - [FAQ](#faq)
 - [Roadmap](#roadmap)
@@ -697,6 +698,36 @@ Here's an example `.babelrc` file:
     "next/babel",
     "stage-0"
   ],
+}
+```
+
+### Customizing code splitting
+
+By default Next.js comes with a good enough code spliting setup. It will move any module used in at-least the 1/2 of all the pages into the common bundle. 
+
+Those modules will be included in the `app.js` which will be loaded with all the pages.
+
+The default setup will work for most of the use-cases. But sometimes you may need to configure it yourself. So, we provide an easy way to configure it via our `next.config.js`.
+
+Here are some examples:
+
+**Move everything inside node_modules into commons**
+
+```
+module.exports = {
+  moveModuleToCommons: function (modulePath, usedInPages, totalPages) {
+    return modulePath.indexOf('node_modules') >= 0
+  }
+}
+```
+
+**Move module used in at-least 80% of all the pages into commons.**
+
+```
+module.exports = {
+  moveModuleToCommons: function (modulePath, usedInPages, totalPages) {
+    return usedInPages >= totalPages * 0.8
+  }
 }
 ```
 

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -36,7 +36,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
   const mainJS = dev
     ? require.resolve('../../client/next-dev') : require.resolve('../../client/next')
 
-  let minChunks
+  let totalPages
 
   const entry = async () => {
     const entries = {
@@ -68,8 +68,8 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
       }
     }
 
-    // calculate minChunks of CommonsChunkPlugin for later use
-    minChunks = Math.max(2, pages.filter((p) => p !== documentPage).length)
+    // calculate total amount of pages except the `_document.js`.
+    totalPages = pages.filter((p) => p !== documentPage).length
 
     return entries
   }
@@ -94,16 +94,20 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
       filename: 'commons.js',
       minChunks (module, count) {
         // In the dev we use on-demand-entries.
-        // So, it makes no sense to use commonChunks based on the minChunks count.
+        // So, it makes no sense to use commonChunks based on the totalPages count.
         // Instead, we move all the code in node_modules into this chunk.
         // With that, we could gain better performance for page-rebuild process.
         if (dev) {
           return module.context && module.context.indexOf('node_modules') >= 0
         }
 
-        // NOTE: it depends on the fact that the entry funtion is always called
-        // before applying CommonsChunkPlugin
-        return count >= minChunks * 0.5
+        // Allow user to decide which module to move into commons
+        if (config.moveModuleToCommons) {
+          return config.moveModuleToCommons(module.context, count, totalPages)
+        }
+
+        // Move modules used in at-least 1/2 of the total pages into commons
+        return count >= totalPages * 0.5
       }
     }),
     // This chunk contains all the webpack related code. So, all the changes

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -103,7 +103,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
 
         // NOTE: it depends on the fact that the entry funtion is always called
         // before applying CommonsChunkPlugin
-        return count >= minChunks
+        return count >= minChunks * 0.5
       }
     }),
     // This chunk contains all the webpack related code. So, all the changes


### PR DESCRIPTION
Move any module in 0.5 of total pages into the commons bundle.

As the pages count increases, it's hard to use a module on all the
pages.
So, now we'll pick a module which is used at-least in half of the pages.
This gives us dramatic space save in individual pages.

Here's the Zeit.co's page sizes **without** this fix:
![without](https://cloud.githubusercontent.com/assets/50838/24771286/aa05b454-1b2a-11e7-9cb3-1ec00be68e2a.png)

Here's with this fix:
![with](https://cloud.githubusercontent.com/assets/50838/24771306/bf3a94b6-1b2a-11e7-9ace-2cd325c4523e.png)
