### PR TITLE
Use nonce attribute for inline script if provided

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -117,6 +117,10 @@ export class Main extends Component {
 }
 
 export class NextScript extends Component {
+  static propTypes = {
+    nonce: PropTypes.string
+  }
+
   static contextTypes = {
     _documentProps: PropTypes.any
   }
@@ -176,7 +180,7 @@ export class NextScript extends Component {
     __NEXT_DATA__.chunks = chunks
 
     return <div>
-      {staticMarkup ? null : <script dangerouslySetInnerHTML={{
+      {staticMarkup ? null : <script nonce={this.props.nonce} dangerouslySetInnerHTML={{
         __html: `
           __NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)}
           module={}


### PR DESCRIPTION
In locked-down CSP environments, the use of inline scripts is considered a CSP violation. In order to use inline scripts without triggering a CSP violation, you can provide a nonce attribute on the `script` tag. This PR allows users to pass in a nonce value as a prop on `NextScript`, which will allow the script to execute without the use of the `unsafe-inline` CSP directive.