### PR TITLE
Use same extensions that webpack supports, with addition of .jsx (patch)

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -137,7 +137,7 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
   } : {}
 
   const resolveConfig = {
-    extensions: ['.js', '.jsx', '.json'],
+    extensions: ['.wasm', '.mjs', '.js', '.jsx', '.json'],
     modules: [
       NEXT_PROJECT_ROOT_NODE_MODULES,
       'node_modules',


### PR DESCRIPTION
Fixes #4956

Based on https://github.com/webpack/webpack/blob/v4.16.5/lib/WebpackOptionsDefaulter.js#L327