### PR TITLE
Update with-react-intl example

### DIFF
--- a/examples/with-react-intl/README.md
+++ b/examples/with-react-intl/README.md
@@ -50,6 +50,7 @@ This example app shows how to integrate [React Intl][] with Next.
 - `<IntlProvider>` creation with `locale`, `messages`, and `initialNow` props
 - Default message extraction via `babel-plugin-react-intl` integration
 - Translation management via build script and customized Next server
+- withIntl HOC for pages because injectIntl do not hoist static methods.
 
 ### Translation Management
 

--- a/examples/with-react-intl/lib/withIntl.js
+++ b/examples/with-react-intl/lib/withIntl.js
@@ -1,0 +1,11 @@
+import hoistNonReactStatics from 'hoist-non-react-statics'
+import { injectIntl } from 'react-intl'
+
+export const hoistStatics = (higherOrderComponent) => (BaseComponent) => {
+  const NewComponent = higherOrderComponent(BaseComponent)
+  hoistNonReactStatics(NewComponent, BaseComponent)
+
+  return NewComponent
+}
+
+export default hoistStatics(injectIntl)

--- a/examples/with-react-intl/package.json
+++ b/examples/with-react-intl/package.json
@@ -10,6 +10,7 @@
     "accepts": "^1.3.3",
     "babel-plugin-react-intl": "^2.3.1",
     "glob": "^7.1.1",
+    "hoist-non-react-statics": "^3.0.0-rc.1",
     "intl": "^1.2.5",
     "next": "latest",
     "react": "^16.0.0",

--- a/examples/with-react-intl/pages/_app.js
+++ b/examples/with-react-intl/pages/_app.js
@@ -12,7 +12,7 @@ if (typeof window !== 'undefined' && window.ReactIntlLocaleData) {
 }
 
 export default class MyApp extends App {
-  static async getInitialProps ({ Component, router, ctx }) {
+  static async getInitialProps({ Component, router, ctx }) {
     let pageProps = {}
 
     if (Component.getInitialProps) {
@@ -22,14 +22,15 @@ export default class MyApp extends App {
     // Get the `locale` and `messages` from the request object on the server.
     // In the browser, use the same values that the server serialized.
     const { req } = ctx
-    const { locale, messages } = req || window.__NEXT_DATA__.props.pageProps
+    const { locale, messages } = req || window.__NEXT_DATA__.props
 
     return { pageProps, locale, messages }
   }
 
-  render () {
+  render() {
     const { Component, pageProps, locale, messages } = this.props
     const now = Date.now()
+
     return (
       <Container>
         <IntlProvider locale={locale} messages={messages} initialNow={now}>

--- a/examples/with-react-intl/pages/_app.js
+++ b/examples/with-react-intl/pages/_app.js
@@ -12,7 +12,7 @@ if (typeof window !== 'undefined' && window.ReactIntlLocaleData) {
 }
 
 export default class MyApp extends App {
-  static async getInitialProps({ Component, router, ctx }) {
+  static async getInitialProps ({ Component, router, ctx }) {
     let pageProps = {}
 
     if (Component.getInitialProps) {
@@ -22,12 +22,12 @@ export default class MyApp extends App {
     // Get the `locale` and `messages` from the request object on the server.
     // In the browser, use the same values that the server serialized.
     const { req } = ctx
-    const { locale, messages } = req || window.__NEXT_DATA__.props
+    const { locale, messages } = req || window.__NEXT_DATA__.props.pageProps
 
     return { pageProps, locale, messages }
   }
 
-  render() {
+  render () {
     const { Component, pageProps, locale, messages } = this.props
     const now = Date.now()
 

--- a/examples/with-react-intl/pages/index.js
+++ b/examples/with-react-intl/pages/index.js
@@ -12,11 +12,11 @@ const { description } = defineMessages({
 })
 
 class Index extends Component {
-  static getInitialProps() {
+  static getInitialProps () {
     // Do something
   }
 
-  render() {
+  render () {
     const { intl } = this.props
 
     return (

--- a/examples/with-react-intl/pages/index.js
+++ b/examples/with-react-intl/pages/index.js
@@ -1,25 +1,38 @@
-import React from 'react'
-import {FormattedMessage, FormattedNumber, defineMessages, injectIntl} from 'react-intl'
+import React, { Component } from 'react'
+import { FormattedMessage, FormattedNumber, defineMessages } from 'react-intl'
 import Head from 'next/head'
 import Layout from '../components/Layout'
+import withIntl from '../lib/withIntl'
 
-const {description} = defineMessages({
+const { description } = defineMessages({
   description: {
     id: 'description',
     defaultMessage: 'An example app integrating React Intl with Next.js'
   }
 })
 
-export default injectIntl(({intl}) => (
-  <Layout>
-    <Head>
-      <meta name='description' content={intl.formatMessage(description)} />
-    </Head>
-    <p>
-      <FormattedMessage id='greeting' defaultMessage='Hello, World!' />
-    </p>
-    <p>
-      <FormattedNumber value={1000} />
-    </p>
-  </Layout>
-))
+class Index extends Component {
+  static getInitialProps() {
+    // Do something
+  }
+
+  render() {
+    const { intl } = this.props
+
+    return (
+      <Layout>
+        <Head>
+          <meta name='description' content={intl.formatMessage(description)} />
+        </Head>
+        <p>
+          <FormattedMessage id='greeting' defaultMessage='Hello, World!' />
+        </p>
+        <p>
+          <FormattedNumber value={1000} />
+        </p>
+      </Layout>
+    )
+  }
+}
+
+export default withIntl(Index)


### PR DESCRIPTION
Changes:
- added withIntl HOC because injectIntl do no hoist static methods
- fixed `Cannot read property 'locale' of undefined`