### PR TITLE
Return empty string instead of null in the Authorization

### DIFF
--- a/examples/with-apollo-auth/lib/initApollo.js
+++ b/examples/with-apollo-auth/lib/initApollo.js
@@ -21,7 +21,7 @@ function create (initialState, { getToken }) {
     return {
       headers: {
         ...headers,
-        authorization: token ? `Bearer ${token}` : null
+        authorization: token ? `Bearer ${token}` : ''
       }
     }
   })


### PR DESCRIPTION
I was unable to make right check of `authorization` in the header on GraphQL side because now it returns `null` as string instead of empty string