### PR TITLE
Readme: make`npm run dev` more obvious 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,8 @@ export default () => <div>Welcome to next.js!</div>
 
 To start the development server from your project directory:
 
-```npm run dev
+```bash
+npm run dev
 ```
 
 Then go to `http://localhost:3000`. 

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,16 @@ Populate `./pages/index.js` inside your project:
 export default () => <div>Welcome to next.js!</div>
 ```
 
-and then just run `npm run dev` and go to `http://localhost:3000`. To use another port, you can run `npm run dev -- -p <your port here>`.
+### Run the development server
+
+To start the development server from your project directory:
+
+```npm run dev
+```
+
+Then go to `http://localhost:3000`. 
+
+To use another port, you can run `npm run dev -- -p <your port here>`.
 
 So far, we get:
 


### PR DESCRIPTION
In several blog posts and articles I found when getting going with Next, it says "just run `next`".  This results in a "No such file or directory" error because next isn't in the path.

Looking in the package.json it has:

```
    "scripts": {
        "dev": "next", …
```

This makes it look like you just type `next` to start the server.

Making this more obvious in the readem with its own "Run the development server" heading would have helped me with that initial confusion. 

Could I suggest someone also goes back and updates articles, like this one, that refer to the `next` command? https://zeit.co/blog/next2

Cheers folks! Looking forward to starting with Next.js