### PR TITLE
Added support for custom asset paths and mapping

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -24,14 +24,15 @@ const {
     query,
     buildId,
     chunks,
-    assetPrefix
+    assetPrefix,
+    assetMap
   },
   location
 } = window
 
 const asPath = getURL()
 
-const pageLoader = new PageLoader(buildId, assetPrefix)
+const pageLoader = new PageLoader(buildId, assetPrefix, assetMap)
 window.__NEXT_LOADED_PAGES__.forEach(({ route, fn }) => {
   pageLoader.registerPage(route, fn)
 })

--- a/examples/custom-asset-map/.gitignore
+++ b/examples/custom-asset-map/.gitignore
@@ -1,0 +1,3 @@
+.next
+.public
+node_modules

--- a/examples/custom-asset-map/README.md
+++ b/examples/custom-asset-map/README.md
@@ -1,0 +1,22 @@
+# Example app using custom `assetMap`
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/custom-asset-map
+cd custom-asset-map
+```
+
+Install it and run as production:
+
+```bash
+npm install
+npm run build
+npm run start
+```
+
+## The idea behind the example
+
+To illustrate usage of `assetMap` option, which allows next.js apps to work with S3 (or alike) based CDNs

--- a/examples/custom-asset-map/components/Counter.js
+++ b/examples/custom-asset-map/components/Counter.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+let count = 0
+
+export default class Counter extends React.Component {
+  add () {
+    count += 1
+    this.forceUpdate()
+  }
+
+  render () {
+    return (
+      <div>
+        <p>Count is: {count}</p>
+        <button onClick={() => this.add()}>Add</button>
+      </div>
+    )
+  }
+}

--- a/examples/custom-asset-map/components/Header.js
+++ b/examples/custom-asset-map/components/Header.js
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/'>
+      <a style={styles.a} >Home</a>
+    </Link>
+
+    <Link href='/about'>
+      <a style={styles.a} >About</a>
+    </Link>
+  </div>
+)
+
+const styles = {
+  a: {
+    marginRight: 10
+  }
+}

--- a/examples/custom-asset-map/next.config.js
+++ b/examples/custom-asset-map/next.config.js
@@ -1,0 +1,14 @@
+const isProd = (process.env.NODE_ENV === 'production')
+
+module.exports = {
+  assetPrefix: !isProd ? '' : 'http://localhost:3080',
+  assetMap: !isProd ? null : {
+    '/page/about': '/page/about/index.js',
+    '/page/': '/page/index.js'
+  },
+
+  // Export just js bundles
+  exportPathMap: function () {
+    return {}
+  }
+}

--- a/examples/custom-asset-map/next.config.js
+++ b/examples/custom-asset-map/next.config.js
@@ -3,7 +3,7 @@ const isProd = (process.env.NODE_ENV === 'production')
 module.exports = {
   assetPrefix: !isProd ? '' : 'http://localhost:3080',
   assetMap: !isProd ? null : {
-    '/page/about': '/page/about/index.js',
+    '/page/about': '/page/about.js',
     '/page/': '/page/index.js'
   },
 

--- a/examples/custom-asset-map/package.json
+++ b/examples/custom-asset-map/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "custom-asset-map",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "postbuild": "next export -o .public",
+    "start": "npm run cdn & NODE_ENV=production next start; kill $!",
+    "cdn": "st --dir .public --port 3080 --no-index --no-dot"
+  },
+  "dependencies": {
+    "next": "file:../..",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "st": "^1.2.2"
+  },
+  "license": "ISC"
+}

--- a/examples/custom-asset-map/pages/about.js
+++ b/examples/custom-asset-map/pages/about.js
@@ -1,0 +1,10 @@
+import Header from '../components/Header'
+import Counter from '../components/Counter'
+
+export default () => (
+  <div>
+    <Header />
+    <p>This is the about page.</p>
+    <Counter />
+  </div>
+)

--- a/examples/custom-asset-map/pages/index.js
+++ b/examples/custom-asset-map/pages/index.js
@@ -1,0 +1,10 @@
+import Header from '../components/Header'
+import Counter from '../components/Counter'
+
+export default () => (
+  <div>
+    <Header />
+    <p>HOME PAGE is here!</p>
+    <Counter />
+  </div>
+)

--- a/examples/custom-asset-path/.gitignore
+++ b/examples/custom-asset-path/.gitignore
@@ -1,0 +1,3 @@
+.next
+.public
+node_modules

--- a/examples/custom-asset-path/README.md
+++ b/examples/custom-asset-path/README.md
@@ -1,0 +1,23 @@
+# Example app using custom `getAssetPath` function
+
+## How to use
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/custom-asset-path
+cd custom-asset-path
+```
+
+Install it and run as production:
+
+```bash
+npm install
+npm run build
+npm run start
+```
+
+## The idea behind the example
+
+To illustrate usage of custom `getAssetPath` funciton, which allows next.js apps to work with S3 (or alike) based CDNs,
+and various asset deploy strategies.

--- a/examples/custom-asset-path/components/Counter.js
+++ b/examples/custom-asset-path/components/Counter.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+let count = 0
+
+export default class Counter extends React.Component {
+  add () {
+    count += 1
+    this.forceUpdate()
+  }
+
+  render () {
+    return (
+      <div>
+        <p>Count is: {count}</p>
+        <button onClick={() => this.add()}>Add</button>
+      </div>
+    )
+  }
+}

--- a/examples/custom-asset-path/components/Header.js
+++ b/examples/custom-asset-path/components/Header.js
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/'>
+      <a style={styles.a} >Home</a>
+    </Link>
+
+    <Link href='/about'>
+      <a style={styles.a} >About</a>
+    </Link>
+  </div>
+)
+
+const styles = {
+  a: {
+    marginRight: 10
+  }
+}

--- a/examples/custom-asset-path/lib/get-asset-path.js
+++ b/examples/custom-asset-path/lib/get-asset-path.js
@@ -1,0 +1,8 @@
+export default function getAssetPath (hash, asset, assetPrefix, assetMap) {
+  // rudimentary `assetMap` support,
+  // meant to be used within custom `get-asset-path` functions
+  if (assetMap && assetMap[asset]) {
+    asset = assetMap[asset]
+  }
+  return `${assetPrefix}/v123/${hash}${asset}`
+}

--- a/examples/custom-asset-path/next.config.js
+++ b/examples/custom-asset-path/next.config.js
@@ -1,0 +1,35 @@
+const isProd = (process.env.NODE_ENV === 'production')
+const path = require('path')
+const relativeAliases = require('./relative-alias-webpack-plugin')
+
+module.exports = {
+  assetPrefix: !isProd ? '' : 'http://localhost:3080',
+  assetMap: !isProd ? null : {
+    '/page/about': '/page/about/index.js',
+    '/page/': '/page/index.js'
+  },
+
+  // Export just js bundles
+  exportPathMap: function () {
+    return {}
+  },
+
+  webpack: function (config, { dev }) {
+    // For the development version, we'll use default mapping.
+    // Because, it supports react hot loading and so on.
+    if (dev) {
+      return config
+    }
+
+    config.plugins = [
+      ...config.plugins,
+      relativeAliases({
+        // replace it for `lib/page-loader.js`
+        './get-asset-path': path.resolve('./lib/get-asset-path.js'),
+        '../lib/get-asset-path': path.resolve('./lib/get-asset-path.js')
+      })
+    ]
+
+    return config
+  }
+}

--- a/examples/custom-asset-path/next.config.js
+++ b/examples/custom-asset-path/next.config.js
@@ -5,7 +5,7 @@ const relativeAliases = require('./relative-alias-webpack-plugin')
 module.exports = {
   assetPrefix: !isProd ? '' : 'http://localhost:3080',
   assetMap: !isProd ? null : {
-    '/page/about': '/page/about/index.js',
+    '/page/about': '/page/about.js',
     '/page/': '/page/index.js'
   },
 

--- a/examples/custom-asset-path/package.json
+++ b/examples/custom-asset-path/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "custom-asset-path",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "postbuild": "next export -o .public && mv .public/_next .public/v123",
+    "start": "npm run cdn & NODE_ENV=production next start; kill $!",
+    "cdn": "st --dir .public --port 3080 --no-index --no-dot"
+  },
+  "dependencies": {
+    "next": "file:../..",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "st": "^1.2.2"
+  },
+  "license": "ISC"
+}

--- a/examples/custom-asset-path/pages/_document.js
+++ b/examples/custom-asset-path/pages/_document.js
@@ -1,0 +1,10 @@
+import Document from 'next/document'
+import _getAssetPath from '../lib/get-asset-path'
+
+export default class MyDocument extends Document {
+  // providing custom _getAssetPath
+  _getAssetPath (hash, asset, assetPrefix, assetMap) {
+    const getAssetPath = this.props.dev ? super._getAssetPath : _getAssetPath
+    return getAssetPath(hash, asset, assetPrefix, assetMap)
+  }
+}

--- a/examples/custom-asset-path/pages/about.js
+++ b/examples/custom-asset-path/pages/about.js
@@ -1,0 +1,10 @@
+import Header from '../components/Header'
+import Counter from '../components/Counter'
+
+export default () => (
+  <div>
+    <Header />
+    <p>This is the about page.</p>
+    <Counter />
+  </div>
+)

--- a/examples/custom-asset-path/pages/index.js
+++ b/examples/custom-asset-path/pages/index.js
@@ -1,0 +1,10 @@
+import Header from '../components/Header'
+import Counter from '../components/Counter'
+
+export default () => (
+  <div>
+    <Header />
+    <p>HOME PAGE is here!</p>
+    <Counter />
+  </div>
+)

--- a/examples/custom-asset-path/relative-alias-webpack-plugin.js
+++ b/examples/custom-asset-path/relative-alias-webpack-plugin.js
@@ -1,0 +1,14 @@
+module.exports = function (aliases) {
+  return {
+    apply: function (compiler) {
+      compiler.plugin('compilation', (compilation) => {
+        compilation.plugin('normal-module-loader', (loaderContext, module) => {
+          const key = module.rawRequest.split('?')[0]
+          if (aliases[key]) {
+            module.resource = aliases[key]
+          }
+        })
+      })
+    }
+  }
+}

--- a/lib/get-asset-path.js
+++ b/lib/get-asset-path.js
@@ -1,0 +1,8 @@
+export default function getAssetPath (hash, asset, assetPrefix = '', assetMap = null) {
+  // rudimentary `assetMap` support,
+  // meant to be used within custom `get-asset-path` functions
+  if (assetMap && assetMap[asset]) {
+    asset = assetMap[asset]
+  }
+  return `${assetPrefix}/_next/${hash}${asset}`
+}

--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -1,12 +1,14 @@
 /* global window, document, __NEXT_DATA__ */
 import EventEmitter from './EventEmitter'
+import getAssetPath from './get-asset-path'
 
 const webpackModule = module
 
 export default class PageLoader {
-  constructor (buildId, assetPrefix) {
+  constructor (buildId, assetPrefix, assetMap) {
     this.buildId = buildId
     this.assetPrefix = assetPrefix
+    this.assetMap = assetMap
 
     this.pageCache = {}
     this.pageLoadedHandlers = {}
@@ -76,7 +78,7 @@ export default class PageLoader {
     }
 
     const script = document.createElement('script')
-    const url = `${this.assetPrefix}/_next/${encodeURIComponent(this.buildId)}/page${scriptRoute}`
+    const url = getAssetPath(encodeURIComponent(this.buildId), `/page${scriptRoute}`, this.assetPrefix, this.assetMap)
     script.src = url
     script.type = 'text/javascript'
     script.onerror = () => {

--- a/server/config.js
+++ b/server/config.js
@@ -8,6 +8,7 @@ const defaultConfig = {
   poweredByHeader: true,
   distDir: '.next',
   assetPrefix: '',
+  assetMap: null,
   configOrigin: 'default',
   useFileSystemPublicRoutes: true,
   pagesGlobPattern: 'pages/**/*.+(js|jsx)'

--- a/server/document.js
+++ b/server/document.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import htmlescape from 'htmlescape'
 import flush from 'styled-jsx/server'
+import _getAssetPath from '../lib/get-asset-path'
 
 const Fragment = React.Fragment || function Fragment ({ children }) {
   return children
@@ -15,11 +16,17 @@ export default class Document extends Component {
   }
 
   static childContextTypes = {
-    _documentProps: PropTypes.any
+    _documentProps: PropTypes.any,
+    getAssetPath: PropTypes.func
+  }
+
+  // allow it to be overwritten by custom _document
+  _getAssetPath (hash, asset, assetPrefix, assetMap) {
+    return _getAssetPath(hash, asset, assetPrefix, assetMap)
   }
 
   getChildContext () {
-    return { _documentProps: this.props }
+    return { _documentProps: this.props, getAssetPath: this._getAssetPath.bind(this) }
   }
 
   render () {
@@ -35,19 +42,21 @@ export default class Document extends Component {
 
 export class Head extends Component {
   static contextTypes = {
-    _documentProps: PropTypes.any
+    _documentProps: PropTypes.any,
+    getAssetPath: PropTypes.func
   }
 
   getChunkPreloadLink (filename) {
     const { __NEXT_DATA__ } = this.context._documentProps
-    let { buildStats, assetPrefix, buildId } = __NEXT_DATA__
+    const getAssetPath = this.context.getAssetPath
+    let { buildStats, assetPrefix, assetMap, buildId } = __NEXT_DATA__
     const hash = buildStats ? buildStats[filename].hash : buildId
 
     return (
       <link
         key={filename}
         rel='preload'
-        href={`${assetPrefix}/_next/${hash}/${filename}`}
+        href={getAssetPath(hash, `/${filename}`, assetPrefix, assetMap)}
         as='script'
       />
     )
@@ -71,12 +80,13 @@ export class Head extends Component {
 
   getPreloadDynamicChunks () {
     const { chunks, __NEXT_DATA__ } = this.context._documentProps
-    let { assetPrefix, buildId } = __NEXT_DATA__
+    const getAssetPath = this.context.getAssetPath
+    let { assetPrefix, assetMap, buildId } = __NEXT_DATA__
     return chunks.map((chunk) => (
       <link
         key={chunk}
         rel='preload'
-        href={`${assetPrefix}/_next/${buildId}/webpack/chunks/${chunk}`}
+        href={getAssetPath(buildId, `/webpack/chunks/${chunk}`, assetPrefix, assetMap)}
         as='script'
       />
     ))
@@ -84,13 +94,14 @@ export class Head extends Component {
 
   render () {
     const { head, styles, __NEXT_DATA__ } = this.context._documentProps
-    const { pathname, buildId, assetPrefix } = __NEXT_DATA__
+    const getAssetPath = this.context.getAssetPath
+    const { pathname, buildId, assetPrefix, assetMap } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
     return <head {...this.props}>
       {(head || []).map((h, i) => React.cloneElement(h, { key: h.key || i }))}
-      <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} as='script' />
-      <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_error.js`} as='script' />
+      <link rel='preload' href={getAssetPath(buildId, `/page${pagePathname}`, assetPrefix, assetMap)} as='script' />
+      <link rel='preload' href={getAssetPath(buildId, `/page/_error.js`, assetPrefix, assetMap)} as='script' />
       {this.getPreloadDynamicChunks()}
       {this.getPreloadMainLinks()}
       {styles || null}
@@ -122,19 +133,21 @@ export class NextScript extends Component {
   }
 
   static contextTypes = {
-    _documentProps: PropTypes.any
+    _documentProps: PropTypes.any,
+    getAssetPath: PropTypes.func
   }
 
   getChunkScript (filename, additionalProps = {}) {
     const { __NEXT_DATA__ } = this.context._documentProps
-    let { buildStats, assetPrefix, buildId } = __NEXT_DATA__
+    const getAssetPath = this.context.getAssetPath
+    let { buildStats, assetPrefix, assetMap, buildId } = __NEXT_DATA__
     const hash = buildStats ? buildStats[filename].hash : buildId
 
     return (
       <script
         key={filename}
         type='text/javascript'
-        src={`${assetPrefix}/_next/${hash}/${filename}`}
+        src={getAssetPath(hash, `/${filename}`, assetPrefix, assetMap)}
         {...additionalProps}
       />
     )
@@ -157,7 +170,8 @@ export class NextScript extends Component {
 
   getDynamicChunks () {
     const { chunks, __NEXT_DATA__ } = this.context._documentProps
-    let { assetPrefix, buildId } = __NEXT_DATA__
+    const getAssetPath = this.context.getAssetPath
+    let { assetPrefix, assetMap, buildId } = __NEXT_DATA__
     return (
       <Fragment>
         {chunks.map((chunk) => (
@@ -165,7 +179,7 @@ export class NextScript extends Component {
             async
             key={chunk}
             type='text/javascript'
-            src={`${assetPrefix}/_next/${buildId}/webpack/chunks/${chunk}`}
+            src={getAssetPath(buildId, `/webpack/chunks/${chunk}`, assetPrefix, assetMap)}
           />
         ))}
       </Fragment>
@@ -174,7 +188,8 @@ export class NextScript extends Component {
 
   render () {
     const { staticMarkup, __NEXT_DATA__, chunks } = this.context._documentProps
-    const { pathname, buildId, assetPrefix } = __NEXT_DATA__
+    const getAssetPath = this.context.getAssetPath
+    const { pathname, buildId, assetPrefix, assetMap } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
     __NEXT_DATA__.chunks = chunks
@@ -196,8 +211,8 @@ export class NextScript extends Component {
           }
         `
       }} />}
-      <script async id={`__NEXT_PAGE__${pathname}`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} />
-      <script async id={`__NEXT_PAGE__/_error`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page/_error.js`} />
+      <script async id={`__NEXT_PAGE__${pathname}`} type='text/javascript' src={getAssetPath(buildId, `/page${pagePathname}`, assetPrefix, assetMap)} />
+      <script async id={`__NEXT_PAGE__/_error`} type='text/javascript' src={getAssetPath(buildId, `/page/_error.js`, assetPrefix, assetMap)} />
       {staticMarkup ? null : this.getDynamicChunks()}
       {staticMarkup ? null : this.getScripts()}
     </Fragment>

--- a/server/export.js
+++ b/server/export.js
@@ -78,6 +78,7 @@ export default async function (dir, options, configuration) {
     buildId,
     nextExport: true,
     assetPrefix: config.assetPrefix.replace(/\/$/, ''),
+    assetMap: config.assetMap,
     dev: false,
     staticMarkup: false,
     hotReloader: null,

--- a/server/index.js
+++ b/server/index.js
@@ -72,6 +72,7 @@ export default class Server {
       buildStats: this.buildStats,
       buildId: this.buildId,
       assetPrefix: this.config.assetPrefix.replace(/\/$/, ''),
+      assetMap: this.config.assetMap,
       availableChunks: dev ? {} : getAvailableChunks(this.dir, this.dist)
     }
 

--- a/server/render.js
+++ b/server/render.js
@@ -41,6 +41,7 @@ async function doRender (req, res, pathname, query, {
   buildStats,
   hotReloader,
   assetPrefix,
+  assetMap,
   availableChunks,
   dir = process.cwd(),
   dev = false,
@@ -108,6 +109,7 @@ async function doRender (req, res, pathname, query, {
       buildId,
       buildStats,
       assetPrefix,
+      assetMap,
       nextExport,
       err: (err) ? serializeError(dev, err) : null
     },

--- a/test/unit/get-asset-path.test.js
+++ b/test/unit/get-asset-path.test.js
@@ -1,0 +1,30 @@
+/* global describe, it, expect */
+
+import getAssetPath from '../../dist/lib/get-asset-path'
+
+describe('getAssetPath', () => {
+  it('should work with just hash and asset', () => {
+    expect(getAssetPath('abc123', '/my_file')).toBe('/_next/abc123/my_file')
+  })
+
+  it('should work with nested asset path', () => {
+    expect(getAssetPath('abc123', '/some_dir/for/my_file')).toBe('/_next/abc123/some_dir/for/my_file')
+  })
+
+  it('should work with full assetPrefix', () => {
+    expect(getAssetPath('abc123', '/page/about', 'http://cdn.example.com')).toBe('http://cdn.example.com/_next/abc123/page/about')
+  })
+
+  it('should work with path only assetPrefix', () => {
+    expect(getAssetPath('abc123', '/page/about', '/custom/prefix')).toBe('/custom/prefix/_next/abc123/page/about')
+  })
+
+  it('should work with assetMap', () => {
+    const assetMap = {
+      '/page/about': '/app/about/index.js',
+      '/page/': '/app/index.js'
+    }
+    expect(getAssetPath('abc123', '/page/about', 'http://cdn.example.com', assetMap)).toBe('http://cdn.example.com/_next/abc123/app/about/index.js')
+    expect(getAssetPath('abc123', '/something/not/in/map', 'http://cdn.example.com', assetMap)).toBe('http://cdn.example.com/_next/abc123/something/not/in/map')
+  })
+})


### PR DESCRIPTION
This PR pulls generation logic for external assets into a single function. And adds mapping support to allow next.js apps to be used with S3-like CDNs. Also it allows to override that function with custom logic to have more complex asset deploy pipeline (like per asset versioning or content hashing).

Added two examples:

`custom-asset-map` – shows how simple mapping could solve S3-like CDN issues (#2053, #2134)

`custom-asset-path` – shows how to use custom `getAssetPath` function in prod setup.

All my changes are grouped into this commit – https://github.com/zeit/next.js/commit/e69e339b9f15878e6f27799087b345e93f2eb4fc

_Second commit fixes styling issues that somehow leaked into the upstream branch and prevented tests from running_

/cc @mtoso @dntrkv @rauchg 