### PR TITLE
Fix Cache Control headers for 404 response from next.js server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -386,6 +386,7 @@ export default class Server {
   async render404 (req, res, parsedUrl = parseUrl(req.url, true)) {
     const { pathname, query } = parsedUrl
     res.statusCode = 404
+    res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
     return this.renderError(null, req, res, pathname, query)
   }
 

--- a/server/render.js
+++ b/server/render.js
@@ -139,7 +139,7 @@ async function doRender (req, res, pathname, query, {
 
 export async function renderScriptError (req, res, page, error) {
   // Asks CDNs and others to not to cache the errored page
-  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+  res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
 
   if (error.code === 'ENOENT' || error.message === 'INVALID_BUILD_ID') {
     res.statusCode = 404

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -78,6 +78,23 @@ describe('Production Usage', () => {
       })
     })
 
+    it('should set correct Cache-Control header for 404 in build folder', async () => {
+      // this is to fix CDNs are caching these 404s
+      const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
+      const res = await fetch(`http://localhost:${appPort}/_next/${buildId}/page/bad-index-file.js`)
+
+      expect(res.status).toBe(404)
+      expect(res.headers.get('Cache-Control')).toBe('no-cache, no-store, max-age=0, must-revalidate')
+    })
+
+    it('should set correct Cache-Control header for 404 on static folder', async () => {
+      // this is to fix where 404 headers are set to 'public, max-age=31536000, immutable'
+      const res = await fetch(`http://localhost:${appPort}/_next//static/common/bad-static.js`)
+
+      expect(res.status).toBe(404)
+      expect(res.headers.get('Cache-Control')).toBe('no-cache, no-store, max-age=0, must-revalidate')
+    })
+
     it('should block special pages', async () => {
       const urls = ['/_document', '/_error']
       for (const url of urls) {


### PR DESCRIPTION
This PR is against 6.1.1 to fix two issues with `Cache-Control` header when next.js server returns 404 responses

1. Adds `max-age=0` to Cache Control for CDNs
2. Overrides 'public, max-age=31536000, immutable' with `no-cache, no-store, max-age=0, must-revalidate` when the response is a 404

We ran into both these issues where the CDN would cache these 404 responses.

[max-age CDN pr reference](https://github.com/zeit/next.js/pull/5088)
[main chunk returns public header reference](https://github.com/zeit/next.js/pull/4322)

Thanks for your consideration