### PR TITLE
Configurable opts for babel-preset-env + babel-plugin-transform-runtime

### DIFF
--- a/examples/with-configured-preset-env/.babelrc
+++ b/examples/with-configured-preset-env/.babelrc
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "production": {
+      "presets": [
+        "next/babel"
+      ]
+    },
+    "development": {
+      "presets": [
+        ["next/babel", {
+          "preset-env": {
+	    "targets": {
+	      "browsers": "last 1 Chrome version",
+	      "node": true
+	    }
+          },
+	  "transform-runtime": {
+	    "regenerator": false,
+	    "useBuiltIns": true,
+	    "polyfill": false
+	  }
+        }]
+      ]
+    }
+  }
+}

--- a/examples/with-configured-preset-env/package.json
+++ b/examples/with-configured-preset-env/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
+  }
+}

--- a/examples/with-configured-preset-env/pages/index.js
+++ b/examples/with-configured-preset-env/pages/index.js
@@ -1,0 +1,21 @@
+import {Component} from 'react'
+
+function * generatorMethod () {
+  yield 1
+}
+
+async function fooBar () {
+  for (let val of generatorMethod()) {
+    return val
+  }
+}
+
+export default class Index extends Component {
+  async otherMethod () {
+    await fooBar()
+  }
+  render () {
+    const foo = new Map([['cats', 'dogs']])
+    return <h1>Garbage {foo.get('cats')}</h1>
+  }
+}

--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -13,9 +13,10 @@ const plugins = envPlugins[process.env.NODE_ENV] || envPlugins['development']
 
 module.exports = (context, opts = {}) => ({
   presets: [
-    [require.resolve('babel-preset-env'), Object.assign({}, opts['preset-env'], {
-      modules: false
-    })],
+    [require.resolve('babel-preset-env'), {
+      modules: false,
+      ...opts['preset-env']
+    }],
     require.resolve('babel-preset-react')
   ],
   plugins: [

--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -11,11 +11,11 @@ const envPlugins = {
 
 const plugins = envPlugins[process.env.NODE_ENV] || envPlugins['development']
 
-module.exports = {
+module.exports = (context, opts = {}) => ({
   presets: [
-    [require.resolve('babel-preset-env'), {
+    [require.resolve('babel-preset-env'), Object.assign({}, opts['preset-env'], {
       modules: false
-    }],
+    })],
     require.resolve('babel-preset-react')
   ],
   plugins: [
@@ -23,7 +23,8 @@ module.exports = {
     require.resolve('./plugins/handle-import'),
     require.resolve('babel-plugin-transform-object-rest-spread'),
     require.resolve('babel-plugin-transform-class-properties'),
-    require.resolve('babel-plugin-transform-runtime'),
+    [require.resolve('babel-plugin-transform-runtime'),
+      opts['transform-runtime'] || {}],
     require.resolve('styled-jsx/babel'),
     ...plugins,
     [
@@ -43,4 +44,4 @@ module.exports = {
       }
     ]
   ]
-}
+})


### PR DESCRIPTION
This adds `preset-env` and `transform-runtime` options to the
`next/babel` Babel preset, which are then passed through to those
presets and transforms. This allows configuration to keep next.js
from the default 'maximum' transform, and instead use built-in
implementations of globals, classes, async, and other commonly-supported
features.

Fixes #2989