### PR TITLE
fix: Update react-uwp example support Next 3

### DIFF
--- a/examples/with-react-uwp/pages/_document.js
+++ b/examples/with-react-uwp/pages/_document.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import Document, { Head, Main, NextScript } from 'next/document'
 
 export default class MyDocument extends Document {
-  static getInitialProps ({ renderPage  }) {
-    const { html, head, errorHtml, chunks } = renderPage()
+  static getInitialProps ({ renderPage }) {
+    const {html, head, errorHtml, chunks} = renderPage()
     return { html, head, errorHtml, chunks }
   }
 

--- a/examples/with-react-uwp/pages/_document.js
+++ b/examples/with-react-uwp/pages/_document.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types'
 import Document, { Head, Main, NextScript } from 'next/document'
 
 export default class MyDocument extends Document {
-  static async getInitialProps ({ req }) {
-    return req
-      ? { userAgent: req.headers['user-agent'] }
-      : { userAgent: navigator.userAgent }
+  static getInitialProps ({ renderPage  }) {
+    const { html, head, errorHtml, chunks } = renderPage()
+    return { html, head, errorHtml, chunks }
   }
+
   static contextTypes = { theme: PropTypes.object };
 
   render () {

--- a/examples/with-react-uwp/pages/index.js
+++ b/examples/with-react-uwp/pages/index.js
@@ -42,7 +42,7 @@ class Index extends Component {
         <DatePicker />
         <ColorPicker />
         <ProgressRing size={50} />
-        <p style={{ textAlign: "center" }}>{userAgent.slice(12)}...</p>
+        <p style={{ textAlign: 'center' }}>{userAgent.slice(12)}...</p>
       </ThemeWrapper>
     )
   }

--- a/examples/with-react-uwp/pages/index.js
+++ b/examples/with-react-uwp/pages/index.js
@@ -12,7 +12,7 @@ import {
 } from 'react-uwp'
 
 class Index extends Component {
-  static getInitialProps ({ req }) {
+  static async getInitialProps ({ req }) {
     let userAgent
     if (process.browser) {
       userAgent = navigator.userAgent
@@ -25,6 +25,7 @@ class Index extends Component {
   static contextTypes = { theme: PropTypes.object }
 
   render () {
+    const { userAgent } = this.props
     return (
       <ThemeWrapper
         style={{
@@ -35,12 +36,13 @@ class Index extends Component {
           alignItems: 'center',
           justifyContent: 'space-around'
         }}
-        theme={getTheme({ userAgent: this.props.userAgent })}
+        theme={getTheme({ userAgent })}
       >
         <Button>Test Button</Button>
         <DatePicker />
         <ColorPicker />
         <ProgressRing size={50} />
+        <p style={{ textAlign: "center" }}>{userAgent.slice(12)}...</p>
       </ThemeWrapper>
     )
   }


### PR DESCRIPTION
v3's `getInitialProps ` is kind a different.
Update example codes support to v3