### PR TITLE
Process available chunk names properly in dev mode

### DIFF
--- a/server/export.js
+++ b/server/export.js
@@ -91,7 +91,7 @@ export default async function (dir, options, configuration) {
     dev: false,
     staticMarkup: false,
     hotReloader: null,
-    availableChunks: getAvailableChunks(distDir)
+    availableChunks: getAvailableChunks(distDir, false)
   }
 
   const {serverRuntimeConfig, publicRuntimeConfig} = nextConfig

--- a/server/index.js
+++ b/server/index.js
@@ -54,7 +54,7 @@ export default class Server {
       distDir: this.distDir,
       hotReloader: this.hotReloader,
       buildId: this.buildId,
-      availableChunks: dev ? {} : getAvailableChunks(this.distDir),
+      availableChunks: dev ? {} : getAvailableChunks(this.distDir, dev),
       generateEtags
     }
 

--- a/server/render.js
+++ b/server/render.js
@@ -238,7 +238,7 @@ function loadChunks ({ dev, distDir, availableChunks }) {
   }
 
   if (dev) {
-    availableChunks = getAvailableChunks(distDir)
+    availableChunks = getAvailableChunks(distDir, dev)
   }
 
   for (var chunk of flushedChunks) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -4,11 +4,14 @@ import { readdirSync, existsSync } from 'fs'
 export const IS_BUNDLED_PAGE = /^bundles[/\\]pages.*\.js$/
 export const MATCH_ROUTE_NAME = /^bundles[/\\]pages[/\\](.*)\.js$/
 
-export function getChunkNameFromFilename (filename) {
+export function getChunkNameFromFilename (filename, dev) {
+  if (dev) {
+    return filename.replace(/.[^.]*$/, '')
+  }
   return filename.replace(/-[^-]*$/, '')
 }
 
-export function getAvailableChunks (distDir) {
+export function getAvailableChunks (distDir, dev) {
   const chunksDir = join(distDir, 'chunks')
   if (!existsSync(chunksDir)) return {}
 
@@ -17,7 +20,7 @@ export function getAvailableChunks (distDir) {
 
   chunkFiles.forEach(filename => {
     if (/\.js$/.test(filename)) {
-      const chunkName = getChunkNameFromFilename(filename)
+      const chunkName = getChunkNameFromFilename(filename, dev)
       chunksMap[chunkName] = filename
     }
   })

--- a/test/unit/server-utils.test.js
+++ b/test/unit/server-utils.test.js
@@ -4,14 +4,28 @@ import { getChunkNameFromFilename } from '../../dist/server/utils'
 
 describe('Server utils', () => {
   describe('getChunkNameFromFilename', () => {
-    it('should strip the hash from the filename', () => {
-      const filename = 'foo_bar_0123456789abcdef-0123456789abcdef.js'
-      expect(getChunkNameFromFilename(filename)).toBe('foo_bar_0123456789abcdef')
+    describe('development mode (no chunkhash)', () => {
+      it('should strip the extension from the filename', () => {
+        const filename = 'foo_bar_0123456789abcdef.js'
+        expect(getChunkNameFromFilename(filename, true)).toBe('foo_bar_0123456789abcdef')
+      })
+
+      it('should only strip the extension even if there\'s a hyphen in the name', () => {
+        const filename = 'foo-bar-0123456789abcdef.js'
+        expect(getChunkNameFromFilename(filename, true)).toBe('foo-bar-0123456789abcdef')
+      })
     })
 
-    it('should only strip the part after the last hyphen in the filename', () => {
-      const filename = 'foo-bar-0123456789abcdef-0123456789abcdef.js'
-      expect(getChunkNameFromFilename(filename)).toBe('foo-bar-0123456789abcdef')
+    describe('production mode (with chunkhash)', () => {
+      it('should strip the hash from the filename', () => {
+        const filename = 'foo_bar_0123456789abcdef-0123456789abcdef.js'
+        expect(getChunkNameFromFilename(filename, false)).toBe('foo_bar_0123456789abcdef')
+      })
+
+      it('should only strip the part after the last hyphen in the filename', () => {
+        const filename = 'foo-bar-0123456789abcdef-0123456789abcdef.js'
+        expect(getChunkNameFromFilename(filename, false)).toBe('foo-bar-0123456789abcdef')
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes #4603.

Tests explain it the best:

```js
    describe('development mode (no chunkhash)', () => {
      it('should strip the extension from the filename', () => {
        const filename = 'foo_bar_0123456789abcdef.js'
        expect(getChunkNameFromFilename(filename, true)).toBe('foo_bar_0123456789abcdef')
      })

      it('should only strip the extension even if there\'s a hyphen in the name', () => {
        const filename = 'foo-bar-0123456789abcdef.js'
        expect(getChunkNameFromFilename(filename, true)).toBe('foo-bar-0123456789abcdef')
      })
    })

    describe('production mode (with chunkhash)', () => {
      it('should strip the hash from the filename', () => {
        const filename = 'foo_bar_0123456789abcdef-0123456789abcdef.js'
        expect(getChunkNameFromFilename(filename, false)).toBe('foo_bar_0123456789abcdef')
      })

      it('should only strip the part after the last hyphen in the filename', () => {
        const filename = 'foo-bar-0123456789abcdef-0123456789abcdef.js'
        expect(getChunkNameFromFilename(filename, false)).toBe('foo-bar-0123456789abcdef')
      })
    })
```