### PR TITLE
Add `externalSourceDirs` option to share code with other projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -931,6 +931,17 @@ module.exports = {
 }
 ```
 
+#### Adding additional source directories
+
+You can specify additional directories from which your pages can import JS code. This is useful for repositories that contain a Next.js site and other projects that share code. Relative paths are resolved relative to the Next.js project directory.
+
+```js
+// next.config.js
+module.exports = {
+  externalSourceDirs: ['../shared']
+}
+```
+
 ### Customizing webpack config
 
 <p><details>

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -156,6 +156,8 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
   }
 
+  const externalSourceDirList = config.externalSourceDirs.map(externalDir => resolve(dir, externalDir))
+
   const nodePathList = (process.env.NODE_PATH || '')
     .split(process.platform === 'win32' ? ';' : ':')
     .filter((p) => !!p)
@@ -201,7 +203,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
   }, {
     test: /\.(js|json)(\?[^?]*)?$/,
     loader: 'emit-file-loader',
-    include: [dir, nextPagesDir],
+    include: [dir, nextPagesDir, ...externalSourceDirList],
     exclude (str) {
       return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
     },
@@ -283,7 +285,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
   }, {
     test: /\.js(\?[^?]*)?$/,
     loader: 'babel-loader',
-    include: [dir],
+    include: [dir, ...externalSourceDirList],
     exclude (str) {
       return /node_modules/.test(str)
     },

--- a/server/config.js
+++ b/server/config.js
@@ -7,6 +7,7 @@ const defaultConfig = {
   webpack: null,
   webpackDevMiddleware: null,
   poweredByHeader: true,
+  externalSourceDirs: [],
   distDir: '.next',
   assetPrefix: '',
   configOrigin: 'default',


### PR DESCRIPTION
This is one step towards supporting monorepos with Next.

Adds a new configuration option called `externalSourceDirs`, which is an array of additional directories that may contain JS code. In this example directory layout, we have a Next project that uses code shared with other projects:

```
.
├── next
│   └── pages
└── shared
    └── module.js
```

To support this, Next needs to tell Webpack about the shared directory:

```js
// next.config.js
module.exports = {
  externalSourceDirs: ['../shared']
}
```
(paths are relative to the Next project root)

One important note is that this commit is not enough for Next to use shared code on the server -- the Webpack bundles work but the server-side code requires a change to the emit-file-loader in another commit.

Test Plan: To ensure nothing has broken, launch one of the example projects and run Next's own tests. Full support for this config option requires a change to emit-file-loader, after which it will be straightforward to add an example project to teach and test this change.