### PR TITLE
Remove dublicate className from head

### DIFF
--- a/lib/head.js
+++ b/lib/head.js
@@ -20,8 +20,7 @@ export function defaultHead (className = NEXT_HEAD_IDENTIFIER) {
 
 function reduceComponents (components) {
   return components
-    .map((c) => c.props.children)
-    .map((children) => React.Children.toArray(children))
+    .map((component) => React.Children.toArray(component.props.children))
     .reduce((a, b) => a.concat(b), [])
     .reduce((a, b) => {
       if (React.Fragment && b.type === React.Fragment) {
@@ -30,8 +29,8 @@ function reduceComponents (components) {
       return a.concat(b)
     }, [])
     .reverse()
-    .concat(...defaultHead())
-    .filter((c) => !!c)
+    .concat(defaultHead())
+    .filter(Boolean)
     .filter(unique())
     .reverse()
     .map((c) => {

--- a/lib/head.js
+++ b/lib/head.js
@@ -12,8 +12,10 @@ class Head extends React.Component {
   }
 }
 
-export function defaultHead () {
-  return [<meta charSet='utf-8' />]
+const NEXT_HEAD_IDENTIFIER = 'next-head'
+
+export function defaultHead (className = NEXT_HEAD_IDENTIFIER) {
+  return [<meta charSet='utf-8' className={className} />]
 }
 
 function reduceComponents (components) {
@@ -33,7 +35,7 @@ function reduceComponents (components) {
     .filter(unique())
     .reverse()
     .map((c) => {
-      const className = (c.props && c.props.className ? c.props.className + ' ' : '') + 'next-head'
+      const className = (c.props && c.props.className ? c.props.className + ' ' : '') + NEXT_HEAD_IDENTIFIER
       return React.cloneElement(c, { className })
     })
 }

--- a/lib/head.js
+++ b/lib/head.js
@@ -13,7 +13,7 @@ class Head extends React.Component {
 }
 
 export function defaultHead () {
-  return [<meta charSet='utf-8' className='next-head' />]
+  return [<meta charSet='utf-8' />]
 }
 
 function reduceComponents (components) {


### PR DESCRIPTION
This PR:

* Removes dublicate `className` in: `<meta charSet="utf-8" class="next-head"/>`
* Refactores head reducer

Special thanks to @udanpe for reporting and @geoffRGWilliams for bringing me on the right tack! 🙌

Closes #4745, #4802 
