### PR TITLE
Added good practice metas to default head. Fix #2492

### DIFF
--- a/lib/head.js
+++ b/lib/head.js
@@ -13,7 +13,11 @@ class Head extends React.Component {
 }
 
 export function defaultHead () {
-  return [<meta charSet='utf-8' className='next-head' />]
+  return [
+    <meta charSet='utf-8' className='next-head' />,
+    <meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no' className='next-head' />,
+    <meta http-equiv='x-ua-compatible' content='ie=edge' className='next-head' />
+  ]
 }
 
 function reduceComponents (components) {


### PR DESCRIPTION
This fixes https://github.com/zeit/next.js/issues/2492.

it adds 2 new default meta tags:
```
<meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no' />,
<meta http-equiv='x-ua-compatible' content='ie=edge' />
```

These metas are fairly popular (https://github.com/h5bp/html5-boilerplate/blob/master/dist/index.html) and only enforce good defaults.