### PR TITLE
FIX with-apollo-auth example token access

### DIFF
--- a/examples/with-apollo-auth/lib/withApollo.js
+++ b/examples/with-apollo-auth/lib/withApollo.js
@@ -22,8 +22,9 @@ export default App => {
 
     static async getInitialProps(ctx) {
       const { Component, router, ctx: { req, res } } = ctx
+      const token = parseCookies(req).token
       const apollo = initApollo({}, {
-        getToken: () => parseCookies(req).token
+        getToken: () => token
       })
 
       ctx.ctx.apolloClient = apollo
@@ -69,7 +70,8 @@ export default App => {
 
       return {
         ...appProps,
-        apolloState
+        apolloState,
+        token
       }
     }
 
@@ -78,7 +80,7 @@ export default App => {
       // `getDataFromTree` renders the component first, the client is passed off as a property.
       // After that rendering is done using Next's normal rendering pipeline
       this.apolloClient = initApollo(props.apolloState, {
-        getToken: () => parseCookies().token
+        getToken: () => props.token
       })
     }
 


### PR DESCRIPTION
in some cases access to the token doesn't work in client side. this access to the token once in getInitialProps method and pass it down using props