### PR TITLE
Allow className to be used on the Main element

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -100,15 +100,20 @@ export class Head extends Component {
 }
 
 export class Main extends Component {
+  static propTypes = {
+    className: PropTypes.string
+  }
+
   static contextTypes = {
     _documentProps: PropTypes.any
   }
 
   render () {
     const { html, errorHtml } = this.context._documentProps
+    const { className } = this.props
     return (
       <Fragment>
-        <div id='__next' dangerouslySetInnerHTML={{ __html: html }} />
+        <div id='__next' dangerouslySetInnerHTML={{ __html: html }} className={className} />
         <div id='__next-error' dangerouslySetInnerHTML={{ __html: errorHtml }} />
       </Fragment>
     )


### PR DESCRIPTION
I was using `next 4.2.3`. I just upgraded to `5.0.0` today and discovered that the classes that were being passed in on the `<Main />` component in the `_document.js` were no longer coming though.

After some digging, it looks like the `className` pass-through was removed in [4.3.0-canary.1](https://github.com/zeit/next.js/commit/7a08e1b5f89040743f8a3e463c2e56bc9ed68ac8).

Clearly, the reason why it was removed was because `<Main />` is now returning a `<Fragment />` instead of a `<div />` as the top-level element. `<Fragment />` does not support `className` as a prop.
https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html

**This PR aims to still allow a user to pass in classes via:**
```
<Main className="my-class my-other-class" />
```
## Styled Components
This is especially important in the case of supporting `styled-components`.

### tl;dr;
`styled-components` requires the `className` pass-through for any component composed with `styled()`.

https://www.styled-components.com/docs/basics#styling-any-components
> The styled method works perfectly on all of your own or any third-party components as well, as long as they pass the className prop to their rendered sub-components, which should pass it too, and so on. Ultimately, the className must be passed down the line to an actual DOM node for the styling to take any effect.

**This used to work, but no longer does:**
```
import { Main } from 'next/document';
import styled from 'styled-components';

const StyledMain = styled(Main)`
	background: blue;
`;
```

## Use Case
**Sticky Vertical Layout**
- `<Header />` fixed to the top
- `<Footer />`sticky to the bottom (content pushed)
- `<Main />` flexes

**No longer works:**
![image](https://user-images.githubusercontent.com/3931162/36192162-7292d3c6-112e-11e8-998f-5de4a2731e95.png)

**Before:**
![image](https://user-images.githubusercontent.com/3931162/36192383-3fa0f21c-112f-11e8-9e4d-7bc9f39f0a77.png)

