### PR TITLE
Layout for persistent components

### DIFF
--- a/examples/with-layout/README.md
+++ b/examples/with-layout/README.md
@@ -26,6 +26,6 @@ now
 
 ## The idea behind the example
 
-Layout component is essential for all sorts of things, mainly for Components that require persistant existance on the page. Components such as Alert, Transitions, and other things...
+Layout component is essential for all sorts of things, mainly for Components that require persistent existance on the page. Components such as Alert, Transitions, and other things...
 
 This example shows you how to setup a layout, which is as easy as creating a _layout.js file and filling it in with whatever you need.

--- a/examples/with-layout/README.md
+++ b/examples/with-layout/README.md
@@ -1,0 +1,31 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/basic-css)
+
+# Basic Layout example
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/basic-css
+cd basic-css
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+Layout component is essential for all sorts of things, mainly for Components that require persistant existance on the page. Components such as Alert, Transitions, and other things...
+
+This example shows you how to setup a layout, which is as easy as creating a _layout.js file and filling it in with whatever you need.

--- a/examples/with-layout/package.json
+++ b/examples/with-layout/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "with-layout",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
+  },
+  "license": "ISC"
+}

--- a/examples/with-layout/pages/_layout.js
+++ b/examples/with-layout/pages/_layout.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class TestLayout extends Component {
+  render () {
+    return <div>
+      <h1>This part will never remount</h1>
+      <p>Using this allows you to add persistent elements such as Alerts, Transitions, etc..</p>
+      {this.props.children}
+    </div>
+  }
+}

--- a/examples/with-layout/pages/b.js
+++ b/examples/with-layout/pages/b.js
@@ -1,0 +1,8 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <p>Page B</p>
+    <Link href='/'><a>Goto Page Index</a></Link>
+  </div>
+)

--- a/examples/with-layout/pages/index.js
+++ b/examples/with-layout/pages/index.js
@@ -1,0 +1,8 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <p>Hello World</p>
+    <Link href='/b'><a>Goto Page B</a></Link>
+  </div>
+)

--- a/lib/app.js
+++ b/lib/app.js
@@ -14,18 +14,16 @@ export default class App extends Component {
   }
 
   render () {
-    const { Component, props, hash, router } = this.props
+    const { Component, Layout, props, hash, router } = this.props
     const url = createUrl(router)
     // If there no component exported we can't proceed.
     // We'll tackle that here.
     if (typeof Component !== 'function') {
       throw new Error(`The default export is not a React Component in page: "${url.pathname}"`)
     }
-    const containerProps = { Component, props, hash, router, url }
+    const containerProps = { Component, Layout, props, hash, router, url }
 
-    return <div>
-      <Container {...containerProps} />
-    </div>
+    return <Container {...containerProps} />
   }
 }
 
@@ -56,7 +54,7 @@ class Container extends Component {
   }
 
   render () {
-    const { Component, props, url } = this.props
+    const { Component, Layout, props, url } = this.props
 
     if (process.env.NODE_ENV === 'production') {
       return (<Component {...props} url={url} />)
@@ -68,7 +66,9 @@ class Container extends Component {
       // https://github.com/gaearon/react-hot-loader/issues/442
       return (
         <AppContainer errorReporter={ErrorDebug}>
-          <Component {...props} url={url} />
+          <Layout url={url}>
+            <Component {...props} url={url} />
+          </Layout>
         </AppContainer>
       )
     }

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default class Layout extends React.Component {
+  render () {
+    return (<div>
+      {this.props.children}
+    </div>)
+  }
+}

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -8,7 +8,7 @@ import { loadGetInitialProps, getURL } from '../utils'
 import { _notifyBuildIdMismatch, _rewriteUrlForNextExport } from './'
 
 export default class Router {
-  constructor (pathname, query, as, { pageLoader, Component, ErrorComponent, err } = {}) {
+  constructor (pathname, query, as, { pageLoader, Component, Layout, ErrorComponent, err } = {}) {
     // represents the current component key
     this.route = toRoute(pathname)
 
@@ -33,6 +33,8 @@ export default class Router {
     this.subscriptions = new Set()
     this.componentLoadCancel = null
     this.onPopState = this.onPopState.bind(this)
+
+    this.Layout = Layout
 
     if (typeof window !== 'undefined') {
       // in order for `e.state` to work on the `onpopstate` event
@@ -69,7 +71,7 @@ export default class Router {
       throw new Error(`Cannot update unavailable route: ${route}`)
     }
 
-    const newData = { ...data, Component }
+    const newData = { ...data, Component, Layout: this.Layout }
     this.components[route] = newData
 
     if (route === this.route) {
@@ -89,6 +91,8 @@ export default class Router {
     this.events.emit('routeChangeStart', url)
     const routeInfo = await this.getRouteInfo(route, pathname, query, url)
     const { error } = routeInfo
+
+    routeInfo.Layout = this.Layout
 
     if (error && error.cancelled) {
       return
@@ -239,6 +243,9 @@ export default class Router {
     this.pathname = pathname
     this.query = query
     this.asPath = as
+
+    data.Layout = this.Layout
+
     this.notify(data)
   }
 

--- a/pages/_layout.js
+++ b/pages/_layout.js
@@ -1,0 +1,1 @@
+module.exports = require('next/layout')

--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -38,7 +38,8 @@ module.exports = {
           'next/head': relativeResolve('../../../lib/head'),
           'next/document': relativeResolve('../../../server/document'),
           'next/router': relativeResolve('../../../lib/router'),
-          'next/error': relativeResolve('../../../lib/error')
+          'next/error': relativeResolve('../../../lib/error'),
+          'next/layout': relativeResolve('../../../lib/layout')
         }
       }
     ]

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -18,7 +18,8 @@ import rootModuleRelativePath from './root-module-relative-path'
 const documentPage = join('pages', '_document.js')
 const defaultPages = [
   '_error.js',
-  '_document.js'
+  '_document.js',
+  '_layout.js'
 ]
 const nextPagesDir = join(__dirname, '..', '..', 'pages')
 const nextNodeModulesDir = join(__dirname, '..', '..', '..', 'node_modules')
@@ -49,7 +50,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
     }
 
     const pages = await glob('pages/**/*.js', { cwd: dir })
-    const devPages = pages.filter((p) => p === 'pages/_document.js' || p === 'pages/_error.js')
+    const devPages = pages.filter((p) => p === 'pages/_document.js' || p === 'pages/_error.js' || p === 'pages/_layout.js')
 
     // In the dev environment, on-demand-entry-handler will take care of
     // managing pages.
@@ -234,6 +235,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
                   'next/document': relativeResolve('../../server/document'),
                   'next/router': relativeResolve('../../lib/router'),
                   'next/error': relativeResolve('../../lib/error'),
+                  'next/layout': relativeResolve('../../lib/layout'),
                   'styled-jsx/style': relativeResolve('styled-jsx/style')
                 }
               }

--- a/server/render.js
+++ b/server/render.js
@@ -53,12 +53,16 @@ async function doRender (req, res, pathname, query, {
 
   const dist = getConfig(dir).distDir
 
-  let [Component, Document] = await Promise.all([
+  let [Component, Document, Layout] = await Promise.all([
     requireModule(join(dir, dist, 'dist', 'pages', page)),
-    requireModule(join(dir, dist, 'dist', 'pages', '_document'))
+    requireModule(join(dir, dist, 'dist', 'pages', '_document')),
+    requireModule(join(dir, dist, 'dist', 'pages', '_layout'))
   ])
+
   Component = Component.default || Component
   Document = Document.default || Document
+  Layout = Layout.default || Layout
+
   const asPath = req.url
   const ctx = { err, req, res, pathname, query, asPath }
   const props = await loadGetInitialProps(Component, ctx)
@@ -69,6 +73,7 @@ async function doRender (req, res, pathname, query, {
   const renderPage = () => {
     const app = createElement(App, {
       Component,
+      Layout,
       props,
       router: new Router(pathname, query)
     })
@@ -240,7 +245,7 @@ export function serveStatic (req, res, path) {
 
 async function ensurePage (page, { dir, hotReloader }) {
   if (!hotReloader) return
-  if (page === '_error' || page === '_document') return
+  if (page === '_error' || page === '_document' || page === '_layout') return
 
   await hotReloader.ensurePage(page)
 }


### PR DESCRIPTION
A quick working implementation of an optional top-most component that wraps pages, in other words this is the missing layout system.

I had some trouble figuring out how next handled default files, so I did my best to make it work with minimum amount of code change or impact on existing projects.

The way it works is simple, if there's a `_layout.js` file inside the pages folder, it'll use that to wrap Component. Othwerwise, it uses the default Layout ( which is basically a div wrapper ).

Related to this: https://github.com/zeit/next.js/issues/88