### PR TITLE
add onTouchStart for mobile browsers

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -114,7 +114,8 @@ export default class Link extends Component {
     // This will return the first child, if multiple are provided it will throw an error
     const child = Children.only(children)
     const props = {
-      onClick: this.linkClicked
+      onClick: this.linkClicked,
+      onTouchStart: this.linkClicked
     }
 
     // If child is an <a> tag and doesn't have a href attribute we specify it so that repetition is not needed by the user


### PR DESCRIPTION
seems like onClick is deprecated in several mobile browsers (e.g. Chrome on Android) so this fixes issue #335