### PR TITLE
Fix escape issue

### DIFF
--- a/examples/with-material-ui-next/pages/_document.js
+++ b/examples/with-material-ui-next/pages/_document.js
@@ -9,11 +9,7 @@ export default class MyDocument extends Document {
     const styleContext = getDefaultContext()
     return {
       ...page,
-      styles: (
-        <style id='jss-server-side' type='text/css'>
-          {styleContext.styleManager.sheetsToString()}
-        </style>
-      )
+      styles: <style id='jss-server-side' dangerouslySetInnerHTML={{ __html: styleContext.styleManager.sheetsToString() }} />
     }
   }
 


### PR DESCRIPTION
For instance:
```css
.MuiGrid-gutter-xs-8-1393152966 &gt; .MuiGrid-typeItem-3088349198 {
  font-family: &quot;Roboto&quot;, &quot;Helvetica&quot;, &quot;Arial&quot;, sans-serif;
}
```