### PR TITLE
Add the ability to pass next configuration to production builds

### DIFF
--- a/server/build/index.js
+++ b/server/build/index.js
@@ -7,9 +7,9 @@ import webpack from './webpack'
 import replaceCurrentBuild from './replace'
 import md5File from 'md5-file/promise'
 
-export default async function build (dir) {
+export default async function build (dir, conf = null) {
   const buildDir = join(tmpdir(), uuid.v4())
-  const compiler = await webpack(dir, { buildDir })
+  const compiler = await webpack(dir, { buildDir, conf })
 
   try {
     await runCompiler(compiler)

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -27,9 +27,9 @@ const interpolateNames = new Map(defaultPages.map((p) => {
 
 const relativeResolve = rootModuleRelativePath(require)
 
-export default async function createCompiler (dir, { dev = false, quiet = false, buildDir } = {}) {
+export default async function createCompiler (dir, { dev = false, quiet = false, buildDir, conf = null } = {}) {
   dir = resolve(dir)
-  const config = getConfig(dir)
+  const config = getConfig(dir, conf)
   const defaultEntries = dev ? [
     join(__dirname, '..', '..', 'client', 'webpack-hot-middleware-client'),
     join(__dirname, '..', '..', 'client', 'on-demand-entries-client')


### PR DESCRIPTION
We added support to pass a custom configuration as an object in development in PR #2058. 

If we try to build a production release, we should be able to pass the same or a modified object to the production builder.

At the moment, it's only working in development and creating production builds fails...