### PR TITLE
Prefix process.env to avoid inconsistency

### DIFF
--- a/examples/with-universal-configuration/env-config.js
+++ b/examples/with-universal-configuration/env-config.js
@@ -1,5 +1,5 @@
 const prod = process.env.NODE_ENV === 'production'
 
 module.exports = {
-  'BACKEND_URL': prod ? 'https://api.example.com' : 'https://localhost:8080'
+  'process.env.BACKEND_URL': prod ? 'https://api.example.com' : 'https://localhost:8080'
 }

--- a/examples/with-universal-configuration/pages/index.js
+++ b/examples/with-universal-configuration/pages/index.js
@@ -1,5 +1,3 @@
-/* global BACKEND_URL */
-
 export default () => (
-  <div>Loading data from { BACKEND_URL }</div>
+  <div>Loading data from { process.env.BACKEND_URL }</div>
 )


### PR DESCRIPTION
This is how we should have displayed it from the beginning 👌 