### PR TITLE
Persistent layout (top-level app component) supporting page by page without any workaround

### DIFF
--- a/examples/persistent-layout/components/AppLayout.js
+++ b/examples/persistent-layout/components/AppLayout.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default class AppLayout extends React.Component {
+  render () {
+    return (
+      <div>
+        <h1>App header</h1>
+        {this.props.children}
+      </div>
+    )
+  }
+}

--- a/examples/persistent-layout/package.json
+++ b/examples/persistent-layout/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "persistent-layout",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "license": "ISC"
+}

--- a/examples/persistent-layout/pages/about.js
+++ b/examples/persistent-layout/pages/about.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import AppLayout from '../components/AppLayout'
+
+export default class AboutPage extends React.Component {
+  static layout = AppLayout
+
+  render () {
+    return (
+      <div>
+        about
+      </div>
+    )
+  }
+}

--- a/examples/persistent-layout/pages/index.js
+++ b/examples/persistent-layout/pages/index.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import Link from 'next/link'
+import AppLayout from '../components/AppLayout'
+
+export default class IndexPage extends React.Component {
+  static layout = AppLayout
+
+  render () {
+    return (
+      <div>
+        index
+        <Link href='/about'>
+          <a>about</a>
+        </Link>
+      </div>
+    )
+  }
+}

--- a/lib/app.js
+++ b/lib/app.js
@@ -72,9 +72,17 @@ class Container extends Component {
 
   render () {
     const { Component, props, url } = this.props
+    const Layout = (typeof Component.layout === 'function') ? Component.layout : null
+    const component = Layout ? (
+      <Layout pageProps={props} url={url}>
+        <Component {...props} url={url} />
+      </Layout>
+    ) : (
+      <Component {...props} url={url} />
+    )
 
     if (process.env.NODE_ENV === 'production') {
-      return (<Component {...props} url={url} />)
+      return component
     } else {
       const ErrorDebug = require('./error-debug').default
       const { AppContainer } = require('react-hot-loader')
@@ -83,7 +91,7 @@ class Container extends Component {
       // https://github.com/gaearon/react-hot-loader/issues/442
       return (
         <AppContainer warnings={false} errorReporter={ErrorDebug}>
-          <Component {...props} url={url} />
+          {component}
         </AppContainer>
       )
     }


### PR DESCRIPTION
This PR give a simple approach to support persistent layout and setting it page by page without any workaround.

Just use the static property to define the layout component in a single page. It will be something like:
```js
// pages/about.js
import AppLayout from '../components/AppLayout'

export default class AboutPage extends React.Component {
  static pageLayout = AppLayout

  render () {
    return (
      <div>
        about
      </div>
    )
  }
}
```
and
```js
// components/AppLayout.js
export default class AppLayout extends React.Component {
  render () {
    return (
      <div>
        <h1>App header</h1>
        {this.props.children}
      </div>
    )
  }
}
```
If a page's layout was undefined, it will works just like original situation and won't break anything. 
So you can specify the layout setting page by page, instead of a global layout.
I think this approach can resolve persistent layout problem without any pain that won't harm original page mechanism.