### PR TITLE
Update the custom-server-express with an req.params example

### DIFF
--- a/examples/custom-server-express/pages/index.js
+++ b/examples/custom-server-express/pages/index.js
@@ -5,5 +5,6 @@ export default () => (
   <ul>
     <li><Link href='/b' as='/a'><a>a</a></Link></li>
     <li><Link href='/a' as='/b'><a>b</a></Link></li>
+    <li><Link href='/posts/2'><a>post #2</a></Link></li>
   </ul>
 )

--- a/examples/custom-server-express/pages/posts.js
+++ b/examples/custom-server-express/pages/posts.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react'
+
+export default class extends Component {
+  static getInitialProps ({ query: { id } }) {
+    return { postId: id }
+  }
+
+  render () {
+    return <div>
+      <h1>My blog post #{this.props.postId}</h1>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    </div>
+  }
+}

--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -18,6 +18,10 @@ app.prepare()
     return app.render(req, res, '/a', req.query)
   })
 
+  server.get('/posts/:id', (req, res) => {
+    return app.render(req, res, '/posts', { id: req.params.id })
+  })
+
   server.get('*', (req, res) => {
     return handle(req, res)
   })


### PR DESCRIPTION
Currently, there's no example showing how to use Express params with Next routes.