### PR TITLE
Update custom-server-typescript example

### DIFF
--- a/examples/custom-server-typescript/README.md
+++ b/examples/custom-server-typescript/README.md
@@ -38,3 +38,5 @@ now
 ## The idea behind the example
 
 The example shows how you can use [TypeScript](https://typescriptlang.com) on both the server and the client while using [Nodemon](https://nodemon.io/) to live reload the server code without affecting the Next.js universal code.
+Server entry point is `server/index.ts` in development and `production-server/index.js` in production.
+The second directory should be added to `.gitignore`.

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "nodemon server/index.ts",
     "build": "next build && tsc --module commonjs",
-    "start": "NODE_ENV=production node lib/index.js"
+    "start": "NODE_ENV=production node production-server/index.js"
   },
   "dependencies": {
     "next": "latest",

--- a/examples/custom-server-typescript/tsconfig.json
+++ b/examples/custom-server-typescript/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
+    "jsx": "preserve",
     "allowJs": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
@@ -21,7 +22,7 @@
       "es2015",
       "es2016"
     ],
-    "outDir": "lib/"
+    "outDir": "production-server/"
   },
   "include": [
     "server/**/*.ts"


### PR DESCRIPTION
Context: https://github.com/zeit/next.js/pull/3838#issuecomment-370189242 and below

- Add `"jsx": "preserve"` to `tsconfig.json`
- Rename `lib` to `production-server` to remove incompatibility with other examples

cc @retrixe @khuezy @timneutkens