### PR TITLE
Example: Overwriting meta tag with react-helmet

### DIFF
--- a/examples/with-react-helmet/pages/_document.js
+++ b/examples/with-react-helmet/pages/_document.js
@@ -31,7 +31,8 @@ export default class extends Document {
       htmlAttributes={{lang: 'en'}}
       title='Hello next.js!'
       meta={[
-        { name: 'viewport', content: 'width=device-width, initial-scale=1' }
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        { property: 'og:title', content: 'Hello next.js!' }
       ]}
     />)
   }

--- a/examples/with-react-helmet/pages/about.js
+++ b/examples/with-react-helmet/pages/about.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Helmet from 'react-helmet'
+
+export default class About extends React.Component {
+  static async getInitialProps ({ req }) {
+    if (req) {
+      Helmet.renderStatic()
+    }
+    return { title: 'About' }
+  }
+
+  render () {
+    const { title } = this.props
+    return (
+      <div>
+        <Helmet
+          title={`${title} | Hello next.js!`}
+          meta={[{ property: 'og:title', content: title }]}
+        />
+        About the World
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
Using the react-helmet to override a meta tag `og:title` and be identified by facebook. 
Debug: https://developers.facebook.com/tools/debug