### PR TITLE
[with-apollo] simplify apolloState prop

### DIFF
--- a/examples/with-apollo/lib/with-apollo-client.js
+++ b/examples/with-apollo/lib/with-apollo-client.js
@@ -13,8 +13,6 @@ export default (App) => {
         appProps = await App.getInitialProps(ctx)
       }
 
-      const apolloState = {}
-
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
       const apollo = initApollo()
@@ -26,7 +24,6 @@ export default (App) => {
               {...appProps}
               Component={Component}
               router={router}
-              apolloState={apolloState}
               apolloClient={apollo}
             />
           )
@@ -40,12 +37,10 @@ export default (App) => {
         // getDataFromTree does not call componentWillUnmount
         // head side effect therefore need to be cleared manually
         Head.rewind()
-
-        // Extract query data from the Apollo store
-        apolloState.data = apollo.cache.extract()
-      } else {
-        apolloState.data = {}
       }
+
+      // Extract query data from the Apollo store
+      const apolloState = apollo.cache.extract()
 
       return {
         ...appProps,
@@ -55,7 +50,8 @@ export default (App) => {
 
     constructor (props) {
       super(props)
-      this.apolloClient = initApollo(props.apolloState.data)
+      this.apolloClient = initApollo(props.apolloState
+      )
     }
 
     render () {

--- a/examples/with-apollo/lib/with-apollo-client.js
+++ b/examples/with-apollo/lib/with-apollo-client.js
@@ -50,8 +50,7 @@ export default (App) => {
 
     constructor (props) {
       super(props)
-      this.apolloClient = initApollo(props.apolloState
-      )
+      this.apolloClient = initApollo(props.apolloState)
     }
 
     render () {


### PR DESCRIPTION
As seen on `with-apollo-auth` there are some things that need to be addressed here too.

* #4554 remove useless `apolloState` from App props on `getDataFromTree`
* #4563 simplify `apolloState` prop

Let me know if further changes/fixes are needed. 
Thank you :tada: 