### PR TITLE
Propagate source maps through combine assets step

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-runtime": "6.26.0",
     "babel-template": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
+    "concat-with-sourcemaps": "^1.0.4",
     "cross-spawn": "5.1.0",
     "del": "3.0.0",
     "etag": "1.8.1",

--- a/server/build/plugins/combine-assets-plugin.js
+++ b/server/build/plugins/combine-assets-plugin.js
@@ -1,3 +1,5 @@
+import Concat from 'concat-with-sourcemaps'
+
 // This plugin combines a set of assets into a single asset
 // This should be only used with text assets,
 // otherwise the result is unpredictable.
@@ -9,19 +11,27 @@ export default class CombineAssetsPlugin {
 
   apply (compiler) {
     compiler.plugin('after-compile', (compilation, callback) => {
-      let newSource = ''
+      const concat = new Concat(true, this.output, '\n')
+
       this.input.forEach((name) => {
         const asset = compilation.assets[name]
+        const sourceMap = compilation.assets[`${name}.map`]
         if (!asset) return
 
-        newSource += `${asset.source()}\n`
+        concat.add(name, asset.source(), sourceMap && sourceMap.source())
 
         // We keep existing assets since that helps when analyzing the bundle
       })
 
+      concat.add(null, `//# sourceMappingURL=${this.output}.map\n`)
+
       compilation.assets[this.output] = {
-        source: () => newSource,
-        size: () => newSource.length
+        size: () => concat.content.length,
+        source: () => concat.content
+      }
+      compilation.assets[`${this.output}.map`] = {
+        size: () => concat.sourceMap.length,
+        source: () => concat.sourceMap
       }
 
       callback()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,7 +1160,7 @@ babel-template@7.0.0-beta.0:
     babylon "7.0.0-beta.22"
     lodash "^4.2.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.7.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
   dependencies:
@@ -1733,6 +1733,12 @@ concat-stream@1.6.0, concat-stream@^1.5.2:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+concat-with-sourcemaps@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz#f55b3be2aeb47601b10a2d5259ccfb70fd2f1dd6"
+  dependencies:
+    source-map "^0.5.1"
 
 config-chain@~1.1.8:
   version "1.1.11"
@@ -5427,11 +5433,10 @@ react-dom@16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-hot-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0.tgz#6e28da9d459da8085f5ee8bdd775046ba4b5cd0b"
+react-hot-loader@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.1.1.tgz#e06db8cd0841c41e3ab0b395b2b774126fc8914e"
   dependencies:
-    babel-template "^6.7.0"
     global "^4.3.0"
     react-deep-force-update "^2.1.1"
     react-proxy "^3.0.0-alpha.0"
@@ -6047,7 +6052,7 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
-source-map@0.5.6, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.6, source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 


### PR DESCRIPTION
Allows implementors running custom configs to utilize end to end source-maps.