### PR TITLE
Fix missing polyfills 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,8 @@
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-transform-runtime"
+    ["@babel/plugin-transform-runtime", {
+      "corejs": 2
+    }]
   ]
 }

--- a/client/index.js
+++ b/client/index.js
@@ -14,7 +14,7 @@ import Loadable from 'react-loadable'
 // This is needed because Webpack's dynamic loading(common chunks) code
 // depends on Promise.
 // So, we need to polyfill it.
-// See: https://github.com/webpack/webpack/issues/4254
+// See: https://webpack.js.org/guides/code-splitting/#dynamic-imports
 if (!window.Promise) {
   window.Promise = Promise
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-env": "7.0.0-rc.1",
     "@babel/preset-react": "7.0.0-rc.1",
     "@babel/runtime": "7.0.0-rc.1",
+    "@babel/runtime-corejs2": "7.0.0-rc.1",
     "@babel/template": "7.0.0-rc.1",
     "ansi-html": "0.0.7",
     "autodll-webpack-plugin": "0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -601,6 +601,13 @@
     "@babel/helper-plugin-utils" "7.0.0-beta.42"
     "@babel/plugin-transform-typescript" "7.0.0-beta.42"
 
+"@babel/runtime-corejs2@7.0.0-rc.1":
+  version "7.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-rc.1.tgz#cfef134702b731d69ad35f9b44b9326cc0d879bc"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@7.0.0-rc.1":
   version "7.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-rc.1.tgz#42f36fc5817911c89ea75da2b874054922967616"
@@ -2135,7 +2142,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 


### PR DESCRIPTION
## Issue

Since IE11 doesn't support Promises and Next.js needs them for [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports) we need to add a polyfill for them.

Before the upgrade to Babel 7 Next.js was using [babel-plugin-transform-runtime](https://www.npmjs.com/package/babel-plugin-transform-runtime), a package that automatically added polyfills by referencing them from core-js.

This has been changed in Babel v7: https://babeljs.io/docs/en/next/v7-migration#babel-runtime-babel-plugin-transform-runtime. From now on core-js isn't included per default. I think this is a good thing! 

## Solution

~~There are many different ways I could have fixed this issue. One way could have been to re-add core-js to Next.js. This probably would have been the safest way. But this would also add polyfills to the node.js based files (plus polyfills for e.g. `Set`, `Map`, …).~~

~~Thats why I chose an explicit polyfill. Just for the client part of the Next.js.~~

Edit: Using an explicit polyfill breaks a lot in IE11. Since we also need to polyfill object assign & more.

## Alternatives

- Use core-js@2 + babel-plugin-transform-runtime
- Use Webpack provide plugin
- Deprecate IE11 & Change the documentation 

## Related

Closes: https://github.com/zeit/next.js/pull/4988
Related: https://github.com/zeit/next.js/pull/5006

--------------

Please note that I am not an expert on this topic. Please carefully question my thoughts.
