### PR TITLE
Update Apollo examples

### DIFF
--- a/examples/with-apollo-and-redux/lib/initClient.js
+++ b/examples/with-apollo-and-redux/lib/initClient.js
@@ -1,8 +1,6 @@
 import { ApolloClient, createNetworkInterface } from 'react-apollo'
 
-let apolloClient = null
-
-function _initClient (headers, initialState) {
+export const initClient = (headers, initialState = {}) => {
   return new ApolloClient({
     initialState,
     ssrMode: !process.browser,
@@ -15,14 +13,4 @@ function _initClient (headers, initialState) {
       }
     })
   })
-}
-
-export const initClient = (headers, initialState = {}) => {
-  if (!process.browser) {
-    return _initClient(headers, initialState)
-  }
-  if (!apolloClient) {
-    apolloClient = _initClient(headers, initialState)
-  }
-  return apolloClient
 }

--- a/examples/with-apollo/lib/initClient.js
+++ b/examples/with-apollo/lib/initClient.js
@@ -1,8 +1,6 @@
 import { ApolloClient, createNetworkInterface } from 'react-apollo'
 
-let apolloClient = null
-
-function _initClient (headers, initialState) {
+export const initClient = (headers, initialState = {}) => {
   return new ApolloClient({
     initialState,
     ssrMode: !process.browser,
@@ -15,14 +13,4 @@ function _initClient (headers, initialState) {
       }
     })
   })
-}
-
-export const initClient = (headers, initialState = {}) => {
-  if (!process.browser) {
-    return _initClient(headers, initialState)
-  }
-  if (!apolloClient) {
-    apolloClient = _initClient(headers, initialState)
-  }
-  return apolloClient
 }


### PR DESCRIPTION
Save some keystrokes by returning an instance of ApolloClient, since its "kinda" what we were already doing.