### PR TITLE
[refactor] #3716: X-Powered-By setting (true by default)

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -8,7 +8,8 @@ const defaultConfig = {
   distDir: '.next',
   assetPrefix: '',
   configOrigin: 'default',
-  useFileSystemPublicRoutes: true
+  useFileSystemPublicRoutes: true,
+  xPoweredBy: true
 }
 
 export default function getConfig (dir, customConfig) {

--- a/server/index.js
+++ b/server/index.js
@@ -27,11 +27,10 @@ const blockedPages = {
 }
 
 export default class Server {
-  constructor ({ dir = '.', dev = false, staticMarkup = false, quiet = false, conf = null, xPoweredBy = true } = {}) {
+  constructor ({ dir = '.', dev = false, staticMarkup = false, quiet = false, conf = null } = {}) {
     this.dir = resolve(dir)
     this.dev = dev
     this.quiet = quiet
-    this.xPoweredBy = xPoweredBy
     this.router = new Router()
     this.hotReloader = dev ? this.getHotReloader(this.dir, { quiet, conf }) : null
     this.http = null
@@ -323,7 +322,7 @@ export default class Server {
       return
     }
 
-    if (this.xPoweredBy) {
+    if (this.config.xPoweredBy) {
       res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
     }
     return sendHTML(req, res, html, req.method, this.renderOpts)

--- a/server/index.js
+++ b/server/index.js
@@ -27,10 +27,11 @@ const blockedPages = {
 }
 
 export default class Server {
-  constructor ({ dir = '.', dev = false, staticMarkup = false, quiet = false, conf = null } = {}) {
+  constructor ({ dir = '.', dev = false, staticMarkup = false, quiet = false, conf = null, xPoweredBy = true } = {}) {
     this.dir = resolve(dir)
     this.dev = dev
     this.quiet = quiet
+    this.xPoweredBy = xPoweredBy
     this.router = new Router()
     this.hotReloader = dev ? this.getHotReloader(this.dir, { quiet, conf }) : null
     this.http = null
@@ -322,7 +323,9 @@ export default class Server {
       return
     }
 
-    res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
+    if (this.xPoweredBy) {
+      res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
+    }
     return sendHTML(req, res, html, req.method, this.renderOpts)
   }
 


### PR DESCRIPTION
PR altered to pass a `xPoweredBy` setting in `next.config.js` so that this can be turned on/off without needing to use a custom server necessarily.

```js
module.exports = {
  xPoweredBy: false,
  webpack: async function(config, { dev }) {
  ...
}
```

If you do not pass anything in `next.config.js` it will default to `true`.

Please let me know if we need to add any tests, I did test this via `yarn link` for the following scenarios:
1. `xPoweredBy: false`
2. `xPoweredBy: true`
3. `(not setting it a value in next.config.js)`

~~For custom server settings you can now remove the X-Powered-By if you so choose:
`const app = next({ dev, xPoweredBy: false })`~~

~~If you do not change anything, it will default to true:~~
~~`const app = next({ dev })`~~

~~Please let me know if we need to add any tests, I did test this via `yarn link` for the following scenarios:~~
~~1. `const app = next({ dev, xPoweredBy: true })`~~
~~2. `const app = next({ dev, xPoweredBy: false })`~~
~~3. `const app = next({ dev })`~~

Adding this in the `Production Usage` test seemed like overkill to spin up another instance, however, we absolutely can.