### PR TITLE
Don’t include script that we know is going to error

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -84,12 +84,12 @@ export class Head extends Component {
 
   render () {
     const { head, styles, __NEXT_DATA__ } = this.context._documentProps
-    const { pathname, buildId, assetPrefix } = __NEXT_DATA__
+    const { page, pathname, buildId, assetPrefix } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
     return <head {...this.props}>
       {(head || []).map((h, i) => React.cloneElement(h, { key: h.key || i }))}
-      <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} as='script' />
+      {page !== '_error' && <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} as='script' />}
       <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_error.js`} as='script' />
       {this.getPreloadDynamicChunks()}
       {this.getPreloadMainLinks()}
@@ -173,7 +173,7 @@ export class NextScript extends Component {
 
   render () {
     const { staticMarkup, __NEXT_DATA__, chunks } = this.context._documentProps
-    const { pathname, buildId, assetPrefix } = __NEXT_DATA__
+    const { page, pathname, buildId, assetPrefix } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
     __NEXT_DATA__.chunks = chunks.names
@@ -193,9 +193,18 @@ export class NextScript extends Component {
           __NEXT_REGISTER_CHUNK = function (chunkName, fn) {
             __NEXT_LOADED_CHUNKS__.push({ chunkName: chunkName, fn: fn })
           }
+
+          ${page === '_error' && `
+          __NEXT_REGISTER_PAGE('/index', function() {
+            var error = new Error('Page does not exist: ${htmlescape(pathname)}')
+            error.statusCode = 404
+    
+            return { error: error }
+          })
+          `}
         `
       }} />}
-      <script async id={`__NEXT_PAGE__${pathname}`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} />
+      {page !== '_error' && <script async id={`__NEXT_PAGE__${pathname}`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} />}
       <script async id={`__NEXT_PAGE__/_error`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page/_error.js`} />
       {staticMarkup ? null : this.getDynamicChunks()}
       {staticMarkup ? null : this.getScripts()}

--- a/server/render.js
+++ b/server/render.js
@@ -105,7 +105,8 @@ async function doRender (req, res, pathname, query, {
   const doc = createElement(Document, {
     __NEXT_DATA__: {
       props,
-      pathname,
+      page, // the rendered page
+      pathname, // the requested path
       query,
       buildId,
       buildStats,

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -112,6 +112,11 @@ export default function ({ app }, suiteName, render, fetch) {
       expect($('h2').text()).toBe('This page could not be found.')
     })
 
+    test('error 404 should not have page script', async () => {
+      const $ = await get$('/non-existent')
+      expect($('__NEXT_PAGE__/non-existent').length).toBe(0)
+    })
+
     describe('with the HOC based router', () => {
       it('should navigate as expected', async () => {
         const $ = await get$('/nav/with-hoc')

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -114,7 +114,12 @@ export default function ({ app }, suiteName, render, fetch) {
 
     test('error 404 should not have page script', async () => {
       const $ = await get$('/non-existent')
-      expect($('__NEXT_PAGE__/non-existent').length).toBe(0)
+      $('script[src]').each((index, element) => {
+        const src = $(element).attr('src')
+        if (src.includes('/non-existent')) {
+          throw new Error('Page includes page script')
+        }
+      })
     })
 
     describe('with the HOC based router', () => {


### PR DESCRIPTION
When the `_error` page is being rendered we know the page bundle is empty, because the page doesn't exist. So it doesn't make sense to load the bundle. Instead we immediately register the page as 404.