### PR TITLE
Update styled components for React 16

### DIFF
--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "babel-plugin-styled-components": "^1.1.5",
     "next": "latest",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "styled-components": "^2.1.0"
   },
   "license": "ISC"


### PR DESCRIPTION
Next 4 only works with React 16, so for this example to work we need an update.