### PR TITLE
Display errors when using glamor/server in a custom document

### DIFF
--- a/examples/with-glamor/pages/_document.js
+++ b/examples/with-glamor/pages/_document.js
@@ -4,7 +4,7 @@ import { renderStatic } from 'glamor/server'
 export default class MyDocument extends Document {
   static async getInitialProps ({ renderPage }) {
     const page = renderPage()
-    const styles = renderStatic(() => page.html)
+    const styles = renderStatic(() => page.html || page.errorHtml)
     return { ...page, ...styles }
   }
 

--- a/examples/with-glamorous/pages/_document.js
+++ b/examples/with-glamorous/pages/_document.js
@@ -4,7 +4,7 @@ import { renderStatic } from 'glamor/server'
 export default class MyDocument extends Document {
   static async getInitialProps ({ renderPage }) {
     const page = renderPage()
-    const styles = renderStatic(() => page.html)
+    const styles = renderStatic(() => page.html || page.errorHtml)
     return { ...page, ...styles }
   }
 


### PR DESCRIPTION
When you're using glamor in a custom _document the example shows to use page.html as input. However, when developing it may happen that you get an error. In this case page.html is undefined and page.errorHtml contains the messages.

I updated this in the example so people might not have to look for it anymore.