### PR TITLE
Add viewport meta tag to fix media queries.

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -14,6 +14,7 @@ export default class MyDocument extends Document {
       <html>
         <Head>
           <title>My page</title>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           {this.props.styleTags}
         </Head>
         <body>


### PR DESCRIPTION
* Media queries were not working as expected due to the meta tag missing.
* Copied from:  https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag