### PR TITLE
Fix url prop override

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -45,7 +45,7 @@ export default class App extends Component {
     const {router, Component, pageProps} = this.props
     const url = createUrl(router)
     return <Container>
-      <Component url={url} {...pageProps} />
+      <Component {...pageProps} url={url} />
     </Container>
   }
 }

--- a/test/integration/basic/pages/url-prop-override.js
+++ b/test/integration/basic/pages/url-prop-override.js
@@ -1,0 +1,16 @@
+import React from 'react'
+export default class extends React.Component {
+  static getInitialProps () {
+    return {
+      url: 'test' // This gets overridden by Next in lib/_app.js
+    }
+  }
+  render () {
+    const {url} = this.props
+    return <div>
+      <p id='pathname'>{url.pathname}</p>
+      <p id='query'>{Object.keys(url.query).length}</p>
+      <p id='aspath'>{url.asPath}</p>
+    </div>
+  }
+}

--- a/test/integration/basic/pages/url-prop.js
+++ b/test/integration/basic/pages/url-prop.js
@@ -1,5 +1,4 @@
 export default ({url}) => {
-  console.log(url.query)
   return <div>
     <p id='pathname'>{url.pathname}</p>
     <p id='query'>{Object.keys(url.query).length}</p>

--- a/test/integration/basic/pages/url-prop.js
+++ b/test/integration/basic/pages/url-prop.js
@@ -1,0 +1,8 @@
+export default ({url}) => {
+  console.log(url.query)
+  return <div>
+    <p id='pathname'>{url.pathname}</p>
+    <p id='query'>{Object.keys(url.query).length}</p>
+    <p id='aspath'>{url.asPath}</p>
+  </div>
+}

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -40,6 +40,8 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/custom-extension'),
       renderViaHTTP(context.appPort, '/styled-jsx'),
       renderViaHTTP(context.appPort, '/with-cdm'),
+      renderViaHTTP(context.appPort, '/url-prop'),
+      renderViaHTTP(context.appPort, '/url-prop-override'),
 
       renderViaHTTP(context.appPort, '/nav'),
       renderViaHTTP(context.appPort, '/nav/about'),

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -119,6 +119,22 @@ export default function ({ app }, suiteName, render, fetch) {
       expect($('.as-path-content').text()).toBe('/nav/as-path?aa=10')
     })
 
+    describe('Url prop', () => {
+      it('should provide pathname, query and asPath', async () => {
+        const $ = await get$('/url-prop')
+        expect($('#pathname').text()).toBe('/url-prop')
+        expect($('#query').text()).toBe('0')
+        expect($('#aspath').text()).toBe('/url-prop')
+      })
+
+      it('should override props.url, even when getInitialProps returns url as property', async () => {
+        const $ = await get$('/url-prop-override')
+        expect($('#pathname').text()).toBe('/url-prop-override')
+        expect($('#query').text()).toBe('0')
+        expect($('#aspath').text()).toBe('/url-prop-override')
+      })
+    })
+
     describe('404', () => {
       it('should 404 on not existent page', async () => {
         const $ = await get$('/non-existent')


### PR DESCRIPTION
Previous version override the `url` prop even if it's provided by the user in `getInitialProps`. So we have to keep it like that till the `url` prop is removed.