### PR TITLE
Remove error handling from custom-server-koa's server example

### DIFF
--- a/examples/custom-server-koa/server.js
+++ b/examples/custom-server-koa/server.js
@@ -33,8 +33,7 @@ app.prepare()
   })
 
   server.use(router.routes())
-  server.listen(port, (err) => {
-    if (err) throw err
+  server.listen(port, () => {
     console.log(`> Ready on http://localhost:${port}`)
   })
 })


### PR DESCRIPTION
Koa's `listeningListener` callback is invoked with no arguments according to the Koa's type definitions, hence error handling is extraneous:

```typescript
declare class Application extends EventEmitter {
  // ...
  listen(port?: number, hostname?: string, backlog?: number, listeningListener?: () => void): Server;
  listen(port: number, hostname?: string, listeningListener?: () => void): Server;
  listen(port: number, backlog?: number, listeningListener?: () => void): Server;
  listen(port: number, listeningListener?: () => void): Server;
  listen(path: string, backlog?: number, listeningListener?: () => void): Server;
  listen(path: string, listeningListener?: () => void): Server;
  listen(options: ListenOptions, listeningListener?: () => void): Server;
  listen(handle: any, backlog?: number, listeningListener?: () => void): Server;
  listen(handle: any, listeningListener?: () => void): Server;
  // ...
}
```