### PR TITLE
The type attribute is unnecessary for JavaScript resources

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -132,7 +132,6 @@ export class NextScript extends Component {
     return (
       <script
         key={filename}
-        type='text/javascript'
         src={`${assetPrefix}/_next/${hash}/${filename}`}
         {...additionalProps}
       />
@@ -163,7 +162,6 @@ export class NextScript extends Component {
           <script
             async
             key={chunk}
-            type='text/javascript'
             src={`${assetPrefix}/_next/webpack/chunks/${chunk}`}
           />
         ))}
@@ -204,8 +202,8 @@ export class NextScript extends Component {
           `}
         `
       }} />}
-      {page !== '/_error' && <script async id={`__NEXT_PAGE__${pathname}`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} />}
-      <script async id={`__NEXT_PAGE__/_error`} type='text/javascript' src={`${assetPrefix}/_next/${buildId}/page/_error.js`} />
+      {page !== '/_error' && <script async id={`__NEXT_PAGE__${pathname}`} src={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} />}
+      <script async id={`__NEXT_PAGE__/_error`} src={`${assetPrefix}/_next/${buildId}/page/_error.js`} />
       {staticMarkup ? null : this.getDynamicChunks()}
       {staticMarkup ? null : this.getScripts()}
     </Fragment>


### PR DESCRIPTION
https://validator.w3.org/

Warning:  The type attribute is unnecessary for JavaScript resources.