### PR TITLE
 Copy static assets from .next folder when exporting

### DIFF
--- a/server/export.js
+++ b/server/export.js
@@ -50,10 +50,10 @@ export default async function (dir, options, configuration) {
   }
 
   // Copy .next/static directory
-  if (existsSync(join(dir, '.next', 'static'))) {
-    log('  copying ".next/static" directory')
+  if (existsSync(join(nextDir, 'static'))) {
+    log('  copying "static build" directory')
     await cp(
-      join(dir, '.next', 'static'),
+      join(nextDir, 'static'),
       join(outDir, '_next', 'static')
     )
   }

--- a/server/export.js
+++ b/server/export.js
@@ -49,6 +49,15 @@ export default async function (dir, options, configuration) {
     )
   }
 
+  // Copy .next/static directory
+  if (existsSync(join(dir, '.next', 'static'))) {
+    log('  copying ".next/static" directory')
+    await cp(
+      join(dir, '.next', 'static'),
+      join(outDir, '_next', 'static')
+    )
+  }
+
   // Copy dynamic import chunks
   if (existsSync(join(nextDir, 'chunks'))) {
     log('  copying dynamic import chunks')


### PR DESCRIPTION
The [next-css plugin](https://github.com/zeit/next-plugins/tree/master/packages/next-css) establishes a convention of saving static assets which are generated at compile-time to the `/.next/static` directory. These files are served in the SSR environment from `/_next/static`, but are not currently copied to the output folder when running `next export`. (See https://github.com/zeit/next-plugins/issues/1)

This updates the export command to check for a `static` directory within `.next`, and if it exists copies it to the destination's `_next` directory.