### PR TITLE
Fix loading and rendering GraphQL data on the server in the `with-apollo-and-redux` example

### DIFF
--- a/examples/with-apollo-and-redux/pages/index.js
+++ b/examples/with-apollo-and-redux/pages/index.js
@@ -50,6 +50,6 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default withRedux(initStore, null, mapDispatchToProps)(
-  withApollo(Index)
+export default withApollo(
+  withRedux(initStore, null, mapDispatchToProps)(Index)
 )


### PR DESCRIPTION
I noticed a problem with the way of loading/rendering GraphQL data in the `with-apollo-and-redux` example:
In the index page of this example the server doesn't fetch any data and it just renders "Loading" and then the client does this job.

I figured that we must put `withApollo` in the root of React component tree (in this example before `withRedux`) to solve this problem.