### PR TITLE
Allow static exports without trailing slashes

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,4 +1,4 @@
-/* global window */
+/* global window, __NEXT_DATA__ */
 import _Router from './router'
 import { execOnce } from '../utils'
 
@@ -106,8 +106,11 @@ export function _rewriteUrlForNextExport (url) {
   path = path.replace(/\/$/, '')
 
   let newPath = path
-  // Append a trailing slash if this path does not have an extension
-  if (!/\.[^/]+\/?$/.test(path)) {
+
+  // By default, append a trailing slash if this path does not have an extension
+  const exportTrailingSlashes = __NEXT_DATA__ &&
+    __NEXT_DATA__.nextExportTrailingSlashes
+  if (exportTrailingSlashes && !/\.[^/]+\/?$/.test(path)) {
     newPath = `${path}/`
   }
 

--- a/readme.md
+++ b/readme.md
@@ -1441,7 +1441,7 @@ module.exports = {
 }
 ```
 
-> Note that if the path ends with a directory, it will be exported as `/dir-name/index.html`, but if it ends with an extension, it will be exported as the specified filename, e.g. `/readme.md` above. If you use a file extension other than `.html`, you may need to set the `Content-Type` header to `text/html` when serving this content.
+> Note that if the path ends with a directory, it will be exported as `/dir-name/index.html`, but if it ends with an extension, it will be exported as the specified filename, e.g. `/readme.md` above. If you use a file extension other than `.html`, you may need to set the `Content-Type` header to `text/html` when serving this content. Links to directory pages (`dir-name/index.html`) will contain a trailing slash (`dir-name/`) unless you set `exportTrailingSlashes: false` in `next.config.js`.
 
 In that, you specify what are the pages you need to export as static HTML.
 

--- a/server/config.js
+++ b/server/config.js
@@ -14,7 +14,8 @@ const defaultConfig = {
   useFileSystemPublicRoutes: true,
   generateBuildId: () => uuid.v4(),
   generateEtags: true,
-  pageExtensions: ['jsx', 'js']
+  pageExtensions: ['jsx', 'js'],
+  exportTrailingSlashes: true
 }
 
 export default function getConfig (phase: string, dir: string, customConfig?: ?Object) {

--- a/server/export.js
+++ b/server/export.js
@@ -110,7 +110,8 @@ export default async function (dir, options, configuration) {
 
   // We need this for server rendering the Link component.
   global.__NEXT_DATA__ = {
-    nextExport: true
+    nextExport: true,
+    nextExportTrailingSlashes: nextConfig.exportTrailingSlashes
   }
 
   const exportPathMap = await nextConfig.exportPathMap(defaultPathMap)


### PR DESCRIPTION
Hello, first PR here 😎. Please let me know if anything should change.

Fixes #2944 by adding a `exportTrailingSlashes` option to `next.config.js`.

I'm not crazy about adding to the global `__NEXT_DATA__` object, but it seems the cleanest way to get settings so deep into the rendering logic.

I looked into adding a test for this, but it would seem to add an ugly wart to `integration/static/test/index.test.js`, which only tests a single `next.config.js`. Can definitely add if necessary though.