### PR TITLE
Fix typo in withRouter

### DIFF
--- a/lib/router/with-router.js
+++ b/lib/router/with-router.js
@@ -11,7 +11,7 @@ export default function withRouter (ComposedComponent) {
       router: PropTypes.object
     }
 
-    static displayName = `withRoute(${displayName})`
+    static displayName = `withRouter(${displayName})`
 
     render () {
       const props = {


### PR DESCRIPTION
I noticed that the HoC was renamed from `withRoute` to `withRouter` some time ago, but the `displayName` was not updated accordingly. This PR fixes this issue.