### PR TITLE
docs: removes `npx` info & moves src link up

### DIFF
--- a/examples/with-material-ui/README.md
+++ b/examples/with-material-ui/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/mui-org/material-ui/tree/master/examples/nextjs)
 # Material-UI example
 
 Source code is hosted on the [Material-UI](https://github.com/mui-org/material-ui/tree/master/examples/nextjs) repository.

--- a/examples/with-material-ui/README.md
+++ b/examples/with-material-ui/README.md
@@ -1,34 +1,4 @@
 [![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/mui-org/material-ui/tree/master/examples/nextjs)
 # Material-UI example
 
-## How to use
-
-The source code is hosted on the [Material-UI](https://github.com/mui-org/material-ui/tree/master/examples/nextjs) repository.
-
-Download the example:
-
-```bash
-
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs
-cd nextjs
-```
-
-Install it and run:
-
-```bash
-npm install
-npm run dev
-# or
-yarn
-yarn dev
-```
-
-Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
-
-```bash
-now
-```
-
-## The idea behind the example
-
-This example features how you use [material-ui](https://github.com/mui-org/material-ui) (Material components that implement Google's Material Design) with Next.js.
+Source code is hosted on the [Material-UI](https://github.com/mui-org/material-ui/tree/master/examples/nextjs) repository.

--- a/examples/with-material-ui/README.md
+++ b/examples/with-material-ui/README.md
@@ -3,21 +3,12 @@
 
 ## How to use
 
-### Using `create-next-app`
-
-Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
-
-```bash
-npx create-next-app --example with-material-ui with-material-ui-app
-# or
-yarn create next-app --example with-material-ui with-material-ui-app
-```
-
-### Download manually
+The source code is hosted on the [Material-UI](https://github.com/mui-org/material-ui/tree/master/examples/nextjs) repository.
 
 Download the example:
 
 ```bash
+
 curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs
 cd nextjs
 ```
@@ -41,5 +32,3 @@ now
 ## The idea behind the example
 
 This example features how you use [material-ui](https://github.com/mui-org/material-ui) (Material components that implement Google's Material Design) with Next.js.
-
-:warning: The source code [is hosted](https://github.com/mui-org/material-ui/tree/master/examples/nextjs) on the Material-UI repository.


### PR DESCRIPTION
FIXES: #4970 

confirmed rest of instructions work so left them in, even though duplicate of guide over at Material UI. thoughts?