### PR TITLE
Fix GTAG src

### DIFF
--- a/examples/with-google-analytics/pages/_document.js
+++ b/examples/with-google-analytics/pages/_document.js
@@ -18,7 +18,7 @@ export default class extends Document {
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script
             async
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+            src={`https://googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
           />
           <script
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
Using www in tag src in combination with a query-params and preview mode set to true yields a 404 not found.

**Steps to reproduce**

1.  Make sure you request gtag.js with www in front of src.
2. Put your GTM-container in preview mode
3. Visit the webpage you are working on and open console. Look for 404-errors.
4. Now remove www in front of your src and recompile.
5. Open console and see the 404 error is gone. Copy path to new browser window to confim js is loading.