### PR TITLE
[Fix] with-global-stylesheet example

### DIFF
--- a/examples/with-global-stylesheet/package.json
+++ b/examples/with-global-stylesheet/package.json
@@ -22,8 +22,5 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "sass-loader": "^6.0.6"
-  },
-  "devDependencies": {
-    "now": "^8.3.10"
   }
 }


### PR DESCRIPTION
After installing `create-next-app` I'm faced with an issue during installation of `with-global-stylesheet ` example:
```
create-next-app --example with-global-stylesheet my-app
```
I'm receiving next error:
```
Error! Failed to install react, react-dom, next, try again.
```

If you will go to the folder `cd FOLDER_NAME` and will try to install dependencies manually `yarn/npm install` there will be a detailed error:
```
[4/4] ⠈ now:     at PassThrough.Transform._read (_stream_transform.js:1
error /Users/username/path-to-the-app/my-app/node_modules/now: Command failed.
Exit code: 1
Command: node download/install.js
Arguments: 
Directory: /Users/username/path-to-the-app/my-app/node_modules/now
Output:
> For the source code, check out: https://github.com/zeit/now-cli


{ Error: incorrect header check
    at Zlib.zlibOnError [as onerror] (zlib.js:142:17) errno: -3, code: 'Z_DATA_ERROR' }
```

After reviewing dependencies it looks like devs. forgot to remove `devDependencies` from `package.json`.

Cheers :beers::beers::beers: (=