### PR TITLE
Small grammar mistake

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -552,7 +552,7 @@ componentWillReceiveProps(nextProps) {
 
 > NOTES:
 >
-> Shallow routing works **only** for same page URL changes. For an example, let's assume we've another page called `about`, and you run this:
+> Shallow routing works **only** for same page URL changes. For an example, let's assume we have another page called `about`, and you run this:
 > ```js
 > Router.push('/about?counter=10', '/about?counter=10', { shallow: true })
 > ```


### PR DESCRIPTION
"Let's assume we've another page called..." correct way to say it is "we have". Just a small correction.