### PR TITLE
pass old route to onRouteChangeStart

### DIFF
--- a/examples/with-flow/types/next.js.flow
+++ b/examples/with-flow/types/next.js.flow
@@ -29,7 +29,7 @@ declare module "next/router" {
     route: string;
     pathname: string;
     query: Object;
-    onRouteChangeStart: ?((url: string) => void);
+    onRouteChangeStart: ?((url: string, oldUrl: string) => void);
     onRouteChangeComplete: ?((url: string) => void);
     onRouteChangeError: ?((err: Error & {cancelled: boolean}, url: string) => void);
     push(url: string, as: ?string): Promise<boolean>;

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -104,7 +104,7 @@ export default class Router {
     // This makes sure we only use pathname + query + hash, to mirror `asPath` coming from the server.
     const as = window.location.pathname + window.location.search + window.location.hash
 
-    this.events.emit('routeChangeStart', url)
+    this.events.emit('routeChangeStart', url, url)
     const routeInfo = await this.getRouteInfo(route, pathname, query, as)
     const { error } = routeInfo
 
@@ -172,7 +172,7 @@ export default class Router {
     const { shallow = false } = options
     let routeInfo = null
 
-    this.events.emit('routeChangeStart', as)
+    this.events.emit('routeChangeStart', as, this.asPath)
 
     // If shallow === false and other conditions met, we reuse the
     // existing routeInfo for this route.

--- a/readme.md
+++ b/readme.md
@@ -544,7 +544,7 @@ This uses the same exact parameters as in the `<Link>` component.
 You can also listen to different events happening inside the Router.
 Here's a list of supported events:
 
-- `onRouteChangeStart(url)` - Fires when a route starts to change
+- `onRouteChangeStart(url, oldUrl)` - Fires when a route starts to change
 - `onRouteChangeComplete(url)` - Fires when a route changed completely
 - `onRouteChangeError(err, url)` - Fires when there's an error when changing routes
 - `onBeforeHistoryChange(url)` - Fires just before changing the browser's history
@@ -556,7 +556,8 @@ Here's a list of supported events:
 Here's how to properly listen to the router event `onRouteChangeStart`:
 
 ```js
-Router.onRouteChangeStart = url => {
+Router.onRouteChangeStart = (url, oldUrl) => {
+  console.log('App is changing from: ', oldUrl)
   console.log('App is changing to: ', url)
 }
 ```


### PR DESCRIPTION
Added the previous url as a second parameter to the onRouteChangeStart hook, so that you can specify behavior based on which page you are coming from as well as which page you are going to.