### PR TITLE
Improve glamor example

### DIFF
--- a/examples/with-glamor/.babelrc
+++ b/examples/with-glamor/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [
+    [
+      "transform-react-jsx",
+      { "pragma": "Glamor.createElement" }
+    ]
+  ]
+}

--- a/examples/with-glamor/README.md
+++ b/examples/with-glamor/README.md
@@ -44,3 +44,5 @@ now
 This example features how to use a different styling solution than [styled-jsx](https://github.com/zeit/styled-jsx) that also supports universal styles. That means we can serve the required styles for the first render within the HTML and then load the rest in the client. In this case we are using [glamor](https://github.com/threepointone/glamor).
 
 For this purpose we are extending the `<Document />` and injecting the server side rendered styles into the `<head>`.
+
+In this example a custom React.createElement is used. With the help of a babel plugin we can remove the extra boilerplate introduced by having to import this function anywhere the css prop would be used. Documentation of using the `css` prop with glamor [can be found here](https://github.com/threepointone/glamor/blob/master/docs/createElement.md)

--- a/examples/with-glamor/next.config.js
+++ b/examples/with-glamor/next.config.js
@@ -1,0 +1,16 @@
+const webpack = require('webpack')
+
+module.exports = {
+  webpack: (config, { buildId, dev, isServer, defaultLoaders }) => {
+    const { plugins } = config
+    return {
+      ...config,
+      plugins: [
+        ...(plugins || []),
+        new webpack.ProvidePlugin({
+          Glamor: 'glamor/react'
+        })
+      ]
+    }
+  }
+}

--- a/examples/with-glamor/package.json
+++ b/examples/with-glamor/package.json
@@ -7,6 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "glamor": "^2.20.24",
     "next": "latest",
     "react": "^16.0.0",

--- a/examples/with-glamor/pages/index.js
+++ b/examples/with-glamor/pages/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { style, rehydrate } from 'glamor'
+import { rehydrate } from 'glamor'
 
 // Adds server generated styles to glamor cache.
 // Has to run before any `style()` calls
@@ -8,11 +8,4 @@ if (typeof window !== 'undefined') {
   rehydrate(window.__NEXT_DATA__.ids)
 }
 
-export default () => <h1 {...styles.title}>My page</h1>
-
-const styles = {
-  title: style({
-    color: 'red',
-    fontSize: 50
-  })
-}
+export default () => <h1 css={{ color: 'red', fontSize: 50 }}>My page</h1>


### PR DESCRIPTION
Changes:
- Use css prop on the element to style it
- Add webpack + babelrc configuration to remove otherwise needed import boilerplate [according to glamor docs](https://github.com/threepointone/glamor/blob/master/docs/createElement.md)

Rationale: The killer feature of glamor that makes it so great is that it relieves you from naming classes/styles if you use the custom css prop. Together with the babel plugin you also don't need any extra import wherever the css prop is used.

All the real world uses I've seen of glamor has used the css props so I think the example should reflect this. As an example here is docs how to use glamor with gatsby (using the css prop):
https://www.gatsbyjs.org/docs/glamor/