### PR TITLE
Add Intl API polyfill in with-react-intl example

### DIFF
--- a/examples/with-react-intl/pages/_document.js
+++ b/examples/with-react-intl/pages/_document.js
@@ -5,19 +5,24 @@ import Document, {Head, Main, NextScript} from 'next/document'
 export default class IntlDocument extends Document {
   static async getInitialProps (context) {
     const props = await super.getInitialProps(context)
-    const {req: {localeDataScript}} = context
+    const {req: {locale,localeDataScript}} = context
     return {
       ...props,
+      locale,
       localeDataScript
     }
   }
 
   render () {
+    // Polyfill Intl API for older browsers
+    const polyfill = `https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.${this.props.locale}`;
+
     return (
       <html>
         <Head />
         <body>
           <Main />
+          <script src={polyfill}></script>
           <script
             dangerouslySetInnerHTML={{
               __html: this.props.localeDataScript

--- a/examples/with-react-intl/pages/_document.js
+++ b/examples/with-react-intl/pages/_document.js
@@ -5,7 +5,7 @@ import Document, {Head, Main, NextScript} from 'next/document'
 export default class IntlDocument extends Document {
   static async getInitialProps (context) {
     const props = await super.getInitialProps(context)
-    const {req: {locale,localeDataScript}} = context
+    const {req: {locale, localeDataScript}} = context
     return {
       ...props,
       locale,
@@ -15,14 +15,14 @@ export default class IntlDocument extends Document {
 
   render () {
     // Polyfill Intl API for older browsers
-    const polyfill = `https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.${this.props.locale}`;
+    const polyfill = `https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.${this.props.locale}`
 
     return (
       <html>
         <Head />
         <body>
           <Main />
-          <script src={polyfill}></script>
+          <script src={polyfill} />
           <script
             dangerouslySetInnerHTML={{
               __html: this.props.localeDataScript


### PR DESCRIPTION
Older (and not so older) browser need a polyfill for the Intl API. This PR adds the polyfill (from polyfill.io service) into the _document.js

fix #2181