### PR TITLE
Add missed dev dependencies for examples/using-preact

### DIFF
--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -12,5 +12,9 @@
     "preact": "^7.2.0",
     "preact-compat": "^3.14.0"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "react": "~15.6.1",
+    "react-dom": "~15.6.1"
+  }
 }


### PR DESCRIPTION
examples/using-preact is broken at the moment because react and react-dom dependencies are required in development mode but missed. So `npm run dev` and `npm run build` don't work.