### PR TITLE
Send credentials with on-demand-entries-ping again

### DIFF
--- a/client/on-demand-entries-client.js
+++ b/client/on-demand-entries-client.js
@@ -18,14 +18,14 @@ export default () => {
     try {
       const url = `${assetPrefix}/_next/on-demand-entries-ping?page=${Router.pathname}`
       const res = await fetch(url, {
-        credentials: 'omit'
+        credentials: 'same-origin'
       })
       const payload = await res.json()
       if (payload.invalid) {
         // Payload can be invalid even if the page is not exists.
         // So, we need to make sure it's exists before reloading.
         const pageRes = await fetch(location.href, {
-          credentials: 'omit'
+          credentials: 'same-origin'
         })
         if (pageRes.status === 200) {
           location.reload()


### PR DESCRIPTION
In `client/on-demand-entries-client.js` parameter `{ credentials: 'same-origin' }` of  `fetch()` has been overwritten with `{ credentials: 'omit' }` when universal-webpack has been merged. This currently prevents  on-demand-entries-ping requests from sending cookies which may be required for some development configurations, for example, for authentication. This pull request rolls it back to `credentials: 'same-origin'`.

#### See also:
 - Original issue: #2498
 - Original PR: #2509
 - Offending merge: #3578 (more specifically, [these lines](https://github.com/zeit/next.js/commit/e093441bad588e98765a05df90f76f75283eda07#diff-9a3b2205470e098182c19414ab4d27f2R21))