### PR TITLE
Combine source maps

### DIFF
--- a/server/build/plugins/combine-assets-plugin.js
+++ b/server/build/plugins/combine-assets-plugin.js
@@ -1,3 +1,5 @@
+import { ConcatSource } from 'webpack-sources'
+
 // This plugin combines a set of assets into a single asset
 // This should be only used with text assets,
 // otherwise the result is unpredictable.
@@ -8,23 +10,23 @@ export default class CombineAssetsPlugin {
   }
 
   apply (compiler) {
-    compiler.plugin('after-compile', (compilation, callback) => {
-      let newSource = ''
-      this.input.forEach((name) => {
-        const asset = compilation.assets[name]
-        if (!asset) return
+    compiler.plugin('compilation', (compilation) => {
+      compilation.plugin('optimize-chunk-assets', (chunks, callback) => {
+        const concat = new ConcatSource()
 
-        newSource += `${asset.source()}\n`
+        this.input.forEach((name) => {
+          const asset = compilation.assets[name]
+          if (!asset) return
 
-        // We keep existing assets since that helps when analyzing the bundle
+          concat.add(asset)
+
+          // We keep existing assets since that helps when analyzing the bundle
+        })
+
+        compilation.assets[this.output] = concat
+
+        callback()
       })
-
-      compilation.assets[this.output] = {
-        source: () => newSource,
-        size: () => newSource.length
-      }
-
-      callback()
     })
   }
 }

--- a/server/build/plugins/combine-assets-plugin.js
+++ b/server/build/plugins/combine-assets-plugin.js
@@ -11,7 +11,7 @@ export default class CombineAssetsPlugin {
 
   apply (compiler) {
     compiler.plugin('compilation', (compilation) => {
-      compilation.plugin('optimize-chunk-assets', (chunks, callback) => {
+      compilation.plugin('additional-chunk-assets', (chunks) => {
         const concat = new ConcatSource()
 
         this.input.forEach((name) => {
@@ -23,9 +23,8 @@ export default class CombineAssetsPlugin {
           // We keep existing assets since that helps when analyzing the bundle
         })
 
+        compilation.additionalChunkAssets.push(this.output)
         compilation.assets[this.output] = concat
-
-        callback()
       })
     })
   }

--- a/server/build/plugins/combine-assets-plugin.js
+++ b/server/build/plugins/combine-assets-plugin.js
@@ -25,6 +25,12 @@ export default class CombineAssetsPlugin {
 
         compilation.additionalChunkAssets.push(this.output)
         compilation.assets[this.output] = concat
+
+        // Register the combined file as an output of the associated chunks
+        chunks.filter((chunk) => {
+          return chunk.files.reduce((prev, file) => prev || this.input.includes(file), false)
+        })
+        .forEach((chunk) => chunk.files.push(this.output))
       })
     })
   }

--- a/server/build/plugins/pages-plugin.js
+++ b/server/build/plugins/pages-plugin.js
@@ -1,3 +1,4 @@
+import { ConcatSource } from 'webpack-sources'
 import {
   IS_BUNDLED_PAGE,
   MATCH_ROUTE_NAME
@@ -5,43 +6,48 @@ import {
 
 export default class PagesPlugin {
   apply (compiler) {
-    compiler.plugin('after-compile', (compilation, callback) => {
-      const pages = Object
-        .keys(compilation.namedChunks)
-        .map(key => compilation.namedChunks[key])
-        .filter(chunk => IS_BUNDLED_PAGE.test(chunk.name))
+    compiler.plugin('compilation', (compilation) => {
+      compilation.plugin('optimize-chunk-assets', (chunks, callback) => {
+        const pages = chunks.filter(chunk => IS_BUNDLED_PAGE.test(chunk.name))
 
-      pages.forEach((chunk) => {
-        const page = compilation.assets[chunk.name]
-        const pageName = MATCH_ROUTE_NAME.exec(chunk.name)[1]
-        let routeName = pageName
+        pages.forEach((chunk) => {
+          const pageName = MATCH_ROUTE_NAME.exec(chunk.name)[1]
+          let routeName = pageName
 
-        // We need to convert \ into / when we are in windows
-        // to get the proper route name
-        // Here we need to do windows check because it's possible
-        // to have "\" in the filename in unix.
-        // Anyway if someone did that, he'll be having issues here.
-        // But that's something we cannot avoid.
-        if (/^win/.test(process.platform)) {
-          routeName = routeName.replace(/\\/g, '/')
-        }
+          // We need to convert \ into / when we are in windows
+          // to get the proper route name
+          // Here we need to do windows check because it's possible
+          // to have "\" in the filename in unix.
+          // Anyway if someone did that, he'll be having issues here.
+          // But that's something we cannot avoid.
+          if (/^win/.test(process.platform)) {
+            routeName = routeName.replace(/\\/g, '/')
+          }
 
-        routeName = `/${routeName.replace(/(^|\/)index$/, '')}`
+          routeName = `/${routeName.replace(/(^|\/)index$/, '')}`
 
-        const content = page.source()
-        const newContent = `
-          window.__NEXT_REGISTER_PAGE('${routeName}', function() {
-            var comp = ${content}
-            return { page: comp.default }
-          })
-        `
-        // Replace the exisiting chunk with the new content
-        compilation.assets[chunk.name] = {
-          source: () => newContent,
-          size: () => newContent.length
-        }
+          // Replace the exisiting chunk with the new content
+          const asset = compilation.assets[chunk.name]
+          if (!asset) return
+
+          const concat = new ConcatSource()
+
+          concat.add(`
+            __NEXT_REGISTER_PAGE('${routeName}', function() {
+              var comp = 
+          `)
+          concat.add(asset)
+          concat.add(`
+              return { page: comp.default }
+            })
+          `)
+
+          // Replace the exisiting chunk with the new content
+          compilation.assets[chunk.name] = concat
+        })
+
+        callback()
       })
-      callback()
     })
   }
 }

--- a/server/build/plugins/pages-plugin.js
+++ b/server/build/plugins/pages-plugin.js
@@ -4,50 +4,48 @@ import {
   MATCH_ROUTE_NAME
 } from '../../utils'
 
+class PageChunkTemplatePlugin {
+  apply (chunkTemplate) {
+    chunkTemplate.plugin('render', function (modules, chunk) {
+      if (!IS_BUNDLED_PAGE.test(chunk.name)) {
+        return modules
+      }
+
+      let routeName = MATCH_ROUTE_NAME.exec(chunk.name)[1]
+
+        // We need to convert \ into / when we are in windows
+        // to get the proper route name
+        // Here we need to do windows check because it's possible
+        // to have "\" in the filename in unix.
+        // Anyway if someone did that, he'll be having issues here.
+        // But that's something we cannot avoid.
+      if (/^win/.test(process.platform)) {
+        routeName = routeName.replace(/\\/g, '/')
+      }
+
+      routeName = `/${routeName.replace(/(^|\/)index$/, '')}`
+
+      const source = new ConcatSource()
+
+      source.add(`
+        __NEXT_REGISTER_PAGE('${routeName}', function() {
+          var comp = 
+      `)
+      source.add(modules)
+      source.add(`
+          return { page: comp.default }
+        })
+      `)
+
+      return source
+    })
+  }
+}
+
 export default class PagesPlugin {
   apply (compiler) {
     compiler.plugin('compilation', (compilation) => {
-      compilation.plugin('optimize-chunk-assets', (chunks, callback) => {
-        const pages = chunks.filter(chunk => IS_BUNDLED_PAGE.test(chunk.name))
-
-        pages.forEach((chunk) => {
-          const pageName = MATCH_ROUTE_NAME.exec(chunk.name)[1]
-          let routeName = pageName
-
-          // We need to convert \ into / when we are in windows
-          // to get the proper route name
-          // Here we need to do windows check because it's possible
-          // to have "\" in the filename in unix.
-          // Anyway if someone did that, he'll be having issues here.
-          // But that's something we cannot avoid.
-          if (/^win/.test(process.platform)) {
-            routeName = routeName.replace(/\\/g, '/')
-          }
-
-          routeName = `/${routeName.replace(/(^|\/)index$/, '')}`
-
-          // Replace the exisiting chunk with the new content
-          const asset = compilation.assets[chunk.name]
-          if (!asset) return
-
-          const concat = new ConcatSource()
-
-          concat.add(`
-            __NEXT_REGISTER_PAGE('${routeName}', function() {
-              var comp = 
-          `)
-          concat.add(asset)
-          concat.add(`
-              return { page: comp.default }
-            })
-          `)
-
-          // Replace the exisiting chunk with the new content
-          compilation.assets[chunk.name] = concat
-        })
-
-        callback()
-      })
+      compilation.chunkTemplate.apply(new PageChunkTemplatePlugin())
     })
   }
 }

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -149,6 +149,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
         output: 'app.js'
       }),
       new webpack.optimize.UglifyJsPlugin({
+        exclude: ['manifest.js', 'commons.js', 'main.js'],
         compress: { warnings: false },
         sourceMap: false
       })

--- a/server/index.js
+++ b/server/index.js
@@ -408,7 +408,11 @@ export default class Server {
   }
 
   handleBuildId (buildId, res) {
-    if (this.dev) return true
+    if (this.dev) {
+      res.setHeader('Cache-Control', 'no-store, must-revalidate')
+      return true
+    }
+
     if (buildId !== this.renderOpts.buildId) {
       return false
     }
@@ -428,13 +432,17 @@ export default class Server {
   }
 
   handleBuildHash (filename, hash, res) {
-    if (this.dev) return
+    if (this.dev) {
+      res.setHeader('Cache-Control', 'no-store, must-revalidate')
+      return true
+    }
 
     if (hash !== this.buildStats[filename].hash) {
       throw new Error(`Invalid Build File Hash(${hash}) for chunk: ${filename}`)
     }
 
     res.setHeader('Cache-Control', 'max-age=365000000, immutable')
+    return true
   }
 
   send404 (res) {

--- a/server/render.js
+++ b/server/render.js
@@ -96,11 +96,6 @@ async function doRender (req, res, pathname, query, {
   }
 
   const docProps = await loadGetInitialProps(Document, { ...ctx, renderPage })
-  // While developing, we should not cache any assets.
-  // So, we use a different buildId for each page load.
-  // With that we can ensure, we have unique URL for assets per every page load.
-  // So, it'll prevent issues like this: https://git.io/vHLtb
-  const devBuildId = Date.now()
 
   if (res.finished) return
 
@@ -110,7 +105,7 @@ async function doRender (req, res, pathname, query, {
       props,
       pathname,
       query,
-      buildId: dev ? devBuildId : buildId,
+      buildId,
       buildStats,
       assetPrefix,
       nextExport,


### PR DESCRIPTION
Restores #3121 and reworks webpack plugins to utilize chunk templates, which are how the rest of webpack boilerplate is generated.

Fixes #2990
Restores #3121
Fixes #3134
