### PR TITLE
Firebase server side auth example update: don't fetch messages server-side if user is not found

### DIFF
--- a/examples/with-firebase-authentication/pages/index.js
+++ b/examples/with-firebase-authentication/pages/index.js
@@ -6,8 +6,10 @@ import clientCredentials from '../credentials/client'
 export default class Index extends Component {
   static async getInitialProps ({req, query}) {
     const user = req && req.session ? req.session.decodedToken : null
-    const snap = await req.firebaseServer.database().ref('messages').once('value')
-    return { user, messages: snap.val() }
+    // don't fetch anything from firebase if the user is not found
+    const snap = user && await req.firebaseServer.database().ref('messages').once('value')
+    const messages = snap && snap.val();
+    return { user, messages }
   }
 
   constructor (props) {

--- a/examples/with-firebase-authentication/pages/index.js
+++ b/examples/with-firebase-authentication/pages/index.js
@@ -8,7 +8,7 @@ export default class Index extends Component {
     const user = req && req.session ? req.session.decodedToken : null
     // don't fetch anything from firebase if the user is not found
     const snap = user && await req.firebaseServer.database().ref('messages').once('value')
-    const messages = snap && snap.val();
+    const messages = snap && snap.val()
     return { user, messages }
   }
 


### PR DESCRIPTION
Currently, the component always fetch everything under '/messages' even if the user is not authenticated on the server side. Update it to not fetch if the user is not found as a better example on handling.