### PR TITLE
[Working] Fix pnpm require error [Help needed]

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,1 +1,3 @@
-module.exports = require('next/document')
+const path = require('path')
+module.exports = require(!process.browser ? 'next/document'
+  : path.resolve(__dirname, '/../server/document'))

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,1 +1,3 @@
-module.exports = require('next/error')
+const path = require('path')
+module.exports = require(!process.browser ? 'next/error'
+  : path.resolve(__dirname, '/../lib/error'))


### PR DESCRIPTION
### * This is an unfinished working draft *

- [x] pages/_document
- [x] pages/_error
- [ ] next/link
- [ ] next/router
- [ ] next/dynamic
- [ ] next/document
- [ ] next/error

Without this patch pnpm won't start with the following error:
```js
 ERROR  Failed to compile with 2 errors

These modules were not found:

* ../../../../../../../../.registry.npmjs.org/next/3.0.6/node_modules/next/dist/server/document.js
 in ./node_modules/.registry.npmjs.org/next/3.0.6/node_modules/next/dist/pages/_document.js?entry
* ../../../../../../../../.registry.npmjs.org/next/3.0.6/node_modules/next/dist/lib/error.js
 in ./node_modules/.registry.npmjs.org/next/3.0.6/node_modules/next/dist/pages/_error.js?entry

> Ready on http://localhost:3000
{ Error: Cannot find module '../../../../../../../../.registry.npmjs.org/next/3.0.6/node_modules/next/dist/lib/error.js'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (./.next/dist/pages/_error.js:4:18)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3) code: 'MODULE_NOT_FOUND' }
```
But `import Link from 'next/link'` still not works. 
`require` is needed in order to import `next/` based modules.
```js
import Link from 'next/link' // not work
const Link = require(process.browser ? '../node_modules/next/link' : 'next/link'); // works
```