### PR TITLE
Properly recover from HMR errors

### DIFF
--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -87,9 +87,14 @@ export default class PageLoader {
   // This method if called by the route code.
   registerPage (route, regFn) {
     const register = () => {
-      const { error, page } = regFn()
-      this.pageCache[route] = { error, page }
-      this.pageRegisterEvents.emit(route, { error, page })
+      try {
+        const { error, page } = regFn()
+        this.pageCache[route] = { error, page }
+        this.pageRegisterEvents.emit(route, { error, page })
+      } catch (error) {
+        this.pageCache[route] = { error }
+        this.pageRegisterEvents.emit(route, { error })
+      }
     }
 
     // Wait for webpack to became idle if it's not.


### PR DESCRIPTION
Make sure page-loader doesn't throw errors when registering.
Even if it does it, we need to mark it as a page error.

This will fix our HMR not recovering issues.