### PR TITLE
Make internal urls status code to 200 always

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -61,12 +61,13 @@ export default class Server {
       parsedUrl.query = parseQs(parsedUrl.query)
     }
 
+    res.statusCode = 200
     return this.run(req, res, parsedUrl)
-    .catch((err) => {
-      if (!this.quiet) console.error(err)
-      res.statusCode = 500
-      res.end(STATUS_CODES[500])
-    })
+      .catch((err) => {
+        if (!this.quiet) console.error(err)
+        res.statusCode = 500
+        res.end(STATUS_CODES[500])
+      })
   }
 
   getRequestHandler () {


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/2298

Sometimes user could set it to something else via the custom server API. So, we need to make sure it's always 200.