### PR TITLE
Update @types/next to latest in typescript example.

### DIFF
--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^16.2.0"
   },
   "devDependencies": {
-    "@types/next": "^2.4.7",
+    "@types/next": "latest",
     "@types/react": "^16.0.36"
   },
   "license": "ISC"


### PR DESCRIPTION
Updating to a more recent version of `@types/next` fixes an error I encountered while building a new app on top of the "with-typescript" example:

`Property `push` not found in SingletonRouter`

Additional context: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26665

To test, add a simple Router.push operation to the `pages/index.tsx`

```
import Router from 'next/router'
// ...
<span onClick={() => Router.push({ pathname: '/about' })}>TEST</span>
```