### PR TITLE
Disable comparisons to fix mapbox-gl bundling

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -153,7 +153,12 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
       }),
       new UglifyJSPlugin({
         parallel: true,
-        sourceMap: false
+        sourceMap: false,
+        uglifyOptions: {
+          compress: {
+            comparisons: false
+          }
+        }
       })
     )
     plugins.push(new webpack.optimize.ModuleConcatenationPlugin())


### PR DESCRIPTION
This is temporary fix for failing to uglify libraries like mapbox-gl:

References:
- https://github.com/mishoo/UglifyJS2/issues/2520
- https://github.com/facebookincubator/create-react-app/pull/2379