### PR TITLE
Fix router not working in Cypress tests

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -185,7 +185,8 @@ export default class Router {
   }
 
   changeState (method, url, as, options = {}) {
-    if (window.frameElement) {
+    if (window.frameElement && !window.Cypress) {
+      // The Cyrpress testing tool runs tests inside an iFrame but preserves full browser history support
       execOnce(warn)(`Warning: You're using Next.js inside an iFrame. Browser history is disabled.`)
     } else if (method !== 'pushState' || getURL() !== as) {
       window.history[method]({ url, as, options }, null, as)


### PR DESCRIPTION
While adding Cypress tests to my Next.js app, we discovered the Next.js router doesn't work in these tests because they run in an iFrame. Next.js sees this and disables the router.

Even though the test runs in an iFrame, Cypress preserves full browser history support, so the router shouldn't be disabled in this case.

This change bypasses the iFrame check when in the Cypress testing environment.

Let me know if you want any changes!

I've verified this change works on this pull request: https://github.com/BeeDesignLLC/GlutenProject.com/pull/151