### PR TITLE
Warn if a specific page is not found in build manifest

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -43,6 +43,18 @@ export function renderErrorToHTML (err, req, res, pathname, query, opts = {}) {
   return doRender(req, res, pathname, query, { ...opts, err, page: '/_error' })
 }
 
+function getPageFiles (buildManifest, page) {
+  const normalizedPage = normalizePagePath(page)
+  const files = buildManifest.pages[normalizedPage]
+
+  if (!files) {
+    console.warn(`Could not find files for ${normalizedPage} in .next/build-manifest.json`)
+    return []
+  }
+
+  return files
+}
+
 async function doRender (req, res, pathname, query, {
   err,
   page,
@@ -87,9 +99,9 @@ async function doRender (req, res, pathname, query, {
   const devFiles = buildManifest.devFiles
   const files = [
     ...new Set([
-      ...buildManifest.pages[normalizePagePath(page)],
-      ...buildManifest.pages[normalizePagePath('/_app')],
-      ...buildManifest.pages[normalizePagePath('/_error')]
+      ...getPageFiles(buildManifest, page),
+      ...getPageFiles(buildManifest, '/_app'),
+      ...getPageFiles(buildManifest, '/_error')
     ])
   ]
 


### PR DESCRIPTION
There's an edge case @timothyis is running into, this will show exactly what files are missing.

I currently can't reproduce, so this is a first step at providing better error messages