### PR TITLE
Prevent an error when the first argument of import is a template

### DIFF
--- a/server/build/babel/plugins/handle-import.js
+++ b/server/build/babel/plugins/handle-import.js
@@ -6,6 +6,7 @@ import { dirname, resolve, sep } from 'path'
 import Crypto from 'crypto'
 
 const TYPE_IMPORT = 'Import'
+const TYPE_TEMPLATE_LITERAL = 'TemplateLiteral'
 
 /*
  Added "typeof require.resolveWeak !== 'function'" check instead of
@@ -63,7 +64,7 @@ export default () => ({
 
   visitor: {
     CallExpression (path, state) {
-      if (path.node.callee.type === TYPE_IMPORT) {
+      if (path.node.callee.type === TYPE_IMPORT && path.node.arguments[0].type !== TYPE_TEMPLATE_LITERAL) {
         const moduleName = path.node.arguments[0].value
         const sourceFilename = state.file.opts.filename
 


### PR DESCRIPTION
Fixes one of the problems described in #4433.

The handle-import plugin can't deal with [webpack's dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports). Before this change an unhelpful error was appearing in the console and the build was broken. The change ignores such imports altogether, resulting in no error.

Handling template literals by Next.js can be added later on, but maybe it would be better done through a webpack plugin instead of a babel one.