### PR TITLE
Upgrade gh-pages example to next 6.0.3

### DIFF
--- a/examples/gh-pages/.babelrc
+++ b/examples/gh-pages/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "next/babel"
-  ],
-  "plugins": [
-    ["transform-define", "./env-config.js"]
-  ]
-}

--- a/examples/gh-pages/.babelrc.js
+++ b/examples/gh-pages/.babelrc.js
@@ -1,0 +1,10 @@
+const env = require('./env-config')
+
+module.exports = {
+  'presets': [
+    'next/babel'
+  ],
+  'plugins': [
+    ['transform-define', env]
+  ]
+}


### PR DESCRIPTION
Hello! I have got an error while building [gh-pages example](https://github.com/zeit/next.js/tree/canary/examples/gh-pages) with next 6.0.3. I have found solution to use CommonJS modules in `.babelrc`

This resolves #4227