### PR TITLE
fix: page-loader load script path

### DIFF
--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -72,7 +72,7 @@ export default class PageLoader {
     let scriptRoute = route
 
     if (__NEXT_DATA__.nextExport) {
-      scriptRoute = route === '/' ? '/index.js' : `${route}/index.js`
+      scriptRoute = route === '/' ? '/index.js' : `${route}.js`
     }
 
     const script = document.createElement('script')


### PR DESCRIPTION
Closes: https://github.com/zeit/next.js/issues/3454
And fixes failing tests on current `canary` branch

Problems happen because `page-loader` expects javascript paths
/dynamic/index.js
/level1/index.js
/level1/about/index.js

while they are exported in `out` dir as
/dynamic.js
/level1.js
/level1/about.js

This PR changes path in page loader `loadScript`.

My first attempt to fix was by changing paths in export but that path proved to be more complicated, styles didn't work and some links were breaking.