### PR TITLE
Fix with-redux-saga server rendered clock, fixes #3760

### DIFF
--- a/examples/with-redux-saga/README.md
+++ b/examples/with-redux-saga/README.md
@@ -61,7 +61,7 @@ The second example, under `components/add-count.js`, shows a simple add counter 
 
 ## What changed with next-redux-saga
 
-The digital clock is updated every 800ms using the `runClockSaga` found in `saga.js`.
+The digital clock is updated every second using the `runClockSaga` found in `saga.js`.
 
 All pages are also being wrapped by `next-redux-saga` using a helper function from `store.js`:
 

--- a/examples/with-redux-saga/pages/index.js
+++ b/examples/with-redux-saga/pages/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
 
-import {increment, loadData, startClock} from '../actions'
+import {increment, loadData, startClock, tickClock} from '../actions'
 import {withReduxSaga} from '../store'
 import Page from '../components/page'
 
 class Counter extends React.Component {
-  static async getInitialProps ({store}) {
+  static async getInitialProps ({store, isServer}) {
+    store.dispatch(tickClock(isServer))
     store.dispatch(increment())
     if (!store.getState().placeholderData) {
       store.dispatch(loadData())

--- a/examples/with-redux-saga/pages/other.js
+++ b/examples/with-redux-saga/pages/other.js
@@ -1,11 +1,12 @@
 import React from 'react'
 
-import {increment, startClock} from '../actions'
+import {increment, startClock, tickClock} from '../actions'
 import {withReduxSaga} from '../store'
 import Page from '../components/page'
 
 class Counter extends React.Component {
-  static async getInitialProps ({store}) {
+  static async getInitialProps ({store, isServer}) {
+    store.dispatch(tickClock(isServer))
     store.dispatch(increment())
   }
 

--- a/examples/with-redux-saga/saga.js
+++ b/examples/with-redux-saga/saga.js
@@ -13,7 +13,7 @@ function * runClockSaga () {
   yield take(actionTypes.START_CLOCK)
   while (true) {
     yield put(tickClock(false))
-    yield call(delay, 800)
+    yield call(delay, 1000)
   }
 }
 


### PR DESCRIPTION
Also updated the tick interval to one second, the clock works better this way and this is how the with-redux example is currently implemented as well.