### PR TITLE
Make webpack CommonsChunkPlugin chunking default configurable

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -145,13 +145,7 @@ export default async function createCompiler (dir, { buildId, dev = false, quiet
           return false
         }
 
-        // If there are one or two pages, only move modules to common if they are
-        // used in all of the pages. Otherwise, move modules used in at-least
-        // 1/2 of the total pages into commons.
-        if (totalPages <= 2) {
-          return count >= totalPages
-        }
-        return count >= totalPages * 0.5
+        return config.webpackModuleShouldBeCommonInProduction({totalPages, count})
       }
     }),
     // This chunk splits out react and react-dom in production to make sure it does not go through uglify. This saved multiple seconds on production builds.

--- a/server/config.js
+++ b/server/config.js
@@ -5,6 +5,15 @@ const cache = new Map()
 const defaultConfig = {
   webpack: null,
   webpackDevMiddleware: null,
+  webpackModuleShouldBeCommonInProduction: function ({totalPages, count}) {
+    // If there are one or two pages, only move modules to common if they are
+    // used in all of the pages. Otherwise, move modules used in at-least
+    // 1/2 of the total pages into commons.
+    if (totalPages <= 2) {
+      return count >= totalPages
+    }
+    return count >= totalPages * 0.5
+  },
   poweredByHeader: true,
   distDir: '.next',
   assetPrefix: '',


### PR DESCRIPTION
A while ago (in #1644) we updated the default for minimum refs to chunk a file into commons from the previous (which I believe was a static integer, or at least was at some point), and made it so that the file had to be used in >50% of the pages to be packaged in the commons.

The problem is that people may use pages in different ways, particularly if they're using a custom server instead of the default page routing. For example, I use Styled Components, and put a `styles.js` file alongside my various page JSX files. Others may colocate JSX components inside pages, which could be very reasonable depending on the project.

In any case, it's very possible to load up your /pages directory with JS files that add into the default logic's perception of "page count", since there's no singular way to determine what is and is not a page without analyzing the code within.

I'd propose that leave this as the default behavior, since that makes sense enough if you're using Next in the OOTB manner, but allow for configuration if needed. @rauchg suggested as much in #1644 but it seems like that fell out in the final version (#1659)

If this seems good to all I'll add examples / update docs. LMK, thanks!