### PR TITLE
Update Webpack to v2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "url": "0.11.0",
     "uuid": "3.0.1",
     "walk": "^2.3.9",
-    "webpack": "^2.6.1",
+    "webpack": "2.6.1",
     "webpack-dev-middleware": "1.10.2",
     "webpack-hot-middleware": "2.18.0",
     "write-file-webpack-plugin": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "url": "0.11.0",
     "uuid": "3.0.1",
     "walk": "^2.3.9",
-    "webpack": "2.6.0",
+    "webpack": "^2.6.1",
     "webpack-dev-middleware": "1.10.2",
     "webpack-hot-middleware": "2.18.0",
     "write-file-webpack-plugin": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5424,9 +5424,9 @@ webpack-sources@^0.2.3:
     source-list-map "^1.1.1"
     source-map "~0.5.3"
 
-webpack@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.6.0.tgz#7e650a92816abff5db5f43316b0b8b19b13d76c1"
+webpack@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.6.1.tgz#2e0457f0abb1ac5df3ab106c69c672f236785f07"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"


### PR DESCRIPTION
Also, added the `^` so that future Webpack patches won’t be missed.

Should fix https://github.com/zeit/next.js/issues/2244.