### PR TITLE
Update glob-promise to latest 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "fresh": "0.5.2",
     "friendly-errors-webpack-plugin": "1.6.1",
     "glob": "7.1.2",
-    "glob-promise": "3.2.0",
+    "glob-promise": "3.3.0",
     "hoist-non-react-statics": "2.3.1",
     "htmlescape": "1.1.1",
     "http-status": "1.0.1",


### PR DESCRIPTION
v3.2.0 pulls in 20+ MB worth of devDeps of which some are deprecated, and these are shown as warnings to the users of Next.js. Dropping these devDeps is the only change between 3.2.0 and 3.3.0 (see https://github.com/ahmadnassri/glob-promise/releases)

Related glob-promise issue https://github.com/ahmadnassri/glob-promise/pull/52

This seems to decrease the total size of dependencies Next.js installs about 14MB (~8%).

cc @timneutkens, you seem to be the one spotting this issue originally.