### PR TITLE
Update example: Semantic-UI

### DIFF
--- a/examples/with-semantic-ui/package.json
+++ b/examples/with-semantic-ui/package.json
@@ -7,14 +7,14 @@
     "start": "next start"
   },
   "dependencies": {
-    "@zeit/next-css": "^0.1.2",
-    "file-loader": "^1.1.9",
+    "@zeit/next-css": "^0.2.0",
+    "file-loader": "^1.1.11",
     "next": "latest",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "semantic-ui-css": "^2.2.12",
-    "semantic-ui-react": "^0.78.2",
-    "url-loader": "^0.6.2"
+    "semantic-ui-css": "^2.3.3",
+    "semantic-ui-react": "^0.82.0",
+    "url-loader": "^1.0.1"
   },
   "license": "ISC"
 }

--- a/examples/with-semantic-ui/pages/_document.js
+++ b/examples/with-semantic-ui/pages/_document.js
@@ -1,0 +1,17 @@
+import Document, { Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render () {
+    return (
+      <html>
+        <Head>
+          <link rel='stylesheet' href='/_next/static/style.css' />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/examples/with-semantic-ui/pages/index.js
+++ b/examples/with-semantic-ui/pages/index.js
@@ -8,7 +8,7 @@ export default () => (
       <Modal.Content image>
         <Modal.Description>
           <Header>Default Profile Image</Header>
-          <p>We've found the following gravatar image associated with your e-mail address.</p>
+          <p>We have found the following gravatar image associated with your e-mail address.</p>
           <p>Is it okay to use this photo?</p>
         </Modal.Description>
       </Modal.Content>

--- a/examples/with-semantic-ui/pages/index.js
+++ b/examples/with-semantic-ui/pages/index.js
@@ -1,19 +1,8 @@
-import 'semantic-ui-css/components/modal.css'
-import 'semantic-ui-css/components/header.css'
-import 'semantic-ui-css/components/button.css'
-import 'semantic-ui-css/components/list.css'
-import 'semantic-ui-css/components/icon.css'
-import 'semantic-ui-css/themes/default/assets/fonts/icons.eot'
-import 'semantic-ui-css/themes/default/assets/fonts/icons.woff'
-import 'semantic-ui-css/themes/default/assets/fonts/icons.woff2'
+import 'semantic-ui-css/semantic.min.css'
 import { Modal, Header, Button, List, Icon } from 'semantic-ui-react'
-import Head from 'next/head'
 
 export default () => (
   <div>
-    <Head>
-      <link rel='stylesheet' href='/_next/static/style.css' />
-    </Head>
     <Modal trigger={<Button>Show Modal</Button>}>
       <Modal.Header>Select a Photo</Modal.Header>
       <Modal.Content image>
@@ -25,7 +14,7 @@ export default () => (
       </Modal.Content>
     </Modal>
 
-    <List vertical relaxed>
+    <List relaxed>
       <List.Item>
         <List.Content>
           <List.Header as='a'>Next.js</List.Header>


### PR DESCRIPTION
The existing example currently does not work because of outdated usage patterns. This PR seeks to update these patterns to the latest recommended best practice while bumping versions.

# Summary

- Bumped version numbers in `package.json`;
- Moved `<link />` tag from `pages/index.js` to `pages/_document.js` as is [recommended](https://github.com/zeit/next-plugins/tree/master/packages/next-css#usage);
- Replace individual css/font imports with import of minified CSS as is [recommended](https://react.semantic-ui.com/usage#semantic-ui-css-package);
- Removed prop (no longer used) from `<List />` element.