### PR TITLE
Fix a mistake in chunk name generation

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -4,6 +4,10 @@ import { readdirSync, existsSync } from 'fs'
 export const IS_BUNDLED_PAGE = /^bundles[/\\]pages.*\.js$/
 export const MATCH_ROUTE_NAME = /^bundles[/\\]pages[/\\](.*)\.js$/
 
+export function getChunkNameFromFilename (filename) {
+  return filename.replace(/-[^-]*$/, '')
+}
+
 export function getAvailableChunks (distDir) {
   const chunksDir = join(distDir, 'chunks')
   if (!existsSync(chunksDir)) return {}
@@ -13,7 +17,7 @@ export function getAvailableChunks (distDir) {
 
   chunkFiles.forEach(filename => {
     if (/\.js$/.test(filename)) {
-      const chunkName = filename.replace(/-[^-]*/, '')
+      const chunkName = getChunkNameFromFilename(filename)
       chunksMap[chunkName] = filename
     }
   })

--- a/test/unit/server-utils.test.js
+++ b/test/unit/server-utils.test.js
@@ -1,0 +1,17 @@
+/* global describe, it, expect */
+
+import { getChunkNameFromFilename } from '../../dist/server/utils'
+
+describe('Server utils', () => {
+  describe('getChunkNameFromFilename', () => {
+    it('should strip the hash from the filename', () => {
+      const filename = 'foo_bar_0123456789abcdef-0123456789abcdef.js'
+      expect(getChunkNameFromFilename(filename)).toBe('foo_bar_0123456789abcdef')
+    })
+
+    it('should only strip the part after the last hyphen in the filename', () => {
+      const filename = 'foo-bar-0123456789abcdef-0123456789abcdef.js'
+      expect(getChunkNameFromFilename(filename)).toBe('foo-bar-0123456789abcdef')
+    })
+  })
+})


### PR DESCRIPTION
This fixes a missed bug introduced in #4510.

Because the regexp was `/-[^-]*/` and not `/-[^-]*$/`, a wrong part of the filename was being removed:

```
bad:
'foo-bar-0123456789abcdef-0123456789abcdef.js' -> 'foo-0123456789abcdef-0123456789abcdef.js'

good:
'foo-bar-0123456789abcdef-0123456789abcdef.js' -> 'foo-bar-0123456789abcdef'
```

By a stroke of luck this didn't affect the existing dynamically generated chunks. To prevent regression I've added unit tests for the function that generates the name.

Btw. in the original issue (#4433) I used the right regexp, I just used the wrong regexp in #4510.

cc @timneutkens 