### PR TITLE
Add docker example for setting environment variables at runtime

### DIFF
--- a/examples/with-universal-configuration-runtime-docker/.dockerignore
+++ b/examples/with-universal-configuration-runtime-docker/.dockerignore
@@ -1,0 +1,3 @@
+.next/
+node_modules/
+Dockerfile

--- a/examples/with-universal-configuration-runtime-docker/Dockerfile
+++ b/examples/with-universal-configuration-runtime-docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:9-slim AS builder
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:9-alpine
+WORKDIR /app
+COPY --from=builder /app .
+EXPOSE 3000
+CMD npm start

--- a/examples/with-universal-configuration-runtime-docker/Dockerfile
+++ b/examples/with-universal-configuration-runtime-docker/Dockerfile
@@ -1,12 +1,10 @@
-FROM node:9-slim AS builder
-WORKDIR /app
-COPY package.json .
-RUN npm install
-COPY . .
-RUN npm run build
+FROM mhart/alpine-node
 
-FROM node:9-alpine
 WORKDIR /app
-COPY --from=builder /app .
+COPY . .
+
+RUN yarn install
+RUN yarn build
+
 EXPOSE 3000
-CMD npm start
+CMD ["yarn", "start"]

--- a/examples/with-universal-configuration-runtime-docker/Dockerfile.multistage
+++ b/examples/with-universal-configuration-runtime-docker/Dockerfile.multistage
@@ -1,0 +1,14 @@
+# Do the npm install or yarn install in the full image
+FROM mhart/alpine-node AS builder
+WORKDIR /app
+COPY package.json .
+RUN yarn install
+COPY . .
+RUN yarn build
+
+# And then copy over node_modules, etc from that stage to the smaller base image
+FROM mhart/alpine-node:base
+WORKDIR /app
+COPY --from=builder /app .
+EXPOSE 3000
+CMD ["node_modules/.bin/next", "start"]

--- a/examples/with-universal-configuration-runtime-docker/README.md
+++ b/examples/with-universal-configuration-runtime-docker/README.md
@@ -1,0 +1,46 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-universal-configuration-runtime-docker&env=API_URL&docker=true)
+
+# With universal runtime configuration
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-universal-configuration-runtime-docker with-universal-configuration-runtime-docker-app
+# or
+yarn create next-app --example with-universal-configuration-runtime-docker with-universal-configuration-runtime-docker-app
+```
+
+### Download manually
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-universal-configuration-runtime-docker
+cd with-universal-configuration-runtime-docker
+```
+
+Build it and run:
+
+```bash
+# build
+docker build -t next-app .
+# run
+docker run --rm -it \
+  -p 3000:3000 \
+  -e "API_URL=https://example.com" \
+  next-app
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now --docker -e API_URL="https://example.com"
+```
+
+## The idea behind the example
+
+This example show how to set custom environment variables for your docker application at runtime

--- a/examples/with-universal-configuration-runtime-docker/README.md
+++ b/examples/with-universal-configuration-runtime-docker/README.md
@@ -1,6 +1,6 @@
 [![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-universal-configuration-runtime-docker&env=API_URL&docker=true)
 
-# With universal runtime configuration
+# With universal runtime configuration in docker
 
 ## How to use
 
@@ -23,12 +23,18 @@ curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 
 cd with-universal-configuration-runtime-docker
 ```
 
-Build it and run:
+Build it with docker:
 
 ```bash
 # build
 docker build -t next-app .
-# run
+# or, use multi-stage builds to build a smaller docker image
+docker build -t next-app -f ./Dockerfile.multistage .
+```
+
+Run it:
+
+```bash
 docker run --rm -it \
   -p 3000:3000 \
   -e "API_URL=https://example.com" \
@@ -41,6 +47,12 @@ Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.
 now --docker -e API_URL="https://example.com"
 ```
 
+>*Note: Multi-stage only works in OSS plan. [\[#962\]](https://github.com/zeit/now-cli/issues/962#issuecomment-383860104)*
+
 ## The idea behind the example
 
-This example show how to set custom environment variables for your docker application at runtime
+This example show how to set custom environment variables for your __docker application__ at runtime.
+
+The `dockerfile` is the simplest way to run Next.js app in docker, and the size of output image is `173MB`. However, for an even smaller build, you can do multi-stage builds with `dockerfile.multistage`. The size of output image is `85MB`.
+
+You can check the [Example Dockerfile for your own Node.js project](https://github.com/mhart/alpine-node/tree/43ca9e4bc97af3b1f124d27a2cee002d5f7d1b32#example-dockerfile-for-your-own-nodejs-project) section in [mhart/alpine-node](https://github.com/mhart/alpine-node) for more details.

--- a/examples/with-universal-configuration-runtime-docker/lib/env.js
+++ b/examples/with-universal-configuration-runtime-docker/lib/env.js
@@ -1,0 +1,1 @@
+export default ('undefined' !== typeof window ? window.__ENV__ : process.env)

--- a/examples/with-universal-configuration-runtime-docker/package.json
+++ b/examples/with-universal-configuration-runtime-docker/package.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "htmlescape": "1.1.1",
+    "next": "latest",
+    "react": "16.2.0",
+    "react-dom": "16.2.0"
+  }
+}

--- a/examples/with-universal-configuration-runtime-docker/pages/_document.js
+++ b/examples/with-universal-configuration-runtime-docker/pages/_document.js
@@ -1,0 +1,27 @@
+import Document_, { Head, Main, NextScript } from 'next/document'
+import htmlescape from 'htmlescape'
+
+const { API_URL } = process.env
+const env = { API_URL }
+
+export default class Document extends Document_ {
+  static async getInitialProps (ctx) {
+    const props = await Document_.getInitialProps(ctx)
+    return props
+  }
+
+  render () {
+    return (
+      <html>
+        <Head />
+        <body>
+          <Main />
+          <script
+            dangerouslySetInnerHTML={{ __html: '__ENV__ = ' + htmlescape(env) }}
+          />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/examples/with-universal-configuration-runtime-docker/pages/index.js
+++ b/examples/with-universal-configuration-runtime-docker/pages/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import env from '../lib/env'
+
+const {API_URL} = env
+
+export default class extends React.Component {
+  static async getInitialProps () {
+    // fetch(`${API_URL}/some-path`)
+    return {}
+  }
+
+  render () {
+    return <div>
+            The API_URL is {API_URL}
+    </div>
+  }
+}


### PR DESCRIPTION
Add docker example for setting environment variables at runtime.

----
UPDATE:

Here I made two dockerfiles:
1. `dockerfile`: the simplest way to run Next.js app in docker (173MB) [\[demo\]](https://with-universal-configuration-runtime-docker-bxkuprrsog.now.sh/)
2. `dockerfile.multistage`: use multi-stage builds to build a smaller docker image (85MB) [\[demo\]](https://with-universal-configuration-runtime-docker-azvmlppsvt.now.sh/)