### PR TITLE
Fix custom-server-typescript not typechecking

### DIFF
--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,6 +1,6 @@
 {
   "watch": ["server/**/*.ts"],
   "execMap": {
-    "ts": "ts-node --compilerOptions '{\"module\":\"commonjs\"}'"
+    "ts": "ts-node --typeCheck --compilerOptions '{\"module\":\"commonjs\"}'"
   }
 }


### PR DESCRIPTION
Hi

In the current version of the example __custom-server-typescript__, types are never checked.
For instance, change the following line :
```
const dev = process.env.NODE_ENV !== 'production'
```
by :
```
const dev: number = process.env.NODE_ENV !== 'production'
```
then run `npm run dev`. The application launches perfectly, no error is thrown.

In dev environnement, it is preferable to check types all the time, to get immediate feedback. This PR activates type checking. Only when using nodemon, so no impact on production.


Now the above code will (rightfully) refuse to compile : 
```
TSError: ⨯ Unable to compile TypeScript
server/index.ts (6,7): Type 'boolean' is not assignable to type 'number'
```
