### PR TITLE
Allow next.config.js to export a function

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/lib/constants')

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,4 @@
+export const PHASE_EXPORT = 'phase-export'
+export const PHASE_PRODUCTION_BUILD = 'phase-production-build'
+export const PHASE_PRODUCTION_SERVER = 'phase-production-server'
+export const PHASE_DEVELOPMENT_SERVER = 'phase-development-server'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prefetch.js",
     "router.js",
     "asset.js",
-    "error.js"
+    "error.js",
+    "constants.js"
   ],
   "bin": {
     "next": "./dist/bin/next"

--- a/readme.md
+++ b/readme.md
@@ -1009,6 +1009,36 @@ module.exports = {
 }
 ```
 
+Or use a function:
+
+```js
+module.exports = (phase, {defaultConfig}){
+  // 
+  // https://github.com/zeit/
+  return {
+    /* config options here */
+  }
+}
+```
+
+`phase` is the current context in which the configuration is loaded. You can see all phases here: [contants](./lib/constants.js)
+Phases can be imported from `next/constants`:
+
+```js
+const {PHASE_DEVELOPMENT_SERVER} = require('next/constants')
+module.exports = (phase, {defaultConfig}){
+  if(phase === PHASE_DEVELOPMENT_SERVER) {
+    return {
+      /* development only config options here */
+    }
+  }
+
+  return {
+    /* config options for all phases except development here */
+  }
+}
+```
+
 #### Setting a custom build directory
 
 You can specify a name to use for a custom build directory. For example, the following config will create a `build` folder instead of a `.next` folder. If no configuration is specified then next will create a `.next` folder.

--- a/server/build/index.js
+++ b/server/build/index.js
@@ -2,12 +2,12 @@ import { join } from 'path'
 import fs from 'mz/fs'
 import uuid from 'uuid'
 import webpack from 'webpack'
-import getConfig from '../config'
+import getConfig, {phases} from '../config'
 import getBaseWebpackConfig from './webpack'
 import md5File from 'md5-file/promise'
 
 export default async function build (dir, conf = null) {
-  const config = getConfig('build', dir, conf)
+  const config = getConfig(phases.PRODUCTION_BUILD, dir, conf)
   const buildId = uuid.v4()
 
   try {

--- a/server/build/index.js
+++ b/server/build/index.js
@@ -2,12 +2,13 @@ import { join } from 'path'
 import fs from 'mz/fs'
 import uuid from 'uuid'
 import webpack from 'webpack'
-import getConfig, {phases} from '../config'
+import getConfig from '../config'
+import {PHASE_PRODUCTION_BUILD} from '../../lib/constants'
 import getBaseWebpackConfig from './webpack'
 import md5File from 'md5-file/promise'
 
 export default async function build (dir, conf = null) {
-  const config = getConfig(phases.PRODUCTION_BUILD, dir, conf)
+  const config = getConfig(PHASE_PRODUCTION_BUILD, dir, conf)
   const buildId = uuid.v4()
 
   try {

--- a/server/build/index.js
+++ b/server/build/index.js
@@ -7,7 +7,7 @@ import getBaseWebpackConfig from './webpack'
 import md5File from 'md5-file/promise'
 
 export default async function build (dir, conf = null) {
-  const config = getConfig(dir, conf)
+  const config = getConfig('build', dir, conf)
   const buildId = uuid.v4()
 
   try {

--- a/server/config.js
+++ b/server/config.js
@@ -2,13 +2,6 @@ import findUp from 'find-up'
 
 const cache = new Map()
 
-export const phases = {
-  PRODUCTION_BUILD: 'PRODUCTION_BUILD',
-  PRODUCTION_SERVER: 'PRODUCTION_SERVER',
-  DEVELOPMENT_SERVER: 'DEVELOPMENT_SERVER',
-  EXPORT: 'EXPORT'
-}
-
 const defaultConfig = {
   webpack: null,
   webpackDevMiddleware: null,
@@ -27,7 +20,7 @@ export default function getConfig (phase, dir, customConfig) {
   return cache.get(dir)
 }
 
-function loadConfig (phase, dir, customConfig) {
+export function loadConfig (phase, dir, customConfig) {
   if (customConfig && typeof customConfig === 'object') {
     customConfig.configOrigin = 'server'
     return withDefaults(customConfig)
@@ -42,7 +35,7 @@ function loadConfig (phase, dir, customConfig) {
     const userConfigModule = require(path)
     userConfig = userConfigModule.default || userConfigModule
     if (typeof userConfigModule === 'function') {
-      userConfig = userConfigModule(phase, {defaultConfig, phases})
+      userConfig = userConfigModule(phase, {defaultConfig})
     }
     userConfig.configOrigin = 'next.config.js'
   }

--- a/server/config.js
+++ b/server/config.js
@@ -2,6 +2,13 @@ import findUp from 'find-up'
 
 const cache = new Map()
 
+export const phases = {
+  PRODUCTION_BUILD: 'production-build',
+  PRODUCTION_SERVER: 'production-server',
+  DEVELOPMENT_SERVER: 'development-server',
+  EXPORT: 'export'
+}
+
 const defaultConfig = {
   webpack: null,
   webpackDevMiddleware: null,
@@ -35,7 +42,7 @@ function loadConfig (phase, dir, customConfig) {
     const userConfigModule = require(path)
     userConfig = userConfigModule.default || userConfigModule
     if (typeof userConfigModule === 'function') {
-      userConfig = userConfigModule(phase, {defaultConfig})
+      userConfig = userConfigModule(phase, {defaultConfig, phases})
     }
     userConfig.configOrigin = 'next.config.js'
   }

--- a/server/config.js
+++ b/server/config.js
@@ -13,14 +13,14 @@ const defaultConfig = {
   pageExtensions: ['jsx', 'js'] // jsx before js because otherwise regex matching will match js first
 }
 
-export default function getConfig (dir, customConfig) {
+export default function getConfig (phase, dir, customConfig) {
   if (!cache.has(dir)) {
-    cache.set(dir, loadConfig(dir, customConfig))
+    cache.set(dir, loadConfig(phase, dir, customConfig))
   }
   return cache.get(dir)
 }
 
-function loadConfig (dir, customConfig) {
+function loadConfig (phase, dir, customConfig) {
   if (customConfig && typeof customConfig === 'object') {
     customConfig.configOrigin = 'server'
     return withDefaults(customConfig)
@@ -34,6 +34,9 @@ function loadConfig (dir, customConfig) {
   if (path && path.length) {
     const userConfigModule = require(path)
     userConfig = userConfigModule.default || userConfigModule
+    if (typeof userConfigModule === 'function') {
+      userConfig = userConfigModule(phase, {defaultConfig})
+    }
     userConfig.configOrigin = 'next.config.js'
   }
 

--- a/server/config.js
+++ b/server/config.js
@@ -3,10 +3,10 @@ import findUp from 'find-up'
 const cache = new Map()
 
 export const phases = {
-  PRODUCTION_BUILD: 'production-build',
-  PRODUCTION_SERVER: 'production-server',
-  DEVELOPMENT_SERVER: 'development-server',
-  EXPORT: 'export'
+  PRODUCTION_BUILD: 'PRODUCTION_BUILD',
+  PRODUCTION_SERVER: 'PRODUCTION_SERVER',
+  DEVELOPMENT_SERVER: 'DEVELOPMENT_SERVER',
+  EXPORT: 'EXPORT'
 }
 
 const defaultConfig = {

--- a/server/export.js
+++ b/server/export.js
@@ -4,7 +4,7 @@ import mkdirp from 'mkdirp-then'
 import walk from 'walk'
 import { extname, resolve, join, dirname, sep } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
-import getConfig from './config'
+import getConfig, {phases} from './config'
 import { renderToHTML } from './render'
 import { getAvailableChunks } from './utils'
 import { printAndExit } from '../lib/utils'
@@ -12,7 +12,7 @@ import { setAssetPrefix } from '../lib/asset'
 
 export default async function (dir, options, configuration) {
   dir = resolve(dir)
-  const config = configuration || getConfig('export', dir)
+  const config = configuration || getConfig(phases.EXPORT, dir)
   const nextDir = join(dir, config.distDir)
 
   log(`  using build directory: ${nextDir}`)

--- a/server/export.js
+++ b/server/export.js
@@ -4,7 +4,8 @@ import mkdirp from 'mkdirp-then'
 import walk from 'walk'
 import { extname, resolve, join, dirname, sep } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
-import getConfig, {phases} from './config'
+import getConfig from './config'
+import {PHASE_EXPORT} from '../lib/constants'
 import { renderToHTML } from './render'
 import { getAvailableChunks } from './utils'
 import { printAndExit } from '../lib/utils'
@@ -12,7 +13,7 @@ import { setAssetPrefix } from '../lib/asset'
 
 export default async function (dir, options, configuration) {
   dir = resolve(dir)
-  const config = configuration || getConfig(phases.EXPORT, dir)
+  const config = configuration || getConfig(PHASE_EXPORT, dir)
   const nextDir = join(dir, config.distDir)
 
   log(`  using build directory: ${nextDir}`)

--- a/server/export.js
+++ b/server/export.js
@@ -12,7 +12,7 @@ import { setAssetPrefix } from '../lib/asset'
 
 export default async function (dir, options, configuration) {
   dir = resolve(dir)
-  const config = configuration || getConfig(dir)
+  const config = configuration || getConfig('export', dir)
   const nextDir = join(dir, config.distDir)
 
   log(`  using build directory: ${nextDir}`)

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,8 @@ import {
 } from './render'
 import Router from './router'
 import { getAvailableChunks, isInternalUrl } from './utils'
-import getConfig, {phases} from './config'
+import getConfig from './config'
+import {PHASE_PRODUCTION_SERVER, PHASE_DEVELOPMENT_SERVER} from '../lib/constants'
 // We need to go up one more level since we are in the `dist` directory
 import pkg from '../../package'
 import * as asset from '../lib/asset'
@@ -33,7 +34,7 @@ export default class Server {
     this.quiet = quiet
     this.router = new Router()
     this.http = null
-    const phase = dev ? phases.DEVELOPMENT_SERVER : phases.PRODUCTION_SERVER
+    const phase = dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER
     this.config = getConfig(phase, this.dir, conf)
     this.dist = this.config.distDir
 

--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,8 @@ export default class Server {
     this.quiet = quiet
     this.router = new Router()
     this.http = null
-    this.config = getConfig(this.dir, conf)
+    const phase = dev ? 'development' : 'production'
+    this.config = getConfig(phase, this.dir, conf)
     this.dist = this.config.distDir
 
     this.hotReloader = dev ? this.getHotReloader(this.dir, { quiet, config: this.config }) : null

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,7 @@ import {
 } from './render'
 import Router from './router'
 import { getAvailableChunks, isInternalUrl } from './utils'
-import getConfig from './config'
+import getConfig, {phases} from './config'
 // We need to go up one more level since we are in the `dist` directory
 import pkg from '../../package'
 import * as asset from '../lib/asset'
@@ -33,7 +33,7 @@ export default class Server {
     this.quiet = quiet
     this.router = new Router()
     this.http = null
-    const phase = dev ? 'development' : 'production'
+    const phase = dev ? phases.DEVELOPMENT_SERVER : phases.PRODUCTION_SERVER
     this.config = getConfig(phase, this.dir, conf)
     this.dist = this.config.distDir
 

--- a/test/isolated/_resolvedata/with-function/next.config.js
+++ b/test/isolated/_resolvedata/with-function/next.config.js
@@ -1,0 +1,7 @@
+module.exports = (phase, {defaultConfig}) => {
+  return {
+    phase,
+    defaultConfig,
+    customConfig: true
+  }
+}

--- a/test/isolated/_resolvedata/without-function/next.config.js
+++ b/test/isolated/_resolvedata/without-function/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  customConfig: true
+}

--- a/test/isolated/config.test.js
+++ b/test/isolated/config.test.js
@@ -1,0 +1,41 @@
+/* global describe, it, expect */
+
+import {join} from 'path'
+import getConfig, {loadConfig} from '../../dist/server/config'
+import {PHASE_DEVELOPMENT_SERVER} from '../../dist/lib/constants'
+
+const pathToConfig = join(__dirname, '_resolvedata', 'without-function')
+const pathToConfigFn = join(__dirname, '_resolvedata', 'with-function')
+
+describe('config', () => {
+  it('Should get the configuration', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig)
+    expect(config.customConfig).toBe(true)
+  })
+
+  it('Should pass the phase correctly', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
+    expect(config.phase).toBe(PHASE_DEVELOPMENT_SERVER)
+  })
+
+  it('Should pass the defaultConfig correctly', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
+    expect(config.defaultConfig).toBeDefined()
+  })
+
+  it('Should pass the customConfig correctly', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, {customConfig: true})
+    expect(config.customConfig).toBe(true)
+  })
+
+  it('Should not pass the customConfig when it is null', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, null)
+    expect(config.webpack).toBe(null)
+  })
+
+  it('Should cache on getConfig', () => {
+    const config = getConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig)
+    const config2 = getConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig, {extraConfig: true}) // won't add extraConfig because it's cached.
+    expect(config === config2).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #3857

Example:

`phase` will be one of the phases defined in `next/constants`. So, we can provide configs based on the `phase`.

```js
import { PHASE_PRODUCTION_BUILD } from 'next/constants'

module.exports = (phase, {defaultConfig}) => {
   if (phase === PHASE_PRODUCTION_BUILD) {
     // Do something
   }
   return {} // custom configuration
}
```