### PR TITLE
Add line-height rule for error page h2

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -69,6 +69,7 @@ const styles = {
   h2: {
     fontSize: '14px',
     fontWeight: 'normal',
+    lineHeight: 'inherit',
     margin: 0,
     padding: 0
   }


### PR DESCRIPTION
This is a very small update to the default error page styles. In my use case, I have a main css file that adds some default line-height to heading tags. Unfortunately this messes up the vertical centering of the error page message, so it ends up looking like this:

![image](https://user-images.githubusercontent.com/7340187/29198325-f02796d4-7e10-11e7-904a-f83b0df43631.png)

This PR adds a `line-height: inherit` rule to the h2 tag so it gets the line-height of it's parent and stays unaffected by global default styles.