### PR TITLE
Make sure that 404's is not cached by CDN:s

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -193,7 +193,7 @@ async function doRender (req, res, pathname, query, {
 
 export async function renderScriptError (req, res, page, error) {
   // Asks CDNs and others to not to cache the errored page
-  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+  res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
 
   if (error.code === 'ENOENT' || error.message === 'INVALID_BUILD_ID') {
     res.statusCode = 404


### PR DESCRIPTION
Currently Cloudflare will cache this for 5 minutes which may causes broken user sessions when where is a 404 returned during multiple nodes upgrading to the new asset