### PR TITLE
Use DefinePlugin to pass distDir instead of manually passing

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -133,7 +133,8 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
     .split(process.platform === 'win32' ? ';' : ':')
     .filter((p) => !!p)
 
-  const outputPath = path.join(dir, config.distDir, isServer ? SERVER_DIRECTORY : '')
+  const distDir = path.join(dir, config.distDir)
+  const outputPath = path.join(distDir, isServer ? SERVER_DIRECTORY : '')
   const pagesEntries = await getPages(dir, {nextPagesDir: DEFAULT_PAGES_DIR, dev, buildId, isServer, pageExtensions: config.pageExtensions.join('|')})
   const totalPages = Object.keys(pagesEntries).length
   const clientEntries = !isServer ? {
@@ -259,6 +260,10 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
       }),
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production')
+      }),
+      // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
+      !isServer && dev && new webpack.DefinePlugin({
+        'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)
       }),
       !dev && new webpack.optimize.ModuleConcatenationPlugin(),
       isServer && new PagesManifestPlugin(),

--- a/client/dev-error-overlay/hot-dev-client.js
+++ b/client/dev-error-overlay/hot-dev-client.js
@@ -33,10 +33,6 @@ import stripAnsi from 'strip-ansi'
 import {rewriteStacktrace} from '../source-map-support'
 import fetch from 'unfetch'
 
-const {
-  distDir
-} = window.__NEXT_DATA__
-
 // This alternative WebpackDevServer combines the functionality of:
 // https://github.com/webpack/webpack-dev-server/blob/webpack-1/client/index.js
 // https://github.com/webpack/webpack/blob/webpack-1/hot/dev-server.js
@@ -108,7 +104,8 @@ export default function connect (options) {
       const error = new Error(err.message)
       error.name = err.name
       error.stack = err.stack
-      rewriteStacktrace(error, distDir)
+      // __NEXT_DIST_DIR is provided by webpack
+      rewriteStacktrace(error, process.env.__NEXT_DIST_DIR)
       return error
     }
   }

--- a/server/render.js
+++ b/server/render.js
@@ -165,8 +165,6 @@ async function doRender (req, res, pathname, query, {
   if (!Document.prototype || !Document.prototype.isReactComponent) throw new Error('_document.js is not exporting a React component')
   const doc = <Document {...{
     __NEXT_DATA__: {
-      // Used in development to replace paths for react-error-overlay
-      distDir: dev ? distDir : undefined,
       props, // The result of getInitialProps
       page, // The rendered page
       pathname, // The requested path


### PR DESCRIPTION
This removes `distDir` from the HTML sent to the client as it's static anyway and it might confuse/alarm users when they see it in development mode.