### PR TITLE
Send credentials with on-demand-entries-ping

### DIFF
--- a/client/on-demand-entries-client.js
+++ b/client/on-demand-entries-client.js
@@ -12,14 +12,14 @@ export default ({assetPrefix}) => {
     try {
       const url = `${assetPrefix || ''}/_next/on-demand-entries-ping?page=${Router.pathname}`
       const res = await fetch(url, {
-        credentials: 'omit'
+        credentials: 'same-origin'
       })
       const payload = await res.json()
       if (payload.invalid) {
         // Payload can be invalid even if the page is not exists.
         // So, we need to make sure it's exists before reloading.
         const pageRes = await fetch(location.href, {
-          credentials: 'omit'
+          credentials: 'same-origin'
         })
         if (pageRes.status === 200) {
           location.reload()


### PR DESCRIPTION
In my use case, the client pings are failing since the requests do not send basic auth credentials right now.

This change was made in https://github.com/zeit/next.js/pull/2509

I am not sure why it was undone as a part of https://github.com/zeit/next.js/pull/3578

Can someone explain why? Thanks.