### PR TITLE
Fix hmr failing issue.

### DIFF
--- a/test/integration/basic/test/hmr.js
+++ b/test/integration/basic/test/hmr.js
@@ -23,7 +23,7 @@ export default (context, render) => {
         const errorMessage = await browser
           .waitForElementByCss('pre')
           .elementByCss('pre').text()
-        expect(errorMessage.includes('SyntaxError: Unterminated JSX contents')).toBeTruthy()
+        expect(errorMessage.includes('Unterminated JSX contents')).toBeTruthy()
 
         // add the original content
         writeFileSync(aboutPagePath, originalContent, 'utf8')


### PR DESCRIPTION
The HMR test failing under windows due to an error message difference between both OS.
That's fixed with this PR.