### PR TITLE
fix with-jest-typescript example to next 6 - jest 23

### DIFF
--- a/examples/with-jest-typescript/jest.config.js
+++ b/examples/with-jest-typescript/jest.config.js
@@ -4,7 +4,8 @@ module.exports = {
   setupFiles: ['<rootDir>/jest.setup.js'],
   globals: {
     'ts-jest': {
-      'useBabelrc': true
+      // 'useBabelrc': true,
+      "tsConfigFile": "tsconfig.jest.json"
     }
   },
   testRegex: TEST_REGEX,

--- a/examples/with-jest-typescript/jest.config.js
+++ b/examples/with-jest-typescript/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   globals: {
     'ts-jest': {
       // 'useBabelrc': true,
-      "tsConfigFile": "tsconfig.jest.json"
+      'tsConfigFile': 'tsconfig.jest.json'
     }
   },
   testRegex: TEST_REGEX,

--- a/examples/with-jest-typescript/package.json
+++ b/examples/with-jest-typescript/package.json
@@ -2,13 +2,13 @@
   "name": "with-jest-typescript",
   "version": "1.0.0",
   "scripts": {
-    "test": "NODE_ENV=test jest",
+    "test": "jest",
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
   "dependencies": {
-    "next": "^5.0.0",
+    "next": "^6.0.3",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   },
@@ -20,10 +20,17 @@
     "@zeit/next-typescript": "1.0.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jest": "^22.4.3",
+    "jest": "^23.0.1",
     "react-addons-test-utils": "^15.6.2",
     "react-test-renderer": "^16.2.0",
     "ts-jest": "^22.4.2",
     "typescript": "^2.7.2"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "useBabelrc": true
+      }
+    }
   }
 }

--- a/examples/with-jest-typescript/tsconfig.jest.json
+++ b/examples/with-jest-typescript/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
"useBabelrc: true" ne marche pas dans jest.config.js, mais marche dans package.json (je n'ai pas encore vu pourquoi).
Cet exemple marche en dehors du repository next.js (interférences avec next.js/node_modules/jest-cli).

---
"useBabelrc: true" does not work in jest.config.js, but works in package.json (I have not seen why yet).
This example works outside the repository next.js (interference with next.js / node_modules / jest-cli).