### PR TITLE
Fix import() spec compliance by not loading default export automatically

### DIFF
--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -54,7 +54,7 @@ export default function dynamicComponent (p, o) {
     }
 
     loadComponent () {
-      promise.then((AsyncComponent) => {
+      promise.then(({ default: AsyncComponent, __webpackChunkName }) => {
         // Set a readable displayName for the wrapper component
         const asyncCompName = getDisplayName(AsyncComponent)
         if (asyncCompName) {
@@ -65,7 +65,7 @@ export default function dynamicComponent (p, o) {
           this.setState({ AsyncComponent })
         } else {
           if (this.isServer) {
-            registerChunk(AsyncComponent.__webpackChunkName)
+            registerChunk(__webpackChunkName)
           }
           this.state.AsyncComponent = AsyncComponent
         }
@@ -100,9 +100,9 @@ export default function dynamicComponent (p, o) {
 
       const loadModule = (name) => {
         const promise = modulePromiseMap[name]
-        promise.then((Component) => {
+        promise.then(({ default: Component, __webpackChunkName }) => {
           if (this.isServer) {
-            registerChunk(Component.__webpackChunkName)
+            registerChunk(__webpackChunkName)
           }
           moduleMap[name] = Component
           remainingPromises--

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -13,7 +13,6 @@ const buildImport = (args) => (template(`
         eval('require.ensure = function (deps, callback) { callback(require) }')
         require.ensure([], (require) => {
           let m = require(SOURCE)
-          m = m.default || m
           m.__webpackChunkName = '${args.name}.js'
           resolve(m);
         }, 'chunks/${args.name}.js');
@@ -23,13 +22,12 @@ const buildImport = (args) => (template(`
         const weakId = require.resolveWeak(SOURCE)
         try {
           const weakModule = __webpack_require__(weakId)
-          return resolve(weakModule.default || weakModule)
+          return resolve(weakModule)
         } catch (err) {}
 
         require.ensure([], (require) => {
           try {
             let m = require(SOURCE)
-            m = m.default || m
             resolve(m)
           } catch(error) {
             reject(error)


### PR DESCRIPTION
Resolves #2602 !

Instead of the Babel plugin automatically selecting the default export, `dynamic()` now does. This leaves the behavior of `dynamic()` unchanged.

/cc @arunoda 