### PR TITLE
with-firebase-hosting: fix npm scripts, remove firebase.json predeploy scripts

### DIFF
--- a/examples/with-firebase-hosting/firebase.json
+++ b/examples/with-firebase-hosting/firebase.json
@@ -6,11 +6,9 @@
         "source": "**/**",
         "function": "next"
       }
-    ],
-    "predeploy": "npm run build-public"
+    ]
   },
   "functions": {
-    "source": "dist/functions",
-    "predeploy": "npm run build-funcs && npm run build-app && npm run copy-deps"
+    "source": "dist/functions"
   }
 }

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -1,26 +1,33 @@
 {
   "name": "with-firebase-hosting",
-  "version": "4.0.0",
-  "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
+  "version": "4.0.1",
+  "description":
+    "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
   "scripts": {
-    "dev": "next \"src/app\"",
+    "dev": "next \"src/app/\"",
+    "preserve":
+      "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",
     "serve": "NODE_ENV=production firebase serve",
+    "predeploy":
+      "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps",
     "deploy": "firebase deploy",
     "clean": "rimraf \"dist/functions/**\" && rimraf \"dist/public\"",
     "build-public": "cpx \"src/public/**/*.*\" \"dist/public\" -C",
     "build-funcs": "babel \"src/functions\" --out-dir \"dist/functions\"",
-    "build-app": "next build \"src/app\"",
-    "copy-deps": "cpx \"*{package.json,package-lock.json,yarn.lock}\" \"dist/functions\" -C"
+    "build-app": "next build \"src/app/\"",
+    "copy-deps":
+      "cpx \"*{package.json,package-lock.json,yarn.lock}\" \"dist/functions\" -C",
+    "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {
-    "firebase-admin": "5.12.1",
-    "firebase-functions": "1.0.2",
-    "next": "latest",
-    "react": "16.3.2",
-    "react-dom": "16.3.2"
+    "firebase-admin": "^5.12.1",
+    "firebase-functions": "^1.0.2",
+    "next": "^6.0.3",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
   },
   "devDependencies": {
-    "@babel/cli": "7.0.0-beta.42",
+    "@babel/cli": "^7.0.0-beta.42",
     "cpx": "1.5.0",
     "firebase-tools": "3.18.4",
     "prettier": "1.12.1",

--- a/examples/with-firebase-hosting/src/app/.babelrc
+++ b/examples/with-firebase-hosting/src/app/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["next/babel"]]
+}


### PR DESCRIPTION
* remove `predeploy` scripts from `firebase.json` in favour of `npm` `pre` scripts as they are consistent across `deploy` and `serve` commands. (to revisit once Firebase add support in the `firebase.json` for `preserve`)
* update deps
* workaround some bug where Babel could not resolve the standard `next/babel` config. Explicitly defining this seems to remove the issue.
* closes #4562