### PR TITLE
Fix trouble when fail to build. UglifyJs Unexpected character '`'

### DIFF
--- a/examples/with-scoped-stylesheets-and-postcss/next.config.js
+++ b/examples/with-scoped-stylesheets-and-postcss/next.config.js
@@ -3,10 +3,6 @@ const trash = require('trash')
 
 module.exports = {
   webpack: (config) => {
-    config.plugins = config.plugins.filter(
-      (plugin) => (plugin.constructor.name !== 'UglifyJsPlugin')
-    )
-
     config.module.rules.push(
       {
         test: /\.css$/,

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -150,7 +150,10 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
       new CombineAssetsPlugin({
         input: ['manifest.js', 'commons.js', 'main.js'],
         output: 'app.js'
-      }),
+      })
+    )
+    plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
+    plugins.unshift(
       new UglifyJSPlugin({
         parallel: true,
         sourceMap: false,
@@ -161,7 +164,6 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
         }
       })
     )
-    plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
   }
 
   const nodePathList = (process.env.NODE_PATH || '')


### PR DESCRIPTION
Fix error with Unexpected character '`' when we are trying to build scoped postcss app for production. 

before:
```
npm run build

> with-scoped-stylesheets-and-postcss@1.0.0 build /Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss
> next build

> Using external babel configuration
> Location: "/Users/artemabzanov/projects/forked.next/examples/.babelrc"
> Using "webpack" config function defined in next.config.js.
Warning: postcss-cssnext found a duplicate plugin ('autoprefixer') in your postcss plugins. This might be inefficient. You should remove 'autoprefixer' from your postcss plugin list since it's already included by postcss-cssnext.
Note: If, for a really specific reason, postcss-cssnext warnings are irrelevant for your use case, and you really know what you are doing, you can disable this warnings by setting  'warnForDuplicates' option of postcss-cssnext to 'false'.
> Failed to build on /var/folders/rl/98nbdm411ss96smmktmchdpc0000gn/T/97cdfe9b-9b5e-433f-8d8a-d7fb064e4af5
{ Error: commons.js from UglifyJs
Unexpected character '`' [commons.js:9628,91]
    at /Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/next/dist/server/build/index.js:182:21
    at emitRecords.err (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/webpack/lib/Compiler.js:269:13)
    at Compiler.emitRecords (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/webpack/lib/Compiler.js:375:38)
    at emitAssets.err (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/webpack/lib/Compiler.js:262:10)
    at applyPluginsAsyncSeries1.err (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/webpack/lib/Compiler.js:368:12)
    at next (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/tapable/lib/Tapable.js:218:11)
    at Compiler.compiler.plugin (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/webpack/lib/performance/SizeLimitsPlugin.js:99:4)
    at Compiler.applyPluginsAsyncSeries1 (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/tapable/lib/Tapable.js:222:13)
    at Compiler.afterEmit (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/webpack/lib/Compiler.js:365:9)
    at require.forEach.err (/Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss/node_modules/webpack/lib/Compiler.js:354:15)
  errors:
   [ 'commons.js from UglifyJs\nUnexpected character \'`\' [commons.js:9628,91]' ],
  warnings: [] }
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! with-scoped-stylesheets-and-postcss@1.0.0 build: `next build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the with-scoped-stylesheets-and-postcss@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/artemabzanov/.npm/_logs/2017-11-30T01_01_16_604Z-debug.log
```

after:
```
npm run build

> with-scoped-stylesheets-and-postcss@1.0.0 build /Users/artemabzanov/projects/forked.next/examples/with-scoped-stylesheets-and-postcss
> next build

> Using external babel configuration
> Location: "/Users/artemabzanov/projects/forked.next/examples/.babelrc"
> Using "webpack" config function defined in next.config.js.
Warning: postcss-cssnext found a duplicate plugin ('autoprefixer') in your postcss plugins. This might be inefficient. You should remove 'autoprefixer' from your postcss plugin list since it's already included by postcss-cssnext.
Note: If, for a really specific reason, postcss-cssnext warnings are irrelevant for your use case, and you really know what you are doing, you can disable this warnings by setting  'warnForDuplicates' option of postcss-cssnext to 'false'.
```