### PR TITLE
Use cheap module inline source map

### DIFF
--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -18,9 +18,10 @@ export default class PageLoader {
     if (route[0] !== '/') {
       throw new Error('Route name should start with a "/"')
     }
+    route = route.replace(/index$/, '')
 
     if (route === '/') return route
-    return route.replace(/index$/, '').replace(/\/$/, '')
+    return route.replace(/\/$/, '')
   }
 
   loadPage (route) {

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -294,7 +294,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
     module: {
       rules
     },
-    devtool: dev ? 'inline-source-map' : false,
+    devtool: dev ? 'cheap-module-inline-source-map' : false,
     performance: { hints: false }
   }
 

--- a/test/integration/basic/pages/index.js
+++ b/test/integration/basic/pages/index.js
@@ -1,0 +1,2 @@
+import CDM from '../lib/cdm'
+export default CDM

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -323,7 +323,7 @@ export default (context, render) => {
     })
 
     describe('with different types of urls', () => {
-      it('on normal page', async () => {
+      it('should work with normal page', async () => {
         const browser = await webdriver(context.appPort, '/with-cdm')
         const text = await browser.elementByCss('p').text()
 
@@ -331,7 +331,7 @@ export default (context, render) => {
         browser.close()
       })
 
-      it('on dir/index page ', async () => {
+      it('should work with dir/index page ', async () => {
         const browser = await webdriver(context.appPort, '/nested-cdm/index')
         const text = await browser.elementByCss('p').text()
 
@@ -339,8 +339,24 @@ export default (context, render) => {
         browser.close()
       })
 
-      it('on dir/ page ', async () => {
+      it('should work with dir/ page ', async () => {
         const browser = await webdriver(context.appPort, '/nested-cdm/')
+        const text = await browser.elementByCss('p').text()
+
+        expect(text).toBe('ComponentDidMount executed on client.')
+        browser.close()
+      })
+
+      it('should work with /index page', async () => {
+        const browser = await webdriver(context.appPort, '/index')
+        const text = await browser.elementByCss('p').text()
+
+        expect(text).toBe('ComponentDidMount executed on client.')
+        browser.close()
+      })
+
+      it('should work with / page', async () => {
+        const browser = await webdriver(context.appPort, '/')
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')


### PR DESCRIPTION
Because it's recommended [here](https://github.com/webpack/webpack/issues/2145#issuecomment-294361203) that over the inline-source-maps specially for Chrome.