### PR TITLE
Make BUILD_ID to be available on front-end

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -128,7 +128,8 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
       filename: 'manifest.js'
     }),
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production')
+      'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production'),
+      'BUILD_ID': buildId
     }),
     new PagesPlugin(),
     new DynamicChunksPlugin(),


### PR DESCRIPTION
Use case: creating meta stylesheet links from extracted stylesheets like so:

```jsx
<link rel='stylesheet' type='text/css' href={`/static/${BUILD_ID}.css`} />
```