### PR TITLE
Update next-typescript version in with-typescript example

### DIFF
--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/next": "^2.4.7",
     "@types/react": "^16.0.36",
-    "@zeit/next-typescript": "0.0.11",
+    "@zeit/next-typescript": "0.1.1",
     "typescript": "^2.7.1"
   }
 }


### PR DESCRIPTION
This example gave me 404s on `pages/*.tsx` when using it with the latest nextjs (`5.1.0`) and `@zeit/next-typescript@0.0.11`. The latest next-typescript plugin version (`0.1.1`) fixes it.