### PR TITLE
Optimize the bundle size of Next.js core

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,11 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { AppContainer } from 'react-hot-loader'
 import shallowEquals from './shallow-equals'
 import { warn } from './utils'
-
-const ErrorDebug = process.env.NODE_ENV === 'production'
-  ? null : require('./error-debug').default
 
 export default class App extends Component {
   static childContextTypes = {
@@ -62,11 +58,20 @@ class Container extends Component {
   render () {
     const { Component, props, url } = this.props
 
-    // includes AppContainer which bypasses shouldComponentUpdate method
-    // https://github.com/gaearon/react-hot-loader/issues/442
-    return <AppContainer errorReporter={ErrorDebug}>
-      <Component {...props} url={url} />
-    </AppContainer>
+    if (process.env.NODE_ENV === 'production') {
+      return (<Component {...props} url={url} />)
+    } else {
+      const ErrorDebug = require('./error-debug').default
+      const { AppContainer } = require('react-hot-loader')
+
+      // includes AppContainer which bypasses shouldComponentUpdate method
+      // https://github.com/gaearon/react-hot-loader/issues/442
+      return (
+        <AppContainer errorReporter={ErrorDebug}>
+          <Component {...props} url={url} />
+        </AppContainer>
+      )
+    }
   }
 }
 

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -138,7 +138,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
       plugins.push(new FriendlyErrorsWebpackPlugin())
     }
   } else {
-    plugins.push(new webpack.IgnorePlugin(/redbox-react/, /react-hot-loader/))
+    plugins.push(new webpack.IgnorePlugin(/react-hot-loader/))
     plugins.push(
       new CombineAssetsPlugin({
         input: ['manifest.js', 'commons.js', 'main.js'],

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -107,7 +107,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
         // used in all of the pages. Otherwise, move modules used in at-least
         // 1/2 of the total pages into commons.
         if (totalPages <= 2) {
-          return count === totalPages
+          return count >= totalPages
         }
         return count >= totalPages * 0.5
       }
@@ -138,6 +138,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
       plugins.push(new FriendlyErrorsWebpackPlugin())
     }
   } else {
+    plugins.push(new webpack.IgnorePlugin(/redbox-react/, /react-hot-loader/))
     plugins.push(
       new CombineAssetsPlugin({
         input: ['manifest.js', 'commons.js', 'main.js'],
@@ -309,15 +310,6 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
     },
     devtool: dev ? 'cheap-module-inline-source-map' : false,
     performance: { hints: false }
-  }
-
-  if (!dev) {
-    // We do this to use the minified version of React in production.
-    // This will significant file size redution when turned off uglifyjs.
-    webpackConfig.resolve.alias = {
-      'react': require.resolve('react/dist/react.min.js'),
-      'react-dom': require.resolve('react-dom/dist/react-dom.min.js')
-    }
   }
 
   if (config.webpack) {


### PR DESCRIPTION
Some of the optimizations we did:

* Remove the `react-hot-loader` from production
* Remove the `react-dom/dist` as it's getting replicated in some bundles
* Make sure common module are working when we've one or two pages.