### PR TITLE
Fixed Material UI example

### DIFF
--- a/examples/with-material-ui-next/components/withRoot.js
+++ b/examples/with-material-ui-next/components/withRoot.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react'
 import { JssProvider } from 'react-jss'
-import { withStyles, createStyleSheet, MuiThemeProvider } from 'material-ui/styles'
+import { withStyles, MuiThemeProvider } from 'material-ui/styles'
 import { getContext } from '../styles/context'
 
 // Apply some reset
-const styleSheet = createStyleSheet(theme => ({
+const styles = theme => ({
   '@global': {
     html: {
       background: theme.palette.background.default,
@@ -15,11 +15,11 @@ const styleSheet = createStyleSheet(theme => ({
       margin: 0
     }
   }
-}))
+})
 
 let AppWrapper = props => props.children
 
-AppWrapper = withStyles(styleSheet)(AppWrapper)
+AppWrapper = withStyles(styles)(AppWrapper)
 
 function withRoot (BaseComponent) {
   class WithRoot extends Component {


### PR DESCRIPTION
`createStyleSheet()` has been removed from [material-ui/styles](https://github.com/callemall/material-ui/blob/9a6a3dde01d51de89c0b7ef3fd911cb3b8c798f4/src/styles/index.js).