### PR TITLE
Prevent unsetting title from document

### DIFF
--- a/client/head-manager.js
+++ b/client/head-manager.js
@@ -30,8 +30,8 @@ export default class HeadManager {
       tags[h.type] = components
     })
 
-    if (tags.title) {
-      this.updateTitle(tags.title ? tags.title[0] : null)
+    if (tags.title && tags.title[0]) {
+      this.updateTitle(tags.title[0])
     }
 
     const types = ['meta', 'base', 'link', 'style', 'script']

--- a/client/head-manager.js
+++ b/client/head-manager.js
@@ -30,7 +30,9 @@ export default class HeadManager {
       tags[h.type] = components
     })
 
-    this.updateTitle(tags.title ? tags.title[0] : null)
+    if (tags.title) {
+      this.updateTitle(tags.title ? tags.title[0] : null)
+    }
 
     const types = ['meta', 'base', 'link', 'style', 'script']
     types.forEach((type) => {

--- a/test/integration/basic/pages/_document.js
+++ b/test/integration/basic/pages/_document.js
@@ -1,0 +1,21 @@
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  static async getInitialProps (ctx) {
+    return await Document.getInitialProps(ctx)
+  }
+
+  render () {
+    return (
+      <html>
+        <Head>
+          <title>Default document title</title>
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/test/integration/basic/pages/head-without-title.js
+++ b/test/integration/basic/pages/head-without-title.js
@@ -1,0 +1,8 @@
+import Head from 'next/head'
+
+export default () => <div>
+  <Head>
+    <meta content='my meta' />
+  </Head>
+  <h1>I should use default title from document</h1>
+</div>

--- a/test/integration/basic/pages/nav/about.js
+++ b/test/integration/basic/pages/nav/about.js
@@ -1,7 +1,11 @@
+import Head from 'next/head'
 import Link from 'next/link'
 
 export default () => (
   <div className='nav-about'>
+    <Head>
+      <title>About</title>
+    </Head>
     <Link href='/nav'>
       <a id='home-link'>Go Back</a>
     </Link>

--- a/test/integration/basic/pages/nav/head-without-title.js
+++ b/test/integration/basic/pages/nav/head-without-title.js
@@ -1,0 +1,8 @@
+import Head from 'next/head'
+
+export default () => <div className='head-without-title'>
+  <Head>
+    <meta content='my meta' />
+  </Head>
+  <h1>I should use default title from document after client navigates there.</h1>
+</div>

--- a/test/integration/basic/pages/nav/index.js
+++ b/test/integration/basic/pages/nav/index.js
@@ -38,6 +38,7 @@ export default class extends Component {
         <Link href='/nav/as-path' as='/as/path'><a id='as-path-link' style={linkStyle}>As Path</a></Link>
         <Link href='/nav/as-path'><a id='as-path-link-no-as' style={linkStyle}>As Path (No as)</a></Link>
         <Link href='/nav/as-path-using-router'><a id='as-path-using-router-link' style={linkStyle}>As Path (Using Router)</a></Link>
+        <Link href='/nav/head-without-title'><a id='head-without-title-link' style={linkStyle}>Head without title</a></Link>
         <button
           onClick={() => this.visitQueryStringPage()}
           style={linkStyle}

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -479,5 +479,37 @@ export default (context, render) => {
         browser.close()
       })
     })
+
+    describe('head-manager updates title', async () => {
+      it('should set document title', async () => {
+        const browser = await webdriver(context.appPort, '/nav')
+        const title = await browser.title()
+
+        expect(title).toBe('Default document title')
+        browser.close()
+      })
+
+      it('should set page title', async () => {
+        const browser = await webdriver(context.appPort, '/nav')
+        const title = await browser
+          .elementByCss('#about-link').click()
+          .waitForElementByCss('.nav-about')
+          .title()
+
+        expect(title).toBe('About')
+        browser.close()
+      })
+
+      it('should set document title if not changed in head', async () => {
+        const browser = await webdriver(context.appPort, '/nav')
+        const title = await browser
+          .elementByCss('#head-without-title-link').click()
+          .waitForElementByCss('.head-without-title')
+          .title()
+
+        expect(title).toBe('Default document title')
+        browser.close()
+      })
+    })
   })
 }

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -31,6 +31,7 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/error'),
       renderViaHTTP(context.appPort, '/finish-response'),
       renderViaHTTP(context.appPort, '/head'),
+      renderViaHTTP(context.appPort, '/head-without-title'),
       renderViaHTTP(context.appPort, '/json'),
       renderViaHTTP(context.appPort, '/link'),
       renderViaHTTP(context.appPort, '/stateful'),

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -45,6 +45,7 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/nav/querystring'),
       renderViaHTTP(context.appPort, '/nav/self-reload'),
       renderViaHTTP(context.appPort, '/nav/hash-changes'),
+      renderViaHTTP(context.appPort, '/nav/head-without-title'),
       renderViaHTTP(context.appPort, '/nav/shallow-routing'),
       renderViaHTTP(context.appPort, '/nav/redirect'),
       renderViaHTTP(context.appPort, '/nav/as-path'),

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -1,8 +1,9 @@
 /* global describe, test, it, expect */
 
+import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'
 
-export default function ({ app }, suiteName, render, fetch) {
+export default function (context, suiteName, render, fetch) {
   async function get$ (path, query) {
     const html = await render(path, query)
     return cheerio.load(html)
@@ -141,6 +142,16 @@ export default function ({ app }, suiteName, render, fetch) {
         const $ = await get$('/nav/with-hoc')
 
         expect($('#asPath').text()).toBe('Current asPath: /nav/with-hoc')
+      })
+    })
+
+    describe('with browser', () => {
+      test('header manager renders title from document', async () => {
+        const browser = await webdriver(context.appPort, '/head-without-title')
+        const title = await browser.title()
+
+        expect(title).toBe('Default document title')
+        browser.close()
       })
     })
   })

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -1,9 +1,8 @@
 /* global describe, test, it, expect */
 
-import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'
 
-export default function (context, suiteName, render, fetch) {
+export default function ({ app }, suiteName, render, fetch) {
   async function get$ (path, query) {
     const html = await render(path, query)
     return cheerio.load(html)
@@ -20,6 +19,11 @@ export default function (context, suiteName, render, fetch) {
       const $ = await get$('/stateful')
       const answer = $('#answer')
       expect(answer.text()).toBe('The answer is 42')
+    })
+
+    test('header helper renders title from document', async () => {
+      const html = await (render('/head-without-title'))
+      expect(html).toContain('<title>Default document title</title>')
     })
 
     test('header helper renders header information', async () => {
@@ -142,16 +146,6 @@ export default function (context, suiteName, render, fetch) {
         const $ = await get$('/nav/with-hoc')
 
         expect($('#asPath').text()).toBe('Current asPath: /nav/with-hoc')
-      })
-    })
-
-    describe('with browser', () => {
-      test('header manager renders title from document', async () => {
-        const browser = await webdriver(context.appPort, '/head-without-title')
-        const title = await browser.title()
-
-        expect(title).toBe('Default document title')
-        browser.close()
       })
     })
   })


### PR DESCRIPTION
Fixes #3527

On the client, if there was no title tag in Head it was set to null, even though it could be set inside of Document (so it got overwritten).

I'm not really sure it's a good place for this test. I couldn't find a category, that was used for testing client rendering and wasn't scoped for particular functionality (like navigation).