### PR TITLE
Update the reason example to use reason@3

### DIFF
--- a/examples/with-reasonml/bsconfig.json
+++ b/examples/with-reasonml/bsconfig.json
@@ -6,5 +6,6 @@
   "package-specs": ["commonjs"],
   "bsc-flags": [
     "-bs-super-errors"
-  ]
+  ],
+  "refmt": 3
 }

--- a/examples/with-reasonml/components/Counter.re
+++ b/examples/with-reasonml/components/Counter.re
@@ -1,21 +1,22 @@
 type action =
   | Add;
 
-let component = ReasonReact.reducerComponent "Counter";
+let component = ReasonReact.reducerComponent("Counter");
 
-let make _children => {
+let make = (_children) => {
   ...component,
-  initialState: fun () => 0,
-  reducer: fun action state =>
+  initialState: () => 0,
+  reducer: (action, state) =>
     switch action {
-    | Add => ReasonReact.Update {state + 1}
+    | Add => ReasonReact.Update(state + 1)
     },
-  render: fun self => {
-    let countMsg = "Count: " ^ (string_of_int self.state);
-
+  render: (self) => {
+    let countMsg = "Count: " ++ string_of_int(self.state);
     <div>
-      <p> (ReasonReact.stringToElement countMsg) </p>
-      <button onClick=(self.reduce (fun _event => Add))> (ReasonReact.stringToElement "Add") </button>
+      <p> (ReasonReact.stringToElement(countMsg)) </p>
+      <button onClick=(self.reduce((_event) => Add))>
+        (ReasonReact.stringToElement("Add"))
+      </button>
     </div>
   }
 };

--- a/examples/with-reasonml/components/Header.re
+++ b/examples/with-reasonml/components/Header.re
@@ -1,13 +1,12 @@
-let component = ReasonReact.statelessComponent "Header";
-let styles = ReactDOMRe.Style.make
-  marginRight::"10px"
-  ();
-let make _children => {
+let component = ReasonReact.statelessComponent("Header");
+
+let styles = ReactDOMRe.Style.make(~marginRight="10px", ());
+
+let make = (_children) => {
   ...component,
-  render: fun _self => {
+  render: (_self) =>
     <div>
-      <a href="/" style=styles> (ReasonReact.stringToElement "Home") </a>
-      <a href="/about" style=styles> (ReasonReact.stringToElement "About") </a>
+      <a href="/" style=styles> (ReasonReact.stringToElement("Home")) </a>
+      <a href="/about" style=styles> (ReasonReact.stringToElement("About")) </a>
     </div>
-  }
 };

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -2,18 +2,20 @@
   "name": "with-reasonml",
   "version": "1.0.0",
   "scripts": {
-    "dev": "concurrently \"bsb --clean-world -make-world -w\" \"next -w\"",
+    "dev": "concurrently \"bsb -clean-world -make-world -w\" \"next -w\"",
     "build": "bsb -clean-world -make-world && next build",
     "start": "bsb -clean-world -make-world && next start -w"
   },
   "license": "ISC",
   "dependencies": {
-    "babel-plugin-bucklescript": "^0.2.3-1",
-    "bs-platform": "^1.9.3",
+    "babel-plugin-bucklescript": "^0.2.4",
     "concurrently": "^3.5.0",
     "next": "^3.2.2",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "reason-react": "^0.2.3"
+    "reason-react": "^0.2.4"
+  },
+  "devDependencies": {
+    "bs-platform": "^2.1.0"
   }
 }

--- a/examples/with-reasonml/pages/About.re
+++ b/examples/with-reasonml/pages/About.re
@@ -1,15 +1,13 @@
-let component = ReasonReact.statelessComponent "About";
-let make _children => {
+let component = ReasonReact.statelessComponent("About");
+
+let make = (_children) => {
   ...component,
-  render: fun _self => {
+  render: (_self) =>
     <div>
       <Header />
-      <p>(ReasonReact.stringToElement "This is the about page.")</p>
+      <p> (ReasonReact.stringToElement("This is the about page.")) </p>
       <Counter />
     </div>
-  }
 };
-let jsComponent =
-  ReasonReact.wrapReasonForJs
-    ::component
-    (fun _jsProps => make [||])
+
+let jsComponent = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));

--- a/examples/with-reasonml/pages/Index.re
+++ b/examples/with-reasonml/pages/Index.re
@@ -1,15 +1,13 @@
-let component = ReasonReact.statelessComponent "Index";
-let make _children => {
+let component = ReasonReact.statelessComponent("Index");
+
+let make = (_children) => {
   ...component,
-  render: fun _self => {
+  render: (_self) =>
     <div>
       <Header />
-      <p>(ReasonReact.stringToElement "HOME PAGE is here!")</p>
+      <p> (ReasonReact.stringToElement("HOME PAGE is here!")) </p>
       <Counter />
     </div>
-  }
 };
-let jsComponent =
-  ReasonReact.wrapReasonForJs
-    ::component
-    (fun _jsProps => make [||])
+
+let jsComponent = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));


### PR DESCRIPTION
This pull request runs https://github.com/reasonml/upgradeSyntaxFrom2To3 on the source of reasonml's integration example and updates the bs-platform, reason-react and babel-plugin-bucklescript dependencies to the latest versions.

Also fixes "npm run dev" command not cleaning the build files before compiling.