### PR TITLE
Catch errors from update-check

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -114,13 +114,17 @@ export default class Server {
 
   async prepare () {
     if (this.dev && process.stdout.isTTY) {
-      const checkForUpdate = require('update-check')
-      const update = await checkForUpdate(pkg, {
-        distTag: pkg.version.includes('canary') ? 'canary' : 'latest'
-      })
-      if (update) {
-        // bgRed from chalk
-        console.log(`\u001B[41mUPDATE AVAILABLE\u001B[49m The latest version of \`next\` is ${update.latest}`)
+      try {
+        const checkForUpdate = require('update-check')
+        const update = await checkForUpdate(pkg, {
+          distTag: pkg.version.includes('canary') ? 'canary' : 'latest'
+        })
+        if (update) {
+          // bgRed from chalk
+          console.log(`\u001B[41mUPDATE AVAILABLE\u001B[49m The latest version of \`next\` is ${update.latest}`)
+        }
+      } catch (err) {
+        console.error('Error checking updates', err)
       }
     }
 


### PR DESCRIPTION
Makes sure Next.js can be used while being offline.