### PR TITLE
Render error as errorHtml

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -78,16 +78,19 @@ async function doRender (req, res, pathname, query, {
     let html
     let head
     let errorHtml = ''
+
     try {
-      html = render(app)
+      if (err && dev) {
+        errorHtml = render(createElement(ErrorDebug, { error: err }))
+      } else if (err) {
+        errorHtml = render(app)
+      } else {
+        html = render(app)
+      }
     } finally {
       head = Head.rewind() || defaultHead()
     }
     const chunks = loadChunks({ dev, dir, dist, availableChunks })
-
-    if (err && dev) {
-      errorHtml = render(createElement(ErrorDebug, { error: err }))
-    }
 
     return { html, head, errorHtml, chunks }
   }


### PR DESCRIPTION
Render errors in production as `errorHtml` instead of `html` to be consistent with the client.
Fixes #2573, #2964 

This also fixes the issue where styles become messed up after hot reloading.