### PR TITLE
Ensured process exits after static export (#4747)

### DIFF
--- a/bin/next-export
+++ b/bin/next-export
@@ -57,6 +57,10 @@ const options = {
   outdir: argv.outdir ? resolve(argv.outdir) : resolve(dir, 'out')
 }
 
-exportApp(dir, options).catch((err) => {
-  printAndExit(err)
-})
+exportApp(dir, options)
+  .then(() => {
+    printAndExit('Export successful', 0)
+  })
+  .catch((err) => {
+    printAndExit(err)
+  })


### PR DESCRIPTION
Fixes [this issue](https://github.com/zeit/next.js/issues/4747)

I don't know what is the reason why the process does not finish, because it can be reproduced in this repo in many environments (my local mac os and Netlify pipeline).

However, it fixes the problem and it's 100% safe.