### PR TITLE
Allow page extensions in any order

### DIFF
--- a/server/build/webpack/utils.js
+++ b/server/build/webpack/utils.js
@@ -36,7 +36,7 @@ export function createEntry (filePath, {name, pageExtensions} = {}) {
 
   // Makes sure supported extensions are stripped off. The outputted file should always be `.js`
   if (pageExtensions) {
-    entryName = entryName.replace(new RegExp(`\\.+(${pageExtensions})`), '.js')
+    entryName = entryName.replace(new RegExp(`\\.+(${pageExtensions})$`), '.js')
   }
 
   return {

--- a/test/isolated/webpack-utils.test.js
+++ b/test/isolated/webpack-utils.test.js
@@ -28,6 +28,18 @@ describe('createEntry', () => {
     expect(entry.files[0]).toBe('./pages/index.jsx')
   })
 
+  it('Should allow custom extension like .tsx to be turned into .js', () => {
+    const entry = createEntry('pages/index.tsx', {pageExtensions: ['tsx', 'ts'].join('|')})
+    expect(entry.name).toBe(normalize('bundles/pages/index.js'))
+    expect(entry.files[0]).toBe('./pages/index.tsx')
+  })
+
+  it('Should allow custom extension like .tsx to be turned into .js with another order', () => {
+    const entry = createEntry('pages/index.tsx', {pageExtensions: ['ts', 'tsx'].join('|')})
+    expect(entry.name).toBe(normalize('bundles/pages/index.js'))
+    expect(entry.files[0]).toBe('./pages/index.tsx')
+  })
+
   it('Should turn pages/blog/index.js into pages/blog.js', () => {
     const entry = createEntry('pages/blog/index.js')
     expect(entry.name).toBe(normalize('bundles/pages/blog.js'))


### PR DESCRIPTION
Adding custom page extensions wasn't working if 'ts' came before 'tsx'. This should fix it.