### PR TITLE
Allow custom head attributes 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "babel-plugin-transform-react-jsx-source": "6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-plugin-transform-runtime": "6.22.0",
-    "babel-preset-env": "1.5.1",
+    "babel-preset-env": "1.5.2",
     "babel-preset-react": "6.24.1",
     "babel-runtime": "6.23.0",
     "babel-template": "6.24.1",

--- a/server/document.js
+++ b/server/document.js
@@ -83,7 +83,7 @@ export class Head extends Component {
     const { pathname, buildId, assetPrefix, nextExport } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname, nextExport)
 
-    return <head>
+    return <head {...this.props}>
       <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} as='script' />
       <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_error/index.js`} as='script' />
       {this.getPreloadDynamicChunks()}


### PR DESCRIPTION
This PR allows to add static attributes to the `document/head`

## Example: 

**`pages/_document.js`**

```javascript
import Document, { Head, Main, NextScript } from 'next/document'
import flush from 'styled-jsx/server'

export default class MyDocument extends Document {
  static getInitialProps ({ renderPage }) {
    const {html, head, errorHtml, chunks} = renderPage()
    const styles = flush()
    return { html, head, errorHtml, chunks, styles }
  }

  render () {
    return (
      <html>
        <Head data-answer='42' />
        <body>
          <Main />
          <NextScript />
        </body>
      </html>
    )
  }
}
```

## Closes

* #2183
