### PR TITLE
delete files only from outDir for export

### DIFF
--- a/server/export.js
+++ b/server/export.js
@@ -25,7 +25,7 @@ export default async function (dir, options) {
   const buildStats = require(join(nextDir, 'build-stats.json'))
 
   // Initialize the output directory
-  await del(outDir)
+  await del(join(outDir, '*'))
   await mkdirp(join(outDir, '_next', buildStats['app.js'].hash))
   await mkdirp(join(outDir, '_next', buildId))
 


### PR DESCRIPTION
This change makes it so during the export, all of the files are deleted out of the export directory, but not the export directory itself. This makes testing easier because you can keep a web server running without getting permission errors from deleting the folder out from underneath it. 