### PR TITLE
Add `crossOrigin` attribute to all script tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ class MyLink extends React.Component {
         <a onClick={() => setTimeout(() => router.push('/dynamic'), 100)}>
           A route transition will happen after 100ms
         </a>
-      </div>   
+      </div>
     )
   }
 }
@@ -1291,11 +1291,11 @@ The second argument to `webpack` is an object containing properties useful when 
   - `babel` - `Object` the `babel-loader` configuration for Next.js.
   - `hotSelfAccept` - `Object` the `hot-self-accept-loader` configuration. This loader should only be used for advanced use cases. For example [`@zeit/next-typescript`](https://github.com/zeit/next-plugins/tree/master/packages/next-typescript) adds it for top-level typescript pages.
 
-Example usage of `defaultLoaders.babel`: 
+Example usage of `defaultLoaders.babel`:
 
 ```js
 // Example next.config.js for adding a loader that depends on babel-loader
-// This source was taken from the @zeit/next-mdx plugin source: 
+// This source was taken from the @zeit/next-mdx plugin source:
 // https://github.com/zeit/next-plugins/blob/master/packages/next-mdx
 module.exports = {
   webpack: (config, {}) => {
@@ -1413,6 +1413,14 @@ module.exports = {
 
 Note: Next.js will automatically use that prefix in the scripts it loads, but this has no effect whatsoever on `/static`. If you want to serve those assets over the CDN, you'll have to introduce the prefix yourself. One way of introducing a prefix that works inside your components and varies by environment is documented [in this example](https://github.com/zeit/next.js/tree/master/examples/with-universal-configuration).
 
+If your CDN is on a separate domain and you would like assets to be requested using a [CORS aware request](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) you can specify the `assetCrossOrigin` setting which is then used for all Next.js asset tags.
+
+```js
+module.exports = {
+  assetCrossOrigin: 'anonymous'
+}
+```
+
 ## Production deployment
 
 To deploy, instead of running `next`, you want to build for production usage ahead of time. Therefore, building and starting are separate commands:
@@ -1448,7 +1456,7 @@ Note: we recommend putting `.next`, or your [custom dist folder](https://github.
 
 ## Browser support
 
-Next.js supports IE11 and all modern browsers out of the box using [`@babel/preset-env`](https://new.babeljs.io/docs/en/next/babel-preset-env.html). In order to support IE11 Next.js adds a global `Promise` polyfill. In cases where your own code or any external NPM dependencies you are using requires features not supported by your target browsers you will need to implement polyfills. 
+Next.js supports IE11 and all modern browsers out of the box using [`@babel/preset-env`](https://new.babeljs.io/docs/en/next/babel-preset-env.html). In order to support IE11 Next.js adds a global `Promise` polyfill. In cases where your own code or any external NPM dependencies you are using requires features not supported by your target browsers you will need to implement polyfills.
 
 The [polyfills](https://github.com/zeit/next.js/tree/canary/examples/with-polyfills) example demonstrates the recommended approach to implement polyfills.
 
@@ -1479,7 +1487,7 @@ next build
 next export
 ```
 
-By default `next export` doesn't require any configuration. It will generate a default `exportPathMap` containing the routes to pages inside the `pages` directory. This default mapping is available as `defaultPathMap` in the example below. 
+By default `next export` doesn't require any configuration. It will generate a default `exportPathMap` containing the routes to pages inside the `pages` directory. This default mapping is available as `defaultPathMap` in the example below.
 
 If your application has dynamic routes you can add a dynamic `exportPathMap` in `next.config.js`.
 This function is asynchronous and gets the default `exportPathMap` as a parameter.
@@ -1541,7 +1549,7 @@ now
 ### Copying custom files
 
 In case you have to copy custom files like a robots.txt or generate a sitemap.xml you can do this inside of `exportPathMap`.
-`exportPathMap` gets a few contextual parameter to aid you with creating/copying files: 
+`exportPathMap` gets a few contextual parameter to aid you with creating/copying files:
 
 - `dev` - `true` when `exportPathMap` is being called in development. `false` when running `next export`. In development `exportPathMap` is used to define routes and behavior like copying files is not required.
 - `dir` - Absolute path to the project directory

--- a/client/index.js
+++ b/client/index.js
@@ -28,6 +28,7 @@ const {
     query,
     buildId,
     assetPrefix,
+    assetCrossOrigin,
     runtimeConfig
   },
   location
@@ -48,7 +49,7 @@ envConfig.setConfig({
 
 const asPath = getURL()
 
-const pageLoader = new PageLoader(buildId, prefix)
+const pageLoader = new PageLoader(buildId, prefix, assetCrossOrigin)
 window.__NEXT_LOADED_PAGES__.forEach(({ route, fn }) => {
   pageLoader.registerPage(route, fn)
 })

--- a/lib/page-loader.js
+++ b/lib/page-loader.js
@@ -4,9 +4,10 @@ import EventEmitter from './EventEmitter'
 const webpackModule = module
 
 export default class PageLoader {
-  constructor (buildId, assetPrefix) {
+  constructor (buildId, assetPrefix, assetCrossOrigin) {
     this.buildId = buildId
     this.assetPrefix = assetPrefix
+    this.assetCrossOrigin = assetCrossOrigin || null
 
     this.pageCache = {}
     this.pageLoadedHandlers = {}
@@ -71,6 +72,7 @@ export default class PageLoader {
     const script = document.createElement('script')
     const url = `${this.assetPrefix}/_next/static/${encodeURIComponent(this.buildId)}/pages${scriptRoute}`
     script.src = url
+    if (this.assetCrossOrigin) script.crossOrigin = this.assetCrossOrigin
     script.onerror = () => {
       const error = new Error(`Error when loading route: ${route}`)
       error.code = 'PAGE_LOAD_ERROR'

--- a/server/config.js
+++ b/server/config.js
@@ -12,6 +12,7 @@ export type NextConfig = {|
   poweredByHeader: boolean,
   distDir: string,
   assetPrefix: string,
+  assetCrossOrigin: null | string,
   configOrigin: string,
   useFileSystemPublicRoutes: boolean,
   generateBuildId: () => string,
@@ -25,6 +26,7 @@ const defaultConfig: NextConfig = {
   poweredByHeader: true,
   distDir: '.next',
   assetPrefix: '',
+  assetCrossOrigin: null,
   configOrigin: 'default',
   useFileSystemPublicRoutes: true,
   generateBuildId: () => {

--- a/server/document.js
+++ b/server/document.js
@@ -44,7 +44,7 @@ export class Head extends Component {
   }
 
   getCssLinks () {
-    const { assetPrefix, files } = this.context._documentProps
+    const { assetPrefix, assetCrossOrigin, files } = this.context._documentProps
     if(!files || files.length === 0) {
       return null
     }
@@ -60,12 +60,13 @@ export class Head extends Component {
         nonce={this.props.nonce}
         rel='stylesheet'
         href={`${assetPrefix}/_next/${file}`}
+        crossOrigin={assetCrossOrigin}
       />
     })
   }
 
   getPreloadDynamicChunks () {
-    const { dynamicImports, assetPrefix } = this.context._documentProps
+    const { dynamicImports, assetPrefix, assetCrossOrigin } = this.context._documentProps
     return dynamicImports.map((bundle) => {
       return <link
         rel='preload'
@@ -73,12 +74,13 @@ export class Head extends Component {
         href={`${assetPrefix}/_next/${bundle.file}`}
         as='script'
         nonce={this.props.nonce}
+        crossOrigin={assetCrossOrigin}
       />
     })
   }
 
   getPreloadMainLinks () {
-    const { assetPrefix, files } = this.context._documentProps
+    const { assetPrefix, assetCrossOrigin, files } = this.context._documentProps
     if(!files || files.length === 0) {
       return null
     }
@@ -95,20 +97,21 @@ export class Head extends Component {
         rel='preload'
         href={`${assetPrefix}/_next/${file}`}
         as='script'
+        crossOrigin={assetCrossOrigin}
       />
     })
   }
 
   render () {
-    const { head, styles, assetPrefix, __NEXT_DATA__ } = this.context._documentProps
+    const { head, styles, assetPrefix, assetCrossOrigin, __NEXT_DATA__ } = this.context._documentProps
     const { page, pathname, buildId } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
     return <head {...this.props}>
       {(head || []).map((h, i) => React.cloneElement(h, { key: h.key || i }))}
-      {page !== '/_error' && <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} as='script' nonce={this.props.nonce} />}
-      <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages/_app.js`} as='script' nonce={this.props.nonce} />
-      <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages/_error.js`} as='script' nonce={this.props.nonce} />
+      {page !== '/_error' && <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} as='script' nonce={this.props.nonce} crossOrigin={assetCrossOrigin} />}
+      <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages/_app.js`} as='script' nonce={this.props.nonce} crossOrigin={assetCrossOrigin} />
+      <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages/_error.js`} as='script' nonce={this.props.nonce} crossOrigin={assetCrossOrigin }/>
       {this.getPreloadDynamicChunks()}
       {this.getPreloadMainLinks()}
       {this.getCssLinks()}
@@ -143,19 +146,20 @@ export class NextScript extends Component {
   }
 
   getDynamicChunks () {
-    const { dynamicImports, assetPrefix } = this.context._documentProps
+    const { dynamicImports, assetPrefix, assetCrossOrigin } = this.context._documentProps
     return dynamicImports.map((bundle) => {
       return <script
         async
         key={bundle.file}
         src={`${assetPrefix}/_next/${bundle.file}`}
-            nonce={this.props.nonce}
+        nonce={this.props.nonce}
+        crossOrigin={assetCrossOrigin}
       />
     })
   }
 
   getScripts () {
-    const { assetPrefix, files } = this.context._documentProps
+    const { assetPrefix, assetCrossOrigin, files } = this.context._documentProps
     if(!files || files.length === 0) {
       return null
     }
@@ -171,6 +175,7 @@ export class NextScript extends Component {
         src={`${assetPrefix}/_next/${file}`}
         nonce={this.props.nonce}
         async
+        crossOrigin={assetCrossOrigin}
       />
     })
   }
@@ -197,18 +202,18 @@ export class NextScript extends Component {
   }
 
   render () {
-    const { staticMarkup, assetPrefix, devFiles, __NEXT_DATA__ } = this.context._documentProps
+    const { staticMarkup, assetPrefix, assetCrossOrigin, devFiles, __NEXT_DATA__ } = this.context._documentProps
     const { page, pathname, buildId } = __NEXT_DATA__
     const pagePathname = getPagePathname(pathname)
 
     return <Fragment>
-      {devFiles ? devFiles.map((file) => <script key={file} src={`${assetPrefix}/_next/${file}`} nonce={this.props.nonce} />) : null}
+      {devFiles ? devFiles.map((file) => <script key={file} src={`${assetPrefix}/_next/${file}`} nonce={this.props.nonce} crossOrigin={assetCrossOrigin} />) : null}
       {staticMarkup ? null : <script nonce={this.props.nonce} dangerouslySetInnerHTML={{
         __html: NextScript.getInlineScriptSource(this.context._documentProps)
       }} />}
-      {page !== '/_error' && <script async id={`__NEXT_PAGE__${pathname}`} src={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} nonce={this.props.nonce} />}
-      <script async id={`__NEXT_PAGE__/_app`} src={`${assetPrefix}/_next/static/${buildId}/pages/_app.js`} nonce={this.props.nonce} />
-      <script async id={`__NEXT_PAGE__/_error`} src={`${assetPrefix}/_next/static/${buildId}/pages/_error.js`} nonce={this.props.nonce} />
+      {page !== '/_error' && <script async id={`__NEXT_PAGE__${pathname}`} src={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} nonce={this.props.nonce} crossOrigin={assetCrossOrigin} />}
+      <script async id={`__NEXT_PAGE__/_app`} src={`${assetPrefix}/_next/static/${buildId}/pages/_app.js`} nonce={this.props.nonce} crossOrigin={assetCrossOrigin} />
+      <script async id={`__NEXT_PAGE__/_error`} src={`${assetPrefix}/_next/static/${buildId}/pages/_error.js`} nonce={this.props.nonce} crossOrigin={assetCrossOrigin} />
       {staticMarkup ? null : this.getDynamicChunks()}
       {staticMarkup ? null : this.getScripts()}
     </Fragment>

--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,7 @@ export default class Server {
 
     // Only serverRuntimeConfig needs the default
     // publicRuntimeConfig gets it's default in client/index.js
-    const {serverRuntimeConfig = {}, publicRuntimeConfig, assetPrefix, generateEtags} = this.nextConfig
+    const {serverRuntimeConfig = {}, publicRuntimeConfig, assetPrefix, assetCrossOrigin, generateEtags} = this.nextConfig
 
     if (!dev && !fs.existsSync(resolve(this.distDir, BUILD_ID_FILE))) {
       console.error(`> Could not find a valid build in the '${this.distDir}' directory! Try building your app with 'next build' before starting the server.`)
@@ -64,6 +64,7 @@ export default class Server {
     })
 
     this.setAssetPrefix(assetPrefix)
+    this.renderOpts.assetCrossOrigin = assetCrossOrigin
   }
 
   getHotReloader (dir, options) {

--- a/server/render.js
+++ b/server/render.js
@@ -62,6 +62,7 @@ async function doRender (req, res, pathname, query, {
   buildId,
   hotReloader,
   assetPrefix,
+  assetCrossOrigin,
   runtimeConfig,
   distDir,
   dir,
@@ -170,6 +171,7 @@ async function doRender (req, res, pathname, query, {
       query, // querystring parsed / passed by the user
       buildId, // buildId is used to facilitate caching of page bundles, we send it to the client so that pageloader knows where to load bundles
       assetPrefix: assetPrefix === '' ? undefined : assetPrefix, // send assetPrefix to the client side when configured, otherwise don't sent in the resulting HTML
+      assetCrossOrigin, // send assetCrossOrigin to the client
       runtimeConfig, // runtimeConfig if provided, otherwise don't sent in the resulting HTML
       nextExport, // If this is a page exported by `next export`
       err: (err) ? serializeError(dev, err) : undefined // Error if one happened, otherwise don't sent in the resulting HTML
@@ -182,6 +184,7 @@ async function doRender (req, res, pathname, query, {
     files,
     dynamicImports,
     assetPrefix, // We always pass assetPrefix as a top level property since _document needs it to render, even though the client side might not need it
+    assetCrossOrigin, // pass assetCrossOrigin as a top level property since _document needs it to render
     ...docProps
   }} />
 


### PR DESCRIPTION
If this isn't right or you can think of another solution then I'm happy to rework this. It's a feature we would like though, so I thought I'd get some working code to demonstrate it.

---

So that users can opt-in to having `crossOrigin` attributes added to all
Next.js generated script tags and link tags.

The `crossOrigin` tag is needed when trying to use service workers and
having assets on a CDN. Otherwise the service worker can't interrogate
the responses which come back and doesn't know if it's allowed to cache
the responses. This change will let us anonymously request JavaScript
assets so they can be properly cached.

