### PR TITLE
Fix webpack-bundle-analyzer example to work with Next 5

### DIFF
--- a/examples/with-webpack-bundle-analyzer/next.config.js
+++ b/examples/with-webpack-bundle-analyzer/next.config.js
@@ -2,11 +2,11 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const { ANALYZE } = process.env
 
 module.exports = {
-  webpack: function (config) {
+  webpack: function (config, { isServer }) {
     if (ANALYZE) {
       config.plugins.push(new BundleAnalyzerPlugin({
         analyzerMode: 'server',
-        analyzerPort: 8888,
+        analyzerPort: isServer ? 8888 : 8889,
         openAnalyzer: true
       }))
     }


### PR DESCRIPTION
### Problem

The `with-webpack-bundle-analyzer` example is broken in Next 5. Next runs two instances of webpack (client and server) and two instances of `BundleAnalyzerPlugin`, both trying to bind to `:8888`.

### Solution

Use a different port if `isServer` is true