### PR TITLE
Rephrase url deprecation text and add link to next-codemod

### DIFF
--- a/errors/url-deprecated.md
+++ b/errors/url-deprecated.md
@@ -29,6 +29,6 @@ class Page extends React.Component {
 export default withRouter(Page)
 ```
 
-We provide a codemod (a code to code transformation) to automatically change the `url` property usages to using `withRouter` automatically.
+We provide a codemod (a code to code transformation) to automatically change the `url` property usages to `withRouter`.
 
 You can find this codemod and instructions on how to run it here: https://github.com/zeit/next-codemod#url-to-withrouter

--- a/errors/url-deprecated.md
+++ b/errors/url-deprecated.md
@@ -2,11 +2,18 @@
 
 #### Why This Error Occurred
 
-In version prior to 6.x `url` got magically injected into every page component, since this is confusing and can now be added by the user using a custom `_app.js` we have deprecated this feature. To be removed in Next.js 7.0
+In versions prior to 6.x the `url` property got magically injected into every `Page` component (every page inside the `pages` directory).
+
+The reason this is going away is that we want to make things very predictable and explicit. Having a magical url property coming out of nowhere doesn't aid that goal.
 
 #### Possible Ways to Fix It
 
-The easiest way to get the same values that `url` had is to use `withRouter`:
+https://github.com/zeit/next-codemod#url-to-withrouter
+
+Since Next 5 we provide a way to explicitly inject the Next.js router object into pages and all their decending components.
+The `router` property that is injected will hold the same values as `url`, like `pathname`, `asPath`, and `query`.
+
+Here's an example of using `withRouter`:
 
 ```js
 import { withRouter } from 'next/router'
@@ -21,3 +28,7 @@ class Page extends React.Component {
 
 export default withRouter(Page)
 ```
+
+We provide a codemod (a code to code transformation) to automatically change the `url` property usages to using `withRouter` automatically.
+
+You can find this codemod and instructions on how to run it here: https://github.com/zeit/next-codemod#url-to-withrouter

--- a/readme.md
+++ b/readme.md
@@ -1704,7 +1704,7 @@ Please see our [contributing.md](./contributing.md)
 ## Authors
 
 - Arunoda Susiripala ([@arunoda](https://twitter.com/arunoda)) – [ZEIT](https://zeit.co)
-- Tim Neutkens ([@timneutkens](https://github.com/timneutkens)) – [ZEIT](https://zeit.co)
+- Tim Neutkens ([@timneutkens](https://twitter.com/timneutkens)) – [ZEIT](https://zeit.co)
 - Naoyuki Kanezawa ([@nkzawa](https://twitter.com/nkzawa)) – [ZEIT](https://zeit.co)
 - Tony Kovanen ([@tonykovanen](https://twitter.com/tonykovanen)) – [ZEIT](https://zeit.co)
 - Guillermo Rauch ([@rauchg](https://twitter.com/rauchg)) – [ZEIT](https://zeit.co)


### PR DESCRIPTION
Clears up confusion as to what's the best way to handle the deprecated url.

Adds a link to the codemod that allows you to automatically upgrade your codebase to using `withRouter`