### PR TITLE
Fixed typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -454,7 +454,7 @@ componentWillReceiveProps(nextProps) {
 > ```js
 > Router.push('/about?counter=10', '/about?counter=10', { shallow: true })
 > ```
-> Since that's a new page, it'll unload the current page, load the new one and call `getInitialProps` even we asked to do shallow routing.
+> Since that's a new page, it'll unload the current page, load the new one and call `getInitialProps` even though we asked to do shallow routing.
 
 ### Prefetching Pages
 


### PR DESCRIPTION
Under *Shallow Routing*, the line `Since that's a new page, it'll unload the current page, load the new one and call getInitialProps even` **though** `we asked to do shallow routing.` is missing the word `though`.
This PR just adds this word in 😊