### PR TITLE
WIP: Update styled components example

### DIFF
--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "babel-plugin-styled-components": "^1.1.5",
-    "next": "latest",
+    "next": "../../",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "styled-components": "^2.1.0"

--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "babel-plugin-styled-components": "^1.1.5",
-    "next": "../../",
+    "next": "latest",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "styled-components": "^2.1.0"

--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -1,21 +1,28 @@
 import Document, { Head, Main, NextScript } from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
 
 export default class MyDocument extends Document {
+  static getInitialProps ({ renderPage, req }) {
+    const isServer = !!req
+    if (isServer) {
+      // eslint-disable-next-line no-eval
+      const ServerStyleSheet = eval("require('styled-components').ServerStyleSheet")
+      const sheet = new ServerStyleSheet()
+      const page = renderPage(sheet.collectStyles.bind(sheet))
+      const styleTags = sheet.getStyleTags()
+      return { ...page, styleTags }
+    }
+    return {}
+  }
+
   render () {
-    const sheet = new ServerStyleSheet()
-    const main = sheet.collectStyles(<Main />)
-    const styleTags = sheet.getStyleElement()
     return (
       <html>
         <Head>
-          <title>My page</title>
-          {styleTags}
+          <title>Next with styled-components</title>
+          {this.props.styleTags}
         </Head>
         <body>
-          <div className='root'>
-            {main}
-          </div>
+          <Main />
           <NextScript />
         </body>
       </html>


### PR DESCRIPTION
Based on #2010 this updates the styled-components to use the new `renderPage()` signature.

**This doesn't work yet, it throws an error when rendering on the server:** "The default export is not a React Component in page: /"

Any ideas why that could be happening?

/cc @_philpl @jcheroske @iamstarkov 