### PR TITLE
Remove obsolete webpack plugins

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -267,9 +267,6 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
         // required not to cache removed files
         useHashIndex: false
       }),
-      new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production')
-      }),
       // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
       !isServer && dev && new webpack.DefinePlugin({
         'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)

--- a/build/webpack.js
+++ b/build/webpack.js
@@ -271,7 +271,6 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
       !isServer && dev && new webpack.DefinePlugin({
         'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)
       }),
-      !dev && new webpack.optimize.ModuleConcatenationPlugin(),
       isServer && new PagesManifestPlugin(),
       !isServer && new BuildManifestPlugin(),
       !isServer && new PagesPlugin(),

--- a/test/integration/basic/pages/process-env.js
+++ b/test/integration/basic/pages/process-env.js
@@ -1,0 +1,3 @@
+export default () => (
+  <div id='node-env'>{process.env.NODE_ENV}</div>
+)

--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -16,6 +16,7 @@ import hmr from './hmr'
 import errorRecovery from './error-recovery'
 import dynamic from './dynamic'
 import asset from './asset'
+import processEnv from './process-env'
 
 const context = {}
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
@@ -42,6 +43,7 @@ describe('Basic Features', () => {
       renderViaHTTP(context.appPort, '/with-cdm'),
       renderViaHTTP(context.appPort, '/url-prop'),
       renderViaHTTP(context.appPort, '/url-prop-override'),
+      renderViaHTTP(context.appPort, '/process-env'),
 
       renderViaHTTP(context.appPort, '/nav'),
       renderViaHTTP(context.appPort, '/nav/about'),
@@ -71,4 +73,5 @@ describe('Basic Features', () => {
   hmr(context, (p, q) => renderViaHTTP(context.appPort, p, q))
   errorRecovery(context, (p, q) => renderViaHTTP(context.appPort, p, q))
   asset(context)
+  processEnv(context)
 })

--- a/test/integration/basic/test/process-env.js
+++ b/test/integration/basic/test/process-env.js
@@ -1,0 +1,13 @@
+/* global describe, it, expect */
+import webdriver from 'next-webdriver'
+
+export default (context, render) => {
+  describe('process.env', () => {
+    it('should set process.env.NODE_ENV in development', async () => {
+      const browser = await webdriver(context.appPort, '/process-env')
+      const nodeEnv = await browser.elementByCss('#node-env').text()
+      expect(nodeEnv).toBe('development')
+      browser.close()
+    })
+  })
+}

--- a/test/integration/production/pages/process-env.js
+++ b/test/integration/production/pages/process-env.js
@@ -1,0 +1,3 @@
+export default () => (
+  <div id='node-env'>{process.env.NODE_ENV}</div>
+)

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -14,6 +14,7 @@ import {
 import webdriver from 'next-webdriver'
 import fetch from 'node-fetch'
 import dynamicImportTests from './dynamic'
+import processEnv from './process-env'
 import security from './security'
 import {BUILD_MANIFEST, REACT_LOADABLE_MANIFEST} from 'next/constants'
 
@@ -277,5 +278,6 @@ describe('Production Usage', () => {
 
   dynamicImportTests(context, (p, q) => renderViaHTTP(context.appPort, p, q))
 
+  processEnv(context)
   security(context)
 })

--- a/test/integration/production/test/process-env.js
+++ b/test/integration/production/test/process-env.js
@@ -1,0 +1,13 @@
+/* global describe, it, expect */
+import webdriver from 'next-webdriver'
+
+export default (context) => {
+  describe('process.env', () => {
+    it('should set process.env.NODE_ENV in production', async () => {
+      const browser = await webdriver(context.appPort, '/process-env')
+      const nodeEnv = await browser.elementByCss('#node-env').text()
+      expect(nodeEnv).toBe('production')
+      browser.close()
+    })
+  })
+}


### PR DESCRIPTION
Since we are now using webpacks `mode` flag we can get rid of:

* `webpack.optimize.ModuleConcatenationPlugin`
* `webpack.DefinePlugin` (`process.env.NODE_ENV`)

https://webpack.js.org/concepts/mode/