### PR TITLE
Refactor head keys

### DIFF
--- a/lib/head.js
+++ b/lib/head.js
@@ -15,7 +15,9 @@ class Head extends React.Component {
 const NEXT_HEAD_IDENTIFIER = 'next-head'
 
 export function defaultHead (className = NEXT_HEAD_IDENTIFIER) {
-  return [<meta charSet='utf-8' className={className} />]
+  return [
+    <meta key='charSet' charSet='utf-8' className={className} />
+  ]
 }
 
 function reduceComponents (components) {
@@ -33,9 +35,10 @@ function reduceComponents (components) {
     .filter(Boolean)
     .filter(unique())
     .reverse()
-    .map((c) => {
+    .map((c, i) => {
       const className = (c.props && c.props.className ? c.props.className + ' ' : '') + NEXT_HEAD_IDENTIFIER
-      return React.cloneElement(c, { className })
+      const key = c.key || i
+      return React.cloneElement(c, { key, className })
     })
 }
 

--- a/server/document.js
+++ b/server/document.js
@@ -116,7 +116,7 @@ export class Head extends Component {
     }
 
     return <head {...this.props}>
-      {(head || []).map((h, i) => React.cloneElement(h, { key: h.key || i }))}
+      {head}
       {page !== '/_error' && <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} as='script' nonce={this.props.nonce} />}
       <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages/_app.js`} as='script' nonce={this.props.nonce} />
       <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages/_error.js`} as='script' nonce={this.props.nonce} />


### PR DESCRIPTION
We don't need to `React.cloneElement`, twice.
