### PR TITLE
Allow cleaning from non-cwd

### DIFF
--- a/server/build/clean.js
+++ b/server/build/clean.js
@@ -4,5 +4,5 @@ import getConfig from '../config'
 
 export default function clean (dir) {
   const dist = getConfig(dir).distDir
-  return del(resolve(dir, dist))
+  return del(resolve(dir, dist), { force: true })
 }


### PR DESCRIPTION
```
(node:70786) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Cannot delete files/folders outside the current working directory. Can be overriden with the `force` option.
```

This is a follow up to #1158.