### PR TITLE
migrated from apollo-client-preset to apollo-boost

### DIFF
--- a/examples/with-apollo/components/PostUpvoter.js
+++ b/examples/with-apollo/components/PostUpvoter.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { graphql } from 'react-apollo'
-import gql from 'graphql-tag'
+import { gql } from 'apollo-boost'
 
 function PostUpvoter ({ upvote, votes, id }) {
   return (

--- a/examples/with-apollo/lib/initApollo.js
+++ b/examples/with-apollo/lib/initApollo.js
@@ -1,6 +1,6 @@
-import { ApolloClient } from 'apollo-client'
-import { HttpLink } from 'apollo-link-http'
-import { InMemoryCache } from 'apollo-cache-inmemory'
+import { ApolloClient } from 'apollo-boost'
+import { HttpLink } from 'apollo-boost'
+import { InMemoryCache } from 'apollo-boost'
 import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -7,15 +7,13 @@
     "start": "next start"
   },
   "dependencies": {
-    "apollo-client-preset": "1.0.4",
-    "graphql": "0.11.7",
-    "graphql-anywhere": "4.0.2",
-    "graphql-tag": "2.5.0",
+    "apollo-boost": "^0.1.3",
+    "graphql": "0.13.2",
     "isomorphic-unfetch": "2.0.0",
     "next": "latest",
-    "prop-types": "15.6.0",
+    "prop-types": "15.6.1",
     "react": "16.2.0",
-    "react-apollo": "2.0.1",
+    "react-apollo": "2.1.0",
     "react-dom": "16.2.0"
   },
   "author": "",


### PR DESCRIPTION
Since [apollo-client-preset](https://www.npmjs.com/package/apollo-client-preset) has been deprecated, I have migrated the with-apollo example deps and code to utilize [apollo-boost](https://www.npmjs.com/package/apollo-boost). 