### PR TITLE
Check if parsedUrl is an object [Next 3]

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -50,7 +50,7 @@ export default class Server {
 
   handleRequest (req, res, parsedUrl) {
     // Parse url if parsedUrl not provided
-    if (!parsedUrl) {
+    if (!parsedUrl || typeof parsedUrl !== 'object') {
       parsedUrl = parseUrl(req.url, true)
     }
 


### PR DESCRIPTION
Fixes the issues with `router.get('*', handle)` in Express brought up by @wesbos