### PR TITLE
Added `process.browser` to DefinePlugin

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -112,7 +112,8 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
       filename: 'manifest.js'
     }),
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production')
+      'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production'),
+      'process.browser': JSON.stringify(true)
     }),
     new PagesPlugin(),
     new CaseSensitivePathPlugin()


### PR DESCRIPTION
The idea is that there is no need for passing

```js
if (!process.browser) {
  console.log('hello from server!');
}
```

to the client side bundle.

This can also be used for storing server-side-only secrets without leaking it to the client. Although i'm not sure if that's a good idea, because accidentally running the app in `NODE_ENV==development` in "production" would leak all those secrets.

Also, i'm pretty new to next.js and it's codebase so I might have misunderstood some parts and how everything fits together, but I think this should work?