### PR TITLE
Update debug error colors

### DIFF
--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -43,7 +43,7 @@ const styles = {
     fontFamily: '"SF Mono", "Roboto Mono", "Fira Mono", consolas, menlo-regular, monospace',
     fontSize: '13px',
     lineHeight: '18px',
-    color: '#6F6767',
+    color: '#b3adac',
     margin: 0,
     whiteSpace: 'pre-wrap',
     wordWrap: 'break-word',
@@ -53,9 +53,9 @@ const styles = {
   heading: {
     fontFamily: '-apple-system, system-ui, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
     fontSize: '20px',
-    fontWeight: 'bold',
+    fontWeight: '400',
     lineHeight: '28px',
-    color: '#ebe7e5',
+    color: '#ee86ab',
     marginBottom: '0px',
     marginTop: '0px'
   }
@@ -76,5 +76,5 @@ ansiHTML.setColors({
   magenta: 'ebe7e5',
   blue: 'ebe7e5',
   cyan: 'ebe7e5',
-  red: 'f05e93'
+  red: 'ee86ab'
 })

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -7,7 +7,7 @@ export default ({ error, error: { name, message, module } }) => (
     <Head>
       <meta name='viewport' content='width=device-width, initial-scale=1.0' />
     </Head>
-    {module ? <div style={styles.heading}>Error in {module.rawRequest}</div> : null}
+    {module ? <h1 style={styles.heading}>Error in {module.rawRequest}</h1> : null}
     {
       name === 'ModuleBuildError'
       ? <pre style={styles.stack} dangerouslySetInnerHTML={{ __html: ansiHTML(encodeHtml(message)) }} />
@@ -27,10 +27,10 @@ const StackTrace = ({ error: { name, message, stack } }) => (
 
 const styles = {
   errorDebug: {
-    background: '#a6004c',
+    background: '#0e0d0d',
     boxSizing: 'border-box',
     overflow: 'auto',
-    padding: '15px',
+    padding: '24px',
     position: 'fixed',
     left: 0,
     right: 0,
@@ -42,19 +42,22 @@ const styles = {
   stack: {
     fontFamily: '"SF Mono", "Roboto Mono", "Fira Mono", consolas, menlo-regular, monospace',
     fontSize: '13px',
-    color: '#fbe7f1',
+    lineHeight: '18px',
+    color: '#6F6767',
     margin: 0,
     whiteSpace: 'pre-wrap',
     wordWrap: 'break-word',
-    marginTop: '20px'
+    marginTop: '16px'
   },
 
   heading: {
     fontFamily: '-apple-system, system-ui, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
-    fontSize: '15px',
+    fontSize: '20px',
     fontWeight: 'bold',
-    color: '#febfdd',
-    marginBottom: '5px'
+    lineHeight: '28px',
+    color: '#ebe7e5',
+    marginBottom: '0px',
+    marginTop: '0px'
   }
 }
 
@@ -66,12 +69,12 @@ const encodeHtml = str => {
 // https://github.com/babel/babel/blob/master/packages/babel-code-frame/src/index.js
 
 ansiHTML.setColors({
-  reset: ['fff', 'a6004c'],
-  darkgrey: 'e54590',
-  yellow: 'ee8cbb',
-  green: 'f2a2c7',
-  magenta: 'fbe7f1',
-  blue: 'fff',
-  cyan: 'ef8bb9',
-  red: 'fff'
+  reset: ['6F6767', '0e0d0d'],
+  darkgrey: '6F6767',
+  yellow: '6F6767',
+  green: 'ebe7e5',
+  magenta: 'ebe7e5',
+  blue: 'ebe7e5',
+  cyan: 'ebe7e5',
+  red: 'f05e93'
 })

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -55,7 +55,7 @@ const styles = {
     fontSize: '20px',
     fontWeight: '400',
     lineHeight: '28px',
-    color: '#ee86ab',
+    color: '#fff',
     marginBottom: '0px',
     marginTop: '0px'
   }
@@ -76,5 +76,5 @@ ansiHTML.setColors({
   magenta: 'ebe7e5',
   blue: 'ebe7e5',
   cyan: 'ebe7e5',
-  red: 'ee86ab'
+  red: 'ff001f'
 })


### PR DESCRIPTION
Replaces the current error-debug bright fuschia colors with darker, more readable colors. #2100

![next-error-colors](https://user-images.githubusercontent.com/5362652/26864857-88988142-4b5a-11e7-8443-202a60603f8f.png)