### PR TITLE
⚠️ prefetch is a production only feature ⚠️

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -608,7 +608,7 @@ The above `router` object comes with an API similar to [`next/router`](#imperati
 
 ### Prefetching Pages
 
-(This is a production only feature)
+⚠️ This is a production only feature ⚠️
 
 <p><details>
   <summary><b>Examples</b></summary>


### PR DESCRIPTION
I was wondering why I couldn't see the prefetch network request.
Turns out I wasn't forwarding the property to the next router nor I was running the application in production.