### PR TITLE
Change server error overlay to white to be consistent with react-error-overlay

### DIFF
--- a/lib/error-debug.js
+++ b/lib/error-debug.js
@@ -36,7 +36,7 @@ const StackTrace = ({ error: { name, message, stack }, info }: any) => (
 
 export const styles = {
   errorDebug: {
-    background: '#0e0d0d',
+    background: '#ffffff',
     boxSizing: 'border-box',
     overflow: 'auto',
     padding: '24px',
@@ -46,14 +46,14 @@ export const styles = {
     top: 0,
     bottom: 0,
     zIndex: 9999,
-    color: '#b3adac'
+    color: '#000000'
   },
 
   stack: {
     fontFamily: '"SF Mono", "Roboto Mono", "Fira Mono", consolas, menlo-regular, monospace',
     fontSize: '13px',
     lineHeight: '18px',
-    color: '#b3adac',
+    color: '#777',
     margin: 0,
     whiteSpace: 'pre-wrap',
     wordWrap: 'break-word',
@@ -65,7 +65,7 @@ export const styles = {
     fontSize: '20px',
     fontWeight: '400',
     lineHeight: '28px',
-    color: '#fff',
+    color: '#000000',
     marginBottom: '0px',
     marginTop: '0px'
   }


### PR DESCRIPTION
Makes the server error overlay white so it doesn’t flicker when the error is hydrated into the client overlay