### PR TITLE
Fix with-mobx example

### DIFF
--- a/examples/with-mobx/.babelrc
+++ b/examples/with-mobx/.babelrc
@@ -3,6 +3,7 @@
     "next/babel"
   ],
   "plugins": [
-    "transform-decorators-legacy"
+    "transform-decorators-legacy",
+    "transform-class-properties"
   ]
 }

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -15,6 +15,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4"
   }
 }


### PR DESCRIPTION
fixes #4390

## Summary

* Installing only `babel-plugin-transform-decorators-legacy` didn't work
* It also needs to install `babel-plugin-transform-class-properties`

## Screenshot

![capture](https://user-images.githubusercontent.com/15371677/40090439-b02df41c-58ec-11e8-938b-2d1bc15dc59b.gif)
