### PR TITLE
Add client-side render for back pressure responses

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -30,6 +30,10 @@ export async function renderError (err, req, res, pathname, query, opts) {
   sendHTML(req, res, html, req.method, opts)
 }
 
+export function renderBackpressureToHTML (req, res, pathname, query, opts = {}) {
+  return doRender(req, res, pathname, query, { ...opts, backpressure: true })
+}
+
 export function renderErrorToHTML (err, req, res, pathname, query, opts = {}) {
   return doRender(req, res, pathname, query, { ...opts, err, page: '_error' })
 }
@@ -45,7 +49,8 @@ async function doRender (req, res, pathname, query, {
   dir = process.cwd(),
   dev = false,
   staticMarkup = false,
-  nextExport = false
+  nextExport = false,
+  backpressure = false
 } = {}) {
   page = page || pathname
 
@@ -67,6 +72,17 @@ async function doRender (req, res, pathname, query, {
   if (res.finished) return
 
   const renderPage = () => {
+    const chunks = loadChunks({ dev, dir, dist, availableChunks })
+
+    if (backpressure) {
+      return {
+        html: '',
+        head: defaultHead(),
+        errorHtml: '',
+        chunks
+      }
+    }
+
     const app = createElement(App, {
       Component,
       props,
@@ -83,7 +99,6 @@ async function doRender (req, res, pathname, query, {
     } finally {
       head = Head.rewind() || defaultHead()
     }
-    const chunks = loadChunks({ dev, dir, dist, availableChunks })
 
     if (err && dev) {
       errorHtml = render(createElement(ErrorDebug, { error: err }))


### PR DESCRIPTION
This allows for a server that has detected a CPU overload case to push page rendering out to the client rather than handle locally on the server.