### PR TITLE
stop duplicating charset

### DIFF
--- a/examples/with-amp/pages/_document.js
+++ b/examples/with-amp/pages/_document.js
@@ -6,7 +6,6 @@ export default class MyDocument extends Document {
     return (
       <html amp=''>
         <Head>
-          <meta charset='utf-8' />
           <link rel='canonical' href='/' />
           <meta name='viewport' content='width=device-width,minimum-scale=1' />
           <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Roboto' />


### PR DESCRIPTION
**Make amp example valid**

I'm using amp validator chrome plugin which shows that `meta charset=utf-8` is duplicated.
I assume that `Head` component adds `<meta charset="utf-8" class="next-head next-head">`
anyway.
And this line just duplicating it.

<img width="987" alt="screen shot 2018-06-06 at 15 54 45" src="https://user-images.githubusercontent.com/1488195/41036743-198ca00a-69a2-11e8-978c-5a5cb5a994d2.png">
