### PR TITLE
fix regex for pages that end with index

### DIFF
--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -18,7 +18,7 @@ export default class PageLoader {
     if (route[0] !== '/') {
       throw new Error('Route name should start with a "/"')
     }
-    route = route.replace(/index$/, '')
+    route = route.replace(/\/index$/, '/')
 
     if (route === '/') return route
     return route.replace(/\/$/, '')

--- a/server/build/plugins/pages-plugin.js
+++ b/server/build/plugins/pages-plugin.js
@@ -14,7 +14,7 @@ export default class PagesPlugin {
       pages.forEach((chunk) => {
         const page = compilation.assets[chunk.name]
         const pageName = MATCH_ROUTE_NAME.exec(chunk.name)[1]
-        let routeName = `/${pageName.replace(/[/\\]?index$/, '')}`
+        let routeName = pageName
 
         // We need to convert \ into / when we are in windows
         // to get the proper route name
@@ -25,6 +25,8 @@ export default class PagesPlugin {
         if (/^win/.test(process.platform)) {
           routeName = routeName.replace(/\\/g, '/')
         }
+
+        routeName = `/${routeName.replace(/(^|\/)index$/, '')}`
 
         const content = page.source()
         const newContent = `


### PR DESCRIPTION
Client navigation currently fails if the filename of a page ends with **index*
It happens in both v2 and v3

Reproduce the issue:
```jsx
// pages/index.js
import Link from 'next/link'
export default () => <Link href='/abcindex'><a>go</a></Link>

// pages/abcindex.js
export default () => <div>abc</div>
```
1. Open `/`
2. Click the link
3. See 404 error instead of page

This PR fixes it by changing two regular expressions.