### PR TITLE
Use "preset-env" option to configure env preset in with-jest example

### DIFF
--- a/examples/with-jest/.babelrc
+++ b/examples/with-jest/.babelrc
@@ -7,7 +7,13 @@
       "presets": ["next/babel"]
     },
     "test": {
-      "presets": [["env", { "modules": "commonjs" }], "next/babel"]
+      "presets": [
+        ["next/babel", {
+          "preset-env": {
+            "modules": "commonjs"
+          }
+        }]
+      ]
     }
   }
 }


### PR DESCRIPTION
No need to add `env` preset twice.