### PR TITLE
Update TypeScript example to be compatible with React 16

### DIFF
--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -6,11 +6,11 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
-    "@types/react": "^15.0.1",
+    "@types/react": "^16.0.9",
     "concurrently": "^3.1.0",
     "typescript": "^2.1.5"
   }


### PR DESCRIPTION
### Before

```
npm run dev

> with-typescript@1.0.0 dev /Users/banyan/tmp/next.js/examples/with-typescript
> concurrently "tsc --watch" next

[1]
[1] Error: Next.js 4 requires React 16.
[1] Install React 16 with:
[1]   npm remove react react-dom
[1]   npm install --save react@16 react-dom@16
```

### After

```
npm run dev

> with-typescript@1.0.0 dev /Users/banyan/tmp/next.js/examples/with-typescript
> concurrently "tsc --watch" next

[1] > Using external babel configuration
[1] > Location: "/Users/banyan/tmp/next.js/examples/.babelrc"
[0] 16:23:47 - Compilation complete. Watching for file changes.
[0]
[0]
[1]  DONE  Compiled successfully in 2151ms16:23:49
```