### PR TITLE
Uplift with-global-stylesheet example

### DIFF
--- a/examples/with-global-stylesheet/package.json
+++ b/examples/with-global-stylesheet/package.json
@@ -19,8 +19,8 @@
     "postcss-easy-import": "2.0.0",
     "postcss-loader": "1.3.3",
     "raw-loader": "^0.5.1",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "sass-loader": "^4.1.1"
   },
   "devDependencies": {

--- a/examples/with-global-stylesheet/package.json
+++ b/examples/with-global-stylesheet/package.json
@@ -9,21 +9,21 @@
   "author": "Davide Bertola <dade@dadeb.it>",
   "license": "ISC",
   "dependencies": {
-    "autoprefixer": "6.7.6",
-    "babel-plugin-module-resolver": "2.5.0",
+    "autoprefixer": "7.1.5",
+    "babel-plugin-module-resolver": "^2.7.1",
     "babel-plugin-wrap-in-js": "^1.1.0",
-    "glob": "7.1.1",
+    "glob": "^7.1.2",
     "next": "latest",
     "node-sass": "^4.4.0",
-    "normalize.css": "5.0.0",
-    "postcss-easy-import": "2.0.0",
-    "postcss-loader": "1.3.3",
+    "normalize.css": "^7.0.0",
+    "postcss-easy-import": "^3.0.0",
+    "postcss-loader": "^2.0.7",
     "raw-loader": "^0.5.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "sass-loader": "^4.1.1"
+    "sass-loader": "^6.0.6"
   },
   "devDependencies": {
-    "now": "^3.1.0"
+    "now": "^8.3.10"
   }
 }


### PR DESCRIPTION
This example would no longer build with Next 4. Upgrading dependency on React fixed this. While I was at it, I bumped all other dependencies, now all is working like a charm again.