### PR TITLE
Scroll to the hash only if there's one after an error.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -44,12 +44,14 @@ class Container extends Component {
 
   scrollToHash () {
     const { hash } = this.props
+    if (!hash) return
+
     const el = document.getElementById(hash)
-    if (el) {
-      // If we call scrollIntoView() in here without a setTimeout
-      // it won't scroll properly.
-      setTimeout(() => el.scrollIntoView(), 0)
-    }
+    if (!el) return
+
+    // If we call scrollIntoView() in here without a setTimeout
+    // it won't scroll properly.
+    setTimeout(() => el.scrollIntoView(), 0)
   }
 
   shouldComponentUpdate (nextProps) {


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/2193