### PR TITLE
Apply hot-self-accept to all pageExtensions

### DIFF
--- a/build/loaders/hot-self-accept-loader.js
+++ b/build/loaders/hot-self-accept-loader.js
@@ -11,6 +11,14 @@ module.exports = function (content: string, sourceMap: any) {
   this.cacheable()
 
   const options: Options = loaderUtils.getOptions(this)
+  if (!options.extensions) {
+    throw new Error('extensions is not provided to hot-self-accept-loader. Please upgrade all next-plugins to the latest version.')
+  }
+
+  if (!options.include) {
+    throw new Error('include option is not provided to hot-self-accept-loader. Please upgrade all next-plugins to the latest version.')
+  }
+
   const route = getRoute(this.resourcePath, options)
 
   // Webpack has a built in system to prevent default from colliding, giving it a random letter per export.
@@ -37,14 +45,6 @@ module.exports = function (content: string, sourceMap: any) {
 }
 
 function getRoute (resourcePath: string, options: Options) {
-  if (!options.extensions) {
-    throw new Error('extensions is not provided to hot-self-accept-loader. Please upgrade all next-plugins to the latest version.')
-  }
-
-  if (!options.include) {
-    throw new Error('include option is not provided to hot-self-accept-loader. Please upgrade all next-plugins to the latest version.')
-  }
-
   const dir = options.include.find((d) => resourcePath.indexOf(d) === 0)
 
   if (!dir) {

--- a/build/webpack.js
+++ b/build/webpack.js
@@ -60,7 +60,9 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
         include: [
           path.join(dir, 'pages')
         ],
-        extensions: /\.(js|jsx)$/
+        // All pages are javascript files. So we apply hot-self-accept-loader here to facilitate hot reloading of pages.
+        // This makes sure plugins just have to implement `pageExtensions` instead of also implementing the loader
+        extensions: new RegExp(`\\.+(${config.pageExtensions.join('|')})$`)
       }
     }
   }


### PR DESCRIPTION
This makes sure plugins like @zeit/next-typescript or @zeit/next-mdx don't have to provide the `hot-self-accept-loader`.
This fixes for example @zeit/next-mdx, which doesn't implement `pageExtensions` but we do use mdx as top level pages for https://github.com/zeit/docs