### PR TITLE
Improve getDisplayName util

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,6 +46,10 @@ export function printAndExit (message, code = 1) {
 }
 
 export function getDisplayName (Component) {
+  if (typeof Component === 'string') {
+    return Component
+  }
+
   return Component.displayName || Component.name || 'Unknown'
 }
 

--- a/test/unit/getDisplayName.test.js
+++ b/test/unit/getDisplayName.test.js
@@ -1,0 +1,30 @@
+/* global describe, it, expect */
+import { Component } from 'react'
+import { getDisplayName } from '../../dist/lib/utils'
+
+describe('getDisplayName', () => {
+  it('gets the proper display name of a component', () => {
+    class ComponentOne extends Component {
+      render () {
+        return null
+      }
+    }
+
+    class ComponentTwo extends Component {
+      static displayName = 'CustomDisplayName'
+      render () {
+        return null
+      }
+    }
+
+    function FunctionalComponent () {
+      return null
+    }
+
+    expect(getDisplayName(ComponentOne)).toBe('ComponentOne')
+    expect(getDisplayName(ComponentTwo)).toBe('CustomDisplayName')
+    expect(getDisplayName(FunctionalComponent)).toBe('FunctionalComponent')
+    expect(getDisplayName(() => null)).toBe('Unknown')
+    expect(getDisplayName('div')).toBe('div')
+  })
+})


### PR DESCRIPTION
- [x] Add unit test
- [x] Allow to get the display name of a native component (e.g.: `div`) without throwing
- [ ] Remove displayName in production mode