### PR TITLE
downgrading ansi-regex version 4 to 3 - an arrow function was used in…

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "recursive-copy": "2.0.6",
     "send": "0.16.1",
     "source-map-support": "0.4.18",
-    "strip-ansi": "4.0.0",
+    "strip-ansi": "3.0.1",
     "styled-jsx": "2.1.1",
     "touch": "3.1.0",
     "unfetch": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6031,17 +6031,17 @@ stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
-strip-ansi@4.0.0, strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  dependencies:
-    ansi-regex "^3.0.0"
-
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+strip-ansi@3.0.1, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
since there was an arrow function used in strip-ansi version 4, next.js was throwing errors is versions 3+.
so we should either use the old version of strip-ansi or we should compile it.
more info about the problem of version 4 of strip-ansi is found [here](https://github.com/zeit/next.js/issues/2747#issuecomment-338387877).