### PR TITLE
Read compiler.context instead of this.context

### DIFF
--- a/server/on-demand-entry-handler.js
+++ b/server/on-demand-entry-handler.js
@@ -39,7 +39,7 @@ export default function onDemandEntryHandler (devMiddleware, compilers, {
       const allEntries = Object.keys(entries).map((page) => {
         const { name, entry } = entries[page]
         entries[page].status = BUILDING
-        return addEntry(compilation, this.context, name, entry)
+        return addEntry(compilation, compiler.context, name, entry)
       })
 
       Promise.all(allEntries)


### PR DESCRIPTION
`this` breaks when using webpack 4. I guess because we're using multicompiler.