### PR TITLE
Showing available alternative IP when running dev server.

### DIFF
--- a/bin/next-dev
+++ b/bin/next-dev
@@ -17,25 +17,28 @@ const argv = parseArgs(process.argv.slice(2), {
 })
 
 if (!argv.hostname) {
-  // Get available network interfaces
   var address
   const os = require('os')
-  var ifaces = os.networkInterfaces()
+  var aInterfaces = os.networkInterfaces()
 
-  for (var dev in ifaces) {
-    var iface = ifaces[dev].filter(function (details) {
+  // Get available interfaces
+  for (var dev in aInterfaces) {
+    var aInterface = aInterfaces[dev].filter(function (details) {
       return details.family === 'IPv4' && details.internal === false
     })
 
-    if (iface.length > 0) {
-      address = iface[0].address
+    if (aInterface.length > 0) {
+      address = aInterface[0].address
     }
   }
 
   // Print the result
   if (address) {
-    console.log('\x1b[32m', '> Network interface detected: ', address, '\x1b[37m')
-    console.log('> If you wish to use this address instead of localhost, run this command again with "--hostname ' + address + '" ', '\x1b[37m')
+    console.log(`\x1b[32m`,
+      `\n> Network interface detected: `, address, `\x1b[37m`,
+      `\n> Run this command again with `, `\x1b[32m`, `"--hostname ` + address + `" `, `\x1b[37m`,
+      `to access your project from a different device on your network.`
+    )
   }
 }
 

--- a/bin/next-dev
+++ b/bin/next-dev
@@ -16,6 +16,29 @@ const argv = parseArgs(process.argv.slice(2), {
   default: { p: 3000 }
 })
 
+if (!argv.hostname) {
+  // Get available network interfaces
+  var address
+  const os = require('os')
+  var ifaces = os.networkInterfaces()
+
+  for (var dev in ifaces) {
+    var iface = ifaces[dev].filter(function (details) {
+      return details.family === 'IPv4' && details.internal === false
+    })
+
+    if (iface.length > 0) {
+      address = iface[0].address
+    }
+  }
+
+  // Print the result
+  if (address) {
+    console.log('\x1b[32m', '> Network interface detected: ', address, '\x1b[37m')
+    console.log('> If you wish to use this address instead of localhost, run this command again with "--hostname ' + address + '" ', '\x1b[37m')
+  }
+}
+
 if (argv.help) {
   console.log(`
     Description


### PR DESCRIPTION
This small code is intended to make it easier for developers to use an alternative IP instead of localhost by directly showing an available IP to use, as well as the argument required while using the dev server.

This is particularly useful if you want to be able to check the result of your work on multiple devices at the same time, like from your laptop and your smart phone.