### PR TITLE
Add support for pluggable render, to allow use of renderToNodeStream and others

### DIFF
--- a/examples/streaming-render-with-styled-components/.babelrc
+++ b/examples/streaming-render-with-styled-components/.babelrc
@@ -1,0 +1,19 @@
+{
+	"env": {
+		"development": {
+			"presets": "next/babel"
+		},
+		"production": {
+			"presets": "next/babel"
+		},
+		"test": {
+			"presets": [
+				["env", {
+					"modules": "commonjs"
+				}],
+				"next/babel",
+				"rapscallion/babel-plugin-server"
+			]
+		}
+	}
+}

--- a/examples/streaming-render-with-styled-components/README.md
+++ b/examples/streaming-render-with-styled-components/README.md
@@ -1,0 +1,1 @@
+# Streaming Rendering, with Styled Components

--- a/examples/streaming-render-with-styled-components/package.json
+++ b/examples/streaming-render-with-styled-components/package.json
@@ -1,0 +1,17 @@
+{
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "express": "^4.14.0",
+    "lodash": "^4.17.4",
+    "md5": "^2.2.1",
+    "next": "latest",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "stream-template": "0.0.6",
+    "styled-components": "^3.2.3"
+  }
+}

--- a/examples/streaming-render-with-styled-components/pages/_document.js
+++ b/examples/streaming-render-with-styled-components/pages/_document.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import Document, { Head, Main, NextScript } from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+
+export default class MyDocument extends Document {
+  static getInitialProps ({ asPath, renderPage, store }) {
+    const sheet = new ServerStyleSheet()
+    const page = renderPage(App => props =>
+      sheet.collectStyles(<App {...props} />)
+    )
+
+    let htmlStream
+    let errorHtmlStream
+    let styleTags
+
+    if (page.html && typeof page.html !== 'string') {
+      htmlStream = sheet.interleaveWithNodeStream(page.html)
+    } else if (page.errorHtml && typeof page.errorHtml !== 'string') {
+      errorHtmlStream = sheet.interleaveWithNodeStream(page.errorHtml)
+    } else {
+      // Included for the synchronous /b route, see below.
+      styleTags = sheet.getStyleElement()
+    }
+
+    return {
+      ...page,
+      htmlStream,
+      errorHtmlStream,
+      styleTags
+    }
+  }
+
+  // Note: This isn't used by the streaming route (/a), only /b for comparison's sake.
+  render () {
+    return (
+      <html lang='en'>
+        <Head>
+          <meta
+            name='viewport'
+            content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
+          />
+        </Head>
+        <body>
+          {this.props.styleTags}
+          <div className='root'>
+            <Main />
+          </div>
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/examples/streaming-render-with-styled-components/pages/hashes.js
+++ b/examples/streaming-render-with-styled-components/pages/hashes.js
@@ -1,0 +1,30 @@
+import _ from 'lodash'
+import md5 from 'md5'
+import styled from 'styled-components'
+
+let arrayOfLength = len => {
+  return Array.apply(null, Array(len)).map(function () {})
+}
+
+const StyledHash = styled.div`
+  color: #${props => props.hash.substr(0, 6)};
+`
+
+function MakeHash (props) {
+  const hash = md5(props.idx)
+  return <StyledHash hash={hash}>{hash.substr(0, 30)}</StyledHash>
+}
+
+function Hashes (props) {
+  return (
+    <div>
+      {_.map(arrayOfLength(props.hashCount), (object, idx) => {
+        return <MakeHash idx={`${idx}-${props.path}`} key={`MD5:${idx}`} />
+      })}
+    </div>
+  )
+}
+
+export default ({ url: { asPath } }) => {
+  return <Hashes hashCount={2000} path={asPath} />
+}

--- a/examples/streaming-render-with-styled-components/pages/index.js
+++ b/examples/streaming-render-with-styled-components/pages/index.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default () => (
+  <ul>
+    <li>
+      <a href='/b'>Default Next.JS rendering</a>
+    </li>
+    <li>
+      <a href='/a'>Streaming Rendering!</a>
+    </li>
+  </ul>
+)

--- a/examples/streaming-render-with-styled-components/server.js
+++ b/examples/streaming-render-with-styled-components/server.js
@@ -1,0 +1,69 @@
+const React = require('react')
+const { renderToStaticNodeStream } = require('react-dom/server')
+const express = require('express')
+const ST = require('stream-template').encoding('utf8')
+const next = require('next')
+
+const { Head, NextScript } = require('next/document')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = express()
+
+  server.get('/a', (req, res) => {
+    app
+      .renderToParts(req, res, '/hashes', req.query, {
+        renderMethod: renderToStaticNodeStream
+      })
+      .then(({ docProps = {} }) => {
+        const { htmlStream = '', errorHtmlStream = '' } = docProps
+
+        // This template effectively replaces `document.js` in next.
+        const responseRenderer = ST`
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            ${renderToStaticNodeStream(
+              React.createElement(Head, { _documentprops: docProps })
+            )}
+
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+            />
+          </head>
+
+          <body>
+            <div id="root">
+              <div id="__next">${htmlStream}</div>
+              <div id="__next-error">${errorHtmlStream}</div>
+            </div>
+
+            ${renderToStaticNodeStream(
+              React.createElement(NextScript, { _documentprops: docProps })
+            )}
+          </body>
+        </html>
+      `
+
+        responseRenderer.pipe(res)
+      })
+  })
+
+  server.get('/b', (req, res) => {
+    // Normal next.js rendering.
+    return app.render(req, res, '/hashes', req.query)
+  })
+
+  server.get('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(3000, err => {
+    if (err) throw err
+    console.log('> Ready on http://localhost:3000')
+  })
+})

--- a/examples/streaming-render/.babelrc
+++ b/examples/streaming-render/.babelrc
@@ -1,0 +1,19 @@
+{
+	"env": {
+		"development": {
+			"presets": "next/babel"
+		},
+		"production": {
+			"presets": "next/babel"
+		},
+		"test": {
+			"presets": [
+				["env", {
+					"modules": "commonjs"
+				}],
+				"next/babel",
+				"rapscallion/babel-plugin-server"
+			]
+		}
+	}
+}

--- a/examples/streaming-render/README.md
+++ b/examples/streaming-render/README.md
@@ -1,0 +1,1 @@
+# Streaming Rendering

--- a/examples/streaming-render/package.json
+++ b/examples/streaming-render/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "express": "^4.14.0",
+    "lodash": "^4.17.4",
+    "md5": "^2.2.1",
+    "next": "latest",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "stream-template": "0.0.6"
+  }
+}

--- a/examples/streaming-render/pages/_document.js
+++ b/examples/streaming-render/pages/_document.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  static getInitialProps ({ asPath, renderPage, store }) {
+    const page = renderPage()
+
+    let htmlStream
+    let errorHtmlStream
+
+    if (page.html && typeof page.html !== 'string') {
+      htmlStream = page.html
+    } else if (page.errorHtml && typeof page.errorHtml !== 'string') {
+      errorHtmlStream = page.errorHtml
+    }
+
+    return {
+      ...page,
+      htmlStream,
+      errorHtmlStream
+    }
+  }
+
+  // Note: This isn't used by the streaming route (/a), only /b for comparison's sake.
+  render () {
+    return (
+      <html lang='en'>
+        <Head>
+          <meta
+            name='viewport'
+            content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
+          />
+        </Head>
+        <body>
+          <div className='root'>
+            <Main />
+          </div>
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/examples/streaming-render/pages/hashes.js
+++ b/examples/streaming-render/pages/hashes.js
@@ -1,0 +1,25 @@
+import _ from 'lodash'
+import md5 from 'md5'
+
+let arrayOfLength = len => {
+  return Array.apply(null, Array(len)).map(function () {})
+}
+
+function MakeHash (props) {
+  const hash = md5(props.idx)
+  return <div>{hash.substr(0, 30)}</div>
+}
+
+function Hashes (props) {
+  return (
+    <div>
+      {_.map(arrayOfLength(props.hashCount), (object, idx) => {
+        return <MakeHash idx={`${idx}-${props.path}`} key={`MD5:${idx}`} />
+      })}
+    </div>
+  )
+}
+
+export default ({ url: { asPath } }) => {
+  return <Hashes hashCount={2000} path={asPath} />
+}

--- a/examples/streaming-render/pages/index.js
+++ b/examples/streaming-render/pages/index.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default () => (
+  <ul>
+    <li>
+      <a href='/b'>Default Next.JS rendering</a>
+    </li>
+    <li>
+      <a href='/a'>Streaming Rendering!</a>
+    </li>
+  </ul>
+)

--- a/examples/streaming-render/server.js
+++ b/examples/streaming-render/server.js
@@ -1,0 +1,69 @@
+const React = require('react')
+const { renderToStaticNodeStream } = require('react-dom/server')
+const express = require('express')
+const ST = require('stream-template').encoding('utf8')
+const next = require('next')
+
+const { Head, NextScript } = require('next/document')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = express()
+
+  server.get('/a', (req, res) => {
+    app
+      .renderToParts(req, res, '/hashes', req.query, {
+        renderMethod: renderToStaticNodeStream
+      })
+      .then(({ docProps = {} }) => {
+        const { htmlStream = '', errorHtmlStream = '' } = docProps
+
+        // This template effectively replaces `document.js` in next.
+        const responseRenderer = ST`
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            ${renderToStaticNodeStream(
+              React.createElement(Head, { _documentprops: docProps })
+            )}
+
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+            />
+          </head>
+
+          <body>
+            <div id="root">
+              <div id="__next">${htmlStream}</div>
+              <div id="__next-error">${errorHtmlStream}</div>
+            </div>
+
+            ${renderToStaticNodeStream(
+              React.createElement(NextScript, { _documentprops: docProps })
+            )}
+          </body>
+        </html>
+      `
+
+        responseRenderer.pipe(res)
+      })
+  })
+
+  server.get('/b', (req, res) => {
+    // Normal next.js rendering.
+    return app.render(req, res, '/hashes', req.query)
+  })
+
+  server.get('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(3000, err => {
+    if (err) throw err
+    console.log('> Ready on http://localhost:3000')
+  })
+})

--- a/server/document.js
+++ b/server/document.js
@@ -39,7 +39,7 @@ export class Head extends Component {
   }
 
   getChunkPreloadLink (filename) {
-    const { __NEXT_DATA__ } = this.context._documentProps
+    const { __NEXT_DATA__ } = this.context._documentProps || this.props._documentprops
     let { assetPrefix, buildId } = __NEXT_DATA__
     const hash = buildId
 
@@ -54,7 +54,7 @@ export class Head extends Component {
   }
 
   getPreloadMainLinks () {
-    const { dev } = this.context._documentProps
+    const { dev } = this.context._documentProps || this.props._documentprops
     if (dev) {
       return [
         this.getChunkPreloadLink('manifest.js'),
@@ -69,7 +69,7 @@ export class Head extends Component {
   }
 
   getPreloadDynamicChunks () {
-    const { chunks, __NEXT_DATA__ } = this.context._documentProps
+    const { chunks, __NEXT_DATA__ } = this.context._documentProps || this.props._documentprops
     let { assetPrefix } = __NEXT_DATA__
     return chunks.filenames.map((chunk) => (
       <link
@@ -82,7 +82,7 @@ export class Head extends Component {
   }
 
   render () {
-    const { head, styles, __NEXT_DATA__ } = this.context._documentProps
+    const { head, styles, __NEXT_DATA__ } = this.context._documentProps || this.props._documentprops
     const { page, pathname, buildId, assetPrefix } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
@@ -104,7 +104,7 @@ export class Main extends Component {
   }
 
   render () {
-    const { html, errorHtml } = this.context._documentProps
+    const { html, errorHtml } = this.context._documentProps || this.props._documentprops
     return (
       <Fragment>
         <div id='__next' dangerouslySetInnerHTML={{ __html: html }} />
@@ -124,7 +124,7 @@ export class NextScript extends Component {
   }
 
   getChunkScript (filename, additionalProps = {}) {
-    const { __NEXT_DATA__ } = this.context._documentProps
+    const { __NEXT_DATA__ } = this.context._documentProps || this.props._documentprops
     let { assetPrefix, buildId } = __NEXT_DATA__
     const hash = buildId
 
@@ -138,7 +138,7 @@ export class NextScript extends Component {
   }
 
   getScripts () {
-    const { dev } = this.context._documentProps
+    const { dev } = this.context._documentProps || this.props._documentprops
     if (dev) {
       return [
         this.getChunkScript('manifest.js'),
@@ -152,7 +152,7 @@ export class NextScript extends Component {
   }
 
   getDynamicChunks () {
-    const { chunks, __NEXT_DATA__ } = this.context._documentProps
+    const { chunks, __NEXT_DATA__ } = this.context._documentProps || this.props._documentprops
     let { assetPrefix } = __NEXT_DATA__
     return (
       <Fragment>
@@ -168,7 +168,7 @@ export class NextScript extends Component {
   }
 
   render () {
-    const { staticMarkup, __NEXT_DATA__, chunks } = this.context._documentProps
+    const { staticMarkup, __NEXT_DATA__, chunks } = this.context._documentProps || this.props._documentprops
     const { page, pathname, buildId, assetPrefix } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,8 @@ import promisify from './lib/promisify'
 import {
   renderToHTML,
   renderErrorToHTML,
+  renderToParts,
+  renderErrorToParts,
   sendHTML,
   serveStatic,
   renderScriptError
@@ -386,6 +388,21 @@ export default class Server {
         if (!this.quiet) console.error(err)
         res.statusCode = 500
         return this.renderErrorToHTML(err, req, res, pathname, query)
+      }
+    }
+  }
+
+  async renderToParts (req, res, pathname, query, opts) {
+    try {
+      return await renderToParts(req, res, pathname, query, Object.assign({}, this.renderOpts, opts))
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        res.statusCode = 404
+        return renderErrorToParts(null, req, res, pathname, query, Object.assign({}, this.renderOpts, opts))
+      } else {
+        if (!this.quiet) console.error(err)
+        res.statusCode = 500
+        return renderErrorToParts(err, req, res, pathname, query, Object.assign({}, this.renderOpts, opts))
       }
     }
   }

--- a/server/render.js
+++ b/server/render.js
@@ -24,12 +24,22 @@ export function renderToHTML (req, res, pathname, query, opts) {
   return doRender(req, res, pathname, query, opts)
 }
 
+export function renderToParts (req, res, pathname, query, opts) {
+  opts.returnParts = true
+  return doRender(req, res, pathname, query, opts)
+}
+
 export async function renderError (err, req, res, pathname, query, opts) {
   const html = await renderErrorToHTML(err, req, res, query, opts)
   sendHTML(req, res, html, req.method, opts)
 }
 
 export function renderErrorToHTML (err, req, res, pathname, query, opts = {}) {
+  return doRender(req, res, pathname, query, { ...opts, err, page: '/_error' })
+}
+
+export function renderErrorToParts (err, req, res, pathname, query, opts = {}) {
+  opts.returnParts = true
   return doRender(req, res, pathname, query, { ...opts, err, page: '/_error' })
 }
 
@@ -45,7 +55,9 @@ async function doRender (req, res, pathname, query, {
   dir = process.cwd(),
   dev = false,
   staticMarkup = false,
-  nextExport = false
+  nextExport = false,
+  returnParts = false,
+  renderMethod = renderToString
 } = {}) {
   page = page || pathname
 
@@ -75,7 +87,7 @@ async function doRender (req, res, pathname, query, {
       router: new Router(pathname, query, asPath)
     })
 
-    const render = staticMarkup ? renderToStaticMarkup : renderToString
+    const render = staticMarkup ? renderToStaticMarkup : renderMethod
 
     let html
     let head
@@ -101,8 +113,7 @@ async function doRender (req, res, pathname, query, {
 
   if (isResSent(res)) return
 
-  if (!Document.prototype || !Document.prototype.isReactComponent) throw new Error('_document.js is not exporting a React element')
-  const doc = createElement(Document, {
+  const docFinalProps = {
     __NEXT_DATA__: {
       props,
       page, // the rendered page
@@ -118,7 +129,16 @@ async function doRender (req, res, pathname, query, {
     dir,
     staticMarkup,
     ...docProps
-  })
+  }
+
+  if (returnParts) {
+    const parts = renderPage()
+    parts.docProps = docFinalProps
+    return parts
+  }
+
+  if (!Document.prototype || !Document.prototype.isReactComponent) throw new Error('_document.js is not exporting a React element')
+  const doc = createElement(Document, docFinalProps)
 
   return '<!DOCTYPE html>' + renderToStaticMarkup(doc)
 }


### PR DESCRIPTION
This is a revival of #2279, which was made before React 16. Since then we now have access to `ReactDOMServer.renderToNodeStream` and `ReactDOMServer.renderToStaticNodeStream`. 

The approach is the same; allow render to be broken into parts, which can then be turned into streams, or interleaved with streams (see the Styled Components example I included, which is an implementation of the [approach in this article](https://medium.com/styled-components/v3-1-0-such-perf-wow-many-streams-c45c434dbd03)).

This relates to or closes:
 #1209 #1334 #3342 #1210