### PR TITLE
Add data node to serverState declaration

### DIFF
--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -18,7 +18,11 @@ export default ComposedComponent => {
 
     static async getInitialProps (ctx) {
       // Initial serverState with apollo (empty)
-      let serverState = { apollo: { } }
+      let serverState = { 
+        apollo: {
+          data: { }
+        } 
+      }
 
       // Evaluate the composed component's getInitialProps()
       let composedInitialProps = {}


### PR DESCRIPTION
The serverState variable definition did not include the data node, which
may cause parsing errors on the client-side.
  - add data: { } on line 23 within the apollo: { } object