### PR TITLE
Add examples/with-redux-code-splitting.

### DIFF
--- a/examples/with-redux-code-splitting/README.md
+++ b/examples/with-redux-code-splitting/README.md
@@ -1,0 +1,32 @@
+
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-redux-code-splitting)
+
+# Redux with code splitting example
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-redux-code-splitting
+cd with-redux-code-splitting
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+Redux uses single store per application and usually it causes problems for code splitting when you want to load actions and reducers used on the current page only.
+
+This example utilizes [fast-redux](https://github.com/dogada/fast-redux) to split Redux's actions and reducers across pages. In result each page's javascript bundle contains only code that is used on the page. When user navigates to a new page, its actions and reducers are connected to the single shared application store.

--- a/examples/with-redux-code-splitting/config/redux.js
+++ b/examples/with-redux-code-splitting/config/redux.js
@@ -1,0 +1,12 @@
+import { createStore, applyMiddleware } from 'redux'
+import { composeWithDevTools } from 'redux-devtools-extension'
+import thunkMiddleware from 'redux-thunk'
+import withRedux from 'next-redux-wrapper'
+import { rootReducer } from 'fast-redux'
+
+export const initStore = (initialState = {}) => {
+  return createStore(rootReducer, initialState,
+    composeWithDevTools(applyMiddleware(thunkMiddleware)))
+}
+
+export const reduxPage = (comp) => withRedux(initStore)(comp)

--- a/examples/with-redux-code-splitting/containers/about.js
+++ b/examples/with-redux-code-splitting/containers/about.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import {bindActionCreators} from 'redux'
+import {connect} from 'react-redux'
+import {namespaceConfig} from 'fast-redux'
+import Link from 'next/link'
+
+const DEFAULT_STATE = {version: 1}
+
+const {actionCreator, getState: getAboutState} = namespaceConfig('about', DEFAULT_STATE)
+
+const bumpVersion = actionCreator(function bumpVersion (state, increment) {
+  return {...state, version: state.version + increment}
+})
+
+const About = ({ version, bumpVersion }) => (
+  <div>
+    <h1>About us</h1>
+    <h3>Current version: {version}</h3>
+    <p><button onClick={(e) => bumpVersion(1)}>Bump version!</button></p>
+    <Link href='/'><a>Homepage</a></Link>
+  </div>
+)
+
+function mapStateToProps (state) {
+  return getAboutState(state, 'version')
+}
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators({ bumpVersion }, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(About)

--- a/examples/with-redux-code-splitting/containers/homepage.js
+++ b/examples/with-redux-code-splitting/containers/homepage.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import {bindActionCreators} from 'redux'
+import {connect} from 'react-redux'
+import {namespaceConfig} from 'fast-redux'
+import Link from 'next/link'
+
+const DEFAULT_STATE = {build: 1}
+
+const {actionCreator, getState: getHomepageState} = namespaceConfig('homepage', DEFAULT_STATE)
+
+const bumpBuild = actionCreator(function bumpBuild (state, increment) {
+  return {...state, build: state.build + increment}
+})
+
+const Homepage = ({ build, bumpBuild }) => (
+  <div>
+    <h1>Homepage</h1>
+    <h3>Current build: {build}</h3>
+    <p><button onClick={(e) => bumpBuild(1)}>Bump build!</button></p>
+    <Link href='/about'><a>About Us</a></Link>
+  </div>
+)
+
+function mapStateToProps (state) {
+  return getHomepageState(state)
+}
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators({ bumpBuild }, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Homepage)

--- a/examples/with-redux-code-splitting/package.json
+++ b/examples/with-redux-code-splitting/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "with-redux-code-splitting",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "fast-redux": "~0.3.0",
+    "next": "latest",
+    "next-redux-wrapper": "~1.3.2",
+    "react": "~15.6.1",
+    "react-dom": "~15.6.1",
+    "react-redux": "~5.0.5",
+    "redux": "~3.7.2",
+    "redux-devtools-extension": "~2.13.2",
+    "redux-thunk": "~2.2.0"
+  },
+  "author": "Dmytro V. Dogadailo (https://dogada.org)",
+  "license": "ISC"
+}

--- a/examples/with-redux-code-splitting/pages/about.js
+++ b/examples/with-redux-code-splitting/pages/about.js
@@ -1,0 +1,4 @@
+import {reduxPage} from '../config/redux'
+import About from '../containers/about'
+
+export default reduxPage(About)

--- a/examples/with-redux-code-splitting/pages/index.js
+++ b/examples/with-redux-code-splitting/pages/index.js
@@ -1,0 +1,4 @@
+import {reduxPage} from '../config/redux'
+import Homepage from '../containers/homepage'
+
+export default reduxPage(Homepage)


### PR DESCRIPTION
Redux uses single store per application and usually it causes problems for code splitting when you want to load actions and reducers used on the current page only.

This example utilizes fast-redux to split Redux's actions and reducers across pages. In result each page's javascript bundle contains only code that is used on the page.