### PR TITLE
remove assetPrefix in normalizeRoute fn

### DIFF
--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -23,6 +23,9 @@ export default class PageLoader {
     }
     route = route.replace(/index$/, '')
 
+    route = route.replace(this.assetPrefix, '')
+    if (!route) { route = '/' }
+
     if (route === '/') return route
     return route.replace(/\/$/, '')
   }


### PR DESCRIPTION
This change makes it so you can easily serve multiple static next apps from subfolders on the same domain using the already available assetPrefix option.

Without this change the file that's requested is like:
`/${assetPrefix}/_next/c0bae9f4-37d0-4f02-8a91-08fe02d6fbfb/page/${assetPrefix}/index.js`

instead of:
`/${assetPrefix}/_next/c0bae9f4-37d0-4f02-8a91-08fe02d6fbfb/page/index.js`

like you'd want.