### PR TITLE
Speed up tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,16 +8,5 @@
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-runtime"
-  ],
-  "env": {
-    "test": {
-      "presets": [
-        ["./babel", {
-          "preset-env": {
-            "modules": "commonjs"
-          }
-        }]
-       ]
-    }
-  }
+  ]
 }

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["next/babel", {
+      "preset-env": {
+        "modules": "commonjs"
+      }
+    }]
+  ]
+}


### PR DESCRIPTION
As per Logan's suggestion in #4050, previously we ran preset-env preset-react, object rest spread and transform-runtime twice, since they were in the top level of the babelrc and they're also in next/babel. This just moves out the config for /test to it's own .babelrc.