### PR TITLE
Change _error.js example to use `err` prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -849,10 +849,8 @@ __Note: React-components outside of `<Main />` will not be initialised by the br
 import React from 'react'
 
 export default class Error extends React.Component {
-  static getInitialProps({ res, jsonPageRes }) {
-    const statusCode = res
-      ? res.statusCode
-      : jsonPageRes ? jsonPageRes.status : null
+  static getInitialProps({ res, err }) {
+    const statusCode = res ? res.statusCode : err ? err.statusCode : null;
     return { statusCode }
   }
 


### PR DESCRIPTION
The `jsonPageRes` isn't always there, whereas `err` is, and when used,
provides a consistent statusCode in the client when compared to the
server.

Video of error: https://www.youtube.com/watch?v=hrU7zXkz6fA&feature=youtu.be

First version is with the code from the readme. Notice the flash between messages - it's because the client side request doesn't see the status code (because both `res` and `jsonPageRes` are undefined):

```js
static getInitialProps({ res, jsonPageRes }) {
  const statusCode = res
    ? res.statusCode
    : jsonPageRes ? jsonPageRes.status : null;
  return { statusCode };
}
```

Then I switch to the version that I've included in this PR, and restart the `npm run dev` process (I can only assume because "system" files require a restart):

```js
static getInitialProps({ res, err }) {
  const statusCode = res ? res.statusCode : err ? err.statusCode : null;
  return { statusCode };
}
```

And then there's no flash between the text because the status code is consistent.