### PR TITLE
Added <Link scroll> PropType

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -21,6 +21,7 @@ export default class Link extends Component {
     replace: PropTypes.bool,
     shallow: PropTypes.bool,
     passHref: PropTypes.bool,
+    scroll: PropTypes.bool,
     children: PropTypes.oneOfType([
       PropTypes.element,
       (props, propName) => {


### PR DESCRIPTION
This should avoid the angry console warnings when trying to override the default scroll behavior using `<Link scroll={false}>`