### PR TITLE
fix w3c warnings

### DIFF
--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -74,7 +74,6 @@ export default class PageLoader {
     const script = document.createElement('script')
     const url = `${this.assetPrefix}/_next/${encodeURIComponent(this.buildId)}/page${scriptRoute}`
     script.src = url
-    script.type = 'text/javascript'
     script.onerror = () => {
       const error = new Error(`Error when loading route: ${route}`)
       this.pageRegisterEvents.emit(route, { error })

--- a/server/document.js
+++ b/server/document.js
@@ -132,7 +132,6 @@ export class NextScript extends Component {
     return (
       <script
         key={filename}
-        type='text/javascript'
         src={`${assetPrefix}/_next/${hash}/${filename}`}
         {...additionalProps}
       />
@@ -163,7 +162,6 @@ export class NextScript extends Component {
           <script
             async
             key={chunk}
-            type='text/javascript'
             src={`${assetPrefix}/_next/webpack/chunks/${chunk}`}
           />
         ))}
@@ -204,8 +202,8 @@ export class NextScript extends Component {
           `}
         `
       }} />}
-      {page !== '/_error' && <script async id={`__NEXT_PAGE__${pathname}`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} />}
-      <script async id={`__NEXT_PAGE__/_error`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page/_error.js`} />
+      {page !== '/_error' && <script async id={`__NEXT_PAGE__${pathname}`} src={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} />}
+      <script async id={`__NEXT_PAGE__/_error`} src={`${assetPrefix}/_next/${buildId}/page/_error.js`} />
       {staticMarkup ? null : this.getDynamicChunks()}
       {staticMarkup ? null : this.getScripts()}
     </Fragment>


### PR DESCRIPTION
Up until HTML5 `type` was needed for the browser to distinguish between js and other text. With HTML5 it is no longer needed. What browsers do you support?

The issue was raised in https://github.com/mui-org/material-ui/issues/9867. You can reproduce it with the [https://zeit.co/now website](https://validator.w3.org/nu/?doc=https%3A%2F%2Fzeit.co%2Fnow): 
![capture d ecran 2018-01-14 a 16 46 19](https://user-images.githubusercontent.com/3165635/34917729-7ba58f04-f94a-11e7-8db8-2f062ce095b6.png)

I'm assuming it's safe to remove it.