### PR TITLE
fixes bug in with-react-intl example

### DIFF
--- a/examples/with-react-intl/components/PageWithIntl.js
+++ b/examples/with-react-intl/components/PageWithIntl.js
@@ -23,7 +23,7 @@ export default (Page) => {
       // Get the `locale` and `messages` from the request object on the server.
       // In the browser, use the same values that the server serialized.
       const {req} = context
-      const {locale, messages} = req || window.__NEXT_DATA__.props
+      const {locale, messages} = req || window.__NEXT_DATA__.props.pageProps
 
       // Always update the current time on page load/transition because the
       // <IntlProvider> will be a new instance even with pushState routing.


### PR DESCRIPTION
 The variables `messages` and `locale` were undefined on CSR, causing this bug I just reported: #4516

Let me know if you need anything else to merge this.

Fixes #4516