### PR TITLE
Fixed how credentials opt is passed to HttpLink

### DIFF
--- a/examples/with-apollo/lib/initApollo.js
+++ b/examples/with-apollo/lib/initApollo.js
@@ -16,9 +16,7 @@ function create (initialState) {
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
-      opts: {
-        credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
-      }
+      credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
     }),
     cache: new InMemoryCache().restore(initialState || {}),
   })


### PR DESCRIPTION
Prior to react-apollo 2.0 createNetworkInterface accepted the credentials option in {opt: {credentials: 'policy'}}. HttpLink accepts it as {credentials: 'policy'}.

I'm not familiar with how canary and master are used so wasn't sure whether this should be submitted on canary or both canary and master. I'm happy to update this to whatever is most useful to the maintainers.