### PR TITLE
Allow running `getInitialProps` again on the client, on the initial page load

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -146,7 +146,7 @@ async function doRender ({ Component, props, hash, err, emitter }) {
     if (runAgain) {
       const clientProps = await loadGetInitialProps(
         Component,
-        { err, pathname, query, asPath, isFirstRender } // Pass ctx + isFirstRender
+        { err, pathname, query, asPath, serverProps: props } // Pass ctx + serverProps
       )
       Object.assign(props, clientProps) // Merge it with the server generated props.
     }

--- a/client/index.js
+++ b/client/index.js
@@ -55,6 +55,8 @@ export let router
 export let ErrorComponent
 let Component
 
+let isFirstRender = true
+
 export default async () => {
   // Wait for all the dynamic chunks to get loaded
   for (const chunkName of chunks) {
@@ -137,6 +139,20 @@ async function doRender ({ Component, props, hash, err, emitter }) {
     const { pathname, query, asPath } = router
     props = await loadGetInitialProps(Component, { err, pathname, query, asPath })
   }
+
+  // Check if the Component wants to run its getIntialProps function in the client.
+  if (isFirstRender && Component.runInitialPropsAgain) {
+    const runAgain = await Component.runInitialPropsAgain({ err, pathname, query, asPath })
+    if (runAgain) {
+      const clientProps = await loadGetInitialProps(
+        Component,
+        { err, pathname, query, asPath, isFirstRender } // Pass ctx + isFirstRender
+      )
+      Object.assign(props, clientProps) // Merge it with the server generated props.
+    }
+  }
+  // Next getInitialProps are called by Router, so we only need to do this once.
+  isFirstRender = false
 
   if (emitter) {
     emitter.emit('before-reactdom-render', { Component, ErrorComponent })

--- a/client/index.js
+++ b/client/index.js
@@ -142,8 +142,10 @@ async function doRender ({ Component, props, hash, err, emitter }) {
 
   // Check if the Component wants to run its getIntialProps function in the client.
   if (isFirstRender && Component.runInitialPropsAgain) {
-    const runAgain = await Component.runInitialPropsAgain({ err, pathname, query, asPath })
-    if (runAgain) {
+    const runAgain = await Component.runInitialPropsAgain(
+      { err, pathname, query, asPath, serverProps: props }
+    )
+    if (runAgain === true) {
       const clientProps = await loadGetInitialProps(
         Component,
         { err, pathname, query, asPath, serverProps: props } // Pass ctx + serverProps

--- a/test/integration/basic/pages/run-initial-props-again.js
+++ b/test/integration/basic/pages/run-initial-props-again.js
@@ -6,9 +6,9 @@ const Component = ({ fromServer, fromFirstRender }) =>
     {fromFirstRender ? 'fromFirstRender' : ''}
   </div>
 
-Component.getInitialProps = async ({ req, isFirstRender }) => {
+Component.getInitialProps = async ({ req, serverProps }) => {
   if (req) return { fromServer: true }
-  else if (isFirstRender) return { fromFirstRender: true }
+  else if (serverProps) return { fromFirstRender: true }
 }
 
 // Turn it on and off using a query for testing.

--- a/test/integration/basic/pages/run-initial-props-again.js
+++ b/test/integration/basic/pages/run-initial-props-again.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const Component = ({ fromServer, fromFirstRender }) =>
+  <div>
+    {fromServer ? 'fromServer' : ''}
+    {fromFirstRender ? 'fromFirstRender' : ''}
+  </div>
+
+Component.getInitialProps = async ({ req, isFirstRender }) => {
+  if (req) return { fromServer: true }
+  else if (isFirstRender) return { fromFirstRender: true }
+}
+
+// Turn it on and off using a query for testing.
+Component.runInitialPropsAgain = async ({ query }) => query.runInitialPropsAgain
+
+export default Component

--- a/test/integration/basic/pages/without-run-initial-props-again.js
+++ b/test/integration/basic/pages/without-run-initial-props-again.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const Component = ({ fromServer, fromFirstRender }) =>
+  <div>
+    {fromServer ? 'fromServer' : ''}
+    {fromFirstRender ? 'fromFirstRender' : ''}
+  </div>
+
+Component.getInitialProps = async ({ req, isFirstRender }) => {
+  if (req) return { fromServer: true }
+  else if (isFirstRender) return { fromFirstRender: true }
+}
+
+// Don't include runInitialPropsAgain.
+
+export default Component

--- a/test/integration/basic/pages/without-run-initial-props-again.js
+++ b/test/integration/basic/pages/without-run-initial-props-again.js
@@ -6,9 +6,9 @@ const Component = ({ fromServer, fromFirstRender }) =>
     {fromFirstRender ? 'fromFirstRender' : ''}
   </div>
 
-Component.getInitialProps = async ({ req, isFirstRender }) => {
+Component.getInitialProps = async ({ req, serverProps }) => {
   if (req) return { fromServer: true }
-  else if (isFirstRender) return { fromFirstRender: true }
+  else if (serverProps) return { fromFirstRender: true }
 }
 
 // Don't include runInitialPropsAgain.

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -42,6 +42,8 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/link'),
       renderViaHTTP(context.appPort, '/stateful'),
       renderViaHTTP(context.appPort, '/stateless'),
+      renderViaHTTP(context.appPort, '/run-initial-props-again'),
+      renderViaHTTP(context.appPort, '/without-run-initial-props-again'),
       renderViaHTTP(context.appPort, '/styled-jsx'),
       renderViaHTTP(context.appPort, '/with-cdm'),
 

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -53,6 +53,24 @@ export default function ({ app }, suiteName, render) {
       expect($('pre').text().includes(expectedErrorMessage)).toBeTruthy()
     })
 
+    test.only('runInitialPropsAgain resolves to true', async () => {
+      const html = await (render('/run-initial-props-again?runInitialPropsAgain=true'))
+      expect(html.includes('fromServer')).toBeTruthy()
+      expect(html.includes('fromFirstRender')).toBeTruthy()
+    })
+
+    test.only('runInitialPropsAgain resolves to false', async () => {
+      const html = await (render('/run-initial-props-again'))
+      expect(html.includes('fromServer')).toBeTruthy()
+      expect(html.includes('fromFirstRender')).toBeFalsy()
+    })
+
+    test.only('runInitialPropsAgain resolves to undefined', async () => {
+      const html = await (render('/without-run-initial-props-again'))
+      expect(html.includes('fromServer')).toBeTruthy()
+      expect(html.includes('fromFirstRender')).toBeFalsy()
+    })
+
     test('allows to import .json files', async () => {
       const html = await render('/json')
       expect(html.includes('Zeit')).toBeTruthy()

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -53,19 +53,19 @@ export default function ({ app }, suiteName, render) {
       expect($('pre').text().includes(expectedErrorMessage)).toBeTruthy()
     })
 
-    test.only('runInitialPropsAgain resolves to true', async () => {
+    test('runInitialPropsAgain resolves to true', async () => {
       const html = await (render('/run-initial-props-again?runInitialPropsAgain=true'))
       expect(html.includes('fromServer')).toBeTruthy()
       expect(html.includes('fromFirstRender')).toBeTruthy()
     })
 
-    test.only('runInitialPropsAgain resolves to false', async () => {
+    test('runInitialPropsAgain resolves to false', async () => {
       const html = await (render('/run-initial-props-again'))
       expect(html.includes('fromServer')).toBeTruthy()
       expect(html.includes('fromFirstRender')).toBeFalsy()
     })
 
-    test.only('runInitialPropsAgain resolves to undefined', async () => {
+    test('runInitialPropsAgain resolves to undefined', async () => {
       const html = await (render('/without-run-initial-props-again'))
       expect(html.includes('fromServer')).toBeTruthy()
       expect(html.includes('fromFirstRender')).toBeFalsy()


### PR DESCRIPTION
## Expected Behavior
<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->

Sometimes it's really useful to use the async `getInitialProps` method on the client before doing the first `ReactDOM.render`, even on the initial page load. For example this would allow things like using `import()` to dynamically populate a Redux store and pass it to the page.

## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->

There's no way to run `getInitialProps` again on the initial page load.

## PR and proposed implementation
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->

Pages can expose a `runInitialPropsAgain` static method which should return `true` or `false`. `runInitialPropsAgain` receives the same context than `getInitialProps` including `serverProps`.

```javascript
static async runInitialPropsAgain({ pathname, query, serverProps, ... }) {
    return true; // Add your own logic here.
}
```

When it returns `true`, pages can check if `serverProps` is set and define their custom logic. Returned props are merged with the server props.

```javascript
static async getInitialProps({ serverProps }) {
    if (serverProps) {
      const extension1 = await import('./extensions/custom-code-1.js')
      const extension2 = await import('./extensions/custom-code-2.js')
      const store = createStore([extension1, extension2])
      return { store }
    }
  }
```

`serverProps` won't be set again on subsequent renders, when Router is used.

----

I'd love to know if you would merge something like this, and if so, what do I need to change. I'm also open to any other implementation ideas and discussion.

I've also added some tests but I may need more help with that. The code is working great on my projects but I can't get it to work on the tests. I'm not sure what I may be doing wrong.

And by the way, many thanks for this project. We are loving it, **next is awesome!** 🙌 