### PR TITLE
Fix `pageExtensions` config containing multiple periods

### DIFF
--- a/server/build/webpack/utils.js
+++ b/server/build/webpack/utils.js
@@ -32,15 +32,27 @@ export function createEntry (filePath, {name, pageExtensions} = {}) {
   const parsedPath = path.parse(filePath)
   let entryName = name || filePath
 
-  // This makes sure we compile `pages/blog/index.js` to `pages/blog.js`.
-  // Excludes `pages/index.js` from this rule since we do want `/` to route to `pages/index.js`
-  if (parsedPath.dir !== 'pages' && parsedPath.name === 'index') {
-    entryName = `${parsedPath.dir}.js`
-  }
-
-  // Makes sure supported extensions are stripped off. The outputted file should always be `.js`
   if (pageExtensions) {
-    entryName = entryName.replace(new RegExp(`\\.+(${pageExtensions})$`), '.js')
+    // Regular expression to match only the extension of a given file
+    const extensionsRegex = new RegExp(`\\.+(${pageExtensions})$`)
+
+    // This makes sure we compile passed page extensions (including multi-period extensions)
+    // like `pages/blog/index.entry.ts` to `pages/blog.js`
+    // Excludes `pages/index.js` from this rule since we do want `/` to route to `pages/index.js`
+    if (
+      parsedPath.dir !== 'pages' &&
+      parsedPath.base.replace(extensionsRegex, '') === 'index'
+    ) {
+      entryName = `${parsedPath.dir}.js`
+    }
+
+    // Makes sure supported extensions are stripped off. The outputted file should always be `.js`
+    entryName = entryName.replace(extensionsRegex, '.js')
+  } else {
+    // Check to ensure we compile `pages/blog/index.js` to `pages/blog.js`
+    if (parsedPath.dir !== 'pages' && parsedPath.name === 'index') {
+      entryName = `${parsedPath.dir}.js`
+    }
   }
 
   return {

--- a/test/isolated/webpack-utils.test.js
+++ b/test/isolated/webpack-utils.test.js
@@ -40,10 +40,28 @@ describe('createEntry', () => {
     expect(entry.files[0]).toBe('./pages/index.tsx')
   })
 
+  it('Should allow custom multi-period extension like .entry.tsx to be turned into .js', () => {
+    const entry = createEntry('pages/index.entry.tsx', {pageExtensions: ['entry.tsx']})
+    expect(entry.name).toBe(normalize('bundles/pages/index.js'))
+    expect(entry.files[0]).toBe('./pages/index.entry.tsx')
+  })
+
   it('Should turn pages/blog/index.js into pages/blog.js', () => {
     const entry = createEntry('pages/blog/index.js')
     expect(entry.name).toBe(normalize('bundles/pages/blog.js'))
     expect(entry.files[0]).toBe('./pages/blog/index.js')
+  })
+
+  it('Should turn custom extension pages/blog/index.tsx into pages/blog.js', () => {
+    const entry = createEntry('pages/blog/index.tsx', {pageExtensions: ['tsx']})
+    expect(entry.name).toBe(normalize('bundles/pages/blog.js'))
+    expect(entry.files[0]).toBe('./pages/blog/index.tsx')
+  })
+
+  it('Should turn custom multi-period extension pages/blog/index.entry.tsx into pages/blog.js', () => {
+    const entry = createEntry('pages/blog/index.entry.tsx', {pageExtensions: ['entry.tsx']})
+    expect(entry.name).toBe(normalize('bundles/pages/blog.js'))
+    expect(entry.files[0]).toBe('./pages/blog/index.entry.tsx')
   })
 })
 


### PR DESCRIPTION
The goal is to add other components/files/"non-pages" to my `pages/` directory, which I don't want to be split into a separate bundle

The idea was to have a `next.config.js` like:
```js
module.exports = {
  pageExtensions: ['entry.jsx'],
};
```

With the goal being to only bundle `pages/**/*.entry.jsx` as separate pages, and ignore the other `.jsx` & `.js` files.

This mostly works, except for an issue which occurs when the file is named `subdir/index.entry.tsx`, as `path.parse` strips only `.tsx` as the extension, such that `parsedPath.name` returns `index.entry`, and thus failing the `parsedPath.name === 'index'` condition to transform the output page bundle from i.e. `pages/blog/index.entry.ts` to `pages/blog.js`

The solution here instead strips out the extension if the `pageExtensions` argument is passed (instead of just using `parsedPath.name`), and falling back to the previous method if `pageExtensions` is undefined (to remain backwards compatible)