### PR TITLE
Add React production aliases to Babel config (SSR)

### DIFF
--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -30,6 +30,9 @@ module.exports = {
       {
         alias: {
           'babel-runtime': relativeResolve('babel-runtime/package'),
+          'react': relativeResolve('react/dist/react.min.js'),
+          'react-dom': relativeResolve('react-dom/dist/react-dom.min.js'),
+          'react-dom/server': relativeResolve('react-dom/dist/react-dom-server.min.js'),
           'next/link': relativeResolve('../../../lib/link'),
           'next/prefetch': relativeResolve('../../../lib/prefetch'),
           'next/css': relativeResolve('../../../lib/css'),


### PR DESCRIPTION
The second half of my previous PR (#1855). I mistakenly thought this wasn't needed, but I was focused on client-side output only. Oopsie

This sets the proper Babel aliases so that the server (`next start`) will know to use the pre-minified, production files.

_This PR should follow #1862._