### PR TITLE
[update example - with-apollo-and-redux] pin dependencies

### DIFF
--- a/examples/with-apollo-and-redux/package.json
+++ b/examples/with-apollo-and-redux/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "graphql": "^0.9.3",
     "isomorphic-fetch": "^2.2.1",
-    "next": "latest",
+    "next": "^4",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
+    "react": "^16",
     "react-apollo": "^1.1.3",
-    "react-dom": "^15.5.4",
+    "react-dom": "^16",
     "redux": "^3.6.0"
   },
   "author": "",

--- a/examples/with-apollo-and-redux/package.json
+++ b/examples/with-apollo-and-redux/package.json
@@ -9,11 +9,11 @@
   "dependencies": {
     "graphql": "^0.9.3",
     "isomorphic-fetch": "^2.2.1",
-    "next": "^4",
+    "next": "latest",
     "prop-types": "^15.5.8",
-    "react": "^16",
+    "react": "^16.0.0",
     "react-apollo": "^1.1.3",
-    "react-dom": "^16",
+    "react-dom": "^16.0.0",
     "redux": "^3.6.0"
   },
   "author": "",


### PR DESCRIPTION
the combination `next@latest` and `react@15` is not working anymore as the latest next version requires react 16. so we need to pin the dependencies to specific versions