### PR TITLE
fixed react dead code elimination for examples

### DIFF
--- a/examples/with-scoped-stylesheets-and-postcss/.babelrc
+++ b/examples/with-scoped-stylesheets-and-postcss/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    "next/babel",
+    "env"
+  ],
+  "plugins": [
+    [
+      "wrap-in-js",
+      {
+        "extensions": ["css$", "less$"]
+      }
+    ]
+  ]
+}

--- a/examples/with-scoped-stylesheets-and-postcss/next.config.js
+++ b/examples/with-scoped-stylesheets-and-postcss/next.config.js
@@ -3,14 +3,15 @@ const trash = require('trash')
 
 module.exports = {
   webpack: (config) => {
-    config.plugins = config.plugins.filter(
-      (plugin) => (plugin.constructor.name !== 'UglifyJsPlugin')
-    )
+    // config.plugins = config.plugins.filter(
+    //   (plugin) => (plugin.constructor.name !== 'UglifyJsPlugin')
+    // )
 
     config.module.rules.push(
       {
         test: /\.css$/,
         use: [
+          'babel-loader',
           {
             loader: 'emit-file-loader',
             options: {
@@ -26,11 +27,10 @@ module.exports = {
 
                 trash(fileName)
 
-                return ['module.exports = {',
-                  `classNames: ${classNames},`,
-                  `stylesheet: \`${content}\``,
-                  '}'
-                ].join('')
+                return `module.exports = {
+                  classNames: ${classNames},
+                  stylesheet: \`${content}\`
+                }`
               }
             }
           },

--- a/examples/with-scoped-stylesheets-and-postcss/package.json
+++ b/examples/with-scoped-stylesheets-and-postcss/package.json
@@ -20,6 +20,7 @@
     "trash": "^4.0.1"
   },
   "devDependencies": {
+    "babel-plugin-wrap-in-js": "1.1.1",
     "now": "^4.10.3"
   }
 }


### PR DESCRIPTION
## for examples with-scoped-stylesheets-and-postcss
hi,if filter UglifyJsPlugin,react will report dead code elimination has not apply.so I del with .css
['babel-loader','emit-file-loader','skeleton-loader','postcss-loader'] and babel-plugin-wrap-in-js.
my english is poor,chinese english:)