### PR TITLE
Fix for with-ant-design-less for next7.0

### DIFF
--- a/examples/with-ant-design-less/.babelrc
+++ b/examples/with-ant-design-less/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": ["next/babel"],
   "plugins": [
-    "transform-decorators-legacy",
+    ["@babel/plugin-proposal-decorators", { "decoratorsBeforeExport": true }],
     [
       "import",
       {

--- a/examples/with-ant-design-less/package.json
+++ b/examples/with-ant-design-less/package.json
@@ -17,6 +17,6 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "babel-plugin-transform-decorators-legacy": "^1.3.5"
+    "@babel/plugin-proposal-decorators": "^7.1.0"
   }
 }


### PR DESCRIPTION
I have fixed about the modify ant theme for next7.0 because is not working now, So I just add  plugin-proposal-decorators and set the babel config , and delete the deprecated babel-plugin-transform-decorators-legacy, I will apreciate for accept  that pull request, thanks next.js Team :)

