### PR TITLE
Unlink only pages bundle in dev env

### DIFF
--- a/server/build/plugins/unlink-file-plugin.js
+++ b/server/build/plugins/unlink-file-plugin.js
@@ -1,5 +1,6 @@
 import { join } from 'path'
 import { unlink } from 'mz/fs'
+import { IS_BUNDLED_PAGE } from '../../utils'
 
 export default class UnlinkFilePlugin {
   constructor () {
@@ -9,7 +10,7 @@ export default class UnlinkFilePlugin {
   apply (compiler) {
     compiler.plugin('after-emit', (compilation, callback) => {
       const removed = Object.keys(this.prevAssets)
-      .filter((a = '') => a.includes('bundles/pages/') && !compilation.assets[a])
+      .filter((a) => IS_BUNDLED_PAGE.test(a) && !compilation.assets[a])
 
       this.prevAssets = compilation.assets
 

--- a/server/build/plugins/unlink-file-plugin.js
+++ b/server/build/plugins/unlink-file-plugin.js
@@ -9,7 +9,7 @@ export default class UnlinkFilePlugin {
   apply (compiler) {
     compiler.plugin('after-emit', (compilation, callback) => {
       const removed = Object.keys(this.prevAssets)
-      .filter((a) => !compilation.assets[a])
+      .filter((a = '') => a.includes('bundles/pages/') && !compilation.assets[a])
 
       this.prevAssets = compilation.assets
 


### PR DESCRIPTION
I had a situation where some static assets where mysteriously deleted from `.next`.
In my case my fonts where always missing when running app locally.
With the help from @timneutkens I think this small fix should solve the issue.

## Before:
```
 WAIT  Compiling...                                                                                                                                                       09:06:39

---------------------------
prevAssets [ 'static/assets/fonts/334C67_0_0.eot',
  'static/assets/fonts/334C67_0_0.ttf',
  'static/assets/fonts/334C67_0_0.woff',
  'static/assets/fonts/334C67_0_0.woff2',
  'static/assets/fonts/334C67_1_0.eot',
  'static/assets/fonts/334C67_1_0.ttf',
  'static/assets/fonts/334C67_1_0.woff',
  'static/assets/fonts/334C67_1_0.woff2',
  'static/assets/fonts/icon.eot',
  'static/assets/fonts/icon.svg',
  'static/assets/fonts/icon.ttf',
  'static/assets/fonts/icon.woff',
  'app.js',
  'main.js',
  'bundles/pages/_error.js',
  'commons.js',
  'manifest.js',
  'bundles/pages/index.js',
  '2.e0cd5d283f27d6db118b.hot-update.js',
  'e0cd5d283f27d6db118b.hot-update.json',
  'static/style.css',
  'main.js.map',
  'bundles/pages/_error.js.map',
  'commons.js.map',
  '2.e0cd5d283f27d6db118b.hot-update.js.map',
  'static/style.css.map',
  'manifest.js.map',
  'bundles/pages/index.js.map' ]

assets [ 'main.js',
  'bundles/pages/_error.js',
  'commons.js',
  'manifest.js',
  'bundles/pages/index.js',
  '4.224ae263c1327655d859.hot-update.js',
  '224ae263c1327655d859.hot-update.json',
  'static/style.css',
  'app.js',
  'main.js.map',
  'bundles/pages/_error.js.map',
  'commons.js.map',
  'static/style.css.map',
  'manifest.js.map',
  'bundles/pages/index.js.map',
  '4.224ae263c1327655d859.hot-update.js.map' ]

removed [ 'static/assets/fonts/334C67_0_0.eot',
  'static/assets/fonts/334C67_0_0.ttf',
  'static/assets/fonts/334C67_0_0.woff',
  'static/assets/fonts/334C67_0_0.woff2',
  'static/assets/fonts/334C67_1_0.eot',
  'static/assets/fonts/334C67_1_0.ttf',
  'static/assets/fonts/334C67_1_0.woff',
  'static/assets/fonts/334C67_1_0.woff2',
  'static/assets/fonts/icon.eot',
  'static/assets/fonts/icon.svg',
  'static/assets/fonts/icon.ttf',
  'static/assets/fonts/icon.woff',
  '2.e0cd5d283f27d6db118b.hot-update.js',
  'e0cd5d283f27d6db118b.hot-update.json',
  '2.e0cd5d283f27d6db118b.hot-update.js.map' ]
```

## After:
```
 WAIT  Compiling...                                                                                                                                                       09:08:32

---------------------------
prevAssets [ 'static/assets/fonts/334C67_0_0.eot',
  'static/assets/fonts/334C67_0_0.ttf',
  'static/assets/fonts/334C67_0_0.woff',
  'static/assets/fonts/334C67_0_0.woff2',
  'static/assets/fonts/334C67_1_0.eot',
  'static/assets/fonts/334C67_1_0.ttf',
  'static/assets/fonts/334C67_1_0.woff',
  'static/assets/fonts/334C67_1_0.woff2',
  'static/assets/fonts/icon.eot',
  'static/assets/fonts/icon.svg',
  'static/assets/fonts/icon.ttf',
  'static/assets/fonts/icon.woff',
  'app.js',
  'main.js',
  'bundles/pages/_error.js',
  'commons.js',
  'manifest.js',
  'bundles/pages/index.js',
  '2.e0cd5d283f27d6db118b.hot-update.js',
  'e0cd5d283f27d6db118b.hot-update.json',
  'static/style.css',
  'main.js.map',
  'bundles/pages/_error.js.map',
  'commons.js.map',
  '2.e0cd5d283f27d6db118b.hot-update.js.map',
  'static/style.css.map',
  'manifest.js.map',
  'bundles/pages/index.js.map' ]

assets [ 'main.js',
  'bundles/pages/_error.js',
  'commons.js',
  'manifest.js',
  'bundles/pages/index.js',
  '4.dd14c05fcda1c17e3b03.hot-update.js',
  'dd14c05fcda1c17e3b03.hot-update.json',
  'static/style.css',
  'app.js',
  'main.js.map',
  'bundles/pages/_error.js.map',
  'commons.js.map',
  'static/style.css.map',
  'manifest.js.map',
  'bundles/pages/index.js.map',
  '4.dd14c05fcda1c17e3b03.hot-update.js.map' ]

removed []
```

