### PR TITLE
[with-apollo-auth] Remove useless check from constructor

### DIFF
--- a/examples/with-apollo-auth/lib/withApollo.js
+++ b/examples/with-apollo-auth/lib/withApollo.js
@@ -79,9 +79,7 @@ export default App => {
       super(props)
       // `getDataFromTree` renders the component first, the client is passed off as a property.
       // After that rendering is done using Next's normal rendering pipeline
-      this.apolloClient =
-        props.apolloClient ||
-        initApollo(props.apolloState.data, {
+      this.apolloClient = initApollo(props.apolloState.data, {
           getToken: () => parseCookies().token
         })
     }

--- a/examples/with-apollo-auth/lib/withApollo.js
+++ b/examples/with-apollo-auth/lib/withApollo.js
@@ -80,8 +80,8 @@ export default App => {
       // `getDataFromTree` renders the component first, the client is passed off as a property.
       // After that rendering is done using Next's normal rendering pipeline
       this.apolloClient = initApollo(props.apolloState.data, {
-          getToken: () => parseCookies().token
-        })
+        getToken: () => parseCookies().token
+      })
     }
 
     render() {


### PR DESCRIPTION
We don't pass apolloClient as props, so I removed the check as confusing and always false.

see https://github.com/zeit/next.js/blob/canary/examples/with-apollo-auth/lib/withApollo.js#L72-L75

Again please explain me if I am wrong :)
