### PR TITLE
[WIP] isomorphic-style-loader example

### DIFF
--- a/examples/with-isomorphic-style-loader/.babelrc
+++ b/examples/with-isomorphic-style-loader/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    "transform-es2015-modules-commonjs"
+  ]
+}

--- a/examples/with-isomorphic-style-loader/README.md
+++ b/examples/with-isomorphic-style-loader/README.md
@@ -1,0 +1,36 @@
+
+# Example app with [isomorphic-style-loader](https://github.com/kriasoft/isomorphic-style-loader)
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-isomorphic-style-loader
+cd with-isomorphic-style-loader
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example features how to use a different styling solution than [styled-jsx](https://github.com/zeit/styled-jsx) that also supports universal styles. That means we can serve the required styles for the first render within the HTML and then load the rest in the client. In this case we are using [isomorphic-style-loader](https://github.com/kriasoft/isomorphic-style-loader).
+
+Because isomorphic-style-loader requires a custom context when rendering, each page must be wrapped using the `pageWithStyles.js`, which is a [HOC](https://facebook.github.io/react/docs/higher-order-components.html).
+
+Custom Documents cannot pass down a context because the HTML is rendered in a box by next.js.
+
+Also included are some common defaults for postcss, which could be replaced with another loader, like sass.
+
+CSS files are bundled as JavaScript modules in dev mode.

--- a/examples/with-isomorphic-style-loader/components/App.css
+++ b/examples/with-isomorphic-style-loader/components/App.css
@@ -1,0 +1,2 @@
+.root { padding: 10px; }
+.title { color: red; }

--- a/examples/with-isomorphic-style-loader/components/App.js
+++ b/examples/with-isomorphic-style-loader/components/App.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import withStyles from 'isomorphic-style-loader/lib/withStyles'
+import s from './App.css'
+
+console.log(s)
+
+function App () {
+  return (
+    <div className={s.root}>
+      <h1 className={s.title}>Hello, world!</h1>
+    </div>
+  )
+}
+
+export default withStyles(s)(App)

--- a/examples/with-isomorphic-style-loader/next.config.js
+++ b/examples/with-isomorphic-style-loader/next.config.js
@@ -9,9 +9,11 @@ module.exports = {
       const entries = await entry()
       const pages = await glob('pages/**/*.js', { cwd: config.context })
       const nextPages = await glob('node_modules/next/dist/pages/**/*.js', { cwd: config.context })
-      pages.concat(nextPages).forEach((file) => {
-        entries[join('dist', file.replace('node_modules/next/dist', ''))] = [`./${file}?entry`]
+      nextPages.concat(pages).forEach((file) => {
+        entries[join('dist', file.replace('node_modules/next/dist', ''))] = [`./${file}`]
       })
+      entries['app.js'] = entries['main.js']
+      delete entries['main.js']
       return entries
     }
     const cssConfig = {
@@ -23,6 +25,7 @@ module.exports = {
           options: {
             importLoaders: 1,
             modules: true,
+            sourceMap: !!dev,
             minimize: !dev,
             localIdentName: '[name]-[local]-[hash:base64:5]'
           }

--- a/examples/with-isomorphic-style-loader/next.config.js
+++ b/examples/with-isomorphic-style-loader/next.config.js
@@ -1,0 +1,49 @@
+const glob = require('glob-promise')
+const { join } = require('path')
+
+module.exports = {
+  webpack: function (config, { dev }) {
+    const entry = async () => {
+      const entries = {}
+      const cssFiles = await glob('**/*.css', { cwd: config.context, ignore: 'node_modules/**/*' })
+      cssFiles.forEach((file) => { entries[join('dist', file)] = [`./${file}?entry`] })
+      return entries
+    }
+    const cssConfig = {
+      test: /\.css$/,
+      use: [
+        'isomorphic-style-loader',
+        {
+          loader: 'css-loader',
+          options: {
+            importLoaders: 1,
+            modules: true,
+            minimize: !dev,
+            localIdentName: '[name]-[local]-[hash:base64:5]'
+          }
+        },
+        {
+          loader: 'postcss-loader',
+          options: {
+            config: './postcss.config.js'
+          }
+        }
+      ]
+    }
+
+    // Add to next config for client-side bundles
+    config.module.rules.push(cssConfig)
+    return [config, {
+      // Server config
+      // Target is Node-only
+      target: 'async-node',
+      entry,
+      context: config.context,
+      output: config.output,
+      devtool: config.devtool,
+      module: {
+        rules: [cssConfig]
+      }
+    }]
+  }
+}

--- a/examples/with-isomorphic-style-loader/package.json
+++ b/examples/with-isomorphic-style-loader/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "with-isomorphic-style-loader",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "browserslist": [
+    ">1%",
+    "last 4 versions",
+    "Firefox ESR",
+    "not ie < 9"
+  ],
+  "dependencies": {
+    "isomorphic-style-loader": "^1.1.0",
+    "next": "latest",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
+  },
+  "devDependencies": {
+    "autoprefixer": "^6.7.7",
+    "css-loader": "^0.28.0",
+    "glob-promise": "^3.1.0",
+    "postcss-global-import": "^1.0.0",
+    "postcss-import": "^9.1.0",
+    "postcss-loader": "^1.3.3",
+    "webpack": "^2.3.3"
+  }
+}

--- a/examples/with-isomorphic-style-loader/pageWithStyles.js
+++ b/examples/with-isomorphic-style-loader/pageWithStyles.js
@@ -2,13 +2,9 @@ import React, { Component, PropTypes } from 'react'
 
 export default function pageWithStyles (WrappedComponent) {
   class PageWithStyles extends Component {
-    static getInitialProps ({ req }) {
-      return { isServer: !!req }
-    }
-
     getChildContext () {
-      return {
-        insertCss: (...styles) => {
+      const insertCss = typeof window === 'undefined'
+        ? (...styles) => {
           styles.forEach((style) => {
             const cssText = style._getCss()
             if (!~this.props.css.indexOf(cssText)) {
@@ -16,7 +12,12 @@ export default function pageWithStyles (WrappedComponent) {
             }
           })
         }
-      }
+        : (...styles) => {
+          const removeCss = styles.map(x => x._insertCss())
+
+          return () => { removeCss.forEach(f => f()) }
+        }
+      return { insertCss }
     }
 
     render () {

--- a/examples/with-isomorphic-style-loader/pageWithStyles.js
+++ b/examples/with-isomorphic-style-loader/pageWithStyles.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 export default function pageWithStyles (WrappedComponent) {
   class PageWithStyles extends Component {

--- a/examples/with-isomorphic-style-loader/pageWithStyles.js
+++ b/examples/with-isomorphic-style-loader/pageWithStyles.js
@@ -1,0 +1,47 @@
+import React, { Component, PropTypes } from 'react'
+
+export default function pageWithStyles (WrappedComponent) {
+  class PageWithStyles extends Component {
+    static getInitialProps ({ req }) {
+      return { isServer: !!req }
+    }
+
+    getChildContext () {
+      return {
+        insertCss: (...styles) => {
+          styles.forEach((style) => {
+            const cssText = style._getCss()
+            if (!~this.props.css.indexOf(cssText)) {
+              this.props.css.push(cssText)
+            }
+          })
+        }
+      }
+    }
+
+    render () {
+      return (
+        <div>
+          <WrappedComponent {...this.props} />
+          <style
+            className='_isl-styles'
+            dangerouslySetInnerHTML={{ __html: this.props.css.join('') }}
+          />
+        </div>
+      )
+    }
+  }
+
+  PageWithStyles.defaultProps = {
+    css: []
+  }
+
+  PageWithStyles.childContextTypes = {
+    insertCss: PropTypes.func
+  }
+
+  const displayName = WrappedComponent.displayName || WrappedComponent.name || 'Component'
+  PageWithStyles.displayName = `PageWithStyles(${displayName})`
+
+  return PageWithStyles
+}

--- a/examples/with-isomorphic-style-loader/pages/_document.js
+++ b/examples/with-isomorphic-style-loader/pages/_document.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  getChildContext () {
+    return {
+      _documentProps: {
+        ...this.props,
+        dev: false
+      }
+    }
+  }
+
+  render () {
+    return (
+      <html>
+        <Head>
+          <title>My page</title>
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/examples/with-isomorphic-style-loader/pages/index.js
+++ b/examples/with-isomorphic-style-loader/pages/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import App from '../components/App'
+import pageWithStyles from '../pageWithStyles'
+
+function Index () {
+  return <App />
+}
+
+export default pageWithStyles(Index)

--- a/examples/with-isomorphic-style-loader/postcss.config.js
+++ b/examples/with-isomorphic-style-loader/postcss.config.js
@@ -1,0 +1,15 @@
+module.exports = () => ({
+  // The list of plugins for PostCSS
+  // https://github.com/postcss/postcss
+  plugins: [
+    // Transfer @global-import rule by inlining content with :global CSS Modules scope
+    // e.g. @global-import 'draft-js/dist/Draft.css'
+    // https://github.com/scherebedov/postcss-global-import
+    require('postcss-global-import')(),
+    // Transfer @import rule by inlining content, e.g. @import 'normalize.css'
+    // https://github.com/postcss/postcss-import
+    require('postcss-import')(), // Add vendor prefixes to CSS rules using values from caniuse.com
+    // https://github.com/postcss/autoprefixer
+    require('autoprefixer')(/* package.json/browserslist */)
+  ]
+})


### PR DESCRIPTION
This is a work in progress. I've got server-rendering working, but only in production. The next.js hot-reloader in dev mode doesn't work with multiple webpack configs, but I'm looking into either updating that or working out a webpack config that will write CSS files correctly to dist.

First, I tried using emit-file-loader, writing both the output of css-loader and isomorphic-style-loader. The former isn't really what we want (because then what would be the point of using isomorphic-style-loader?), and the latter has `require` statements that are expected to only be used from within a bundle (with special characters and such in the URLs that only webpack understands).

So, I switched gears and created a separate config for CSS files. This bundled the CSS file to something workable. By the way, this separate CSS module is only necessary server-side. The client-side bundles included everything fine from the beginning.

This got me to a working page in production mode. **But**, depending on how I initialized the css property in pageWithStyles.js, it would either only work server-side, or only work client-side. There must be some race condition, but I need a deeper understanding of either next.js or react-dom's renderToString.

Basically, isomorphic-style-loader adds styles to the context through its own HOC's `componentWillMount` method. However, if I initialize css to an empty array in `getInitialProps`, it's like `componentWillMount` is not called server-side, but it does get called client-side. So, you see a flash of unstyled text.

If I use `defaultProps`, as you see in this PR, server-rendering works fine (`componentWillMount` is called server-side), but as soon as the client-side code executes, that `css` property gets cleared again and the styles disappear. I'm not sure how that can happen because I figured `componentWillMount` would be called *again* on the client on load, but I'm either wrong about that or something is setting CSS and then clearing it later, but before the first render.

Ref https://github.com/zeit/next.js/issues/1615

