### PR TITLE
Fix 'Deploy to now' link for with-styled-jsx-plugins example

### DIFF
--- a/examples/with-styled-jsx-plugins/README.md
+++ b/examples/with-styled-jsx-plugins/README.md
@@ -1,4 +1,4 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/basic-css)
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-styled-jsx-plugins)
 
 # With styled-jsx plugins
 


### PR DESCRIPTION
The link pointed to the wrong example directory.