### PR TITLE
[fix] with-apollo: Cannot read property 'data'

### DIFF
--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -17,12 +17,8 @@ export default ComposedComponent => {
     }
 
     static async getInitialProps (ctx) {
-      // Initial serverState with empty apollo data
-      let serverState = {
-        apollo: {
-          data: { }
-        }
-      }
+      // Initial serverState with apollo (empty)
+      let serverState = { apollo: { } }
 
       // Evaluate the composed component's getInitialProps()
       let composedInitialProps = {}

--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -17,7 +17,12 @@ export default ComposedComponent => {
     }
 
     static async getInitialProps (ctx) {
-      let serverState = {}
+      // Initial serverState with empty apollo data
+      let serverState = {
+        apollo: {
+          data: { }
+        }
+      }
 
       // Evaluate the composed component's getInitialProps()
       let composedInitialProps = {}


### PR DESCRIPTION
When we create the initial `serverState`, we need to create the
 eventual construct of the Apollo Data to reside within

Later in the constructor this allows for the `initApollo` to either
 be generated from SSR, or to init from scratch.

Fixes
> Cannot read property 'data' of undefined
> TypeError: Cannot read property 'data' of undefined