### PR TITLE
Fixed example `with-scoped-stylesheets-and-postcss`: css-modules reload update from files [name].css.json.

### DIFF
--- a/examples/with-scoped-stylesheets-and-postcss/next.config.js
+++ b/examples/with-scoped-stylesheets-and-postcss/next.config.js
@@ -17,7 +17,7 @@ module.exports = {
             options: {
               procedure: function (content) {
                 const fileName = `${this._module.userRequest}.json`
-                const classNames = JSON.stringify(require(fileName))
+                const classNames = fs.readFileSync(fileName, "utf8")
 
                 trash(fileName)
 

--- a/examples/with-scoped-stylesheets-and-postcss/next.config.js
+++ b/examples/with-scoped-stylesheets-and-postcss/next.config.js
@@ -1,7 +1,12 @@
+const fs = require('fs')
 const trash = require('trash')
 
 module.exports = {
   webpack: (config) => {
+    config.plugins = config.plugins.filter(
+      (plugin) => (plugin.constructor.name !== 'UglifyJsPlugin')
+    )
+
     config.module.rules.push(
       {
         test: /\.css$/,

--- a/examples/with-scoped-stylesheets-and-postcss/next.config.js
+++ b/examples/with-scoped-stylesheets-and-postcss/next.config.js
@@ -22,7 +22,7 @@ module.exports = {
             options: {
               procedure: function (content) {
                 const fileName = `${this._module.userRequest}.json`
-                const classNames = fs.readFileSync(fileName, "utf8")
+                const classNames = fs.readFileSync(fileName, 'utf8')
 
                 trash(fileName)
 


### PR DESCRIPTION
Hi @thomaslindstrom. require(fileName) is once load file when run next. after that when i change my css, a content <style> on header is change but css-modules that 

`import {classNames} from './styles.css'` 

is not update to a new css on hot reload (it will update when i close and run next again).

i think we can use "fs.readFileSync" instead "require(fileName)". 
`const classNames = fs.readFileSync(fileName, "utf8")`