### PR TITLE
Prepend polyfills only once in with-polyfills example

### DIFF
--- a/examples/with-polyfills/next.config.js
+++ b/examples/with-polyfills/next.config.js
@@ -4,7 +4,7 @@ module.exports = {
     cfg.entry = async () => {
       const entries = await originalEntry()
 
-      if (entries['main.js']) {
+      if (entries['main.js'] && !entries['main.js'].includes('./client/polyfills.js')) {
         entries['main.js'].unshift('./client/polyfills.js')
       }
 


### PR DESCRIPTION
Fixes #4643 by ensuring that the polyfills are not prepended more than once.