### PR TITLE
Dynamic imports with  named exports

### DIFF
--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -31,7 +31,7 @@ export default function dynamicComponent (p, o) {
 
       this.LoadingComponent = options.loading ? options.loading : () => (<p>loading...</p>)
       this.ssr = options.ssr === false ? options.ssr : true
-
+      this.compName = options.component ? options.component : undefined
       this.state = { AsyncComponent: null, asyncElement: null }
       this.isServer = typeof window === 'undefined'
 
@@ -55,7 +55,7 @@ export default function dynamicComponent (p, o) {
 
     loadComponent () {
       promise.then((m) => {
-        const AsyncComponent = m.default || m
+        const AsyncComponent = this.compName ? m[this.compName] : m.default
         // Set a readable displayName for the wrapper component
         const asyncCompName = getDisplayName(AsyncComponent)
         if (asyncCompName) {


### PR DESCRIPTION
This pull request is a feature allowing dynamic imports to import specific components not just default ones from the module.

The current code only allows default exports to be imported to the outer world.

Usage should look like:
`dynamic(import('./moduleName'), { component: 'ComponentName', });`

By this, it will import only 'ComponentName' from the module. It will be useful for structures which are having multiple exports from a single file.