### PR TITLE
✨ Example with alias

### DIFF
--- a/examples/with-alias/.babelrc
+++ b/examples/with-alias/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "alias": {
+          "@": "./"
+        }
+      }
+    ]
+  ]
+}

--- a/examples/with-alias/README.md
+++ b/examples/with-alias/README.md
@@ -1,0 +1,51 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-alias)
+
+# Example app with alias
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-alias
+cd with-alias
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example shows how to configure custom aliases within your next.js project
+using
+[`babel-plugin-module-resolver`](https://github.com/tleunen/babel-plugin-module-resolver).
+
+In the `.babelrc`, we've configured `babel-plugin-module-resolver` to alias `@`
+as the project root `./`, which allows us to import our components within a file
+at any directory level without us having to traverse up for example:
+
+```javascript
+import Heading from '@/components/Heading';
+
+// instead of
+// import Heading from '../../components/Heading';
+```
+
+Another way we can configure `module-resolver` is by setting `"root": ["./"]`,
+this will get rid of the `@` prefix and allow us to import `components` directly.
+
+```javascript
+import Heading from 'components/Heading';
+```
+
+Now we won't need to calculate how many levels of directory we have to go up before accessing the file!

--- a/examples/with-alias/components/Header.js
+++ b/examples/with-alias/components/Header.js
@@ -1,12 +1,12 @@
-import Link from 'next/link';
+import Link from 'next/link'
 
 export default () => (
   <div>
-    <Link href="/">
+    <Link href='/'>
       <a style={{marginRight: 10}}>Home</a>
     </Link>
-    <Link href="/about">
+    <Link href='/about'>
       <a>About</a>
     </Link>
   </div>
-);
+)

--- a/examples/with-alias/components/Header.js
+++ b/examples/with-alias/components/Header.js
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default () => (
+  <div>
+    <Link href="/">
+      <a style={{marginRight: 10}}>Home</a>
+    </Link>
+    <Link href="/about">
+      <a>About</a>
+    </Link>
+  </div>
+);

--- a/examples/with-alias/package.json
+++ b/examples/with-alias/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "with-alias",
+  "version": "1.0.0",
+  "description": "Set alias in next.js",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
+  },
+  "author": "Emmanuel Pilande",
+  "license": "MIT",
+  "devDependencies": {
+    "babel-plugin-module-resolver": "^2.7.1"
+  }
+}

--- a/examples/with-alias/pages/about.js
+++ b/examples/with-alias/pages/about.js
@@ -1,0 +1,8 @@
+import Header from '@/components/Header';
+
+export default () => (
+  <div>
+    <Header />
+    <p>This is the <strong>About</strong> page.</p>
+  </div>
+);

--- a/examples/with-alias/pages/about.js
+++ b/examples/with-alias/pages/about.js
@@ -1,8 +1,8 @@
-import Header from '@/components/Header';
+import Header from '@/components/Header'
 
 export default () => (
   <div>
     <Header />
     <p>This is the <strong>About</strong> page.</p>
   </div>
-);
+)

--- a/examples/with-alias/pages/index.js
+++ b/examples/with-alias/pages/index.js
@@ -1,0 +1,8 @@
+import Header from '@/components/Header';
+
+export default () => (
+  <div>
+    <Header />
+    <p>This is the <strong>Home</strong> page.</p>
+  </div>
+);

--- a/examples/with-alias/pages/index.js
+++ b/examples/with-alias/pages/index.js
@@ -1,8 +1,8 @@
-import Header from '@/components/Header';
+import Header from '@/components/Header'
 
 export default () => (
   <div>
     <Header />
     <p>This is the <strong>Home</strong> page.</p>
   </div>
-);
+)


### PR DESCRIPTION
This example shows how to configure custom aliases within your next.js project using [`babel-plugin-module-resolver`](https://github.com/tleunen/babel-plugin-module-resolver).



Related to https://github.com/zeit/next.js/issues/877, https://github.com/zeit/next.js/issues/946, https://github.com/zeit/next.js/issues/1535.