### PR TITLE
with-apollo: Improve lib/withData

### DIFF
--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -20,11 +20,7 @@ export default ComposedComponent => {
 
     static async getInitialProps(ctx) {
       // Initial serverState with apollo (empty)
-      let serverState = {
-        apollo: {
-          data: {}
-        }
-      }
+      let serverState
 
       // Evaluate the composed component's getInitialProps()
       let composedInitialProps = {}
@@ -38,15 +34,14 @@ export default ComposedComponent => {
       try {
         // Run all GraphQL queries
         await getDataFromTree(
-          <ApolloProvider client={apollo}>
-            <ComposedComponent {...composedInitialProps} />
-          </ApolloProvider>,
+          <ComposedComponent ctx={ctx} {...composedInitialProps} />,
           {
             router: {
               asPath: ctx.asPath,
               pathname: ctx.pathname,
               query: ctx.query
-            }
+            },
+            client: apollo
           }
         )
       } catch (error) {


### PR DESCRIPTION
* pass down getInitialProps ctx to ComposedComponent
* pass apollo client instance directly to getDataFromTree instead of through the ApolloProvider wrapper.
* Avoid redundant empty serverState initialization (It's always initialized)