### PR TITLE
Add with-mobx-state-tree example

### DIFF
--- a/examples/with-mobx-state-tree/.babelrc
+++ b/examples/with-mobx-state-tree/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    "transform-decorators-legacy"
+  ]
+}

--- a/examples/with-mobx-state-tree/README.md
+++ b/examples/with-mobx-state-tree/README.md
@@ -1,0 +1,57 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mobx)
+
+# MobX example
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-mobx
+cd with-mobx
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+## Notes
+This example is a mobx port of the [with-redux](https://github.com/zeit/next.js/tree/master/examples/with-redux) example. Decorator support is activated by adding a `.babelrc` file at the root of the project:
+
+```json
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    "transform-decorators-legacy"
+  ]
+}
+```
+
+### Rehydrating with server data
+Be aware that data that was used on the server (and provided via `getInitialProps`) will be stringified in order to rehydrate the client with it. That means, if you create a store that is, say, an `ObservableMap` and give it as prop to a page, then the server will render appropriately. But stringifying it for the client will turn the `ObservableMap` to an ordinary JavaScript object (which does not have `Map`-style methods and is not an observable). So it is better to create the store as a normal object and turn it into a `Observable` in the `render()` method. This way both sides have an `Observable` to work with.
+
+## The idea behind the example
+
+Usually splitting your app state into `pages` feels natural but sometimes you'll want to have global state for your app. This is an example on how you can use mobx that also works with our universal rendering approach. This is just a way you can do it but it's not the only one.
+
+In this example we are going to display a digital clock that updates every second. The first render is happening in the server and then the browser will take over. To illustrate this, the server rendered clock will have a different background color than the client one.
+
+![](http://i.imgur.com/JCxtWSj.gif)
+
+Our page is located at `pages/index.js` so it will map the route `/`. To get the initial data for rendering we are implementing the static method `getInitialProps`, initializing the mobx store and returning the initial timestamp to be rendered. The root component for the render method is the `mobx-react Provider` that allows us to send the store down to children components so they can access to the state when required.
+
+To pass the initial timestamp from the server to the client we pass it as a prop called `lastUpdate` so then it's available when the client takes over.
+
+The trick here for supporting universal mobx is to separate the cases for the client and the server. When we are on the server we want to create a new store every time, otherwise different users data will be mixed up. If we are in the client we want to use always the same store. That's what we accomplish on `store.js`
+
+The clock, under `components/Clock.js`, has access to the state using the `inject` and `observer` functions from `mobx-react`. In this case Clock is a direct child from the page but it could be deep down the render tree.

--- a/examples/with-mobx-state-tree/README.md
+++ b/examples/with-mobx-state-tree/README.md
@@ -1,6 +1,6 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mobx)
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mobx-state-tree)
 
-# MobX example
+# MobX State Tree example
 
 ## How to use
 
@@ -38,7 +38,7 @@ This example is a mobx port of the [with-redux](https://github.com/zeit/next.js/
 ```
 
 ### Rehydrating with server data
-Be aware that data that was used on the server (and provided via `getInitialProps`) will be stringified in order to rehydrate the client with it. That means, if you create a store that is, say, an `ObservableMap` and give it as prop to a page, then the server will render appropriately. But stringifying it for the client will turn the `ObservableMap` to an ordinary JavaScript object (which does not have `Map`-style methods and is not an observable). So it is better to create the store as a normal object and turn it into a `Observable` in the `render()` method. This way both sides have an `Observable` to work with.
+After initializing the store (and possibly making changes such as fetching data), `getInitialProps` must stringify the store in order to pass it as props to the client. `mobx-state-tree` comes out of the box with a handy method for doing this called `getSnapshot`. The snapshot is sent to the client as `props.initialState` where the pages's `constructor()` may use it to rehydrate the client store.
 
 ## The idea behind the example
 
@@ -48,10 +48,12 @@ In this example we are going to display a digital clock that updates every secon
 
 ![](http://i.imgur.com/JCxtWSj.gif)
 
-Our page is located at `pages/index.js` so it will map the route `/`. To get the initial data for rendering we are implementing the static method `getInitialProps`, initializing the mobx store and returning the initial timestamp to be rendered. The root component for the render method is the `mobx-react Provider` that allows us to send the store down to children components so they can access to the state when required.
+Our page is located at `pages/index.js` so it will map the route `/`. To get the initial data for rendering we are implementing the static method `getInitialProps`, initializing the mobx-state-tree store and returning the initial timestamp to be rendered. The root component for the render method is the `mobx-react <Provider>` that allows us to send the store down to children components so they can access to the state when required.
 
 To pass the initial timestamp from the server to the client we pass it as a prop called `lastUpdate` so then it's available when the client takes over.
 
 The trick here for supporting universal mobx is to separate the cases for the client and the server. When we are on the server we want to create a new store every time, otherwise different users data will be mixed up. If we are in the client we want to use always the same store. That's what we accomplish on `store.js`
 
 The clock, under `components/Clock.js`, has access to the state using the `inject` and `observer` functions from `mobx-react`. In this case Clock is a direct child from the page but it could be deep down the render tree.
+
+As far as how this example differs from the `with-mobx` example, `mobx-state-tree` requires that any changes to the observable data are sent as actions, which are defined on the model in `server.js`. The snapshot feature, while not very useful in this particular case, makes client-side rehydration of the state amazingly easy. Any changes that are made to the store in `getInitialProps` will be refreshed instantly when that page is loaded on the client.

--- a/examples/with-mobx-state-tree/components/Clock.js
+++ b/examples/with-mobx-state-tree/components/Clock.js
@@ -1,0 +1,24 @@
+export default (props) => {
+  return (
+    <div className={props.light ? 'light' : ''}>
+      {format(new Date(props.lastUpdate))}
+      <style jsx>{`
+        div {
+          padding: 15px;
+          color: #82FA58;
+          display: inline-block;
+          font: 50px menlo, monaco, monospace;
+          background-color: #000;
+        }
+
+        .light {
+          background-color: #999;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+const format = t => `${pad(t.getUTCHours())}:${pad(t.getUTCMinutes())}:${pad(t.getUTCSeconds())}`
+
+const pad = n => n < 10 ? `0${n}` : n

--- a/examples/with-mobx-state-tree/components/Page.js
+++ b/examples/with-mobx-state-tree/components/Page.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import Link from 'next/link'
+import { inject, observer } from 'mobx-react'
+import Clock from './Clock'
+
+@inject('store') @observer
+class Page extends React.Component {
+  componentDidMount() {
+    this.props.store.start()
+  }
+
+  componentWillUnmount() {
+    this.props.store.stop()
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>{this.props.title}</h1>
+        <Clock lastUpdate={this.props.store.lastUpdate} light={this.props.store.light} />
+        <nav>
+          <Link href={this.props.linkTo}><a>Navigate</a></Link>
+        </nav>
+      </div>
+    )
+  }
+}
+
+export default Page

--- a/examples/with-mobx-state-tree/package.json
+++ b/examples/with-mobx-state-tree/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "with-mobx",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "mobx": "3.3.1",
+    "mobx-react": "^4.0.4",
+    "mobx-state-tree": "1.0.1",
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "license": "ISC",
+  "devDependencies": {
+    "babel-plugin-transform-decorators-legacy": "^1.3.4"
+  }
+}

--- a/examples/with-mobx-state-tree/pages/index.js
+++ b/examples/with-mobx-state-tree/pages/index.js
@@ -13,7 +13,7 @@ export default class Counter extends React.Component {
 
   constructor(props) {
     super(props)
-    this.store = initStore(props.isServer, Date.now(), props.initialState)
+    this.store = initStore(props.isServer, props.initialState)
   }
 
   render() {

--- a/examples/with-mobx-state-tree/pages/index.js
+++ b/examples/with-mobx-state-tree/pages/index.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Provider } from 'mobx-react'
+import { getSnapshot } from 'mobx-state-tree'
+import { initStore } from '../store'
+import Page from '../components/Page'
+
+export default class Counter extends React.Component {
+  static getInitialProps({ req }) {
+    const isServer = !!req
+    const store = initStore(isServer)
+    return { initialState: getSnapshot(store), isServer }
+  }
+
+  constructor(props) {
+    super(props)
+    this.store = initStore(props.isServer, Date.now(), props.initialState)
+  }
+
+  render() {
+    return (
+      <Provider store={this.store}>
+        <Page title='Index Page' linkTo='/other' />
+      </Provider>
+    )
+  }
+}

--- a/examples/with-mobx-state-tree/pages/other.js
+++ b/examples/with-mobx-state-tree/pages/other.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Provider } from 'mobx-react'
+import { getSnapshot } from 'mobx-state-tree'
+import { initStore } from '../store'
+import Page from '../components/Page'
+
+export default class Counter extends React.Component {
+  static getInitialProps({ req }) {
+    const store = initStore(!!req, Date.now())
+    return { initialState: getSnapshot(store), isServer: !!req }
+  }
+
+  constructor(props) {
+    super(props)
+    this.store = initStore(props.isServer, Date.now(), props.initialState)
+  }
+
+  render() {
+    return (
+      <Provider store={this.store}>
+        <Page title='Other Page' linkTo='/' />
+      </Provider>
+    )
+  }
+}

--- a/examples/with-mobx-state-tree/pages/other.js
+++ b/examples/with-mobx-state-tree/pages/other.js
@@ -6,13 +6,14 @@ import Page from '../components/Page'
 
 export default class Counter extends React.Component {
   static getInitialProps({ req }) {
-    const store = initStore(!!req, Date.now())
-    return { initialState: getSnapshot(store), isServer: !!req }
+    const isServer = !!req
+    const store = initStore(isServer)
+    return { initialState: getSnapshot(store), isServer }
   }
 
   constructor(props) {
     super(props)
-    this.store = initStore(props.isServer, Date.now(), props.initialState)
+    this.store = initStore(props.isServer, props.initialState)
   }
 
   render() {

--- a/examples/with-mobx-state-tree/server.js
+++ b/examples/with-mobx-state-tree/server.js
@@ -1,0 +1,21 @@
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+
+const { createServer } = require('http')
+const { parse } = require('url')
+const next = require('next')
+const mobxReact = require('mobx-react')
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+mobxReact.useStaticRendering(true)
+
+app.prepare().then(() => {
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url, true)
+    handle(req, res, parsedUrl)
+  }).listen(port, err => {
+    if (err) throw err
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})

--- a/examples/with-mobx-state-tree/store.js
+++ b/examples/with-mobx-state-tree/store.js
@@ -1,0 +1,44 @@
+import { types, applySnapshot } from 'mobx-state-tree'
+
+let store = null
+
+const Store = types
+  .model({
+    lastUpdate: types.Date,
+    light: false,
+  })
+  .actions((self) => {
+    let timer;
+    function start() {
+      timer = setInterval(() => {
+        // mobx-state-tree doesn't allow anonymous callbacks changing data
+        // pass off to another action instead
+        self.update();
+      })
+    }
+
+    function update() {
+      self.lastUpdate = Date.now()
+      self.light = true
+    }
+
+    function stop() {
+      clearInterval(timer);
+    }
+
+    return { start, stop, update }
+  })
+
+
+export function initStore(isServer, lastUpdate = Date.now(), snapshot = null) {
+  if (isServer) {
+    store = Store.create({ lastUpdate })
+  }
+  if (store === null) {
+    store = Store.create({ lastUpdate })
+  }
+  if (snapshot) {
+    applySnapshot(store, snapshot)
+  }
+  return store
+}

--- a/examples/with-mobx-state-tree/store.js
+++ b/examples/with-mobx-state-tree/store.js
@@ -30,12 +30,12 @@ const Store = types
   })
 
 
-export function initStore(isServer, lastUpdate = Date.now(), snapshot = null) {
+export function initStore(isServer, snapshot = null) {
   if (isServer) {
-    store = Store.create({ lastUpdate })
+    store = Store.create({ lastUpdate: Date.now() })
   }
   if (store === null) {
-    store = Store.create({ lastUpdate })
+    store = Store.create({ lastUpdate: Date.now() })
   }
   if (snapshot) {
     applySnapshot(store, snapshot)


### PR DESCRIPTION
Wrote up an example using [mobx-state-tree](https://github.com/mobxjs/mobx-state-tree/). It shows off how to easily rehydrate the client-side store after receiving a snapshot of the store from `getInitialProps` on the server.