### PR TITLE
Relay modern example fixes

### DIFF
--- a/examples/with-relay-modern/components/BlogPosts.js
+++ b/examples/with-relay-modern/components/BlogPosts.js
@@ -7,7 +7,7 @@ const BlogPosts = props => {
     <div>
       <h1>Blog posts</h1>
       {props.viewer.allBlogPosts.edges.map(({ node }) =>
-        <BlogPostPreview post={node} />
+        <BlogPostPreview key={node.id}post={node} />
       )}
     </div>
   )
@@ -20,6 +20,7 @@ export default createFragmentContainer(BlogPosts, {
                 edges {
                     node {
                         ...BlogPostPreview_post
+                        id
                     }
                 }
             }

--- a/examples/with-relay-modern/package.json
+++ b/examples/with-relay-modern/package.json
@@ -7,7 +7,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "relay": "relay-compiler --src ./ --exclude **/.next/** **/node_modules/** **/test/**  **/__generated__/** --schema ./schema/schema.graphql",
+    "relay": "relay-compiler --src ./ --exclude '**/.next/**' '**/node_modules/**' '**/test/**'  '**/__generated__/**' --exclude './schema/**' --schema ./schema/schema.graphql",
     "schema": "graphql get-schema dev"
   },
   "author": "",
@@ -19,12 +19,12 @@
     "next": "latest",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-relay": "^1.4.1"
+    "react-relay": "^1.5.0"
   },
   "devDependencies": {
-    "graphql-cli": "^1.0.0-beta.4",
     "babel-plugin-relay": "^1.4.1",
     "graphcool": "^1.2.1",
-    "relay-compiler": "^1.4.1"
+    "graphql-cli": "^1.0.0-beta.4",
+    "relay-compiler": "^1.5.0"
   }
 }


### PR DESCRIPTION
Starting with react-relay@1.5.0 the schema cannot be in the same dir as
the src. This can be fixed by excluding the schema dir. Globs should
also be inside quotation marks, to avoid non-deterministic behavior of
different shells.