### PR TITLE
Check if headers are sent

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,15 +46,25 @@ export function getDisplayName (Component) {
   return Component.displayName || Component.name || 'Unknown'
 }
 
+export function isResSent (res) {
+  return res.finished || res.headersSent
+}
+
 export async function loadGetInitialProps (Component, ctx) {
   if (!Component.getInitialProps) return {}
 
   const props = await Component.getInitialProps(ctx)
-  if (!props && (!ctx.res || !ctx.res.finished)) {
+
+  if (ctx.res && isResSent(ctx.res)) {
+    return props
+  }
+
+  if (!props) {
     const compName = getDisplayName(Component)
     const message = `"${compName}.getInitialProps()" should resolve to an object. But found "${props}" instead.`
     throw new Error(message)
   }
+
   return props
 }
 

--- a/server/render.js
+++ b/server/render.js
@@ -7,7 +7,7 @@ import fresh from 'fresh'
 import requireModule from './require'
 import getConfig from './config'
 import { Router } from '../lib/router'
-import { loadGetInitialProps } from '../lib/utils'
+import { loadGetInitialProps, isResSent } from '../lib/utils'
 import { getAvailableChunks } from './utils'
 import Head, { defaultHead } from '../lib/head'
 import App from '../lib/app'
@@ -66,7 +66,7 @@ async function doRender (req, res, pathname, query, {
   const props = await loadGetInitialProps(Component, ctx)
 
   // the response might be finshed on the getinitialprops call
-  if (res.finished) return
+  if (isResSent(res)) return
 
   const renderPage = (enhancer = Page => Page) => {
     const app = createElement(App, {
@@ -99,7 +99,7 @@ async function doRender (req, res, pathname, query, {
 
   const docProps = await loadGetInitialProps(Document, { ...ctx, renderPage })
 
-  if (res.finished) return
+  if (isResSent(res)) return
 
   if (!Document.prototype || !Document.prototype.isReactComponent) throw new Error('_document.js is not exporting a React element')
   const doc = createElement(Document, {
@@ -155,7 +155,7 @@ export async function renderScriptError (req, res, page, error, customFields, { 
 }
 
 export function sendHTML (req, res, html, method, { dev }) {
-  if (res.finished) return
+  if (isResSent(res)) return
   const etag = generateETag(html)
 
   if (fresh(req.headers, { etag })) {
@@ -179,7 +179,7 @@ export function sendHTML (req, res, html, method, { dev }) {
 }
 
 export function sendJSON (res, obj, method) {
-  if (res.finished) return
+  if (isResSent(res)) return
 
   const json = JSON.stringify(obj)
   res.setHeader('Content-Type', 'application/json')


### PR DESCRIPTION
When a user does this:

```
res.writeHead(status || 302, { Location: destination })
res.end()
```

In getInitialProps we don't stop rendering of the response, causing a `headers already sent` error.

This PR adds a check for [`headersSent`](https://nodejs.org/api/http.html#http_response_headerssent) to stop rendering.


Code derived from zeit/docs:

```
import Router from 'next/router'

export default function redirectTo(destination, { res, status } = {}) {
  if (res) {
    res.writeHead(status || 302, { Location: destination })
    res.end()
  } else {
    if (destination[0] === '/' && destination[1] !== '/') {
      Router.push(destination)
    } else {
      window.location = destination
    }
  }
}
```

```
class RedirectRoute extends React.Component {
    static getInitialProps({ res }) {
      if (typeof window === 'undefined' && !res.writeHead) {
        // This is the SSR mode
        return { metaRedirect: true }
      }

      redirectTo(destination, { res, status: 301 })
      return {}
    }

    render() {
      if (this.props.metaRedirect) {
        return (
          <Head>
            <meta httpEquiv="refresh" content={`0; url=${destination}`} />
          </Head>
        )
      }

      return null
    }
  }
```