### PR TITLE
Remove warning when upvoting a post in apollo examples

### DIFF
--- a/examples/with-apollo-and-redux/components/PostUpvoter.js
+++ b/examples/with-apollo-and-redux/components/PostUpvoter.js
@@ -33,6 +33,7 @@ const upvotePost = gql`
   mutation updatePost($id: ID!, $votes: Int) {
     updatePost(id: $id, votes: $votes) {
       id
+      __typename
       votes
     }
   }
@@ -43,7 +44,9 @@ export default graphql(upvotePost, {
     upvote: (id, votes) => mutate({
       variables: { id, votes },
       optimisticResponse: {
+        __typename: 'Mutation',
         updatePost: {
+          __typename: 'Post',
           id: ownProps.id,
           votes: ownProps.votes + 1
         }

--- a/examples/with-apollo/components/PostUpvoter.js
+++ b/examples/with-apollo/components/PostUpvoter.js
@@ -33,6 +33,7 @@ const upvotePost = gql`
   mutation updatePost($id: ID!, $votes: Int) {
     updatePost(id: $id, votes: $votes) {
       id
+      __typename
       votes
     }
   }
@@ -43,7 +44,9 @@ export default graphql(upvotePost, {
     upvote: (id, votes) => mutate({
       variables: { id, votes },
       optimisticResponse: {
+        __typename: 'Mutation',
         updatePost: {
+          __typename: 'Post',
           id: ownProps.id,
           votes: ownProps.votes + 1
         }


### PR DESCRIPTION
This pull request removes a react-apollo warning when upvoting a post. It also fixes an issue where upvoting a post before the first vote comes back from the server (e.g. double click the upvote button) would throw an error.

This issue seems to have been caused by a breaking change to react-apollo's optimistic ui API.