### PR TITLE
[with-apollo-auth] Remove useless apolloState from App's props

### DIFF
--- a/examples/with-apollo-auth/lib/withApollo.js
+++ b/examples/with-apollo-auth/lib/withApollo.js
@@ -24,7 +24,6 @@ export default App => {
 
     static async getInitialProps(ctx) {
       const { Component, router, ctx: { req, res } } = ctx
-      const apolloState = {}
       const apollo = initApollo({}, {
         getToken: () => parseCookies(req).token
       })
@@ -51,7 +50,6 @@ export default App => {
             {...appProps}
             Component={Component}
             router={router}
-            apolloState={apolloState}
             apolloClient={apollo}
           />
         )
@@ -69,7 +67,7 @@ export default App => {
       }
 
       // Extract query data from the Apollo's store
-      apolloState.data = apollo.cache.extract()
+      const apolloState = { data: apollo.cache.extract() }
 
       return {
         ...appProps,


### PR DESCRIPTION
App component does not need/use apolloState prop, so let's remove it. If I'm wrong please explain me the purpose of this.