### PR TITLE
Fix/Update react-with-styles & aphrodite example

### DIFF
--- a/examples/with-react-with-styles/package.json
+++ b/examples/with-react-with-styles/package.json
@@ -7,12 +7,12 @@
     "start": "next start"
   },
   "dependencies": {
-    "aphrodite": "^1.2.1",
+    "aphrodite": "^1.2.5",
     "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-with-styles": "^1.4.0",
-    "react-with-styles-interface-aphrodite": "^1.2.0"
+    "react-with-styles": "^2.2.0",
+    "react-with-styles-interface-aphrodite": "^3.1.1"
   },
   "license": "MIT"
 }

--- a/examples/with-react-with-styles/withStyles.js
+++ b/examples/with-react-with-styles/withStyles.js
@@ -1,9 +1,9 @@
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet'
 import aphroditeInterface from 'react-with-styles-interface-aphrodite'
-import { css, withStyles, ThemeProvider } from 'react-with-styles'
+import { css, withStyles } from 'react-with-styles'
 import MyDefaultTheme from './defaultTheme'
 
-ThemedStyleSheet.registerDefaultTheme(MyDefaultTheme)
+ThemedStyleSheet.registerTheme(MyDefaultTheme)
 ThemedStyleSheet.registerInterface(aphroditeInterface)
 
-export { css, withStyles, ThemeProvider, ThemedStyleSheet }
+export { css, withStyles, ThemedStyleSheet }


### PR DESCRIPTION
Fixes the with-react-with-styles example. The function registerDefaultTheme is no longer a member of ThemedStyleSheet.

Updates the with-react-with-styles example to be used with the most recent stable builds of aphrodite and react-with-styles.