### PR TITLE
Better data fetching error handling for Apollo examples

### DIFF
--- a/examples/with-apollo-and-redux/components/ErrorMessage.js
+++ b/examples/with-apollo-and-redux/components/ErrorMessage.js
@@ -1,0 +1,13 @@
+export default ({message}) => (
+  <aside>
+    {message}
+    <style jsx>{`
+      aside {
+        padding: 1.5em;
+        font-size: 14px;
+        color: white;
+        background-color: red;
+      }
+    `}</style>
+  </aside>
+)

--- a/examples/with-apollo-and-redux/components/PostList.js
+++ b/examples/with-apollo-and-redux/components/PostList.js
@@ -1,9 +1,11 @@
 import { gql, graphql } from 'react-apollo'
+import ErrorMessage from './ErrorMessage'
 import PostUpvoter from './PostUpvoter'
 
 const POSTS_PER_PAGE = 10
 
-function PostList ({ data: { allPosts, loading, _allPostsMeta }, loadMorePosts }) {
+function PostList ({ data: { loading, error, allPosts, _allPostsMeta }, loadMorePosts }) {
+  if (error) return <ErrorMessage message='Error loading posts.' />
   if (allPosts && allPosts.length) {
     const areMorePosts = allPosts.length < _allPostsMeta.count
     return (

--- a/examples/with-apollo-and-redux/lib/withData.js
+++ b/examples/with-apollo-and-redux/lib/withData.js
@@ -20,23 +20,28 @@ export default ComposedComponent => {
         composedInitialProps = await ComposedComponent.getInitialProps(ctx)
       }
 
-      // Run all graphql queries in the component tree
+      // Run all GraphQL queries in the component tree
       // and extract the resulting data
       if (!process.browser) {
         const apollo = initApollo()
         const redux = initRedux(apollo)
-        // Provide the `url` prop data in case a graphql query uses it
+        // Provide the `url` prop data in case a GraphQL query uses it
         const url = {query: ctx.query, pathname: ctx.pathname}
 
-        // Run all graphql queries
-        const app = (
-          // No need to use the Redux Provider
-          // because Apollo sets up the store for us
-          <ApolloProvider client={apollo} store={redux}>
-            <ComposedComponent url={url} {...composedInitialProps} />
-          </ApolloProvider>
-        )
-        await getDataFromTree(app)
+        try {
+          // Run all GraphQL queries
+          await getDataFromTree(
+            // No need to use the Redux Provider
+            // because Apollo sets up the store for us
+            <ApolloProvider client={apollo} store={redux}>
+              <ComposedComponent url={url} {...composedInitialProps} />
+            </ApolloProvider>
+          )
+        } catch (error) {
+          // Prevent Apollo Client GraphQL errors from crashing SSR.
+          // Handle them in components via the data.error prop:
+          // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
+        }
 
         // Extract query data from the store
         const state = redux.getState()
@@ -44,7 +49,7 @@ export default ComposedComponent => {
         // No need to include other initial Redux state because when it
         // initialises on the client-side it'll create it again anyway
         serverState = {
-          apollo: { // Make sure to only include Apollo's data state
+          apollo: { // Only include the Apollo data state
             data: state.apollo.data
           }
         }

--- a/examples/with-apollo/components/ErrorMessage.js
+++ b/examples/with-apollo/components/ErrorMessage.js
@@ -1,0 +1,13 @@
+export default ({message}) => (
+  <aside>
+    {message}
+    <style jsx>{`
+      aside {
+        padding: 1.5em;
+        font-size: 14px;
+        color: white;
+        background-color: red;
+      }
+    `}</style>
+  </aside>
+)

--- a/examples/with-apollo/components/PostList.js
+++ b/examples/with-apollo/components/PostList.js
@@ -1,9 +1,11 @@
 import { gql, graphql } from 'react-apollo'
+import ErrorMessage from './ErrorMessage'
 import PostUpvoter from './PostUpvoter'
 
 const POSTS_PER_PAGE = 10
 
-function PostList ({ data: { allPosts, loading, _allPostsMeta }, loadMorePosts }) {
+function PostList ({ data: { loading, error, allPosts, _allPostsMeta }, loadMorePosts }) {
+  if (error) return <ErrorMessage message='Error loading posts.' />
   if (allPosts && allPosts.length) {
     const areMorePosts = allPosts.length < _allPostsMeta.count
     return (

--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -19,26 +19,32 @@ export default ComposedComponent => {
         composedInitialProps = await ComposedComponent.getInitialProps(ctx)
       }
 
-      // Run all graphql queries in the component tree
+      // Run all GraphQL queries in the component tree
       // and extract the resulting data
       if (!process.browser) {
         const apollo = initApollo()
-        // Provide the `url` prop data in case a graphql query uses it
+        // Provide the `url` prop data in case a GraphQL query uses it
         const url = {query: ctx.query, pathname: ctx.pathname}
 
-        // Run all graphql queries
-        const app = (
-          <ApolloProvider client={apollo}>
-            <ComposedComponent url={url} {...composedInitialProps} />
-          </ApolloProvider>
-        )
-        await getDataFromTree(app)
+        try {
+          // Run all GraphQL queries
+          await getDataFromTree(
+            <ApolloProvider client={apollo}>
+              <ComposedComponent url={url} {...composedInitialProps} />
+            </ApolloProvider>
+          )
+        } catch (error) {
+          // Prevent Apollo Client GraphQL errors from crashing SSR.
+          // Handle them in components via the data.error prop:
+          // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
+        }
 
-        // Extract query data from the Apollo's store
+        // Extract query data from the Apollo store
         const state = apollo.getInitialState()
 
         serverState = {
-          apollo: { // Make sure to only include Apollo's data state
+          apollo: {
+            // Only include the Apollo data state
             data: state.data
           }
         }


### PR DESCRIPTION
Currently, an Apollo Client GraphQL error in any component will crash SSR. Errors are not handled or displayed in any of the components.

Now these errors are caught and silenced on the server, so that the client can be responsible for handling them via the [`data.error` prop](http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error).

Error messages are displayed inline using a new `ErrorMessage` component, and look like this:

![screen shot 2017-06-10 at 4 51 40 pm](https://user-images.githubusercontent.com/1754873/27000791-2c26804e-4dfd-11e7-8c67-bcc7b0b808b1.png)

I also tidied a few comments in the vicinity of the changes.