### PR TITLE
Add withRoute Higher-Order Component

### DIFF
--- a/examples/using-router/components/ActiveLink.js
+++ b/examples/using-router/components/ActiveLink.js
@@ -1,0 +1,31 @@
+import Router, { withRoute } from 'next/router'
+
+// typically you want to use `next/link` for this usecase
+// but this example shows how you can also access the router
+// and use it manually
+
+const onClickHandler = (href) => (event) => {
+  event.preventDefault()
+  Router.push(href)
+}
+
+const ActiveLink = ({ children, route, href }) => {
+  const active = route.pathname === href
+  const className = active ? 'active' : ''
+  return (
+    <a href='#' onClick={onClickHandler(href)} className={className}>
+      {children}
+      <style jsx>{`
+        a {
+          margin-right: 10px;
+        }
+
+        .active {
+          color: red;
+        }
+      `}</style>
+    </a>
+  )
+}
+
+export default withRoute(ActiveLink)

--- a/examples/using-router/components/Header.js
+++ b/examples/using-router/components/Header.js
@@ -1,31 +1,9 @@
-import Router from 'next/router'
+import ActiveLink from './ActiveLink'
 
 export default () => (
   <div>
-    <Link href='/'>Home</Link>
-    <Link href='/about'>About</Link>
-    <Link href='/error'>Error</Link>
+    <ActiveLink href='/'>Home</ActiveLink>
+    <ActiveLink href='/about'>About</ActiveLink>
+    <ActiveLink href='/error'>Error</ActiveLink>
   </div>
-)
-
-// typically you want to use `next/link` for this usecase
-// but this example shows how you can also access the router
-// and use it manually
-
-function onClickHandler (href) {
-  return (e) => {
-    e.preventDefault()
-    Router.push(href)
-  }
-}
-
-const Link = ({ children, href }) => (
-  <a href='#' onClick={onClickHandler(href)}>
-    {children}
-    <style jsx>{`
-      a {
-        margin-right: 10px;
-      }
-    `}</style>
-  </a>
 )

--- a/examples/using-router/package.json
+++ b/examples/using-router/package.json
@@ -7,6 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^2.2.2",
     "next": "latest",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"

--- a/lib/app.js
+++ b/lib/app.js
@@ -2,15 +2,18 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import shallowEquals from './shallow-equals'
 import { warn } from './utils'
+import { reduceRouterToRoute, propTypeRoute } from './router/with-route'
 
 export default class App extends Component {
   static childContextTypes = {
-    headManager: PropTypes.object
+    headManager: PropTypes.object,
+    route: propTypeRoute
   }
 
   getChildContext () {
-    const { headManager } = this.props
-    return { headManager }
+    const { headManager, router } = this.props
+    const route = reduceRouterToRoute(router)
+    return { headManager, route }
   }
 
   render () {

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -64,6 +64,9 @@ function throwIfNoRouter () {
 // Export the SingletonRouter and this is the public API.
 export default SingletonRouter
 
+// Reexport the withRoute HOC
+export { default as withRoute } from './with-route'
+
 // INTERNAL APIS
 // -------------
 // (do not use following exports inside the app)

--- a/lib/router/with-route.js
+++ b/lib/router/with-route.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import hoistStatics from 'hoist-non-react-statics'
+import { getDisplayName } from '../utils'
+
+export const propTypeRoute = PropTypes.shape({
+  asPath: PropTypes.string,
+  pathname: PropTypes.string,
+  query: PropTypes.object
+})
+
+export default function withRoute (ComposedComponent) {
+  const displayName = getDisplayName(ComposedComponent)
+
+  class WithRouteWrapper extends Component {
+    static contextTypes = {
+      route: propTypeRoute
+    }
+
+    static displayName = `withRoute(${displayName})`
+
+    render () {
+      const props = {
+        route: this.context.route,
+        ...this.props
+      }
+
+      return <ComposedComponent {...props} />
+    }
+  }
+
+  return hoistStatics(WithRouteWrapper, ComposedComponent)
+}
+
+const publicRouteProps = ['asPath', 'pathname', 'query']
+
+export const reduceRouterToRoute = (router) => {
+  return publicRouteProps.reduce((route, propName) => {
+    route[propName] = router[propName]
+    return route
+  }, {})
+}

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "friendly-errors-webpack-plugin": "1.5.0",
     "glob": "7.1.1",
     "glob-promise": "3.1.0",
+    "hoist-non-react-statics": "^2.2.2",
     "htmlescape": "1.1.1",
     "http-status": "1.0.1",
     "json-loader": "0.5.4",

--- a/readme.md
+++ b/readme.md
@@ -465,6 +465,37 @@ Router.onAppUpdated = (nextUrl) => {
 }
 ```
 
+##### `withRoute` Higher-Order Component
+
+<p><details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="./examples/using-router">Basic routing</a></li>
+  </ul>
+</details></p>
+
+If you want to access the current `route` object, you can use the `withRoute` Higher-Order Component:
+
+```jsx
+import { withRoute } from 'next/router'
+
+const ActiveLink = ({ route, ...props }) => {
+  const active = route.pathname === props.href
+  return (
+    <a {...props} className={active  ? 'active' : ''}>Secrets!</a>
+  )
+}
+
+export default withRoute(ActiveLink)
+```
+
+The above route object comes with the following API:
+
+- `pathname` - path section of URL
+- `query` - query string section of URL parsed as an object
+- `asPath` - the actual url path
+
+
 ##### Shallow Routing
 
 <p><details>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,6 +2687,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.2.2.tgz#c0eca5a7d5a28c5ada3107eb763b01da6bfa81fb"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -5386,7 +5390,7 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uglifyjs-webpack-plugin@0.4.6, uglifyjs-webpack-plugin@^0.4.6:
+uglifyjs-webpack-plugin@^0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz#b951f4abb6bd617e66f63eb891498e391763e309"
   dependencies:


### PR DESCRIPTION
I did this PR based on the awesome work of @nwshane in #2056.
Since in this PR the api differs from the initial proposal I decided to create a new PR.

## Differences to #2056

* This PR only exposes the current route instead of the entire router. A route is an Object with the following props: `pathname`, `query`, `asPath`. Later we may add more props if we really need them (e.g.: `components`, `query`).
* ~The `withRoute` hoc takes a reducer function instead of an `options` object. Similar to redux connect method.~
* Name `withRoute` instead of `withRouter`

## API

`withRoute(<Component>)`

~The `mapRouterToProps` function is optional. If you omit it you will get the route object with the following properties:~

**Route object:**

- `pathname` - path section of URL
- `query` - query string section of URL parsed as an object
- `asPath` - the actual url path

## Example

```javascript
import { withRoute } from 'next/router'

export default withRoute(LinkComponent)
```

[examples/using-router](https://github.com/HaNdTriX/next.js/blob/with-route/examples/using-router)

## Todo

* [x] Add route context object
* [x] Add HOC (`withRoute`)
* [x] Add [documentation](https://github.com/HaNdTriX/next.js/tree/with-route#withroute-higher-order-component)
* [x] Update [using-router Example](https://github.com/HaNdTriX/next.js/tree/with-route/examples/using-router)
* [ ] Add tests