### PR TITLE
Update with-emotion to flush SSR styles on refresh

### DIFF
--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -1,8 +1,12 @@
 import Document, { Head, Main, NextScript } from 'next/document'
 import { extractCritical } from 'emotion/server'
+import { flush } from 'emotion'
+
+const dev = process.env.NODE_ENV === 'production'
 
 export default class MyDocument extends Document {
   static getInitialProps ({ renderPage }) {
+    if (dev) { flush() }
     const page = renderPage()
     const styles = extractCritical(page.html)
     return { ...page, ...styles }

--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -2,7 +2,7 @@ import Document, { Head, Main, NextScript } from 'next/document'
 import { extractCritical } from 'emotion/server'
 import { flush } from 'emotion'
 
-const dev = process.env.NODE_ENV === 'production'
+const dev = process.env.NODE_ENV !== 'production'
 
 export default class MyDocument extends Document {
   static getInitialProps ({ renderPage }) {

--- a/examples/with-emotion/pages/index.js
+++ b/examples/with-emotion/pages/index.js
@@ -48,7 +48,7 @@ export default () => {
     }
   `
 
-  const Basic = styled.div`@apply ${basicStyles};`
+  const Basic = styled.div`composes: ${basicStyles};`
   const Combined = styled.div`
     composes: ${basicStyles} ${hoverStyles};
     & code {


### PR DESCRIPTION
This prevents styles which have changed between reloads from being duplicated in the output of `extractCritical`

cc @mitchellhamilton @hamlim @hawkins 