### PR TITLE
fix(with-pkg): Rename `dist` to `server`

### DIFF
--- a/examples/with-pkg/package.json
+++ b/examples/with-pkg/package.json
@@ -25,7 +25,7 @@
       ".next/**/*"
     ],
     "scripts": [
-      ".next/dist/**/*.js"
+      ".next/server/**/*.js"
     ]
   }
 }


### PR DESCRIPTION
This PR is a follow-up to 6.1 breaking #4506: Rename `dist` to `server`