### PR TITLE
fix(with-pkg): update pkg config for next.js

### DIFF
--- a/examples/with-pkg/README.md
+++ b/examples/with-pkg/README.md
@@ -25,10 +25,14 @@ Install it and run:
 
 ```bash
 npm install
-npm run dev
-# or
-yarn
-yarn dev
+yarn run build
+yarn run dist
+```
+
+Run the binary file:
+
+```bash
+PORT=4000 ./dist/with-pkg-macos
 ```
 
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
@@ -39,6 +43,6 @@ now
 
 ## The idea behind the example
 
-This example demostrate how you can use [pkg](https://github.com/zeit/pkg) to create a binary version of a Next.js application.
+This example demonstrate how you can use [pkg](https://github.com/zeit/pkg) to create a binary version of a Next.js application.
 
 To do it we need to create at least a super simple custom server that allow us to run `node server.js` instead of `next` or `next start`. We also need to create a `index.js` that works as the entry point for **pkg**, in that file we force to set NODE_ENV as production.

--- a/examples/with-pkg/README.md
+++ b/examples/with-pkg/README.md
@@ -21,7 +21,7 @@ curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 
 cd with-pkg
 ```
 
-Install it and run:
+Install it and run pkg:
 
 ```bash
 npm install
@@ -29,7 +29,7 @@ yarn run build
 yarn run dist
 ```
 
-Run the binary file:
+Execute the binary file:
 
 ```bash
 PORT=4000 ./dist/with-pkg-macos

--- a/examples/with-pkg/package.json
+++ b/examples/with-pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "with-pkg",
   "version": "1.0.0",
-  "main": "index.js",
+  "bin": "index.js",
   "author": "Sergio Daniel Xalambrí <sergiodxa@gmail.com>",
   "license": "MIT",
   "scripts": {
@@ -10,7 +10,7 @@
     "prestart": "npm run build",
     "start": "NODE_ENV=production node server.js",
     "predist": "npm run build",
-    "dist": "pkg index.js --out-dir dist"
+    "dist": "pkg . --out-dir dist"
   },
   "dependencies": {
     "next": "latest",
@@ -22,8 +22,7 @@
   },
   "pkg": {
     "assets": [
-      ".next",
-      "pages"
+      ".next/**/*"
     ],
     "scripts": [
       ".next/dist/**/*.js"

--- a/examples/with-pkg/server.js
+++ b/examples/with-pkg/server.js
@@ -4,7 +4,7 @@ const next = require('next')
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'
-const app = next({ dev })
+const app = next({ dev, dir: __dirname })
 const handle = app.getRequestHandler()
 
 app.prepare()


### PR DESCRIPTION
This PR fixed the runtime error which mentioned in https://github.com/zeit/next.js/pull/2751#issuecomment-326712975 by @winneon:
```bash
> Could not find a valid build in the '.next' directory! Try building your app with 'next build' before starting the server.
```

cc @sergiodxa 