### PR TITLE
 Allow filtering of props sent to browser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -887,6 +887,8 @@ The `ctx` object is equivalent to the one received in all [`getInitialProps`](#f
 
 - `renderPage` (`Function`) a callback that executes the actual React rendering logic (synchronously). It's useful to decorate this function in order to support server-rendering wrappers like Aphrodite's [`renderStatic`](https://github.com/Khan/aphrodite#server-side-rendering)
 
+In some rare cases, `getInitialProps()` may return data that shouldn't be visible to the browser. `NextScript` accepts `filterProps` (`Function`) where you can intercept and remove those props.
+
 __Note: React-components outside of `<Main />` will not be initialised by the browser. If you need shared components in all your pages (like a menu or a toolbar), do _not_ add application logic  here, but take a look at [this example](https://github.com/zeit/next.js/tree/master/examples/layout-component).__
 
 ### Custom error handling

--- a/server/document.js
+++ b/server/document.js
@@ -119,11 +119,11 @@ export class Main extends Component {
 export class NextScript extends Component {
   static propTypes = {
     nonce: PropTypes.string,
-    propsFilter: PropTypes.func,
+    propsFilter: PropTypes.func
   }
 
   static defaultProps = {
-    propsFilter: props => props,
+    propsFilter: props => props
   }
 
   static contextTypes = {
@@ -183,7 +183,7 @@ export class NextScript extends Component {
     const pagePathname = getPagePathname(pathname)
     const nextData = {
       ...__NEXT_DATA__,
-      props: propsFilter(__NEXT_DATA__.props),
+      props: this.props.propsFilter(__NEXT_DATA__.props)
     }
 
     __NEXT_DATA__.chunks = chunks

--- a/server/document.js
+++ b/server/document.js
@@ -118,7 +118,12 @@ export class Main extends Component {
 
 export class NextScript extends Component {
   static propTypes = {
-    nonce: PropTypes.string
+    nonce: PropTypes.string,
+    propsFilter: PropTypes.func,
+  }
+
+  static defaultProps = {
+    propsFilter: props => props,
   }
 
   static contextTypes = {
@@ -176,13 +181,17 @@ export class NextScript extends Component {
     const { staticMarkup, __NEXT_DATA__, chunks } = this.context._documentProps
     const { pathname, buildId, assetPrefix } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
+    const nextData = {
+      ...__NEXT_DATA__,
+      props: propsFilter(__NEXT_DATA__.props),
+    }
 
     __NEXT_DATA__.chunks = chunks
 
     return <Fragment>
       {staticMarkup ? null : <script nonce={this.props.nonce} dangerouslySetInnerHTML={{
         __html: `
-          __NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)}
+          __NEXT_DATA__ = ${htmlescape(nextData)}
           module={}
           __NEXT_LOADED_PAGES__ = []
           __NEXT_LOADED_CHUNKS__ = []


### PR DESCRIPTION
With a custom Document renderer, `filterProps` can be passed to `NextScript`, which is passed the result of `getInitialProps()`. Enables more complex usecases such as referring to `ctx.req.cookie` on server, but `document.cookie` on client.

For exmaple, imagine this scenario:

```javascript
class About extends React.Component {
  static getInitialProps({ req }) {
    return { req }; // Normally this would cause a serialization error
  }

  render() {
    return <Header req={this.req} />;
  }
}

class Header extends React.Component {
  constructor(props) {
    super(props);
    this.state = {
      // A contrived example, but imagine a component that handles its own cookies, which isn't the page-level component
      loggedIn: parseCookie(props.req ? props.req.cookie : document.cookie),
    };
  }
  render() {
    return <div>{this.state.loggedIn ? 'Logged in' : 'Logged out'}</div>;
  }
}

export default class MyDocument extends Document {
  render() {
    return (
      <html lang="en-AU">
        <Head />
        <body>
          <Main />
          {/* Drop `req` so it never gets to the browser */}
          <NextScriptFilter filterProps={filterOutReq} />
        </body>
      </html>
    );
  }
}

function filterOutReq(props) {
  return {
    ...props,
    req: undefined,
  }
}
```

---

Until merged, my current workaround involves the following:

```javascript
class NextScriptFilter extends React.Component {
  static propTypes = {
    filterProps: propTypes.func,
  };

  static defaultProps = {
    filterProps: p => p,
  };

  static contextTypes = {
    _documentProps: propTypes.any,
  };

  static childContextTypes = {
    _documentProps: propTypes.any,
  };

  getChildContext() {
    /* eslint-disable no-underscore-dangle */
    return {
      _documentProps: {
        ...this.context._documentProps,
        __NEXT_DATA__: {
          ...this.context._documentProps.__NEXT_DATA__,
          props: this.props.filterProps(this.context._documentProps.__NEXT_DATA__.props),
        },
      },
    };
    /* eslint-enable no-underscore-dangle */
  }

  render() {
    return <NextScript />;
  }
}
```