### PR TITLE
Add a test for reloading the page on page script error with prefetch

### DIFF
--- a/test/integration/production/pages/counter.js
+++ b/test/integration/production/pages/counter.js
@@ -20,6 +20,8 @@ export default class extends Component {
     return (
       <div id='counter-page'>
         <Link href='/no-such-page'><a id='no-such-page'>No Such Page</a></Link>
+        <br />
+        <Link href='/no-such-page' prefetch><a id='no-such-page-prefetch'>No Such Page (with prefetch)</a></Link>
         <p>This is the home.</p>
         <div id='counter'>
           Counter: {counter}

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -134,7 +134,7 @@ describe('Production Usage', () => {
       // Since the page is reloaded, when we go back to the counter page again,
       // previous counter value should be gone.
       const counterAfter404Page = await browser
-        .elementByCss('#no-such-page').click()
+        .elementByCss('#no-such-page-prefetch').click()
         .waitForElementByCss('h1')
         .back()
         .waitForElementByCss('#counter-page')

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -7,7 +7,8 @@ import {
   nextBuild,
   startApp,
   stopApp,
-  renderViaHTTP
+  renderViaHTTP,
+  waitFor
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import fetch from 'node-fetch'
@@ -100,6 +101,33 @@ describe('Production Usage', () => {
           .elementByCss('#increase').click().click()
           .elementByCss('#counter').text()
       expect(counter).toBe('Counter: 2')
+
+      // When we go to the 404 page, it'll do a hard reload.
+      // So, it's possible for the front proxy to load a page from another zone.
+      // Since the page is reloaded, when we go back to the counter page again,
+      // previous counter value should be gone.
+      const counterAfter404Page = await browser
+        .elementByCss('#no-such-page').click()
+        .waitForElementByCss('h1')
+        .back()
+        .waitForElementByCss('#counter-page')
+        .elementByCss('#counter').text()
+      expect(counterAfter404Page).toBe('Counter: 0')
+
+      browser.close()
+    })
+
+    it('should reload the page on page script error with prefetch', async () => {
+      const browser = await webdriver(appPort, '/counter')
+      const counter = await browser
+          .elementByCss('#increase').click().click()
+          .elementByCss('#counter').text()
+      expect(counter).toBe('Counter: 2')
+
+      // Let the browser to prefetch the page and error it on the console.
+      await waitFor(3000)
+      const browserLogs = await browser.log('browser')
+      expect(browserLogs[0].message).toMatch(/Page does not exist: \/no-such-page/)
 
       // When we go to the 404 page, it'll do a hard reload.
       // So, it's possible for the front proxy to load a page from another zone.


### PR DESCRIPTION
Check the Link component below:

```jsx
<Link href="/woot" prefetch ><a>Woot</a></Link> 
```

But there's no page called `/woot` in this app.
So, when the user clicks the Link, it should load `/woot` via the server rather doing a client navigation.
This allow the proxy to load the `/woot` from a different zone.

This PR adds a test case for this.