### PR TITLE
Move react{-dom,} to a common chunk in production too

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -250,11 +250,11 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
           // We need to move react-dom explicitly into common chunks.
           // Otherwise, if some other page or module uses it, it might
           // included in that bundle too.
-          if (dev && module.context && module.context.indexOf(`${sep}react${sep}`) >= 0) {
+          if (module.context && module.context.indexOf(`${sep}react${sep}`) >= 0) {
             return true
           }
 
-          if (dev && module.context && module.context.indexOf(`${sep}react-dom${sep}`) >= 0) {
+          if (module.context && module.context.indexOf(`${sep}react-dom${sep}`) >= 0) {
             return true
           }
 


### PR DESCRIPTION
Without this, react-dom gets included in multiple pages.

---

Before:
![before](https://user-images.githubusercontent.com/166147/35834206-e3dc34e2-0ad4-11e8-8201-aa93c1aba1ff.png)

After:
<img width="1919" alt="after" src="https://user-images.githubusercontent.com/166147/35834227-0492deb6-0ad5-11e8-9960-843ad7f84e31.png">

