### PR TITLE
Add dependencies of _app.js to commons

### DIFF
--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -292,7 +292,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
             : null
           )
 
-          if (inAppBundle) {
+          if (inAppBundle && chunks.length > 1) {
             return true
           }
 

--- a/server/build/webpack.js
+++ b/server/build/webpack.js
@@ -283,6 +283,19 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
             return false
           }
 
+          // Check if the module is used in the _app.js bundle
+          // Because _app.js is used on every page we don't want to
+          // duplicate them in other bundles.
+          const chunks = module.getChunks()
+          const inAppBundle = chunks.some(chunk => chunk.entryModule
+            ? chunk.entryModule.name === 'bundles/pages/_app.js'
+            : null
+          )
+
+          if (inAppBundle) {
+            return true
+          }
+
           // commons
           // If there are one or two pages, only move modules to common if they are
           // used in all of the pages. Otherwise, move modules used in at-least


### PR DESCRIPTION
Since `_app.js` is used on every page it makes sense to move it's dependencies to the `commons.js` so that if you require a dependency in `_app.js` and in one of your pages it is not included twice in your bundles. 

This PR modifies the `CommonsChunkPlugin` to move every module that is used in `_app.js` and at least in one other bundle.