### PR TITLE
fix preset-env modules config

### DIFF
--- a/build/babel/preset.js
+++ b/build/babel/preset.js
@@ -33,7 +33,7 @@ module.exports = (context, opts = {}) => ({
     [require('@babel/preset-env').default, {
       // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
       // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
-      modules: isDevelopment && isProduction ? false : 'auto',
+      modules: isDevelopment || isProduction ? false : 'auto',
       ...opts['preset-env']
     }],
     [require('@babel/preset-react'), {


### PR DESCRIPTION
I think this might have been a typo introduced by https://github.com/zeit/next.js/pull/5081, as I don't see a case where isDevelopment && isProduction would ever be true.