### PR TITLE
Fix @babel/env modules config

### DIFF
--- a/build/babel/preset.js
+++ b/build/babel/preset.js
@@ -33,7 +33,7 @@ module.exports = (context, opts = {}) => ({
     [require('@babel/preset-env').default, {
       // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
       // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
-      modules: isDevelopment && isProduction ? false : 'auto',
+      modules: isDevelopment || isProduction ? false : 'auto',
       ...opts['preset-env']
     }],
     [require('@babel/preset-react'), {


### PR DESCRIPTION
Probably an oversight but currently env preset's `modules` option always evaluates to 'auto'. We probably want it to be set to false, especially in prod, to have Webpack handle modules natively.