### PR TITLE
Adding bugs and homepage fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "./dist/server/next.js",
   "license": "MIT",
   "repository": "zeit/next.js",
+  "bugs": "https://github.com/zeit/next.js/issues",
+  "homepage": "https://zeit.co/next",
   "files": [
     "dist",
     "babel.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "zeit/next.js",
   "bugs": "https://github.com/zeit/next.js/issues",
-  "homepage": "https://zeit.co/next",
+  "homepage": "https://github.com/zeit/next.js",
   "files": [
     "dist",
     "babel.js",


### PR DESCRIPTION
This adds bugs and homepage entries to the package.json. This helps these links render on npm, and can lead developers to the right place to put issues and to find more information. I have included the url which redirects to the github repository in case this changes later, for the homepage field.

Hopefully, this makes the package a bit more usable. Not a big fix, at all.