### PR TITLE
Fix example with-custom-babel-config: update to Babel 7

### DIFF
--- a/examples/with-custom-babel-config/.babelrc
+++ b/examples/with-custom-babel-config/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
     "next/babel",
-    "stage-0"
+    ["@babel/preset-stage-0", { "decoratorsLegacy": true }]
   ],
 }

--- a/examples/with-custom-babel-config/package.json
+++ b/examples/with-custom-babel-config/package.json
@@ -16,6 +16,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "babel-preset-stage-0": "^6.16.0"
+    "@babel/preset-stage-0": "^7.0.0-beta.46"
   }
 }


### PR DESCRIPTION
The option `"decoratorsLegacy": true` seems mandatory, fails without it:

> The new decorators proposal is not supported yet. You must pass the `"decoratorsLegacy": true` option to @babel/preset-stage-0