### PR TITLE
Fix SVG component example dependencies

### DIFF
--- a/examples/svg-components/package.json
+++ b/examples/svg-components/package.json
@@ -7,7 +7,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest"
+    "next": "latest",
+    "react": "latest,
+    "react-dom": "latest"
   },
   "devDependencies": {
     "babel-plugin-inline-react-svg": "^0.2.0"


### PR DESCRIPTION
React and ReactDOM aren't defined in the package.json, making the example fail if you just deploy it to Now.