### PR TITLE
Downgrade strip-ansi to support IE11/Google Fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "recursive-copy": "2.0.6",
     "send": "0.16.1",
     "source-map-support": "0.4.18",
-    "strip-ansi": "4.0.0",
+    "strip-ansi": "3.0.1",
     "styled-jsx": "2.2.1",
     "touch": "3.1.0",
     "unfetch": "3.0.0",


### PR DESCRIPTION
A few discussions:
https://github.com/zeit/next.js/issues/2747
https://github.com/zeit/next.js/issues/3126