### PR TITLE
Add support for exportPathMap in development

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -81,7 +81,6 @@ export default class Server {
     })
 
     this.setAssetPrefix(assetPrefix)
-    this.defineRoutes()
   }
 
   getHotReloader (dir, options) {
@@ -119,6 +118,7 @@ export default class Server {
   }
 
   async prepare () {
+    await this.defineRoutes()
     if (this.hotReloader) {
       await this.hotReloader.start()
     }
@@ -139,7 +139,7 @@ export default class Server {
     }
   }
 
-  defineRoutes () {
+  async defineRoutes () {
     const routes = {
       '/_next-prefetcher.js': async (req, res, params) => {
         const p = join(__dirname, '../client/next-prefetcher-bundle.js')
@@ -303,9 +303,20 @@ export default class Server {
     }
 
     if (this.nextConfig.useFileSystemPublicRoutes) {
+      if (this.dev && this.nextConfig.exportPathMap) {
+        console.log('Defining routes from exportPathMap')
+        const exportPathMap = await this.nextConfig.exportPathMap({}) // In development we can't give a default path mapping
+        for (const path in exportPathMap) {
+          const options = exportPathMap[path]
+          routes[path] = async (req, res, params, parsedUrl) => {
+            await this.render(req, res, options.page, options.query, parsedUrl)
+          }
+        }
+      }
+
       routes['/:path*'] = async (req, res, params, parsedUrl) => {
         const { pathname, query } = parsedUrl
-        await this.render(req, res, pathname, query)
+        await this.render(req, res, pathname, query, parsedUrl)
       }
     }
 

--- a/server/index.js
+++ b/server/index.js
@@ -303,6 +303,8 @@ export default class Server {
     }
 
     if (this.nextConfig.useFileSystemPublicRoutes) {
+      // Makes `next export` exportPathMap work in development mode.
+      // So that the user doesn't have to define a custom server reading the exportPathMap
       if (this.dev && this.nextConfig.exportPathMap) {
         console.log('Defining routes from exportPathMap')
         const exportPathMap = await this.nextConfig.exportPathMap({}) // In development we can't give a default path mapping

--- a/test/integration/static/test/dev.js
+++ b/test/integration/static/test/dev.js
@@ -1,0 +1,24 @@
+/* global describe, it, expect */
+import webdriver from 'next-webdriver'
+
+export default function (context) {
+  describe('Render in development mode', () => {
+    it('should render the home page', async () => {
+      const browser = await webdriver(context.port, '/')
+      const text = await browser
+        .elementByCss('#home-page p').text()
+
+      expect(text).toBe('This is the home page')
+      browser.close()
+    })
+
+    it('should render pages only existent in exportPathMap page', async () => {
+      const browser = await webdriver(context.port, '/dynamic/one')
+      const text = await browser
+        .elementByCss('#dynamic-page p').text()
+
+      expect(text).toBe('next export is nice')
+      browser.close()
+    })
+  })
+}

--- a/test/integration/static/test/index.test.js
+++ b/test/integration/static/test/index.test.js
@@ -5,16 +5,22 @@ import {
   nextBuild,
   nextExport,
   startStaticServer,
-  stopApp
+  launchApp,
+  stopApp,
+  killApp,
+  findPort,
+  renderViaHTTP
 } from 'next-test-utils'
 
 import ssr from './ssr'
 import browser from './browser'
+import dev from './dev'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 
 const appDir = join(__dirname, '../')
 const context = {}
+const devContext = {}
 
 describe('Static Export', () => {
   beforeAll(async () => {
@@ -24,9 +30,22 @@ describe('Static Export', () => {
 
     context.server = await startStaticServer(join(appDir, 'out'))
     context.port = context.server.address().port
+
+    devContext.appPort = await findPort()
+    devContext.server = await launchApp(join(__dirname, '../'), devContext.appPort, true)
+
+    // pre-build all pages at the start
+    await Promise.all([
+      renderViaHTTP(devContext.appPort, '/'),
+      renderViaHTTP(devContext.appPort, '/dynamic/one')
+    ])
   })
-  afterAll(() => stopApp(context.server))
+  afterAll(() => {
+    stopApp(context.server)
+    killApp(devContext.server)
+  })
 
   ssr(context)
   browser(context)
+  dev(context)
 })


### PR DESCRIPTION
Paths defined in exportPathMap now work in development. 
Makes https://github.com/zeit/next.js/wiki/Centralizing-Routing obsolete.