### PR TITLE
Add test case for reloading the page on page script error

### DIFF
--- a/test/integration/production/pages/counter.js
+++ b/test/integration/production/pages/counter.js
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { Component } from 'react'
+import Router from 'next/router'
+
+let counter = 0
+
+export default class extends Component {
+  increase () {
+    counter++
+    this.forceUpdate()
+  }
+
+  visitQueryStringPage () {
+    const href = { pathname: '/nav/querystring', query: { id: 10 } }
+    const as = { pathname: '/nav/querystring/10', hash: '10' }
+    Router.push(href, as)
+  }
+
+  render () {
+    return (
+      <div id='counter-page'>
+        <Link href='/no-such-page'><a id='no-such-page'>No Such Page</a></Link>
+        <p>This is the home.</p>
+        <div id='counter'>
+          Counter: {counter}
+        </div>
+        <button id='increase' onClick={() => this.increase()}>Increase</button>
+      </div>
+    )
+  }
+}

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -93,6 +93,24 @@ describe('Production Usage', () => {
       const data = await renderViaHTTP(appPort, '/static/data/item.txt')
       expect(data).toBe('item')
     })
+
+    it('should reload the page on page script error', async () => {
+      const browser = await webdriver(appPort, '/counter')
+      const counter = await browser
+          .elementByCss('#increase').click().click()
+          .elementByCss('#counter').text()
+      expect(counter).toBe('Counter: 2')
+
+      const counterAfter404Page = await browser
+        .elementByCss('#no-such-page').click()
+        .waitForElementByCss('h1')
+        .back()
+        .waitForElementByCss('#counter-page')
+        .elementByCss('#counter').text()
+      expect(counterAfter404Page).toBe('Counter: 0')
+
+      browser.close()
+    })
   })
 
   describe('X-Powered-By header', () => {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -101,6 +101,10 @@ describe('Production Usage', () => {
           .elementByCss('#counter').text()
       expect(counter).toBe('Counter: 2')
 
+      // When we go to the 404 page, it'll do a hard reload.
+      // So, it's possible for the front proxy to load a page from another zone.
+      // Since the page is reloaded, when we go back to the counter page again,
+      // previous counter value should be gone.
       const counterAfter404Page = await browser
         .elementByCss('#no-such-page').click()
         .waitForElementByCss('h1')


### PR DESCRIPTION
When we got an error from a "page script loading" in the client navigation, we should visit the page with a hard reload.
So, the proxy server can render a page from a different zone.

This PR adds a test case for that. So, we won't break that functionality.