### PR TITLE
Set babel cache directory inside build dir

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -164,12 +164,14 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
   }
 
+  const outputPath = buildDir ? join(buildDir, '.next') : join(dir, config.distDir)
+
   const nodePathList = (process.env.NODE_PATH || '')
     .split(process.platform === 'win32' ? ';' : ':')
     .filter((p) => !!p)
 
   const mainBabelOptions = {
-    cacheDirectory: true,
+    cacheDirectory: join(outputPath, 'cache'),
     presets: []
   }
 
@@ -287,7 +289,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     },
     options: {
       babelrc: false,
-      cacheDirectory: true,
+      cacheDirectory: mainBabelOptions.cacheDirectory,
       presets: [require.resolve('./babel/preset')]
     }
   }, {
@@ -304,7 +306,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     context: dir,
     entry,
     output: {
-      path: buildDir ? join(buildDir, '.next') : join(dir, config.distDir),
+      path: outputPath,
       filename: '[name]',
       libraryTarget: 'commonjs2',
       publicPath: `/_next/${buildId}/webpack/`,


### PR DESCRIPTION
This can potentially fix #3276 and other similar issues.

Use case it fixes:

1. Babel plugins do something that modifies files in `.next` directory (e.g. copies static files there)
2. Babel creates caches in `node_modules/.cache`
3. User makes some changes and next.js clears .next directory
4. Build runs again, but babel sees cache in `node_modules/.cache`. It skips running babel plugins that should modify files in `.next`
5. Suddenly the second time app is run `.next` is missing some files

I'm not 100% sure I'll fix things but has potential to make them better