### PR TITLE
Treat navigation to empty hash as hash navigate

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -244,7 +244,7 @@ export default class Router {
 
   onlyAHashChange (as) {
     if (!this.asPath) return false
-    const [ oldUrlNoHash ] = this.asPath.split('#')
+    const [ oldUrlNoHash, oldHash ] = this.asPath.split('#')
     const [ newUrlNoHash, newHash ] = as.split('#')
 
     // If the urls are change, there's more than a hash change
@@ -252,14 +252,11 @@ export default class Router {
       return false
     }
 
-    // If there's no hash in the new url, we can't consider it as a hash change
-    if (!newHash) {
-      return false
-    }
-
-    // Now there's a hash in the new URL.
-    // We don't need to worry about the old hash.
-    return true
+    // If the hash has changed, then it's a hash only change.
+    // This check is necessary to handle both the enter and
+    // leave hash === '' cases. The identity case falls through
+    // and is treated as a next reload.
+    return oldHash !== newHash
   }
 
   scrollToHash (as) {

--- a/test/integration/basic/pages/nav/hash-changes.js
+++ b/test/integration/basic/pages/nav/hash-changes.js
@@ -21,6 +21,9 @@ export default class SelfReload extends Component {
         <Link href='/nav/hash-changes'>
           <a id='page-url'>Page URL</a>
         </Link>
+        <Link href='#'>
+          <a id='via-empty-hash'>Via Empty Hash</a>
+        </Link>
         <p>COUNT: {this.props.count}</p>
       </div>
     )

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -188,6 +188,21 @@ export default (context, render) => {
         })
       })
 
+      describe('when hash set to empty', () => {
+        it('should not run getInitialProps', async () => {
+          const browser = await webdriver(context.appPort, '/nav/hash-changes')
+
+          const counter = await browser
+            .elementByCss('#via-a').click()
+            .elementByCss('#via-empty-hash').click()
+            .elementByCss('p').text()
+
+          expect(counter).toBe('COUNT: 0')
+
+          browser.close()
+        })
+      })
+
       describe('when hash changed to a different hash', () => {
         it('should not run getInitialProps', async () => {
           const browser = await webdriver(context.appPort, '/nav/hash-changes')


### PR DESCRIPTION
`#` -> `#foo` and `#foo` -> `#` now operate in the same way.