### PR TITLE
Update reason example to version 3 syntax and fix errors

### DIFF
--- a/examples/with-reasonml/bsconfig.json
+++ b/examples/with-reasonml/bsconfig.json
@@ -6,5 +6,6 @@
   "package-specs": ["commonjs"],
   "bsc-flags": [
     "-bs-super-errors"
-  ]
+  ],
+  "refmt": 3
 }

--- a/examples/with-reasonml/components/Counter.re
+++ b/examples/with-reasonml/components/Counter.re
@@ -1,21 +1,22 @@
 type action =
   | Add;
 
-let component = ReasonReact.reducerComponent "Counter";
+let component = ReasonReact.reducerComponent("Counter");
 
-let make _children => {
+let make = (_children) => {
   ...component,
-  initialState: fun () => 0,
-  reducer: fun action state =>
+  initialState: () => 0,
+  reducer: (action, state) =>
     switch action {
-    | Add => ReasonReact.Update {state + 1}
+    | Add => ReasonReact.Update(state + 1)
     },
-  render: fun self => {
-    let countMsg = "Count: " ^ (string_of_int self.state);
-
+  render: (self) => {
+    let countMsg = "Count: " ++ string_of_int(self.state);
     <div>
-      <p> (ReasonReact.stringToElement countMsg) </p>
-      <button onClick=(self.reduce (fun _event => Add))> (ReasonReact.stringToElement "Add") </button>
+      <p> (ReasonReact.stringToElement(countMsg)) </p>
+      <button onClick=(self.reduce((_event) => Add))>
+        (ReasonReact.stringToElement("Add"))
+      </button>
     </div>
   }
 };

--- a/examples/with-reasonml/components/Header.re
+++ b/examples/with-reasonml/components/Header.re
@@ -1,13 +1,12 @@
-let component = ReasonReact.statelessComponent "Header";
-let styles = ReactDOMRe.Style.make
-  marginRight::"10px"
-  ();
-let make _children => {
+let component = ReasonReact.statelessComponent("Header");
+
+let styles = ReactDOMRe.Style.make(~marginRight="10px", ());
+
+let make = (_children) => {
   ...component,
-  render: fun _self => {
+  render: (_self) =>
     <div>
-      <a href="/" style=styles> (ReasonReact.stringToElement "Home") </a>
-      <a href="/about" style=styles> (ReasonReact.stringToElement "About") </a>
+      <a href="/" style=styles> (ReasonReact.stringToElement("Home")) </a>
+      <a href="/about" style=styles> (ReasonReact.stringToElement("About")) </a>
     </div>
-  }
 };

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -8,12 +8,14 @@
   },
   "license": "ISC",
   "dependencies": {
-    "babel-plugin-bucklescript": "^0.2.3-1",
-    "bs-platform": "^1.9.3",
-    "concurrently": "^3.5.0",
-    "next": "^3.2.2",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
-    "reason-react": "^0.2.3"
+    "babel-plugin-bucklescript": "^0.2.4",
+    "next": "^4.1.4",
+    "react": "^16.1.1",
+    "react-dom": "^16.1.1",
+    "reason-react": "^0.3.0"
+  },
+  "devDependencies": {
+    "bs-platform": "^2.1.0",
+    "webpack": "^3.8.1"
   }
 }

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -2,7 +2,7 @@
   "name": "with-reasonml",
   "version": "1.0.0",
   "scripts": {
-    "dev": "concurrently \"bsb --clean-world -make-world -w\" \"next -w\"",
+    "dev": "concurrently \"bsb -clean-world -make-world -w\" \"next -w\"",
     "build": "bsb -clean-world -make-world && next build",
     "start": "bsb -clean-world -make-world && next start -w"
   },

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "bs-platform": "^2.1.0",
+    "concurrently": "^3.5.1",
     "webpack": "^3.8.1"
   }
 }

--- a/examples/with-reasonml/pages/About.re
+++ b/examples/with-reasonml/pages/About.re
@@ -1,15 +1,13 @@
-let component = ReasonReact.statelessComponent "About";
-let make _children => {
+let component = ReasonReact.statelessComponent("About");
+
+let make = (_children) => {
   ...component,
-  render: fun _self => {
+  render: (_self) =>
     <div>
       <Header />
-      <p>(ReasonReact.stringToElement "This is the about page.")</p>
+      <p> (ReasonReact.stringToElement("This is the about page.")) </p>
       <Counter />
     </div>
-  }
 };
-let jsComponent =
-  ReasonReact.wrapReasonForJs
-    ::component
-    (fun _jsProps => make [||])
+
+let jsComponent = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));

--- a/examples/with-reasonml/pages/Index.re
+++ b/examples/with-reasonml/pages/Index.re
@@ -1,15 +1,13 @@
-let component = ReasonReact.statelessComponent "Index";
-let make _children => {
+let component = ReasonReact.statelessComponent("Index");
+
+let make = (_children) => {
   ...component,
-  render: fun _self => {
+  render: (_self) =>
     <div>
       <Header />
-      <p>(ReasonReact.stringToElement "HOME PAGE is here!")</p>
+      <p> (ReasonReact.stringToElement("HOME PAGE is here!")) </p>
       <Counter />
     </div>
-  }
 };
-let jsComponent =
-  ReasonReact.wrapReasonForJs
-    ::component
-    (fun _jsProps => make [||])
+
+let jsComponent = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));


### PR DESCRIPTION
Fixes #3348 

I'm aware that #3341 exists, but that PR uses old versions of React and Next dependencies.

This PR was modelled after the project generated by the official ReasonReact project, i.e. the project generated by:

```
bsb -init my-react-app -theme react
```

## What this PR does

- Upgrade syntax from version 2 to 3.
- Run `refmt` on all files.
- Split up `dependencies` and `devDependencies`.
- Upgrade all dependencies.
- Add `webpack` as a dependency (as per reason-react [example](https://github.com/reasonml-community/reason-react-example/blob/master/package.json#L28)). `npm run build` fails without it with error like this: 

  ```
  [4/4] Building pages/Index.cmj
  module.js:544
      throw err;
      ^

  Error: Cannot find module 'webpack/lib/RequestShortener'
  <stack trace omitted>
  ```

## Some issues with the current example (copied from issue #3348 )

- old syntax
- old dependencies
- mixing of `dependencies` and `devDependencies`
- `dev` script doesn't clean build folder