### PR TITLE
Implement the correct browser behavior for hash changes.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -132,9 +132,10 @@ export default class Router {
     const { pathname, query } = parse(url, true)
 
     // If the url change is only related to a hash change
-    // We should not proceed. We should only replace the state.
+    // We should not proceed. We should only change the state.
     if (this.onlyAHashChange(as)) {
-      this.changeState('replaceState', url, as)
+      this.changeState(method, url, as)
+      this.scrollToHash(as)
       return
     }
 
@@ -259,6 +260,14 @@ export default class Router {
     // Now there's a hash in the new URL.
     // We don't need to worry about the old hash.
     return true
+  }
+
+  scrollToHash (as) {
+    const [ , hash ] = as.split('#')
+    const el = document.getElementById(hash)
+    if (el) {
+      el.scrollIntoView()
+    }
   }
 
   urlIsNew (pathname, query) {


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/2098

Now `next/link` should work exactly like browser's `<a/>` when handling hashes.