### PR TITLE
use null instead of empty string for coerced className

### DIFF
--- a/examples/active-class-name/components/Link.js
+++ b/examples/active-class-name/components/Link.js
@@ -5,9 +5,10 @@ import React, { Children } from 'react'
 const ActiveLink = ({ router, children, ...props }) => {
   const child = Children.only(children)
 
-  let className = child.props.className || ''
+  let className = child.props.className || null
   if (router.pathname === props.href && props.activeClassName) {
-    className = `${className} ${props.activeClassName}`.trim()
+    className = `${className !== null ? className : ''} ${props.activeClassName}`.trim()
+    console.log(className)
   }
 
   delete props.activeClassName


### PR DESCRIPTION
Using null will remove the `class` attribute from the underlying `<a>` while `''` renders `<a class>`.

This is only an issue when neither a `className` nor an `activeClassName` is provided to this component.