### PR TITLE
Use deterministic names for dynamic import

### DIFF
--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -2,7 +2,7 @@
 // We've added support for SSR with this version
 import template from 'babel-template'
 import syntax from 'babel-plugin-syntax-dynamic-import'
-import { dirname, resolve } from 'path'
+import { dirname, resolve, sep } from 'path'
 import Crypto from 'crypto'
 
 const TYPE_IMPORT = 'Import'
@@ -62,7 +62,7 @@ export default () => ({
         const modulePath = getModulePath(sourceFilename, moduleName)
         const modulePathHash = Crypto.createHash('md5').update(modulePath).digest('hex')
 
-        const relativeModulePath = modulePath.replace(process.cwd(), '')
+        const relativeModulePath = modulePath.replace(`${process.cwd()}${sep}`, '')
         const name = `${relativeModulePath.replace(/[^\w]/g, '-')}-${modulePathHash}`
 
         const newImport = buildImport({

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -45,7 +45,7 @@ export function getModulePath (sourceFilename, moduleName) {
 
   const cleanedModulePath = modulePath
     .replace(/(index){0,1}\.js$/, '') // remove .js, index.js
-    .replace(/\/$/, '') // remove end slash
+    .replace(/[/\\]$/, '') // remove end slash
 
   return cleanedModulePath
 }

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -2,7 +2,8 @@
 // We've added support for SSR with this version
 import template from 'babel-template'
 import syntax from 'babel-plugin-syntax-dynamic-import'
-import UUID from 'uuid'
+import { dirname, resolve } from 'path'
+import Crypto from 'crypto'
 
 const TYPE_IMPORT = 'Import'
 
@@ -37,14 +38,33 @@ const buildImport = (args) => (template(`
   )
 `))
 
+export function getModulePath (sourceFilename, moduleName) {
+  // resolve only if it's a local module
+  const modulePath = (moduleName[0] === '.')
+    ? resolve(dirname(sourceFilename), moduleName) : moduleName
+
+  const cleanedModulePath = modulePath
+    .replace(/(index){0,1}\.js$/, '') // remove .js, index.js
+    .replace(/\/$/, '') // remove end slash
+
+  return cleanedModulePath
+}
+
 export default () => ({
   inherits: syntax,
 
   visitor: {
-    CallExpression (path) {
+    CallExpression (path, state) {
       if (path.node.callee.type === TYPE_IMPORT) {
         const moduleName = path.node.arguments[0].value
-        const name = `${moduleName.replace(/[^\w]/g, '-')}-${UUID.v4()}`
+        const sourceFilename = state.file.opts.filename
+
+        const modulePath = getModulePath(sourceFilename, moduleName)
+        const modulePathHash = Crypto.createHash('md5').update(modulePath).digest('hex')
+
+        const relativeModulePath = modulePath.replace(process.cwd(), '')
+        const name = `${relativeModulePath.replace(/[^\w]/g, '-')}-${modulePathHash}`
+
         const newImport = buildImport({
           name
         })({

--- a/test/unit/handle-import-babel-plugin.test.js
+++ b/test/unit/handle-import-babel-plugin.test.js
@@ -1,0 +1,36 @@
+/* global describe, it, expect */
+import { getModulePath } from '../../dist/server/build/babel/plugins/handle-import'
+
+describe('handle-import-babel-plugin', () => {
+  describe('getModulePath', () => {
+    it('should not do anything to NPM modules', () => {
+      const mPath = getModulePath('/abc/pages/about.js', 'cool-module')
+      expect(mPath).toBe('cool-module')
+    })
+
+    it('should not do anything to private NPM modules', () => {
+      const mPath = getModulePath('/abc/pages/about.js', '@zeithq/cool-module')
+      expect(mPath).toBe('@zeithq/cool-module')
+    })
+
+    it('should resolve local modules', () => {
+      const mPath = getModulePath('/abc/pages/about.js', '../components/hello.js')
+      expect(mPath).toBe('/abc/components/hello')
+    })
+
+    it('should remove index.js', () => {
+      const mPath = getModulePath('/abc/pages/about.js', '../components/c1/index.js')
+      expect(mPath).toBe('/abc/components/c1')
+    })
+
+    it('should remove .js', () => {
+      const mPath = getModulePath('/abc/pages/about.js', '../components/bb.js')
+      expect(mPath).toBe('/abc/components/bb')
+    })
+
+    it('should remove end slash', () => {
+      const mPath = getModulePath('/abc/pages/about.js', '../components/bb/')
+      expect(mPath).toBe('/abc/components/bb')
+    })
+  })
+})

--- a/test/unit/handle-import-babel-plugin.test.js
+++ b/test/unit/handle-import-babel-plugin.test.js
@@ -1,6 +1,11 @@
 /* global describe, it, expect */
 import { getModulePath } from '../../dist/server/build/babel/plugins/handle-import'
-import { sep } from 'path'
+
+function cleanPath (mPath) {
+  return mPath
+    .replace(/\\/g, '/')
+    .replace(/^.*:/, '')
+}
 
 describe('handle-import-babel-plugin', () => {
   describe('getModulePath', () => {
@@ -16,22 +21,22 @@ describe('handle-import-babel-plugin', () => {
 
     it('should resolve local modules', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/hello.js')
-      expect(mPath).toBe('/abc/components/hello'.replace(/\/g/, sep))
+      expect(cleanPath(mPath)).toBe('/abc/components/hello')
     })
 
     it('should remove index.js', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/c1/index.js')
-      expect(mPath).toBe('/abc/components/c1'.replace(/\/g/, sep))
+      expect(cleanPath(mPath)).toBe('/abc/components/c1')
     })
 
     it('should remove .js', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/bb.js')
-      expect(mPath).toBe('/abc/components/bb'.replace(/\/g/, sep))
+      expect(cleanPath(mPath)).toBe('/abc/components/bb')
     })
 
     it('should remove end slash', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/bb/')
-      expect(mPath).toBe('/abc/components/bb'.replace(/\/g/, sep))
+      expect(cleanPath(mPath)).toBe('/abc/components/bb')
     })
   })
 })

--- a/test/unit/handle-import-babel-plugin.test.js
+++ b/test/unit/handle-import-babel-plugin.test.js
@@ -1,5 +1,6 @@
 /* global describe, it, expect */
 import { getModulePath } from '../../dist/server/build/babel/plugins/handle-import'
+import { sep } from 'path'
 
 describe('handle-import-babel-plugin', () => {
   describe('getModulePath', () => {
@@ -15,22 +16,22 @@ describe('handle-import-babel-plugin', () => {
 
     it('should resolve local modules', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/hello.js')
-      expect(mPath).toBe('/abc/components/hello')
+      expect(mPath).toBe('/abc/components/hello'.replace(/\/g/, sep))
     })
 
     it('should remove index.js', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/c1/index.js')
-      expect(mPath).toBe('/abc/components/c1')
+      expect(mPath).toBe('/abc/components/c1'.replace(/\/g/, sep))
     })
 
     it('should remove .js', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/bb.js')
-      expect(mPath).toBe('/abc/components/bb')
+      expect(mPath).toBe('/abc/components/bb'.replace(/\/g/, sep))
     })
 
     it('should remove end slash', () => {
       const mPath = getModulePath('/abc/pages/about.js', '../components/bb/')
-      expect(mPath).toBe('/abc/components/bb')
+      expect(mPath).toBe('/abc/components/bb'.replace(/\/g/, sep))
     })
   })
 })


### PR DESCRIPTION
This will prevent having different names for dynamic modules for the same underline module.