### PR TITLE
Fix devtoolModuleFilenames for react-error-overlay

### DIFF
--- a/client/dev-error-overlay/hot-dev-client.js
+++ b/client/dev-error-overlay/hot-dev-client.js
@@ -55,9 +55,11 @@ let customHmrEventHandler
 export default function connect (options) {
   // Open stack traces in an editor.
   ErrorOverlay.setEditorHandler(function editorHandler ({ fileName, lineNumber, colNumber }) {
+    // Resolve invalid paths coming from react-error-overlay
+    const resolvedFilename = fileName.replace(/^webpack:\/\//, '')
     fetch(
       '/_next/development/open-stack-frame-in-editor' +
-        `?fileName=${window.encodeURIComponent(fileName)}` +
+        `?fileName=${window.encodeURIComponent(resolvedFilename)}` +
         `&lineNumber=${lineNumber || 1}` +
         `&colNumber=${colNumber || 1}`
     )


### PR DESCRIPTION
## Issue

Currently react-error-overlays launch-editor functionality doesn’t work because the module paths are in the wrong format.

## Todo

- [x] Keep source-maps enabled

## Related

https://github.com/zeit/next.js/pull/4979