### PR TITLE
Warn and exit if React 15 used inside the project.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,19 @@ import { getAvailableChunks } from './utils'
 import getConfig from './config'
 // We need to go up one more level since we are in the `dist` directory
 import pkg from '../../package'
+import reactPkg from 'react/package'
+
+// TODO: Remove this in Next.js 5
+if (!(/^16\./.test(reactPkg.version))) {
+  const message = `
+Error: Next.js 4 requires React 16.
+Install React 16 with:
+  npm remove react react-dom
+  npm install --save react@16 react-dom@16
+`
+  console.error(message)
+  process.exit(1)
+}
 
 const internalPrefixes = [
   /^\/_next\//,


### PR DESCRIPTION
This usually helps when upgrading Next.js.
So, users know what to do.

<img width="630" alt="screen shot 2017-10-10 at 1 53 33 am" src="https://user-images.githubusercontent.com/50838/31357027-dfd491a2-ad5d-11e7-94b1-29ec77e90adc.png">
