### PR TITLE
update hoist-non-react-statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "fresh": "0.5.2",
     "friendly-errors-webpack-plugin": "1.6.1",
     "glob": "7.1.2",
-    "hoist-non-react-statics": "2.5.0",
+    "hoist-non-react-statics": "2.5.5",
     "htmlescape": "1.1.1",
     "http-errors": "1.6.2",
     "http-status": "1.0.1",


### PR DESCRIPTION
you folks should really use semver ranges, but since greenkeeper
is no longer running for this branch things have fallen behind

in particular, there seems to be an incompatibility with multiple
v2.x versions of this package in the same bundle as displayed here:

https://github.com/styled-components/styled-components/issues/1972

When I force resolution to a particular h-n-r-s version, the issue
goes away. This is true for both next 6 and next 7 canary.

But really you folks should use semver carets instead of pinning