### PR TITLE
react-hot-loader: 4.0.0 -> 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "path-to-regexp": "2.1.0",
     "prop-types": "15.6.0",
     "prop-types-exact": "1.1.1",
-    "react-hot-loader": "4.0.0",
+    "react-hot-loader": "4.0.1",
     "recursive-copy": "2.0.6",
     "resolve": "1.5.0",
     "send": "0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5416,6 +5416,14 @@ prop-types@15.6.0, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
@@ -5554,14 +5562,14 @@ react-dom@16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-hot-loader@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.0.0.tgz#3452fa9bc0d0ba9dfc5b0ccfa25101ca8dbd2de2"
+react-hot-loader@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.0.1.tgz#48284350ae5d7ba07dac872bd5bbc6e477352593"
   dependencies:
     fast-levenshtein "^2.0.6"
     global "^4.3.0"
     hoist-non-react-statics "^2.5.0"
-    prop-types "^15.6.0"
+    prop-types "^15.6.1"
     shallowequal "^1.0.2"
 
 react@16.2.0:


### PR DESCRIPTION
I am using mobx with next.js
Sometimes hot reloading fails with an error.
<details><summary>Open stacktrace</summary>
<p>

```
Cannot read property '0' of null
TypeError: Cannot read property '0' of null
    at bindDependencies (http://localhost:3000/_next/-/page/index.js:42990:28)
    at trackDerivedFunction (http://localhost:3000/_next/-/page/index.js:42972:5)
    at Reaction.webpackJsonp../node_modules/mobx/lib/mobx.module.js.Reaction.track (http://localhost:3000/_next/-/page/index.js:43164:22)
    at ProxyComponent.reactiveRender [as render] (http://localhost:3000/_next/-/page/index.js:39408:22)
    at finishClassComponent (http://localhost:3000/_next/-/main.js:19188:33)
    at updateClassComponent (http://localhost:3000/_next/-/main.js:19156:12)
    at beginWork (http://localhost:3000/_next/-/main.js:19777:16)
    at performUnitOfWork (http://localhost:3000/_next/-/main.js:22609:16)
    at workLoop (http://localhost:3000/_next/-/main.js:22638:26)
    at renderRoot (http://localhost:3000/_next/-/main.js:22669:9)
```
</p>
</details>
<br>
That issue was fixed in react-hot-loader 4.0.1