### PR TITLE
Pass in the generated asPath instead of a full url

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -101,9 +101,11 @@ export default class Router {
 
     const { pathname, query } = this
     const url = window.location.href
+    // This makes sure we only use pathname + query + hash, to mirror `asPath` coming from the server.
+    const as = window.location.pathname + window.location.search + window.location.hash
 
     this.events.emit('routeChangeStart', url)
-    const routeInfo = await this.getRouteInfo(route, pathname, query, url)
+    const routeInfo = await this.getRouteInfo(route, pathname, query, as)
     const { error } = routeInfo
 
     if (error && error.cancelled) {


### PR DESCRIPTION
Fixes #4620 

On the server and when navigating pages, the `asPath` is the pathname + query + hash visible to the users, not an url. This makes sure that we keep it consistent between hot reloads.