### PR TITLE
Remove dublicate className from head (followup)

### DIFF
--- a/lib/head.js
+++ b/lib/head.js
@@ -29,7 +29,7 @@ function reduceComponents (components) {
       return a.concat(b)
     }, [])
     .reverse()
-    .concat(defaultHead())
+    .concat(defaultHead(''))
     .filter(Boolean)
     .filter(unique())
     .reverse()

--- a/test/integration/basic/pages/default-head.js
+++ b/test/integration/basic/pages/default-head.js
@@ -1,0 +1,7 @@
+import React from 'react'
+import Head from 'next/head'
+
+export default () => <div>
+  <Head />
+  <h1>next-head, but only once.</h1>
+</div>

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -28,6 +28,7 @@ describe('Basic Features', () => {
     // pre-build all pages at the start
     await Promise.all([
       renderViaHTTP(context.appPort, '/async-props'),
+      renderViaHTTP(context.appPort, '/default-head'),
       renderViaHTTP(context.appPort, '/empty-get-initial-props'),
       renderViaHTTP(context.appPort, '/error'),
       renderViaHTTP(context.appPort, '/finish-response'),

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -26,6 +26,13 @@ export default function ({ app }, suiteName, render, fetch) {
       expect(answer.text()).toBe('The answer is 42')
     })
 
+    // default-head contains an empty <Head />.
+    test('header renders default charset', async () => {
+      const html = await (render('/default-head'))
+      expect(html.includes('<meta charSet="utf-8" class="next-head"/>')).toBeTruthy()
+      expect(html.includes('next-head, but only once.')).toBeTruthy()
+    })
+
     test('header helper renders header information', async () => {
       const html = await (render('/head'))
       expect(html.includes('<meta charSet="iso-8859-5" class="next-head"/>')).toBeTruthy()


### PR DESCRIPTION
Sorry missed the test 😬

This is a followup of: https://github.com/zeit/next.js/pull/5026