### PR TITLE
Examples/custom server charset

### DIFF
--- a/examples/custom-charset/README.md
+++ b/examples/custom-charset/README.md
@@ -1,0 +1,25 @@
+# Custom Charset example
+
+## How to use
+
+### Download manually
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/custom-charset
+cd custom-charset
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```

--- a/examples/custom-charset/README.md
+++ b/examples/custom-charset/README.md
@@ -23,3 +23,7 @@ Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.
 ```bash
 now
 ```
+
+## The idea behind the example
+
+The goal of this example is to demonstrate how to set character encoding both client-side and server-side. The app is built using a custom express server and the headers are set there. Those headers are then passed to the client via the getInitialProps method and the meta tag. If no character encoding is set either server-side or client-side then the app will default to utf-8 encoding.

--- a/examples/custom-charset/package.json
+++ b/examples/custom-charset/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "custom-charset",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "express": "^4.14.0",
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  }
+}

--- a/examples/custom-charset/pages/index.js
+++ b/examples/custom-charset/pages/index.js
@@ -3,7 +3,7 @@ import Head from 'next/head'
 export default class Index extends React.Component {
   static async getInitialProps ({res}) {
     let contentType = res._headers['content-type']
-    let charSet = contentType ? contentType.slice(contentType.indexOf('=') + 1, contentType.length) : 'utf-8';
+    let charSet = contentType ? contentType.slice(contentType.indexOf('=') + 1, contentType.length) : 'utf-8'
     return { charSet }
   }
   render () {

--- a/examples/custom-charset/pages/index.js
+++ b/examples/custom-charset/pages/index.js
@@ -3,17 +3,17 @@ import Head from 'next/head'
 export default class Index extends React.Component {
   static async getInitialProps ({res}) {
     let contentType = res._headers['content-type']
-    let charSet = contentType.slice(contentType.indexOf('=') + 1, contentType.length)
+    let charSet = contentType ? contentType.slice(contentType.indexOf('=') + 1, contentType.length) : 'utf-8';
     return { charSet }
   }
   render () {
     return (
-      <ul>
+      <div>
         <Head>
-          <meta charSet={this.props.charSet} class='next-head' />
+          <meta charSet={this.props.charSet} className='next-head' />
           <div>Current charSet {this.props.charSet}</div>
         </Head>
-      </ul>
+      </div>
     )
   }
 }

--- a/examples/custom-charset/pages/index.js
+++ b/examples/custom-charset/pages/index.js
@@ -1,22 +1,19 @@
 import React from 'react'
-import Link from 'next/link'
 import Head from 'next/head'
 export default class Index extends React.Component {
-
   static async getInitialProps ({res}) {
     let contentType = res._headers['content-type']
-    let charSet = contentType.slice(contentType.indexOf('=') + 1, contentType.length);
+    let charSet = contentType.slice(contentType.indexOf('=') + 1, contentType.length)
     return { charSet }
   }
-
-  render(){
+  render () {
     return (
-        <ul>
+      <ul>
         <Head>
-            <meta charSet={this.props.charSet} class="next-head"/>
-            <div>Current charSet: {this.props.charSet}</div>
+          <meta charSet={this.props.charSet} class='next-head' />
+          <div>Current charSet {this.props.charSet}</div>
         </Head>
-        </ul>
-      )
+      </ul>
+    )
   }
 }

--- a/examples/custom-charset/pages/index.js
+++ b/examples/custom-charset/pages/index.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import Link from 'next/link'
+import Head from 'next/head'
+export default class Index extends React.Component {
+
+  static async getInitialProps ({res}) {
+    let contentType = res._headers['content-type']
+    let charSet = contentType.slice(contentType.indexOf('=') + 1, contentType.length);
+    return { charSet }
+  }
+
+  render(){
+    return (
+        <ul>
+        <Head>
+            <meta charSet={this.props.charSet} class="next-head"/>
+            <div>Current charSet: {this.props.charSet}</div>
+        </Head>
+        </ul>
+      )
+  }
+}

--- a/examples/custom-charset/server.js
+++ b/examples/custom-charset/server.js
@@ -17,14 +17,6 @@ app.prepare()
 
   server.use(setCharset)
 
-  server.get('/a', (req, res) => {
-    return app.render(req, res, '/b', req.query)
-  })
-
-  server.get('/b', (req, res) => {
-    return app.render(req, res, '/a', req.query)
-  })
-
   server.get('*', (req, res) => {
     return handle(req, res)
   })

--- a/examples/custom-charset/server.js
+++ b/examples/custom-charset/server.js
@@ -1,0 +1,36 @@
+const express = require('express')
+const next = require('next')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+var setCharset = (req, res, next) => {
+  res.set({'Content-Type': 'text/html; charset=iso-8859-2'})
+  next();
+}
+
+app.prepare()
+.then(() => {
+  const server = express()
+
+  server.use(setCharset)
+
+  server.get('/a', (req, res) => {
+    return app.render(req, res, '/b', req.query)
+  })
+
+  server.get('/b', (req, res) => {
+    return app.render(req, res, '/a', req.query)
+  })
+
+  server.get('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(port, (err) => {
+    if (err) throw err
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})

--- a/examples/custom-charset/server.js
+++ b/examples/custom-charset/server.js
@@ -6,9 +6,9 @@ const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const handle = app.getRequestHandler()
 
-var setCharset = (req, res, next) => {
+let setCharset = (req, res, next) => {
   res.set({'Content-Type': 'text/html; charset=iso-8859-2'})
-  next();
+  next()
 }
 
 app.prepare()


### PR DESCRIPTION
## Custom-charset

### In reference to: 
#3333
#3401

### How

Used the [custom-server-express](https://github.com/zeit/next.js/tree/canary/examples/custom-server-express) example as a foundation and added middleware that sets the header for character sets. The res header is then passed to get initial props as a string.

### Potential Concerns

The one concern I would have is the expression used in getInitialProps to parse "charset" from "content-type". I'm sure there's a better regex expression that's more robust and handles bad content-type inputs but I'm not entirely sure.