### PR TITLE
Remove config from bin/next since it's unused

### DIFF
--- a/bin/next
+++ b/bin/next
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
-import { join, resolve } from 'path'
+import { join } from 'path'
 import { spawn } from 'cross-spawn'
 import pkg from '../../package.json'
-import getConfig from '../server/config'
 
 if (pkg.peerDependencies) {
   Object.keys(pkg.peerDependencies).forEach(dependency => {

--- a/bin/next
+++ b/bin/next
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
-
 import { join, resolve } from 'path'
 import { spawn } from 'cross-spawn'
-import { watchFile } from 'fs'
 import pkg from '../../package.json'
 import getConfig from '../server/config'
 
@@ -88,10 +86,10 @@ const startProcess = () => {
 }
 
 let proc = startProcess()
-const { pagesDirectory = resolve(process.cwd(), 'pages') } = getConfig(process.cwd())
 
 if (cmd === 'dev') {
-  watchFile(`${resolve(pagesDirectory, '..')}/next.config.js`, (cur, prev) => {
+  const {watchFile} = require('fs')
+  watchFile(`${process.cwd()}/next.config.js`, (cur, prev) => {
     if (cur.size > 0 || prev.size > 0) {
       console.log('\n> Found a change in next.config.js, restarting the server...')
       // Don't listen to 'close' now since otherwise parent gets killed by listener


### PR DESCRIPTION
Makes no sense to get the config on build/start. But it also makes no sense to do it for dev. So I've removed it :smile:

Saves ~100ms when booting up depending on the config.