### PR TITLE
Wrap app component with enhancer when rendering

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -82,11 +82,7 @@ async function doRender (req, res, pathname, query, {
   if (isResSent(res)) return
 
   const renderPage = (enhancer = Page => Page) => {
-    const app = createElement(enhancer(App), {
-      Component: enhancer(Component),
-      router,
-      ...props
-    })
+    const app = createElement(enhancer(App), { Component, router, ...props })
 
     const render = staticMarkup ? renderToStaticMarkup : renderToString
 

--- a/server/render.js
+++ b/server/render.js
@@ -82,7 +82,7 @@ async function doRender (req, res, pathname, query, {
   if (isResSent(res)) return
 
   const renderPage = (enhancer = Page => Page) => {
-    const app = createElement(App, {
+    const app = createElement(enhancer(App), {
       Component: enhancer(Component),
       router,
       ...props


### PR DESCRIPTION
Fixes flickering problem found in #4249 (ref: https://github.com/mui-org/material-ui/issues/11209) when trying to use `_app.js` to inject styles instead of wrapping each page separately.

Currently `App` is not wrapped with the `enhancer` function from custom `_document.js` when being rendered on the server. This causes HOC's and custom `App` components that rely on getting state from the root document, such as css-in-js styling solutions, to function incorrectly. The custom `App` component needs the same shared state from `enhancer` function as other components for styling to work. I can't come up with any other sane way to share the state.
