### PR TITLE
[WIP] Support custom regex for excluding modules from Webpack loaders

### DIFF
--- a/examples/transpile-node-modules/app/.babelrc
+++ b/examples/transpile-node-modules/app/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "next/babel"
+  ]
+}

--- a/examples/transpile-node-modules/app/next.config.js
+++ b/examples/transpile-node-modules/app/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  transpileModules: [
+    /node_modules\/component-[a|b]/
+  ]
+}

--- a/examples/transpile-node-modules/app/next.config.js
+++ b/examples/transpile-node-modules/app/next.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  transpileModules: [
-    /node_modules\/component-[a|b]/
-  ]
+  exclude: /node_modules(?!\/component-[a|b])/
 }

--- a/examples/transpile-node-modules/app/package.json
+++ b/examples/transpile-node-modules/app/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "name": "app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "keywords": [],
+  "author": "Giuseppe Gurgone",
+  "license": "MIT",
+  "dependencies": {
+    "component-a": "file:../component-a",
+    "component-b": "file:../component-b",
+    "next": "file:../../../",
+    "react": "^16.1.1",
+    "react-dom": "^16.1.1"
+  }
+}

--- a/examples/transpile-node-modules/app/pages/index.js
+++ b/examples/transpile-node-modules/app/pages/index.js
@@ -1,0 +1,24 @@
+import Logo from 'component-a'
+
+export default () => (
+  <div>
+    <Logo />
+    <style jsx>{`
+      div {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+
+      div:hover {
+        top: 2em;
+        right: 2em;
+        bottom: 2em;
+        left: 2em;
+        box-shadow: 0 2px 30px black;
+      }
+    `}</style>
+  </div>
+)

--- a/examples/transpile-node-modules/app/pages/index.js
+++ b/examples/transpile-node-modules/app/pages/index.js
@@ -1,4 +1,4 @@
-import Logo from 'component-a'
+import Logo from 'component-a/lib/zeit'
 
 export default () => (
   <div>

--- a/examples/transpile-node-modules/component-a/constants.js
+++ b/examples/transpile-node-modules/component-a/constants.js
@@ -1,0 +1,1 @@
+export const color = 'black'

--- a/examples/transpile-node-modules/component-a/lib/zeit.js
+++ b/examples/transpile-node-modules/component-a/lib/zeit.js
@@ -1,0 +1,30 @@
+import {color} from '../constants'
+import Logo from 'component-b'
+
+export default () => (
+  <h1>
+    <span>Zeit</span>
+    <Logo />
+    <style jsx>{`
+      h1 {
+        display: inline-block;
+        margin: 0;
+        padding: 0;
+        line-height: 1;
+        color: ${color};
+      }
+      span {
+        border: 0;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+        white-space: nowrap;
+      }
+    `}</style>
+  </h1>
+)

--- a/examples/transpile-node-modules/component-a/package.json
+++ b/examples/transpile-node-modules/component-a/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "component-a",
+  "version": "1.0.0",
+  "description": "a test component",
+  "main": "lib/zeit.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Giuseppe Gurgone",
+  "license": "MIT",
+  "dependencies": {
+    "component-b": "file:../component-b"
+  }
+}

--- a/examples/transpile-node-modules/component-b/index.js
+++ b/examples/transpile-node-modules/component-b/index.js
@@ -1,0 +1,16 @@
+export default () => (
+  <span>
+    <style jsx>{`
+       span::before {
+        content: "▲";
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        color: inherit;
+        font-size: inherit;
+        font-family: sans-serif;
+        line-height: 0;
+      }
+    `}</style>
+  </span>
+)

--- a/examples/transpile-node-modules/component-b/package.json
+++ b/examples/transpile-node-modules/component-b/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "component-b",
+  "version": "1.0.0",
+  "description": "b test component",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Giuseppe Gurgone",
+  "license": "MIT"
+}

--- a/readme.md
+++ b/readme.md
@@ -1060,20 +1060,18 @@ Note: Next.js will automatically use that prefix in the scripts it loads, but th
 
 <p><details>
   <summary><b>Examples</b></summary>
-  <ul><li><a href="./examples/with-es6-npm-module-pages">Transpile NPM modules</a></li></ul>
+  <ul><li><a href="./examples/transpile-node-modules">Transpile NPM modules</a></li></ul>
 </details></p>
 
-By default Next.js won't transpile your app dependencies (`node_modules`) such as third parties libraries or components. However it still makes it possible to selectively transform some of them (or all if you will) via the `transpileModules` option in `next.config.js`.
+By default, Next.js won't transpile files within your app's dependencies (`node_modules`) such as third parties libraries or components. However,  you may provide a custom `exclude` option within `next.config.js` in order to modify which files are excluded and selectively transform some (or all) of your app's dependencies.
 
 ```js
 module.exports = {
-  transpileModules: [
-    /node_modules\/react-button/
-  ]
+  exclude: /node_modules(?!\/react-button)/
 }
 ```
 
-`transpileModules` must be an array of regular expressions. When building, Next.js will transpile all of the modules that match at least one of the regular expressions, using the `.babelrc` configuration and falling back to `next/babel` if you don't have one.
+The `exclude` option should be a regular expression (the default value is `/node_modules/` in order to exclude all dependencies). When building, Next.js will skip transpiling any the modules that match this regular expression, using the `.babelrc` configuration and falling back to `next/babel` if you don't have one.
 
 > Note: Currently, Next.js only supports modules installed into `node_modules`. Transpiling modules linked with `npm link <my-comp-name>` might not work as expected or at all.
 

--- a/readme.md
+++ b/readme.md
@@ -1056,6 +1056,28 @@ module.exports = {
 
 Note: Next.js will automatically use that prefix in the scripts it loads, but this has no effect whatsoever on `/static`. If you want to serve those assets over the CDN, you'll have to introduce the prefix yourself. One way of introducing a prefix that works inside your components and varies by environment is documented [in this example](https://github.com/zeit/next.js/tree/master/examples/with-universal-configuration).
 
+### Transpile NPM modules
+
+<p><details>
+  <summary><b>Examples</b></summary>
+  <ul><li><a href="./examples/with-es6-npm-module-pages">Transpile NPM modules</a></li></ul>
+</details></p>
+
+By default Next.js won't transpile your app dependencies (`node_modules`) such as third parties libraries or components. However it still makes it possible to selectively transform some of them (or all if you will) via the `transpileModules` option in `next.config.js`.
+
+```js
+module.exports = {
+  transpileModules: [
+    /node_modules\/react-button/
+  ]
+}
+```
+
+`transpileModules` must be an array of regular expressions. When building, Next.js will transpile all of the modules that match at least one of the regular expressions, using the `.babelrc` configuration and falling back to `next/babel` if you don't have one.
+
+> Note: Currently, Next.js only supports modules installed into `node_modules`. Transpiling modules linked with `npm link <my-comp-name>` might not work as expected or at all.
+
+
 ## Production deployment
 
 To deploy, instead of running `next`, you want to build for production usage ahead of time. Therefore, building and starting are separate commands:

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -38,6 +38,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
   ] : []
   const mainJS = dev
     ? require.resolve('../../client/next-dev') : require.resolve('../../client/next')
+  const excludeRegex = config.exclude || /node_modules/
 
   let totalPages
 
@@ -201,7 +202,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
   }, {
     test: /\.(js|jsx)(\?[^?]*)?$/,
     loader: 'react-hot-loader/webpack',
-    exclude: /node_modules/
+    exclude: excludeRegex
   }] : [])
   .concat([{
     test: /\.json$/,
@@ -211,7 +212,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     loader: 'emit-file-loader',
     include: [dir, nextPagesDir],
     exclude (str) {
-      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
+      return excludeRegex.test(str) && str.indexOf(nextPagesDir) !== 0
     },
     options: {
       name: 'dist/[path][name].[ext]',
@@ -301,7 +302,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     loader: 'babel-loader',
     include: nextPagesDir,
     exclude (str) {
-      return /node_modules/.test(str) && str.indexOf(nextPagesDir) !== 0
+      return excludeRegex.test(str) && str.indexOf(nextPagesDir) !== 0
     },
     options: {
       babelrc: false,
@@ -313,7 +314,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
     loader: 'babel-loader',
     include: [dir],
     exclude (str) {
-      return /node_modules/.test(str)
+      return excludeRegex.test(str)
     },
     options: mainBabelOptions
   }])


### PR DESCRIPTION
This allows the user to specify a custom regular expression to exclude modules from being handled by JS webpack loaders. The regex can be customized to include certain dependencies if transpiling is needed for those modules. (Possible fix for #706)

Example next.config.js (enables transpiling for files within `node_modules/my-module`):
```
module.exports = {
  exclude: /node_modules(?!\/my-module)/
}
```