### PR TITLE
Remove `type==="a"` check when setting props

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -122,7 +122,7 @@ export default class Link extends Component {
     }
 
     // If child is an <a> tag and doesn't have a href attribute we specify it so that repetition is not needed by the user
-    if (child.type === 'a' && !('href' in child.props)) {
+    if (child.props.is === "a" || !('href' in child.props)) {
       props.href = as || href
     }
 

--- a/lib/link.js
+++ b/lib/link.js
@@ -122,7 +122,7 @@ export default class Link extends Component {
     }
 
     // If child is an <a> tag and doesn't have a href attribute we specify it so that repetition is not needed by the user
-    if (child.props.is === "a" || !('href' in child.props)) {
+    if (!('href' in child.props)) {
       props.href = as || href
     }
 


### PR DESCRIPTION
I ran into an issue when statically exporting a site that used a `<Link>` which wrapped a custom element. The custom element was a wrapper around an `<a>` tag with custom styling - the dom node was just an `<a>` with some text and css - but because the literal _type_ was not `<a>`, the href of the `<a>` tag ended up as `undefined`.

Example:

```javascript
import { Link } from 'next/link';

const CustomLink = ({ href, children }) => (
  <a href={href } style={{ color: '#f00' }}>{children}</a>
);

const routes = { home: "/", docs: "/docs" };

export default () => (
  <div class="toolbar">
    { Object.keys(routes).map(title => (
      <Link href={routes[title]}>
        <CustomLink>{title}</CustomLink>
      </Link>
    ))}
  </div>
); 
```

I've taken the easiest approach - simply removing the `a` check, but leaving the check for `href`. There's a more complicated approach that could be taken, where we clone the element, assign it a ref, and check the dom node; but that seems like it may be overkill.

Using version 3.0.0-beta.8.