### PR TITLE
Support _app approach for upgraded Redux Wrapper

### DIFF
--- a/examples/with-redux-wrapper/.npmrc
+++ b/examples/with-redux-wrapper/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+save-exact=true

--- a/examples/with-redux-wrapper/package.json
+++ b/examples/with-redux-wrapper/package.json
@@ -1,20 +1,20 @@
 {
   "name": "with-redux-wrapper",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "next-redux-wrapper": "^1.0.0",
-    "react": "^16.0.0",
-    "redux-devtools-extension": "^2.13.2",
-    "react-dom": "^16.0.0",
-    "react-redux": "^5.0.1",
-    "redux": "^3.6.0",
-    "redux-thunk": "^2.1.0"
+    "next": "6.0.0",
+    "next-redux-wrapper": "latest",
+    "react": "16.3.2",
+    "react-dom": "16.3.2",
+    "react-redux": "5.0.7",
+    "redux": "4.0.0",
+    "redux-devtools-extension": "2.13.2",
+    "redux-thunk": "2.2.0"
   },
   "license": "ISC"
 }

--- a/examples/with-redux-wrapper/package.json
+++ b/examples/with-redux-wrapper/package.json
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "6.0.0",
+    "next": "latest",
     "next-redux-wrapper": "latest",
     "react": "16.3.2",
     "react-dom": "16.3.2",

--- a/examples/with-redux-wrapper/pages/_app.js
+++ b/examples/with-redux-wrapper/pages/_app.js
@@ -1,8 +1,10 @@
 import React from 'react'
+import {Provider} from 'react-redux'
+import App, {Container} from 'next/app'
 import withRedux from 'next-redux-wrapper'
 import {initStore} from '../store'
 
-export default withRedux(initStore)(class MyApp extends React.Component {
+export default withRedux(initStore)(class MyApp extends App {
   static async getInitialProps ({Component, ctx}) {
     return {
       pageProps: (Component.getInitialProps ? await Component.getInitialProps(ctx) : {})
@@ -10,7 +12,11 @@ export default withRedux(initStore)(class MyApp extends React.Component {
   }
 
   render () {
-    const {Component, pageProps} = this.props
-    return <Component {...pageProps} />
+    const {Component, pageProps, store} = this.props
+    return <Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
+    </Container>
   }
 })

--- a/examples/with-redux-wrapper/pages/_app.js
+++ b/examples/with-redux-wrapper/pages/_app.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import withRedux from 'next-redux-wrapper'
+import {initStore} from '../store'
+
+export default withRedux(initStore)(class MyApp extends React.Component {
+  static async getInitialProps ({Component, ctx}) {
+    return {
+      pageProps: (Component.getInitialProps ? await Component.getInitialProps(ctx) : {})
+    }
+  }
+
+  render () {
+    const {Component, pageProps} = this.props
+    return <Component {...pageProps} />
+  }
+})

--- a/examples/with-redux-wrapper/pages/index.js
+++ b/examples/with-redux-wrapper/pages/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { bindActionCreators } from 'redux'
-import { initStore, startClock, addCount, serverRenderClock } from '../store'
-import withRedux from 'next-redux-wrapper'
+import { startClock, addCount, serverRenderClock } from '../store'
+import { connect } from 'react-redux'
 import Page from '../components/Page'
 
 class Counter extends React.Component {
@@ -34,4 +34,4 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-export default withRedux(initStore, null, mapDispatchToProps)(Counter)
+export default connect(null, mapDispatchToProps)(Counter)

--- a/examples/with-redux-wrapper/pages/other.js
+++ b/examples/with-redux-wrapper/pages/other.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { bindActionCreators } from 'redux'
-import { initStore, startClock, addCount, serverRenderClock } from '../store'
-import withRedux from 'next-redux-wrapper'
+import { startClock, addCount, serverRenderClock } from '../store'
+import { connect } from 'react-redux'
 import Page from '../components/Page'
 
 class Counter extends React.Component {
@@ -33,4 +33,4 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-export default withRedux(initStore, null, mapDispatchToProps)(Counter)
+export default connect(null, mapDispatchToProps)(Counter)


### PR DESCRIPTION
In order to support #4129 an upgraded version of `next-redux-wrapper` was released, so the example was upgraded.