### PR TITLE
Add exportAssetPrefix config option

### DIFF
--- a/server/export.js
+++ b/server/export.js
@@ -80,6 +80,11 @@ export default async function (dir, options) {
     hotReloader: null
   }
 
+  // Static hosted sites sometimes have different url requirements
+  if (config.exportAssetPrefix) {
+    renderOpts.assetPrefix = config.exportAssetPrefix.replace(/\/$/, '')
+  }
+
   // We need this for server rendering the Link component.
   global.__NEXT_DATA__ = {
     nextExport: true


### PR DESCRIPTION
Github project pages for example, by default, have the root of the
page on a subdirectory. It is needed to be able to specify the static
asset prefix without changing the way next.js handles next dev/start