### PR TITLE
feat: error when exported path has no backslash

### DIFF
--- a/server/export.js
+++ b/server/export.js
@@ -91,6 +91,9 @@ export default async function (dir, options, configuration) {
 
   for (const path of exportPaths) {
     log(`  exporting path: ${path}`)
+    if (!path.startsWith('/')) {
+      throw new Error(`path "${path}" doesn't start with a backslash`)
+    }
 
     const { page, query = {} } = exportPathMap[path]
     const req = { url: path }


### PR DESCRIPTION
This is alternative to https://github.com/zeit/next.js/pull/3453 if you would merge one then close the other.

This PR will show an error and stop `next export` when the path in `next.config.js` doesn't start with a backslash.

At the moment `canary` branch has failing tests and this PR should fix them: https://github.com/zeit/next.js/pull/3455