### PR TITLE
customize root node id

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -56,8 +56,9 @@ delete window.__NEXT_LOADED_PAGES__
 window.__NEXT_REGISTER_PAGE = pageLoader.registerPage.bind(pageLoader)
 
 const headManager = new HeadManager()
-const appContainer = document.getElementById(`__next${process.env.ROOT_NODE}`)
-const errorContainer = document.getElementById(`__next-error${process.env.ROOT_NODE}`)
+const appContainer = document.getElementById(`__next${window.__NEXT_ROOT_NODE__}`)
+const errorContainer = document.getElementById(`__next-error${window.__NEXT_ROOT_NODE__}`)
+delete window.__NEXT_ROOT_NODE__
 
 let lastAppProps
 let webpackHMR

--- a/client/index.js
+++ b/client/index.js
@@ -56,8 +56,8 @@ delete window.__NEXT_LOADED_PAGES__
 window.__NEXT_REGISTER_PAGE = pageLoader.registerPage.bind(pageLoader)
 
 const headManager = new HeadManager()
-const appContainer = document.getElementById('__next')
-const errorContainer = document.getElementById('__next-error')
+const appContainer = document.getElementById(`__next${process.env.ROOT_NODE}`)
+const errorContainer = document.getElementById(`__next-error${process.env.ROOT_NODE}`)
 
 let lastAppProps
 let webpackHMR

--- a/server/document.js
+++ b/server/document.js
@@ -127,8 +127,8 @@ export class Main extends Component {
     const { html, errorHtml } = this.context._documentProps
     return (
       <Fragment>
-        <div id='__next' dangerouslySetInnerHTML={{ __html: html }} />
-        <div id='__next-error' dangerouslySetInnerHTML={{ __html: errorHtml }} />
+        <div id={`__next${process.env.ROOT_NODE}`} dangerouslySetInnerHTML={{ __html: html }} />
+        <div id={`__next-error${process.env.ROOT_NODE}`} dangerouslySetInnerHTML={{ __html: errorHtml }} />
       </Fragment>
     )
   }

--- a/server/document.js
+++ b/server/document.js
@@ -8,6 +8,10 @@ const Fragment = React.Fragment || function Fragment ({ children }) {
   return <div>{children}</div>
 }
 
+const rootNode = (process.env.ROOT_NODE)
+  ? `-${process.env.ROOT_NODE}`
+  : ''
+
 export default class Document extends Component {
   static childContextTypes = {
     _documentProps: PropTypes.any
@@ -127,8 +131,8 @@ export class Main extends Component {
     const { html, errorHtml } = this.context._documentProps
     return (
       <Fragment>
-        <div id={`__next${process.env.ROOT_NODE}`} dangerouslySetInnerHTML={{ __html: html }} />
-        <div id={`__next-error${process.env.ROOT_NODE}`} dangerouslySetInnerHTML={{ __html: errorHtml }} />
+        <div id={`__next${rootNode}`} dangerouslySetInnerHTML={{ __html: html }} />
+        <div id={`__next-error${rootNode}`} dangerouslySetInnerHTML={{ __html: errorHtml }} />
       </Fragment>
     )
   }
@@ -181,6 +185,7 @@ export class NextScript extends Component {
     const { page, pathname } = __NEXT_DATA__
 
     return `
+      __NEXT_ROOT_NODE__ = ${htmlescape(rootNode)}
       __NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)}
       module={}
       __NEXT_LOADED_PAGES__ = []


### PR DESCRIPTION
### Reason
currently, it is not possible to have multiple applications running on the same page, this PR purpose is to address this.

A use case when this is needed is when you are working on a microfrontend environment and your page needs to render react in multiple spaces

example:
```
<body>
  <fragment src="http://header"></fragment>
  <fragment src="http://home" primary></fragment>
  <fragment src="http://footer" async></fragment>
</body>
```

each fragment here  is a link to a next.js application

### Usage in package.json

```"dev": "ROOT_NODE=header next start"```