### PR TITLE
fix(webpack): Fixed webpack externals config issue

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -79,10 +79,6 @@ function externalsConfig (dir, isServer) {
         return callback()
       }
 
-      if (res.match(/node_modules[/\\].*\.js/)) {
-        return callback(null, `commonjs ${request}`)
-      }
-
       callback()
     })
   })


### PR DESCRIPTION
Hi Guys

Here is a sample project to explain this issue:

https://github.com/AlloVince/webpack-playground/tree/master/nextjs-mini

When we happens to use some libraries which names including ".js", webpack loaders will not work correct due to externals config.

In my sample project, I  would like to use "highlight.js", when I try to import its style file by

```
import hljsCss from 'highlight.js/styles/dark.css';
```

My expect outputting is

```
exports.push([module.i, "dark css content here", ""]);
```

Actually outputting is

```
module.exports = require("highlight.js/styles/dark.css");
```

However, there PR fix maybe not appropriate, I tried modified codes in my next.js project, no bad effects were found, maybe a precise whitelist  is a better way, please let me know which libraries you want to handle them as externals

Best regards