### PR TITLE
Match externals ending in .js not everything with .js

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -79,7 +79,7 @@ function externalsConfig (dir, isServer) {
         return callback()
       }
 
-      if (res.match(/node_modules[/\\].*\.js/)) {
+      if (res.match(/node_modules[/\\].*\.js$/)) {
         return callback(null, `commonjs ${request}`)
       }
 


### PR DESCRIPTION
Closes #4014

Makes sure highlight.js/styles/dark.css doesn’t get caught by externals.