### PR TITLE
Fix with-amp example

### DIFF
--- a/examples/with-amp/pages/_document.js
+++ b/examples/with-amp/pages/_document.js
@@ -1,16 +1,4 @@
 import Document, { Head } from 'next/document'
-import { DOMProperty } from 'react-dom/lib/ReactInjection'
-import { properties as DOMProperties } from 'react-dom/lib/DOMProperty'
-
-// By default React limit the set of valid DOM elements and attributes
-// (https://github.com/facebook/react/issues/140) this config whitelist
-// Amp elements/attributes
-if (typeof DOMProperties.amp === 'undefined') {
-  DOMProperty.injectDOMPropertyConfig({
-    Properties: { amp: DOMProperty.MUST_USE_ATTRIBUTE },
-    isCustomAttribute: attributeName => attributeName.startsWith('amp-')
-  })
-}
 
 export default class MyDocument extends Document {
   render () {


### PR DESCRIPTION
React v16 supports invalid DOM attributes now. 
ReactInjection and DOMProperty throws an error.
Reference: #3152