### PR TITLE
Update withData.js - support withRouter HOC

### DIFF
--- a/examples/with-apollo-auth/lib/withData.js
+++ b/examples/with-apollo-auth/lib/withData.js
@@ -54,7 +54,13 @@ export default ComposedComponent => {
             <ComposedComponent url={url} {...composedInitialProps} />
           </ApolloProvider>
         )
-        await getDataFromTree(app)
+        await getDataFromTree(app, {
+          router: {
+            query: context.query,
+            pathname: context.pathname,
+            asPath: context.asPath
+          }
+        })
 
         // Extract query data from the Apollo's store
         const state = apollo.getInitialState()


### PR DESCRIPTION
Add support for using withRouter as HOC with this example.

Passing router context manually fixes this, based on, https://github.com/zeit/next.js/issues/2908#issuecomment-338244804

This PR https://github.com/zeit/next.js/pull/3149, it it released yet? I am on 4.1.4 and I still require the above fix to make it work. 