### PR TITLE
Fixed server status message in with-redux-observable-example.

### DIFF
--- a/examples/with-redux-observable/components/CharacterInfo.js
+++ b/examples/with-redux-observable/components/CharacterInfo.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-const CharacterInfo = ({character, error, fetchCharacter, isFetchedOnServer = false}) => (
+const CharacterInfo = ({ character, error, fetchCharacter, isFetchedOnServer = false }) => (
   <div className='CharacterInfo'>
     {
       error ? <p>We encountered and error.</p>
@@ -15,7 +15,7 @@ const CharacterInfo = ({character, error, fetchCharacter, isFetchedOnServer = fa
 
     }
     <p>
-      ( was character fetched on server? -
+      (was character fetched on server? -{' '}
       <b>{isFetchedOnServer.toString()})</b>
     </p>
     <style jsx>{`

--- a/examples/with-redux-observable/redux/actions.js
+++ b/examples/with-redux-observable/redux/actions.js
@@ -6,7 +6,7 @@ export const startFetchingCharacters = () => ({
 export const stopFetchingCharacters = () => ({
   type: types.STOP_FETCHING_CHARACTERS
 })
-export const fetchCharacter = isServer => ({
+export const fetchCharacter = (isServer = false) => ({
   type: types.FETCH_CHARACTER,
   payload: { isServer }
 })

--- a/examples/with-redux-observable/redux/epics.js
+++ b/examples/with-redux-observable/redux/epics.js
@@ -11,12 +11,11 @@ export const fetchUserEpic = (action$, state$) =>
     ofType(types.START_FETCHING_CHARACTERS),
     mergeMap(action => {
       return interval(3000).pipe(
-        map(x =>
-          actions.fetchCharacter({
-            isServer: state$.value.isServer
-          })
-        ),
-        takeUntil(action$.ofType(types.STOP_FETCHING_CHARACTERS))
+        map(x => actions.fetchCharacter()),
+        takeUntil(action$.ofType(
+          types.STOP_FETCHING_CHARACTERS,
+          types.FETCH_CHARACTER_FAILURE
+        ))
       )
     })
   )
@@ -31,14 +30,14 @@ export const fetchCharacterEpic = (action$, state$) =>
         map(response =>
           actions.fetchCharacterSuccess(
             response.response,
-            state$.value.isServer
+            action.payload.isServer
           )
         ),
         catchError(error =>
           of(
             actions.fetchCharacterFailure(
               error.xhr.response,
-              state$.value.isServer
+              action.payload.isServer
             )
           )
         )


### PR DESCRIPTION
**Changes:**
- Fixed "was character fetched on server" message by properly passing `isServer`.
- Stop fetching if there was an error (currently it keeps sending requests to the same endpoint every 3 sec)

**Related:**
- https://github.com/zeit/next.js/pull/4818
- https://github.com/zeit/next.js/issues/4724

