### PR TITLE
Update deprecated firebase method

### DIFF
--- a/examples/with-firebase-authentication/pages/index.js
+++ b/examples/with-firebase-authentication/pages/index.js
@@ -33,7 +33,7 @@ export default class Index extends Component {
     firebase.auth().onAuthStateChanged(user => {
       if (user) {
         this.setState({ user: user })
-        return user.getToken()
+        return user.getIdToken()
           .then((token) => {
             // eslint-disable-next-line no-undef
             return fetch('/api/login', {


### PR DESCRIPTION
getToken is now deprecated, you'll get the following message if using the previous code:

firebase.User.prototype.getToken is deprecated. Please use firebase.User.prototype.getIdToken instead.