### PR TITLE
Fix infinite recursion when requesting /static/ and /_next/

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -18,8 +18,8 @@ import getConfig from './config'
 import pkg from '../../package'
 
 const internalPrefixes = [
-  /^\/_next\//,
-  /^\/static\//
+  /^\/_next\/./,
+  /^\/static\/./
 ]
 
 const blockedPages = {


### PR DESCRIPTION
Fixes #2617 

What happens right now is that `/static/` and `/_next/` (without anything added to the end) cause a infinite recursion cause they match the criteria to be an internal file. and keep rendering the same thing.

Happens both locally and in production, so I guess we'd best backport this to 2.x too.