### PR TITLE
Remove module.exports from client bundles

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -185,7 +185,8 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
         }
         return '[name]'
       },
-      libraryTarget: 'commonjs2',
+      libraryTarget: isServer ? 'commonjs2' : 'jsonp',
+      libraryExport: isServer ? undefined : '',
       hotUpdateChunkFilename: 'static/webpack/[id].[hash].hot-update.js',
       hotUpdateMainFilename: 'static/webpack/[hash].hot-update.json',
       // This saves chunks with the name given via `import()`

--- a/build/webpack.js
+++ b/build/webpack.js
@@ -186,7 +186,6 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
         return '[name]'
       },
       libraryTarget: isServer ? 'commonjs2' : 'jsonp',
-      libraryExport: isServer ? undefined : '',
       hotUpdateChunkFilename: 'static/webpack/[id].[hash].hot-update.js',
       hotUpdateMainFilename: 'static/webpack/[hash].hot-update.json',
       // This saves chunks with the name given via `import()`

--- a/server/document.js
+++ b/server/document.js
@@ -182,7 +182,6 @@ export class NextScript extends Component {
 
     return `
       __NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)}
-      module={}
       __NEXT_LOADED_PAGES__ = []
 
       __NEXT_REGISTER_PAGE = function (route, fn) {


### PR DESCRIPTION
Removes `module.exports` so that `module` is no longer required

Ref: https://github.com/zeit/next.js/pull/4943#discussion_r213232263

This saves 15 bytes from every client bundle + 9 bytes from the initial HTML.