### PR TITLE
Allow the customized onClick

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -119,7 +119,7 @@ export default class Link extends Component {
   render () {
     let { children } = this.props
     let { href, as } = this
-    // Deprecated. Warning shown by propType check. If the childen provided is a string (<Link>example</Link>) we wrap it in an <a> tag
+    // Deprecated. Warning shown by propType check. If the children provided is a string (<Link>example</Link>) we wrap it in an <a> tag
     if (typeof children === 'string') {
       children = <a>{children}</a>
     }
@@ -127,7 +127,12 @@ export default class Link extends Component {
     // This will return the first child, if multiple are provided it will throw an error
     const child = Children.only(children)
     const props = {
-      onClick: this.linkClicked
+      onClick: (...args) => {
+        if (child.props && child.props.onClick) {
+          child.props.onClick(...args)
+        }
+        this.linkClicked(...args)
+      }
     }
 
     // If child is an <a> tag and doesn't have a href attribute, or if the 'passHref' property is


### PR DESCRIPTION
For our use case, we need to fire our Analytics related calls when people click the link. The current `onClick` in Next/Link does not allow us to easy to do that. We have to something like:

```
const Link = ({ onClick, href, children, ...rest }) => (
  <span onClick={onClick} {...rest}>
		<NextLink route={href} >
			<span>{children}</span>
		</NextLink>
	</span>
)
```

And later on

```
<Link href='/abc' onClick={onImageClick}>
  <ImageComponent content="something random" />
</Link>

```

Note, we can not do the below, because of [this](https://github.com/zeit/next.js/blob/canary/lib/link.js#L149) overrides my onClick callback. 😢 
```
<Link href='/abc' >
  <ImageComponent content="something random" onClick={onImageClick} />
</Link>

```

It would be helpful, we would accept customized onClick callback on NextLink.