### PR TITLE
Require files directly instead of resolving them

### DIFF
--- a/server/require.js
+++ b/server/require.js
@@ -1,6 +1,0 @@
-import resolve from './resolve'
-
-export default async function requireModule (path) {
-  const f = await resolve(path)
-  return require(f)
-}


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/3682

Old:

```
component fetching: 27.335ms
component fetching: 11.558ms
component fetching: 2.292ms
component fetching: 17.421ms
component fetching: 2.629ms
component fetching: 5.179ms
component fetching: 3.961ms
component fetching: 3.998ms
component fetching: 4.922ms
component fetching: 4.229ms
component fetching: 1.790ms
component fetching: 3.081ms
component fetching: 2.728ms
component fetching: 3.907ms
component fetching: 13.300ms
component fetching: 2.233ms
component fetching: 8.058ms
component fetching: 1.657ms
component fetching: 2.269ms
component fetching: 2.376ms
component fetching: 1.650ms
component fetching: 1.671ms
component fetching: 4.337ms
component fetching: 5.558ms
component fetching: 1.759ms
component fetching: 1.480ms
component fetching: 1.976ms
component fetching: 2.299ms
component fetching: 5.189ms
component fetching: 4.323ms
component fetching: 1.980ms
component fetching: 1.661ms
component fetching: 22.161ms
component fetching: 7.424ms
component fetching: 7.250ms
component fetching: 1.503ms
component fetching: 1.699ms
component fetching: 6.749ms
component fetching: 1.990ms
component fetching: 3.022ms
component fetching: 6.880ms
component fetching: 3.279ms
component fetching: 1.786ms
component fetching: 2.764ms
component fetching: 1.579ms
component fetching: 1.482ms
component fetching: 2.081ms
component fetching: 3.501ms
component fetching: 1.551ms
component fetching: 1.743ms
component fetching: 2.351ms
component fetching: 6.141ms
component fetching: 1.977ms
component fetching: 1.456ms
component fetching: 1.553ms
component fetching: 3.221ms
component fetching: 1.388ms
component fetching: 2.732ms
component fetching: 2.252ms
component fetching: 1.563ms
component fetching: 1.801ms
component fetching: 4.789ms
component fetching: 1.456ms
component fetching: 1.754ms
component fetching: 1.224ms
component fetching: 1.647ms
component fetching: 1.162ms
component fetching: 4.631ms
component fetching: 1.256ms
component fetching: 1.483ms
component fetching: 1.462ms
component fetching: 1.647ms
component fetching: 1.690ms
component fetching: 1.950ms
component fetching: 5.786ms
component fetching: 1.671ms
component fetching: 6.056ms
component fetching: 1.947ms
component fetching: 1.882ms
component fetching: 3.140ms
component fetching: 1.996ms
component fetching: 2.885ms
component fetching: 2.292ms
component fetching: 4.953ms
component fetching: 3.683ms
component fetching: 1.256ms
component fetching: 1.469ms
component fetching: 1.808ms
component fetching: 1.986ms
component fetching: 2.724ms
component fetching: 1.756ms
component fetching: 2.551ms
component fetching: 3.197ms
component fetching: 2.969ms
component fetching: 2.357ms
component fetching: 3.384ms
component fetching: 3.233ms
component fetching: 1.899ms
component fetching: 2.082ms
component fetching: 2.347ms
```

New:

```
t: 8.020ms
t: 0.030ms
t: 0.041ms
t: 0.028ms
t: 0.038ms
t: 0.034ms
t: 0.030ms
t: 0.042ms
t: 0.037ms
t: 0.054ms
t: 0.038ms
t: 0.028ms
t: 0.029ms
t: 0.051ms
t: 0.035ms
t: 0.040ms
t: 0.027ms
t: 0.037ms
t: 0.029ms
t: 0.028ms
t: 0.039ms
t: 0.034ms
t: 0.030ms
t: 0.030ms
t: 0.033ms
t: 0.033ms
t: 0.031ms
t: 0.027ms
t: 0.027ms
t: 0.035ms
t: 0.029ms
t: 0.032ms
t: 0.029ms
t: 0.055ms
t: 0.221ms
t: 0.054ms
t: 0.031ms
t: 0.040ms
t: 0.032ms
t: 0.041ms
t: 0.032ms
t: 0.037ms
t: 0.046ms
t: 0.039ms
t: 0.028ms
t: 0.032ms
t: 0.108ms
t: 0.032ms
t: 0.030ms
t: 0.038ms
t: 0.029ms
t: 0.042ms
t: 0.040ms
t: 0.056ms
t: 0.060ms
t: 0.029ms
t: 0.027ms
t: 0.029ms
t: 0.030ms
t: 0.031ms
t: 0.037ms
t: 0.028ms
t: 0.030ms
t: 0.033ms
t: 0.032ms
t: 0.030ms
t: 0.039ms
t: 0.033ms
t: 0.034ms
t: 0.032ms
t: 0.039ms
t: 0.027ms
t: 0.037ms
t: 0.028ms
t: 0.026ms
t: 0.031ms
t: 0.027ms
t: 0.038ms
t: 0.037ms
t: 0.035ms
t: 0.078ms
t: 0.031ms
t: 0.033ms
t: 0.097ms
t: 0.050ms
t: 0.030ms
t: 0.032ms
t: 0.066ms
t: 0.035ms
t: 0.035ms
t: 0.029ms
t: 0.031ms
t: 0.036ms
t: 0.033ms
t: 0.030ms
t: 0.075ms
t: 0.035ms
t: 0.028ms
t: 0.029ms
t: 0.026ms
```