### PR TITLE
use underscore in node_modules in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@
   language: "node_js",
   node_js: ["6"],
   cache: {
-    directories: ["node-modules"]
+    directories: ["node_modules"]
   },
   before_install: [
     "rm yarn.lock",


### PR DESCRIPTION
The cached directory for node_modules has a dash. AFAIK node uses an underscore, not a dash, for node_modules.

Alternatively, remove it from cached directories if the typo isn't causing any problems.