### PR TITLE
Update with-custom-babel-config example

### DIFF
--- a/examples/with-custom-babel-config/.babelrc
+++ b/examples/with-custom-babel-config/.babelrc
@@ -1,6 +1,8 @@
 {
   "presets": [
-    "next/babel",
-    ["@babel/preset-stage-0", { "decoratorsLegacy": true }]
+    "next/babel"
   ],
+  "plugins": [
+    "@babel/plugin-proposal-do-expressions"
+  ]
 }

--- a/examples/with-custom-babel-config/package.json
+++ b/examples/with-custom-babel-config/package.json
@@ -16,6 +16,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@babel/preset-stage-0": "^7.0.0-beta.46"
+    "@babel/plugin-proposal-do-expressions": "7.0.0-beta.56"
   }
 }


### PR DESCRIPTION
## Issue

Running [examples/with-custom-babel-config](https://github.com/zeit/next.js/tree/canary/examples/with-custom-babel-config) will result in the following error message:

```
./pages/index.js
Module build failed (from /some_path/next.js/dist/build/webpack/loaders/next-babel-loader.js):
Error: [BABEL] /some_path/next.js/examples/with-custom-babel-config/pages/index.js: 
As of v7.0.0-beta.55, we've removed Babel's Stage presets.
Please consider reading our blog post on this decision at
https://babeljs.io/blog/2018/07/27/removing-babels-stage-presets
for more details. TL;DR is that it's more beneficial in the
  long run to explicitly add which proposals to use.

...
```

## Explanation

Babel removed Babel's Stage presets on July 27, 2018.

More info: https://babeljs.io/blog/2018/07/27/removing-babels-stage-presets

## Solution

I've updated the example so ist just uses the babel plugin it actually needs.

## Related 

Closes: #4772