### PR TITLE
Show webpack errors in all pages.

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import exact from 'prop-types-exact'
 import HTTPStatus from 'http-status'
 import Head from './head'
 
@@ -10,9 +9,9 @@ export default class Error extends React.Component {
     return { statusCode }
   }
 
-  static propTypes = exact({
+  static propTypes = {
     statusCode: PropTypes.number
-  })
+  }
 
   render () {
     const { statusCode } = this.props

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -299,19 +299,29 @@ export default class Router {
       cancelled = true
     }
 
-    const Component = await this.fetchRoute(route)
+    try {
+      const Component = await this.fetchRoute(route)
 
-    if (cancelled) {
-      const error = new Error(`Abort fetching component for route: "${route}"`)
-      error.cancelled = true
-      throw error
+      if (cancelled) {
+        const error = new Error(`Abort fetching component for route: "${route}"`)
+        error.cancelled = true
+        throw error
+      }
+
+      if (cancel === this.componentLoadCancel) {
+        this.componentLoadCancel = null
+      }
+
+      return Component
+    } catch (err) {
+      // There's an error in loading the route.
+      // Usually this happens when there's a failure in the webpack build
+      // So in that case, we need to load the page with full SSR
+      // That'll clean the invalid exising client side information.
+      // (Like cached routes)
+      window.location.href = as
+      throw err
     }
-
-    if (cancel === this.componentLoadCancel) {
-      this.componentLoadCancel = null
-    }
-
-    return Component
   }
 
   async getInitialProps (Component, ctx) {


### PR DESCRIPTION
When there's a webpack error that means HMR failed too.
So, showing other pages won't makes sense since the user can't edit them and get changes via HMR.
That's why now we show the error on all pages.