### PR TITLE
Fix error pages' cdn cache issue.

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -123,6 +123,9 @@ export async function renderScript (req, res, page, opts) {
 }
 
 export async function renderScriptError (req, res, page, error, customFields, opts) {
+  // Asks CDNs and others to not to cache the errored page
+  res.setHeader('Cache-Control', 'no-store, must-revalidate')
+
   if (error.code === 'ENOENT') {
     res.setHeader('Content-Type', 'text/javascript')
     res.end(`


### PR DESCRIPTION
We do this by providing some headers mentioning not to cache.
Headers are set based on this: http://stackoverflow.com/a/2068407/457224
(Of course, we don't need to look for IE6 and older clients)