### PR TITLE
Add a better filename to the dynamic import chunk.

### DIFF
--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -45,8 +45,10 @@ export default () => ({
   visitor: {
     CallExpression (path) {
       if (path.node.callee.type === TYPE_IMPORT) {
+        const moduleName = path.node.arguments[0].value
+        const name = `${moduleName.replace(/[^\w]/g, '-')}-${UUID.v4()}`
         const newImport = buildImport({
-          name: UUID.v4()
+          name
         })({
           SOURCE: path.node.arguments
         })


### PR DESCRIPTION
With this we can see the import name in the filename.
This helps a lot in debugging and analyzing the webpack bundle.

See:
![screen shot 2017-06-29 at 5 04 46 am](https://user-images.githubusercontent.com/50838/27665045-969dfbca-5c88-11e7-8d61-3c0dd6811dd3.png)

