### PR TITLE
Fix an issue where two-page sites didn't split code.

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -102,7 +102,12 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
           return module.context && module.context.indexOf('node_modules') >= 0
         }
 
-        // Move modules used in at-least 1/2 of the total pages into commons.
+        // If there are one or two pages, only move modules to common if they are
+        // used in all of the pages. Otherwise, move modules used in at-least
+        // 1/2 of the total pages into commons.
+        if (totalPages <= 2) {
+          return count === totalPages
+        }
         return count >= totalPages * 0.5
       }
     }),


### PR DESCRIPTION
Thanks for all the work you do!

I made a site with two pages, one of which had a lot of code and the other of which had a small amount. But then I noticed when loading the small page that the browser was still loading all the code for the big one, which made me think that perhaps code splitting was broken.

Digging in a little, I found that the next webpack config puts a module in the commons chunk if it is used by at least 50% of pages, which is a reasonable strategy. Unfortunately, with a two-page site, this means that all modules end up in the commons chunk.

This fix should make it so that two-page sites only put a module in the commons chunk if the module is in both pages.

Thanks!