### PR TITLE
Add babel-jest dependency to with-jest example app

### DIFF
--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -7,6 +7,7 @@
     "react-dom": "16.2.0"
   },
   "devDependencies": {
+    "babel-jest": "^22.4.3",
     "enzyme": "3.2.0",
     "enzyme-adapter-react-16": "1.1.1",
     "jest": "22.0.1",


### PR DESCRIPTION
Fixes the error reported [here](https://github.com/zeit/next.js/issues/4227#issuecomment-386000285) in #4227.

The `with-jest` example app does not work out of the box. When running `yarn test` this is the regular output:

```
$ yarn test
yarn run v1.5.1
warning package.json: No license field
$ NODE_ENV=test jest
 FAIL  __tests__/index.test.js
  ● Test suite failed to run

    Plugin 0 specified in "/Users/ernesto/code/with-jest-app/node_modules/next/babel.js" provided an invalid property of "default" (While processing preset: "/Users/ernesto/code/with-jest-app/node_mod
ules/next/babel.js")

      at Plugin.init (node_modules/babel-core/lib/transformation/plugin.js:131:13)
          at Array.map (<anonymous>)
          at Array.map (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        2.994s
Ran all test suites.
error An unexpected error occurred: "Command failed.
Exit code: 1
Command: sh
Arguments: -c NODE_ENV=test jest
Directory: /Users/ernesto/code/with-jest-app
Output:
".
```

After this fix the tests run flawlessly:

```
$ yarn test
yarn run v1.5.1
warning package.json: No license field
$ NODE_ENV=test jest
 PASS  __tests__/index.test.js
  With Enzyme
    ✓ App shows "Hello world!" (37ms)
  With Snapshot Testing
    ✓ App shows "Hello world!" (48ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   1 passed, 1 total
Time:        3.824s
Ran all test suites.
✨  Done in 4.91s.
```
