### PR TITLE
Remove the React 15 support comment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,6 @@ Install it:
 npm install --save next react react-dom
 ```
 
-> Next.js only supports [React 16](https://reactjs.org/blog/2017/09/26/react-v16.0.html).<br/>
-> We had to drop React 15 support due to the way React 16 works and how we use it.
-
 and add a script to your package.json like this:
 
 ```json


### PR DESCRIPTION
Next.js supports React 15 / React-like alternatives that don’t have the `rehydrate` method (preact) again since Next.js 5+. It’s still not recommended to use React 15. But there’s no need to mention that here as this is the initial installation and we instruct the user to install the latest version of React.