### PR TITLE
Treat production and development error objects the same

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -109,9 +109,7 @@ export async function renderError (error) {
   console.error(errorMessage)
 
   if (prod) {
-    const initProps = { err: error, pathname, query, asPath }
-    const props = await loadGetInitialProps(ErrorComponent, initProps)
-    ReactDOM.render(createElement(ErrorComponent, props), errorContainer)
+    ReactDOM.render(createElement(ErrorComponent, { error }), errorContainer)
   } else {
     ReactDOM.render(createElement(ErrorDebugComponent, { error }), errorContainer)
   }


### PR DESCRIPTION
At some point we introduced a split in how we pass errors around in
dev versus prod, and instead of passing the original error object
we began to modify it in production. We also ran an additional
`loadGetInitialProps()`, which caused anything in `_error`'s initial
props method to be loaded twice client-side (first with the previous
path, then with the new path, but both with the same error).

It's unclear to me why this was necessary in the first place, so I've
returned to passing the same `error` object to both the dev and prod
error views. cc/ @arunoda

This resolves #1814 by passing the actual error to the production
`_error` page.

Resolves #1814