### PR TITLE
Ignoring elliptic precomputed folder to decrease build size

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -74,6 +74,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
   }
 
   const plugins = [
+    new webpack.IgnorePlugin(/(precomputed)/, /node_modules.+(elliptic)/),
     new webpack.LoaderOptionsPlugin({
       options: {
         context: dir,


### PR DESCRIPTION
Webpack 2 uses elliptic folder which adds it to the final build. This will reduce the final build size.