### PR TITLE
Expose mechanism to monitor render events

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/client/index')

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "babel.js",
+    "client.js",
     "link.js",
     "css.js",
     "head.js",

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -43,6 +43,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     const entries = {
       'main.js': [
         ...defaultEntries,
+        ...config.clientBootstrap || [],
         mainJS
       ]
     }


### PR DESCRIPTION
Doing this to allow for live-tracking of startup performance of our app in production.

Example:

```
let renderStart = Date.now();

emitter.on('before-reactdom-render', () => {
  renderStart = Date.now();
});

emitter.on('after-reactdom-render', ({ appProps }) => {
  const duration = Date.now() - renderStart;
  trackDuration('ui.page.render', duration, {
    route: appProps.router.asPath,
  });
});

```