### PR TITLE
Refactor the build server to remove tie to fs

### DIFF
--- a/server/build/index.js
+++ b/server/build/index.js
@@ -1,6 +1,5 @@
 import { tmpdir } from 'os'
 import { join } from 'path'
-import getConfig from '../config'
 import fs from 'mz/fs'
 import uuid from 'uuid'
 import del from 'del'
@@ -14,10 +13,8 @@ export default async function build (dir) {
 
   try {
     await runCompiler(compiler)
-
-    // Pass in both the buildDir and the dir to retrieve config
-    await writeBuildStats(buildDir, dir)
-    await writeBuildId(buildDir, dir)
+    await writeBuildStats(buildDir)
+    await writeBuildId(buildDir)
   } catch (err) {
     console.error(`> Failed to build on ${buildDir}`)
     throw err
@@ -48,24 +45,22 @@ function runCompiler (compiler) {
   })
 }
 
-async function writeBuildStats (buildDir, dir) {
-  const dist = getConfig(dir).distDir
+async function writeBuildStats (dir) {
   // Here we can't use hashes in webpack chunks.
   // That's because the "app.js" is not tied to a chunk.
   // It's created by merging a few assets. (commons.js and main.js)
   // So, we need to generate the hash ourself.
   const assetHashMap = {
     'app.js': {
-      hash: await md5File(join(buildDir, dist, 'app.js'))
+      hash: await md5File(join(dir, '.next', 'app.js'))
     }
   }
-  const buildStatsPath = join(buildDir, dist, 'build-stats.json')
+  const buildStatsPath = join(dir, '.next', 'build-stats.json')
   await fs.writeFile(buildStatsPath, JSON.stringify(assetHashMap), 'utf8')
 }
 
-async function writeBuildId (buildDir, dir) {
-  const dist = getConfig(dir).distDir
-  const buildIdPath = join(buildDir, dist, 'BUILD_ID')
+async function writeBuildId (dir) {
+  const buildIdPath = join(dir, '.next', 'BUILD_ID')
   const buildId = uuid.v4()
   await fs.writeFile(buildIdPath, buildId, 'utf8')
 }

--- a/server/build/replace.js
+++ b/server/build/replace.js
@@ -4,10 +4,9 @@ import getConfig from '../config'
 
 export default async function replaceCurrentBuild (dir, buildDir) {
   const dist = getConfig(dir).distDir
-  const buildDist = getConfig(buildDir).distDir
   const _dir = join(dir, dist)
-  const _buildDir = join(buildDir, dist)
-  const oldDir = join(buildDir, `${buildDist}.old`)
+  const _buildDir = join(buildDir, '.next')
+  const oldDir = join(buildDir, '.next.old')
 
   try {
     await move(_dir, oldDir)

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -265,7 +265,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
     context: dir,
     entry,
     output: {
-      path: join(buildDir || dir, config.distDir),
+      path: buildDir ? join(buildDir, '.next') : join(dir, config.distDir),
       filename: '[name]',
       libraryTarget: 'commonjs2',
       publicPath: '/_webpack/',


### PR DESCRIPTION
As discussed in #1645 
Can remove the need to merge config within the temporary build, as `server/build/replace.js` is responsible for moving the temp directory to the output directory, unlike `dev` where that is handled by webpack

This pr reverts the original file of server/index.js
and makes a few changes to the webpack and replace files

