### PR TITLE
Check if matched before reading value

### DIFF
--- a/server/build/plugins/pages-manifest-plugin.js
+++ b/server/build/plugins/pages-manifest-plugin.js
@@ -13,7 +13,12 @@ export default class PagesManifestPlugin {
       const pages = {}
 
       for (const entry of entries) {
-        const pagePath = MATCH_ROUTE_NAME.exec(entry.name)[1]
+        const result = MATCH_ROUTE_NAME.exec(entry.name)
+        if (!result) {
+          continue
+        }
+
+        const pagePath = result[1]
 
         if (!pagePath) {
           continue


### PR DESCRIPTION
In zeit.co we add extra entries, which caused an error.