### PR TITLE
Allow pages to be render functions (allows persistent layout with no magic)

### DIFF
--- a/examples/with-render-function-pages/components/Layout.js
+++ b/examples/with-render-function-pages/components/Layout.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react'
+import Link from 'next/link'
+
+const linkStyle = {
+  marginRight: 10
+}
+
+export default class Layout extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      counter: 0
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        <header>
+          <Link href='/'><a style={linkStyle}>Home</a></Link>
+          <Link href='/about'><a style={linkStyle}>About</a></Link>
+          <button onClick={() => {
+            this.setState({
+              counter: this.state.counter + 1
+            })
+          }}>
+            Count: {this.state.counter}
+          </button>
+        </header>
+
+        <div>
+          {this.props.children}
+        </div>
+      </div>
+    )
+  }
+}

--- a/examples/with-render-function-pages/package.json
+++ b/examples/with-render-function-pages/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "with-render-function-pages",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "license": "ISC"
+}

--- a/examples/with-render-function-pages/pages/about.js
+++ b/examples/with-render-function-pages/pages/about.js
@@ -1,0 +1,15 @@
+import Layout from '../components/Layout'
+
+const About = () => (
+  <div>
+    The counter lives on because these pages use render functions!
+  </div>
+)
+
+export default function render () {
+  return (
+    <Layout>
+      <About />
+    </Layout>
+  )
+}

--- a/examples/with-render-function-pages/pages/index.js
+++ b/examples/with-render-function-pages/pages/index.js
@@ -1,0 +1,15 @@
+import Layout from '../components/Layout'
+
+const Home = () => (
+  <div>
+    Try out the counter and then go to the about page.
+  </div>
+)
+
+export default function render () {
+  return (
+    <Layout>
+      <Home />
+    </Layout>
+  )
+}

--- a/lib/app.js
+++ b/lib/app.js
@@ -83,7 +83,11 @@ class Container extends Component {
       // https://github.com/gaearon/react-hot-loader/issues/442
       return (
         <AppContainer warnings={false} errorReporter={ErrorDebug}>
-          <Component {...props} url={url} />
+          {
+            Component.name === 'render'
+              ? Component({...props, url})
+              : <Component {...props} url={url} />
+          }
         </AppContainer>
       )
     }


### PR DESCRIPTION
By adding the ability to define a page as a function instead of a component, you can easily create persistent layouts by the natural way that React diffs the tree.

The proposal here is that if the exported function is named `render`, then it's treated as a render function rather than a component. In that case, the return value of that function is rendered rather than creating an element from the component. Any matching root components stay mounted across page transitions. Because you're in control of what is rendered at the root, you can have multiple possible roots that mount/unmount as desired. For example, you could have pages `a` and `b` use `LayoutFoo` and `c` and `d` use `LayoutBar`. `LayoutFoo` would stay mounted while on `a` and `b`, but it would be unmounted when going to `c` and `d`. In this way, this PR is more generic than #3288.

Only a [slight tweak to lib/app.js](https://github.com/jdeal/next.js/commit/086f27bd04310d265aa49b766a1982f3464fe418) is required to make this possible. The rest of this PR is a new example to demonstrate a persistent layout with render function pages.