### PR TITLE
Dev server utilizes paths from config.exportPathMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "source-map-support": "0.4.15",
     "strip-ansi": "4.0.0",
     "styled-jsx": "^1.0.8",
+    "through2": "^2.0.3",
     "touch": "3.1.0",
     "unfetch": "3.0.0",
     "url": "0.11.0",

--- a/server/index.js
+++ b/server/index.js
@@ -178,6 +178,7 @@ export default class Server {
       '/_next/:buildId/page/:path*': async (req, res, params) => {
         const paths = params.path || ['']
         let page = `/${paths.join('/')}`
+        let originalPage = page
 
         // TODO: This should reroute the path to a static page + query, but
         // thus far, it won't load the new route or replace the component.
@@ -207,7 +208,7 @@ export default class Server {
           }
         }
 
-        await renderScript(req, res, page, this.renderOpts)
+        await renderScript(req, res, page, this.renderOpts, originalPage)
       },
 
       // It's very important keep this route's param optional.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4549,7 +4549,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -5284,6 +5284,13 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
+through2@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -5386,7 +5393,7 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uglifyjs-webpack-plugin@0.4.6, uglifyjs-webpack-plugin@^0.4.6:
+uglifyjs-webpack-plugin@^0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz#b951f4abb6bd617e66f63eb891498e391763e309"
   dependencies:
@@ -5676,7 +5683,7 @@ xss-filters@1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/xss-filters/-/xss-filters-1.2.7.tgz#59fa1de201f36f2f3470dcac5f58ccc2830b0a9a"
 
-xtend@^4.0.0, xtend@^4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Fixes #2823 by allowing the dev server to utilize the paths from `exportPathMap` to load dynamic pages that would otherwise not be available until after `next export`. 

On another note, this relieves strict static users from being required to use the `as` prop in Links eg. `<Link href='...' as='...' />` is now just `<Link href='...' />`. Since the dev server now understands how to route any static paths to dynamic path/query pairs, masking the route is unnecessary because dev behavior is exactly the same as the statically exported site structure.