### PR TITLE
[with-react-i18next] Fix flickering on page change via <Link />

### DIFF
--- a/examples/with-react-i18next/lib/withI18next.js
+++ b/examples/with-react-i18next/lib/withI18next.js
@@ -11,7 +11,7 @@ export const withI18next = (namespaces = ['common']) => ComposedComponent => {
       ? await ComposedComponent.getInitialProps(ctx)
       : {}
 
-    const i18nInitialProps = ctx.req && !process.browser 
+    const i18nInitialProps = ctx.req 
       ? getInitialProps(ctx.req, namespaces)
       : await loadNamespaces({
           components: [{ props: { namespaces } }],

--- a/examples/with-react-i18next/lib/withI18next.js
+++ b/examples/with-react-i18next/lib/withI18next.js
@@ -1,4 +1,4 @@
-import { translate } from 'react-i18next'
+import { translate, loadNamespaces } from 'react-i18next'
 import { getInitialProps, I18n } from '../i18n'
 
 export const withI18next = (namespaces = ['common']) => ComposedComponent => {
@@ -11,8 +11,12 @@ export const withI18next = (namespaces = ['common']) => ComposedComponent => {
       ? await ComposedComponent.getInitialProps(ctx)
       : {}
 
-    const i18nInitialProps =
-      ctx.req && !process.browser ? getInitialProps(ctx.req, namespaces) : {}
+    const i18nInitialProps = ctx.req && !process.browser 
+      ? getInitialProps(ctx.req, namespaces)
+      : await loadNamespaces({
+          components: [{ props: { namespaces } }],
+          i18n: I18n,
+        });
 
     return {
       ...composedInitialProps,


### PR DESCRIPTION
This PR fixes an issue when navigating over pages via link causes screen flickering while `i18next` loads locales. Especially it is very noticable when using `nextjs: 6.0.0` with layout in custom `_app.js`

The issue was caused by waiting in browser
https://github.com/zeit/next.js/blob/8588e8d8126f7dd330614baa9f962e1db7e16130/examples/with-react-i18next/lib/withI18next.js#L5

the empty object in browser
https://github.com/zeit/next.js/blob/8588e8d8126f7dd330614baa9f962e1db7e16130/examples/with-react-i18next/lib/withI18next.js#L15

and this line
https://github.com/i18next/react-i18next/blob/c2fd0024a458cd54d0eff5a305f759ddffca2133/src/I18n.js#L113

![2018-05-09_13-32-27](https://user-images.githubusercontent.com/5203820/39811056-2ef2eec2-5390-11e8-927c-0ed42cdc970a.gif)

`getInitialProps` was resolved immediately, because of empty object, so `nextjs` allowed route change. Then renders `react-i18next` with waiting set to `true` which returns `null`.

Initially i was thinking that it was `react-i18next` issue. Not providing any ways to pass a `<Loader />` while waiting. But then I have read the documentation of `react-i18next` I came to the conclusion that you can control the waiting process and don't allow `nextjs` to change the route.

`react-i18next` [provides](https://react.i18next.com/misc/serverside-rendering#loadnamespaces-helper) method that loads namespaces and returns promise for this usecases. Now client awaits while all namespaces for page are loaded. 

![2018-05-09_13-36-54](https://user-images.githubusercontent.com/5203820/39811613-f70a2b54-5391-11e8-87cd-85b4d8764a02.gif)

In my opinion, in this PR the `components` arg in `loadNamespaces` is made a bit like a hack, because they assumes that you will be using this with `react-router` match.

```jsx
import { I18nextProvider, loadNamespaces } from 'react-i18next';
import { match } from 'react-router';

match({...matchArguments}, (error, redirectLocation, renderProps) => {
   loadNamespaces({ ...renderProps, i18n: i18nInstance })
   .then(()=>{
      // All i18n namespaces required to render this route are loaded   
   })
});
```

But it works as expected 😃 