### PR TITLE
Removing unneeded dev dependency

### DIFF
--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -12,7 +12,6 @@
     "start": "next start"
   },
   "devDependencies": {
-    "babel-jest": "^18.0.0",
     "enzyme": "^2.5.1",
     "jest-cli": "^18.0.0",
     "react-addons-test-utils": "^15.4.2",


### PR DESCRIPTION
babel-jest is included automatically by jest when a babel config is present, so including it manually here doesn't do anything.

> "Note: babel-jest is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project."
http://facebook.github.io/jest/docs/en/getting-started.html#using-babel