### PR TITLE
Remove unused flow definitions

### DIFF
--- a/examples/with-flow/flow-typed/next.js.flow
+++ b/examples/with-flow/flow-typed/next.js.flow
@@ -24,19 +24,6 @@ declare module "next/error" {
   declare module.exports: Class<React$Component<{statusCode: number}, any>>;
 }
 
-declare module "next/router" {
-  declare module.exports: {
-    route: string;
-    pathname: string;
-    query: Object;
-    onRouteChangeStart: ?((url: string) => void);
-    onRouteChangeComplete: ?((url: string) => void);
-    onRouteChangeError: ?((err: Error & {cancelled: boolean}, url: string) => void);
-    push(url: string, as: ?string): Promise<boolean>;
-    replace(url: string, as: ?string): Promise<boolean>;
-  };
-}
-
 declare module "next/document" {
   declare export var Head: Class<React$Component<any, any>>;
   declare export var Main: Class<React$Component<any, any>>;


### PR DESCRIPTION
The `with-flow` sample has some obsolete definitions which are unused by the sample code. Removing the un-imported declarations is the easiest approach.