### PR TITLE
Expose totalPages to the webpack decorator

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -314,7 +314,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
   }
 
   if (typeof config.webpack === 'function') {
-    webpackConfig = config.webpack(webpackConfig, {dir, dev, isServer, buildId, config, defaultLoaders})
+    webpackConfig = config.webpack(webpackConfig, {dir, dev, isServer, buildId, config, defaultLoaders, totalPages})
   }
 
   return webpackConfig


### PR DESCRIPTION
Follow-up on #3600

totalPages is the only variable we didn't expose to the client, the rest is all exposed in the config.