### PR TITLE
Replace deprecated `props.url` in examples

### DIFF
--- a/examples/with-ioc/pages/about.js
+++ b/examples/with-ioc/pages/about.js
@@ -1,1 +1,1 @@
-export default props => <h1>About foo {props.url.query.foo} – no `Link` ({typeof props.Link}) available here</h1>
+export default props => <h1>About foo – no `Link` ({typeof props.Link}) available here</h1>

--- a/examples/with-next-routes/pages/about.js
+++ b/examples/with-next-routes/pages/about.js
@@ -1,1 +1,5 @@
-export default props => <h1>About foo {props.url.query.foo}</h1>
+import { withRouter } from 'next/router'
+
+const About = ({router}) => <h1>About foo {router.query.foo}</h1>
+
+export default withRouter(About)


### PR DESCRIPTION
Following https://github.com/zeit/next.js/pull/4952

I found two examples with the deprecated`props.url` :
- `with-ioc`
- `with-next-routes`