### PR TITLE
Use printAndExit with error

### DIFF
--- a/bin/next-build
+++ b/bin/next-build
@@ -44,6 +44,5 @@ if (!existsSync(join(dir, 'pages'))) {
 
 build(dir)
   .catch((err) => {
-    console.error(err)
-    process.exit(1)
+    printAndExit(err)
   })


### PR DESCRIPTION
Fixes #4085

This makes sure we don't exit before logging the message, which happens in some cases.