### PR TITLE
Make sure react always ends up in the commons bundle

### DIFF
--- a/build/webpack.js
+++ b/build/webpack.js
@@ -99,6 +99,11 @@ function optimizationConfig ({dir, dev, isServer, totalPages}) {
     chunks: 'all',
     minChunks: totalPages > 2 ? totalPages * 0.5 : 2
   }
+  config.splitChunks.cacheGroups.react = {
+    name: 'commons',
+    chunks: 'all',
+    test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/
+  }
 
   return config
 }


### PR DESCRIPTION
Fixes an edge case where some library imports react-dom by itself, like react-spring.