### PR TITLE
Update babel-plugin-module-resolver version in with-global-stylesheet

### DIFF
--- a/examples/with-global-stylesheet/package.json
+++ b/examples/with-global-stylesheet/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "autoprefixer": "7.1.5",
-    "babel-plugin-module-resolver": "^2.7.1",
+    "babel-plugin-module-resolver": "^3.1.1",
     "babel-plugin-wrap-in-js": "^1.1.0",
     "glob": "^7.1.2",
     "next": "latest",


### PR DESCRIPTION
## Summary

I found build error, so I've updated babel-plugin-module-resolver.

## Logs

```
% yarn build
yarn run v1.6.0
$ next build
> Using external babel configuration
> Location: "/path/to/with-global-stylesheet/.babelrc"
> Failed to build
{ Error: (client) ./pages/index.js
Module build failed: TypeError: Cannot read property '1' of undefined
    at Plugin.manipulateOptions (/path/to/with-global-stylesheet/node_modules/babel-plugin-module-resolver/lib/index.js:88:9)
    at normalizeOptions (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/normalize-opts.js:80:17)
    at runSync (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/index.js:34:84)
    at runAsync (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/index.js:25:14)
    at /path/to/with-global-stylesheet/node_modules/@babel/core/lib/transform.js:32:34
    at process._tickCallback (internal/process/next_tick.js:176:11)
 @ multi ./pages/index.js
    at /path/to/with-global-stylesheet/node_modules/next/dist/server/build/index.js:141:31
    at runWithDependencies (/path/to/with-global-stylesheet/node_modules/webpack/lib/MultiCompiler.js:154:4)
    at /path/to/with-global-stylesheet/node_modules/async/dist/async.js:1126:9
    at /path/to/with-global-stylesheet/node_modules/async/dist/async.js:473:16
    at iteratorCallback (/path/to/with-global-stylesheet/node_modules/async/dist/async.js:1050:13)
    at /path/to/with-global-stylesheet/node_modules/async/dist/async.js:958:16
    at /path/to/with-global-stylesheet/node_modules/async/dist/async.js:1123:13
    at runCompilers (/path/to/with-global-stylesheet/node_modules/webpack/lib/MultiCompiler.js:96:47)
    at fn (/path/to/with-global-stylesheet/node_modules/webpack/lib/MultiCompiler.js:101:6)
    at compiler.run (/path/to/with-global-stylesheet/node_modules/webpack/lib/MultiCompiler.js:150:5)
    at emitRecords.err (/path/to/with-global-stylesheet/node_modules/webpack/lib/Compiler.js:265:13)
    at Compiler.emitRecords (/path/to/with-global-stylesheet/node_modules/webpack/lib/Compiler.js:371:38)
    at emitAssets.err (/path/to/with-global-stylesheet/node_modules/webpack/lib/Compiler.js:258:10)
    at applyPluginsAsyncSeries1.err (/path/to/with-global-stylesheet/node_modules/webpack/lib/Compiler.js:364:12)
    at next (/path/to/with-global-stylesheet/node_modules/tapable/lib/Tapable.js:218:11)
    at Compiler.compiler.plugin (/path/to/with-global-stylesheet/node_modules/webpack/lib/performance/SizeLimitsPlugin.js:99:4)
  errors:
   [ '(client) ./pages/index.js\nModule build failed: TypeError: Cannot read property \'1\' of undefined\n    at Plugin.manipulateOptions (/path/to/with-global-stylesheet/node_modules/babel-plugin-module-resolver/lib/index.js:88:9)\n    at normalizeOptions (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/normalize-opts.js:80:17)\n    at runSync (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/index.js:34:84)\n    at runAsync (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/index.js:25:14)\n    at /path/to/with-global-stylesheet/node_modules/@babel/core/lib/transform.js:32:34\n    at process._tickCallback (internal/process/next_tick.js:176:11)\n @ multi ./pages/index.js',
     '(server) ./pages/index.js\nModule build failed: TypeError: Cannot read property \'1\' of undefined\n    at Plugin.manipulateOptions (/path/to/with-global-stylesheet/node_modules/babel-plugin-module-resolver/lib/index.js:88:9)\n    at normalizeOptions (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/normalize-opts.js:80:17)\n    at runSync (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/index.js:34:84)\n    at runAsync (/path/to/with-global-stylesheet/node_modules/@babel/core/lib/transformation/index.js:25:14)\n    at /path/to/with-global-stylesheet/node_modules/@babel/core/lib/transform.js:32:34\n    at process._tickCallback (internal/process/next_tick.js:176:11)\n @ multi ./pages/index.js' ],
  warnings: [] }
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```