### PR TITLE
Upgrade react-hot-loader (add React 16 Support) (Fixes React 16 dev compile errors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "pkg-up": "2.0.0",
     "prop-types": "15.6.0",
     "prop-types-exact": "1.1.1",
-    "react-hot-loader": "3.0.0-beta.7",
+    "react-hot-loader": "^3.0.0",
     "recursive-copy": "2.0.6",
     "send": "0.15.6",
     "source-map-support": "0.4.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5414,9 +5414,9 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-deep-force-update@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"
+react-deep-force-update@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
 react-dom@16.0.0:
   version "16.0.0"
@@ -5427,16 +5427,16 @@ react-dom@16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-hot-loader@3.0.0-beta.7:
-  version "3.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0-beta.7.tgz#d5847b8165d731c4d5b30d86d5d4716227a0fa83"
+react-hot-loader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0.tgz#6e28da9d459da8085f5ee8bdd775046ba4b5cd0b"
   dependencies:
     babel-template "^6.7.0"
     global "^4.3.0"
-    react-deep-force-update "^2.0.1"
+    react-deep-force-update "^2.1.1"
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
-    source-map "^0.4.4"
+    source-map "^0.6.1"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
@@ -5545,8 +5545,8 @@ recursive-copy@2.0.6:
     slash "^1.0.0"
 
 redbox-react@^1.3.6:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/redbox-react/-/redbox-react-1.4.2.tgz#7fe35d3c567301e97938cc7fd6a10918f424c6b4"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/redbox-react/-/redbox-react-1.5.0.tgz#04dab11557d26651bf3562a67c22ace56c5d3967"
   dependencies:
     error-stack-parser "^1.3.6"
     object-assign "^4.0.1"
@@ -6038,6 +6038,10 @@ source-map@^0.4.4:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 source-map@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Next.js's `yarn.lock` file has the `redbox-react` [dependency locked at 1.4.2](https://github.com/zeit/next.js/blob/master/yarn.lock#L5548), effectively forcing `yarn` users to use a `redbox-react` version that is incompatible with React 16. 

(it makes reference to [`react-dom/lib/*`](https://reactjs.org/blog/2017/09/26/react-v16.0.html#packaging) files, causing a compile error):

```
 ERROR  Failed to compile with 19 errors                                                                                               15:24:10

These dependencies were not found:

* react/lib/React in ./node_modules/next/node_modules/redbox-react/node_modules/react-dom/lib/ReactDOMOption.js, ./node_modules/next/node_modules/redbox-react/node_modules/react-dom/lib/ReactMount.js and 3 others
* react/lib/ReactComponentTreeHook in ./node_modules/next/node_modules/redbox-react/node_modules/react-dom/lib/ReactDOMUnknownPropertyHook.js, ./node_modules/next/node_modules/redbox-react/node_modules/react-dom/lib/ReactDOMInvalidARIAHook.js and 5 others
* react/lib/ReactCurrentOwner in ./node_modules/next/node_modules/redbox-react/node_modules/react-dom/lib/traverseAllChildren.js, ./node_modules/next/node_modules/redbox-react/node_modules/react-dom/lib/ReactUpdateQueue.js and 4 others
* react/lib/getNextDebugID in ./node_modules/next/node_modules/redbox-react/node_modules/react-dom/lib/instantiateReactComponent.js

To install them, you can run: npm install --save react/lib/React react/lib/ReactComponentTreeHook react/lib/ReactCurrentOwner react/lib/getNextDebugID
```
Previous version of `react-hot-loader` (`3.0.0-beta.7`) [always _imported_](https://github.com/gaearon/react-hot-loader/blob/v3.0.0-beta.7/src/AppContainer.dev.js#L5) `redbox-react` in development ([even though Next.js overrides the `errorReporter`](https://github.com/zeit/next.js/blob/master/lib/app.js#L87)). 

Now, however, [`redbox-react` is no longer automatically imported 🎉](https://github.com/gaearon/react-hot-loader/commit/31fba045e980c34a12a9c8c4558008126f71f309) within `react-hot-loader`.

Version `3.0.0` (released today), in addition to fixing the above error through not requiring `redbox-react`, adds various other React 16 compatibility updates (see https://github.com/gaearon/react-hot-loader/commits/v3.0.0).

I've also upgraded the `yarn.lock` entry for `redbox-react` just to be safe, as `react-hot-loader` still currently has it listed as a dependency.

