### PR TITLE
Webpack's ModuleConcatenationPlugin plugin doesn't work well with HMR.

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -131,8 +131,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
     }),
     new PagesPlugin(),
     new DynamicChunksPlugin(),
-    new CaseSensitivePathPlugin(),
-    new webpack.optimize.ModuleConcatenationPlugin()
+    new CaseSensitivePathPlugin()
   ]
 
   if (dev) {
@@ -156,6 +155,7 @@ export default async function createCompiler (dir, { dev = false, quiet = false,
         sourceMap: false
       })
     )
+    plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
   }
 
   const nodePathList = (process.env.NODE_PATH || '')


### PR DESCRIPTION
So, now we only use it for production.
This is how we can re-produce this error: https://github.com/arunoda/webpack-module-concat-hmr-issues

May be related: https://github.com/webpack/webpack/issues/3627