### PR TITLE
Fix incorrect wording

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -114,7 +114,7 @@ async function doRender (req, res, pathname, query, {
 
   if (isResSent(res)) return
 
-  if (!Document.prototype || !Document.prototype.isReactComponent) throw new Error('_document.js is not exporting a React element')
+  if (!Document.prototype || !Document.prototype.isReactComponent) throw new Error('_document.js is not exporting a React component')
   const doc = createElement(Document, {
     __NEXT_DATA__: {
       props,


### PR DESCRIPTION
I can't use a functional component with `_document.js`.
[is-react](https://www.npmjs.com/package/is-react) can be used for another potential implementation of the warning logic, but maybe relying on `React.createElement()` internal checks is enough.