### PR TITLE
Fix Fela example

### DIFF
--- a/examples/with-fela/pages/_document.js
+++ b/examples/with-fela/pages/_document.js
@@ -22,7 +22,7 @@ export default class MyDocument extends Document {
           <title>My page</title>
           <style
             dangerouslySetInnerHTML={{ __html: this.props.css }}
-            id="fela-stylesheet"
+            id='fela-stylesheet'
           />
         </Head>
         <body>

--- a/examples/with-fela/pages/_document.js
+++ b/examples/with-fela/pages/_document.js
@@ -20,7 +20,10 @@ export default class MyDocument extends Document {
       <html>
         <Head>
           <title>My page</title>
-          <style id='fela-stylesheet'>{this.props.css}</style>
+          <style
+            dangerouslySetInnerHTML={{ __html: this.props.css }}
+            id="fela-stylesheet"
+          />
         </Head>
         <body>
           <Main />

--- a/examples/with-fela/pages/index.js
+++ b/examples/with-fela/pages/index.js
@@ -2,6 +2,7 @@ import { createComponent } from 'react-fela'
 import Page from '../layout'
 
 const title = ({ size }) => ({
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
   fontSize: size + 'px',
   color: 'red'
 })


### PR DESCRIPTION
Styles must be set via the innerHTML. Otherwise, a fontFamily "Segoe
UI” will have encoded quotes.