### PR TITLE
Block special pages from the public.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,11 @@ const internalPrefixes = [
   /^\/static\//
 ]
 
+const blockedPages = {
+  '/_document': true,
+  '/_error': true
+}
+
 export default class Server {
   constructor ({ dir = '.', dev = false, staticMarkup = false, quiet = false, conf = null } = {}) {
     this.dir = resolve(dir)
@@ -249,6 +254,10 @@ export default class Server {
   async render (req, res, pathname, query, parsedUrl) {
     if (this.isInternalUrl(req)) {
       return this.handleRequest(req, res, parsedUrl)
+    }
+
+    if (blockedPages[pathname]) {
+      return await this.render404(req, res, parsedUrl)
     }
 
     if (this.config.poweredByHeader) {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -49,6 +49,14 @@ describe('Production Usage', () => {
       const res2 = await fetch(url, { headers })
       expect(res2.status).toBe(304)
     })
+
+    it('should block special pages', async () => {
+      const urls = ['/_document', '/_error']
+      for (const url of urls) {
+        const html = await renderViaHTTP(appPort, url)
+        expect(html).toMatch(/404/)
+      }
+    })
   })
 
   describe('With navigation', () => {


### PR DESCRIPTION
Otherwise, users could invoke 500 errors by visiting a URL.