### PR TITLE
Add React's production aliases

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -298,6 +298,14 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
     performance: { hints: false }
   }
 
+  if (!dev) {
+    webpackConfig.resolve.alias = {
+      'react': require.resolve('react/dist/react.min.js'),
+      'react-dom': require.resolve('react-dom/dist/react-dom.min.js'),
+      'react-dom/server': require.resolve('react-dom/dist/react-dom-server.min.js')
+    }
+  }
+
   if (config.webpack) {
     console.log('> Using "webpack" config function defined in next.config.js.')
     webpackConfig = await config.webpack(webpackConfig, { dev })


### PR DESCRIPTION
Using `examples/hello-world` as a basic starting point, these changes produce a bundle that is `1kB` (min) smaller. The compilation process is also faster! 

On my workhorse, I'm seeing `5.6s` vs `6.0s`.  <-- Really marginal here, but this difference translates to a larger difference on more standard hardware. Eg, the difference is `1.5s` on my laptop... and the difference will only increase with more complex projects!

Relevant thread: [Twitter](https://twitter.com/lukeed05/status/859532890463281156)