### PR TITLE
Fix logic to generate manifest in webpack config

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -227,7 +227,7 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
         }
       }),
       // We use a manifest file in development to speed up HMR
-      dev && !isServer && new webpack.optimize.CommonsChunkPlugin({
+      !isServer && new webpack.optimize.CommonsChunkPlugin({
         name: 'manifest.js',
         filename: dev ? 'static/commons/manifest.js' : 'static/commons/manifest-[chunkhash].js'
       })

--- a/server/document.js
+++ b/server/document.js
@@ -61,16 +61,8 @@ export class Head extends Component {
   }
 
   getPreloadMainLinks () {
-    const { dev } = this.context._documentProps
-    if (dev) {
-      return [
-        ...this.getChunkPreloadLink('manifest.js'),
-        ...this.getChunkPreloadLink('main.js')
-      ]
-    }
-
-    // In the production mode, we have a single asset with all the JS content.
     return [
+      ...this.getChunkPreloadLink('manifest.js'),
       ...this.getChunkPreloadLink('main.js')
     ]
   }


### PR DESCRIPTION
Else `manifest-[chunkhash].js` will never be generated outside `dev` mode.