### PR TITLE
Fix __route error when importing a page inside a page

### DIFF
--- a/server/build/loaders/hot-self-accept-loader.js
+++ b/server/build/loaders/hot-self-accept-loader.js
@@ -5,6 +5,8 @@ module.exports = function (content, sourceMap) {
 
   const route = getRoute(this)
 
+  // Webpack has a built in system to prevent default from colliding, giving it a random letter per export. 
+  // We can safely check if Component is undefined since all other pages imported into the entrypoint don't have __webpack_exports__.default
   this.callback(null, `${content}
     (function (Component, route) {
       if(!Component) return

--- a/server/build/loaders/hot-self-accept-loader.js
+++ b/server/build/loaders/hot-self-accept-loader.js
@@ -5,7 +5,7 @@ module.exports = function (content, sourceMap) {
 
   const route = getRoute(this)
 
-  // Webpack has a built in system to prevent default from colliding, giving it a random letter per export. 
+  // Webpack has a built in system to prevent default from colliding, giving it a random letter per export.
   // We can safely check if Component is undefined since all other pages imported into the entrypoint don't have __webpack_exports__.default
   this.callback(null, `${content}
     (function (Component, route) {

--- a/server/build/loaders/hot-self-accept-loader.js
+++ b/server/build/loaders/hot-self-accept-loader.js
@@ -7,6 +7,7 @@ module.exports = function (content, sourceMap) {
 
   this.callback(null, `${content}
     (function (Component, route) {
+      if(!Component) return
       if (!module.hot) return
       module.hot.accept()
       Component.__route = route


### PR DESCRIPTION
When importing a page inside a page the hot-self-accept-loader is included in the bundle twice. Webpack has a built in system to prevent `default` from colliding, giving it a random letter per export. We can safely check if `Component` is undefined since all other pages imported into the entrypoint don't have `__webpack_exports__.default`
or module.exports.