### PR TITLE
[WIP] Allow to fetch pages via dynamic import

### DIFF
--- a/examples/with-link-page/README.md
+++ b/examples/with-link-page/README.md
@@ -1,0 +1,43 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-link-page)
+
+# With Link Page example
+
+## How to use
+
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-link-page with-link-page-app
+```
+
+### Download manually
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-link-page
+cd with-link-page
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example is an optimization for the usual `Link` component. Now, we include a special page prop with the dynamically imported page.
+Then it'll use that to fetch the component and page will be cache-able across multiple builds of the page.
+
+In this case, we need to analyze the `Link` statically. That's the only requirement of this feature.

--- a/examples/with-link-page/package.json
+++ b/examples/with-link-page/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hello-world",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "license": "ISC"
+}

--- a/examples/with-link-page/pages/about.js
+++ b/examples/with-link-page/pages/about.js
@@ -1,0 +1,3 @@
+export default () => (
+  <div>About us</div>
+)

--- a/examples/with-link-page/pages/contact.js
+++ b/examples/with-link-page/pages/contact.js
@@ -1,0 +1,3 @@
+export default () => (
+  <div>Contact us</div>
+)

--- a/examples/with-link-page/pages/index.js
+++ b/examples/with-link-page/pages/index.js
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>Hello World.
+    <br />
+    <Link page={import('./about.js')} href='/about'><a>About</a></Link>
+    <br />
+    <Link page={import('./contact.js')} href='/contact?map=1' prefetch><a>Contact</a></Link>
+  </div>
+)

--- a/lib/link.js
+++ b/lib/link.js
@@ -17,6 +17,7 @@ export default class Link extends Component {
   static propTypes = exact({
     href: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
     as: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    page: PropTypes.object,
     prefetch: PropTypes.bool,
     replace: PropTypes.bool,
     shallow: PropTypes.bool,
@@ -47,7 +48,7 @@ export default class Link extends Component {
       return
     }
 
-    const { shallow } = this.props
+    const { shallow, page } = this.props
     let { href, as } = this
 
     if (!isLocal(href)) {
@@ -72,7 +73,7 @@ export default class Link extends Component {
     const changeMethod = replace ? 'replace' : 'push'
 
     // straight up redirect
-    Router[changeMethod](href, as, { shallow })
+    Router[changeMethod](href, as, { shallow, page })
       .then((success) => {
         if (!success) return
         if (scroll) window.scrollTo(0, 0)
@@ -83,8 +84,15 @@ export default class Link extends Component {
   }
 
   prefetch () {
-    if (!this.props.prefetch) return
+    const { prefetch, page } = this.props
+    if (!prefetch) return
     if (typeof window === 'undefined') return
+
+    if (page) {
+      // Prefetch the page instead of href (url)
+      Router.prefetch(page)
+      return
+    }
 
     // Prefetch the JSON page if asked (only in the client)
     const { pathname } = window.location

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -118,7 +118,6 @@ export default class Router {
 
   async change (method, _url, _as, options) {
     const page = options.page
-    delete options.page
 
     // If url and as provided as an object representation,
     // we'll format them into the string version here.
@@ -187,6 +186,12 @@ export default class Router {
   }
 
   changeState (method, url, as, options = {}) {
+    // options might take some non serializable fields.
+    // In that case, we need to remove them before storing it in the
+    // history's state.
+    // This is not a frequent operation. So, following is the best way
+    // to do it since it won't add any overhead to the client side bundle.
+    options = JSON.parse(JSON.stringify(options))
     if (method !== 'pushState' || getURL() !== as) {
       window.history[method]({ url, as, options }, null, as)
     }

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -117,6 +117,9 @@ export default class Router {
   }
 
   async change (method, _url, _as, options) {
+    const page = options.page
+    delete options.page
+
     // If url and as provided as an object representation,
     // we'll format them into the string version here.
     const url = typeof _url === 'object' ? format(_url) : _url
@@ -159,7 +162,7 @@ export default class Router {
     if (shallow && this.isShallowRoutingPossible(route)) {
       routeInfo = this.components[route]
     } else {
-      routeInfo = await this.getRouteInfo(route, pathname, query, as)
+      routeInfo = await this.getRouteInfo(route, pathname, query, as, { page })
     }
 
     const { error } = routeInfo
@@ -189,13 +192,13 @@ export default class Router {
     }
   }
 
-  async getRouteInfo (route, pathname, query, as) {
+  async getRouteInfo (route, pathname, query, as, options) {
     let routeInfo = null
 
     try {
       routeInfo = this.components[route]
       if (!routeInfo) {
-        routeInfo = { Component: await this.fetchComponent(route, as) }
+        routeInfo = { Component: await this.fetchComponent(route, as, options) }
       }
 
       const { Component } = routeInfo
@@ -286,6 +289,11 @@ export default class Router {
   }
 
   async prefetch (url) {
+    // If this is not an string, it's a promise.
+    // So, we only need to resolve it
+    if (typeof url === 'object') {
+      return (await url).default
+    }
     // We don't add support for prefetch in the development mode.
     // If we do that, our on-demand-entries optimization won't performs better
     if (process.env.NODE_ENV === 'development') return
@@ -295,14 +303,20 @@ export default class Router {
     return this.prefetchQueue.add(() => this.fetchRoute(route))
   }
 
-  async fetchComponent (route, as) {
+  async fetchComponent (route, as, options = {}) {
     let cancelled = false
     const cancel = this.componentLoadCancel = function () {
       cancelled = true
     }
 
     try {
-      const Component = await this.fetchRoute(route)
+      let Component
+
+      if (options.page) {
+        Component = (await options.page).default
+      } else {
+        Component = await this.fetchRoute(route)
+      }
 
       if (cancelled) {
         const error = new Error(`Abort fetching component for route: "${route}"`)

--- a/test/integration/basic/pages/nav/index.js
+++ b/test/integration/basic/pages/nav/index.js
@@ -38,6 +38,7 @@ export default class extends Component {
         <Link href='/nav/as-path' as='/as/path'><a id='as-path-link' style={linkStyle}>As Path</a></Link>
         <Link href='/nav/as-path'><a id='as-path-link-no-as' style={linkStyle}>As Path (No as)</a></Link>
         <Link href='/nav/as-path-using-router'><a id='as-path-using-router-link' style={linkStyle}>As Path (Using Router)</a></Link>
+        <Link href='/nav/about' page={import('./about')}><a id='use-imported-page' style={linkStyle}>Use Imported Page</a></Link>
         <button
           onClick={() => this.visitQueryStringPage()}
           style={linkStyle}

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -461,5 +461,22 @@ export default (context, render) => {
         })
       })
     })
+
+    describe('with imported page', () => {
+      it('should navigate via the client side', async () => {
+        const browser = await webdriver(context.appPort, '/nav')
+
+        const counterText = await browser
+          .elementByCss('#increase').click()
+          .elementByCss('#use-imported-page').click()
+          .waitForElementByCss('.nav-about')
+          .elementByCss('#home-link').click()
+          .waitForElementByCss('.nav-home')
+          .elementByCss('#counter').text()
+
+        expect(counterText).toBe('Counter: 1')
+        browser.close()
+      })
+    })
   })
 }


### PR DESCRIPTION
This is an optimization to our `Link` component which fetches pages via dynamic import. (By statically analyzing Link elements)

With this case, we can support caching pages across multiple builds.

Here's how to use it:

```js
<Link href='/about?team=1' page={import('./about.js')}>
  <a>About</a>
</Link>
```

Have a look at the new `page` prop.

## Issues(questions) we need to address

* [x] Syntax
* [x] Write tests
* [ ] Code Refactor (Specially on the router)
* [ ] Docs