### PR TITLE
Update with-redux-saga example with code from next-redux-saga

### DIFF
--- a/examples/with-redux-saga/store.js
+++ b/examples/with-redux-saga/store.js
@@ -23,7 +23,20 @@ export function configureStore (initialState = exampleInitialState) {
     bindMiddleware([sagaMiddleware])
   )
 
-  store.sagaTask = sagaMiddleware.run(rootSaga)
+  /**
+   * next-redux-saga depends on `runSagaTask` and `sagaTask` being attached to the store.
+   *
+   *   `runSagaTask` is used to rerun the rootSaga on the client when in sync mode (default)
+   *   `sagaTask` is used to await the rootSaga task before sending results to the client
+   *
+   */
+
+  store.runSagaTask = () => {
+    store.sagaTask = sagaMiddleware.run(rootSaga)
+  }
+
+  // run the rootSaga initially
+  store.runSagaTask()
   return store
 }
 


### PR DESCRIPTION
From #4098: this fixes an error I was getting:

```
store.runSagaTask is not a function
```

Copies `configureStore` code directly from [next-redux-saga](https://github.com/bmealhouse/next-redux-saga)