### PR TITLE
Create full path to distDir

### DIFF
--- a/server/build/index.js
+++ b/server/build/index.js
@@ -7,6 +7,7 @@ import del from 'del'
 import webpack from './webpack'
 import replaceCurrentBuild from './replace'
 import md5File from 'md5-file/promise'
+import mkdirp from 'mkdirp-then'
 
 export default async function build (dir) {
   const buildDir = join(tmpdir(), uuid.v4())
@@ -50,6 +51,7 @@ function runCompiler (compiler) {
 
 async function writeBuildStats (buildDir, dir) {
   const dist = getConfig(dir).distDir
+  await mkdirp(join(buildDir, dist))
   // Here we can't use hashes in webpack chunks.
   // That's because the "app.js" is not tied to a chunk.
   // It's created by merging a few assets. (commons.js and main.js)
@@ -65,6 +67,7 @@ async function writeBuildStats (buildDir, dir) {
 
 async function writeBuildId (buildDir, dir) {
   const dist = getConfig(dir).distDir
+  await mkdirp(join(buildDir, dist))
   const buildIdPath = join(buildDir, dist, 'BUILD_ID')
   const buildId = uuid.v4()
   await fs.writeFile(buildIdPath, buildId, 'utf8')


### PR DESCRIPTION
I tried setting `distDir` to `dist/client` and my build failed since `dist` didn't exist yet. This should resolve that issue.

Btw, I didn't have time to do a proper pull request for this so I did a quick file edit directly on GitHub. Seems safe enough for this minor change.