### PR TITLE
Ensure comparison of routes is tolerant of an initially undefined query

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -303,7 +303,7 @@ export default class Router {
   }
 
   urlIsNew (pathname, query) {
-    return this.pathname !== pathname || !shallowEquals(query, this.query)
+    return this.pathname !== pathname || !shallowEquals(query || {}, this.query || {})
   }
 
   isShallowRoutingPossible (route) {

--- a/test/unit/router.test.js
+++ b/test/unit/router.test.js
@@ -63,4 +63,14 @@ describe('Router', () => {
       expect(Object.keys(pageLoader.loaded)).toEqual(routes)
     })
   })
+
+  describe('.urlIsNew()', () => {
+    it('should handle undefined starting query parameters', () => {
+      const pageLoader = new PageLoader()
+      const router = new Router('/', undefined, '/', { pageLoader })
+      // This function will call shallowEqual with the query below and the undefined value set in
+      // the constructor.
+      router.urlIsNew('/', { queryVariable: '1' })
+    })
+  })
 })


### PR DESCRIPTION
In the situation where query parameters are used but are not a part of the original URL, Next.js will throw an error. This happens when `this.query` is compared against the new query object using the `shallow-compare` function which expects Objects as its input.

See below:
```
    // Current URL is www.my-company.com/user

    const router = this.props.router;
    const href = `${router.pathname}?searchQuery=${value}`;
    router.replace(href, href, { shallow: true });
```

I considered altering shallow compare but decided it was better to put this in the router for two reasons.

1. Since in JS, everything is an object, ensuring the type was valid in `shallow-compare.js` would be a lot of code for a little benefit. That is unless you wanted to pull in lodash.

2. `shallowCompare` like anything can only be so defensive. The onus is on the caller to pass in the right params. Since the function is really `shallowObjectCompare` and we're passing undefined, I felt like the correct thing to do was to pass in a valid object.