### PR TITLE
Improved stacktraces (minor)

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -106,6 +106,8 @@ export default async ({
   ErrorComponent = await pageLoader.loadPage('/_error')
   App = await pageLoader.loadPage('/_app')
 
+  let initialErr = err
+
   try {
     Component = await pageLoader.loadPage(page)
 
@@ -113,8 +115,8 @@ export default async ({
       throw new Error(`The default export is not a React Component in page: "${pathname}"`)
     }
   } catch (error) {
-    applySourceMapsAndLog(error)
-    Component = ErrorComponent
+    // This catches errors like throwing in the top level of a module
+    initialErr = error
   }
 
   router = createRouter(pathname, query, asPath, {
@@ -123,7 +125,7 @@ export default async ({
     App,
     Component,
     ErrorComponent,
-    err
+    err: initialErr
   })
 
   router.subscribe(({ Component, props, hash, err }) => {
@@ -131,7 +133,7 @@ export default async ({
   })
 
   const hash = location.hash.substring(1)
-  render({ Component, props, hash, err, emitter })
+  render({ Component, props, hash, err: initialErr, emitter })
 
   return emitter
 }

--- a/client/next-dev.js
+++ b/client/next-dev.js
@@ -4,8 +4,6 @@ import ErrorDebugComponent from '../lib/error-debug'
 import initOnDemandEntries from './on-demand-entries-client'
 import initWebpackHMR from './webpack-hot-middleware-client'
 
-require('@zeit/source-map-support/browser-source-map-support')
-
 window.next = next
 
 initNext({ ErrorDebugComponent, stripAnsi })

--- a/client/next-dev.js
+++ b/client/next-dev.js
@@ -3,10 +3,12 @@ import initNext, * as next from './'
 import {ClientDebug} from '../lib/error-debug'
 import initOnDemandEntries from './on-demand-entries-client'
 import initWebpackHMR from './webpack-hot-middleware-client'
+import {AppContainer as HotAppContainer} from 'react-hot-loader'
+import {rewriteErrorTrace} from './source-map-support'
 
 window.next = next
 
-initNext({ ErrorDebugComponent: ClientDebug, stripAnsi })
+initNext({ HotAppContainer, ErrorDebugComponent: ClientDebug, rewriteErrorTrace, stripAnsi })
   .then((emitter) => {
     initOnDemandEntries()
     initWebpackHMR()

--- a/client/next-dev.js
+++ b/client/next-dev.js
@@ -1,12 +1,12 @@
 import stripAnsi from 'strip-ansi'
 import initNext, * as next from './'
-import ErrorDebugComponent from '../lib/error-debug'
+import {ClientDebug} from '../lib/error-debug'
 import initOnDemandEntries from './on-demand-entries-client'
 import initWebpackHMR from './webpack-hot-middleware-client'
 
 window.next = next
 
-initNext({ ErrorDebugComponent, stripAnsi })
+initNext({ ErrorDebugComponent: ClientDebug, stripAnsi })
   .then((emitter) => {
     initOnDemandEntries()
     initWebpackHMR()

--- a/client/next-dev.js
+++ b/client/next-dev.js
@@ -4,11 +4,11 @@ import {ClientDebug} from '../lib/error-debug'
 import initOnDemandEntries from './on-demand-entries-client'
 import initWebpackHMR from './webpack-hot-middleware-client'
 import {AppContainer as HotAppContainer} from 'react-hot-loader'
-import {rewriteErrorTrace} from './source-map-support'
+import {applySourcemaps} from './source-map-support'
 
 window.next = next
 
-initNext({ HotAppContainer, ErrorDebugComponent: ClientDebug, rewriteErrorTrace, stripAnsi })
+initNext({ HotAppContainer, ErrorDebugComponent: ClientDebug, applySourcemaps, stripAnsi })
   .then((emitter) => {
     initOnDemandEntries()
     initWebpackHMR()

--- a/client/source-map-support.js
+++ b/client/source-map-support.js
@@ -5,7 +5,7 @@ import {SourceMapConsumer} from 'source-map'
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
 export async function rewriteErrorTrace (e: any): Promise<void> {
-  if (!e || typeof e.stack !== 'string') {
+  if (!e || typeof e.stack !== 'string' || e.sourceMapsApplied) {
     return
   }
 
@@ -16,6 +16,8 @@ export async function rewriteErrorTrace (e: any): Promise<void> {
   }))
 
   e.stack = result.join('\n')
+  // This is to make sure we don't apply the sourcemaps twice on the same object
+  e.sourceMapsApplied = true
 }
 
 async function rewriteTraceLine (trace: string): Promise<string> {

--- a/client/source-map-support.js
+++ b/client/source-map-support.js
@@ -1,4 +1,5 @@
 // @flow
+import fetch from 'unfetch'
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
 export async function rewriteErrorTrace (e: any): Promise<void> {
@@ -30,7 +31,6 @@ async function rewriteTraceLine (trace: string): Promise<string> {
 
   const mapPath = `${filePath}.map`
 
-  const fetch = require('unfetch')
   const res = await fetch(mapPath)
   if (res.status !== 200) {
     return trace

--- a/client/source-map-support.js
+++ b/client/source-map-support.js
@@ -2,7 +2,7 @@
 import fetch from 'unfetch'
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
-export async function rewriteErrorTrace (e: any): Promise<void> {
+export async function rewriteErrorTrace (e: any): Promise<Error> {
   if (!e || typeof e.stack !== 'string' || e.sourceMapsApplied) {
     return
   }
@@ -16,6 +16,8 @@ export async function rewriteErrorTrace (e: any): Promise<void> {
   e.stack = result.join('\n')
   // This is to make sure we don't apply the sourcemaps twice on the same object
   e.sourceMapsApplied = true
+
+  return e
 }
 
 async function rewriteTraceLine (trace: string): Promise<string> {

--- a/client/source-map-support.js
+++ b/client/source-map-support.js
@@ -1,7 +1,4 @@
 // @flow
-import fetch from 'unfetch'
-import {SourceMapConsumer} from 'source-map'
-
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
 export async function rewriteErrorTrace (e: any): Promise<void> {
@@ -33,12 +30,14 @@ async function rewriteTraceLine (trace: string): Promise<string> {
 
   const mapPath = `${filePath}.map`
 
+  const fetch = require('unfetch')
   const res = await fetch(mapPath)
   if (res.status !== 200) {
     return trace
   }
 
   const mapContents = await res.json()
+  const {SourceMapConsumer} = require('source-map')
   const map = new SourceMapConsumer(mapContents)
   const originalPosition = map.originalPositionFor({
     line: Number(m[2]),

--- a/client/source-map-support.js
+++ b/client/source-map-support.js
@@ -1,0 +1,53 @@
+// @flow
+import fetch from 'unfetch'
+import {SourceMapConsumer} from 'source-map'
+
+const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
+
+export async function rewriteErrorTrace (e: any): Promise<void> {
+  if (!e || typeof e.stack !== 'string') {
+    return
+  }
+
+  const lines = e.stack.split('\n')
+
+  const result = await Promise.all(lines.map((line) => {
+    return rewriteTraceLine(line)
+  }))
+
+  e.stack = result.join('\n')
+}
+
+async function rewriteTraceLine (trace: string): Promise<string> {
+  const m = trace.match(filenameRE)
+  if (m == null) {
+    return trace
+  }
+
+  const filePath = m[1]
+  if (filePath.match(/node_modules/)) {
+    return trace
+  }
+
+  const mapPath = `${filePath}.map`
+
+  const res = await fetch(mapPath)
+  if (res.status !== 200) {
+    return trace
+  }
+
+  const mapContents = await res.json()
+  const map = new SourceMapConsumer(mapContents)
+  const originalPosition = map.originalPositionFor({
+    line: Number(m[2]),
+    column: Number(m[3])
+  })
+
+  if (originalPosition.source != null) {
+    const { source, line, column } = originalPosition
+    const mappedPosition = `(${source.replace(/^webpack:\/\/\//, '')}:${String(line)}:${String(column)})`
+    return trace.replace(filenameRE, mappedPosition)
+  }
+
+  return trace
+}

--- a/client/source-map-support.js
+++ b/client/source-map-support.js
@@ -2,7 +2,7 @@
 import fetch from 'unfetch'
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
-export async function rewriteErrorTrace (e: any): Promise<Error> {
+export async function applySourcemaps (e: any): Promise<void> {
   if (!e || typeof e.stack !== 'string' || e.sourceMapsApplied) {
     return
   }
@@ -16,8 +16,6 @@ export async function rewriteErrorTrace (e: any): Promise<Error> {
   e.stack = result.join('\n')
   // This is to make sure we don't apply the sourcemaps twice on the same object
   e.sourceMapsApplied = true
-
-  return e
 }
 
 async function rewriteTraceLine (trace: string): Promise<string> {

--- a/lib/app.js
+++ b/lib/app.js
@@ -5,10 +5,6 @@ import { execOnce, warn, loadGetInitialProps } from './utils'
 import { makePublicRouterInstance } from './router'
 
 export default class App extends Component {
-  state = {
-    hasError: null
-  }
-
   static displayName = 'App'
 
   static async getInitialProps ({ Component, router, ctx }) {
@@ -31,8 +27,18 @@ export default class App extends Component {
     }
   }
 
-  async componentDidCatch (err, info) {
-    window.next.renderError({err, info})
+  componentDidCatch (err, info) {
+    // To provide clearer stacktraces in error-debug.js in development
+    // To provide clearer stacktraces in app.js in production
+    err.info = info
+
+    if (process.env.NODE_ENV === 'production') {
+      // In production we render _error.js
+      window.next.renderError({err})
+    } else {
+      // In development we throw the error up to AppContainer from react-hot-loader
+      throw err
+    }
   }
 
   render () {
@@ -76,20 +82,7 @@ export class Container extends Component {
 
   render () {
     const {children} = this.props
-
-    if (process.env.NODE_ENV === 'production') {
-      return <>{children}</>
-    } else {
-      const { AppContainer } = require('react-hot-loader')
-
-      // includes AppContainer which bypasses shouldComponentUpdate method
-      // https://github.com/gaearon/react-hot-loader/issues/442
-      return (
-        <AppContainer warnings={false}>
-          {children}
-        </AppContainer>
-      )
-    }
+    return <>{children}</>
   }
 }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -24,18 +24,15 @@ export default class App extends Component {
 
   getChildContext () {
     const { headManager } = this.props
-    const {hasError} = this.state
     return {
       headManager,
       router: makePublicRouterInstance(this.props.router),
-      _containerProps: {...this.props, hasError}
+      _containerProps: {...this.props}
     }
   }
 
-  componentDidCatch (error, info) {
-    error.stack = `${error.stack}\n\n${info.componentStack}`
-    window.next.renderError({err: error})
-    this.setState({ hasError: true })
+  async componentDidCatch (err, info) {
+    window.next.renderError({err, info})
   }
 
   render () {
@@ -78,24 +75,17 @@ export class Container extends Component {
   }
 
   render () {
-    const { hasError } = this.context._containerProps
-
-    if (hasError) {
-      return null
-    }
-
     const {children} = this.props
 
     if (process.env.NODE_ENV === 'production') {
       return <>{children}</>
     } else {
-      const ErrorDebug = require('./error-debug').default
       const { AppContainer } = require('react-hot-loader')
 
       // includes AppContainer which bypasses shouldComponentUpdate method
       // https://github.com/gaearon/react-hot-loader/issues/442
       return (
-        <AppContainer warnings={false} errorReporter={ErrorDebug}>
+        <AppContainer warnings={false}>
           {children}
         </AppContainer>
       )

--- a/lib/app.js
+++ b/lib/app.js
@@ -34,7 +34,7 @@ export default class App extends Component {
 
   componentDidCatch (error, info) {
     error.stack = `${error.stack}\n\n${info.componentStack}`
-    window.next.renderError(error)
+    window.next.renderError({err: error})
     this.setState({ hasError: true })
   }
 

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ansiHTML from 'ansi-html'
 import Head from './head'
-import {rewriteErrorTrace} from '../client/source-map-support'
+import {applySourcemaps} from '../client/source-map-support'
 
 // On the client side the error can come from multiple places for example react-hot-loader or client/index.js
 // `componentDidCatch` doesn't support asynchronous execution, so we have to handle sourcemap support here
@@ -18,7 +18,7 @@ export class ClientDebug extends React.Component {
     }
 
     // Since componentDidMount doesn't handle errors we use then/catch here
-    rewriteErrorTrace(error).then(() => {
+    applySourcemaps(error).then(() => {
       this.setState({mappedError: error})
     }).catch(console.error)
   }

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -3,7 +3,7 @@ import ansiHTML from 'ansi-html'
 import Head from './head'
 import {rewriteErrorTrace} from '../client/source-map-support'
 
-// On the client side it can come from multiple places for example react-hot-loader or client/index.js
+// On the client side the error can come from multiple places for example react-hot-loader or client/index.js
 // `componentDidCatch` doesn't support asynchronous execution, so we have to handle sourcemap support here
 export class ClientDebug extends React.Component {
   state = {

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -36,7 +36,7 @@ export class ClientDebug extends React.Component {
   }
 }
 
-// On the server side the error comes from a single place, so `ErrorDebug` is rendered directly.
+// On the server side the error has sourcemaps already applied, so `ErrorDebug` is rendered directly.
 export default function ErrorDebug ({error}) {
   const { name, message, module } = error
   return (

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -1,27 +1,65 @@
 import React from 'react'
 import ansiHTML from 'ansi-html'
 import Head from './head'
+import {rewriteErrorTrace} from '../client/source-map-support'
 
-export default ({ error, error: { name, message, module } }) => (
-  <div style={styles.errorDebug}>
-    <Head>
-      <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-    </Head>
-    {module ? <h1 style={styles.heading}>Error in {module.rawRequest}</h1> : null}
-    {
-      name === 'ModuleBuildError'
-        ? <pre style={styles.stack} dangerouslySetInnerHTML={{ __html: ansiHTML(encodeHtml(message)) }} />
-        : <StackTrace error={error} />
+// On the client side it can come from multiple places for example react-hot-loader or client/index.js
+// `componentDidCatch` doesn't support asynchronous execution, so we have to handle sourcemap support here
+export class ClientDebug extends React.Component {
+  state = {
+    mappedError: null
+  }
+  async componentDidMount () {
+    const {error} = this.props
+
+    // If sourcemaps were already applied there is no need to set the state
+    if (error.sourceMapsApplied) {
+      return
     }
-  </div>
-)
+    await rewriteErrorTrace(error)
+    this.setState({mappedError: error})
+  }
 
-const StackTrace = ({ error: { name, message, stack } }) => (
+  render () {
+    const {mappedError} = this.state
+    const {error} = this.props
+    if (!error.sourceMapsApplied && mappedError === null) {
+      return <div style={styles.errorDebug}>
+        <h1 style={styles.heading}>Loading stacktrace...</h1>
+      </div>
+    }
+
+    return <ErrorDebug error={error} />
+  }
+}
+
+// On the server side the error comes from a single place, so `ErrorDebug` is rendered directly.
+export default function ErrorDebug ({error}) {
+  const { name, message, module } = error
+  return (
+    <div style={styles.errorDebug}>
+      <Head>
+        <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+      </Head>
+      {module ? <h1 style={styles.heading}>Error in {module.rawRequest}</h1> : null}
+      {
+        name === 'ModuleBuildError'
+          ? <pre style={styles.stack} dangerouslySetInnerHTML={{ __html: ansiHTML(encodeHtml(message)) }} />
+          : <StackTrace error={error} />
+      }
+    </div>
+  )
+}
+
+const StackTrace = ({ error: { name, message, stack, info } }) => (
   <div>
     <div style={styles.heading}>{message || name}</div>
     <pre style={styles.stack}>
       {stack}
     </pre>
+    {info && <pre style={styles.stack}>
+      {info.componentStack}
+    </pre>}
   </div>
 )
 
@@ -36,7 +74,8 @@ const styles = {
     right: 0,
     top: 0,
     bottom: 0,
-    zIndex: 9999
+    zIndex: 9999,
+    color: '#b3adac'
   },
 
   stack: {

--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -9,15 +9,18 @@ export class ClientDebug extends React.Component {
   state = {
     mappedError: null
   }
-  async componentDidMount () {
+  componentDidMount () {
     const {error} = this.props
 
     // If sourcemaps were already applied there is no need to set the state
     if (error.sourceMapsApplied) {
       return
     }
-    await rewriteErrorTrace(error)
-    this.setState({mappedError: error})
+
+    // Since componentDidMount doesn't handle errors we use then/catch here
+    rewriteErrorTrace(error).then(() => {
+      this.setState({mappedError: error})
+    }).catch(console.error)
   }
 
   render () {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@babel/runtime": "7.0.0-beta.42",
     "@babel/template": "7.0.0-beta.42",
     "@zeit/check-updates": "1.1.1",
-    "@zeit/source-map-support": "0.6.2",
     "ansi-html": "0.0.7",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.0-beta.2",

--- a/server/build/babel/preset.js
+++ b/server/build/babel/preset.js
@@ -23,17 +23,6 @@ function styledJsxOptions (opts) {
   return opts
 }
 
-const envPlugins = {
-  'development': [
-    require('@babel/plugin-transform-react-jsx-source')
-  ],
-  'production': [
-    require('babel-plugin-transform-react-remove-prop-types')
-  ]
-}
-
-const plugins = envPlugins[process.env.NODE_ENV] || envPlugins['development']
-
 module.exports = (context, opts = {}) => ({
   presets: [
     [require('@babel/preset-env'), {
@@ -53,6 +42,6 @@ module.exports = (context, opts = {}) => ({
       regenerator: true
     }],
     [require('styled-jsx/babel'), styledJsxOptions(opts['styled-jsx'])],
-    ...plugins
-  ]
+    process.env.NODE_ENV === 'production' && require('babel-plugin-transform-react-remove-prop-types')
+  ].filter(Boolean)
 })

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -16,6 +16,7 @@ import BuildManifestPlugin from './plugins/build-manifest-plugin'
 
 const presetItem = createConfigItem(require('./babel/preset'), {type: 'preset'})
 const hotLoaderItem = createConfigItem(require('react-hot-loader/babel'), {type: 'plugin'})
+const reactJsxSourceItem = createConfigItem(require('@babel/plugin-transform-react-jsx-source'), {type: 'plugin'})
 
 const nextDir = path.join(__dirname, '..', '..', '..')
 const nextNodeModulesDir = path.join(nextDir, 'node_modules')
@@ -34,7 +35,8 @@ function babelConfig (dir, {isServer, dev}) {
     cacheDirectory: true,
     presets: [],
     plugins: [
-      dev && !isServer && hotLoaderItem
+      dev && !isServer && hotLoaderItem,
+      dev && reactJsxSourceItem
     ].filter(Boolean)
   }
 
@@ -119,7 +121,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
   } : {}
 
   let webpackConfig = {
-    devtool: dev ? 'source-map' : false,
+    devtool: dev ? 'cheap-module-source-map' : false,
     name: isServer ? 'server' : 'client',
     cache: true,
     target: isServer ? 'node' : 'web',
@@ -139,14 +141,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       libraryTarget: 'commonjs2',
       // This saves chunks with the name given via require.ensure()
       chunkFilename: '[name]-[chunkhash].js',
-      strictModuleExceptionHandling: true,
-      devtoolModuleFilenameTemplate (info) {
-        if (dev) {
-          return info.absoluteResourcePath
-        }
-
-        return `${info.absoluteResourcePath.replace(dir, '.').replace(nextDir, './node_modules/next')}`
-      }
+      strictModuleExceptionHandling: true
     },
     performance: { hints: false },
     resolve: {

--- a/server/index.js
+++ b/server/index.js
@@ -336,8 +336,8 @@ export default class Server {
         res.statusCode = 404
         return this.renderErrorToHTML(null, req, res, pathname, query)
       } else {
-        const {rewriteErrorTrace} = require('./lib/source-map-support')
-        await rewriteErrorTrace(err)
+        const {applySourcemaps} = require('./lib/source-map-support')
+        await applySourcemaps(err)
         if (!this.quiet) console.error(err)
         res.statusCode = 500
         return this.renderErrorToHTML(err, req, res, pathname, query)

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/first, no-return-await */
-require('@zeit/source-map-support').install()
 import { resolve, join, sep } from 'path'
 import { parse as parseUrl } from 'url'
 import { parse as parseQs } from 'querystring'

--- a/server/index.js
+++ b/server/index.js
@@ -336,6 +336,8 @@ export default class Server {
         res.statusCode = 404
         return this.renderErrorToHTML(null, req, res, pathname, query)
       } else {
+        const {rewriteErrorTrace} = require('./lib/source-map-support')
+        await rewriteErrorTrace(err)
         if (!this.quiet) console.error(err)
         res.statusCode = 500
         return this.renderErrorToHTML(err, req, res, pathname, query)

--- a/server/lib/source-map-support.js
+++ b/server/lib/source-map-support.js
@@ -1,7 +1,7 @@
 // @flow
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
-export async function rewriteErrorTrace (e: any): Promise<void> {
+export async function rewriteErrorTrace (e: any): Promise<Error> {
   if (!e || typeof e.stack !== 'string' || e.sourceMapsApplied) {
     return
   }
@@ -15,6 +15,7 @@ export async function rewriteErrorTrace (e: any): Promise<void> {
   e.stack = result.join('\n')
   // This is to make sure we don't apply the sourcemaps twice on the same object
   e.sourceMapsApplied = true
+  return e
 }
 
 async function rewriteTraceLine (trace: string): Promise<string> {

--- a/server/lib/source-map-support.js
+++ b/server/lib/source-map-support.js
@@ -8,7 +8,7 @@ const access = promisify(fs.access)
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
 export async function rewriteErrorTrace (e: any): Promise<void> {
-  if (!e || typeof e.stack !== 'string') {
+  if (!e || typeof e.stack !== 'string' || e.sourceMapsApplied) {
     return
   }
 
@@ -19,6 +19,8 @@ export async function rewriteErrorTrace (e: any): Promise<void> {
   }))
 
   e.stack = result.join('\n')
+  // This is to make sure we don't apply the sourcemaps twice on the same object
+  e.sourceMapsApplied = true
 }
 
 async function rewriteTraceLine (trace: string): Promise<string> {

--- a/server/lib/source-map-support.js
+++ b/server/lib/source-map-support.js
@@ -1,0 +1,55 @@
+// @flow
+import fs from 'fs'
+import promisify from './promisify'
+import {SourceMapConsumer} from 'source-map'
+
+const readFile = promisify(fs.readFile)
+const access = promisify(fs.access)
+const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
+
+export async function rewriteErrorTrace (e: any): Promise<void> {
+  if (!e || typeof e.stack !== 'string') {
+    return
+  }
+
+  const lines = e.stack.split('\n')
+
+  const result = await Promise.all(lines.map((line) => {
+    return rewriteTraceLine(line)
+  }))
+
+  e.stack = result.join('\n')
+}
+
+async function rewriteTraceLine (trace: string): Promise<string> {
+  const m = trace.match(filenameRE)
+  if (m == null) {
+    return trace
+  }
+
+  const filePath = m[1]
+  const mapPath = `${filePath}.map`
+
+  try {
+    await access(mapPath, (fs.constants || fs).R_OK)
+  } catch (err) {
+    return trace
+  }
+
+  const mapContents = await readFile(mapPath)
+  const map = new SourceMapConsumer(JSON.parse(mapContents))
+  const originalPosition = map.originalPositionFor({
+    line: Number(m[2]),
+    column: Number(m[3])
+  })
+
+  console.log('POSITION', originalPosition)
+
+  if (originalPosition.source != null) {
+    const { source, line, column } = originalPosition
+    const mappedPosition = `(${source.replace(/^webpack:\/\/\//, '')}:${String(line)}:${String(column)})`
+    return trace.replace(filenameRE, mappedPosition)
+  }
+
+  return trace
+}

--- a/server/lib/source-map-support.js
+++ b/server/lib/source-map-support.js
@@ -1,7 +1,7 @@
 // @flow
 const filenameRE = /\(([^)]+\.js):(\d+):(\d+)\)$/
 
-export async function rewriteErrorTrace (e: any): Promise<Error> {
+export async function applySourcemaps (e: any): Promise<void> {
   if (!e || typeof e.stack !== 'string' || e.sourceMapsApplied) {
     return
   }
@@ -15,7 +15,6 @@ export async function rewriteErrorTrace (e: any): Promise<Error> {
   e.stack = result.join('\n')
   // This is to make sure we don't apply the sourcemaps twice on the same object
   e.sourceMapsApplied = true
-  return e
 }
 
 async function rewriteTraceLine (trace: string): Promise<string> {

--- a/server/lib/source-map-support.js
+++ b/server/lib/source-map-support.js
@@ -45,8 +45,6 @@ async function rewriteTraceLine (trace: string): Promise<string> {
     column: Number(m[3])
   })
 
-  console.log('POSITION', originalPosition)
-
   if (originalPosition.source != null) {
     const { source, line, column } = originalPosition
     const mappedPosition = `(${source.replace(/^webpack:\/\/\//, '')}:${String(line)}:${String(column)})`

--- a/server/render.js
+++ b/server/render.js
@@ -12,7 +12,7 @@ import Head, { defaultHead } from '../lib/head'
 import ErrorDebug from '../lib/error-debug'
 import { flushChunks } from '../lib/dynamic'
 import { BUILD_MANIFEST } from '../lib/constants'
-import { rewriteErrorTrace } from './lib/source-map-support'
+import { applySourcemaps } from './lib/source-map-support'
 
 const logger = console
 
@@ -50,7 +50,7 @@ async function doRender (req, res, pathname, query, {
 } = {}) {
   page = page || pathname
 
-  await rewriteErrorTrace(err)
+  await applySourcemaps(err)
 
   if (hotReloader) { // In dev mode we use on demand entries to compile the page before rendering
     await ensurePage(page, { dir, hotReloader })

--- a/server/render.js
+++ b/server/render.js
@@ -12,6 +12,7 @@ import Head, { defaultHead } from '../lib/head'
 import ErrorDebug from '../lib/error-debug'
 import { flushChunks } from '../lib/dynamic'
 import { BUILD_MANIFEST } from '../lib/constants'
+import { rewriteErrorTrace } from './lib/source-map-support'
 
 const logger = console
 
@@ -48,6 +49,8 @@ async function doRender (req, res, pathname, query, {
   nextExport = false
 } = {}) {
   page = page || pathname
+
+  await rewriteErrorTrace(err)
 
   if (hotReloader) { // In dev mode we use on demand entries to compile the page before rendering
     await ensurePage(page, { dir, hotReloader })

--- a/server/render.js
+++ b/server/render.js
@@ -95,7 +95,7 @@ async function doRender (req, res, pathname, query, {
       if (err && dev) {
         errorHtml = render(createElement(ErrorDebug, { error: err }))
       } else if (err) {
-        errorHtml = render(app)
+        html = render(app)
       } else {
         html = render(app)
       }

--- a/test/integration/basic/pages/error-in-the-browser-global-scope.js
+++ b/test/integration/basic/pages/error-in-the-browser-global-scope.js
@@ -1,0 +1,5 @@
+if (typeof window !== 'undefined') {
+  throw new Error('An Expected error occured')
+}
+
+export default () => <div />

--- a/test/integration/basic/pages/error-inside-browser-page.js
+++ b/test/integration/basic/pages/error-inside-browser-page.js
@@ -1,0 +1,9 @@
+import React from 'react'
+export default class ErrorInRenderPage extends React.Component {
+  render () {
+    if (typeof window !== 'undefined') {
+      throw new Error('An Expected error occured')
+    }
+    return <div />
+  }
+}

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -1,6 +1,7 @@
 /* global describe, it, expect */
 
 import webdriver from 'next-webdriver'
+import {waitFor} from 'next-test-utils'
 
 export default (context, render) => {
   describe('Client Navigation', () => {
@@ -451,6 +452,24 @@ export default (context, render) => {
           expect(asPath).toBe('/nav/as-path-using-router')
           browser.close()
         })
+      })
+    })
+
+    describe('runtime errors', () => {
+      it('should show ErrorDebug when a client side error is thrown inside a component', async () => {
+        const browser = await webdriver(context.appPort, '/error-inside-browser-page')
+        await waitFor(2000)
+        const text = await browser.elementByCss('body').text()
+        expect(text).toMatch(/An Expected error occured/)
+        expect(text).toMatch(/pages\/error-inside-browser-page\.js:5:0/)
+      })
+
+      it('should show ErrorDebug when a client side error is thrown outside a component', async () => {
+        const browser = await webdriver(context.appPort, '/error-in-the-browser-global-scope')
+        await waitFor(2000)
+        const text = await browser.elementByCss('body').text()
+        expect(text).toMatch(/An Expected error occured/)
+        expect(text).toMatch(/pages\/error-in-the-browser-global-scope\.js:2:0/)
       })
     })
 

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -104,11 +104,14 @@ export default function ({ app }, suiteName, render, fetch) {
     test('error-inside-page', async () => {
       const $ = await get$('/error-inside-page')
       expect($('pre').text()).toMatch(/This is an expected error/)
+      // Check if the the source map line is correct
+      expect($('body').text()).toMatch(/pages\/error-inside-page\.js:2:0/)
     })
 
     test('error-in-the-global-scope', async () => {
       const $ = await get$('/error-in-the-global-scope')
       expect($('pre').text()).toMatch(/aa is not defined/)
+      expect($('body').text()).toMatch(/pages\/error-in-the-global-scope\.js:1:0/)
     })
 
     test('asPath', async () => {

--- a/test/integration/production/pages/error-in-browser-render.js
+++ b/test/integration/production/pages/error-in-browser-render.js
@@ -1,0 +1,9 @@
+import React from 'react'
+export default class ErrorInRenderPage extends React.Component {
+  render () {
+    if (typeof window !== 'undefined') {
+      throw new Error('An Expected error occured')
+    }
+    return <div />
+  }
+}

--- a/test/integration/production/pages/error-in-ssr-render.js
+++ b/test/integration/production/pages/error-in-ssr-render.js
@@ -1,0 +1,6 @@
+import React from 'react'
+export default class ErrorInRenderPage extends React.Component {
+  render () {
+    throw new Error('An Expected error occured')
+  }
+}

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -74,6 +74,26 @@ describe('Production Usage', () => {
     })
   })
 
+  describe('Runtime errors', () => {
+    it('should render a server side error on the client side', async () => {
+      const browser = await webdriver(appPort, '/error-in-ssr-render')
+      await waitFor(2000)
+      const text = await browser.elementByCss('body').text()
+      // this makes sure we don't leak the actual error to the client side in production
+      expect(text).toMatch(/Internal Server Error\./)
+      const headingText = await browser.elementByCss('h1').text()
+      // This makes sure we render statusCode on the client side correctly
+      expect(headingText).toBe('500')
+    })
+
+    it('should render a client side component error', async () => {
+      const browser = await webdriver(appPort, '/error-in-browser-render')
+      await waitFor(2000)
+      const text = await browser.elementByCss('body').text()
+      expect(text).toMatch(/An unexpected error has occurred\./)
+    })
+  })
+
   describe('Misc', () => {
     it('should handle already finished responses', async () => {
       const res = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,12 +759,6 @@
     postcss-loader "^2.0.10"
     style-loader "^0.19.1"
 
-"@zeit/source-map-support@0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@zeit/source-map-support/-/source-map-support-0.6.2.tgz#0efd478f24a606726948165e53a8efe89e24036f"
-  dependencies:
-    source-map "^0.6.0"
-
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -6929,7 +6923,7 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@0.6.1, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 


### PR DESCRIPTION
Fixes #3735 with the change to `devtool`.

This change will introduce proper source map support for all modules. It'll also improve recompile time by using cheap-module-source-map instead of source-map. In practice this only improves compile times and has no real downside when debugging.

When an error is thrown we call `applySourcemaps` which will load the sourcemap associated with each line stacktrace line, then it'll find the real line using the `source-map` module and return the newly constructed error line. This is very similar to how Vue handles server side errors.

Besides that I also noticed our `componentDidCatch` only worked in production mode, since react-hot-loader's appContainer implemented `componentDidCatch`. Now we catch the error in `App` and throw it up to `AppContainer` in development.