### PR TITLE
Remove reference to ./css.js from npm files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "client.js",
     "config.js",
     "constants.js",
-    "css.js",
     "document.js",
     "dynamic.js",
     "error.js",


### PR DESCRIPTION
./css.js has been removed with [e093441](https://github.com/zeit/next.js/commit/e093441bad588e98765a05df90f76f75283eda07#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)