### PR TITLE
Asset prefix support

### DIFF
--- a/client/on-demand-entries-client.js
+++ b/client/on-demand-entries-client.js
@@ -3,6 +3,12 @@
 import Router from '../lib/router'
 import fetch from 'unfetch'
 
+const {
+  __NEXT_DATA__: {
+    assetPrefix
+  }
+} = window
+
 export default () => {
   Router.ready(() => {
     Router.router.events.on('routeChangeComplete', ping)
@@ -10,7 +16,7 @@ export default () => {
 
   async function ping () {
     try {
-      const url = `/_next/on-demand-entries-ping?page=${Router.pathname}`
+      const url = `${assetPrefix}/_next/on-demand-entries-ping?page=${Router.pathname}`
       const res = await fetch(url, {
         credentials: 'same-origin'
       })

--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -58,7 +58,7 @@ export default () => {
     }
   } = window
 
-  webpackHotMiddlewareClient.setOptions({
+  webpackHotMiddlewareClient.setOptionsAndConnect({
     overlay: false,
     reload: true,
     path: `${assetPrefix}/_next/webpack-hmr`

--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -1,4 +1,4 @@
-import webpackHotMiddlewareClient from 'webpack-hot-middleware/client?overlay=false&reload=true&path=/_next/webpack-hmr'
+import webpackHotMiddlewareClient from 'webpack-hot-middleware/client?autoConnect=false'
 import Router from '../lib/router'
 
 export default () => {
@@ -51,6 +51,12 @@ export default () => {
       }
     }
   }
+ 
+  webpackHotMiddlewareClient.setOptions({
+    overlay: false,
+    reload: true,
+    path: window.__NEXT_DATA__.assetPrefix + '/_next/webpack-hmr'
+  })
 
   webpackHotMiddlewareClient.subscribe((obj) => {
     const fn = handlers[obj.action]

--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -52,10 +52,16 @@ export default () => {
     }
   }
 
+  const {
+    __NEXT_DATA__: {
+      assetPrefix
+    }
+  } = window
+
   webpackHotMiddlewareClient.setOptions({
     overlay: false,
     reload: true,
-    path: window.__NEXT_DATA__.assetPrefix + '/_next/webpack-hmr'
+    path: `${assetPrefix}/_next/webpack-hmr`
   })
 
   webpackHotMiddlewareClient.subscribe((obj) => {

--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -51,7 +51,7 @@ export default () => {
       }
     }
   }
- 
+
   webpackHotMiddlewareClient.setOptions({
     overlay: false,
     reload: true,

--- a/examples/with-app-subroute/next.config.js
+++ b/examples/with-app-subroute/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  assetPrefix: '/blog'
+}

--- a/examples/with-app-subroute/package.json
+++ b/examples/with-app-subroute/package.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "next": "^3.2.2",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
+  },
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  }
+}

--- a/examples/with-app-subroute/pages/index.js
+++ b/examples/with-app-subroute/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <div>Welcome to the blog page</div>

--- a/examples/with-app-subroute/readme.md
+++ b/examples/with-app-subroute/readme.md
@@ -1,0 +1,31 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-app-subroute)
+
+# With app on subroute
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/hello-world
+cd hello-world
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example shows how to run a Next.js application on a subroute, like `/blog` or `/admin`.
+
+To change the path open `next.config.js` and edit `assetPrefix`.

--- a/examples/with-app-subroute/server.js
+++ b/examples/with-app-subroute/server.js
@@ -1,0 +1,27 @@
+const express = require('express')
+const next = require('next')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+const config = require('./next.config')
+
+app.prepare()
+.then(() => {
+  const server = express()
+
+  server.get(config.assetPrefix, (req, res) => {
+    return app.render(req, res, '/', req.query)
+  })
+
+  server.use(config.assetPrefix, (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(port, (err) => {
+    if (err) throw err
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "walk": "^2.3.9",
     "webpack": "3.3.0",
     "webpack-dev-middleware": "1.11.0",
-    "webpack-hot-middleware": "2.18.2",
+    "webpack-hot-middleware": "2.19.0",
     "write-file-webpack-plugin": "4.1.0",
     "xss-filters": "1.2.7"
   },

--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -194,7 +194,7 @@ export default class HotReloader {
     const webpackDevMiddleware = WebpackDevMiddleware(compiler, webpackDevMiddlewareConfig)
 
     const webpackHotMiddleware = WebpackHotMiddleware(compiler, {
-      path: `/_next/webpack-hmr`,
+      path: '/_next/webpack-hmr',
       log: false,
       heartbeat: 2500
     })

--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -179,7 +179,7 @@ export default class HotReloader {
     ]
 
     let webpackDevMiddlewareConfig = {
-      publicPath: `/_next/${this.buildId}/webpack/`,
+      publicPath: `${this.config.assetPrefix}/_next/${this.buildId}/webpack/`,
       noInfo: true,
       quiet: true,
       clientLogLevel: 'warning',
@@ -194,7 +194,7 @@ export default class HotReloader {
     const webpackDevMiddleware = WebpackDevMiddleware(compiler, webpackDevMiddlewareConfig)
 
     const webpackHotMiddleware = WebpackHotMiddleware(compiler, {
-      path: '/_next/webpack-hmr',
+      path: `/_next/webpack-hmr`,
       log: false,
       heartbeat: 2500
     })


### PR DESCRIPTION
This PR extends the support for assetPrefixing - based off the comments on this issue: https://github.com/zeit/next.js/issues/257

This is dependant on a change to the webpack-hot-middleware component. PR here: https://github.com/glenjamin/webpack-hot-middleware/pull/245

Usage:
To use this, we have to set the assetPrefix in our next config.
We also need to set there server to listen on that path and use next as the request handler. For Example, if your assetPrefix is '/metro', then a line like this is needed in your server config.

`
server.use('/metro', app.getRequestHandler()) // where app is next
`