### PR TITLE
Use latest instead of zones

### DIFF
--- a/examples/with-zones/blog/package.json
+++ b/examples/with-zones/blog/package.json
@@ -6,7 +6,7 @@
     "start": "next start -p 5000"
   },
   "dependencies": {
-    "next": "zones",
+    "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },


### PR DESCRIPTION
I'm assuming the zones feature has already been released.
https://github.com/zeit/next.js/blob/2a845a61b747b71adc4df84f9261391d12547733/examples/with-zones/home/package.json#L9

> $ npm info next

> { name: 'next',
  'dist-tags':
   { latest: '5.0.0',
     beta: '4.0.0-beta.6',
     canary: '4.4.0-canary.3',
     zones: '4.3.0-zones.1' },