### PR TITLE
Update .babelrc

### DIFF
--- a/examples/with-styled-components/.babelrc
+++ b/examples/with-styled-components/.babelrc
@@ -4,7 +4,7 @@
   ],
   "plugins": [
     [
-      "styled-components", 
+      "babel-plugin-styled-components", 
       {
         "ssr": true, 
         "displayName": true, 


### PR DESCRIPTION
Some really nasty Internal Server errors come as a result of not having the correct module name here.