### PR TITLE
Allow etags to be disabled with config option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1047,6 +1047,17 @@ module.exports = {
 }
 ```
 
+#### Disabling etag generation
+
+You can disable etag generation for HTML pages depending on your cache strategy. If no configuration is specified then next will generate etags for every page.
+
+```js
+// next.config.js
+module.exports = {
+  generateEtags: false
+}
+```
+
 #### Configuring the onDemandEntries
 
 Next exposes some options that give you some control over how the server will dispose or keep in memories pages built:

--- a/readme.md
+++ b/readme.md
@@ -1049,7 +1049,7 @@ module.exports = {
 
 #### Disabling etag generation
 
-You can disable etag generation for HTML pages depending on your cache strategy. If no configuration is specified then next will generate etags for every page.
+You can disable etag generation for HTML pages depending on your cache strategy. If no configuration is specified then Next will generate etags for every page.
 
 ```js
 // next.config.js

--- a/server/config.js
+++ b/server/config.js
@@ -10,6 +10,7 @@ const defaultConfig = {
   assetPrefix: '',
   configOrigin: 'default',
   useFileSystemPublicRoutes: true,
+  generateEtags: true,
   pageExtensions: ['jsx', 'js'] // jsx before js because otherwise regex matching will match js first
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -45,6 +45,10 @@ export default class Server {
       updateNotifier(pkg, 'next')
     }
 
+    // Only serverRuntimeConfig needs the default
+    // publicRuntimeConfig gets it's default in client/index.js
+    const {serverRuntimeConfig = {}, publicRuntimeConfig, assetPrefix, generateEtags} = this.nextConfig
+
     if (!dev && !fs.existsSync(resolve(dir, this.dist, 'BUILD_ID'))) {
       console.error(`> Could not find a valid build in the '${this.dist}' directory! Try building your app with 'next build' before starting the server.`)
       process.exit(1)
@@ -57,12 +61,9 @@ export default class Server {
       dist: this.dist,
       hotReloader: this.hotReloader,
       buildId: this.buildId,
-      availableChunks: dev ? {} : getAvailableChunks(this.dir, this.dist)
+      availableChunks: dev ? {} : getAvailableChunks(this.dir, this.dist),
+      generateEtags
     }
-
-    // Only serverRuntimeConfig needs the default
-    // publicRuntimeConfig gets it's default in client/index.js
-    const {serverRuntimeConfig = {}, publicRuntimeConfig, assetPrefix} = this.nextConfig
 
     // Only the `publicRuntimeConfig` key is exposed to the client side
     // It'll be rendered as part of __NEXT_DATA__ on the client side
@@ -357,7 +358,7 @@ export default class Server {
     if (this.nextConfig.poweredByHeader) {
       res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
     }
-    return sendHTML(req, res, html, req.method, this.renderOpts, this.nextConfig)
+    return sendHTML(req, res, html, req.method, this.renderOpts)
   }
 
   async renderToHTML (req, res, pathname, query) {
@@ -386,7 +387,7 @@ export default class Server {
 
   async renderError (err, req, res, pathname, query) {
     const html = await this.renderErrorToHTML(err, req, res, pathname, query)
-    return sendHTML(req, res, html, req.method, this.renderOpts, this.nextConfig)
+    return sendHTML(req, res, html, req.method, this.renderOpts)
   }
 
   async renderErrorToHTML (err, req, res, pathname, query) {

--- a/server/index.js
+++ b/server/index.js
@@ -357,7 +357,7 @@ export default class Server {
     if (this.nextConfig.poweredByHeader) {
       res.setHeader('X-Powered-By', `Next.js ${pkg.version}`)
     }
-    return sendHTML(req, res, html, req.method, this.renderOpts)
+    return sendHTML(req, res, html, req.method, this.renderOpts, this.nextConfig)
   }
 
   async renderToHTML (req, res, pathname, query) {
@@ -386,7 +386,7 @@ export default class Server {
 
   async renderError (err, req, res, pathname, query) {
     const html = await this.renderErrorToHTML(err, req, res, pathname, query)
-    return sendHTML(req, res, html, req.method, this.renderOpts)
+    return sendHTML(req, res, html, req.method, this.renderOpts, this.nextConfig)
   }
 
   async renderErrorToHTML (err, req, res, pathname, query) {

--- a/server/render.js
+++ b/server/render.js
@@ -15,18 +15,18 @@ import { flushChunks } from '../lib/dynamic'
 
 const logger = console
 
-export async function render (req, res, pathname, query, opts, nextOpts) {
+export async function render (req, res, pathname, query, opts) {
   const html = await renderToHTML(req, res, pathname, query, opts)
-  sendHTML(req, res, html, req.method, opts, nextOpts)
+  sendHTML(req, res, html, req.method, opts)
 }
 
 export function renderToHTML (req, res, pathname, query, opts) {
   return doRender(req, res, pathname, query, opts)
 }
 
-export async function renderError (err, req, res, pathname, query, opts, nextOpts) {
+export async function renderError (err, req, res, pathname, query, opts) {
   const html = await renderErrorToHTML(err, req, res, query, opts)
-  sendHTML(req, res, html, req.method, opts, nextOpts)
+  sendHTML(req, res, html, req.method, opts)
 }
 
 export function renderErrorToHTML (err, req, res, pathname, query, opts = {}) {
@@ -138,7 +138,7 @@ export async function renderScriptError (req, res, page, error) {
   res.end('500 - Internal Error')
 }
 
-export function sendHTML (req, res, html, method, { dev }, { generateEtags }) {
+export function sendHTML (req, res, html, method, { dev, generateEtags }) {
   if (isResSent(res)) return
   const etag = generateEtags && generateETag(html)
 

--- a/test/integration/custom-server/next.config.js
+++ b/test/integration/custom-server/next.config.js
@@ -2,5 +2,6 @@ module.exports = {
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60
-  }
+  },
+  generateEtags: process.env.GENERATE_ETAGS === 'true'
 }


### PR DESCRIPTION
This PR allows etag generation to be disabled via a config option. 

The goal is to allow developers to decide when to send an etag header depending on the cache strategy being used.

This can also help save some CPU ticks by eliminating calls to crypto functions during SSR.