### PR TITLE
Create truly static HTML pages with no javascript at all

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -85,16 +85,20 @@ export class Head extends Component {
 
   render () {
     const { head, styles, __NEXT_DATA__ } = this.context._documentProps
-    const { page, pathname, buildId, assetPrefix } = __NEXT_DATA__
+    const { page, pathname, buildId, assetPrefix, strictHTML } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
     return <head {...this.props}>
       {(head || []).map((h, i) => React.cloneElement(h, { key: h.key || i }))}
-      {page !== '/_error' && <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} as='script' />}
-      <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_app.js`} as='script' />
-      <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_error.js`} as='script' />
-      {this.getPreloadDynamicChunks()}
-      {this.getPreloadMainLinks()}
+
+      { !strictHTML ? ([
+        (page !== '/_error' && <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page${pagePathname}`} as='script' />),
+        <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_app.js`} as='script' />,
+        <link rel='preload' href={`${assetPrefix}/_next/${buildId}/page/_error.js`} as='script' />,
+        this.getPreloadDynamicChunks(),
+        this.getPreloadMainLinks()
+      ]) : null }
+
       {styles || null}
       {this.props.children}
     </head>


### PR DESCRIPTION
This allows you to create truly static HTML pages with no javascript included at all.

**Usage:** 
1. create a custom `_document.js` file setting `__NEXT_DATA__.strictHTML = true` and override the default `render()` function.

```
import Document, { Head } from 'next/document'

export default class MyDocument extends Document {
  constructor(props) {
    super(props)
    const { __NEXT_DATA__ } = props
    __NEXT_DATA__.strictHTML = true
  }

  render() {
    const { html } = this.props
    return (
      <html>
        <body>
          <div dangerouslySetInnerHTML={{ __html: html }} />
        </body>
      </html>
    )
  }
}
```

2. create `index.js` with anything you want in it. 

```
export default () => [<h1>Hello</h1>]
```

3. end result of this `index.html`

```
<!DOCTYPE html><html><body><div><h1>Hello</h1></div></body></html>
```


