### PR TITLE
Fix and improve example : with-componentdidcatch

### DIFF
--- a/examples/with-componentdidcatch/package.json
+++ b/examples/with-componentdidcatch/package.json
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "6.0.0-canary.6",
+    "next": "6.0.3",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/examples/with-componentdidcatch/package.json
+++ b/examples/with-componentdidcatch/package.json
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "6.0.3",
+    "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/examples/with-componentdidcatch/pages/_app.js
+++ b/examples/with-componentdidcatch/pages/_app.js
@@ -1,48 +1,9 @@
-import App, { Container } from 'next/app'
-import React from 'react'
+import App from 'next/app'
 
 export default class MyApp extends App {
-  static async getInitialProps ({ Component, router, ctx }) {
-    let pageProps = {}
-
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx)
-    }
-
-    return { pageProps }
-  }
-
-  state = { error: null, errorInfo: null }
-
   componentDidCatch (error, errorInfo) {
-    this.setState({ error, errorInfo })
-
-    // If you wish to render error with the usual error page, you can use :
-    // super.componentDidCatch(error, errorInfo)
-  }
-
-  render () {
-    const { Component, pageProps } = this.props
-
-    if (this.state.errorInfo) {
-      return (
-        <Container>
-          <div>
-            <h2>Something went wrong.</h2>
-            <details style={{ whiteSpace: 'pre-wrap' }}>
-              {this.state.error && this.state.error.toString()}
-              <br />
-              {this.state.errorInfo.componentStack}
-            </details>
-          </div>
-        </Container>
-      )
-    }
-
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    console.log('CUSTOM ERROR HANDLING', error)
+    // This is needed to render errors correctly in development / production
+    super.componentDidCatch(error, errorInfo)
   }
 }

--- a/examples/with-componentdidcatch/pages/_app.js
+++ b/examples/with-componentdidcatch/pages/_app.js
@@ -1,9 +1,48 @@
-import App from 'next/app'
+import App, { Container } from 'next/app'
+import React from 'react'
 
 export default class MyApp extends App {
+  static async getInitialProps ({ Component, router, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps }
+  }
+
+  state = { error: null, errorInfo: null }
+
   componentDidCatch (error, errorInfo) {
-    console.log('CUSTOM ERROR HANDLING', error)
-    // This is needed to render errors correctly in development / production
-    super.componentDidCatch(error, errorInfo)
+    this.setState({ error, errorInfo })
+
+    // If you wish to render error with the usual error page, you can use :
+    // super.componentDidCatch(error, errorInfo)
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+
+    if (this.state.errorInfo) {
+      return (
+        <Container>
+          <div>
+            <h2>Something went wrong.</h2>
+            <details style={{ whiteSpace: 'pre-wrap' }}>
+              {this.state.error && this.state.error.toString()}
+              <br />
+              {this.state.errorInfo.componentStack}
+            </details>
+          </div>
+        </Container>
+      )
+    }
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
   }
 }

--- a/examples/with-componentdidcatch/pages/index.js
+++ b/examples/with-componentdidcatch/pages/index.js
@@ -1,7 +1,30 @@
-export default () => {
-  // componentDidCatch only catches client-side errors
-  if (typeof window !== 'undefined') {
-    throw new Error('Test')
+import React, { Component } from 'react'
+
+class BuggyCounter extends Component {
+  state = {
+    counter: 0
   }
-  return <div>server rendered</div>
+
+  handleClick = () => {
+    this.setState(({ counter }) => ({
+      counter: counter + 1
+    }))
+  }
+
+  render () {
+    if (this.state.counter === 5) {
+      // Simulate a JS error
+      throw new Error('I crashed!')
+    }
+
+    return <h1 onClick={this.handleClick}>{this.state.counter}</h1>
+  }
 }
+
+export default () => (
+  <div>
+    <p>Click on the number to increase the counter.</p>
+    <p>The counter is programmed to throw an error when it reaches 5.</p>
+    <BuggyCounter />
+  </div>
+)

--- a/examples/with-componentdidcatch/pages/index.js
+++ b/examples/with-componentdidcatch/pages/index.js
@@ -1,4 +1,7 @@
 export default () => {
-  // Render time error
-  throw new Error('Test')
+  // componentDidCatch only catches client-side errors
+  if (typeof window !== 'undefined') {
+    throw new Error('Test')
+  }
+  return <div>server rendered</div>
 }

--- a/examples/with-componentdidcatch/readme.md
+++ b/examples/with-componentdidcatch/readme.md
@@ -41,4 +41,4 @@ now
 
 ## The idea behind the example
 
-This example shows how to catch errors caught by `componentDidCatch` in React's client side.
+This example shows how to catch errors caught by `componentDidCatch` in React's **client** side.


### PR DESCRIPTION
In this PR, I wrote 2 commits :

- https://github.com/zeit/next.js/commit/b6d2a727b9e9bd60295a9322eeb61cf22e09b051 Fix the example, by throwing an error only on the client-side (thanks @timneutkens for your help on that 😁)

- https://github.com/zeit/next.js/commit/b08863c7a98c8a869293b882008700c9da24e732 Improve the example. I transposed the [error boundaries demo](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) in [react docs](https://reactjs.org/docs/error-boundaries.html#live-demo) to Next.js.