### PR TITLE
Support external `_document` and `_app` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage
 # test output
 test/**/out
 .DS_Store
+
+# Editor artifacts
+.idea

--- a/readme.md
+++ b/readme.md
@@ -964,7 +964,7 @@ Next.js uses the `App` component to initialize pages. You can override it and co
 - Custom error handling using `componentDidCatch`
 - Inject additional data into pages (for example by processing GraphQL queries)
 
-To override, create the `./pages/_app.js` file and override the App class as shown below:
+To override, create a component extending `App` and export it from a `./pages/_app.js` file or provide an `appComponentPath` config setting.
 
 ```js
 import App, {Container} from 'next/app'
@@ -1002,7 +1002,7 @@ export default class MyApp extends App {
 - Is used to change the initial server side rendered document markup
 - Commonly used to implement server side rendering for css-in-js libraries like [styled-components](./examples/with-styled-components), [glamorous](./examples/with-glamorous) or [emotion](with-emotion). [styled-jsx](https://github.com/zeit/styled-jsx) is included with Next.js by default.
 
-Pages in `Next.js` skip the definition of the surrounding document's markup. For example, you never include `<html>`, `<body>`, etc. To override that default behavior, you must create a file at `./pages/_document.js`, where you can extend the `Document` class:
+Pages in `Next.js` skip the definition of the surrounding document's markup. For example, you never include `<html>`, `<body>`, etc. To override that default behavior, you must create a file exporting a component that extends the `Document` class. You can put that file in `./pages/_document.js` or provide an explicit file path via the `documentPath` config setting.
 
 ```jsx
 // _document is only rendered on the server side and not on the client side

--- a/server/index.js
+++ b/server/index.js
@@ -61,7 +61,9 @@ export default class Server {
       hotReloader: this.hotReloader,
       buildId: this.buildId,
       availableChunks: dev ? {} : getAvailableChunks(this.dir, this.dist),
-      generateEtags
+      generateEtags,
+      documentPath: this.nextConfig.documentPath,
+      appComponentPath: this.nextConfig.appComponentPath
     }
 
     // Only the `publicRuntimeConfig` key is exposed to the client side

--- a/server/render.js
+++ b/server/render.js
@@ -46,7 +46,9 @@ async function doRender (req, res, pathname, query, {
   dir = process.cwd(),
   dev = false,
   staticMarkup = false,
-  nextExport = false
+  nextExport = false,
+  documentPath: documentPathFromConfig,
+  appComponentPath: appPathFromConfig
 } = {}) {
   page = page || pathname
 
@@ -56,8 +58,10 @@ async function doRender (req, res, pathname, query, {
     await ensurePage(page, { dir, hotReloader })
   }
 
-  const documentPath = join(dir, dist, 'dist', 'bundles', 'pages', '_document')
-  const appPath = join(dir, dist, 'dist', 'bundles', 'pages', '_app')
+  const documentPath = documentPathFromConfig ||
+    join(dir, dist, 'dist', 'bundles', 'pages', '_document')
+  const appPath = appPathFromConfig ||
+    join(dir, dist, 'dist', 'bundles', 'pages', '_app')
   const buildManifest = require(join(dir, dist, BUILD_MANIFEST))
   let [Component, Document, App] = await Promise.all([
     requirePage(page, {dir, dist}),

--- a/test/integration/custom-app-document/next.config.js
+++ b/test/integration/custom-app-document/next.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  appComponentPath: require.resolve('./test/external-app'),
+  documentPath: require.resolve('./test/external-document')
+}

--- a/test/integration/custom-app-document/pages/about.js
+++ b/test/integration/custom-app-document/pages/about.js
@@ -1,0 +1,6 @@
+import Link from 'next/link'
+
+export default () => <div>
+  <div className='page-about'>about</div>
+  <Link href='/'><a id='home-link'>home</a></Link>
+</div>

--- a/test/integration/custom-app-document/pages/index.js
+++ b/test/integration/custom-app-document/pages/index.js
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+export default () => <div>
+  <div className='page-index'>index</div>
+  <Link href='/about'><a id='about-link'>about</a></Link>
+</div>

--- a/test/integration/custom-app-document/test/client.js
+++ b/test/integration/custom-app-document/test/client.js
@@ -1,0 +1,84 @@
+/* global describe, it, expect */
+
+import webdriver from 'next-webdriver'
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { check } from 'next-test-utils'
+
+export default (context, render) => {
+  describe('Client side', () => {
+    it('should detect the changes to pages/_app.js and display it', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      const text = await browser
+        .elementByCss('#hello-hmr').text()
+      expect(text).toBe('Hello HMR')
+
+      const appPath = join(__dirname, '../', 'pages', '_app.js')
+
+      const originalContent = readFileSync(appPath, 'utf8')
+      const editedContent = originalContent.replace('Hello HMR', 'Hi HMR')
+
+      // change the content
+      writeFileSync(appPath, editedContent, 'utf8')
+
+      await check(
+        () => browser.elementByCss('body').text(),
+        /Hi HMR/
+      )
+
+      // add the original content
+      writeFileSync(appPath, originalContent, 'utf8')
+
+      await check(
+        () => browser.elementByCss('body').text(),
+        /Hello HMR/
+      )
+
+      browser.close()
+    })
+
+    it('should detect the changes to pages/_document.js and display it', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      const text = await browser
+        .elementByCss('#hello-hmr').text()
+      expect(text).toBe('Hello HMR')
+
+      const appPath = join(__dirname, '../', 'pages', '_document.js')
+
+      const originalContent = readFileSync(appPath, 'utf8')
+      const editedContent = originalContent.replace('Hello Document HMR', 'Hi Document HMR')
+
+      // change the content
+      writeFileSync(appPath, editedContent, 'utf8')
+
+      await check(
+        () => browser.elementByCss('body').text(),
+        /Hi Document HMR/
+      )
+
+      // add the original content
+      writeFileSync(appPath, originalContent, 'utf8')
+
+      await check(
+        () => browser.elementByCss('body').text(),
+        /Hello Document HMR/
+      )
+
+      browser.close()
+    })
+
+    it('should keep state between page navigations', async () => {
+      const browser = await webdriver(context.appPort, '/')
+
+      const randomNumber = await browser.elementByCss('#random-number').text()
+
+      const switchedRandomNumer = await browser
+        .elementByCss('#about-link').click()
+        .waitForElementByCss('.page-about')
+        .elementByCss('#random-number').text()
+
+      expect(switchedRandomNumer).toBe(randomNumber)
+      browser.close()
+    })
+  })
+}

--- a/test/integration/custom-app-document/test/external-app.js
+++ b/test/integration/custom-app-document/test/external-app.js
@@ -1,0 +1,44 @@
+import App, {Container} from '../../../../app'
+import React from 'react'
+
+class Layout extends React.Component {
+  state = {
+    random: false
+  }
+
+  componentDidMount () {
+    this.setState({random: Math.random()})
+  }
+
+  render () {
+    const {children} = this.props
+    const {random} = this.state
+    return <div>
+      <p id='hello-app'>Hello App</p>
+      <p id='hello-hmr'>Hello HMR</p>
+      <p id='random-number'>{random}</p>
+      {children}
+    </div>
+  }
+}
+
+export default class MyApp extends App {
+  static async getInitialProps ({ Component, router, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return {pageProps}
+  }
+
+  render () {
+    const {Component, pageProps} = this.props
+    return <Container>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </Container>
+  }
+}

--- a/test/integration/custom-app-document/test/external-document.js
+++ b/test/integration/custom-app-document/test/external-document.js
@@ -1,0 +1,24 @@
+import Document, { Head, Main, NextScript } from '../../../../document'
+
+export default class MyDocument extends Document {
+  static async getInitialProps (ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps, customProperty: 'Hello Document' }
+  }
+
+  render () {
+    return (
+      <html>
+        <Head>
+          <style>{`body { margin: 0 } /* custom! */`}</style>
+        </Head>
+        <body className='custom_class'>
+          <p id='custom-property'>{this.props.customProperty}</p>
+          <p id='document-hmr'>Hello Document HMR</p>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/test/integration/custom-app-document/test/index.test.js
+++ b/test/integration/custom-app-document/test/index.test.js
@@ -1,0 +1,31 @@
+/* global jasmine, describe, beforeAll, afterAll */
+
+import { join } from 'path'
+import {
+  renderViaHTTP,
+  fetchViaHTTP,
+  findPort,
+  launchApp,
+  killApp
+} from 'next-test-utils'
+
+// test suits
+import rendering from './rendering'
+
+const context = {}
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+describe('External document and app modules', () => {
+  beforeAll(async () => {
+    context.appPort = await findPort()
+    context.server = await launchApp(join(__dirname, '../'), context.appPort, true)
+
+    // pre-build all pages at the start
+    await Promise.all([
+      renderViaHTTP(context.appPort, '/')
+    ])
+  })
+  afterAll(() => killApp(context.server))
+
+  rendering(context, 'Rendering via HTTP', (p, q) => renderViaHTTP(context.appPort, p, q), (p, q) => fetchViaHTTP(context.appPort, p, q))
+})

--- a/test/integration/custom-app-document/test/rendering.js
+++ b/test/integration/custom-app-document/test/rendering.js
@@ -1,0 +1,36 @@
+/* global describe, test, expect */
+
+import cheerio from 'cheerio'
+
+export default function ({ app }, suiteName, render, fetch) {
+  async function get$ (path, query) {
+    const html = await render(path, query)
+    return cheerio.load(html)
+  }
+
+  describe(suiteName, () => {
+    describe('_document', () => {
+      test('It has a custom body class', async () => {
+        const $ = await get$('/')
+        expect($('body').hasClass('custom_class'))
+      })
+
+      test('It injects custom head tags', async () => {
+        const $ = await get$('/')
+        expect($('head').text().includes('body { margin: 0 }'))
+      })
+
+      test('It passes props from Document.getInitialProps to Document', async () => {
+        const $ = await get$('/')
+        expect($('#custom-property').text() === 'Hello Document')
+      })
+    })
+
+    describe('_app', () => {
+      test('It shows a custom tag', async () => {
+        const $ = await get$('/')
+        expect($('hello-app').text() === 'Hello App')
+      })
+    })
+  })
+}


### PR DESCRIPTION
If multiple applications need to use share the same `Document` or `App` components, currently you have to create local `_app.js` and `_document.js` files that import and re-export the shared modules. Having the ability to set file paths via configuration allows you to avoid this boilerplate.
