### PR TITLE
Only use Node 6 as the testing Node.js version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
       - google-chrome-stable
 language: node_js
 node_js:
-  - "4"
   - "6"
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)


### PR DESCRIPTION
It's safe to use this as we don't use any version specific Node.js features.
This makes passing tests faster. (Specially on windows tests)