### PR TITLE
with-styled-components: Move babel plugin to dev dependency

### DIFF
--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -7,11 +7,13 @@
     "start": "next start"
   },
   "dependencies": {
-    "babel-plugin-styled-components": "^1.1.5",
     "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "styled-components": "^2.1.0"
+  },
+  "devDependencies": {
+    "babel-plugin-styled-components": "^1.1.5"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
`with-styled-components` example should list `babel-plugin-styled-components` as a dev dependency, not a regular dependency.