### PR TITLE
Use development babel presets if it's we are not in production.

### DIFF
--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -9,7 +9,7 @@ const envPlugins = {
   ]
 }
 
-const plugins = envPlugins[process.env.NODE_ENV] || []
+const plugins = envPlugins[process.env.NODE_ENV] || envPlugins['development']
 
 module.exports = {
   presets: [


### PR DESCRIPTION
Otherwise, user has to expose it's NODE_ENV env variable as "development."
Usually, that's unlikely to happen.