### PR TITLE
Added 404 error to invalid Router.push()s - Fixes #1596.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -269,6 +269,8 @@ export default class Router {
     }
 
     const jsonPageRes = await this.fetchRoute(route)
+    if (jsonPageRes.status === 404) throw Error('404 Route not found:\n\n' + jsonPageRes.url)
+
     let jsonData
     // We can call .json() only once for a response.
     // That's why we need to keep a copy of data if we already parsed it.


### PR DESCRIPTION
The error in #1596 was being caused by calling .json() on a 404 response. This fixes the issue by checking the status of the response and throwing an error if appropriate.