### PR TITLE
added "hashChangeStart" and "hashChangeComplete" events

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -15,7 +15,7 @@ const SingletonRouter = {
 
 // Create public properties and methods of the router in the SingletonRouter
 const propertyFields = ['components', 'pathname', 'route', 'query', 'asPath']
-const routerEvents = ['routeChangeStart', 'beforeHistoryChange', 'routeChangeComplete', 'routeChangeError']
+const routerEvents = ['routeChangeStart', 'beforeHistoryChange', 'routeChangeComplete', 'routeChangeError', 'hashChangeStart', 'hashChangeComplete']
 const coreMethodFields = ['push', 'replace', 'reload', 'back', 'prefetch', 'beforePopState']
 
 propertyFields.forEach((field) => {

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -148,8 +148,10 @@ export default class Router {
     // If the url change is only related to a hash change
     // We should not proceed. We should only change the state.
     if (this.onlyAHashChange(as)) {
+      this.events.emit('hashChangeStart', as)
       this.changeState(method, url, as)
       this.scrollToHash(as)
+      this.events.emit('hashChangeComplete', as)
       return true
     }
 

--- a/readme.md
+++ b/readme.md
@@ -553,6 +553,8 @@ Here's a list of supported events:
 - `onRouteChangeComplete(url)` - Fires when a route changed completely
 - `onRouteChangeError(err, url)` - Fires when there's an error when changing routes
 - `onBeforeHistoryChange(url)` - Fires just before changing the browser's history
+- `onHashChangeStart(url)` - Fires when the hash will change but not the page
+- `onHashChangeComplete(url)` - Fires when the hash has changed but not the page
 
 > Here `url` is the URL shown in the browser. If you call `Router.push(url, as)` (or similar), then the value of `url` will be `as`.
 


### PR DESCRIPTION
This PR adds events for when there is a hash-only change in the URL. This is needed because `window.addEventListener('hashchange', ...)` does not work with next.js because it is using pushState.