### PR TITLE
Properly escape the dot character in regexp

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -6,7 +6,7 @@ export const MATCH_ROUTE_NAME = /^bundles[/\\]pages[/\\](.*)\.js$/
 
 export function getChunkNameFromFilename (filename, dev) {
   if (dev) {
-    return filename.replace(/.[^.]*$/, '')
+    return filename.replace(/\.[^.]*$/, '')
   }
   return filename.replace(/-[^-]*$/, '')
 }


### PR DESCRIPTION
A follow-up to #4604: the dot in the regexp was not escaped as intended. By default `*` matches greedily, so the results are the same, but the new regexp should be more clear. Sorry for the mistake.