### PR TITLE
Ignore chrome checksum on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 # Install scripts. (runs after repo cloning)
 install:
   # Install Google Chrome for e2e testing
-  - choco install googlechrome
+  - choco install --ignore-checksums googlechrome
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Minimalistic framework for server-rendered React applications",
   "main": "./dist/server/next.js",
   "license": "MIT",


### PR DESCRIPTION
Appveyor tests no longer breaks due to chrome installation. 
See: https://goo.gl/pNe7iu 
It failed randomly due to some checksum issues. 
Since we don't care about privacy or security in the CI, we can ignore checking the checksum.