### PR TITLE
React Fiber v16.0.0-alpha.13 support

### DIFF
--- a/client/next-dev.js
+++ b/client/next-dev.js
@@ -1,5 +1,4 @@
 import 'react-hot-loader/patch'
-import ReactReconciler from 'react-dom/lib/ReactReconciler'
 import initOnDemandEntries from './on-demand-entries-client'
 import initWebpackHMR from './webpack-hot-middleware-client'
 
@@ -35,17 +34,3 @@ next.default()
   .catch((err) => {
     console.error(`${err.message}\n${err.stack}`)
   })
-
-// This is a patch to catch most of the errors throw inside React components.
-const originalMountComponent = ReactReconciler.mountComponent
-ReactReconciler.mountComponent = function (...args) {
-  try {
-    return originalMountComponent(...args)
-  } catch (err) {
-    if (!err.abort) {
-      next.renderError(err)
-      err.abort = true
-    }
-    throw err
-  }
-}

--- a/package.json
+++ b/package.json
@@ -124,15 +124,15 @@
     "node-fetch": "1.7.1",
     "node-notifier": "5.1.2",
     "nyc": "11.0.3",
-    "react": "15.5.4",
-    "react-dom": "15.5.4",
+    "react": "^16.0.0-alpha.13",
+    "react-dom": "^16.0.0-alpha.13",
     "standard": "9.0.2",
     "taskr": "1.0.6",
     "wd": "1.4.0"
   },
   "peerDependencies": {
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^16.0.0-alpha.13",
+    "react-dom": "^16.0.0-alpha.13"
   },
   "jest": {
     "testEnvironment": "node",

--- a/server/document.js
+++ b/server/document.js
@@ -18,6 +18,13 @@ export default class Document extends Component {
     return { _documentProps: this.props }
   }
 
+  // eslint-disable-next-line camelcase
+  unstable_handleError (err) {
+    if (typeof window !== 'undefined' && window.next && window.next.renderError) {
+      window.next.renderError(err)
+    }
+  }
+
   render () {
     return <html>
       <Head />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4339,7 +4339,7 @@ prop-types-exact@^1.1.1:
     has "^1.0.1"
     object.assign "^4.0.4"
 
-prop-types@15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@15.5.10, prop-types@^15.5.4, prop-types@^15.5.6:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4429,14 +4429,14 @@ react-deep-force-update@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"
 
-react-dom@15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
+react-dom@^16.0.0-alpha.13:
+  version "16.0.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0-alpha.13.tgz#c2b39aaf8645f1d664619fb49a1fbb9f60719c23"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "~15.5.7"
+    prop-types "^15.5.6"
 
 react-hot-loader@3.0.0-beta.7:
   version "3.0.0-beta.7"
@@ -4455,14 +4455,14 @@ react-proxy@^3.0.0-alpha.0:
   dependencies:
     lodash "^4.6.1"
 
-react@15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
+react@^16.0.0-alpha.13:
+  version "16.0.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0-alpha.13.tgz#de37e035b06283a15cfb916c6943b9b066b25de0"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "^15.5.7"
+    prop-types "^15.5.6"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Implement unstable_handleError boundary instead of deprecated react-dom/lib/ReactReconciler.mountComponent monkeypatch