### PR TITLE
fix : example/with-noscript to use next@latest and react-dom

### DIFF
--- a/examples/with-noscript/components/Noscript.js
+++ b/examples/with-noscript/components/Noscript.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOMServer from 'react-dom/lib/ReactDOMServer'
+import ReactDOMServer from 'react-dom/server'
 
 export default function Noscript (props) {
   const staticMarkup = ReactDOMServer.renderToStaticMarkup(props.children)

--- a/examples/with-noscript/next.config.js
+++ b/examples/with-noscript/next.config.js
@@ -2,7 +2,7 @@ module.exports = {
   webpack: (config, { dev }) => {
     if (!dev) {
       config.resolve.alias = {
-        'react-dom/server': require.resolve('react-dom/dist/react-dom-server.min.js')
+        'react-dom/server': require.resolve('react-dom/umd/react-dom-server.browser.production.min.js')
       }
     }
     return config

--- a/examples/with-noscript/package.json
+++ b/examples/with-noscript/package.json
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^3.0.3",
+    "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-lazyload": "^2.2.7"


### PR DESCRIPTION
#2767

Since #3113 updated the react version to `^16.0.0` the location of react-dom has changed.

Now uses `next@latest` instead of `^3.0.3`



