### PR TITLE
Fix server key warning

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -204,7 +204,7 @@ export class NextScript extends Component {
     const pagePathname = getPagePathname(pathname)
 
     return <Fragment>
-      {devFiles ? devFiles.map((file) => <script src={`${assetPrefix}/_next/${file}`} nonce={this.props.nonce} />) : null}
+      {devFiles ? devFiles.map((file) => <script key={file} src={`${assetPrefix}/_next/${file}`} nonce={this.props.nonce} />) : null}
       {staticMarkup ? null : <script nonce={this.props.nonce} dangerouslySetInnerHTML={{
         __html: NextScript.getInlineScriptSource(this.context._documentProps)
       }} />}


### PR DESCRIPTION
The current canary version shows the following warning in development mode:

```log
Warning: Each child in an array or iterator should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.
    in script
    in NextScript
    in body
    in html
    in Document
```

This PR adds proper keys to the devFiles on the server.

Related https://github.com/zeit/next.js/pull/4954