### PR TITLE
Add System.import support same as import

### DIFF
--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -5,6 +5,7 @@ import syntax from 'babel-plugin-syntax-dynamic-import'
 import UUID from 'uuid'
 
 const TYPE_IMPORT = 'Import'
+const PATTERN_SYSTEM_IMPORT = 'System.import'
 
 const buildImport = (args) => (template(`
   (
@@ -44,7 +45,7 @@ export default () => ({
 
   visitor: {
     CallExpression (path) {
-      if (path.node.callee.type === TYPE_IMPORT) {
+      if (path.node.callee.type === TYPE_IMPORT || path.get('callee').matchesPattern(PATTERN_SYSTEM_IMPORT)) {
         const newImport = buildImport({
           name: UUID.v4()
         })({

--- a/test/integration/basic/pages/dynamic/ssr-system-import.js
+++ b/test/integration/basic/pages/dynamic/ssr-system-import.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(System.import('../../components/hello1'))
+
+export default Hello

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -94,5 +94,10 @@ export default function ({ app }, suiteName, render) {
       const $ = await get$('/dynamic/no-ssr-custom-loading')
       expect($('p').text()).toBe('LOADING')
     })
+
+    test('render dynmaic system import components via SSR', async () => {
+      const $ = await get$('/dynamic/ssr-system-import')
+      expect($('p').text()).toBe('Hello World 1')
+    })
   })
 }


### PR DESCRIPTION
Some IDE or tools not support `import()`.

This pr transform `System.import()` same as `import()`