### PR TITLE
renderPage API for top-level component rendering & layout feature implementation

### DIFF
--- a/examples/with-next-layouts/layouts/AppLayout.js
+++ b/examples/with-next-layouts/layouts/AppLayout.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import delay from '../modules/delay'
+
+export default class AppLayout extends React.Component {
+  static async getInitialProps () {
+    return {
+      delay: await delay(1000)
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        <h1>App header</h1>
+        {this.props.children}
+      </div>
+    )
+  }
+}

--- a/examples/with-next-layouts/layouts/ContentLayout.js
+++ b/examples/with-next-layouts/layouts/ContentLayout.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import delay from '../modules/delay'
+import AppLayout from './AppLayout'
+
+export default class ContentLayout extends React.Component {
+  static parentLayout = AppLayout
+  static async getInitialProps () {
+    return {
+      delay: await delay(2000)
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        <hr />
+        {this.props.children}
+        <hr />
+      </div>
+    )
+  }
+}

--- a/examples/with-next-layouts/modules/delay.js
+++ b/examples/with-next-layouts/modules/delay.js
@@ -1,0 +1,6 @@
+export default function delay (ms) {
+  return new Promise(resolve => setTimeout(() => {
+    console.log(`sleep ${ms} ms.`)
+    resolve(ms)
+  }, ms))
+}

--- a/examples/with-next-layouts/modules/next-layouts.js
+++ b/examples/with-next-layouts/modules/next-layouts.js
@@ -1,0 +1,81 @@
+import React from 'react'
+const defaultOptions = {
+  getInitialPropsMode: 'sequential'
+}
+
+export default function applyLayout (PageComponent, options) {
+  options = Object.assign({}, defaultOptions, options)
+
+  if (!isFunction(PageComponent.layout)) {
+    warn('Missing static property "layout" of page component.')
+    return PageComponent
+  }
+
+  if (isFunction(PageComponent.renderPage)) {
+    warn('You should not define static property "renderPage" of page component when the layout is applying')
+    return PageComponent
+  }
+
+  // collect layouts & getInitialProps
+  let layouts = [PageComponent.layout]
+  while (isFunction(layouts[0].parentLayout)) {
+    layouts.unshift(layouts[0].parentLayout)
+  }
+  const layoutGetInitialPropsList = layouts.map(Layout => isFunction(Layout.getInitialProps) ? Layout.getInitialProps : () => ({}))
+  const pageGetInitialProps = isFunction(PageComponent.getInitialProps) ? PageComponent.getInitialProps : () => ({})
+
+  PageComponent.getInitialProps = async(ctx) => {
+    let layoutPropsList = []
+    let pageProps
+
+    if (options.getInitialPropsMode === 'sequential') {
+      for (const layoutGetInitialProps of layoutGetInitialPropsList) {
+        const layoutProps = await layoutGetInitialProps(ctx)
+        layoutPropsList.push(layoutProps)
+      }
+      pageProps = await pageGetInitialProps(ctx)
+    } else if (options.getInitialPropsMode === 'concurrent') {
+      const promises = layoutGetInitialPropsList.map(layoutGetInitialProps => layoutGetInitialProps(ctx))
+      promises.push(pageGetInitialProps(ctx))
+      const promiseResults = await Promise.all(promises)
+      pageProps = promiseResults.pop()
+      layoutPropsList = promiseResults
+    }
+
+    return { layoutPropsList, pageProps }
+  }
+
+  PageComponent.renderPage = ({ Component, props: { layoutPropsList, pageProps }, url }) => {
+    return renderLayout({ Component, layouts, pageProps, layoutPropsList, url })
+  }
+
+  return PageComponent
+}
+
+function renderLayout ({ Component, layouts, pageProps, layoutPropsList, url }) {
+  const Layout = layouts[0]
+  const layoutProps = layoutPropsList[0]
+  return (Layout) ? (
+    <Layout {...layoutProps} pageProps={pageProps} url={url}>
+      {renderLayout({
+        Component,
+        layouts: layouts.slice(1, layouts.length),
+        pageProps,
+        layoutPropsList: layoutPropsList.slice(1, layoutPropsList.length),
+        url
+      })}
+    </Layout>
+  ) : (
+    <Component {...pageProps} url={url} />
+  )
+}
+
+function isFunction (func) {
+  return typeof func === 'function'
+}
+
+function warn (message) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(message)
+  }
+}

--- a/examples/with-next-layouts/package.json
+++ b/examples/with-next-layouts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "with-next-layouts",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "license": "ISC"
+}

--- a/examples/with-next-layouts/pages/about.js
+++ b/examples/with-next-layouts/pages/about.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import delay from '../modules/delay'
+import applyLayout from '../modules/next-layouts'
+import ContentLayout from '../components/ContentLayout'
+
+class AboutPage extends React.Component {
+  static layout = ContentLayout
+  static async getInitialProps () {
+    return {
+      delay: await delay(3000)
+    }
+  }
+
+  render () {
+    return (
+      <p>about</p>
+    )
+  }
+}
+
+export default applyLayout(AboutPage, {
+  getInitialPropsMode: 'concurrent'
+})

--- a/examples/with-next-layouts/pages/index.js
+++ b/examples/with-next-layouts/pages/index.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import Link from 'next/link'
+import delay from '../modules/delay'
+import applyLayout from '../modules/next-layouts'
+import ContentLayout from '../components/ContentLayout'
+
+class IndexPage extends React.Component {
+  static layout = ContentLayout
+  static async getInitialProps () {
+    return {
+      delay: await delay(3000)
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        index
+        <Link href='/about'>
+          <a>about</a>
+        </Link>
+      </div>
+    )
+  }
+}
+
+export default applyLayout(IndexPage)

--- a/lib/app.js
+++ b/lib/app.js
@@ -72,9 +72,14 @@ class Container extends Component {
 
   render () {
     const { Component, props, url } = this.props
+    const page = (typeof Component.renderPage === 'function') ? (
+      Component.renderPage(this.props)
+    ) : (
+      <Component {...props} url={url} />
+    )
 
     if (process.env.NODE_ENV === 'production') {
-      return (<Component {...props} url={url} />)
+      return page
     } else {
       const ErrorDebug = require('./error-debug').default
       const { AppContainer } = require('react-hot-loader')
@@ -83,7 +88,7 @@ class Container extends Component {
       // https://github.com/gaearon/react-hot-loader/issues/442
       return (
         <AppContainer warnings={false} errorReporter={ErrorDebug}>
-          <Component {...props} url={url} />
+          {page}
         </AppContainer>
       )
     }


### PR DESCRIPTION
This PR implement the `renderPage` approach in Next.js core, according to discussing in https://github.com/zeit/next.js/pull/3461#issuecomment-352631686. & https://github.com/zeit/next.js/pull/3471

This way can make core API of Next.js stay bare minimal, yet flexible.
With this core API, we can define a static property "renderPage" of page component.
It will be used to decide how page render at top level.

ex:
```js
class IndexPage extends React.Component {
  static renderPage({ Component, props, url }) {
    return (
      <AppLayout>
        <Component {...props} url={url} />
      </AppLayout>
    )
  }

  render () {
    return (
      <p>Index</p>
    )
  }
}
```
And this is enough for us to implement any extra features for persistent layout outside of Next.js core.


So I also implement a sample of third-party extension for layout feature [in this PR](https://github.com/zeit/next.js/pull/3552/files#diff-2f826f233c68478d2b3457c14c12be0b) (outside of Next.js core).

It support the multiple layer, layout's getInitialProps, and getInitialProps's concurrent mode.
so we can do something like:
```js
// layouts/AppLayout.js
import React from 'react'
import delay from '../modules/delay'

export default class AppLayout extends React.Component {
  static async getInitialProps () {
    return {
      delay: await delay(1000)
    }
  }

  render () {
    return (
      <div>
        <h1>App header</h1>
        {this.props.children}
      </div>
    )
  }
}
```

```js
// layouts/ContentLayout.js
import AppLayout from './AppLayout'

export default class ContentLayout extends React.Component {
  static parentLayout = AppLayout
  static async getInitialProps () {
    return {
      delay: await delay(2000)
    }
  }

  render () {
    return (
      <div>
        <hr />
        {this.props.children}
        <hr />
      </div>
    )
  }
}

```

```js
// pages/about.js
import React from 'react'
import delay from '../modules/delay'
import applyLayout from '../modules/next-layouts'
import ContentLayout from '../layouts/ContentLayout'

class AboutPage extends React.Component {
  static layout = ContentLayout
  static async getInitialProps () {
    return {
      delay: await delay(3000)
    }
  }

  render () {
    return (
      <p>about</p>
    )
  }
}

export default applyLayout(AboutPage, {
  getInitialPropsMode: 'concurrent'
})
```


and the output page view will be:
![image](https://user-images.githubusercontent.com/6021943/34746303-76f9b4fa-f5ce-11e7-9aaa-1f4dfa6cb15a.png)


If this approach will be accepted, I think we can make this module to be a npm package that naming "next-layouts".
  
  