### PR TITLE
Emit ES6 code for module source in emit file load

### DIFF
--- a/server/build/loaders/emit-file-loader.js
+++ b/server/build/loaders/emit-file-loader.js
@@ -12,7 +12,7 @@ module.exports = function (content, sourceMap) {
 
   const emit = (code, map) => {
     this.emitFile(interpolatedName, code, map)
-    this.callback(null, code, map)
+    this.callback(null, content, sourceMap)
   }
 
   if (query.transform) {


### PR DESCRIPTION
Previously the commonjs modules were being passed into webpack dependency layer, preventing tree shaking.