### PR TITLE
Fixed with-relay-modern example package.json

### DIFF
--- a/examples/with-relay-modern/package.json
+++ b/examples/with-relay-modern/package.json
@@ -7,7 +7,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "relay": "relay-compiler --src ./ --exclude '**/.next/**' '**/node_modules/**' '**/test/**'  '**/__generated__/**' --exclude './schema/**' --schema ./schema/schema.graphql",
+    "relay": "relay-compiler --src ./ --exclude '**/.next/**' '**/node_modules/**' '**/test/**'  '**/__generated__/**' --exclude '**/schema/**' --schema ./schema/schema.graphql",
     "schema": "graphql get-schema dev"
   },
   "author": "",
@@ -15,6 +15,7 @@
   "dependencies": {
     "dotenv": "^4.0.0",
     "dotenv-webpack": "^1.5.4",
+    "graphql": "^0.13.2",
     "isomorphic-unfetch": "^2.0.0",
     "next": "latest",
     "react": "^16.2.0",


### PR DESCRIPTION
   Fix on relay script to proper ignore schema files
   added graphql as explict dependency


I needed that changes to run this example on my mac machine