### PR TITLE
Update emotion examples with new API for SSR and React endpoint

### DIFF
--- a/examples/with-emotion/package.json
+++ b/examples/with-emotion/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "with-emotion",
-  "version": "1.0.0",
-  "scripts": {
-    "dev": "next",
-    "build": "next build",
-    "start": "next start"
-  },
-  "dependencies": {
-    "emotion": "^4.1.2",
-    "next": "^2.4.6",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
-  },
-  "license": "ISC"
+	"name": "with-emotion",
+	"version": "1.0.0",
+	"scripts": {
+		"dev": "next",
+		"build": "next build",
+		"start": "next start"
+	},
+	"dependencies": {
+		"emotion": "^5.0.0",
+		"next": "^2.4.6",
+		"react": "^15.6.1",
+		"react-dom": "^15.6.1"
+	},
+	"license": "ISC"
 }

--- a/examples/with-emotion/package.json
+++ b/examples/with-emotion/package.json
@@ -1,16 +1,16 @@
 {
-	"name": "with-emotion",
-	"version": "1.0.0",
-	"scripts": {
-		"dev": "next",
-		"build": "next build",
-		"start": "next start"
-	},
-	"dependencies": {
-		"emotion": "^5.0.0",
-		"next": "^2.4.6",
-		"react": "^15.6.1",
-		"react-dom": "^15.6.1"
-	},
-	"license": "ISC"
+  "name": "with-emotion",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "emotion": "^5.0.0",
+    "next": "^2.4.6",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
+  },
+  "license": "ISC"
 }

--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -2,32 +2,32 @@ import Document, { Head, Main, NextScript } from 'next/document'
 import { extractCritical } from 'emotion/server'
 
 export default class MyDocument extends Document {
-	static getInitialProps({ renderPage }) {
-		const page = renderPage()
-		const styles = extractCritical(page.html)
-		return { ...page, ...styles }
-	}
+  static getInitialProps ({ renderPage }) {
+    const page = renderPage()
+    const styles = extractCritical(page.html)
+    return { ...page, ...styles }
+  }
 
-	constructor(props) {
-		super(props)
-		const { __NEXT_DATA__, ids } = props
-		if (ids) {
-			__NEXT_DATA__.ids = this.props.ids
-		}
-	}
+  constructor (props) {
+    super(props)
+    const { __NEXT_DATA__, ids } = props
+    if (ids) {
+      __NEXT_DATA__.ids = this.props.ids
+    }
+  }
 
-	render() {
-		return (
-			<html>
-				<Head>
-					<title>With Emotion</title>
-					<style dangerouslySetInnerHTML={{ __html: this.props.css }} />
-				</Head>
-				<body>
-					<Main />
-					<NextScript />
-				</body>
-			</html>
-		)
-	}
+  render () {
+    return (
+      <html>
+        <Head>
+          <title>With Emotion</title>
+          <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
 }

--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -1,33 +1,33 @@
 import Document, { Head, Main, NextScript } from 'next/document'
-import { renderStaticOptimized } from 'emotion/server'
+import { extractCritical } from 'emotion/server'
 
 export default class MyDocument extends Document {
-  static getInitialProps ({ renderPage }) {
-    const page = renderPage()
-    const styles = renderStaticOptimized(() => page.html)
-    return { ...page, ...styles }
-  }
+	static getInitialProps({ renderPage }) {
+		const page = renderPage()
+		const styles = extractCritical(page.html)
+		return { ...page, ...styles }
+	}
 
-  constructor (props) {
-    super(props)
-    const { __NEXT_DATA__, ids } = props
-    if (ids) {
-      __NEXT_DATA__.ids = this.props.ids
-    }
-  }
+	constructor(props) {
+		super(props)
+		const { __NEXT_DATA__, ids } = props
+		if (ids) {
+			__NEXT_DATA__.ids = this.props.ids
+		}
+	}
 
-  render () {
-    return (
-      <html>
-        <Head>
-          <title>With Emotion</title>
-          <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </html>
-    )
-  }
+	render() {
+		return (
+			<html>
+				<Head>
+					<title>With Emotion</title>
+					<style dangerouslySetInnerHTML={{ __html: this.props.css }} />
+				</Head>
+				<body>
+					<Main />
+					<NextScript />
+				</body>
+			</html>
+		)
+	}
 }

--- a/examples/with-emotion/pages/index.js
+++ b/examples/with-emotion/pages/index.js
@@ -5,11 +5,11 @@ import styled from 'emotion/react'
 // Adds server generated styles to emotion cache.
 // '__NEXT_DATA__.ids' is set in '_document.js'
 if (typeof window !== 'undefined') {
-	hydrate(window.__NEXT_DATA__.ids)
+  hydrate(window.__NEXT_DATA__.ids)
 }
 
 export default () => {
-	injectGlobal`
+  injectGlobal`
     html, body {
       padding: 3rem 1rem;
       margin: 0;
@@ -20,7 +20,7 @@ export default () => {
     }
   `
 
-	const basicStyles = fragment`
+  const basicStyles = fragment`
     background-color: white;
     color: cornflowerblue;
     border: 1px solid lightgreen;
@@ -31,13 +31,13 @@ export default () => {
     margin: 3rem 0;
     padding: 1rem 0.5rem;
   `
-	const hoverStyles = fragment`
+  const hoverStyles = fragment`
     color: white;
     background-color: lightgray;
     border-color: aqua;
     box-shadow: -15px -15px 0 0 aqua, -30px -30px 0 0 cornflowerblue;
   `
-	const bounce = keyframes`
+  const bounce = keyframes`
     from {
       transform: scale(1.01);
     }
@@ -46,34 +46,34 @@ export default () => {
     }
   `
 
-	const Basic = styled.div`@apply ${basicStyles};`
-	const Combined = styled.div`
-		@apply ${basicStyles};
-		&:hover {
-			@apply ${hoverStyles};
-		}
-		& code {
-			background-color: linen;
-		}
-	`
-	const Animated = styled.div`
-		@apply ${basicStyles};
-		&:hover {
-			@apply ${hoverStyles};
-		}
-		& code {
-			background-color: linen;
-		}
-		animation: ${props => props.animation} 0.2s infinite ease-in-out alternate;
-	`
+  const Basic = styled.div`@apply ${basicStyles};`
+  const Combined = styled.div`
+    @apply ${basicStyles};
+    &:hover {
+      @apply ${hoverStyles};
+    }
+    & code {
+      background-color: linen;
+    }
+  `
+  const Animated = styled.div`
+    @apply ${basicStyles};
+    &:hover {
+      @apply ${hoverStyles};
+    }
+    & code {
+      background-color: linen;
+    }
+    animation: ${props => props.animation} 0.2s infinite ease-in-out alternate;
+  `
 
-	return (
-		<div>
-			<Basic>Cool Styles</Basic>
-			<Combined>
-				With <code>:hover</code>.
-			</Combined>
-			<Animated animation={bounce}>Let's bounce.</Animated>
-		</div>
-	)
+  return (
+    <div>
+      <Basic>Cool Styles</Basic>
+      <Combined>
+        With <code>:hover</code>.
+      </Combined>
+      <Animated animation={bounce}>Let's bounce.</Animated>
+    </div>
+  )
 }

--- a/examples/with-emotion/pages/index.js
+++ b/examples/with-emotion/pages/index.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import { hydrate, keyframes, fragment, injectGlobal } from 'emotion'
-import styled from 'emotion/styled'
+import styled from 'emotion/react'
 
 // Adds server generated styles to emotion cache.
 // '__NEXT_DATA__.ids' is set in '_document.js'
 if (typeof window !== 'undefined') {
-  hydrate(window.__NEXT_DATA__.ids)
+	hydrate(window.__NEXT_DATA__.ids)
 }
 
 export default () => {
-  injectGlobal`
+	injectGlobal`
     html, body {
       padding: 3rem 1rem;
       margin: 0;
@@ -20,7 +20,7 @@ export default () => {
     }
   `
 
-  const basicStyles = fragment`
+	const basicStyles = fragment`
     background-color: white;
     color: cornflowerblue;
     border: 1px solid lightgreen;
@@ -31,13 +31,13 @@ export default () => {
     margin: 3rem 0;
     padding: 1rem 0.5rem;
   `
-  const hoverStyles = fragment`
+	const hoverStyles = fragment`
     color: white;
     background-color: lightgray;
     border-color: aqua;
     box-shadow: -15px -15px 0 0 aqua, -30px -30px 0 0 cornflowerblue;
   `
-  const bounce = keyframes`
+	const bounce = keyframes`
     from {
       transform: scale(1.01);
     }
@@ -46,38 +46,34 @@ export default () => {
     }
   `
 
-  const Basic = styled.div`@apply ${basicStyles};`
-  const Combined = styled.div`
-    @apply ${basicStyles};
-    &:hover {
-      @apply ${hoverStyles};
-    }
-    & code {
-      background-color: linen;
-    }
-  `
-  const Animated = styled.div`
-    @apply ${basicStyles};
-    &:hover {
-      @apply ${hoverStyles};
-    }
-    & code {
-      background-color: linen;
-    }
-    animation: ${props => props.animation} 0.2s infinite ease-in-out alternate;
-  `
+	const Basic = styled.div`@apply ${basicStyles};`
+	const Combined = styled.div`
+		@apply ${basicStyles};
+		&:hover {
+			@apply ${hoverStyles};
+		}
+		& code {
+			background-color: linen;
+		}
+	`
+	const Animated = styled.div`
+		@apply ${basicStyles};
+		&:hover {
+			@apply ${hoverStyles};
+		}
+		& code {
+			background-color: linen;
+		}
+		animation: ${props => props.animation} 0.2s infinite ease-in-out alternate;
+	`
 
-  return (
-    <div>
-      <Basic>
-        Cool Styles
-      </Basic>
-      <Combined>
-        With <code>:hover</code>.
-      </Combined>
-      <Animated animation={bounce}>
-        Let's bounce.
-      </Animated>
-    </div>
-  )
+	return (
+		<div>
+			<Basic>Cool Styles</Basic>
+			<Combined>
+				With <code>:hover</code>.
+			</Combined>
+			<Animated animation={bounce}>Let's bounce.</Animated>
+		</div>
+	)
 }


### PR DESCRIPTION
This PR fixes this issue [#80](https://github.com/tkh44/emotion/issues/80) opened up at https://github.com/tkh44/emotion.

The `emotion/server` export changed names and the react `styled` imports changed as well. I also manually bumped the version of emotion in the `package.json` file.

It looks like something in my config changed the indentation significantly. Not sure what could have caused that but if anyone has tips on how to resolve let me know!