### PR TITLE
fix setInterval usage in mobx examples to work in firefox

### DIFF
--- a/examples/with-mobx-state-tree/store.js
+++ b/examples/with-mobx-state-tree/store.js
@@ -14,7 +14,7 @@ const Store = types
         // mobx-state-tree doesn't allow anonymous callbacks changing data
         // pass off to another action instead
         self.update()
-      })
+      }, 1000)
     }
 
     function update () {

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -14,7 +14,7 @@ class Store {
     this.timer = setInterval(() => {
       this.lastUpdate = Date.now()
       this.light = true
-    })
+    }, 1000)
   }
 
   stop = () => clearInterval(this.timer)


### PR DESCRIPTION
This PR defines the delay when using `setInterval` in the `mobx` and `mobx-state-tree` examples. Not explicitly setting the delay would still work when running in chrome, but not completely in firefox. There would be no errors, but the setInterval callback would only get called once.