### PR TITLE
Reload the page only if the change is for the current page.

### DIFF
--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -32,17 +32,22 @@ export default () => {
 
       const { err, Component } = Router.components[route] || {}
 
+      if (err) {
+        // reload to recover from runtime errors
+        Router.reload(route)
+      }
+
+      if (Router.route !== route) {
+        // If this is a not a change for a currently viewing page.
+        // We don't need to worry about it.
+        return
+      }
+
       if (!Component) {
         // This only happens when we create a new page without a default export.
         // If you removed a default export from a exising viewing page, this has no effect.
         console.log(`Hard reloading due to no default component in page: ${route}`)
         window.location.reload()
-        return
-      }
-
-      if (err) {
-        // reload to recover from runtime errors
-        Router.reload(route)
       }
     }
   }


### PR DESCRIPTION
Sometimes, we've to reload the page for some changes.
Even if so, we need to do it if that change is for the current page.