### PR TITLE
Fix dynamic import in non webpack env regression #3345

### DIFF
--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -16,23 +16,33 @@ const TYPE_IMPORT = 'Import'
 
 const buildImport = (args) => (template(`
   (
-    new (require('next/dynamic').SameLoopPromise)((resolve, reject) => {
-      const weakId = require.resolveWeak(SOURCE)
-      try {
-        const weakModule = __webpack_require__(weakId)
-        return resolve(weakModule)
-      } catch (err) {}
-
-      require.ensure([], (require) => {
-        try {
+    typeof require.resolveWeak !== 'function' ?
+      new (require('next/dynamic').SameLoopPromise)((resolve, reject) => {
+        eval('require.ensure = function (deps, callback) { callback(require) }')
+        require.ensure([], (require) => {
           let m = require(SOURCE)
-          m.__webpackChunkName = '${args.name}'
-          resolve(m)
-        } catch(error) {
-          reject(error)
-        }
-      }, 'chunks/${args.name}');
-    })
+          m.__webpackChunkName = '${args.name}.js'
+          resolve(m);
+        }, 'chunks/${args.name}.js');
+      })
+      :
+      new (require('next/dynamic').SameLoopPromise)((resolve, reject) => {
+        const weakId = require.resolveWeak(SOURCE)
+        try {
+          const weakModule = __webpack_require__(weakId)
+          return resolve(weakModule)
+        } catch (err) {}
+
+        require.ensure([], (require) => {
+          try {
+            let m = require(SOURCE)
+            m.__webpackChunkName = '${args.name}'
+            resolve(m)
+          } catch(error) {
+            reject(error)
+          }
+        }, 'chunks/${args.name}');
+      })
   )
 `))
 


### PR DESCRIPTION
Just in case #3345 was a regression and nextjs should still support non webpack node envs for testing.