### PR TITLE
expose buildId to custom webpack configs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -934,7 +934,7 @@ In order to extend our usage of `webpack`, you can define a function that extend
 // (But you could use ES2015 features supported by your Node.js version)
 
 module.exports = {
-  webpack: (config, { dev }) => {
+  webpack: (config, { buildId, dev }) => {
     // Perform customizations to webpack config
 
     // Important: return the modified config

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -335,7 +335,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
 
   if (config.webpack) {
     console.log(`> Using "webpack" config function defined in ${config.configOrigin}.`)
-    webpackConfig = await config.webpack(webpackConfig, { dev })
+    webpackConfig = await config.webpack(webpackConfig, { buildId, dev })
   }
   return webpack(webpackConfig)
 }


### PR DESCRIPTION
It's useful to have the buildId in the custom webpack configuration.

Our specific use case is that we're using https://github.com/jmshal/webpack-bugsnag-plugin to automatically upload our sourcemap to bugsnag on build. To do that, we need to provide an "appVersion" (buildId basically), and that "appVersion" needs to be the same value that we provide to the bugsnag library when we initialize it on app start (we do this in _document.js). We are already using buildId in to initialize bugsnag on app start, so this would tie the two together and allow us to connect source maps with specific production builds.

I'm sure there are other use cases as well!