### PR TITLE
Keep some buffered pages, that won't be disposed. Fix #1939

### DIFF
--- a/test/integration/ondemand/pages/third.js
+++ b/test/integration/ondemand/pages/third.js
@@ -1,0 +1,5 @@
+export default () => (
+  <div>
+    <p>Third Page</p>
+  </div>
+)

--- a/test/integration/ondemand/test/index.test.js
+++ b/test/integration/ondemand/test/index.test.js
@@ -32,15 +32,26 @@ describe('On Demand Entries', () => {
   })
 
   it('should dispose inactive pages', async () => {
+<<<<<<< HEAD
     await renderViaHTTP(context.appPort, '/_next/-/page/about')
+=======
+    const indexPagePath = resolve(__dirname, '../.next/bundles/pages/index.js')
+    expect(existsSync(indexPagePath)).toBeTruthy()
+    // Render two pages after the index, since the server keeps at least two pages
+    await renderViaHTTP(context.appPort, '/about')
+>>>>>>> Keep some buffered pages, that won't be disposed. Fix #1939
     const aboutPagePath = resolve(__dirname, '../.next/bundles/pages/about.js')
-    expect(existsSync(aboutPagePath)).toBeTruthy()
+    await renderViaHTTP(context.appPort, '/third')
+    const thirdPagePath = resolve(__dirname, '../.next/bundles/pages/third.js')
 
     // Wait maximum of jasmine.DEFAULT_TIMEOUT_INTERVAL checking
     // for disposing /about
     while (true) {
       await waitFor(1000 * 1)
-      if (!existsSync(aboutPagePath)) return
+      // Assert that the two lastly demanded page are not disposed
+      expect(existsSync(aboutPagePath)).toBeTruthy()
+      expect(existsSync(thirdPagePath)).toBeTruthy()
+      if (!existsSync(indexPagePath)) return
     }
   })
 })

--- a/test/integration/ondemand/test/index.test.js
+++ b/test/integration/ondemand/test/index.test.js
@@ -22,7 +22,10 @@ describe('On Demand Entries', () => {
   afterAll(() => killApp(context.server))
 
   it('should compile pages for SSR', async () => {
+    // The buffer of built page uses the on-demand-entries-ping to know which pages should be
+    // buffered. Therefore, we need to double each render call with a ping.
     const pageContent = await renderViaHTTP(context.appPort, '/')
+    await renderViaHTTP(context.appPort, '/_next/on-demand-entries-ping', {page: '/'})
     expect(pageContent.includes('Index Page')).toBeTruthy()
   })
 
@@ -32,16 +35,16 @@ describe('On Demand Entries', () => {
   })
 
   it('should dispose inactive pages', async () => {
-<<<<<<< HEAD
-    await renderViaHTTP(context.appPort, '/_next/-/page/about')
-=======
     const indexPagePath = resolve(__dirname, '../.next/bundles/pages/index.js')
     expect(existsSync(indexPagePath)).toBeTruthy()
+
     // Render two pages after the index, since the server keeps at least two pages
-    await renderViaHTTP(context.appPort, '/about')
->>>>>>> Keep some buffered pages, that won't be disposed. Fix #1939
+    await renderViaHTTP(context.appPort, '/_next/-/page/about')
+    await renderViaHTTP(context.appPort, '/_next/on-demand-entries-ping', {page: '/about'})
     const aboutPagePath = resolve(__dirname, '../.next/bundles/pages/about.js')
-    await renderViaHTTP(context.appPort, '/third')
+
+    await renderViaHTTP(context.appPort, '/_next/-/page/third')
+    await renderViaHTTP(context.appPort, '/_next/on-demand-entries-ping', {page: '/third'})
     const thirdPagePath = resolve(__dirname, '../.next/bundles/pages/third.js')
 
     // Wait maximum of jasmine.DEFAULT_TIMEOUT_INTERVAL checking


### PR DESCRIPTION
Implementation of @arunoda's suggestion of letting the user decide how many page should be kept in memory before disposing them.

@sedubois made his point for not over disposing built pages, so I won't repeat him, but I think he has a point:
> This would allow to then have fast client-side transitions (after the first load), which allows to have a feel of these transitions without needing to deploy to prod.

The implementation is pretty naive, `pagesBuffer` works as a queue (first in, first out) of max length two (or whatever the user set), we keep in the buffer the last requested pages. If you'd like me to encapsulate the pagesBuffer logic in, do not hesitate, I didn't want to add any non needed abstraction :)