### PR TITLE
example with-sentry note that server side logging available too

### DIFF
--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -46,3 +46,4 @@ now
 This example show you how to add Sentry to catch errors in next.js
 
 You will need a Sentry DSN for your project. You can get it from the Settings of your Project, in **Client Keys (DSN)**, and copy the string labeled **DSN (Public)**.
+Note that if you are using a custom server, there is logging available for common platforms: https://docs.sentry.io/platforms/javascript/express/?platform=node


### PR DESCRIPTION
Trivial note to remind anyone doing sentry that they should consider doing server side logging too.

Update: turns out this only logs errors generated in server.js.  See https://github.com/zeit/next.js/issues/1852#issuecomment-425413264 for workaround