### PR TITLE
Added missing `as` propType to `Link`.

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -16,6 +16,7 @@ export default class Link extends Component {
 
   static propTypes = exact({
     href: PropTypes.string,
+    as: PropTypes.string,
     prefetch: PropTypes.bool,
     children: PropTypes.oneOfType([
       PropTypes.element,


### PR DESCRIPTION
This was causing the error `Failed prop type: Link: unknown props found: as in Link` when used with [`next-routes`](https://github.com/fridays/next-routes).