### PR TITLE
Ensure both variables are objects before checking their properties

### DIFF
--- a/lib/shallow-equals.js
+++ b/lib/shallow-equals.js
@@ -1,4 +1,11 @@
 export default function shallowEquals (a, b) {
+  const aTypeof = typeof a
+  const bTypeof = typeof b
+
+  if (aTypeof === 'undefined' && bTypeof === 'undefined') return true
+
+  if (aTypeof !== Object || bTypeof !== Object) return false
+
   for (const i in a) {
     if (b[i] !== a[i]) return false
   }


### PR DESCRIPTION
Fixes #2943

Considers the arguments equal if they're both undefined and not equal if either of them is not an Object.