### PR TITLE
Downgrade webpack-hot-middleware to 2.19.1 (patch)

### DIFF
--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -9,8 +9,8 @@ const {
 
 export default () => {
   webpackHotMiddlewareClient.setOptionsAndConnect({
-    overlay: false,
-    reload: true,
+    overlay: 'false',
+    reload: 'true',
     path: `${assetPrefix}/_next/webpack-hmr`
   })
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "walk": "2.3.9",
     "webpack": "3.10.0",
     "webpack-dev-middleware": "1.12.0",
-    "webpack-hot-middleware": "2.21.0",
+    "webpack-hot-middleware": "2.19.1",
     "webpack-sources": "1.1.0",
     "write-file-webpack-plugin": "4.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6871,9 +6871,9 @@ webpack-dev-middleware@1.12.0:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-hot-middleware@2.21.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.21.0.tgz#7b3c113a7a4b301c91e0749573c7aab28b414b52"
+webpack-hot-middleware@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.19.1.tgz#5db32c31c955c1ead114d37c7519ea554da0d405"
   dependencies:
     ansi-html "0.0.7"
     html-entities "^1.2.0"
@@ -7031,10 +7031,6 @@ xdg-basedir@^3.0.0:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
-
-xss-filters@1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/xss-filters/-/xss-filters-1.2.7.tgz#59fa1de201f36f2f3470dcac5f58ccc2830b0a9a"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Fixes case where hot reloading breaks when something throws inside the main

```js
throw new Error('')
export default () => <div></div>
```

