### PR TITLE
Removes Windows Webpack Polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "glob-promise": "3.1.0",
     "htmlescape": "1.1.1",
     "http-status": "1.0.1",
-    "is-windows-bash": "1.0.3",
     "json-loader": "0.5.4",
     "loader-utils": "1.1.0",
     "md5-file": "3.1.1",

--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -2,7 +2,6 @@ import { join, relative, sep } from 'path'
 import WebpackDevMiddleware from 'webpack-dev-middleware'
 import WebpackHotMiddleware from 'webpack-hot-middleware'
 import onDemandEntryHandler from './on-demand-entry-handler'
-import isWindowsBash from 'is-windows-bash'
 import webpack from './build/webpack'
 import clean from './build/clean'
 import getConfig from './config'
@@ -172,22 +171,13 @@ export default class HotReloader {
       /(^|[/\\])\../, // .dotfiles
       /node_modules/
     ]
-    const windowsSettings = isWindowsBash() ? {
-      lazy: false,
-      watchOptions: {
-        ignored,
-        aggregateTimeout: 300,
-        poll: true
-      }
-    } : {}
 
     let webpackDevMiddlewareConfig = {
       publicPath: '/_next/webpack/',
       noInfo: true,
       quiet: true,
       clientLogLevel: 'warning',
-      watchOptions: { ignored },
-      ...windowsSettings
+      watchOptions: { ignored }
     }
 
     if (this.config.webpackDevMiddleware) {


### PR DESCRIPTION
Per #2328, the Windows 10 Creators Update fixed the issue with file watchers on WSL. This removes webpack polling from the config.

Older versions of windows 10 will lose live reloading, but the creators update is free and I think most developers will have upgraded to it for the numerous WSL improvements. Microsoft started [pushing the update in early April](https://blogs.windows.com/windowsexperience/2017/04/11/how-to-get-the-windows-10-creators-update/#7E5dzmUmhoIP4gfp.97).

We could try to leave this in and target a specific version of Windows 10 for polling, but I don't know if it's worth it (the check relies on a file read operation). Happy to have that discussion though! 

I'm out this next week and won't have access to a Windows machine, but am happy to do additional work / testing if desired. I've confirmed it works as expected on the latest version of Windows