### PR TITLE
Keep warnings when process.env.NODE_ENV is not production

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -31,7 +31,7 @@ export default class Error extends React.Component {
   }
 }
 
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV !== 'production') {
   Error.propTypes = {
     statusCode: PropTypes.number
   }

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -78,7 +78,7 @@ export default class Router {
     }
 
     const { url, as, options } = e.state
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV !== 'production') {
       if (typeof url === 'undefined' || typeof as === 'undefined') {
         console.warn('`popstate` event triggered but `event.state` did not have `url` or `as` https://err.sh/zeit/next.js/popstate-state-empty')
       }


### PR DESCRIPTION
This way the warnings will work in test mode. (`process.env.NODE_ENV === „test“`)

