### PR TITLE
Set `this.mounted` to false when dynamic component is unmounted

### DIFF
--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -137,6 +137,10 @@ export default function dynamicComponent (p, o) {
       this.loadBundle(nextProps)
     }
 
+    componentWillUnmount () {
+      this.mounted = false
+    }
+
     render () {
       const { AsyncComponent, asyncElement } = this.state
       const { LoadingComponent } = this


### PR DESCRIPTION
Otherwise you may get a React warning about calling setState() on an unmounted component.