### PR TITLE
[WIP] Added dontScroll & disableScrolling. Updated scrollToHash.

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -33,6 +33,7 @@ export default class Router {
     this.subscriptions = new Set()
     this.componentLoadCancel = null
     this.onPopState = this.onPopState.bind(this)
+    this.dontScroll = false
 
     if (typeof window !== 'undefined') {
       // in order for `e.state` to work on the `onpopstate` event
@@ -263,6 +264,8 @@ export default class Router {
   }
 
   scrollToHash (as) {
+    if (this.dontScroll) return
+
     const [ , hash ] = as.split('#')
     const el = document.getElementById(hash)
     if (el) {
@@ -353,6 +356,10 @@ export default class Router {
   subscribe (fn) {
     this.subscriptions.add(fn)
     return () => this.subscriptions.delete(fn)
+  }
+
+  disableScrolling () {
+    this.dontScroll = true
   }
 }
 


### PR DESCRIPTION
These are the purposed changes from #2520 by @arunoda. Working on the corresponding example, docs, & tests.

Currently, cannot expose `disableScrolling`. 

```js
import Router from 'next/router'

Router.disableScrolling()
```

I'm pretty sure it is because I have to provide it as a property to the [`SingletonRouter`](https://github.com/rockchalkwushock/next.js/blob/v3-beta/lib/router/index.js#L15) since it represents the Public API used by the client instead of the server.

I've tried providing `disableScrolling` as an element in all 3 of the arrays with no such luck in exposing it. Not understanding how to achieve this 😕 

Also am curious if we want to allow the user to pass a prop `disableScrolling` on `<Link />` when performing shallow routing via the `shallow` prop.

```js
// ./lib/link.js
static propTypes = {
  disableScrolling: PropTypes.bool
}
```

```js
import Link from 'next/link'

/...
  <Link href='#foo' shallow disableScrolling>
    <a onClick={e => this._customScroller(e, 'foo')>To Foo</a>
  </Link>
/...
```