### PR TITLE
Corrected dependencies for preact and inferno

### DIFF
--- a/examples/using-inferno/package.json
+++ b/examples/using-inferno/package.json
@@ -11,7 +11,9 @@
     "inferno-compat": "^1.4.0",
     "inferno-server": "^1.4.0",
     "module-alias": "^2.0.0",
-    "next": "latest"
+    "next": "latest",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "author": "",
   "license": "MIT"

--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -10,7 +10,9 @@
     "module-alias": "^2.0.0",
     "next": "latest",
     "preact": "^7.2.0",
-    "preact-compat": "^3.14.0"
+    "preact-compat": "^3.14.0",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
I received the following errors

```
{ Error: Cannot find module 'react/dist/react.min.js'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.resolve (internal/module.js:18:19)
    at _callee2$ (/Users/a.marchenko/Downloads/using-preact/node_modules/next/dist/server/build/webpack.js:516:34)
    at tryCatch (/Users/a.marchenko/Downloads/using-preact/node_modules/regenerator-runtime/runtime.js:65:40)
    at Generator.invoke [as _invoke] (/Users/a.marchenko/Downloads/using-preact/node_modules/regenerator-runtime/runtime.js:303:22)
    at Generator.prototype.(anonymous function) [as next] (/Users/a.marchenko/Downloads/using-preact/node_modules/regenerator-runtime/runtime.js:117:21)
    at step (/Users/a.marchenko/Downloads/using-preact/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/a.marchenko/Downloads/using-preact/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
    at Promise (<anonymous>)
    at F (/Users/a.marchenko/Downloads/using-preact/node_modules/core-js/library/modules/_export.js:35:28) code: 'MODULE_NOT_FOUND' }
```
The build requires React