### PR TITLE
Make production compilation faster (patch)

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -42,7 +42,7 @@ function runCompiler (compiler) {
     webpackCompiler.run((err, stats) => {
       if (err) return reject(err)
 
-      const jsonStats = stats.toJson("errors-only")
+      const jsonStats = stats.toJson('errors-only')
 
       if (jsonStats.errors.length > 0) {
         const error = new Error(jsonStats.errors[0])

--- a/build/index.js
+++ b/build/index.js
@@ -42,7 +42,7 @@ function runCompiler (compiler) {
     webpackCompiler.run((err, stats) => {
       if (err) return reject(err)
 
-      const jsonStats = stats.toJson()
+      const jsonStats = stats.toJson("errors-only")
 
       if (jsonStats.errors.length > 0) {
         const error = new Error(jsonStats.errors[0])


### PR DESCRIPTION
I have spend whole day on profiling next.js compiling performance and one of the easy hacks to reduce built time is avoid doing full `stats.toJson()` that is heavy by default.