### PR TITLE
Point to styled-jsx npm package's readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ export default () => (
 )
 ```
 
-Please see the [styled-jsx documentation](https://github.com/zeit/styled-jsx) for more examples.
+Please see the [styled-jsx documentation](https://www.npmjs.com/package/styled-jsx) for more examples.
 
 #### CSS-in-JS
 


### PR DESCRIPTION
As we add new features and update README.md in zeit/styled-jsx people ask questions, typically why doesn't x works.
Master shouldn't be the source of truth, better link to the npm package's landing page.