### PR TITLE
Fix HMR http request timeout issue under node 8.

### DIFF
--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -156,7 +156,8 @@ export default class HotReloader {
 
     this.webpackHotMiddleware = webpackHotMiddleware(compiler, {
       path: '/_next/webpack-hmr',
-      log: false
+      log: false,
+      heartbeat: 2500
     })
     this.onDemandEntries = onDemandEntryHandler(this.webpackDevMiddleware, compiler, {
       dir: this.dir,


### PR DESCRIPTION
The fix is to add a heartbeat less than 5 secs.
More info: https://github.com/glenjamin/webpack-hot-middleware/issues/210