### PR TITLE
examples: add create-next-app

### DIFF
--- a/examples/active-class-name/README.md
+++ b/examples/active-class-name/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example active-class-name active-class-name-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/basic-css/README.md
+++ b/examples/basic-css/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example basic-css basic-css-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/custom-server-express/README.md
+++ b/examples/custom-server-express/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example custom-server-express custom-server-express-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/custom-server-fastify/README.md
+++ b/examples/custom-server-fastify/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example custom-server-fastify custom-server-fastify-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/custom-server-hapi/README.md
+++ b/examples/custom-server-hapi/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example custom-server-hapi custom-server-hapi-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/custom-server-koa/README.md
+++ b/examples/custom-server-koa/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example custom-server-koa custom-server-koa-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/custom-server-micro/README.md
+++ b/examples/custom-server-micro/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example custom-server-micro custom-server-micro-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/custom-server-nodemon/README.md
+++ b/examples/custom-server-nodemon/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example custom-server-nodemon custom-server-nodemon-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example custom-server custom-server-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/data-fetch/README.md
+++ b/examples/data-fetch/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example data-fetch data-fetch-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/form-handler/README.md
+++ b/examples/form-handler/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example form-handler form-handler-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/head-elements/README.md
+++ b/examples/head-elements/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example head-elements head-elements-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example hello-world hello-world-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/layout-component/README.md
+++ b/examples/layout-component/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example layout-component layout-component-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/nested-components/README.md
+++ b/examples/nested-components/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example nested-components nested-components-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/page-transitions/README.md
+++ b/examples/page-transitions/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example page-transitions page-transitions-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/parameterized-routing/README.md
+++ b/examples/parameterized-routing/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example parameterized-routing parameterized-routing-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example progressive-render progressive-render-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/root-static-files/README.md
+++ b/examples/root-static-files/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example root-static-files root-static-files-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/shared-modules/README.md
+++ b/examples/shared-modules/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example shared-modules shared-modules-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/ssr-caching/README.md
+++ b/examples/ssr-caching/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example ssr-caching ssr-caching-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/svg-components/README.md
+++ b/examples/svg-components/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example svg-components svg-components-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/using-inferno/README.md
+++ b/examples/using-inferno/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example using-inferno using-inferno-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/using-preact/README.md
+++ b/examples/using-preact/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example using-preact using-preact-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/using-router/README.md
+++ b/examples/using-router/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example using-router using-router-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/using-with-router/README.md
+++ b/examples/using-with-router/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example using-with-router using-with-router-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-absolute-imports/README.md
+++ b/examples/with-absolute-imports/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-absolute-imports with-absolute-imports-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-algolia-react-instantsearch/README.md
+++ b/examples/with-algolia-react-instantsearch/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-algolia-react-instantsearch with-algolia-react-instantsearch-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-amp/README.md
+++ b/examples/with-amp/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-amp with-amp-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js.git):
 
 ```bash

--- a/examples/with-ant-design/README.md
+++ b/examples/with-ant-design/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-ant-design with-ant-design-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-antd-mobile/README.md
+++ b/examples/with-antd-mobile/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-antd-mobile with-antd-mobile-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-aphrodite/README.md
+++ b/examples/with-aphrodite/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-aphrodite with-aphrodite-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-apollo-and-redux/README.md
+++ b/examples/with-apollo-and-redux/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-apollo-and-redux with-apollo-and-redux-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-apollo-auth/README.md
+++ b/examples/with-apollo-auth/README.md
@@ -7,6 +7,17 @@ https://next-with-apollo-auth.now.sh
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-apollo-auth with-apollo-auth-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-apollo/README.md
+++ b/examples/with-apollo/README.md
@@ -7,6 +7,17 @@ https://next-with-apollo.now.sh
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-apollo with-apollo-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-asset-imports/README.md
+++ b/examples/with-asset-imports/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-asset-imports with-asset-imports-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-babel-macros/README.md
+++ b/examples/with-babel-macros/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-babel-macros with-babel-macros-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-cxs/README.md
+++ b/examples/with-cxs/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-cxs with-cxs-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-dotenv/README.md
+++ b/examples/with-dotenv/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-dotenv with-dotenv-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-dynamic-import/README.md
+++ b/examples/with-dynamic-import/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-dynamic-import with-dynamic-import-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-electron/readme.md
+++ b/examples/with-electron/readme.md
@@ -2,7 +2,18 @@
 
 **You can find a detailed documentation about how to build Electron apps with Next.js [here](https://leo.im/2017/electron-next)!**
 
-## Usage
+## How to use
+
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-electron with-electron-app
+```
+
+### Download manually
 
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 

--- a/examples/with-emotion/README.md
+++ b/examples/with-emotion/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-emotion with-emotion-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-fela/README.md
+++ b/examples/with-fela/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-fela with-fela-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-firebase-authentication/README.md
+++ b/examples/with-firebase-authentication/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-firebase-authentication with-firebase-authentication-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-firebase-hosting with-firebase-hosting-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-flow/README.md
+++ b/examples/with-flow/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-flow with-flow-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-freactal/README.md
+++ b/examples/with-freactal/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-freactal with-freactal-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-glamor/README.md
+++ b/examples/with-glamor/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-glamor with-glamor-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-glamorous/README.md
+++ b/examples/with-glamorous/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-glamorous with-glamorous-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-global-stylesheet/README.md
+++ b/examples/with-global-stylesheet/README.md
@@ -6,6 +6,17 @@ This is an example of how you can include a global stylesheet in a next.js webap
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-global-stylesheet with-global-stylesheet-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-hashed-statics/README.md
+++ b/examples/with-hashed-statics/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-hashed-statics with-hashed-statics-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-higher-order-component/README.md
+++ b/examples/with-higher-order-component/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-higher-order-component with-higher-order-component-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 Install it and run:

--- a/examples/with-i18next/README.md
+++ b/examples/with-i18next/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-i18next with-i18next-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-jest/README.md
+++ b/examples/with-jest/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-jest with-jest-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-kea/README.md
+++ b/examples/with-kea/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-kea with-kea-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-loading/README.md
+++ b/examples/with-loading/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-loading with-loading-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-material-ui-next/README.md
+++ b/examples/with-material-ui-next/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-material-ui-next with-material-ui-next-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/callemall/material-ui):
 
 ```bash

--- a/examples/with-material-ui/README.md
+++ b/examples/with-material-ui/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-material-ui with-material-ui-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-mobx with-mobx-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-next-routes/README.md
+++ b/examples/with-next-routes/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-next-routes with-next-routes-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-noscript/README.md
+++ b/examples/with-noscript/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-noscript with-noscript-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ## Development

--- a/examples/with-pkg/README.md
+++ b/examples/with-pkg/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-pkg with-pkg-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-portals/README.md
+++ b/examples/with-portals/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-portals with-portals-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-prefetching/README.md
+++ b/examples/with-prefetching/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-prefetching with-prefetching-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-pretty-url-routing/README.md
+++ b/examples/with-pretty-url-routing/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-pretty-url-routing with-pretty-url-routing-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-react-ga/README.md
+++ b/examples/with-react-ga/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-react-ga with-react-ga-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-react-helmet/README.md
+++ b/examples/with-react-helmet/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-react-helmet with-react-helmet-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-react-intl/README.md
+++ b/examples/with-react-intl/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-react-intl with-react-intl-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js.git):
 
 ```bash

--- a/examples/with-react-md/README.md
+++ b/examples/with-react-md/README.md
@@ -6,6 +6,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-react-md with-react-md-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-react-toolbox/README.md
+++ b/examples/with-react-toolbox/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-react-toolbox with-react-toolbox-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-react-uwp/README.md
+++ b/examples/with-react-uwp/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-react-uwp with-react-uwp-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-react-with-styles/README.md
+++ b/examples/with-react-with-styles/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-react-with-styles with-react-with-styles-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-reasonml/README.md
+++ b/examples/with-reasonml/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-reasonml with-reasonml-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-rebass/README.md
+++ b/examples/with-rebass/README.md
@@ -6,6 +6,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-rebass with-rebass-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-recompose/README.md
+++ b/examples/with-recompose/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-recompose with-recompose-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-redux-code-splitting/README.md
+++ b/examples/with-redux-code-splitting/README.md
@@ -5,6 +5,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-redux-code-splitting with-redux-code-splitting-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-redux-observable/README.md
+++ b/examples/with-redux-observable/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-redux-observable with-redux-observable-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-redux-reselect-recompose/README.md
+++ b/examples/with-redux-reselect-recompose/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-redux-reselect-recompose with-redux-reselect-recompose-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-redux-saga/README.md
+++ b/examples/with-redux-saga/README.md
@@ -6,6 +6,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-redux-saga with-redux-saga-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-redux/README.md
+++ b/examples/with-redux/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-redux with-redux-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-refnux/README.md
+++ b/examples/with-refnux/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-refnux with-refnux-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-relay-modern/README.md
+++ b/examples/with-relay-modern/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-relay-modern with-relay-modern-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-scoped-stylesheets-and-postcss/README.md
+++ b/examples/with-scoped-stylesheets-and-postcss/README.md
@@ -5,6 +5,17 @@ This is an example of using scoped stylesheets and PostCSS, heavily influenced b
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-scoped-stylesheets-and-postcss with-scoped-stylesheets-and-postcss-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-semantic-ui/README.md
+++ b/examples/with-semantic-ui/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-semantic-ui with-semantic-ui-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-sentry with-sentry-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 Install it and run:

--- a/examples/with-shallow-routing/README.md
+++ b/examples/with-shallow-routing/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-shallow-routing with-shallow-routing-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-socket.io/README.md
+++ b/examples/with-socket.io/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-socket.io with-socket.io-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-static-export/README.md
+++ b/examples/with-static-export/README.md
@@ -2,6 +2,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-static-export with-static-export-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-styled-components/README.md
+++ b/examples/with-styled-components/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-styled-components with-styled-components-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-styled-jsx-plugins/README.md
+++ b/examples/with-styled-jsx-plugins/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-styled-jsx-plugins with-styled-jsx-plugins-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-styled-jsx-scss/README.md
+++ b/examples/with-styled-jsx-scss/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-styled-jsx-scss with-styled-jsx-scss-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-styletron/README.md
+++ b/examples/with-styletron/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-styletron with-styletron-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-sw-precache/README.md
+++ b/examples/with-sw-precache/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-sw-precache with-sw-precache-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -6,6 +6,17 @@ This is an example of how you can include a global stylesheet in a next.js webap
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-tailwindcss with-tailwindcss-app
+```
+
+### Download manually
+
 If you like [create-next-app](https://github.com/segmentio/create-next-app) and/or [yarn](https://yarnpkg.com/en/docs/cli/create) simply run:
 
 ```bash

--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -4,7 +4,18 @@
 
 This is a really simple project that show the usage of Next.js with TypeScript.  
 
-## How to use it?  
+## How to use
+
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-typescript with-typescript-app
+```
+
+### Download manually it?  
 
 ```
 npm install

--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -4,7 +4,7 @@
 
 This is a really simple project that show the usage of Next.js with TypeScript.  
 
-## How to use
+## How to use it?
 
 ### Using `create-next-app`
 
@@ -15,8 +15,17 @@ npm i -g create-next-app
 create-next-app --example with-typescript with-typescript-app
 ```
 
-### Download manually it?  
+### Download manually
 
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+  
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/master | tar -xz --strip=2 next.js-master/examples/with-typescript
+cd with-typescript
+```
+
+Install it and run:
+ 
 ```
 npm install
 npm run dev

--- a/examples/with-universal-configuration-runtime/readme.md
+++ b/examples/with-universal-configuration-runtime/readme.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-universal-configuration-runtime with-universal-configuration-runtime-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-universal-configuration/README.md
+++ b/examples/with-universal-configuration/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-universal-configuration with-universal-configuration-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-url-object-routing/README.md
+++ b/examples/with-url-object-routing/README.md
@@ -3,6 +3,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-url-object-routing with-url-object-routing-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-webpack-bundle-analyzer/README.md
+++ b/examples/with-webpack-bundle-analyzer/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-webpack-bundle-analyzer with-webpack-bundle-analyzer-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash

--- a/examples/with-webpack-bundle-size-analyzer/README.md
+++ b/examples/with-webpack-bundle-size-analyzer/README.md
@@ -4,6 +4,17 @@
 
 ## How to use
 
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-webpack-bundle-size-analyzer with-webpack-bundle-size-analyzer-app
+```
+
+### Download manually
+
 Download the example [or clone the repo](https://github.com/zeit/next.js):
 
 ```bash


### PR DESCRIPTION
This PR adds [`create-next-app`](https://github.com/segmentio/create-next-app) to all the examples that have a `How to use`/`Usage` section adding the command line utility and a `Download manually` heading