### PR TITLE
Remove the default HMR error overlay

### DIFF
--- a/client/webpack-hot-middleware-client.js
+++ b/client/webpack-hot-middleware-client.js
@@ -1,5 +1,5 @@
 import 'event-source-polyfill'
-import webpackHotMiddlewareClient from 'webpack-hot-middleware/client?autoConnect=false'
+import webpackHotMiddlewareClient from 'webpack-hot-middleware/client?autoConnect=false&overlay=false&reload=true'
 import Router from '../lib/router'
 
 const {
@@ -10,8 +10,6 @@ const {
 
 export default () => {
   webpackHotMiddlewareClient.setOptionsAndConnect({
-    overlay: 'false',
-    reload: 'true',
     path: `${assetPrefix}/_next/webpack-hmr`
   })
 


### PR DESCRIPTION
This is supplied by webpack-hot-middleware.
I also added a test case to prevent this from popping up again.