### PR TITLE
Update with-markdown example

### DIFF
--- a/examples/with-markdown/package.json
+++ b/examples/with-markdown/package.json
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "markdown-in-js": "1.1.3",    
+    "markdown-in-js": "^1.1.4",
     "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"


### PR DESCRIPTION
I have updated [examples/with-markdown](https://github.com/zeit/next.js/tree/canary/examples/with-markdown) in order to make it works with next 6 🎉 

<details>
<summary>Error</summary>
Error: Plugin/Preset files are not allowed to export objects, only functions. In /Users/zhenyatelegin/Desktop/next.js/examples/with-markdown/node_modules/markdown-in-js/babel.js
</details>