### PR TITLE
Use bs-next and next/link in with-reasonml example

### DIFF
--- a/examples/with-reasonml/bsconfig.json
+++ b/examples/with-reasonml/bsconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "with-reasonml",
   "sources": ["components", "pages"],
-  "bs-dependencies": ["reason-react"],
+  "bs-dependencies": ["reason-react", "bs-next"],
   "reason": { "react-jsx": 2 },
   "package-specs": ["commonjs"],
   "bsc-flags": [

--- a/examples/with-reasonml/components/Header.re
+++ b/examples/with-reasonml/components/Header.re
@@ -6,7 +6,11 @@ let make = (_children) => {
   ...component,
   render: (_self) =>
     <div>
-      <a href="/" style=styles> (ReasonReact.stringToElement("Home")) </a>
-      <a href="/about" style=styles> (ReasonReact.stringToElement("About")) </a>
+      <Next.Link href="/">
+        <a style=styles> (ReasonReact.stringToElement("Home")) </a>
+      </Next.Link>
+      <Next.Link href="/about">
+        <a style=styles> (ReasonReact.stringToElement("About")) </a>
+      </Next.Link>
     </div>
 };

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -12,7 +12,8 @@
     "next": "latest",
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
-    "reason-react": "^0.3.0"
+    "reason-react": "^0.3.0",
+    "bs-next": "^2.0.0"
   },
   "devDependencies": {
     "bs-platform": "^2.1.0",


### PR DESCRIPTION
Fixes #4028 by using Next.Link wrapped neatly by bs-next.