### PR TITLE
Apply .babelrc's own config when it specifies `babelrc: false`

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -174,6 +174,9 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     // That's why we need to do this.
     const { options } = externalBabelConfig
     mainBabelOptions.babelrc = options.babelrc !== false
+    if (!mainBabelOptions.babelrc) {
+      Object.assign(mainBabelOptions, externalBabelConfig.options)
+    }
   } else {
     mainBabelOptions.babelrc = false
   }


### PR DESCRIPTION
This is one step towards supporting monorepos with Next.

When a .babelrc file specifies `babelrc: false`, Next currently ignores the .babelrc file entirely rather than applying its own rules. This PR changes Next's behavior so that the .babelrc file's own configuration is applied.

This is useful for when you want Next to load code that's outside of the project root:
```
.
├── next
│   ├── .babelrc
│   └── pages
└── shared
    └── module.js
```

In this setup, we want the code in `shared/module.js` to get the `next/babel` preset when that shared code is loaded via Next, but not when it's loaded in other (non-Next) projects.

In Next's .babelrc you could write:
```js
{
  "babelrc": false, // Just use this .babelrc for all source files
  // Specify custom plugins to apply to all files
  "plugins": [
    "transform-decorators-legacy"
  ]
}
```

Before this PR, Next would ignore the `"plugins"` and all other parts of the Babel config because it specifies `babelrc: false`. With this PR, Next will honor the Babel config in this .babelrc file. If you don't want any plugins aside from the default `next/babel` preset, then write just `{ "babelrc": false }` in the .babelrc.

Test Plan: Since the examples directory contains a .babelrc file with `babelrc: false`, run examples that use this .babelrc (ex: `with-apollo`). Add some more configuration rules to `examples/.babelrc` and ensure they get applied too.