### PR TITLE
with-socket.io Example updated with _app.js

### DIFF
--- a/examples/with-socket.io/pages/_app.js
+++ b/examples/with-socket.io/pages/_app.js
@@ -3,7 +3,7 @@ import React from 'react'
 import io from 'socket.io-client'
 
 class MyApp extends App {
-  static async getInitialProps({ Component, ctx }) {
+  static async getInitialProps ({ Component, ctx }) {
     let pageProps = {}
 
     if (Component.getInitialProps) {
@@ -15,7 +15,7 @@ class MyApp extends App {
   state = {
     socket: null
   }
-  componentDidMount() {
+  componentDidMount () {
     // connect to WS server and listen event
     const socket = io()
     this.setState({ socket })

--- a/examples/with-socket.io/pages/_app.js
+++ b/examples/with-socket.io/pages/_app.js
@@ -1,0 +1,39 @@
+import App, {Container} from 'next/app'
+import React from 'react'
+import io from 'socket.io-client'
+
+class MyApp extends App {
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps }
+  }
+  state = {
+    socket: null
+  }
+  componentDidMount() {
+    // connect to WS server and listen event
+    const socket = io()
+    this.setState({ socket })
+  }
+
+  // close socket connection
+  componentWillUnmount () {
+    this.state.socket.close()
+  }
+
+  render () {
+    const {Component, pageProps} = this.props
+    return (
+      <Container>
+        <Component {...pageProps} socket={this.state.socket} />
+      </Container>
+    )
+  }
+}
+
+export default MyApp

--- a/examples/with-socket.io/pages/clone.js
+++ b/examples/with-socket.io/pages/clone.js
@@ -31,7 +31,7 @@ class ChatTwo extends Component {
       this.setState({ subscribed: true })
     }
   }
-  componentDidMount() {
+  componentDidMount () {
     this.subscribe()
   }
 
@@ -39,7 +39,7 @@ class ChatTwo extends Component {
     this.subscribe()
   }
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps (props, state) {
     if (props.socket && !state.subscribe) return { subscribe: true }
     return null
   }
@@ -87,9 +87,9 @@ class ChatTwo extends Component {
     return (
       <main>
         <div>
-          <Link href="/"><a>{`Chat One ${ this.state.newMessage > 0 ? `( ${this.state.newMessage} new message )` : ''}`}</a></Link>
+          <Link href={'/'}><a>{`Chat One ${this.state.newMessage > 0 ? `( ${this.state.newMessage} new message )` : ''}`}</a></Link>
           <br />
-          <Link href="/clone"><a>{'Chat Two'}</a></Link>
+          <Link href={'/clone'}><a>{'Chat Two'}</a></Link>
           <ul>
             {this.state.messages.map(message =>
               <li key={message.id}>{message.value}</li>

--- a/examples/with-socket.io/pages/clone.js
+++ b/examples/with-socket.io/pages/clone.js
@@ -2,10 +2,10 @@ import { Component } from 'react'
 import Link from 'next/link'
 import fetch from 'isomorphic-unfetch'
 
-class ChatOne extends Component {
+class ChatTwo extends Component {
   // fetch old messages data from the server
   static async getInitialProps ({ req }) {
-    const response = await fetch('http://localhost:3000/messages/chat1')
+    const response = await fetch('http://localhost:3000/messages/chat2')
     const messages = await response.json()
     return { messages }
   }
@@ -26,8 +26,8 @@ class ChatOne extends Component {
   subscribe = () => {
     if (this.state.subscribe && !this.state.subscribed) {
       // connect to WS server and listen event
-      this.props.socket.on('message.chat1', this.handleMessage)
-      this.props.socket.on('message.chat2', this.handleOtherMessage)
+      this.props.socket.on('message.chat2', this.handleMessage)
+      this.props.socket.on('message.chat1', this.handleOtherMessage)
       this.setState({ subscribed: true })
     }
   }
@@ -46,8 +46,8 @@ class ChatOne extends Component {
 
   // close socket connection
   componentWillUnmount () {
-    this.props.socket.off('message.chat1', this.handleMessage)
-    this.props.socket.off('message.chat2', this.handleOtherMessage)
+    this.props.socket.off('message.chat1', this.handleOtherMessage)
+    this.props.socket.off('message.chat2', this.handleMessage)
   }
 
   // add messages from server to the state
@@ -74,7 +74,7 @@ class ChatOne extends Component {
     }
 
     // send object to WS server
-    this.props.socket.emit('message.chat1', message)
+    this.props.socket.emit('message.chat2', message)
 
     // add it to state and clean current input value
     this.setState(state => ({
@@ -87,9 +87,9 @@ class ChatOne extends Component {
     return (
       <main>
         <div>
-          <Link href="/"><a>{'Chat One'}</a></Link>
+          <Link href="/"><a>{`Chat One ${ this.state.newMessage > 0 ? `( ${this.state.newMessage} new message )` : ''}`}</a></Link>
           <br />
-          <Link href="/clone"><a>{`Chat Two ${ this.state.newMessage > 0 ? `( ${this.state.newMessage} new message )` : ''}`}</a></Link>
+          <Link href="/clone"><a>{'Chat Two'}</a></Link>
           <ul>
             {this.state.messages.map(message =>
               <li key={message.id}>{message.value}</li>
@@ -110,4 +110,4 @@ class ChatOne extends Component {
   }
 }
 
-export default ChatOne
+export default ChatTwo

--- a/examples/with-socket.io/pages/index.js
+++ b/examples/with-socket.io/pages/index.js
@@ -31,7 +31,7 @@ class ChatOne extends Component {
       this.setState({ subscribed: true })
     }
   }
-  componentDidMount() {
+  componentDidMount () {
     this.subscribe()
   }
 
@@ -39,7 +39,7 @@ class ChatOne extends Component {
     this.subscribe()
   }
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps (props, state) {
     if (props.socket && !state.subscribe) return { subscribe: true }
     return null
   }
@@ -87,9 +87,9 @@ class ChatOne extends Component {
     return (
       <main>
         <div>
-          <Link href="/"><a>{'Chat One'}</a></Link>
+          <Link href={'/'}><a>{'Chat One'}</a></Link>
           <br />
-          <Link href="/clone"><a>{`Chat Two ${ this.state.newMessage > 0 ? `( ${this.state.newMessage} new message )` : ''}`}</a></Link>
+          <Link href={'/clone'}><a>{`Chat Two ${this.state.newMessage > 0 ? `( ${this.state.newMessage} new message )` : ''}`}</a></Link>
           <ul>
             {this.state.messages.map(message =>
               <li key={message.id}>{message.value}</li>

--- a/examples/with-socket.io/server.js
+++ b/examples/with-socket.io/server.js
@@ -9,19 +9,26 @@ const nextApp = next({ dev })
 const nextHandler = nextApp.getRequestHandler()
 
 // fake DB
-const messages = []
+const messages = {
+  chat1: [],
+  chat2: []
+}
 
 // socket.io server
 io.on('connection', socket => {
-  socket.on('message', (data) => {
-    messages.push(data)
-    socket.broadcast.emit('message', data)
+  socket.on('message.chat1', (data) => {
+    messages['chat1'].push(data)
+    socket.broadcast.emit('message.chat1', data)
+  })
+  socket.on('message.chat2', (data) => {
+    messages['chat2'].push(data)
+    socket.broadcast.emit('message.chat2', data)
   })
 })
 
 nextApp.prepare().then(() => {
-  app.get('/messages', (req, res) => {
-    res.json(messages)
+  app.get('/messages/:chat', (req, res) => {
+    res.json(messages[req.params.chat])
   })
 
   app.get('*', (req, res) => {


### PR DESCRIPTION
with-socket.io example was using a single index file and was managing connection in there. This would lead handling connection (disconnecting and reconnecting) in each added page.

I updated example with addition of `_app.js` and handled connection in there. This helped only subscribing to event in page and maintaining connection throughout example.