### PR TITLE
Use null instead of empty string

### DIFF
--- a/examples/active-class-name/components/Link.js
+++ b/examples/active-class-name/components/Link.js
@@ -7,7 +7,7 @@ const ActiveLink = ({ router, children, ...props }) => {
 
   let className = child.props.className || null
   if (router.pathname === props.href && props.activeClassName) {
-    className = `${className} ${props.activeClassName}`.trim()
+className = `${className !== null ? className : ''} ${activeClassName}`.trim()
   }
 
   delete props.activeClassName

--- a/examples/active-class-name/components/Link.js
+++ b/examples/active-class-name/components/Link.js
@@ -7,7 +7,7 @@ const ActiveLink = ({ router, children, ...props }) => {
 
   let className = child.props.className || null
   if (router.pathname === props.href && props.activeClassName) {
-className = `${className !== null ? className : ''} ${activeClassName}`.trim()
+className = `${props.className !== null ? props.className : ''} ${activeClassName}`.trim()
   }
 
   delete props.activeClassName

--- a/examples/active-class-name/components/Link.js
+++ b/examples/active-class-name/components/Link.js
@@ -5,7 +5,7 @@ import React, { Children } from 'react'
 const ActiveLink = ({ router, children, ...props }) => {
   const child = Children.only(children)
 
-  let className = child.props.className || ''
+  let className = child.props.className || null
   if (router.pathname === props.href && props.activeClassName) {
     className = `${className} ${props.activeClassName}`.trim()
   }


### PR DESCRIPTION
Using null will remove the `class` attribute from the underlying `<a>` while `''` renders `<a class>`.

This is only an issue when neither a `className` nor an `activeClassName` is provided to this component.