### PR TITLE
Fix generated page chunk when libraryTarget is umd

### DIFF
--- a/server/build/plugins/pages-plugin.js
+++ b/server/build/plugins/pages-plugin.js
@@ -27,9 +27,8 @@ class PageChunkTemplatePlugin {
 
       const source = new ConcatSource()
 
-      source.add(`
-        __NEXT_REGISTER_PAGE('${routeName}', function() {
-          var comp = 
+      source.add(`__NEXT_REGISTER_PAGE('${routeName}', function() {
+          var comp =
       `)
       source.add(modules)
       source.add(`


### PR DESCRIPTION
This fixes the generated page chunk created by the webpack `pages-plugin` which adds a new line in the beginning of the template, when using `output.libraryTarget` set to be [`umd`](https://webpack.js.org/configuration/output/#module-definition-systems) it returns the module.

Consider the following example, which is the output with the previous implementation:

```js
(function webpackUniversalModuleDefinition(root, factory) {
  if(typeof exports === 'object' && typeof module === 'object')
    module.exports = factory();
  else if(typeof define === 'function' && define.amd)
    define([], factory);
  else if(typeof exports === 'object')
    exports["MyLibrary"] = factory();
  else
    root["MyLibrary"] = factory();
})(typeof self !== 'undefined' ? self : this, function() {
  return
    __NEXT_REGISTER_PAGE(...)
});
```

`__NEXT_REGISTER_PAGE()` won't be executed since a `return` statement followed by a new line is the same as having a semicolon inserted right after the `return`. By removing the new line in the beginning of the source concatenation (which I suppose was added for stylistic reasons) this works as expected.