### PR TITLE
Update React on with-socket.io example

### DIFF
--- a/examples/with-socket.io/package.json
+++ b/examples/with-socket.io/package.json
@@ -5,8 +5,8 @@
     "express": "^4.15.2",
     "isomorphic-fetch": "^2.2.1",
     "next": "latest",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "socket.io": "^1.7.3",
     "socket.io-client": "^1.7.3"
   },


### PR DESCRIPTION
Next.js v4 requires React v16.
The example works perfectly with version 16 of React.