### PR TITLE
with-reasonml: use default exports

### DIFF
--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -2,9 +2,9 @@
   "name": "with-reasonml",
   "version": "1.0.0",
   "scripts": {
-    "dev": "concurrently \"bsb -clean-world -make-world -w\" \"next -w\"",
-    "build": "bsb -clean-world -make-world && next build",
-    "start": "bsb -clean-world -make-world && next start -w"
+    "dev": "bsb -clean-world -make-world && next dev lib/js",
+    "build": "bsb -clean-world -make-world && next build lib/js",
+    "start": "next start lib/js"
   },
   "license": "ISC",
   "dependencies": {

--- a/examples/with-reasonml/pages/about.js
+++ b/examples/with-reasonml/pages/about.js
@@ -1,4 +1,0 @@
-import { jsComponent as About } from './About.re'
-import React from 'react'
-
-export default () => <About />

--- a/examples/with-reasonml/pages/about.re
+++ b/examples/with-reasonml/pages/about.re
@@ -10,4 +10,4 @@ let make = (_children) => {
     </div>
 };
 
-let jsComponent = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));
+let default = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));

--- a/examples/with-reasonml/pages/index.js
+++ b/examples/with-reasonml/pages/index.js
@@ -1,3 +1,0 @@
-import { jsComponent as Index } from './Index.re'
-
-export default () => <Index />

--- a/examples/with-reasonml/pages/index.re
+++ b/examples/with-reasonml/pages/index.re
@@ -10,4 +10,4 @@ let make = (_children) => {
     </div>
 };
 
-let jsComponent = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));
+let default = ReasonReact.wrapReasonForJs(~component, (_jsProps) => make([||]));


### PR DESCRIPTION
Here is a suggestion for the ReasonML example to remove the js files for pages, which basically just wrap a default export.

ReasonML enables ES6 default exports so that's done here, but this way we have to use the lib/js directory the bucklescript compiler targets. I think it's a very acceptable tradeoff in this example.