### PR TITLE
Eliminate context code based on process.browser  

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -274,6 +274,10 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
         // required not to cache removed files
         useHashIndex: false
       }),
+      // Removes server/client code by minifier
+      new webpack.DefinePlugin({
+        'process.browser': JSON.stringify(!isServer)
+      }),
       // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
       !isServer && dev && new webpack.DefinePlugin({
         'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)

--- a/test/integration/production/pages/process-env.js
+++ b/test/integration/production/pages/process-env.js
@@ -1,3 +1,12 @@
+
+if (process.browser) {
+  global.__THIS_SHOULD_ONLY_BE_DEFINED_IN_BROWSER_CONTEXT__ = true
+}
+
+if (!process.browser) {
+  global.__THIS_SHOULD_ONLY_BE_DEFINED_IN_SERVER_CONTEXT__ = true
+}
+
 export default () => (
   <div id='node-env'>{process.env.NODE_ENV}</div>
 )

--- a/test/integration/production/test/process-env.js
+++ b/test/integration/production/test/process-env.js
@@ -1,5 +1,11 @@
 /* global describe, it, expect */
 import webdriver from 'next-webdriver'
+import { readFile } from 'fs'
+import { promisify } from 'util'
+import { join } from 'path'
+
+const readFileAsync = promisify(readFile)
+const readNextBuildFile = (relativePath) => readFileAsync(join(__dirname, '../.next', relativePath), 'utf8')
 
 export default (context) => {
   describe('process.env', () => {
@@ -8,6 +14,22 @@ export default (context) => {
       const nodeEnv = await browser.elementByCss('#node-env').text()
       expect(nodeEnv).toBe('production')
       browser.close()
+    })
+  })
+
+  describe('process.browser', () => {
+    it('should eliminate server only code on the client', async () => {
+      const buildId = await readNextBuildFile('./BUILD_ID')
+      const clientCode = await readNextBuildFile(`./static/${buildId}/pages/process-env.js`)
+      expect(clientCode).toMatch(/__THIS_SHOULD_ONLY_BE_DEFINED_IN_BROWSER_CONTEXT__/)
+      expect(clientCode).not.toMatch(/__THIS_SHOULD_ONLY_BE_DEFINED_IN_SERVER_CONTEXT__/)
+    })
+
+    it('should eliminate client only code on the server', async () => {
+      const buildId = await readNextBuildFile('./BUILD_ID')
+      const serverCode = await readNextBuildFile(`./server/static/${buildId}/pages/process-env.js`)
+      expect(serverCode).not.toMatch(/__THIS_SHOULD_ONLY_BE_DEFINED_IN_BROWSER_CONTEXT__/)
+      expect(serverCode).toMatch(/__THIS_SHOULD_ONLY_BE_DEFINED_IN_SERVER_CONTEXT__/)
     })
   })
 }


### PR DESCRIPTION
This PR allows next.js to eliminate context based code. 

## Example

```js
if (process.browser) {
   console.log('This code will be removed from the server bundle')
}
```

```js
if (!process.browser) {
   console.log('This code will be removed from the client bundle')
}
```

In addition to that it will remove webpacks process module.

## Todo

- [x]  Add `webpack.DefinePlugin`
- [x] Add client test
- [x] Add server test

<hr />

**Edit:** The older commits (prop-type stuff) will be part of a different PR.