### PR TITLE
Drop prepare requirement from production server

### DIFF
--- a/packages/next/server/router.js
+++ b/packages/next/server/router.js
@@ -1,29 +1,26 @@
 import pathMatch from './lib/path-match'
 
-const route = pathMatch()
+export const route = pathMatch()
 
 export default class Router {
-  constructor () {
-    this.routes = new Map()
+  constructor (routes = []) {
+    this.routes = routes
   }
 
-  add (method, path, fn) {
-    const routes = this.routes.get(method) || new Set()
-    routes.add({ match: route(path), fn })
-    this.routes.set(method, routes)
+  add (route) {
+    this.routes.unshift(route)
   }
 
   match (req, res, parsedUrl) {
-    const routes = this.routes.get(req.method)
-    if (!routes) return
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return
+    }
 
     const { pathname } = parsedUrl
-    for (const r of routes) {
-      const params = r.match(pathname)
+    for (const route of this.routes) {
+      const params = route.match(pathname)
       if (params) {
-        return async () => {
-          return r.fn(req, res, params, parsedUrl)
-        }
+        return () => route.fn(req, res, params, parsedUrl)
       }
     }
   }

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -61,6 +61,21 @@ describe('Production Usage', () => {
       expect(res.status).toBe(404)
     })
 
+    it('should render 501 if the HTTP method is not GET or HEAD', async () => {
+      const url = `http://localhost:${appPort}/_next/abcdef`
+      const methods = ['POST', 'PUT', 'DELETE']
+      for (const method of methods) {
+        const res = await fetch(url, {method})
+        expect(res.status).toBe(501)
+      }
+    })
+
+    it('should set Content-Length header', async () => {
+      const url = `http://localhost:${appPort}`
+      const res = await fetch(url)
+      expect(res.headers.get('Content-Length')).toBeDefined()
+    })
+
     it('should set Cache-Control header', async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
       const buildManifest = require(join('../.next', BUILD_MANIFEST))


### PR DESCRIPTION
As prepare is only needed to boot up the hot reloader + exportPathMap routes in development, it's not longer a requirement in the production server.