### PR TITLE
Add active class to link

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,12 +9,13 @@ const ErrorDebug = process.env.NODE_ENV === 'production'
 
 export default class App extends Component {
   static childContextTypes = {
-    headManager: PropTypes.object
+    headManager: PropTypes.object,
+    router: PropTypes.object
   }
 
   getChildContext () {
-    const { headManager } = this.props
-    return { headManager }
+    const { headManager, router } = this.props
+    return { headManager, router }
   }
 
   render () {

--- a/lib/link.js
+++ b/lib/link.js
@@ -27,6 +27,10 @@ export default class Link extends Component {
     ]).isRequired
   }
 
+  static contextTypes = {
+    router: PropTypes.object
+  }
+
   componentWillReceiveProps (nextProps) {
     this.formatUrls(nextProps)
   }
@@ -106,6 +110,7 @@ export default class Link extends Component {
   render () {
     let { children } = this.props
     let { href, as } = this
+    const {route: currentRoute} = this.context.router
     // Deprecated. Warning shown by propType check. If the childen provided is a string (<Link>example</Link>) we wrap it in an <a> tag
     if (typeof children === 'string') {
       children = <a>{children}</a>
@@ -120,6 +125,11 @@ export default class Link extends Component {
     // If child is an <a> tag and doesn't have a href attribute we specify it so that repetition is not needed by the user
     if (child.type === 'a' && !('href' in child.props)) {
       props.href = as || href
+    }
+
+    if (currentRoute === href) {
+      props.className = (props.className || '') + ' active'
+      console.log('As route')
     }
 
     return React.cloneElement(child, props)

--- a/lib/link.js
+++ b/lib/link.js
@@ -129,7 +129,6 @@ export default class Link extends Component {
 
     if (currentRoute === href) {
       props.className = (props.className || '') + ' active'
-      console.log('As route')
     }
 
     return React.cloneElement(child, props)


### PR DESCRIPTION
Fixes #141 

![active-link](https://cloud.githubusercontent.com/assets/6324199/26026680/272cbf80-3800-11e7-808a-ade962ca6932.gif)

Adds `active` class to a `<Link>` component if the current route matches the href property.
Since we clone the `<a>` inside of the `<Link>` component it can be scope-styled using styled-jsx without any modifications.

```jsx
import Link from 'next/link'
export default () => (
  <div>
    Hello World.
    <Link href='/about'><a>About</a></Link>
    <Link href='/'><a>Home</a></Link>
    <style jsx>{`
      a.active {
        color: red;
      }
    `}</style>
  </div>
)
```
