### PR TITLE
Fix production builds for the Material-UI example

### DIFF
--- a/examples/with-material-ui/next.config.js
+++ b/examples/with-material-ui/next.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  webpack: (config) => {
+    // Remove minifed react aliases for material-ui so production builds work
+    if (config.resolve.alias) {
+      delete config.resolve.alias.react
+      delete config.resolve.alias['react-dom']
+    }
+
+    return config
+  }
+}

--- a/examples/with-material-ui/package.json
+++ b/examples/with-material-ui/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "material-ui": "^0.17.4",
+    "material-ui": "^0.18.0",
     "next": "latest",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",


### PR DESCRIPTION
I fixed the broken production builds for the Material-UI example and:

- Removed the redundant `getMuiTheme()` calls.
- Improved the execution of `injectTapEventPlugin()` so that React doesn't print warnings on the server and it only ever gets executed once (even during hot reloading).
- Removed `window` and `req` checks in favor of `process.browser`.
- Removed unused `isServer`.