### PR TITLE
Send credentials with on-demand-entries-ping

### DIFF
--- a/client/on-demand-entries-client.js
+++ b/client/on-demand-entries-client.js
@@ -11,12 +11,16 @@ export default () => {
   async function ping () {
     try {
       const url = `/_next/on-demand-entries-ping?page=${Router.pathname}`
-      const res = await fetch(url)
+      const res = await fetch(url, {
+        credentials: 'same-origin'
+      })
       const payload = await res.json()
       if (payload.invalid) {
         // Payload can be invalid even if the page is not exists.
         // So, we need to make sure it's exists before reloading.
-        const pageRes = await fetch(location.href)
+        const pageRes = await fetch(location.href, {
+          credentials: 'same-origin'
+        })
         if (pageRes.status === 200) {
           location.reload()
         }


### PR DESCRIPTION
Fixed #2498

on-demand-entries-ping now fetch with option `credentials: 'same-origin'`