### PR TITLE
Ensuring that only components are processed by the hot-self-accept-lo…

### DIFF
--- a/server/build/loaders/hot-self-accept-loader.js
+++ b/server/build/loaders/hot-self-accept-loader.js
@@ -9,9 +9,11 @@ module.exports = function (content, sourceMap) {
 
   // Webpack has a built in system to prevent default from colliding, giving it a random letter per export.
   // We can safely check if Component is undefined since all other pages imported into the entrypoint don't have __webpack_exports__.default
+  // We must also check that the file is actually a Component (function). Any other files pulled into this will likely error when trying to add __route
   this.callback(null, `${content}
     (function (Component, route) {
-      if(!Component) return
+      if (!Component) return
+      if (Object.isFrozen(Component)) return
       if (!module.hot) return
       module.hot.accept()
       Component.__route = route


### PR DESCRIPTION
The hot-self-accept-loader only check to see that _something_ was passed into it (for the `Component`)

This PR checks to see that the `Component` is not frozen, to avoid trying to add `__route` to a read-only object.

`Component` will frozen in the following example:

```
/pages
  -> apps/
    -> Admin
      -> __pages.js 
      -> index.js
      -> create_user.js
```

```js
// __pages.js
export Index from './index';
export CreateUser from './create_user'
```

`Cannot set property __route of #<Object> which has only a getter`
☝️ This is thrown because `Componet` is `__pages.js` which is `readonly` since it is only exporting other files.

I understand that this might be considered an anti-pattern, but I think it's best for next to at least not completely fail to render when this is encountered.