### PR TITLE
Load chunks in SSR mode only if they exists in the filesystem

### DIFF
--- a/server/export.js
+++ b/server/export.js
@@ -6,12 +6,13 @@ import { resolve, join, dirname, sep } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import getConfig from './config'
 import { renderToHTML } from './render'
+import { getAvailableChunks } from './utils'
 import { printAndExit } from '../lib/utils'
 
 export default async function (dir, options) {
   dir = resolve(dir)
   const config = getConfig(dir)
-  const nextDir = join(dir, config.distDir || '.next')
+  const nextDir = join(dir, config.distDir)
 
   log(`  using build directory: ${nextDir}`)
 
@@ -79,7 +80,8 @@ export default async function (dir, options) {
     assetPrefix: config.assetPrefix.replace(/\/$/, ''),
     dev: false,
     staticMarkup: false,
-    hotReloader: null
+    hotReloader: null,
+    availableChunks: getAvailableChunks(dir, config.distDir)
   }
 
   // We need this for server rendering the Link component.

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ import {
 import Router from './router'
 import HotReloader from './hot-reloader'
 import { resolveFromList } from './resolve'
+import { getAvailableChunks } from './utils'
 import getConfig from './config'
 // We need to go up one more level since we are in the `dist` directory
 import pkg from '../../package'
@@ -43,7 +44,7 @@ export default class Server {
       buildStats: this.buildStats,
       buildId: this.buildId,
       assetPrefix: this.config.assetPrefix.replace(/\/$/, ''),
-      availableChunks: dev ? {} : this.getAvailableChunks()
+      availableChunks: dev ? {} : getAvailableChunks(this.dir, this.dist)
     }
 
     this.defineRoutes()
@@ -387,21 +388,5 @@ export default class Server {
   send404 (res) {
     res.statusCode = 404
     res.end('404 - Not Found')
-  }
-
-  getAvailableChunks () {
-    const chunksDir = join(this.dir, this.dist, 'chunks')
-    if (!fs.existsSync(chunksDir)) return {}
-
-    const chunksMap = {}
-    const chunkFiles = fs.readdirSync(chunksDir)
-
-    chunkFiles.forEach(filename => {
-      if (/\.js$/.test(filename)) {
-        chunksMap[filename] = true
-      }
-    })
-
-    return chunksMap
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -42,7 +42,8 @@ export default class Server {
       hotReloader: this.hotReloader,
       buildStats: this.buildStats,
       buildId: this.buildId,
-      assetPrefix: this.config.assetPrefix.replace(/\/$/, '')
+      assetPrefix: this.config.assetPrefix.replace(/\/$/, ''),
+      availableChunks: dev ? {} : this.getAvailableChunks()
     }
 
     this.defineRoutes()
@@ -386,5 +387,21 @@ export default class Server {
   send404 (res) {
     res.statusCode = 404
     res.end('404 - Not Found')
+  }
+
+  getAvailableChunks () {
+    const chunksDir = join(this.dir, this.dist, 'chunks')
+    if (!fs.existsSync(chunksDir)) return {}
+
+    const chunksMap = {}
+    const chunkFiles = fs.readdirSync(chunksDir)
+
+    chunkFiles.forEach(filename => {
+      if (/\.js$/.test(filename)) {
+        chunksMap[filename] = true
+      }
+    })
+
+    return chunksMap
   }
 }

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,2 +1,21 @@
+import { join } from 'path'
+import { readdirSync, existsSync } from 'fs'
+
 export const IS_BUNDLED_PAGE = /^bundles[/\\]pages.*\.js$/
 export const MATCH_ROUTE_NAME = /^bundles[/\\]pages[/\\](.*)\.js$/
+
+export function getAvailableChunks (dir, dist) {
+  const chunksDir = join(dir, dist, 'chunks')
+  if (!existsSync(chunksDir)) return {}
+
+  const chunksMap = {}
+  const chunkFiles = readdirSync(chunksDir)
+
+  chunkFiles.forEach(filename => {
+    if (/\.js$/.test(filename)) {
+      chunksMap[filename] = true
+    }
+  })
+
+  return chunksMap
+}

--- a/test/integration/basic/components/welcome.js
+++ b/test/integration/basic/components/welcome.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default class Welcome extends React.Component {
+  state = { name: null }
+
+  componentDidMount () {
+    const { name } = this.props
+    this.setState({ name })
+  }
+
+  render () {
+    const { name } = this.state
+    if (!name) return null
+
+    return (
+      <p>Welcome, {name}</p>
+    )
+  }
+}

--- a/test/integration/basic/pages/dynamic/index.js
+++ b/test/integration/basic/pages/dynamic/index.js
@@ -1,0 +1,7 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/dynamic/no-chunk'><a>No Chunk</a></Link>
+  </div>
+)

--- a/test/integration/basic/pages/dynamic/no-chunk.js
+++ b/test/integration/basic/pages/dynamic/no-chunk.js
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic'
+import Welcome from '../../components/welcome'
+
+const Welcome2 = dynamic(import('../../components/welcome'))
+
+export default () => (
+  <div>
+    <Welcome name='normal' />
+    <Welcome2 name='dynamic' />
+  </div>
+)

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -1,0 +1,61 @@
+/* global describe, it, expect */
+import webdriver from 'next-webdriver'
+import cheerio from 'cheerio'
+import { waitFor } from 'next-test-utils'
+
+export default (context, render) => {
+  describe('Dynamic import', () => {
+    describe('with SSR', () => {
+      async function get$ (path, query) {
+        const html = await render(path, query)
+        return cheerio.load(html)
+      }
+
+      it('should render dynmaic import components', async () => {
+        const $ = await get$('/dynamic/ssr')
+        expect($('p').text()).toBe('Hello World 1')
+      })
+
+      it('should stop render dynmaic import components', async () => {
+        const $ = await get$('/dynamic/no-ssr')
+        expect($('p').text()).toBe('loading...')
+      })
+
+      it('should stop render dynmaic import components with custom loading', async () => {
+        const $ = await get$('/dynamic/no-ssr-custom-loading')
+        expect($('p').text()).toBe('LOADING')
+      })
+    })
+
+    describe('with browser', () => {
+      it('should render the page client side', async () => {
+        const browser = await webdriver(context.appPort, '/dynamic/no-ssr-custom-loading')
+
+        while (true) {
+          const bodyText = await browser
+            .elementByCss('body').text()
+          if (/Hello World 1/.test(bodyText)) break
+          await waitFor(1000)
+        }
+
+        browser.close()
+      })
+
+      it('should render even there are no physical chunk exists', async () => {
+        const browser = await webdriver(context.appPort, '/dynamic/no-chunk')
+
+        while (true) {
+          const bodyText = await browser
+            .elementByCss('body').text()
+          if (
+            /Welcome, normal/.test(bodyText) &&
+            /Welcome, dynamic/.test(bodyText)
+          ) break
+          await waitFor(1000)
+        }
+
+        browser.close()
+      })
+    })
+  })
+}

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -15,6 +15,7 @@ import rendering from './rendering'
 import misc from './misc'
 import clientNavigation from './client-navigation'
 import hmr from './hmr'
+import dynamic from './dynamic'
 
 const context = {}
 context.app = nextServer({
@@ -64,5 +65,6 @@ describe('Basic Features', () => {
   xPoweredBy(context)
   misc(context)
   clientNavigation(context, (p, q) => renderViaHTTP(context.appPort, p, q))
+  dynamic(context, (p, q) => renderViaHTTP(context.appPort, p, q))
   hmr(context, (p, q) => renderViaHTTP(context.appPort, p, q))
 })

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -79,20 +79,5 @@ export default function ({ app }, suiteName, render) {
       expect($('h1').text()).toBe('404')
       expect($('h2').text()).toBe('This page could not be found.')
     })
-
-    test('render dynmaic import components via SSR', async () => {
-      const $ = await get$('/dynamic/ssr')
-      expect($('p').text()).toBe('Hello World 1')
-    })
-
-    test('stop render dynmaic import components in SSR', async () => {
-      const $ = await get$('/dynamic/no-ssr')
-      expect($('p').text()).toBe('loading...')
-    })
-
-    test('stop render dynmaic import components in SSR with custom loading', async () => {
-      const $ = await get$('/dynamic/no-ssr-custom-loading')
-      expect($('p').text()).toBe('LOADING')
-    })
   })
 }

--- a/test/integration/production/components/hello1.js
+++ b/test/integration/production/components/hello1.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello World 1</p>
+)

--- a/test/integration/production/components/welcome.js
+++ b/test/integration/production/components/welcome.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default class Welcome extends React.Component {
+  state = { name: null }
+
+  componentDidMount () {
+    const { name } = this.props
+    this.setState({ name })
+  }
+
+  render () {
+    const { name } = this.state
+    if (!name) return null
+
+    return (
+      <p>Welcome, {name}</p>
+    )
+  }
+}

--- a/test/integration/production/pages/dynamic/index.js
+++ b/test/integration/production/pages/dynamic/index.js
@@ -1,0 +1,7 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/dynamic/no-chunk'><a>No Chunk</a></Link>
+  </div>
+)

--- a/test/integration/production/pages/dynamic/no-chunk.js
+++ b/test/integration/production/pages/dynamic/no-chunk.js
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic'
+import Welcome from '../../components/welcome'
+
+const Welcome2 = dynamic(import('../../components/welcome'))
+
+export default () => (
+  <div>
+    <Welcome name='normal' />
+    <Welcome2 name='dynamic' />
+  </div>
+)

--- a/test/integration/production/pages/dynamic/no-ssr-custom-loading.js
+++ b/test/integration/production/pages/dynamic/no-ssr-custom-loading.js
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(import('../../components/hello1'), {
+  ssr: false,
+  loading: () => (<p>LOADING</p>)
+})
+
+export default Hello

--- a/test/integration/production/pages/dynamic/no-ssr.js
+++ b/test/integration/production/pages/dynamic/no-ssr.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(import('../../components/hello1'), { ssr: false })
+
+export default Hello

--- a/test/integration/production/pages/dynamic/ssr.js
+++ b/test/integration/production/pages/dynamic/ssr.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(import('../../components/hello1'))
+
+export default Hello

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -11,12 +11,15 @@ import {
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import fetch from 'node-fetch'
+import dynamicImportTests from '../../basic/test/dynamic'
 
 const appDir = join(__dirname, '../')
 let appPort
 let server
 let app
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 40000
+
+const context = {}
 
 describe('Production Usage', () => {
   beforeAll(async () => {
@@ -28,7 +31,7 @@ describe('Production Usage', () => {
     })
 
     server = await startApp(app)
-    appPort = server.address().port
+    context.appPort = appPort = server.address().port
   })
   afterAll(() => stopApp(server))
 
@@ -77,4 +80,6 @@ describe('Production Usage', () => {
       browser.close()
     })
   })
+
+  dynamicImportTests(context, (p, q) => renderViaHTTP(context.appPort, p, q))
 })


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/2073
Sometimes, it's possible to have dynamically imported module without an actual physical file (chunk).
This is because the same module imported normally and exists in the app's main JS bundle.

So, we need to make sure to ignore such modules when the page loads with SSR.