### PR TITLE
"Unhandled Rejection (TypeError): Cannot read property 'call' of undefined" when trying to change pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ coverage
 # test output
 test/**/out
 .DS_Store
+
+# Editor
+**/.idea

--- a/examples/with-ant-design-less/.babelrc
+++ b/examples/with-ant-design-less/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": ["next/babel"],
   "plugins": [
-    "transform-decorators-legacy",
     [
       "import",
       {

--- a/examples/with-ant-design-less/components/Header.js
+++ b/examples/with-ant-design-less/components/Header.js
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/'>
+      <a style={styles.a} >Home</a>
+    </Link>
+
+    <Link href='/calendar'>
+      <a style={styles.a} >Calendar</a>
+    </Link>
+
+      <Link href='/card'>
+          <a style={styles.a} >Card</a>
+      </Link>
+
+  </div>
+)
+
+const styles = {
+  a: {
+    marginRight: 10
+  }
+}

--- a/examples/with-ant-design-less/index.js
+++ b/examples/with-ant-design-less/index.js
@@ -7,10 +7,42 @@ export default ({ children }) =>
     <Head>
       <meta name='viewport' content='width=device-width, initial-scale=1' />
       <meta charSet='utf-8' />
-      <link rel='stylesheet' href='/_next/static/style.css' />
     </Head>
     <style jsx global>{`
+      * {
+        font-family: Menlo, Monaco, 'Lucida Console', 'Liberation Mono',
+          'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New',
+          monospace, serif;
+      }
       body {
+        margin: 0;
+        padding: 25px 50px;
+      }
+      a {
+        color: #22bad9;
+      }
+      p {
+        font-size: 14px;
+        line-height: 24px;
+      }
+      article {
+        margin: 0 auto;
+        max-width: 650px;
+      }
+      button {
+        align-items: center;
+        background-color: #22bad9;
+        border: 0;
+        color: white;
+        display: flex;
+        padding: 5px 7px;
+      }
+      button:active {
+        background-color: #1b9db7;
+        transition: background-color 0.3s;
+      }
+      button:focus {
+        outline: none;
       }
     `}</style>
     {children}

--- a/examples/with-ant-design-less/package.json
+++ b/examples/with-ant-design-less/package.json
@@ -7,16 +7,13 @@
     "start": "next start"
   },
   "dependencies": {
-    "@zeit/next-less": "0.3.0",
-    "antd": "^3.5.4",
-    "babel-plugin-import": "^1.7.0",
-    "less": "3.0.4",
+    "@zeit/next-less": "^1.0.1",
+    "antd": "^3.9.2",
+    "babel-plugin-import": "^1.9.1",
+    "less": "3.8.1",
     "next": "latest",
-    "react": "^16.4.0",
-    "react-dom": "^16.4.0"
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2"
   },
-  "license": "ISC",
-  "devDependencies": {
-    "babel-plugin-transform-decorators-legacy": "^1.3.5"
-  }
+  "license": "ISC"
 }

--- a/examples/with-ant-design-less/pages/calendar.js
+++ b/examples/with-ant-design-less/pages/calendar.js
@@ -1,0 +1,14 @@
+import {Calendar} from "antd";
+import Header from "../components/Header";
+import Layout from '../index.js'
+
+function onPanelChange(value, mode) {
+    console.log(value, mode);
+}
+
+export default () => (
+    <Layout style={{marginTop: 100}}>
+        <Header/>
+        <Calendar onPanelChange={onPanelChange}/>
+    </Layout>
+);

--- a/examples/with-ant-design-less/pages/card.js
+++ b/examples/with-ant-design-less/pages/card.js
@@ -1,0 +1,18 @@
+import {Card} from "antd";
+import Header from "../components/Header";
+import Layout from '../index.js'
+
+export default () => (
+    <Layout style={{marginTop: 100}}>
+        <Header/>
+        <Card
+            title="Card title"
+            extra={<a href="#">More</a>}
+            style={{width: 300}}
+        >
+            <p>Card content</p>
+            <p>Card content</p>
+            <p>Card content</p>
+        </Card>
+    </Layout>
+);

--- a/examples/with-ant-design-less/pages/index.js
+++ b/examples/with-ant-design-less/pages/index.js
@@ -1,11 +1,13 @@
 import Layout from '../index.js'
 import { Form, Select, InputNumber, DatePicker, Switch, Slider, Button } from 'antd'
+import Header from "../components/Header";
 
 const FormItem = Form.Item
 const Option = Select.Option
 
 export default () => (
   <Layout>
+    <Header/>
     <div style={{ marginTop: 100 }}>
       <Form layout='horizontal'>
         <FormItem


### PR DESCRIPTION
I am experiencing a fatal issue when trying to click links in an example with pages including less files.  I did this as a pull request so there would be an easily repeatable testcase available. (originally was working on this as a pull request to upgrade example to next 7 and hope to finish submitting as such  when issue fixed)
 
1)  Logs are full of "chunk styles [mini-css-extract-plugin] Conflicting order between..." statements:
![image](https://user-images.githubusercontent.com/1892132/45784750-be25f700-bc1e-11e8-917b-2f54ff5d68cb.png)
There is some indication we could just [ignore the warnings](https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250#issuecomment-421989979) if next.js can't do anything about this (but I couldn't figure it out).

2)  "Unhandled Rejection (TypeError): Cannot read property 'call' of undefined" when trying to change pages.
![image](https://user-images.githubusercontent.com/1892132/45784853-2543ab80-bc1f-11e8-972c-c86a203ef196.png)

Note that this issue goes away after reload.  It also doesn't seem to happen in production build. Not using less at all seems to fix the problem.