### PR TITLE
Fix a/b typo in custom-server-typescript routing

### DIFF
--- a/examples/custom-server-typescript/pages/index.tsx
+++ b/examples/custom-server-typescript/pages/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 export default () => (
   <ul>
-    <li><Link href='/b' as='/a'><a>a</a></Link></li>
-    <li><Link href='/a' as='/b'><a>b</a></Link></li>
+    <li><Link href='/a' as='/a'><a>a</a></Link></li>
+    <li><Link href='/b' as='/b'><a>b</a></Link></li>
   </ul>
 )

--- a/examples/custom-server-typescript/server/index.ts
+++ b/examples/custom-server-typescript/server/index.ts
@@ -14,9 +14,9 @@ app.prepare()
     const { pathname, query } = parsedUrl
 
     if (pathname === '/a') {
-      app.render(req, res, '/b', query)
-    } else if (pathname === '/b') {
       app.render(req, res, '/a', query)
+    } else if (pathname === '/b') {
+      app.render(req, res, '/b', query)
     } else {
       handle(req, res, parsedUrl)
     }


### PR DESCRIPTION
Previously, `a` link was pointing to `b` page and vice-versa.
This PR fixes this typo in custom-server-typescript.