### PR TITLE
Routing to new URL, but same component

### DIFF
--- a/examples/with-react-ga/components/Layout.js
+++ b/examples/with-react-ga/components/Layout.js
@@ -1,5 +1,10 @@
 import React from 'react'
+import Router from 'next/router'
 import { initGA, logPageView } from '../utils/analytics'
+
+Router.onRouteChangeComplete = (url) => {
+  logPageView()
+}
 
 export default class Layout extends React.Component {
   componentDidMount () {


### PR DESCRIPTION
Say if you have a shoe store and you are browsing a shoe, then you see a suggestion of another shoe. 

After clicking the next shoe, you might have the same component, so the component is already mounted, however you might want to log the new visit to the next shoe.