### PR TITLE
Update 404 static cache header to not cache

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -310,6 +310,7 @@ export default class Server {
   async render404 (req, res, parsedUrl = parseUrl(req.url, true)) {
     const { pathname, query } = parsedUrl
     res.statusCode = 404
+    res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
     return this.renderError(null, req, res, pathname, query)
   }
 

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -91,6 +91,14 @@ describe('Production Usage', () => {
       })
     })
 
+    it('should set correct Cache-Control header for static 404s', async () => {
+      // this is to fix where 404 headers are set to 'public, max-age=31536000, immutable'
+      const res = await fetch(`http://localhost:${appPort}/_next//static/common/bad-static.js`)
+
+      expect(res.status).toBe(404)
+      expect(res.headers.get('Cache-Control')).toBe('no-cache, no-store, max-age=0, must-revalidate')
+    })
+
     it('should block special pages', async () => {
       const urls = ['/_document', '/_error']
       for (const url of urls) {


### PR DESCRIPTION
This PR is to fix issue with `Cache-Control` header when next.js server returns 404 responses

1. Overrides 'public, max-age=31536000, immutable' with `no-cache, no-store, max-age=0, must-revalidate` when the response is a 404

We ran into this issue where the CDN would cache the 404 responses.

[main chunk returns public header reference](https://github.com/zeit/next.js/pull/4322)
[old pr against master](https://github.com/zeit/next.js/pull/5142)

Thanks for your consideration