### PR TITLE
Use a more appropriate regexp for removing hash from a filename

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -13,7 +13,7 @@ export function getAvailableChunks (dir, dist) {
 
   chunkFiles.forEach(filename => {
     if (/\.js$/.test(filename)) {
-      const chunkName = filename.replace(/-.*/, '')
+      const chunkName = filename.replace(/-[^-]*/, '')
       chunksMap[chunkName] = filename
     }
   })


### PR DESCRIPTION
Fixes one of the problems described in #4433.

The old regexp was removing everything after a hyphen, so with a chunk name like so:

```
chunks/path-to-a-file-[hash].js
```

the saved chunk name was

```
chunks/path
```

This caused problems, because webpack by default changes `/` to `-` in chunk names generated e.g. by ``import(`foo/${bar}`)``.

After this change the chunk name will be

```
chunks/path-to-a-file
```