### PR TITLE
Add missing url prop

### DIFF
--- a/examples/with-apollo/lib/withData.js
+++ b/examples/with-apollo/lib/withData.js
@@ -32,9 +32,16 @@ export default ComposedComponent => {
       // and extract the resulting data
       const apollo = initApollo()
       try {
+        // create the url prop which is passed to every page
+        const url = {
+          query: ctx.query,
+          asPath: ctx.asPath,
+          pathname: ctx.pathname,
+        };
+
         // Run all GraphQL queries
         await getDataFromTree(
-          <ComposedComponent ctx={ctx} {...composedInitialProps} />,
+          <ComposedComponent ctx={ctx} url={url} {...composedInitialProps} />,
           {
             router: {
               asPath: ctx.asPath,


### PR DESCRIPTION
This was causing react-apollo  to crash on any SSR page that needed the page's query to make the GraphQL queries. 

It's magically passed on the client, but we have to manually pass it to the composed component here