### PR TITLE
Remove `stage-0` from dependencies on example

### DIFF
--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "babel-plugin-styled-components": "^1.1.4",
-    "babel-preset-stage-0": "^6.24.1",
     "next": "latest",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",


### PR DESCRIPTION
This PR removes `babel-preset-stage-0` from the dependencies list, that was missing on #1959.