### PR TITLE
Defer routeChangeComplete until head was updated

### DIFF
--- a/client/head-manager.js
+++ b/client/head-manager.js
@@ -13,6 +13,10 @@ export default class HeadManager {
     this.updatePromise = null
   }
 
+  async waitForUpdateToComplete () {
+    return this.updatePromise
+  }
+
   updateHead (head) {
     const promise = this.updatePromise = Promise.resolve().then(() => {
       if (promise !== this.updatePromise) return

--- a/client/index.js
+++ b/client/index.js
@@ -99,6 +99,7 @@ export default async ({
     App,
     Component,
     ErrorComponent,
+    headManager,
     err: initialErr
   })
 

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -17,7 +17,7 @@ const historyMethodWarning = execOnce((method) => {
 export default class Router {
   static events = new EventEmitter()
 
-  constructor (pathname, query, as, { initialProps, pageLoader, App, Component, ErrorComponent, err } = {}) {
+  constructor (pathname, query, as, { initialProps, pageLoader, App, Component, headManager, ErrorComponent, err } = {}) {
     // represents the current component key
     this.route = toRoute(pathname)
 
@@ -44,6 +44,7 @@ export default class Router {
     this.asPath = as
     this.subscriptions = new Set()
     this.componentLoadCancel = null
+    this.headManager = headManager
     this._beforePopState = () => true
 
     if (typeof window !== 'undefined') {
@@ -132,6 +133,8 @@ export default class Router {
       throw error
     }
 
+    await this.headManager.waitForUpdateToComplete()
+
     Router.events.emit('routeChangeComplete', url)
   }
 
@@ -212,6 +215,8 @@ export default class Router {
       Router.events.emit('routeChangeError', error, as)
       throw error
     }
+
+    await this.headManager.waitForUpdateToComplete()
 
     Router.events.emit('routeChangeComplete', as)
     return true

--- a/test/integration/with-router/components/header-nav.js
+++ b/test/integration/with-router/components/header-nav.js
@@ -14,7 +14,8 @@ class HeaderNav extends React.Component {
     this.state = {
       activeURL: router.asPath,
       activeURLTopLevelRouterDeprecatedBehavior: router.asPath,
-      activeURLTopLevelRouter: router.asPath
+      activeURLTopLevelRouter: router.asPath,
+      title: null
     }
   }
 
@@ -32,7 +33,8 @@ class HeaderNav extends React.Component {
 
   handleRouteChange = url => {
     this.setState({
-      activeURL: url
+      activeURL: url,
+      title: window.document.title
     })
   };
 
@@ -60,6 +62,8 @@ class HeaderNav extends React.Component {
             </Link>
           ))
         }
+
+        <div className='title'>{this.state.title}</div>
       </nav>
     )
   }

--- a/test/integration/with-router/pages/a.js
+++ b/test/integration/with-router/pages/a.js
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { withRouter } from 'next/router'
+import Head from 'next/head'
 
 class PageA extends React.Component {
   goToB () {
@@ -9,6 +10,9 @@ class PageA extends React.Component {
   render () {
     return (
       <div id='page-a'>
+        <Head>
+          <title>page-a</title>
+        </Head>
         <button onClick={() => this.goToB()}>Go to B</button>
       </div>
     )

--- a/test/integration/with-router/pages/b.js
+++ b/test/integration/with-router/pages/b.js
@@ -1,9 +1,13 @@
 import * as React from 'react'
+import Head from 'next/head'
 
 class PageB extends React.Component {
   render () {
     return (
       <div id='page-b'>
+        <Head>
+          <title>page-b</title>
+        </Head>
         <p>Page B!</p>
       </div>
     )

--- a/test/integration/with-router/test/index.test.js
+++ b/test/integration/with-router/test/index.test.js
@@ -77,4 +77,20 @@ describe('withRouter', () => {
 
     browser.close()
   })
+
+  it('fires routeChangeComplete after head update', async () => {
+    const browser = await webdriver(appPort, '/a')
+    await browser.waitForElementByCss('#page-a')
+
+    let title = await browser.elementByCss('.title').text()
+    expect(title).toBe('')
+
+    await browser.elementByCss('button').click()
+    await browser.waitForElementByCss('#page-b')
+
+    title = await browser.elementByCss('.title').text()
+    expect(title).toBe('page-b')
+
+    browser.close()
+  })
 })


### PR DESCRIPTION
## What problem are we trying to solve?

Currently the `routeChangeComplete` event fires before the head was updated.

## Solution

Defer the `routeChangeComplete` event until the head update is done.

Closes: #4044, #4889 
Related: #574, #4838