### PR TITLE
readme: fix next() api documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -721,7 +721,6 @@ app.prepare().then(() => {
 ```
 
 The `next` API is as follows:
-- `next(path: string, opts: object)` - `path` is where the Next project is located
 - `next(opts: object)`
 
 Supported options:


### PR DESCRIPTION
Very minor tweak to the readme, it mentions you can do `next(path, options)`, but it is actually just `next(options)`, where path is instead specified with `options.dir`. The readme already covers `options.dir` just below.