### PR TITLE
fix(store): product env cannot find module 'redux-devtools-extension'.

### DIFF
--- a/examples/with-redux-saga/store.js
+++ b/examples/with-redux-saga/store.js
@@ -1,5 +1,4 @@
 import {createStore, applyMiddleware} from 'redux'
-import {composeWithDevTools} from 'redux-devtools-extension'
 import withRedux from 'next-redux-wrapper'
 import nextReduxSaga from 'next-redux-saga'
 import createSagaMiddleware from 'redux-saga'
@@ -9,11 +8,19 @@ import rootSaga from './saga'
 
 const sagaMiddleware = createSagaMiddleware()
 
+const bindMiddleware = (middleware) => {
+  if (process.env.NODE_ENV !== 'production') {
+    const { composeWithDevTools } = require('redux-devtools-extension')
+    return composeWithDevTools(applyMiddleware(...middleware))
+  }
+  return applyMiddleware(...middleware)
+}
+
 export function configureStore (initialState = exampleInitialState) {
   const store = createStore(
     rootReducer,
     initialState,
-    composeWithDevTools(applyMiddleware(sagaMiddleware))
+    bindMiddleware([sagaMiddleware])
   )
 
   store.sagaTask = sagaMiddleware.run(rootSaga)


### PR DESCRIPTION
There is a problem with the store.js when devDependencies is not installed in the production environment.

Problem description:
- Cannot find module 'redux-devtools-extension'