### PR TITLE
Remove hardcoded address from ws example.

### DIFF
--- a/examples/with-socket.io/pages/index.js
+++ b/examples/with-socket.io/pages/index.js
@@ -22,7 +22,7 @@ class HomePage extends Component {
 
   // connect to WS server and listen event
   componentDidMount () {
-    this.socket = io('http://localhost:3000/')
+    this.socket = io()
     this.socket.on('message', this.handleMessage)
   }
 


### PR DESCRIPTION
With a hard coded address on the client, the app no longer works when deploying, which is annoying since there's a handy 'deploy now' button on the readme.

By removing the hard coded address socket.io will connect to the location host automatically so it works both on development and production.