### PR TITLE
Handle throwing undefined

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -22,7 +22,15 @@ export default class App extends Component {
     }
   }
 
-  componentDidCatch (error, info) {
+  componentDidCatch (rawError, info) {
+    let error = rawError
+    if (!error) {
+      const componentName = this.props.Component.displayName || this.props.Component.name
+      error = new Error(
+        `Undefined was thrown while rendering component "${componentName}".\nStacktrace won't be complete.`
+      )
+    }
+
     error.stack = `${error.stack}\n\n${info.componentStack}`
     window.next.renderError(error)
     this.setState({ hasError: true })

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -208,7 +208,14 @@ export default class Router {
       routeInfo.props = await this.getInitialProps(Component, ctx)
 
       this.components[route] = routeInfo
-    } catch (err) {
+    } catch (rawErr) {
+      let err = rawErr
+      if (!err) {
+        err = new Error(
+          `Undefined was thrown while rendering page "${pathname}".\nStacktrace won't be complete.`
+        )
+      }
+
       if (err.cancelled) {
         return { error: err }
       }

--- a/server/index.js
+++ b/server/index.js
@@ -316,7 +316,14 @@ export default class Server {
 
     try {
       return await renderToHTML(req, res, pathname, query, this.renderOpts)
-    } catch (err) {
+    } catch (rawErr) {
+      let err = rawErr
+      if (!err) {
+        err = new Error(
+          `Undefined was thrown while rendering page "${pathname}".\nStacktrace won't be complete.`
+        )
+      }
+
       if (err.code === 'ENOENT') {
         res.statusCode = 404
         return this.renderErrorToHTML(null, req, res, pathname, query)

--- a/test/integration/basic/pages/undefined-error.js
+++ b/test/integration/basic/pages/undefined-error.js
@@ -1,0 +1,3 @@
+export default () => {
+  throw undefined // eslint-disable-line
+}

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -35,6 +35,7 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/stateful'),
       renderViaHTTP(context.appPort, '/stateless'),
       renderViaHTTP(context.appPort, '/styled-jsx'),
+      renderViaHTTP(context.appPort, '/undefined-error'),
       renderViaHTTP(context.appPort, '/with-cdm'),
 
       renderViaHTTP(context.appPort, '/nav'),

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -101,6 +101,11 @@ export default function ({ app }, suiteName, render, fetch) {
       expect($('pre').text()).toMatch(/This is an expected error/)
     })
 
+    test('undefined error', async () => {
+      const $ = await get$('/undefined-error')
+      expect($('pre').text()).toMatch(/Undefined was thrown while rendering page "\/undefined-error".\nStacktrace won't be complete./)
+    })
+
     test('asPath', async () => {
       const $ = await get$('/nav/as-path', { aa: 10 })
       expect($('.as-path-content').text()).toBe('/nav/as-path?aa=10')


### PR DESCRIPTION
This PR handles throwing `undefined` from component or `getInitialProps`.
Current behaviour causes `Internal Serve Error` or internal exception caused by reading `stack` of undefined, which is not very helpful if someone ever throws undefined. This PR handles those cases (server side, client side and HMR) and tries to provide some context that might be helpful for debugging.

Fixes #3186 