### PR TITLE
Fixed typo in with-flow example readme

### DIFF
--- a/examples/with-flow/README.md
+++ b/examples/with-flow/README.md
@@ -6,7 +6,7 @@
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash
-curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-styled-components
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-flow
 cd with-flow
 ```
 


### PR DESCRIPTION
curl is using with-styled-components instead of with-flow