### PR TITLE
Don't comment after locking with the bot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -3,7 +3,4 @@
 # Number of days of inactivity before a closed issue or pull request is locked
 daysUntilLock: 181
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically locked because it has not had recent
-  activity. Please open a new issue for related bugs and link to relevant
-  comments in this thread.
+lockComment: false


### PR DESCRIPTION
I noticed that lock bot is enabled on this repo now. If you don't have the lock bot leave a comment, people won't get lots and lots of notifications and you'll still be able to lock these old issues.