### PR TITLE
Remove Fragment from Main component

### DIFF
--- a/server/document.js
+++ b/server/document.js
@@ -126,9 +126,7 @@ export class Main extends Component {
   render () {
     const { html } = this.context._documentProps
     return (
-      <Fragment>
-        <div id='__next' dangerouslySetInnerHTML={{ __html: html }} />
-      </Fragment>
+      <div id='__next' dangerouslySetInnerHTML={{ __html: html }} />
     )
   }
 }


### PR DESCRIPTION
Since `__next-error` is no longer necessary, there is no need to wrap the `__next` div in `Fragment`.