### PR TITLE
Fix svg-components example and improve babel example file

### DIFF
--- a/examples/svg-components/package.json
+++ b/examples/svg-components/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "latest,
+    "react": "latest",
     "react-dom": "latest"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -1094,7 +1094,8 @@ Here's an example `.babelrc` file:
 
 ```json
 {
-  "presets": ["next/babel", "env"]
+  "presets": ["next/babel"],
+  "plugins": []
 }
 ```
 


### PR DESCRIPTION
The reason why I updated the `.babelrc` example file is because I faced an issue upgrading a project to next5. After upgrading the version, my pages and components weren't exported correctly.

The issue was that I extended the babel config to add a custom plugin and the `babel-preset-env` in the example is already in `babel/env`. Once I removed the `env` preset from my custom `.babelrc` file, the project compiled fine.