### PR TITLE
Make sure externals logic works on Windows.

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -71,7 +71,7 @@ function externalsConfig (dir, isServer) {
       }
 
       // Webpack itself has to be compiled because it doesn't always use module relative paths
-      if (res.match(/node_modules\/.*\.js/) && !res.match(/node_modules\/webpack/)) {
+      if (res.match(/node_modules[/\\].*\.js/) && !res.match(/node_modules[/\\]webpack/)) {
         return callback(null, `commonjs ${request}`)
       }
 


### PR DESCRIPTION
This should fix failing tests on Windows.