### PR TITLE
Fix broken readme link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1638,7 +1638,7 @@ Next.js bundles [styled-jsx](https://github.com/zeit/styled-jsx) supporting scop
 
 We track V8. Since V8 has wide support for ES6 and `async` and `await`, we transpile those. Since V8 doesn’t support class decorators, we don’t transpile those.
 
-See [this](https://github.com/zeit/next.js/blob/master/server/build/webpack.js#L79) and [this](https://github.com/zeit/next.js/issues/26)
+See the  documentation about [customizing the babel config](#customizing-babel-config) and [next/preset](./build/babel/preset.js) for more information.
 
 </details>
 


### PR DESCRIPTION
As reported by @ranyitz the links in the documentation about ['What syntactic features are transpiled? How do I change them?'](https://github.com/zeit/next.js#faq) are broken.

I updated the links and the text to reflect the latest changes.

Closes #4974 
Related https://github.com/zeit/next.js/commit/eb74ff4bf9e3b83edee346fc0dfa99e7e7cc086c 