### PR TITLE
Fix swallowed unhandled rejections on the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "unfetch": "3.0.0",
     "url": "0.11.0",
     "webpack": "4.18.1",
-    "webpack-dev-middleware": "3.2.0",
+    "webpack-dev-middleware": "3.4.0",
     "webpack-hot-middleware": "2.22.3",
     "webpack-sources": "1.2.0",
     "webpackbar": "2.6.3",


### PR DESCRIPTION
An upstream bug in webpack-dev-middleware caused unhandled rejections to be swallowed on the server. This applied only to the custom-server usage of next.js in development.

**More info:**

* https://github.com/webpack/webpack-dev-middleware/issues/339
* https://github.com/webpack/webpack-dev-middleware/pull/340

Closes: https://github.com/zeit/next.js/issues/5251