### PR TITLE
Dynamic component support with multiple modules

### DIFF
--- a/examples/with-dynamic-import/components/hello6.js
+++ b/examples/with-dynamic-import/components/hello6.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello World 6 (imported dynamiclly) </p>
+)

--- a/examples/with-dynamic-import/components/hello7.js
+++ b/examples/with-dynamic-import/components/hello7.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello World 7 (imported dynamiclly) </p>
+)

--- a/examples/with-dynamic-import/pages/index.js
+++ b/examples/with-dynamic-import/pages/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Router from 'next/router'
 import Header from '../components/Header'
 import Counter from '../components/Counter'
 import dynamic from 'next/dynamic'
@@ -23,35 +24,63 @@ const DynamicComponentWithAsyncReactor = asyncReactor(async () => {
 const DynamicComponent5 = dynamic(import('../components/hello5'))
 
 const DynamicBundle = dynamic({
-  modules: ({
-    Hello6: import('../components/hello6'),
-    Hello7: import('../components/hello7')
-  }),
+  modules: (props) => {
+    const components = {
+      Hello6: import('../components/hello6')
+    }
+
+    if (props.showMore) {
+      components.Hello7 = import('../components/hello7')
+    }
+
+    return components
+  },
   render: (props, { Hello6, Hello7 }) => (
     <div style={{padding: 10, border: '1px solid #888'}}>
       <Hello6 />
-      <Hello7 />
+      {Hello7 ? <Hello7 /> : null}
     </div>
   )
 })
 
-export default () => (
-  <div>
-    <Header />
-    <DynamicComponent />
-    <DynamicComponentWithCustomLoading />
-    <DynamicComponentWithNoSSR />
-    <DynamicComponentWithAsyncReactor />
-    <DynamicBundle />
-    {
-      /*
-        Since DynamicComponent5 does not render in the client,
-        it won't get downloaded.
-      */
-    }
-    { React.noSuchField === true ? <DynamicComponent5 /> : null }
+export default class Index extends React.Component {
+  static getInitialProps ({ query }) {
+    return { showMore: Boolean(query.showMore) }
+  }
 
-    <p>HOME PAGE is here!</p>
-    <Counter />
-  </div>
-)
+  toggleShowMore () {
+    const { showMore } = this.props
+    if (showMore) {
+      Router.push('/')
+      return
+    }
+
+    Router.push('/?showMore=1')
+  }
+
+  render () {
+    const { showMore } = this.props
+
+    return (
+      <div>
+        <Header />
+        <DynamicComponent />
+        <DynamicComponentWithCustomLoading />
+        <DynamicComponentWithNoSSR />
+        <DynamicComponentWithAsyncReactor />
+        <DynamicBundle showMore={showMore} />
+        <button onClick={() => this.toggleShowMore()}>Toggle Show More</button>
+        {
+          /*
+            Since DynamicComponent5 does not render in the client,
+            it won't get downloaded.
+          */
+        }
+        { React.noSuchField === true ? <DynamicComponent5 /> : null }
+
+        <p>HOME PAGE is here!</p>
+        <Counter />
+      </div>
+    )
+  }
+}

--- a/examples/with-dynamic-import/pages/index.js
+++ b/examples/with-dynamic-import/pages/index.js
@@ -22,6 +22,19 @@ const DynamicComponentWithAsyncReactor = asyncReactor(async () => {
 
 const DynamicComponent5 = dynamic(import('../components/hello5'))
 
+const DynamicBundle = dynamic({
+  modules: ({
+    Hello6: import('../components/hello6'),
+    Hello7: import('../components/hello7')
+  }),
+  render: (props, { Hello6, Hello7 }) => (
+    <div style={{padding: 10, border: '1px solid #888'}}>
+      <Hello6 />
+      <Hello7 />
+    </div>
+  )
+})
+
 export default () => (
   <div>
     <Header />
@@ -29,6 +42,7 @@ export default () => (
     <DynamicComponentWithCustomLoading />
     <DynamicComponentWithNoSSR />
     <DynamicComponentWithAsyncReactor />
+    <DynamicBundle />
     {
       /*
         Since DynamicComponent5 does not render in the client,

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -1,11 +1,18 @@
 import React from 'react'
+import { execOnce, warn } from './utils'
 
-let currentChunks = []
+const printDeprecateMessage = execOnce(() => warn(
+  'Dynamic imports with \'next/dynamic\' is deprecated. Use \'next/async\' instead.'
+))
+
+let currentChunks = new Set()
 
 export default function dynamicComponent (promise, options = {}) {
   return class DynamicComponent extends React.Component {
     constructor (...args) {
       super(...args)
+
+      printDeprecateMessage()
 
       this.LoadingComponent = options.loading ? options.loading : () => (<p>loading...</p>)
       this.ssr = options.ssr === false ? options.ssr : true
@@ -30,7 +37,7 @@ export default function dynamicComponent (promise, options = {}) {
           this.setState({ AsyncComponent })
         } else {
           if (this.isServer) {
-            currentChunks.push(AsyncComponent.__webpackChunkName)
+            registerChunk(AsyncComponent.__webpackChunkName)
           }
           this.state.AsyncComponent = AsyncComponent
         }
@@ -54,9 +61,13 @@ export default function dynamicComponent (promise, options = {}) {
   }
 }
 
+export function registerChunk (chunk) {
+  currentChunks.add(chunk)
+}
+
 export function flushChunks () {
-  const chunks = currentChunks
-  currentChunks = []
+  const chunks = Array.from(currentChunks)
+  currentChunks.clear()
   return chunks
 }
 

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -1,27 +1,49 @@
 import React from 'react'
-import { execOnce, warn } from './utils'
-
-const printDeprecateMessage = execOnce(() => warn(
-  'Dynamic imports with \'next/dynamic\' is deprecated. Use \'next/async\' instead.'
-))
 
 let currentChunks = new Set()
 
-export default function dynamicComponent (promise, options = {}) {
+export default function dynamicComponent (p, o) {
+  let promise
+  let options
+
+  if (p instanceof SameLoopPromise) {
+    promise = p
+    options = o || {}
+  } else {
+    // Now we are trying to use the modules and render fields in options to load modules.
+    if (!p.modules || !p.render) {
+      const errorMessage = 'Options to `next/dynamic` should contains `modules` and `render` fields.'
+      throw new Error(errorMessage)
+    }
+
+    if (o) {
+      const errorMessage = 'Include options in the first argument which contains `modules` and `render` fields.'
+      throw new Error(errorMessage)
+    }
+
+    options = p
+  }
+
   return class DynamicComponent extends React.Component {
     constructor (...args) {
       super(...args)
 
-      printDeprecateMessage()
-
       this.LoadingComponent = options.loading ? options.loading : () => (<p>loading...</p>)
       this.ssr = options.ssr === false ? options.ssr : true
 
-      this.state = { AsyncComponent: null }
+      this.state = { AsyncComponent: null, asyncElement: null }
       this.isServer = typeof window === 'undefined'
 
       if (this.ssr) {
+        this.load()
+      }
+    }
+
+    load () {
+      if (promise) {
         this.loadComponent()
+      } else {
+        this.loadBundle()
       }
     }
 
@@ -44,19 +66,53 @@ export default function dynamicComponent (promise, options = {}) {
       })
     }
 
+    loadBundle () {
+      const moduleNames = Object.keys(options.modules)
+      let remainingPromises = moduleNames.length
+      const moduleMap = {}
+
+      const renderModules = () => {
+        DynamicComponent.displayName = 'DynamicBundle'
+        const asyncElement = options.render(this.props, moduleMap)
+        if (this.mounted) {
+          this.setState({ asyncElement })
+        } else {
+          this.state.asyncElement = asyncElement
+        }
+      }
+
+      const loadModule = (name) => {
+        const promise = options.modules[name]
+        promise.then((Component) => {
+          if (this.isServer) {
+            registerChunk(Component.__webpackChunkName)
+          }
+          moduleMap[name] = Component
+          remainingPromises--
+          if (remainingPromises === 0) {
+            renderModules()
+          }
+        })
+      }
+
+      moduleNames.forEach(loadModule)
+    }
+
     componentDidMount () {
       this.mounted = true
       if (!this.ssr) {
-        this.loadComponent()
+        this.load()
       }
     }
 
     render () {
-      const { AsyncComponent } = this.state
+      const { AsyncComponent, asyncElement } = this.state
       const { LoadingComponent } = this
-      if (!AsyncComponent) return (<LoadingComponent {...this.props} />)
 
-      return <AsyncComponent {...this.props} />
+      if (asyncElement) return asyncElement
+      if (AsyncComponent) return (<AsyncComponent {...this.props} />)
+
+      return (<LoadingComponent {...this.props} />)
     }
   }
 }

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -34,6 +34,11 @@ export default function dynamicComponent (p, o) {
       this.state = { AsyncComponent: null, asyncElement: null }
       this.isServer = typeof window === 'undefined'
 
+      // This flag is used to load the bundle again, if needed
+      this.loadBundleAgain = null
+      // This flag keeps track of the whether we are loading a bundle or not.
+      this.loadingBundle = false
+
       if (this.ssr) {
         this.load()
       }
@@ -43,7 +48,7 @@ export default function dynamicComponent (p, o) {
       if (promise) {
         this.loadComponent()
       } else {
-        this.loadBundle()
+        this.loadBundle(this.props)
       }
     }
 
@@ -66,14 +71,25 @@ export default function dynamicComponent (p, o) {
       })
     }
 
-    loadBundle () {
-      const moduleNames = Object.keys(options.modules)
+    loadBundle (props) {
+      this.loadBundleAgain = null
+      this.loadingBundle = true
+
+      // Run this for prop changes as well.
+      const modulePromiseMap = options.modules(props)
+      const moduleNames = Object.keys(modulePromiseMap)
       let remainingPromises = moduleNames.length
       const moduleMap = {}
 
       const renderModules = () => {
+        if (this.loadBundleAgain) {
+          this.loadBundle(this.loadBundleAgain)
+          return
+        }
+
+        this.loadingBundle = false
         DynamicComponent.displayName = 'DynamicBundle'
-        const asyncElement = options.render(this.props, moduleMap)
+        const asyncElement = options.render(props, moduleMap)
         if (this.mounted) {
           this.setState({ asyncElement })
         } else {
@@ -82,7 +98,7 @@ export default function dynamicComponent (p, o) {
       }
 
       const loadModule = (name) => {
-        const promise = options.modules[name]
+        const promise = modulePromiseMap[name]
         promise.then((Component) => {
           if (this.isServer) {
             registerChunk(Component.__webpackChunkName)
@@ -103,6 +119,19 @@ export default function dynamicComponent (p, o) {
       if (!this.ssr) {
         this.load()
       }
+    }
+
+    componentWillReceiveProps (nextProps) {
+      if (promise) return
+
+      this.setState({ asyncElement: null })
+
+      if (this.loadingBundle) {
+        this.loadBundleAgain = nextProps
+        return
+      }
+
+      this.loadBundle(nextProps)
     }
 
     render () {

--- a/readme.md
+++ b/readme.md
@@ -663,9 +663,15 @@ export default () => (
 import dynamic from 'next/dynamic'
 
 const HelloBundle = dynamic({
-  modules: {
-    Hello1: import('../components/hello1'),
-    Hello2: import('../components/hello2')
+  modules: (props) => {
+    const components {
+      Hello1: import('../components/hello1'),
+      Hello2: import('../components/hello2')
+    }
+
+    // Add remove components based on props
+
+    return components
   },
   render: (props, { Hello1, Hello2 }) => (
     <div>

--- a/readme.md
+++ b/readme.md
@@ -657,23 +657,27 @@ export default () => (
 )
 ```
 
-#### 4. With [async-reactor](https://github.com/xtuc/async-reactor)
-
-> SSR support is not available here
+#### 4. With Multiple Modules At Once
 
 ```js
-import { asyncReactor } from 'async-reactor'
-const DynamicComponentWithAsyncReactor = asyncReactor(async () => {
-  const Hello4 = await import('../components/hello4')
-  return (<Hello4 />)
+import dynamic from 'next/dynamic'
+
+const HelloBundle = dynamic({
+  modules: {
+    Hello1: import('../components/hello1'),
+    Hello2: import('../components/hello2')
+  },
+  render: (props, { Hello1, Hello2 }) => (
+    <div>
+      <h1>{props.title}</h1>
+      <Hello1 />
+      <Hello2 />
+    </div>
+  )
 })
 
 export default () => (
-  <div>
-    <Header />
-    <DynamicComponentWithAsyncReactor />
-    <p>HOME PAGE is here!</p>
-  </div>
+  <HelloBundle title="Dynamic Bundle"/>
 )
 ```
 

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -14,7 +14,6 @@ const buildImport = (args) => (template(`
         require.ensure([], (require) => {
           let m = require(SOURCE)
           m = m.default || m
-          require('next/dynamic').registerChunk('${args.name}.js')
           m.__webpackChunkName = '${args.name}.js'
           resolve(m);
         }, 'chunks/${args.name}.js');

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -14,6 +14,7 @@ const buildImport = (args) => (template(`
         require.ensure([], (require) => {
           let m = require(SOURCE)
           m = m.default || m
+          require('next/dynamic').registerChunk('${args.name}.js')
           m.__webpackChunkName = '${args.name}.js'
           resolve(m);
         }, 'chunks/${args.name}.js');

--- a/test/integration/basic/components/hello-context.js
+++ b/test/integration/basic/components/hello-context.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class extends React.Component {
+  static contextTypes = {
+    data: PropTypes.object
+  }
+
+  render () {
+    const { data } = this.context
+    return (
+      <div>{data.title}</div>
+    )
+  }
+}

--- a/test/integration/basic/components/hello2.js
+++ b/test/integration/basic/components/hello2.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello World 2</p>
+)

--- a/test/integration/basic/pages/dynamic/bundle.js
+++ b/test/integration/basic/pages/dynamic/bundle.js
@@ -1,19 +1,55 @@
+import React from 'react'
 import dynamic from 'next/dynamic'
+import Router from 'next/router'
 
 const HelloBundle = dynamic({
-  modules: {
-    Hello1: import('../../components/hello1'),
-    Hello2: import('../../components/hello2')
+  modules: (props) => {
+    const components = {
+      Hello1: import('../../components/hello1')
+    }
+
+    if (props.showMore) {
+      components.Hello2 = import('../../components/hello2')
+    }
+
+    return components
   },
   render: (props, { Hello1, Hello2 }) => (
     <div>
       <h1>{props.title}</h1>
       <Hello1 />
-      <Hello2 />
+      {Hello2? <Hello2 /> : null}
     </div>
   )
 })
 
-export default () => (
-  <HelloBundle title="Dynamic Bundle"/>
-)
+export default class Bundle extends React.Component {
+  static getInitialProps ({ query }) {
+    return { showMore: Boolean(query.showMore) }
+  }
+
+  toggleShowMore () {
+    if (this.props.showMore) {
+      Router.push('/dynamic/bundle')
+      return
+    }
+
+    Router.push('/dynamic/bundle?showMore=1')
+  }
+
+  render () {
+    const { showMore } = this.props
+
+    return (
+      <div>
+        <HelloBundle showMore={showMore} title="Dynamic Bundle"/>
+        <button
+          id="toggle-show-more"
+          onClick={() => this.toggleShowMore()}
+        >
+          Toggle Show More
+        </button>
+      </div>
+    )
+  }
+}

--- a/test/integration/basic/pages/dynamic/bundle.js
+++ b/test/integration/basic/pages/dynamic/bundle.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import dynamic from 'next/dynamic'
 import Router from 'next/router'
+import PropTypes from 'prop-types'
 
 const HelloBundle = dynamic({
   modules: (props) => {
     const components = {
+      HelloContext: import('../../components/hello-context'),
       Hello1: import('../../components/hello1')
     }
 
@@ -14,9 +16,10 @@ const HelloBundle = dynamic({
 
     return components
   },
-  render: (props, { Hello1, Hello2 }) => (
+  render: (props, { HelloContext, Hello1, Hello2 }) => (
     <div>
       <h1>{props.title}</h1>
+      <HelloContext />
       <Hello1 />
       {Hello2? <Hello2 /> : null}
     </div>
@@ -26,6 +29,16 @@ const HelloBundle = dynamic({
 export default class Bundle extends React.Component {
   static getInitialProps ({ query }) {
     return { showMore: Boolean(query.showMore) }
+  }
+
+  static childContextTypes = {
+    data: PropTypes.object 
+  }
+
+  getChildContext () {
+    return {
+      data: { title: 'ZEIT Rocks' }
+    }
   }
 
   toggleShowMore () {

--- a/test/integration/basic/pages/dynamic/bundle.js
+++ b/test/integration/basic/pages/dynamic/bundle.js
@@ -1,0 +1,19 @@
+import dynamic from 'next/dynamic'
+
+const HelloBundle = dynamic({
+  modules: {
+    Hello1: import('../../components/hello1'),
+    Hello2: import('../../components/hello2')
+  },
+  render: (props, { Hello1, Hello2 }) => (
+    <div>
+      <h1>{props.title}</h1>
+      <Hello1 />
+      <Hello2 />
+    </div>
+  )
+})
+
+export default () => (
+  <HelloBundle title="Dynamic Bundle"/>
+)

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -25,6 +25,14 @@ export default (context, render) => {
         const $ = await get$('/dynamic/no-ssr-custom-loading')
         expect($('p').text()).toBe('LOADING')
       })
+
+      it('should render dynamic imports bundle', async () => {
+        const $ = await get$('/dynamic/bundle')
+        const bodyText = $('body').text()
+        expect(/Dynamic Bundle/.test(bodyText)).toBe(true)
+        expect(/Hello World 1/.test(bodyText)).toBe(true)
+        expect(/Hello World 2/.test(bodyText)).toBe(true)
+      })
     })
 
     describe('with browser', () => {
@@ -50,6 +58,23 @@ export default (context, render) => {
           if (
             /Welcome, normal/.test(bodyText) &&
             /Welcome, dynamic/.test(bodyText)
+          ) break
+          await waitFor(1000)
+        }
+
+        browser.close()
+      })
+
+      it('should render dynamic imports bundle', async () => {
+        const browser = await webdriver(context.appPort, '/dynamic/bundle')
+
+        while (true) {
+          const bodyText = await browser
+            .elementByCss('body').text()
+          if (
+            /Dynamic Bundle/.test(bodyText) &&
+            /Hello World 1/.test(bodyText) &&
+            /Hello World 2/.test(bodyText)
           ) break
           await waitFor(1000)
         }

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -73,42 +73,59 @@ export default (context, render) => {
         browser.close()
       })
 
-      it('should render dynamic imports bundle', async () => {
-        const browser = await webdriver(context.appPort, '/dynamic/bundle')
+      describe('with bundle', () => {
+        it('should render components', async () => {
+          const browser = await webdriver(context.appPort, '/dynamic/bundle')
 
-        while (true) {
-          const bodyText = await browser
-            .elementByCss('body').text()
-          if (
-            /Dynamic Bundle/.test(bodyText) &&
-            /Hello World 1/.test(bodyText) &&
-            !(/Hello World 2/.test(bodyText))
-          ) break
-          await waitFor(1000)
-        }
+          while (true) {
+            const bodyText = await browser
+              .elementByCss('body').text()
+            if (
+              /Dynamic Bundle/.test(bodyText) &&
+              /Hello World 1/.test(bodyText) &&
+              !(/Hello World 2/.test(bodyText))
+            ) break
+            await waitFor(1000)
+          }
 
-        browser.close()
-      })
+          browser.close()
+        })
 
-      it('should render dynamic imports bundle and reactive to prop changes', async () => {
-        const browser = await webdriver(context.appPort, '/dynamic/bundle')
+        it('should render support React context', async () => {
+          const browser = await webdriver(context.appPort, '/dynamic/bundle')
 
-        await browser
-          .waitForElementByCss('#toggle-show-more')
-          .elementByCss('#toggle-show-more').click()
+          while (true) {
+            const bodyText = await browser
+              .elementByCss('body').text()
+            if (
+              /ZEIT Rocks/.test(bodyText)
+            ) break
+            await waitFor(1000)
+          }
 
-        while (true) {
-          const bodyText = await browser
-            .elementByCss('body').text()
-          if (
-            /Dynamic Bundle/.test(bodyText) &&
-            /Hello World 1/.test(bodyText) &&
-            /Hello World 2/.test(bodyText)
-          ) break
-          await waitFor(1000)
-        }
+          browser.close()
+        })
 
-        browser.close()
+        it('should load new components and render for prop changes', async () => {
+          const browser = await webdriver(context.appPort, '/dynamic/bundle')
+
+          await browser
+            .waitForElementByCss('#toggle-show-more')
+            .elementByCss('#toggle-show-more').click()
+
+          while (true) {
+            const bodyText = await browser
+              .elementByCss('body').text()
+            if (
+              /Dynamic Bundle/.test(bodyText) &&
+              /Hello World 1/.test(bodyText) &&
+              /Hello World 2/.test(bodyText)
+            ) break
+            await waitFor(1000)
+          }
+
+          browser.close()
+        })
       })
     })
   })

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -31,6 +31,14 @@ export default (context, render) => {
         const bodyText = $('body').text()
         expect(/Dynamic Bundle/.test(bodyText)).toBe(true)
         expect(/Hello World 1/.test(bodyText)).toBe(true)
+        expect(/Hello World 2/.test(bodyText)).toBe(false)
+      })
+
+      it('should render dynamic imports bundle with additional components', async () => {
+        const $ = await get$('/dynamic/bundle?showMore=1')
+        const bodyText = $('body').text()
+        expect(/Dynamic Bundle/.test(bodyText)).toBe(true)
+        expect(/Hello World 1/.test(bodyText)).toBe(true)
         expect(/Hello World 2/.test(bodyText)).toBe(true)
       })
     })
@@ -67,6 +75,27 @@ export default (context, render) => {
 
       it('should render dynamic imports bundle', async () => {
         const browser = await webdriver(context.appPort, '/dynamic/bundle')
+
+        while (true) {
+          const bodyText = await browser
+            .elementByCss('body').text()
+          if (
+            /Dynamic Bundle/.test(bodyText) &&
+            /Hello World 1/.test(bodyText) &&
+            !(/Hello World 2/.test(bodyText))
+          ) break
+          await waitFor(1000)
+        }
+
+        browser.close()
+      })
+
+      it('should render dynamic imports bundle and reactive to prop changes', async () => {
+        const browser = await webdriver(context.appPort, '/dynamic/bundle')
+
+        await browser
+          .waitForElementByCss('#toggle-show-more')
+          .elementByCss('#toggle-show-more').click()
 
         while (true) {
           const bodyText = await browser

--- a/test/integration/production/components/hello-context.js
+++ b/test/integration/production/components/hello-context.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class extends React.Component {
+  static contextTypes = {
+    data: PropTypes.object
+  }
+
+  render () {
+    const { data } = this.context
+    return (
+      <div>{data.title}</div>
+    )
+  }
+}

--- a/test/integration/production/components/hello2.js
+++ b/test/integration/production/components/hello2.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello World 2</p>
+)

--- a/test/integration/production/pages/dynamic/bundle.js
+++ b/test/integration/production/pages/dynamic/bundle.js
@@ -1,19 +1,55 @@
+import React from 'react'
 import dynamic from 'next/dynamic'
+import Router from 'next/router'
 
 const HelloBundle = dynamic({
-  modules: {
-    Hello1: import('../../components/hello1'),
-    Hello2: import('../../components/hello2')
+  modules: (props) => {
+    const components = {
+      Hello1: import('../../components/hello1')
+    }
+
+    if (props.showMore) {
+      components.Hello2 = import('../../components/hello2')
+    }
+
+    return components
   },
   render: (props, { Hello1, Hello2 }) => (
     <div>
       <h1>{props.title}</h1>
       <Hello1 />
-      <Hello2 />
+      {Hello2? <Hello2 /> : null}
     </div>
   )
 })
 
-export default () => (
-  <HelloBundle title="Dynamic Bundle"/>
-)
+export default class Bundle extends React.Component {
+  static getInitialProps ({ query }) {
+    return { showMore: Boolean(query.showMore) }
+  }
+
+  toggleShowMore () {
+    if (this.props.showMore) {
+      Router.push('/dynamic/bundle')
+      return
+    }
+
+    Router.push('/dynamic/bundle?showMore=1')
+  }
+
+  render () {
+    const { showMore } = this.props
+
+    return (
+      <div>
+        <HelloBundle showMore={showMore} title="Dynamic Bundle"/>
+        <button
+          id="toggle-show-more"
+          onClick={() => this.toggleShowMore()}
+        >
+          Toggle Show More
+        </button>
+      </div>
+    )
+  }
+}

--- a/test/integration/production/pages/dynamic/bundle.js
+++ b/test/integration/production/pages/dynamic/bundle.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import dynamic from 'next/dynamic'
 import Router from 'next/router'
+import PropTypes from 'prop-types'
 
 const HelloBundle = dynamic({
   modules: (props) => {
     const components = {
+      HelloContext: import('../../components/hello-context'),
       Hello1: import('../../components/hello1')
     }
 
@@ -14,9 +16,10 @@ const HelloBundle = dynamic({
 
     return components
   },
-  render: (props, { Hello1, Hello2 }) => (
+  render: (props, { HelloContext, Hello1, Hello2 }) => (
     <div>
       <h1>{props.title}</h1>
+      <HelloContext />
       <Hello1 />
       {Hello2? <Hello2 /> : null}
     </div>
@@ -26,6 +29,16 @@ const HelloBundle = dynamic({
 export default class Bundle extends React.Component {
   static getInitialProps ({ query }) {
     return { showMore: Boolean(query.showMore) }
+  }
+
+  static childContextTypes = {
+    data: PropTypes.object 
+  }
+
+  getChildContext () {
+    return {
+      data: { title: 'ZEIT Rocks' }
+    }
   }
 
   toggleShowMore () {

--- a/test/integration/production/pages/dynamic/bundle.js
+++ b/test/integration/production/pages/dynamic/bundle.js
@@ -1,0 +1,19 @@
+import dynamic from 'next/dynamic'
+
+const HelloBundle = dynamic({
+  modules: {
+    Hello1: import('../../components/hello1'),
+    Hello2: import('../../components/hello2')
+  },
+  render: (props, { Hello1, Hello2 }) => (
+    <div>
+      <h1>{props.title}</h1>
+      <Hello1 />
+      <Hello2 />
+    </div>
+  )
+})
+
+export default () => (
+  <HelloBundle title="Dynamic Bundle"/>
+)


### PR DESCRIPTION
> This is a backward compatible change to our existing `next/dynamic` API.

Sometimes we need to import a few modules at once. And select some components based on props.
This new API makes it simple.

Here's the basic usage:

```js
import dynamic from 'next/dynamic'

const HelloBundle = dynamic({
  modules: (props) => {
    const components {
      Hello1: import('../components/hello1'),
      Hello2: import('../components/hello2')
    }

    // Add remove components based on props

    return components
  },
  render: (props, { Hello1, Hello2 }) => (
    <div>
      <h1>{props.title}</h1>
      <Hello1 />
      <Hello2 />
    </div>
  )
})

export default () => (
  <HelloBundle title="Dynamic Bundle"/>
)
```

But with the prop changes, you can make this very powerful.
[See this example](https://github.com/zeit/next.js/pull/2235/files#diff-33c76b614bc2ba4411701614eb59a5c7)