### PR TITLE
Update with-apollo for Apollo 2.0

### DIFF
--- a/examples/.prettierrc
+++ b/examples/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "singleQuote": true,
+  "semi": false
+}

--- a/examples/.prettierrc
+++ b/examples/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "tabWidth": 2,
-  "trailingComma": "none",
-  "printWidth": 100,
-  "singleQuote": true,
-  "semi": false
-}

--- a/examples/with-apollo/components/PostList.js
+++ b/examples/with-apollo/components/PostList.js
@@ -1,4 +1,5 @@
-import { gql, graphql } from 'react-apollo'
+import { graphql } from 'react-apollo'
+import gql from 'graphql-tag'
 import ErrorMessage from './ErrorMessage'
 import PostUpvoter from './PostUpvoter'
 

--- a/examples/with-apollo/components/PostUpvoter.js
+++ b/examples/with-apollo/components/PostUpvoter.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { gql, graphql } from 'react-apollo'
+import { graphql } from 'react-apollo'
+import gql from 'graphql-tag'
 
 function PostUpvoter ({ upvote, votes, id }) {
   return (

--- a/examples/with-apollo/components/Submit.js
+++ b/examples/with-apollo/components/Submit.js
@@ -1,7 +1,8 @@
-import { gql, graphql } from 'react-apollo'
+import { graphql } from 'react-apollo'
+import gql from 'graphql-tag'
 
-function Submit ({ createPost }) {
-  function handleSubmit (e) {
+function Submit({ createPost }) {
+  function handleSubmit(e) {
     e.preventDefault()
 
     let title = e.target.elements.title.value
@@ -27,9 +28,9 @@ function Submit ({ createPost }) {
   return (
     <form onSubmit={handleSubmit}>
       <h1>Submit</h1>
-      <input placeholder='title' name='title' />
-      <input placeholder='url' name='url' />
-      <button type='submit'>Submit</button>
+      <input placeholder="title" name="title" />
+      <input placeholder="url" name="url" />
+      <button type="submit">Submit</button>
       <style jsx>{`
         form {
           border-bottom: 1px solid #ececec;
@@ -62,17 +63,18 @@ const createPost = gql`
 
 export default graphql(createPost, {
   props: ({ mutate }) => ({
-    createPost: (title, url) => mutate({
-      variables: { title, url },
-      updateQueries: {
-        allPosts: (previousResult, { mutationResult }) => {
-          const newPost = mutationResult.data.createPost
-          return Object.assign({}, previousResult, {
-            // Append the new post
-            allPosts: [newPost, ...previousResult.allPosts]
-          })
+    createPost: (title, url) =>
+      mutate({
+        variables: { title, url },
+        updateQueries: {
+          allPosts: (previousResult, { mutationResult }) => {
+            const newPost = mutationResult.data.createPost
+            return Object.assign({}, previousResult, {
+              // Append the new post
+              allPosts: [newPost, ...previousResult.allPosts]
+            })
+          }
         }
-      }
-    })
+      })
   })
 })(Submit)

--- a/examples/with-apollo/lib/initApollo.js
+++ b/examples/with-apollo/lib/initApollo.js
@@ -1,27 +1,29 @@
-import { ApolloClient, createNetworkInterface } from 'react-apollo'
+import ApolloClient from 'apollo-client'
+import Link from 'apollo-link-http'
+import Cache from 'apollo-cache-inmemory'
 import fetch from 'isomorphic-fetch'
 
 let apolloClient = null
+let apolloCache = null
 
 // Polyfill fetch() on the server (used by apollo-client)
 if (!process.browser) {
   global.fetch = fetch
 }
 
-function create (initialState) {
+const create = initialState => {
+  apolloCache = new Cache()
+
   return new ApolloClient({
-    initialState,
-    ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
-    networkInterface: createNetworkInterface({
-      uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
-      opts: { // Additional fetch() options like `credentials` or `headers`
-        credentials: 'same-origin'
-      }
-    })
+    link: new Link({
+      uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'
+    }),
+    cache: apolloCache.restore(initialState || {}),
+    ssrMode: !process.browser // Disables forceFetch on the server (so queries are only run once)
   })
 }
 
-export default function initApollo (initialState) {
+const initApollo = initialState => {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (!process.browser) {
@@ -35,3 +37,9 @@ export default function initApollo (initialState) {
 
   return apolloClient
 }
+
+const getCache = () => {
+  return apolloCache
+}
+
+export { initApollo, getCache }

--- a/examples/with-apollo/lib/initApollo.js
+++ b/examples/with-apollo/lib/initApollo.js
@@ -4,7 +4,6 @@ import Cache from 'apollo-cache-inmemory'
 import fetch from 'isomorphic-fetch'
 
 let apolloClient = null
-let apolloCache = null
 
 // Polyfill fetch() on the server (used by apollo-client)
 if (!process.browser) {

--- a/examples/with-apollo/lib/initApollo.js
+++ b/examples/with-apollo/lib/initApollo.js
@@ -1,6 +1,6 @@
 import ApolloClient from 'apollo-client'
-import Link from 'apollo-link-http'
-import Cache from 'apollo-cache-inmemory'
+import { HttpLink } from 'apollo-link-http'
+import { InMemoryCache } from 'apollo-cache-inmemory'
 import fetch from 'isomorphic-fetch'
 
 let apolloClient = null
@@ -12,10 +12,10 @@ if (!process.browser) {
 
 function create(initialState) {
   return new ApolloClient({
-    link: new Link({
+    link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'
     }),
-    cache: new Cache().restore(initialState || {}),
+    cache: new InMemoryCache().restore(initialState || {}),
     ssrMode: !process.browser // Disables forceFetch on the server (so queries are only run once)
   })
 }

--- a/examples/with-apollo/lib/initApollo.js
+++ b/examples/with-apollo/lib/initApollo.js
@@ -11,19 +11,17 @@ if (!process.browser) {
   global.fetch = fetch
 }
 
-const create = initialState => {
-  apolloCache = new Cache()
-
+function create(initialState) {
   return new ApolloClient({
     link: new Link({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'
     }),
-    cache: apolloCache.restore(initialState || {}),
+    cache: new Cache().restore(initialState || {}),
     ssrMode: !process.browser // Disables forceFetch on the server (so queries are only run once)
   })
 }
 
-const initApollo = initialState => {
+export default function initApollo(initialState) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (!process.browser) {
@@ -37,9 +35,3 @@ const initApollo = initialState => {
 
   return apolloClient
 }
-
-const getCache = () => {
-  return apolloCache
-}
-
-export { initApollo, getCache }

--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ApolloProvider, getDataFromTree } from 'react-apollo'
 import Head from 'next/head'
-import { initApollo, getCache } from './initApollo'
+import initApollo from './initApollo'
 
 // Gets the display name of a JSX component for dev tools
 const getComponentDisplayName = Component => {
@@ -29,7 +29,6 @@ export default ComposedComponent => {
       // and extract the resulting data
       if (!process.browser) {
         const apollo = initApollo()
-        const apolloCache = getCache()
 
         // Provide the `url` prop data in case a GraphQL query uses it
         const url = { query: ctx.query, pathname: ctx.pathname }
@@ -50,7 +49,7 @@ export default ComposedComponent => {
         Head.rewind()
 
         // Extract query data from the Apollo store
-        const state = apolloCache.extract()
+        const state = apollo.queryManager.dataStore.getCache().extract()
 
         serverState = {
           apollo: {

--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -2,10 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ApolloProvider, getDataFromTree } from 'react-apollo'
 import Head from 'next/head'
-import initApollo from './initApollo'
+import { initApollo, getCache } from './initApollo'
 
 // Gets the display name of a JSX component for dev tools
-function getComponentDisplayName (Component) {
+const getComponentDisplayName = Component => {
   return Component.displayName || Component.name || 'Unknown'
 }
 
@@ -16,7 +16,7 @@ export default ComposedComponent => {
       serverState: PropTypes.object.isRequired
     }
 
-    static async getInitialProps (ctx) {
+    static async getInitialProps(ctx) {
       let serverState = {}
 
       // Evaluate the composed component's getInitialProps()
@@ -29,8 +29,10 @@ export default ComposedComponent => {
       // and extract the resulting data
       if (!process.browser) {
         const apollo = initApollo()
+        const apolloCache = getCache()
+
         // Provide the `url` prop data in case a GraphQL query uses it
-        const url = {query: ctx.query, pathname: ctx.pathname}
+        const url = { query: ctx.query, pathname: ctx.pathname }
         try {
           // Run all GraphQL queries
           await getDataFromTree(
@@ -48,7 +50,7 @@ export default ComposedComponent => {
         Head.rewind()
 
         // Extract query data from the Apollo store
-        const state = apollo.getInitialState()
+        const state = apolloCache.extract()
 
         serverState = {
           apollo: {
@@ -64,12 +66,12 @@ export default ComposedComponent => {
       }
     }
 
-    constructor (props) {
+    constructor(props) {
       super(props)
       this.apollo = initApollo(this.props.serverState)
     }
 
-    render () {
+    render() {
       return (
         <ApolloProvider client={this.apollo}>
           <ComposedComponent {...this.props} />

--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -49,7 +49,7 @@ export default ComposedComponent => {
         Head.rewind()
 
         // Extract query data from the Apollo store
-        const state = apollo.queryManager.dataStore.getCache().extract()
+        const state = apollo.cache.extract()
 
         serverState = {
           apollo: {

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -11,6 +11,7 @@
     "apollo-client": "2.0.1",
     "apollo-link-http": "1.0.0",
     "graphql": "0.11.7",
+    "graphql-tag": "2.5.0",
     "isomorphic-fetch": "2.2.1",
     "next": "4.1.3",
     "prop-types": "15.6.0",

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -7,15 +7,15 @@
     "start": "next start"
   },
   "dependencies": {
-    "apollo-cache-inmemory": "^0.2.0-beta.3",
-    "apollo-client": "^2.0.0-beta.3",
-    "apollo-link-http": "^0.6.1-beta.6",
-    "graphql": "0.11.6",
+    "apollo-cache-inmemory": "1.0.0",
+    "apollo-client": "2.0.1",
+    "apollo-link-http": "1.0.0",
+    "graphql": "0.11.7",
     "isomorphic-fetch": "2.2.1",
-    "next": "4.0.0-beta.2",
+    "next": "4.1.3",
     "prop-types": "15.6.0",
     "react": "16.0.0",
-    "react-apollo": "1.4.16",
+    "react-apollo": "2.0.0",
     "react-dom": "16.0.0"
   },
   "author": "",

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -1,19 +1,22 @@
 {
   "name": "with-apollo",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
   "dependencies": {
-    "graphql": "^0.9.3",
-    "isomorphic-fetch": "^2.2.1",
-    "next": "latest",
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "react-apollo": "^1.1.3"
+    "apollo-cache-inmemory": "^0.2.0-beta.3",
+    "apollo-client": "^2.0.0-beta.3",
+    "apollo-link-http": "^0.6.1-beta.6",
+    "graphql": "0.11.6",
+    "isomorphic-fetch": "2.2.1",
+    "next": "4.0.0-beta.2",
+    "prop-types": "15.6.0",
+    "react": "16.0.0",
+    "react-apollo": "1.4.16",
+    "react-dom": "16.0.0"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
I was playing around with `next@beta` and `apollo-client@beta` and thought I would update the example while at it.

The guide here https://github.com/apollographql/apollo-client/blob/master/Upgrade.md gives instructions on how to update. Exposing the apolloCache feels odd, but that comes with splitting the `initApollo` into it's own file. I left it like this for consistency with the previous version.

Since it's using @beta deps it would be ideal to wait until these are all @latest before merging for consistency with the other examples and so not to confuse people.