### PR TITLE
Remove unnecessary lookup in example with emotion

### DIFF
--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -12,7 +12,7 @@ export default class MyDocument extends Document {
     super(props)
     const { __NEXT_DATA__, ids } = props
     if (ids) {
-      __NEXT_DATA__.ids = this.props.ids
+      __NEXT_DATA__.ids = ids
     }
   }
 


### PR DESCRIPTION
I believe that in React `props` received as the argument and `this.props` are the same.