### PR TITLE
Add better error reporting

### DIFF
--- a/bin/next
+++ b/bin/next
@@ -12,7 +12,11 @@ if (pkg.peerDependencies) {
       // When 'npm link' is used it checks the clone location. Not the project.
       require.resolve(dependency)
     } catch (err) {
-      console.warn(`${dependency} not found. Please install ${dependency} using 'npm install ${dependency}'`)
+      if (dependency === 'react' || dependency === 'react-dom') {
+        console.warn('The module \'' + dependency + '\' was not found. Next.js requires that you include it in \'dependencies\' of your \'package.json\'.\n To add it, run \'npm install --save ' + dependency + '\'')
+      } else {
+        console.warn(`${dependency} not found. Please install ${dependency} using 'npm install ${dependency}'`)
+      }
     }
   })
 }

--- a/bin/next
+++ b/bin/next
@@ -12,11 +12,7 @@ if (pkg.peerDependencies) {
       // When 'npm link' is used it checks the clone location. Not the project.
       require.resolve(dependency)
     } catch (err) {
-      if (dependency === 'react' || dependency === 'react-dom') {
-        console.warn('The module \'' + dependency + '\' was not found. Next.js requires that you include it in \'dependencies\' of your \'package.json\'.\n To add it, run \'npm install --save ' + dependency + '\'')
-      } else {
-        console.warn(`${dependency} not found. Please install ${dependency} using 'npm install ${dependency}'`)
-      }
+      console.warn('The module \'' + dependency + '\' was not found. Next.js requires that you include it in \'dependencies\' of your \'package.json\'.\n To add it, run \'npm install --save ' + dependency + '\'')
     }
   })
 }


### PR DESCRIPTION
#2087 
Not sure if I did this 100% correct so I'm open to suggestions, but this seems to work in throwing a more verbose error message to the console if 'react' or 'react-dom' is not in the dependencies list.