### PR TITLE
Prefer <script defer> over <script async>

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -147,8 +147,8 @@ export class NextScript extends Component {
           }
         `
       }} />}
-      <script async type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pathname}`} />
-      <script async type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page/_error`} />
+      <script defer type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pathname}`} />
+      <script defer type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page/_error`} />
       {staticMarkup ? null : this.getScripts()}
     </div>
   }

--- a/server/document.js
+++ b/server/document.js
@@ -127,8 +127,8 @@ export class NextScript extends Component {
     }
 
     // In the production mode, we have a single asset with all the JS content.
-    // So, we can load the script with async
-    return [this.getChunkScript('app.js', { async: true })]
+    // So, we can load the script with defer
+    return [this.getChunkScript('app.js', { defer: true })]
   }
 
   render () {

--- a/server/document.js
+++ b/server/document.js
@@ -70,9 +70,9 @@ export class Head extends Component {
     const { pathname, buildId, assetPrefix } = __NEXT_DATA__
 
     return <head>
+      {this.getPreloadMainLinks()}
       <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page${pathname}`} as='script' />
       <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_error`} as='script' />
-      {this.getPreloadMainLinks()}
       {(head || []).map((h, i) => React.cloneElement(h, { key: i }))}
       {styles || null}
       {this.props.children}
@@ -147,9 +147,9 @@ export class NextScript extends Component {
           }
         `
       }} />}
+      {staticMarkup ? null : this.getScripts()}
       <script defer type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pathname}`} />
       <script defer type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page/_error`} />
-      {staticMarkup ? null : this.getScripts()}
     </div>
   }
 }


### PR DESCRIPTION
Prefer `<script defer>` over `<script async>` so that quickly downloaded scripts don't block the initial render. This also ensures that the page script is always executed before the error script since `async` scripts can execute in any order.

I also moved `app.js` to the top of the script lists since it has to be downloaded/executed before anything else can actually initialise (the browser uses the `<link rel='preload'>` order to infer the download priority).

See: https://calendar.perfplanet.com/2016/prefer-defer-over-async/