### PR TITLE
Pass apollo client in context

### DIFF
--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -10,20 +10,21 @@ function getComponentDisplayName(Component) {
 }
 
 export default ComposedComponent => {
-  return class WithData extends React.Component {
+  class WithData extends React.Component {
     static displayName = `WithData(${getComponentDisplayName(
-      ComposedComponent
+      ComposedComponent,
     )})`
+
     static propTypes = {
-      serverState: PropTypes.object.isRequired
+      serverState: PropTypes.object, // eslint-disable-line
     }
 
     static async getInitialProps(ctx) {
       // Initial serverState with apollo (empty)
       let serverState = {
         apollo: {
-          data: {}
-        }
+          data: {},
+        },
       }
 
       // Evaluate the composed component's getInitialProps()
@@ -34,49 +35,54 @@ export default ComposedComponent => {
 
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
-      const apollo = initApollo()
-      try {
-        // Run all GraphQL queries
-        await getDataFromTree(
-          <ApolloProvider client={apollo}>
-            <ComposedComponent {...composedInitialProps} />
-          </ApolloProvider>,
-          {
-            router: {
-              asPath: ctx.asPath,
-              pathname: ctx.pathname,
-              query: ctx.query
-            }
-          }
-        )
-      } catch (error) {
-        // Prevent Apollo Client GraphQL errors from crashing SSR.
-        // Handle them in components via the data.error prop:
-        // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
-      }
-
       if (!process.browser) {
+        const apollo = initApollo()
+
+        try {
+          // Run all GraphQL queries
+          await getDataFromTree(
+            <ApolloProvider client={apollo}>
+              <ComposedComponent {...composedInitialProps} />
+            </ApolloProvider>,
+            {
+              router: {
+                asPath: ctx.asPath,
+                pathname: ctx.pathname,
+                query: ctx.query,
+              },
+            },
+          )
+        } catch (error) {
+          console.log('WITH APOLLO COMPONENT FAILED ', error)
+          // Prevent Apollo Client GraphQL errors from crashing SSR.
+          // Handle them in components via the data.error prop:
+          // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
+        }
         // getDataFromTree does not call componentWillUnmount
         // head side effect therefore need to be cleared manually
         Head.rewind()
-      }
 
-      // Extract query data from the Apollo store
-      serverState = {
-        apollo: {
-          data: apollo.cache.extract()
+        // Extract query data from the Apollo store
+        serverState = {
+          apollo: {
+            data: apollo.cache.extract(),
+          },
         }
       }
 
       return {
         serverState,
-        ...composedInitialProps
+        ...composedInitialProps,
       }
     }
 
     constructor(props) {
       super(props)
       this.apollo = initApollo(this.props.serverState.apollo.data)
+    }
+
+    getChildContext() {
+      return { apolloClient: this.apollo }
     }
 
     render() {
@@ -87,4 +93,10 @@ export default ComposedComponent => {
       )
     }
   }
+
+  WithData.childContextTypes = {
+    apolloClient: PropTypes.object,
+  }
+
+  return WithData
 }


### PR DESCRIPTION
Right now it is not possible to execute custom mutations or queries when using `withApollo` HOC. I believe it kind of makes sense to pass apolloClient in [react context](https://reactjs.org/docs/context.html). (or in props when using [getContext](https://github.com/acdlite/recompose/blob/master/docs/API.md#getcontext))