### PR TITLE
Fixed SSR bug in parseCookies in with-apollo-auth example

### DIFF
--- a/examples/with-apollo-auth/lib/with-data.js
+++ b/examples/with-apollo-auth/lib/with-data.js
@@ -7,8 +7,10 @@ import initApollo from './init-apollo'
 
 function parseCookies (ctx = {}, options = {}) {
   return cookie.parse(
-    ctx.req && ctx.req.headers.cookie
+    ctx.req
       ? ctx.req.headers.cookie
+          ? ctx.req.headers.cookie
+          : ''
       : document.cookie,
     options
   )


### PR DESCRIPTION
If you do a **server-side** GraphQL query without a cookie set in `ctx.req.headers` you will get the error: `ReferenceError: document is not defined` because there is no `document` in Node.js.

This PR fixes the logic in `parseCookies` to prevent that from happening.

Also wanted to say thanks @jesstelford for this example! It's great!