### PR TITLE
Material-UI example: Pass through unrelated props to wrapped component

### DIFF
--- a/examples/with-material-ui-next/components/withRoot.js
+++ b/examples/with-material-ui-next/components/withRoot.js
@@ -46,7 +46,7 @@ function withRoot (BaseComponent) {
         <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
           <MuiThemeProvider theme={context.theme} sheetsManager={context.sheetsManager}>
             <AppWrapper>
-              <BaseComponent />
+              <BaseComponent {...this.props} />
             </AppWrapper>
           </MuiThemeProvider>
         </JssProvider>


### PR DESCRIPTION
According to the [convention](https://facebook.github.io/react/docs/higher-order-components.html#convention-pass-unrelated-props-through-to-the-wrapped-component), the new HOC in the material-ui-next example should pass unrelated properties to it's wrapped component.

This is especially useful if you're composing multiple HOCs together.
