### PR TITLE
Material UI Next example: Use module-scoped singleton

### DIFF
--- a/examples/with-material-ui-next/styles/context.js
+++ b/examples/with-material-ui-next/styles/context.js
@@ -17,6 +17,8 @@ const theme = createMuiTheme({
 const jss = create(preset())
 jss.options.createGenerateClassName = createGenerateClassName
 
+let context
+
 function createContext () {
   return {
     jss,
@@ -30,20 +32,20 @@ function createContext () {
 
 export function setContext () {
   // Singleton hack as there is no way to pass variables from _document.js to pages yet.
-  global.__INIT_MATERIAL_UI__ = createContext()
+  context = createContext()
 }
 
 export function getContext () {
   // Make sure to create a new store for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (!process.browser) {
-    return global.__INIT_MATERIAL_UI__
+    return context
   }
 
   // Reuse context on the client-side
-  if (!global.__INIT_MATERIAL_UI__) {
-    global.__INIT_MATERIAL_UI__ = createContext()
+  if (!context) {
+    context = createContext()
   }
 
-  return global.__INIT_MATERIAL_UI__
+  return context
 }


### PR DESCRIPTION
The `material-ui-next` example stores a singleton instance of its JSS context on the global object. Because ES6 module imports resolve to the same reference when imported into multiple files, this singleton object can simply be stored in the module itself to avoid polluting the global namespace.