### PR TITLE
Set Cache-Control max-age to a year

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -417,7 +417,7 @@ export default class Server {
       return false
     }
 
-    res.setHeader('Cache-Control', 'max-age=365000000, immutable')
+    res.setHeader('Cache-Control', 'max-age=31536000, immutable')
     return true
   }
 
@@ -441,7 +441,7 @@ export default class Server {
       throw new Error(`Invalid Build File Hash(${hash}) for chunk: ${filename}`)
     }
 
-    res.setHeader('Cache-Control', 'max-age=365000000, immutable')
+    res.setHeader('Cache-Control', 'max-age=31536000, immutable')
     return true
   }
 


### PR DESCRIPTION
I assume this was a typo but the current max-age for the Cache-Control header is a large value between 11 and 12 years. This sets it to a year.