### PR TITLE
Add a default value of '{}' to query in the export mode.

### DIFF
--- a/server/export.js
+++ b/server/export.js
@@ -88,7 +88,7 @@ export default async function (dir, options) {
   for (const path of exportPaths) {
     log(`  exporting path: ${path}`)
 
-    const { page, query } = exportPathMap[path]
+    const { page, query = {} } = exportPathMap[path]
     const req = { url: path }
     const res = {}
 

--- a/test/integration/static/next.config.js
+++ b/test/integration/static/next.config.js
@@ -3,6 +3,7 @@ module.exports = {
     return {
       '/': { page: '/' },
       '/about': { page: '/about' },
+      '/get-initial-props-with-no-query': { page: '/get-initial-props-with-no-query' },
       '/counter': { page: '/counter' },
       '/dynamic-imports': { page: '/dynamic-imports' },
       '/dynamic': { page: '/dynamic', query: { text: 'cool dynamic text' } },

--- a/test/integration/static/pages/get-initial-props-with-no-query.js
+++ b/test/integration/static/pages/get-initial-props-with-no-query.js
@@ -1,0 +1,11 @@
+const Page = ({ query }) => (
+  <div>
+    { `Query is: ${query}` }
+  </div>
+)
+
+Page.getInitialProps = ({ query }) => {
+  return { query: JSON.stringify(query) }
+}
+
+export default Page

--- a/test/integration/static/test/ssr.js
+++ b/test/integration/static/test/ssr.js
@@ -22,5 +22,10 @@ export default function (context) {
       const html = await renderViaHTTP(context.port, '/dynamic-imports')
       expect(html).toMatch(/Welcome to dynamic imports./)
     })
+
+    it('should give empty object for query if there is no query', async() => {
+      const html = await renderViaHTTP(context.port, '/get-initial-props-with-no-query')
+      expect(html).toMatch(/Query is: {}/)
+    })
   })
 }


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/1974