### PR TITLE
Remove __next-error div

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -14,9 +14,9 @@ export default class Document extends Component {
   }
 
   static getInitialProps ({ renderPage }) {
-    const { html, head, errorHtml, buildManifest } = renderPage()
+    const { html, head, buildManifest } = renderPage()
     const styles = flush()
-    return { html, head, errorHtml, styles, buildManifest }
+    return { html, head, styles, buildManifest }
   }
 
   getChildContext () {
@@ -124,11 +124,10 @@ export class Main extends Component {
   }
 
   render () {
-    const { html, errorHtml } = this.context._documentProps
+    const { html } = this.context._documentProps
     return (
       <Fragment>
         <div id='__next' dangerouslySetInnerHTML={{ __html: html }} />
-        <div id='__next-error' dangerouslySetInnerHTML={{ __html: errorHtml }} />
       </Fragment>
     )
   }

--- a/server/render.js
+++ b/server/render.js
@@ -138,11 +138,10 @@ async function doRender (req, res, pathname, query, {
 
     let html
     let head
-    let errorHtml = ''
 
     try {
       if (err && dev) {
-        errorHtml = render(<ErrorDebug error={err} />)
+        html = render(<ErrorDebug error={err} />)
       } else if (err) {
         html = render(app)
       } else {
@@ -152,7 +151,7 @@ async function doRender (req, res, pathname, query, {
       head = Head.rewind() || defaultHead()
     }
 
-    return { html, head, errorHtml, buildManifest }
+    return { html, head, buildManifest }
   }
 
   await Loadable.preloadAll() // Make sure all dynamic imports are loaded


### PR DESCRIPTION
`__next-error` is no longer needed as we always render in the `__next` div since a while.