### PR TITLE
[Bug?] componentDidMount does not execute on client on nested pages

### DIFF
--- a/test/integration/basic/lib/cdm.js
+++ b/test/integration/basic/lib/cdm.js
@@ -1,0 +1,19 @@
+import React, {Component} from 'react'
+
+export default class extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      mounted: false
+    }
+  }
+
+  componentDidMount () {
+    this.setState({mounted: true})
+  }
+
+  render () {
+    return <p>ComponentDidMount {this.state.mounted ? 'executed on client' : 'not executed'}.</p>
+  }
+}

--- a/test/integration/basic/pages/nested-cdm/index.js
+++ b/test/integration/basic/pages/nested-cdm/index.js
@@ -1,0 +1,2 @@
+import CDM from '../../lib/cdm'
+export default CDM

--- a/test/integration/basic/pages/with-cdm.js
+++ b/test/integration/basic/pages/with-cdm.js
@@ -1,0 +1,2 @@
+import CDM from '../lib/cdm'
+export default CDM

--- a/test/integration/basic/test/cdm.js
+++ b/test/integration/basic/test/cdm.js
@@ -11,7 +11,24 @@ export default (context) => {
       browser.close()
     })
 
-    it('on nested-cdm/index.js page', async () => {
+    it('on /nested-cdm page', async () => {
+      const browser = await webdriver(context.appPort, '/nested-cdm')
+      const text = await browser.elementByCss('p').text()
+
+      expect(text).toBe('ComponentDidMount executed on client.')
+      browser.close()
+    })
+
+    it('on /nested-cdm/ page', async () => {
+      const browser = await webdriver(context.appPort, '/nested-cdm/')
+      const text = await browser.elementByCss('p').text()
+
+      // This fails.
+      expect(text).toBe('ComponentDidMount executed on client.')
+      browser.close()
+    })
+
+    it('on /nested-cdm/index page', async () => {
       const browser = await webdriver(context.appPort, '/nested-cdm/index')
       const text = await browser.elementByCss('p').text()
 

--- a/test/integration/basic/test/cdm.js
+++ b/test/integration/basic/test/cdm.js
@@ -1,0 +1,23 @@
+/* global describe, it, expect */
+import webdriver from 'next-webdriver'
+
+export default (context) => {
+  describe('componentDidMount', () => {
+    it('on normal page', async () => {
+      const browser = await webdriver(context.appPort, '/with-cdm')
+      const text = await browser.elementByCss('p').text()
+
+      expect(text).toBe('ComponentDidMount executed on client.')
+      browser.close()
+    })
+
+    it('on nested-cdm/index.js page', async () => {
+      const browser = await webdriver(context.appPort, '/nested-cdm/index')
+      const text = await browser.elementByCss('p').text()
+
+      // This fails.
+      expect(text).toBe('ComponentDidMount executed on client.')
+      browser.close()
+    })
+  })
+}

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -15,6 +15,7 @@ import rendering from './rendering'
 import misc from './misc'
 import clientNavigation from './client-navigation'
 import hmr from './hmr'
+import cdm from './cdm'
 
 const context = {}
 context.app = nextServer({
@@ -42,6 +43,7 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/stateful'),
       renderViaHTTP(context.appPort, '/stateless'),
       renderViaHTTP(context.appPort, '/styled-jsx'),
+      renderViaHTTP(context.appPort, '/with-cdm'),
 
       renderViaHTTP(context.appPort, '/nav'),
       renderViaHTTP(context.appPort, '/nav/about'),
@@ -49,7 +51,9 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/nav/self-reload'),
       renderViaHTTP(context.appPort, '/nav/hash-changes'),
       renderViaHTTP(context.appPort, '/nav/shallow-routing'),
-      renderViaHTTP(context.appPort, '/nav/redirect')
+      renderViaHTTP(context.appPort, '/nav/redirect'),
+
+      renderViaHTTP(context.appPort, '/nested-cdm/index')
     ])
   })
   afterAll(() => stopApp(context.server))
@@ -60,4 +64,5 @@ describe('Basic Features', () => {
   misc(context)
   clientNavigation(context, (p, q) => renderViaHTTP(context.appPort, p, q))
   hmr(context, (p, q) => renderViaHTTP(context.appPort, p, q))
+  cdm(context)
 })

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -53,6 +53,8 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/nav/shallow-routing'),
       renderViaHTTP(context.appPort, '/nav/redirect'),
 
+      renderViaHTTP(context.appPort, '/nested-cdm'),
+      renderViaHTTP(context.appPort, '/nested-cdm/'),
       renderViaHTTP(context.appPort, '/nested-cdm/index')
     ])
   })


### PR DESCRIPTION
I have a feeling this is a known behaviour / limitation. Please close this PR if that's the case.

Adding `componentDidMount` on a nested `index.js` page will not be executed on the client. I thought a PR with a failing test is a better demo than an issue.

Happy to clean this and go spelunking for a solution if this is a real bug. :+1:

```bash
$ yarn test
# snip
 FAIL  test/integration/basic/test/index.test.js (62.625s)
  ● Basic Features › componentDidMount › on nested-cdm/index.js page

    expect(received).toBe(expected)

    Expected value to be (using ===):
      "ComponentDidMount executed on client."
    Received:
      "ComponentDidMount not executed."
# snip
    componentDidMount
      ✓ on normal page (1482ms)
      ✕ on nested-cdm/index.js page (1702ms)
```