### PR TITLE
Update next 5.0.1-canary.2 to avoid build errors

### DIFF
--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
+    "next": "5.0.1-canary.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-native-web": "^0.4.0"


### PR DESCRIPTION
Please check this [link](https://github.com/zeit/next.js/issues/3738) as it has already been discussed,
updating the file so that it is easier for others to start without build errors :)