### PR TITLE
Fix with-jest example

### DIFF
--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -3,17 +3,17 @@
   "version": "1.0.0",
   "dependencies": {
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "16.4.2",
+    "react-dom": "16.4.2"
   },
   "devDependencies": {
-    "babel-core": "7.0.0-bridge.0",
-    "babel-jest": "22.4.3",
-    "enzyme": "3.2.0",
-    "enzyme-adapter-react-16": "1.1.1",
-    "jest": "22.0.1",
+    "@babel/core": "7.0.0-rc.1",
+    "babel-jest": "23.4.2",
+    "enzyme": "3.4.3",
+    "enzyme-adapter-react-16": "1.2.0",
+    "jest": "23.5.0",
     "react-addons-test-utils": "15.6.2",
-    "react-test-renderer": "16.2.0"
+    "react-test-renderer": "16.4.2"
   },
   "scripts": {
     "test": "NODE_ENV=test jest",


### PR DESCRIPTION
Running the [with-jest](https://github.com/zeit/next.js/tree/canary/examples/with-jest) example  results in the following error:

```log
 FAIL  __tests__/index.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins
      
      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.943s
Ran all test suites.
error Command failed with exit code 1.
```

Upgrading the dependencies (jest) to the latest version helps!

[More info](https://github.com/jsdom/jsdom/issues/2304)

Related #4776