### PR TITLE
dynamic imports fix  for non-webpack environments.

### DIFF
--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -20,7 +20,8 @@ const buildImport = (args) => (template(`
       })
       :
       new (require('next/dynamic').SameLoopPromise)((resolve, reject) => {
-        const weakId = require.resolveWeak(SOURCE)
+        eval('require.ensure = function (deps, callback) { callback(require) }')
+        const weakId = require.resolveWeak ? require.resolveWeak(SOURCE) : /*require.resolveWeak*/(SOURCE)
         try {
           const weakModule = __webpack_require__(weakId)
           return resolve(weakModule)

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -9,7 +9,7 @@ const TYPE_IMPORT = 'Import'
 
 const buildImport = (args) => (template(`
   (
-    typeof window === 'undefined' ?
+    typeof require.resolveWeak !== 'function' ?
       new (require('next/dynamic').SameLoopPromise)((resolve, reject) => {
         eval('require.ensure = function (deps, callback) { callback(require) }')
         require.ensure([], (require) => {
@@ -20,8 +20,7 @@ const buildImport = (args) => (template(`
       })
       :
       new (require('next/dynamic').SameLoopPromise)((resolve, reject) => {
-        eval('require.ensure = function (deps, callback) { callback(require) }')
-        const weakId = require.resolveWeak ? require.resolveWeak(SOURCE) : /*require.resolveWeak*/(SOURCE)
+        const weakId = require.resolveWeak(SOURCE)
         try {
           const weakModule = __webpack_require__(weakId)
           return resolve(weakModule)

--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -7,6 +7,13 @@ import Crypto from 'crypto'
 
 const TYPE_IMPORT = 'Import'
 
+/*
+ Added "typeof require.resolveWeak !== 'function'" check instead of
+ "typeof window === 'undefined'" to support dynamic impports in non-webpack environments.
+ "require.resolveWeak" and "require.ensure" are webpack specific methods.
+ They would fail in Node/CommonJS environments.
+*/
+
 const buildImport = (args) => (template(`
   (
     typeof require.resolveWeak !== 'function' ?


### PR DESCRIPTION
Added issue description in #3345 .

Feature detection condition comes handy rather than `typeof window` because of webpack specific methods `require.resolveWeak` and `resolve.ensure` fails in non-webpack environments.

The issue was not with `window` object but with `require.resolveWeak` and `require.ensure` methods used in next handle-import.js file. Both these methods are specific to webpack and would not be available in `node/commonjs` environment.  Jest runs in Node environment and does not recognize `require.resolveWeak` and `require.ensure` methods.

TC39 [dynamic import proposal](https://github.com/tc39/proposal-dynamic-import) works pretty well with Jest testing. Please refer to the [repo](https://github.com/PrudviGali/dynamic-imports-jest-testing). But Nextjs implementation of dynamic imports fails in jest because of above two methods [repo](https://github.com/PrudviGali/nextjs-dynamic-import-test-fail).

@arunoda already mentioned that should not use `process.env.NODE_ENV === 'test'` in #3405. Assuming this would be the appropriate way of handling this issue #3345 .

