### PR TITLE
Use separate tsconfig for server in custom-server-typescript example

### DIFF
--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "nodemon server/index.ts",
-    "build": "next build && tsc --module commonjs",
+    "build": "next build && tsc --project tsconfig.server.json",
     "start": "NODE_ENV=production node production-server/index.js"
   },
   "dependencies": {

--- a/examples/custom-server-typescript/tsconfig.json
+++ b/examples/custom-server-typescript/tsconfig.json
@@ -21,10 +21,6 @@
       "dom",
       "es2015",
       "es2016"
-    ],
-    "outDir": "production-server/"
-  },
-  "include": [
-    "server/**/*.ts"
-  ]
+    ]
+  }
 }

--- a/examples/custom-server-typescript/tsconfig.server.json
+++ b/examples/custom-server-typescript/tsconfig.server.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "production-server/"
+  },
+  "include": ["server/**/*.ts"]
+}


### PR DESCRIPTION
This PR adds `tsconfig.server.json` file to custom-server-typescript example. Without this file, there may be problems because of `"include": ["server/**/*.ts"]` in the main `tsconfig.json`. In my case this was breaking linting – it only ran for ts files in `server` directory.

cc @retrixe