### PR TITLE
Add stringify advice to MobX example readme.

### DIFF
--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -37,6 +37,9 @@ This example is a mobx port of the [with-redux](https://github.com/zeit/next.js/
 }
 ```
 
+### Rehydrating with server data
+Be aware that data that was used on the server (and provided via `getInitialProps`) will be stringified in order to rehydrate the client with it. That means, if you create a store that is, say, an `ObservableMap` and give it as prop to a page, then the server will render appropriately. But stringifying it for the client will turn the `ObservableMap` to an ordinary JavaScript object (which does not have `Map`-style methods and is not an observable). So it is better to create the store as a normal object and turn it into a `Observable` in the `render()` method. This way both sides have an `Observable` to work with.
+
 ## The idea behind the example
 
 Usually splitting your app state into `pages` feels natural but sometimes you'll want to have global state for your app. This is an example on how you can use mobx that also works with our universal rendering approach. This is just a way you can do it but it's not the only one.


### PR DESCRIPTION
I just ran into this problem where a MobX-Observable that I created in `getInitialProps` ended up as an ordinary Object in the client, due to stringifying it. Maybe this is clear for many devs, but I thought it would be nice to add this hint to the README. What do you think?