### PR TITLE
Serve static `/_next/static/*` relative from `dir` directory

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -241,7 +241,7 @@ export default class Server {
       },
 
       '/_next/static/:path*': async (req, res, params) => {
-        const p = join(this.dist, 'static', ...(params.path || []))
+        const p = join(this.dir, this.dist, 'static', ...(params.path || []))
         await this.serveStatic(req, res, p)
       },
 


### PR DESCRIPTION
The static folder for webpack built assets (`.next/static`) served on `/_next/static/*` doesn't resolve to a path correctly when the `distDir` in `next.config.js` is set outside of the next.js "dest" `dir`

e.g. Consider the following structure:
```
.
├── build
└── src
    ├── next.config.js
    └── pages
```

With `next.config.js` defined as:
```js
module.exports = { distDir: '../build' }
```

Running using `next src`, it tries to serve: `/_next/static/*` from `ROOT/${config.destDir}/static`

i.e. `ROOT/../build/static` rather than `ROOT/src/../build/static`

This can be reproduced via :
```sh
yarn && yarn next src

mkdir build/static
echo 'foo' > build/static/bar.txt # fake an asset that may be built via webpack (i.e. css)
curl http://localhost:3000/_next/static/bar.txt

# Will return 404 page source before change, and 'foo' after change -- as expected
```

I couldn't find any other locations where this change is also required

Temporarily hacked around it by serving the folder via the express.static middleware:
```js
app.use('/_next/static', express.static('dist/static'))
```
