### PR TITLE
Update package.json

### DIFF
--- a/examples/with-i18next/package.json
+++ b/examples/with-i18next/package.json
@@ -7,12 +7,12 @@
     "start": "next start"
   },
   "dependencies": {
-    "i18next": "^7.1.3",
+    "i18next": "^10.0.7",
     "isomorphic-unfetch": "^2.0.0",
     "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-i18next": "^2.2.1"
+    "react-i18next": "^6.1.0"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
Upgrade i18next & react-i18next

On react v16.0.0, React.propTypes are deprecated.
Upgrade react-i18next to v6.1.0 which using PropTypes Package.