### PR TITLE
[Discussion] Using Rapscallion with NextJS

### DIFF
--- a/examples/express-with-rapscallion/.babelrc
+++ b/examples/express-with-rapscallion/.babelrc
@@ -1,0 +1,19 @@
+{
+	"env": {
+		"development": {
+			"presets": "next/babel"
+		},
+		"production": {
+			"presets": "next/babel"
+		},
+		"test": {
+			"presets": [
+				["env", {
+					"modules": "commonjs"
+				}],
+				"next/babel",
+				"rapscallion/babel-plugin-server"
+			]
+		}
+	}
+}

--- a/examples/express-with-rapscallion/README.md
+++ b/examples/express-with-rapscallion/README.md
@@ -1,0 +1,1 @@
+# Express with Rapscallion

--- a/examples/express-with-rapscallion/package.json
+++ b/examples/express-with-rapscallion/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "express": "^4.14.0",
+    "lodash": "^4.17.4",
+    "md5": "^2.2.1",
+    "next": "latest",
+    "rapscallion": "^2.1.7",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
+  }
+}

--- a/examples/express-with-rapscallion/pages/hashes.js
+++ b/examples/express-with-rapscallion/pages/hashes.js
@@ -1,0 +1,25 @@
+import _ from 'lodash'
+import md5 from 'md5'
+
+let arrayOfLength = (len) => {
+  return Array.apply(null, Array(len)).map(function () {})
+}
+
+function MakeHash (props) {
+  const hash = md5(props.idx)
+  return (
+    <div>
+      {hash.substr(0, 15)}
+    </div>
+  )
+}
+
+function Hashes (props) {
+  return <div cacheKey={`MD5List:length-${props.hashCount}`}>
+    {_.map(arrayOfLength(props.hashCount), (object, idx) => {
+      return <MakeHash idx={idx} key={`MD5:${idx}`} cacheKey={`MD5:${idx}`} />
+    })}
+  </div>
+}
+
+export default() => <Hashes hashCount={3000} />

--- a/examples/express-with-rapscallion/pages/index.js
+++ b/examples/express-with-rapscallion/pages/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+export default () => (
+  <ul>
+    <li><a href='/b'>Default Next.JS rendering</a></li>
+    <li><a href='/a'>Rapscallion rendering, with component caching</a></li>
+  </ul>
+)

--- a/examples/express-with-rapscallion/server.js
+++ b/examples/express-with-rapscallion/server.js
@@ -1,0 +1,64 @@
+const React = require('react')
+const express = require('express')
+const next = require('next')
+const {
+  render,
+  template
+} = require('rapscallion')
+
+const { Head, NextScript } = require('next/document')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare()
+.then(() => {
+  const server = express()
+
+  server.get('/a', (req, res) => {
+    app.renderToParts(req, res, '/hashes', req.query, {
+      renderMethod: render
+    })
+      .then((data) => {
+        // This template effectively replaces `document.js` in next.
+        const responseRenderer = template`
+          <!DOCTYPE html>
+          <html>
+            ${render(React.createElement(Head, {_documentProps: data.docProps}))}
+            <body>
+              <div id="__next">${data.html}</div>
+              <div id="__next-error">${data.errorHtml}</div>
+
+              <script>
+                document.querySelector("#__next > [data-reactroot]").setAttribute("data-react-checksum", "${() => data.html.checksum()}")
+              </script>
+
+              ${render(React.createElement(NextScript, {_documentProps: data.docProps}))}
+            </body>
+          </html>
+        `
+
+        // You could also return a stream and pipe it to `res`.
+        responseRenderer
+          .toPromise()
+          .then((data) => {
+            res.end(data)
+          })
+      })
+  })
+
+  server.get('/b', (req, res) => {
+    // Normal next.js rendering.
+    return app.render(req, res, '/hashes', req.query)
+  })
+
+  server.get('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(3000, (err) => {
+    if (err) throw err
+    console.log('> Ready on http://localhost:3000')
+  })
+})

--- a/server/document.js
+++ b/server/document.js
@@ -35,7 +35,7 @@ export class Head extends Component {
   }
 
   getChunkPreloadLink (filename) {
-    const { __NEXT_DATA__ } = this.context._documentProps
+    const { __NEXT_DATA__ } = this.context._documentProps || this.props._documentProps
     let { buildStats, assetPrefix, buildId } = __NEXT_DATA__
     const hash = buildStats ? buildStats[filename].hash : buildId
 
@@ -50,7 +50,7 @@ export class Head extends Component {
   }
 
   getPreloadMainLinks () {
-    const { dev } = this.context._documentProps
+    const { dev } = this.context._documentProps || this.props._documentProps
     if (dev) {
       return [
         this.getChunkPreloadLink('manifest.js'),
@@ -66,7 +66,7 @@ export class Head extends Component {
   }
 
   getPreloadDynamicChunks () {
-    const { chunks, __NEXT_DATA__ } = this.context._documentProps
+    const { chunks, __NEXT_DATA__ } = this.context._documentProps || this.props._documentProps
     let { assetPrefix } = __NEXT_DATA__
     return chunks.map((chunk) => (
       <link
@@ -79,7 +79,7 @@ export class Head extends Component {
   }
 
   render () {
-    const { head, styles, __NEXT_DATA__ } = this.context._documentProps
+    const { head, styles, __NEXT_DATA__ } = this.context._documentProps || this.props._documentProps
     const { pathname, buildId, assetPrefix, nextExport } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname, nextExport)
 
@@ -117,7 +117,7 @@ export class NextScript extends Component {
   }
 
   getChunkScript (filename, additionalProps = {}) {
-    const { __NEXT_DATA__ } = this.context._documentProps
+    const { __NEXT_DATA__ } = this.context._documentProps || this.props._documentProps
     let { buildStats, assetPrefix, buildId } = __NEXT_DATA__
     const hash = buildStats ? buildStats[filename].hash : buildId
 
@@ -132,7 +132,7 @@ export class NextScript extends Component {
   }
 
   getScripts () {
-    const { dev } = this.context._documentProps
+    const { dev } = this.context._documentProps || this.props._documentProps
     if (dev) {
       return [
         this.getChunkScript('manifest.js'),
@@ -147,7 +147,7 @@ export class NextScript extends Component {
   }
 
   getDynamicChunks () {
-    const { chunks, __NEXT_DATA__ } = this.context._documentProps
+    const { chunks, __NEXT_DATA__ } = this.context._documentProps || this.props._documentProps
     let { assetPrefix } = __NEXT_DATA__
     return (
       <div>
@@ -164,7 +164,7 @@ export class NextScript extends Component {
   }
 
   render () {
-    const { staticMarkup, __NEXT_DATA__, chunks } = this.context._documentProps
+    const { staticMarkup, __NEXT_DATA__, chunks } = this.context._documentProps || this.props._documentProps
     const { pathname, nextExport, buildId, assetPrefix } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname, nextExport)
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ import http, { STATUS_CODES } from 'http'
 import {
   renderToHTML,
   renderErrorToHTML,
+  renderToParts,
   sendHTML,
   serveStatic,
   renderScript,
@@ -272,6 +273,16 @@ export default class Server {
         if (!this.quiet) console.error(err)
         res.statusCode = 500
         return this.renderErrorToHTML(err, req, res, pathname, query)
+      }
+    }
+  }
+
+  async renderToParts (req, res, pathname, query, opts) {
+    try {
+      return await renderToParts(req, res, pathname, query, Object.assign({}, this.renderOpts, opts))
+    } catch (err) {
+      return {
+        err
       }
     }
   }


### PR DESCRIPTION
This adds support for, and an example of, using Rapscallion (or 
potentially other alternate React renderers) with Next. This has been 
discussed in #1334 and #1209. I'm submitting this as a proof of 
concept for discussion, though the changes are fairly minimal. I'm 
hoping with some bit of feedback we can add this for real!

The issue as mentioned by @arunoda elsewhere is that `document.js` 
uses `renderToString()` directly, which makes it difficult to inject an
alternate renderer method.

**What I did here:**

1. creating a `renderToParts()` method, which in turn calls doRender with
added configuration to allow for the replacement of `renderToString`,
and keeping `renderToString` as the default.

2. Jettison `document.js`, and in the example `server.js` use
[Rapscallion templating](https://github.com/FormidableLabs/rapscallion#template) to effectively do the same thing.

3. 🎉🎉🎉!

**The main issue this raised:**

* The subcomponents of `Document` (`Head`, `NextScript`) rely on
context, and thus are difficult to interface with except through
`Document`. I got around this by falling back to props when context was
not defined. Hacky of course, and probably is the main thing we'd need
to refactor to do this "right".

**Results:**

The test I created for examples was to generate a MD5 hash for the first
3000 integers. Since this is deterministic, I cached it with
Rapscallion. `renderToString` continued to render it as normal on
baseline. The test run was with apache benchmark, `ab -n 500 -c 10`.

Baseline:

```
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   0.4      0       4
Processing:   239 1293 246.1   1253    2099
Waiting:      238 1291 245.8   1251    2099
Total:        240 1293 246.1   1254    2100

Percentage of the requests served within a certain time (ms)
  50%   1254
  66%   1337
  75%   1425
  80%   1444
  90%   1588
  95%   1886
  98%   1981
  99%   1981
 100%   2100 (longest request)
```

With Rapscallion:

```
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   0.3      0       4
Processing:    97  204  39.6    190     318
Waiting:       97  202  38.6    189     318
Total:         98  205  39.6    191     319

Percentage of the requests served within a certain time (ms)
  50%    191
  66%    205
  75%    224
  80%    235
  90%    269
  95%    307
  98%    315
  99%    315
 100%    319 (longest request)
```

... or a roughly 6-7x improvement. Not super-surprising, since caching,
but for us a larger portion of each page is static, or at least made up of
pure components with predictable I/O — being able to cache those, 
while leaving other areas to be completely dynamic, is a huge win.

I played around with Rapscallion's streaming rendering as well, but I
think that'll be most useful with something a little more real-world.
Streaming seemed to have a small perf hit that gradually lessens the
larger the CPU effort / payload becomes. If you were adding a bunch
of CSS output in your header, for example, I think streaming would
greatly improve load time.

So yeah, open to suggestions here. I think this is a good stab at a
general interface for getting "parts" for a more atomic Next render,
but the API of that could certainly be better. Looking forward to
hearing what you think!

Love,
@gcpantazis + @thumbtack ❤️