### PR TITLE
production error show the 'html'

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -89,6 +89,11 @@ async function doRender (req, res, pathname, query, {
       errorHtml = render(createElement(ErrorDebug, { error: err }))
     }
 
+    // production show error to 'html'
+    if (err && !dev) {
+      html = ''
+    }
+
     return { html, head, errorHtml, chunks }
   }
 


### PR DESCRIPTION
## Production error html = ''

### if in the production environment , the page will show two error page, so I think set html = '' in the production environment