### PR TITLE
Make dynamic import spec compliant.

### DIFF
--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -54,7 +54,8 @@ export default function dynamicComponent (p, o) {
     }
 
     loadComponent () {
-      promise.then((AsyncComponent) => {
+      promise.then((module) => {
+        const AsyncComponent = module.default || module
         // Set a readable displayName for the wrapper component
         const asyncCompName = getDisplayName(AsyncComponent)
         if (asyncCompName) {
@@ -65,7 +66,7 @@ export default function dynamicComponent (p, o) {
           this.setState({ AsyncComponent })
         } else {
           if (this.isServer) {
-            registerChunk(AsyncComponent.__webpackChunkName)
+            registerChunk(module.__webpackChunkName)
           }
           this.state.AsyncComponent = AsyncComponent
         }
@@ -100,9 +101,10 @@ export default function dynamicComponent (p, o) {
 
       const loadModule = (name) => {
         const promise = modulePromiseMap[name]
-        promise.then((Component) => {
+        promise.then((module) => {
+          const Component = module.default || module
           if (this.isServer) {
-            registerChunk(Component.__webpackChunkName)
+            registerChunk(module.__webpackChunkName)
           }
           moduleMap[name] = Component
           remainingPromises--

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -54,8 +54,8 @@ export default function dynamicComponent (p, o) {
     }
 
     loadComponent () {
-      promise.then((module) => {
-        const AsyncComponent = module.default || module
+      promise.then((m) => {
+        const AsyncComponent = m.default || m
         // Set a readable displayName for the wrapper component
         const asyncCompName = getDisplayName(AsyncComponent)
         if (asyncCompName) {
@@ -66,7 +66,7 @@ export default function dynamicComponent (p, o) {
           this.setState({ AsyncComponent })
         } else {
           if (this.isServer) {
-            registerChunk(module.__webpackChunkName)
+            registerChunk(m.__webpackChunkName)
           }
           this.state.AsyncComponent = AsyncComponent
         }
@@ -101,10 +101,10 @@ export default function dynamicComponent (p, o) {
 
       const loadModule = (name) => {
         const promise = modulePromiseMap[name]
-        promise.then((module) => {
-          const Component = module.default || module
+        promise.then((m) => {
+          const Component = m.default || m
           if (this.isServer) {
-            registerChunk(module.__webpackChunkName)
+            registerChunk(m.__webpackChunkName)
           }
           moduleMap[name] = Component
           remainingPromises--

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -13,7 +13,6 @@ const buildImport = (args) => (template(`
         eval('require.ensure = function (deps, callback) { callback(require) }')
         require.ensure([], (require) => {
           let m = require(SOURCE)
-          m = m.default || m
           m.__webpackChunkName = '${args.name}.js'
           resolve(m);
         }, 'chunks/${args.name}.js');
@@ -23,13 +22,12 @@ const buildImport = (args) => (template(`
         const weakId = require.resolveWeak(SOURCE)
         try {
           const weakModule = __webpack_require__(weakId)
-          return resolve(weakModule.default || weakModule)
+          return resolve(weakModule)
         } catch (err) {}
 
         require.ensure([], (require) => {
           try {
             let m = require(SOURCE)
-            m = m.default || m
             resolve(m)
           } catch(error) {
             reject(error)


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/2602

Now we simply return the whole module incl. default field
In 'next/dynamic' we pick the default field if there is.
Since modules with default is mostly used next/dynamic, for the enduser, this change has no effect.