### PR TITLE
Remove of no-cache since its not correctly used when scripts are not loaded

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -139,7 +139,7 @@ async function doRender (req, res, pathname, query, {
 
 export async function renderScriptError (req, res, page, error) {
   // Asks CDNs and others to not to cache the errored page
-  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+  res.setHeader('Cache-Control', 'no-store, must-revalidate')
 
   if (error.code === 'ENOENT' || error.message === 'INVALID_BUILD_ID') {
     res.statusCode = 404


### PR DESCRIPTION
```
"no-cache" indicates that the returned response can't be used to satisfy a subsequent request to the same URL without first checking with the server if the response has changed. As a result, if a proper validation token (ETag) is present, no-cache incurs a roundtrip to validate the cached response, but can eliminate the download if the resource has not changed.
```

We do not respond with a E-TAG since there is no resource for this. 

```
By contrast, "no-store" is much simpler. It simply disallows the browser and all intermediate caches from storing any version of the returned response—for example, one containing private personal or banking data. Every time the user requests this asset, a request is sent to the server and a full response is downloaded.
```

Or we could skip the semantically correct and just return status code 500 when there is a wrong INVALID_BUILD_ID. In my feeling this only happens when upgrading a web service across multiple nodes.

User hits A and gets the server response, then fetches the scripts which hit B which isn't upgraded yet and that returns 404. In the best of the worlds the user should now navigate again and everything will be resolved. But what happens when the 404 gets stucked is very troublesome as its not resolvable by the client. And CDN's never caches 500's. So I would say this is more correct to avoid the problem. 