### PR TITLE
Example: Externals - config for untranspiled external packages

### DIFF
--- a/examples/with-externals/README.md
+++ b/examples/with-externals/README.md
@@ -1,0 +1,39 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-externals)
+# Example app with added support for `npm link`-ed local packages
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-externals
+cd with-externals
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example features:
+
+* A custom next.config.js to have Webpack process any node_modules of a certain scope as if it were local (untranspiled) code
+* Have webpack-dev-server properly track any changes in `npm link`ed node_modules so HMR will work for these packages as well
+
+The example does not feature the actual external package. You'll have to create one yourself and use `npm link` to try it out.
+Note that you'll need to modify `next.config.js` with your own npm scope name.
+
+## How to run it
+
+```sh
+npm install
+npm run dev
+```

--- a/examples/with-externals/next.config.js
+++ b/examples/with-externals/next.config.js
@@ -1,0 +1,26 @@
+const webpack = require("webpack")
+
+// Update these to match your package scope name.
+const internalNodeModulesRegExp = /@zeit(?!.*node_modules)/
+const externalNodeModulesRegExp = /node_modules(?!\/@zeit(?!.*node_modules))/
+
+module.exports = {
+  webpack: (config, { dev, isServer, defaultLoaders }) => {
+    config.resolve.symlinks = false
+    config.externals = config.externals.map(external => {
+      if (typeof external !== "function") return external
+      return (ctx, req, cb) => (internalNodeModulesRegExp.test(req) ? cb() : external(ctx, req, cb))
+    })
+    config.module.rules.push({
+      test: /\.+(js|jsx)$/,
+      loader: defaultLoaders.babel,
+      include: [internalNodeModulesRegExp]
+    })
+    return config
+  },
+  webpackDevMiddleware: config => {
+    const ignored = [config.watchOptions.ignored[0], externalNodeModulesRegExp]
+    config.watchOptions.ignored = ignored
+    return config
+  }
+}

--- a/examples/with-externals/package.json
+++ b/examples/with-externals/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "with-externals",
+  "version": "1.0.0",
+  "description": "Adds support for external untranspiled node_modules, including `npm link`ed packages",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/with-externals/pages/index.js
+++ b/examples/with-externals/pages/index.js
@@ -1,0 +1,3 @@
+import React from "react"
+
+export default () => <div>Hello World.</div>


### PR DESCRIPTION
This provides an example `next.config.js` which adds support for external untranspiled npm packages. It overrides Webpack's `externals` so it will process these packages and configures webpack-dev-server to enable HMR on `npm link`ed local packages.