### PR TITLE
Revert "remove relative path to babel-runtime (#3119)"

### DIFF
--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -1,4 +1,3 @@
-const babelRuntimePath = require.resolve('babel-runtime/package').replace(/[\\/]package\.json$/, '')
 const relativeResolve = require('../root-module-relative-path').default(require)
 
 // Resolve styled-jsx plugins
@@ -58,7 +57,7 @@ module.exports = (context, opts = {}) => ({
       require.resolve('babel-plugin-module-resolver'),
       {
         alias: {
-          'babel-runtime': babelRuntimePath,
+          'babel-runtime': relativeResolve('babel-runtime/package'),
           'next/link': relativeResolve('../../../lib/link'),
           'next/prefetch': relativeResolve('../../../lib/prefetch'),
           'next/css': relativeResolve('../../../lib/css'),

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -303,7 +303,6 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
           return { content, sourceMap }
         }
 
-        const babelRuntimePath = require.resolve('babel-runtime/package').replace(/[\\/]package\.json$/, '')
         const transpiled = babelCore.transform(content, {
           babelrc: false,
           sourceMaps: dev ? 'both' : false,
@@ -319,7 +318,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
               require.resolve('babel-plugin-module-resolver'),
               {
                 alias: {
-                  'babel-runtime': babelRuntimePath,
+                  'babel-runtime': relativeResolve('babel-runtime/package'),
                   'next/link': relativeResolve('../../lib/link'),
                   'next/prefetch': relativeResolve('../../lib/prefetch'),
                   'next/css': relativeResolve('../../lib/css'),


### PR DESCRIPTION
This reverts commit 8eb80342362c545e511c3b0c5416f4542610ca46.

Fixes #3543

Related to https://github.com/zeit/next.js/pull/3119