### PR TITLE
with-reasonml example: better setup

### DIFF
--- a/examples/with-reasonml/.gitignore
+++ b/examples/with-reasonml/.gitignore
@@ -1,3 +1,4 @@
 bs
 .merlin
 lib/
+*.bs.js

--- a/examples/with-reasonml/bsconfig.json
+++ b/examples/with-reasonml/bsconfig.json
@@ -3,7 +3,11 @@
   "sources": ["components", "pages"],
   "bs-dependencies": ["reason-react", "bs-next"],
   "reason": { "react-jsx": 2 },
-  "package-specs": ["commonjs"],
+  "package-specs": {
+    "module": "commonjs",
+    "in-source": true
+  },
+  "suffix": ".bs.js",
   "bsc-flags": [
     "-bs-super-errors"
   ],

--- a/examples/with-reasonml/next.config.js
+++ b/examples/with-reasonml/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['jsx', 'js', 'bs.js']
+}

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -2,9 +2,9 @@
   "name": "with-reasonml",
   "version": "1.0.0",
   "scripts": {
-    "dev": "bsb -clean-world -make-world && next dev lib/js",
-    "build": "bsb -clean-world -make-world && next build lib/js",
-    "start": "next start lib/js"
+    "dev": "concurrently \"bsb -clean-world -make-world -w\" \"next dev\"",
+    "build": "bsb -clean-world -make-world && next build",
+    "start": "next start"
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
With this setup we're compiling the .re/.ml files directly to source directories with a .bs.js extension, and enabling next.js to pick up that extension for pages.

This has multiple advantages:
- We can re-enable the bs watcher to hot reload components and pages in dev mode when the .re/.ml files are changed
- Use this setup to include ReasonML to existing next.js projects, since pages and components can be either JS or ReasonML, and they will both work with this setup
- Doesn't rely on bs-loader which is deprecated, and follows the officially recommended setup with `in-source`