### PR TITLE
Fix null pointer exception in with-react-18next

### DIFF
--- a/examples/with-react-i18next/i18n.js
+++ b/examples/with-react-i18next/i18n.js
@@ -45,7 +45,7 @@ i18n.getInitialProps = (req, namespaces) => {
   req.i18n.languages.forEach((l) => {
     initialI18nStore[l] = {}
     namespaces.forEach((ns) => {
-      initialI18nStore[l][ns] = req.i18n.services.resourceStore.data[l][ns] || {}
+      initialI18nStore[l][ns] = (req.i18n.services.resourceStore.data[l] || {})[ns] || {}
     })
   })
 


### PR DESCRIPTION
The example no longer crashes when a user chooses a non-existing language (e.g. goes to localhost:3000/?lng=ru)

Before this PR: 
```
TypeError: Cannot read property 'home' of undefined
    at /private/tmp/next.js/examples/with-react-i18next/i18n.js:48:33
    at Array.forEach (<anonymous>)
    at forEach (/private/tmp/next.js/examples/with-react-i18next/i18n.js:47:16)
    at Array.forEach (<anonymous>)
    at I18n.forEach [as getInitialProps] (/private/tmp/next.js/examples/with-react-i18next/i18n.js:45:22)
    at Object.getInitialProps (/private/tmp/next.js/examples/with-react-i18next/lib/withI18next.js:15:42)
    at tryCatch (/private/tmp/next.js/examples/with-react-i18next/node_modules/regenerator-runtime/runtime.js:62:40)
```

After this PR: the page uses fallback language (i.e. en).

cc  @jamuhl