### PR TITLE
Rewrite with-dotenv example

### DIFF
--- a/examples/with-dotenv/.babelrc
+++ b/examples/with-dotenv/.babelrc
@@ -1,13 +1,17 @@
 {
   "presets": [
-    "next/babel",
+    "next/babel"
   ],
   "env": {
     "development": {
-      "plugins": ["inline-dotenv"]
+      "plugins": ["dotenv-import"]
     },
     "production": {
-      "plugins": ["transform-inline-environment-variables"]
+      "plugins": [
+        ["dotenv-import", {
+          "path": ".env.production"
+        }]
+      ]
     }
   }
 }

--- a/examples/with-dotenv/.env.production
+++ b/examples/with-dotenv/.env.production
@@ -1,1 +1,1 @@
-TEST=it works!
+TEST=it works! in production though!

--- a/examples/with-dotenv/README.md
+++ b/examples/with-dotenv/README.md
@@ -26,16 +26,12 @@ now
 
 ## The idea behind the example
 
-This example shows the most basic idea of babel replacement from multiple environment. We have 1 env variable: `TEST` which will be replaced in development env and in production env with different babel plugin. In local development, babel reads .env file and replace process.env.* in your nextjs files. In production env (such as heroku), babel reads the ENV and replace process.env.* in your nextjs files. Thus no more needed to commit your secrets anymore.
+This example shows how to use .env files to specify environment variables. It handles both variables already in the environment and variables defined in a `.env` file.
+
+This example showcases using a `.env.production` file for environment configuration, but it can use the same file – and/or simple environment variables.
+
+Instead of overriding `process.env.*`, it provides a fake `@env` module which you can load the environment variables from.
+
+This is of course [all configurable](https://github.com/tusbar/babel-plugin-dotenv-import).
 
 Of course, please put .env* in your .gitignore when using this example locally.
-
-## Troubleshooting
-
-### Environment variables not showing on the page
-
-If for some reason the variable is not displayed on the page, try clearing the `babel-loader` cache:
-
-```
-rm -rf ./node_modules/.cache/babel-loader
-```

--- a/examples/with-dotenv/package.json
+++ b/examples/with-dotenv/package.json
@@ -9,9 +9,10 @@
   "dependencies": {
     "next": "latest",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "babel-plugin-inline-dotenv": "^1.1.1",
-    "babel-plugin-transform-inline-environment-variables": "^0.1.1"
+    "react-dom": "^16.0.0"
+  },
+  "devDependencies": {
+    "babel-plugin-dotenv-import": "^1.2.1"
   },
   "license": "ISC"
 }

--- a/examples/with-dotenv/pages/index.js
+++ b/examples/with-dotenv/pages/index.js
@@ -1,3 +1,5 @@
+import { TEST } from '@env'
+
 export default () => (
-  <div>{ process.env.TEST }</div>
+  <div>{ TEST }</div>
 )


### PR DESCRIPTION
This uses a new babel plugin I’ve just released:
babel-plugin-dotenv-import. This is clearly opinionated and uses a
different convention than what people usually do: it does not replace
`process.env.*`.

The reason for this is that none of the babel plugins out there allowed
destructuring `process.env`, and `process.env` feels weird in the
browser.

This example was not working at all in production mode as it would only
use existing environement variables and ignore .env files completely
(which defeats the purpose of this example).

The plugin features a few options:

- Specifying a custom .env file (`path`).
- A `safe` mode to only allow using variables defined in .env.
- White and black listing variables (`whitelist` and `blacklist`).
- Changing the `@env` module name (`moduleName`).

https://github.com/tusbar/babel-plugin-dotenv-import