### PR TITLE
Use existing route info when Router.reload() is called.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -81,8 +81,8 @@ export default class Router {
 
     if (route !== this.route) return
 
+    const { pathname, query } = this
     const url = window.location.href
-    const { pathname, query } = parse(url, true)
 
     this.events.emit('routeChangeStart', url)
     const routeInfo = await this.getRouteInfo(route, pathname, query, url)


### PR DESCRIPTION
Earlier, it tries to get that info from the location.href.
That's incorrect.