### PR TITLE
Make non-existent routes under `/_next` return 404

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -180,6 +180,11 @@ export default class Server {
         }
       }
 
+      // This path is needed because `render()` does a check for `/_next` and the calls the routing again
+      routes['/_next/:path*'] = async (req, res, params, parsedUrl) => {
+        await this.render404(req, res, parsedUrl)
+      }
+
       // It's very important keep this route's param optional.
       // (but it should support as many as params, seperated by '/')
       // Othewise this will lead to a pretty simple DOS attack.

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -2,7 +2,7 @@
 
 import cheerio from 'cheerio'
 
-export default function ({ app }, suiteName, render, fetch) {
+export default function ({ app }, suiteName, render, fetch, appPort) {
   async function get$ (path, query) {
     const html = await render(path, query)
     return cheerio.load(html)
@@ -121,6 +121,11 @@ export default function ({ app }, suiteName, render, fetch) {
     test('setting Content-Type in getInitialProps', async () => {
       const res = await fetch('/custom-encoding')
       expect(res.headers.get('Content-Type')).toMatch('text/html; charset=iso-8859-2')
+    })
+
+    test('should render 404 for _next routes that do not exist', async () => {
+      const res = await fetch('/_next/abcdef')
+      expect(res.status).toBe(404)
     })
 
     test('allows to import .json files', async () => {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -54,6 +54,12 @@ describe('Production Usage', () => {
       expect(res2.status).toBe(304)
     })
 
+    it('should render 404 for _next routes that do not exist', async () => {
+      const url = `http://localhost:${appPort}/_next/abcdef`
+      const res = await fetch(url)
+      expect(res.status).toBe(404)
+    })
+
     it('should set Cache-Control header', async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
       const buildManifest = require(join('../.next', BUILD_MANIFEST))


### PR DESCRIPTION
Fixes #5114

Also adds a test for it.