### PR TITLE
Fix azure-pipeline tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fkill": "5.1.0",
     "flatten": "1.0.2",
     "flow-bin": "0.73.0",
-    "get-port": "3.2.0",
+    "get-port": "4.0.0",
     "husky": "0.14.3",
     "jest-cli": "21.2.0",
     "lerna": "^3.4.0",

--- a/test/integration/app-aspath/test/index.test.js
+++ b/test/integration/app-aspath/test/index.test.js
@@ -32,24 +32,22 @@ describe('App asPath', () => {
     const appPath = join(__dirname, '../', 'pages', '_app.js')
     const originalContent = readFileSync(appPath, 'utf8')
 
-    try {
-      const text = await browser.elementByCss('body').text()
-      expect(text).toBe('{ "url": { "query": {}, "pathname": "/", "asPath": "/" } }')
+    const text = await browser.elementByCss('body').text()
+    expect(text).toBe('{ "url": { "query": {}, "pathname": "/", "asPath": "/" } }')
 
-      const editedContent = originalContent.replace('find this', 'replace with this')
+    const editedContent = originalContent.replace('find this', 'replace with this')
 
-      // Change the content to trigger a bundle rebuild
-      await writeFileSync(appPath, editedContent, 'utf8')
+    // Change the content to trigger a bundle rebuild
+    await writeFileSync(appPath, editedContent, 'utf8')
 
-      // Wait for the bundle rebuild
-      await waitFor(5000)
+    // Wait for the bundle rebuild
+    await waitFor(5000)
 
-      const newContent = await browser.elementByCss('body').text()
-      expect(newContent).toBe('{ "url": { "query": {}, "pathname": "/", "asPath": "/" } }')
-    } finally {
-      // Change back to the original content
-      writeFileSync(appPath, originalContent, 'utf8')
-      browser.close()
-    }
+    const newContent = await browser.elementByCss('body').text()
+    expect(newContent).toBe('{ "url": { "query": {}, "pathname": "/", "asPath": "/" } }')
+
+    // Change back to the original content
+    writeFileSync(appPath, originalContent, 'utf8')
+    browser.quit()
   })
 })

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -1,24 +1,27 @@
-/* global describe, it, expect */
+/* eslint-env jest */
 
 import webdriver from 'next-webdriver'
 import {waitFor, getReactErrorOverlayContent} from 'next-test-utils'
 
 export default (context, render) => {
   describe('Client Navigation', () => {
+    let browser
+    afterEach(() => browser.quit())
+
     describe('with <Link/>', () => {
       it('should navigate the page', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
+
         const text = await browser
           .elementByCss('#about-link').click()
           .waitForElementByCss('.nav-about')
           .elementByCss('p').text()
 
         expect(text).toBe('This is the about page.')
-        browser.close()
       })
 
       it('should navigate via the client side', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
 
         const counterText = await browser
           .elementByCss('#increase').click()
@@ -29,38 +32,36 @@ export default (context, render) => {
           .elementByCss('#counter').text()
 
         expect(counterText).toBe('Counter: 1')
-        browser.close()
       })
     })
 
     describe('With url property', () => {
       it('Should keep immutable pathname, asPath and query', async () => {
-        const browser = await webdriver(context.appPort, '/nav/url-prop-change')
+        browser = await webdriver(context.appPort, '/nav/url-prop-change')
+
         await browser.elementByCss('#add-query').click()
         const urlResult = await browser.elementByCss('#url-result').text()
         const previousUrlResult = await browser.elementByCss('#previous-url-result').text()
 
         expect(JSON.parse(urlResult)).toMatchObject({'query': {'added': 'yes'}, 'pathname': '/nav/url-prop-change', 'asPath': '/nav/url-prop-change?added=yes'})
         expect(JSON.parse(previousUrlResult)).toMatchObject({'query': {}, 'pathname': '/nav/url-prop-change', 'asPath': '/nav/url-prop-change'})
-
-        browser.close()
       })
     })
 
     describe('with <a/> tag inside the <Link />', () => {
       it('should navigate the page', async () => {
-        const browser = await webdriver(context.appPort, '/nav/about')
+        browser = await webdriver(context.appPort, '/nav/about')
+
         const text = await browser
           .elementByCss('#home-link').click()
           .waitForElementByCss('.nav-home')
           .elementByCss('p').text()
 
         expect(text).toBe('This is the home.')
-        browser.close()
       })
 
       it('should not navigate if the <a/> tag has a target', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
 
         const counterText = await browser
           .elementByCss('#increase').click()
@@ -68,81 +69,75 @@ export default (context, render) => {
           .elementByCss('#counter').text()
 
         expect(counterText).toBe('Counter: 1')
-        browser.close()
       })
     })
 
     describe('with unexpected <a/> nested tag', () => {
       it('should not redirect if passHref prop is not defined in Link', async () => {
-        const browser = await webdriver(context.appPort, '/nav/pass-href-prop')
+        browser = await webdriver(context.appPort, '/nav/pass-href-prop')
+
         const text = await browser
           .elementByCss('#without-href').click()
           .waitForElementByCss('.nav-pass-href-prop')
           .elementByCss('p').text()
 
         expect(text).toBe('This is the passHref prop page.')
-        browser.close()
       })
 
       it('should redirect if passHref prop is defined in Link', async () => {
-        const browser = await webdriver(context.appPort, '/nav/pass-href-prop')
+        browser = await webdriver(context.appPort, '/nav/pass-href-prop')
+
         const text = await browser
           .elementByCss('#with-href').click()
           .waitForElementByCss('.nav-home')
           .elementByCss('p').text()
 
         expect(text).toBe('This is the home.')
-        browser.close()
       })
     })
 
     describe('with empty getInitialProps()', () => {
       it('should render an error', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/nav')
-          await browser.elementByCss('#empty-props').click()
+        browser = await webdriver(context.appPort, '/nav')
 
-          await waitFor(3000)
+        await browser.elementByCss('#empty-props').click()
+        await waitFor(3000)
 
-          expect(await getReactErrorOverlayContent(browser)).toMatch(
-            /should resolve to an object\. But found "null" instead\./
-          )
-        } finally {
-          if (browser) {
-            browser.close()
-          }
-        }
+        const reactOverlay = await getReactErrorOverlayContent(browser)
+        expect(reactOverlay).toMatch(
+          /should resolve to an object\. But found "null" instead\./
+        )
       })
     })
 
     describe('with the same page but different querystring', () => {
       it('should navigate the page', async () => {
-        const browser = await webdriver(context.appPort, '/nav/querystring?id=1')
+        browser = await webdriver(context.appPort, '/nav/querystring?id=1')
+
         const text = await browser
           .elementByCss('#next-id-link').click()
           .waitForElementByCss('.nav-id-2')
           .elementByCss('p').text()
 
         expect(text).toBe('2')
-        browser.close()
       })
 
       it('should remove querystring', async () => {
-        const browser = await webdriver(context.appPort, '/nav/querystring?id=1')
+        browser = await webdriver(context.appPort, '/nav/querystring?id=1')
+
         const text = await browser
           .elementByCss('#main-page').click()
           .waitForElementByCss('.nav-id-0')
           .elementByCss('p').text()
 
         expect(text).toBe('0')
-        browser.close()
       })
     })
 
     describe('with the current url', () => {
       it('should reload the page', async () => {
-        const browser = await webdriver(context.appPort, '/nav/self-reload')
+        browser = await webdriver(context.appPort, '/nav/self-reload')
+
         const defaultCount = await browser.elementByCss('p').text()
         expect(defaultCount).toBe('COUNT: 0')
 
@@ -151,11 +146,10 @@ export default (context, render) => {
           .elementByCss('p').text()
 
         expect(countAfterClicked).toBe('COUNT: 1')
-        browser.close()
       })
 
       it('should always replace the state', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
 
         const countAfterClicked = await browser
           .elementByCss('#self-reload-link').click()
@@ -171,192 +165,146 @@ export default (context, render) => {
         await browser
           .back()
           .waitForElementByCss('.nav-home')
-
-        browser.close()
       })
     })
 
     describe('with onClick action', () => {
       it('should reload the page and perform additional action', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/nav/on-click')
-          const defaultCountQuery = await browser.elementByCss('#query-count').text()
-          const defaultCountState = await browser.elementByCss('#state-count').text()
-          expect(defaultCountQuery).toBe('QUERY COUNT: 0')
-          expect(defaultCountState).toBe('STATE COUNT: 0')
+        browser = await webdriver(context.appPort, '/nav/on-click')
 
-          await browser.elementByCss('#on-click-link').click()
+        const defaultCountQuery = await browser.elementByCss('#query-count').text()
+        const defaultCountState = await browser.elementByCss('#state-count').text()
+        expect(defaultCountQuery).toBe('QUERY COUNT: 0')
+        expect(defaultCountState).toBe('STATE COUNT: 0')
 
-          const countQueryAfterClicked = await browser.elementByCss('#query-count').text()
-          const countStateAfterClicked = await browser.elementByCss('#state-count').text()
-          expect(countQueryAfterClicked).toBe('QUERY COUNT: 1')
-          expect(countStateAfterClicked).toBe('STATE COUNT: 1')
-        } finally {
-          if (browser) {
-            browser.close()
-          }
-        }
+        await browser.elementByCss('#on-click-link').click()
+
+        const countQueryAfterClicked = await browser.elementByCss('#query-count').text()
+        const countStateAfterClicked = await browser.elementByCss('#state-count').text()
+        expect(countQueryAfterClicked).toBe('QUERY COUNT: 1')
+        expect(countStateAfterClicked).toBe('STATE COUNT: 1')
       })
 
       it('should not reload if default was prevented', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/nav/on-click')
-          const defaultCountQuery = await browser.elementByCss('#query-count').text()
-          const defaultCountState = await browser.elementByCss('#state-count').text()
-          expect(defaultCountQuery).toBe('QUERY COUNT: 0')
-          expect(defaultCountState).toBe('STATE COUNT: 0')
+        browser = await webdriver(context.appPort, '/nav/on-click')
 
-          await browser.elementByCss('#on-click-link-prevent-default').click()
+        const defaultCountQuery = await browser.elementByCss('#query-count').text()
+        const defaultCountState = await browser.elementByCss('#state-count').text()
+        expect(defaultCountQuery).toBe('QUERY COUNT: 0')
+        expect(defaultCountState).toBe('STATE COUNT: 0')
 
-          const countQueryAfterClicked = await browser.elementByCss('#query-count').text()
-          const countStateAfterClicked = await browser.elementByCss('#state-count').text()
-          expect(countQueryAfterClicked).toBe('QUERY COUNT: 0')
-          expect(countStateAfterClicked).toBe('STATE COUNT: 1')
+        await browser.elementByCss('#on-click-link-prevent-default').click()
 
-          await browser.elementByCss('#on-click-link').click()
+        const countQueryAfterClicked = await browser.elementByCss('#query-count').text()
+        const countStateAfterClicked = await browser.elementByCss('#state-count').text()
+        expect(countQueryAfterClicked).toBe('QUERY COUNT: 0')
+        expect(countStateAfterClicked).toBe('STATE COUNT: 1')
 
-          const countQueryAfterClickedAgain = await browser.elementByCss('#query-count').text()
-          const countStateAfterClickedAgain = await browser.elementByCss('#state-count').text()
-          expect(countQueryAfterClickedAgain).toBe('QUERY COUNT: 1')
-          expect(countStateAfterClickedAgain).toBe('STATE COUNT: 2')
-        } finally {
-          if (browser) {
-            browser.close()
-          }
-        }
+        await browser.elementByCss('#on-click-link').click()
+
+        const countQueryAfterClickedAgain = await browser.elementByCss('#query-count').text()
+        const countStateAfterClickedAgain = await browser.elementByCss('#state-count').text()
+        expect(countQueryAfterClickedAgain).toBe('QUERY COUNT: 1')
+        expect(countStateAfterClickedAgain).toBe('STATE COUNT: 2')
       })
 
       it('should always replace the state and perform additional action', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
 
-          await browser.elementByCss('#on-click-link').click().waitForElementByCss('#on-click-page')
+        await browser.elementByCss('#on-click-link').click().waitForElementByCss('#on-click-page')
 
-          const defaultCountQuery = await browser.elementByCss('#query-count').text()
-          expect(defaultCountQuery).toBe('QUERY COUNT: 1')
+        const defaultCountQuery = await browser.elementByCss('#query-count').text()
+        expect(defaultCountQuery).toBe('QUERY COUNT: 1')
 
-          await browser.elementByCss('#on-click-link').click()
-          const countQueryAfterClicked = await browser.elementByCss('#query-count').text()
-          const countStateAfterClicked = await browser.elementByCss('#state-count').text()
-          expect(countQueryAfterClicked).toBe('QUERY COUNT: 2')
-          expect(countStateAfterClicked).toBe('STATE COUNT: 1')
+        await browser.elementByCss('#on-click-link').click()
+        const countQueryAfterClicked = await browser.elementByCss('#query-count').text()
+        const countStateAfterClicked = await browser.elementByCss('#state-count').text()
+        expect(countQueryAfterClicked).toBe('QUERY COUNT: 2')
+        expect(countStateAfterClicked).toBe('STATE COUNT: 1')
 
-          // Since we replace the state, back button would simply go us back to /nav
-          await browser.back().waitForElementByCss('.nav-home')
-        } finally {
-          if (browser) {
-            browser.close()
-          }
-        }
+        // Since we replace the state, back button would simply go us back to /nav
+        await browser.back().waitForElementByCss('.nav-home')
       })
     })
 
     describe('with hash changes', () => {
       describe('when hash change via Link', () => {
         it('should not run getInitialProps', async () => {
-          const browser = await webdriver(context.appPort, '/nav/hash-changes')
+          browser = await webdriver(context.appPort, '/nav/hash-changes')
 
           const counter = await browser
             .elementByCss('#via-link').click()
             .elementByCss('p').text()
 
           expect(counter).toBe('COUNT: 0')
-
-          browser.close()
         })
 
         it('should scroll to the specified position on the same page', async () => {
-          let browser
-          try {
-            browser = await webdriver(context.appPort, '/nav/hash-changes')
+          browser = await webdriver(context.appPort, '/nav/hash-changes')
 
-            // Scrolls to item 400 on the page
-            const scrollPosition = await browser
-              .elementByCss('#scroll-to-item-400').click()
-              .eval('window.pageYOffset')
+          // Scrolls to item 400 on the page
+          const scrollPosition = await browser
+            .elementByCss('#scroll-to-item-400').click()
+            .eval('window.pageYOffset')
 
-            expect(scrollPosition).toBe(7258)
+          expect(scrollPosition).toBe(7258)
 
-            // Scrolls back to top when scrolling to `#` with no value.
-            const scrollPositionAfterEmptyHash = await browser
-              .elementByCss('#via-empty-hash').click()
-              .eval('window.pageYOffset')
+          // Scrolls back to top when scrolling to `#` with no value.
+          const scrollPositionAfterEmptyHash = await browser
+            .elementByCss('#via-empty-hash').click()
+            .eval('window.pageYOffset')
 
-            expect(scrollPositionAfterEmptyHash).toBe(0)
-          } finally {
-            if (browser) {
-              browser.close()
-            }
-          }
+          expect(scrollPositionAfterEmptyHash).toBe(0)
         })
 
         it('should scroll to the specified position on the same page with a name property', async () => {
-          let browser
-          try {
-            browser = await webdriver(context.appPort, '/nav/hash-changes')
+          browser = await webdriver(context.appPort, '/nav/hash-changes')
 
-            // Scrolls to item 400 with name="name-item-400" on the page
-            const scrollPosition = await browser
-              .elementByCss('#scroll-to-name-item-400').click()
-              .eval('window.pageYOffset')
+          // Scrolls to item 400 with name="name-item-400" on the page
+          const scrollPosition = await browser
+            .elementByCss('#scroll-to-name-item-400').click()
+            .eval('window.pageYOffset')
 
-            console.log(scrollPosition)
+          console.log(scrollPosition)
 
-            expect(scrollPosition).toBe(16258)
+          expect(scrollPosition).toBe(16258)
 
-            // Scrolls back to top when scrolling to `#` with no value.
-            const scrollPositionAfterEmptyHash = await browser
-              .elementByCss('#via-empty-hash').click()
-              .eval('window.pageYOffset')
+          // Scrolls back to top when scrolling to `#` with no value.
+          const scrollPositionAfterEmptyHash = await browser
+            .elementByCss('#via-empty-hash').click()
+            .eval('window.pageYOffset')
 
-            expect(scrollPositionAfterEmptyHash).toBe(0)
-          } finally {
-            if (browser) {
-              browser.close()
-            }
-          }
+          expect(scrollPositionAfterEmptyHash).toBe(0)
         })
 
         it('should scroll to the specified position to a new page', async () => {
-          let browser
-          try {
-            browser = await webdriver(context.appPort, '/nav')
+          browser = await webdriver(context.appPort, '/nav')
 
-            // Scrolls to item 400 on the page
-            await browser
-              .elementByCss('#scroll-to-hash').click()
-              .waitForElementByCss('#hash-changes-page')
+          // Scrolls to item 400 on the page
+          await browser
+            .elementByCss('#scroll-to-hash').click()
+            .waitForElementByCss('#hash-changes-page')
 
-            const scrollPosition = await browser.eval('window.pageYOffset')
-            expect(scrollPosition).toBe(7258)
-          } finally {
-            if (browser) {
-              browser.close()
-            }
-          }
+          const scrollPosition = await browser.eval('window.pageYOffset')
+          expect(scrollPosition).toBe(7258)
         })
       })
 
       describe('when hash change via A tag', () => {
         it('should not run getInitialProps', async () => {
-          const browser = await webdriver(context.appPort, '/nav/hash-changes')
+          browser = await webdriver(context.appPort, '/nav/hash-changes')
 
           const counter = await browser
             .elementByCss('#via-a').click()
             .elementByCss('p').text()
 
           expect(counter).toBe('COUNT: 0')
-
-          browser.close()
         })
       })
 
       describe('when hash get removed', () => {
         it('should not run getInitialProps', async () => {
-          const browser = await webdriver(context.appPort, '/nav/hash-changes')
+          browser = await webdriver(context.appPort, '/nav/hash-changes')
 
           const counter = await browser
             .elementByCss('#via-a').click()
@@ -364,14 +312,12 @@ export default (context, render) => {
             .elementByCss('p').text()
 
           expect(counter).toBe('COUNT: 1')
-
-          browser.close()
         })
       })
 
       describe('when hash set to empty', () => {
         it('should not run getInitialProps', async () => {
-          const browser = await webdriver(context.appPort, '/nav/hash-changes')
+          browser = await webdriver(context.appPort, '/nav/hash-changes')
 
           const counter = await browser
             .elementByCss('#via-a').click()
@@ -379,14 +325,12 @@ export default (context, render) => {
             .elementByCss('p').text()
 
           expect(counter).toBe('COUNT: 0')
-
-          browser.close()
         })
       })
 
       describe('when hash changed to a different hash', () => {
         it('should not run getInitialProps', async () => {
-          const browser = await webdriver(context.appPort, '/nav/hash-changes')
+          browser = await webdriver(context.appPort, '/nav/hash-changes')
 
           const counter = await browser
             .elementByCss('#via-a').click()
@@ -394,30 +338,29 @@ export default (context, render) => {
             .elementByCss('p').text()
 
           expect(counter).toBe('COUNT: 0')
-
-          browser.close()
         })
       })
     })
 
     describe('with shallow routing', () => {
       it('should update the url without running getInitialProps', async () => {
-        const browser = await webdriver(context.appPort, '/nav/shallow-routing')
+        browser = await webdriver(context.appPort, '/nav/shallow-routing')
         const counter = await browser
           .elementByCss('#increase').click()
           .elementByCss('#increase').click()
           .elementByCss('#counter').text()
+
         expect(counter).toBe('Counter: 2')
 
         const getInitialPropsRunCount = await browser
           .elementByCss('#get-initial-props-run-count').text()
-        expect(getInitialPropsRunCount).toBe('getInitialProps run count: 1')
 
-        browser.close()
+        expect(getInitialPropsRunCount).toBe('getInitialProps run count: 1')
       })
 
       it('should handle the back button and should not run getInitialProps', async () => {
-        const browser = await webdriver(context.appPort, '/nav/shallow-routing')
+        browser = await webdriver(context.appPort, '/nav/shallow-routing')
+
         let counter = await browser
           .elementByCss('#increase').click()
           .elementByCss('#increase').click()
@@ -431,13 +374,12 @@ export default (context, render) => {
 
         const getInitialPropsRunCount = await browser
           .elementByCss('#get-initial-props-run-count').text()
-        expect(getInitialPropsRunCount).toBe('getInitialProps run count: 1')
 
-        browser.close()
+        expect(getInitialPropsRunCount).toBe('getInitialProps run count: 1')
       })
 
       it('should run getInitialProps always when rending the page to the screen', async () => {
-        const browser = await webdriver(context.appPort, '/nav/shallow-routing')
+        browser = await webdriver(context.appPort, '/nav/shallow-routing')
 
         const counter = await browser
           .elementByCss('#increase').click()
@@ -447,45 +389,47 @@ export default (context, render) => {
           .back()
           .waitForElementByCss('.shallow-routing')
           .elementByCss('#counter').text()
+
         expect(counter).toBe('Counter: 2')
 
         const getInitialPropsRunCount = await browser
           .elementByCss('#get-initial-props-run-count').text()
-        expect(getInitialPropsRunCount).toBe('getInitialProps run count: 2')
 
-        browser.close()
+        expect(getInitialPropsRunCount).toBe('getInitialProps run count: 2')
       })
     })
 
     describe('with URL objects', () => {
       it('should work with <Link/>', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
+
         const text = await browser
           .elementByCss('#query-string-link').click()
           .waitForElementByCss('.nav-querystring')
           .elementByCss('p').text()
+
         expect(text).toBe('10')
 
-        expect(await browser.url())
-          .toBe(`http://localhost:${context.appPort}/nav/querystring/10#10`)
-        browser.close()
+        const url = await browser.url()
+        expect(url).toBe(`http://localhost:${context.appPort}/nav/querystring/10#10`)
       })
 
       it('should work with "Router.push"', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
+
         const text = await browser
           .elementByCss('#query-string-button').click()
           .waitForElementByCss('.nav-querystring')
           .elementByCss('p').text()
+
         expect(text).toBe('10')
 
-        expect(await browser.url())
-          .toBe(`http://localhost:${context.appPort}/nav/querystring/10#10`)
-        browser.close()
+        const url = await browser.url()
+        expect(url).toBe(`http://localhost:${context.appPort}/nav/querystring/10#10`)
       })
 
       it('should work with the "replace" prop', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
 
         let stackLength = await browser
           .eval('window.history.length')
@@ -514,71 +458,69 @@ export default (context, render) => {
           .eval('window.history.length')
 
         expect(stackLength).toBe(3)
-
-        browser.close()
       })
     })
 
     describe('with getInitialProp redirect', () => {
       it('should redirect the page via client side', async () => {
-        const browser = await webdriver(context.appPort, '/nav')
+        browser = await webdriver(context.appPort, '/nav')
+
         const text = await browser
           .elementByCss('#redirect-link').click()
           .waitForElementByCss('.nav-about')
           .elementByCss('p').text()
 
         expect(text).toBe('This is the about page.')
-        browser.close()
       })
 
       it('should redirect the page when loading', async () => {
-        const browser = await webdriver(context.appPort, '/nav/redirect')
+        browser = await webdriver(context.appPort, '/nav/redirect')
+
         const text = await browser
           .waitForElementByCss('.nav-about')
           .elementByCss('p').text()
 
         expect(text).toBe('This is the about page.')
-        browser.close()
       })
     })
 
     describe('with different types of urls', () => {
       it('should work with normal page', async () => {
-        const browser = await webdriver(context.appPort, '/with-cdm')
+        browser = await webdriver(context.appPort, '/with-cdm')
+
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
       })
 
       it('should work with dir/ page', async () => {
-        const browser = await webdriver(context.appPort, '/nested-cdm')
+        browser = await webdriver(context.appPort, '/nested-cdm')
+
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
       })
 
       it('should work with /index page', async () => {
-        const browser = await webdriver(context.appPort, '/index')
+        browser = await webdriver(context.appPort, '/index')
+
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
       })
 
       it('should work with / page', async () => {
-        const browser = await webdriver(context.appPort, '/')
+        browser = await webdriver(context.appPort, '/')
+
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
       })
     })
 
     describe('with the HOC based router', () => {
       it('should navigate as expected', async () => {
-        const browser = await webdriver(context.appPort, '/nav/with-hoc')
+        browser = await webdriver(context.appPort, '/nav/with-hoc')
 
         const pathname = await browser.elementByCss('#pathname').text()
         expect(pathname).toBe('Current path: /nav/with-hoc')
@@ -592,144 +534,115 @@ export default (context, render) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the home.')
-        browser.close()
       })
     })
 
     describe('with asPath', () => {
       describe('inside getInitialProps', () => {
         it('should show the correct asPath with a Link with as prop', async () => {
-          const browser = await webdriver(context.appPort, '/nav')
+          browser = await webdriver(context.appPort, '/nav')
+
           const asPath = await browser
             .elementByCss('#as-path-link').click()
             .waitForElementByCss('.as-path-content')
             .elementByCss('.as-path-content').text()
 
           expect(asPath).toBe('/as/path')
-          browser.close()
         })
 
         it('should show the correct asPath with a Link without the as prop', async () => {
-          const browser = await webdriver(context.appPort, '/nav')
+          browser = await webdriver(context.appPort, '/nav')
+
           const asPath = await browser
             .elementByCss('#as-path-link-no-as').click()
             .waitForElementByCss('.as-path-content')
             .elementByCss('.as-path-content').text()
 
           expect(asPath).toBe('/nav/as-path')
-          browser.close()
         })
       })
 
       describe('with next/router', () => {
         it('should show the correct asPath', async () => {
-          const browser = await webdriver(context.appPort, '/nav')
+          browser = await webdriver(context.appPort, '/nav')
+
           const asPath = await browser
             .elementByCss('#as-path-using-router-link').click()
             .waitForElementByCss('.as-path-content')
             .elementByCss('.as-path-content').text()
 
           expect(asPath).toBe('/nav/as-path-using-router')
-          browser.close()
         })
       })
 
       describe('with next/link', () => {
         it('should use pushState with same href and different asPath', async () => {
-          let browser
-          try {
-            browser = await webdriver(context.appPort, '/nav/as-path-pushstate')
-            await browser.elementByCss('#hello').click().waitForElementByCss('#something-hello')
-            const queryOne = JSON.parse(await browser.elementByCss('#router-query').text())
-            expect(queryOne.something).toBe('hello')
-            await browser.elementByCss('#same-query').click().waitForElementByCss('#something-same-query')
-            const queryTwo = JSON.parse(await browser.elementByCss('#router-query').text())
-            expect(queryTwo.something).toBe('hello')
-            await browser.back().waitForElementByCss('#something-hello')
-            const queryThree = JSON.parse(await browser.elementByCss('#router-query').text())
-            expect(queryThree.something).toBe('hello')
-          } finally {
-            if (browser) {
-              browser.close()
-            }
-          }
+          browser = await webdriver(context.appPort, '/nav/as-path-pushstate')
+
+          await browser.elementByCss('#hello').click().waitForElementByCss('#something-hello')
+          const queryOne = JSON.parse(await browser.elementByCss('#router-query').text())
+          expect(queryOne.something).toBe('hello')
+
+          await browser.elementByCss('#same-query').click().waitForElementByCss('#something-same-query')
+          const queryTwo = JSON.parse(await browser.elementByCss('#router-query').text())
+          expect(queryTwo.something).toBe('hello')
+
+          await browser.back().waitForElementByCss('#something-hello')
+          const queryThree = JSON.parse(await browser.elementByCss('#router-query').text())
+          expect(queryThree.something).toBe('hello')
         })
       })
     })
 
     describe('runtime errors', () => {
       it('should show ErrorDebug when a client side error is thrown inside a component', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/error-inside-browser-page')
-          await waitFor(3000)
-          const text = await getReactErrorOverlayContent(browser)
-          expect(text).toMatch(/An Expected error occured/)
-          expect(text).toMatch(/pages\/error-inside-browser-page\.js:5/)
-        } finally {
-          if (browser) {
-            browser.close()
-          }
-        }
+        browser = await webdriver(context.appPort, '/error-inside-browser-page')
+        await waitFor(3000)
+        const text = await getReactErrorOverlayContent(browser)
+        expect(text).toMatch(/An Expected error occured/)
+        expect(text).toMatch(/pages\/error-inside-browser-page\.js:5/)
       })
 
       it('should show ErrorDebug when a client side error is thrown outside a component', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/error-in-the-browser-global-scope')
-          await waitFor(3000)
-          const text = await getReactErrorOverlayContent(browser)
-          expect(text).toMatch(/An Expected error occured/)
-          expect(text).toMatch(/error-in-the-browser-global-scope\.js:2/)
-        } finally {
-          if (browser) {
-            browser.close()
-          }
-        }
+        browser = await webdriver(context.appPort, '/error-in-the-browser-global-scope')
+        await waitFor(3000)
+        const text = await getReactErrorOverlayContent(browser)
+        expect(text).toMatch(/An Expected error occured/)
+        expect(text).toMatch(/error-in-the-browser-global-scope\.js:2/)
       })
     })
 
     describe('with 404 pages', () => {
       it('should 404 on not existent page', async () => {
-        const browser = await webdriver(context.appPort, '/non-existent')
+        browser = await webdriver(context.appPort, '/non-existent')
         expect(await browser.elementByCss('h1').text()).toBe('404')
         expect(await browser.elementByCss('h2').text()).toBe('This page could not be found.')
-        browser.close()
       })
 
       it('should 404 for <page>/', async () => {
-        const browser = await webdriver(context.appPort, '/nav/about/')
+        browser = await webdriver(context.appPort, '/nav/about/')
         expect(await browser.elementByCss('h1').text()).toBe('404')
         expect(await browser.elementByCss('h2').text()).toBe('This page could not be found.')
-        browser.close()
       })
 
       it('should should not contain a page script in a 404 page', async () => {
-        const browser = await webdriver(context.appPort, '/non-existent')
+        browser = await webdriver(context.appPort, '/non-existent')
         const scripts = await browser.elementsByCss('script[src]')
         for (const script of scripts) {
           const src = await script.getAttribute('src')
           expect(src.includes('/non-existent')).toBeFalsy()
         }
-        browser.close()
       })
     })
 
     describe('updating head while client routing', () => {
       it('should update head during client routing', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/nav/head-1')
-          expect(await browser.elementByCss('meta[name="description"]').getAttribute('content')).toBe('Head One')
-          await browser.elementByCss('#to-head-2').click().waitForElementByCss('#head-2')
-          expect(await browser.elementByCss('meta[name="description"]').getAttribute('content')).toBe('Head Two')
-          await browser.elementByCss('#to-head-1').click().waitForElementByCss('#head-1')
-          expect(await browser.elementByCss('meta[name="description"]').getAttribute('content')).toBe('Head One')
-        } finally {
-          if (browser) {
-            browser.close()
-          }
-        }
+        browser = await webdriver(context.appPort, '/nav/head-1')
+        expect(await browser.elementByCss('meta[name="description"]').getAttribute('content')).toBe('Head One')
+        await browser.elementByCss('#to-head-2').click().waitForElementByCss('#head-2')
+        expect(await browser.elementByCss('meta[name="description"]').getAttribute('content')).toBe('Head Two')
+        await browser.elementByCss('#to-head-1').click().waitForElementByCss('#head-1')
+        expect(await browser.elementByCss('meta[name="description"]').getAttribute('content')).toBe('Head One')
       })
     })
   })

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -12,22 +12,19 @@ import {
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
-const appDir = join(__dirname, '../')
 let appPort
 let server
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 
-const context = {}
-
 const startServer = async (optEnv = {}) => {
+  const appDir = join(__dirname, '../')
   const scriptPath = join(appDir, 'server.js')
-  context.appPort = appPort = await findPort()
-  const env = Object.assign(
-    {},
-    clone(process.env),
-    { PORT: `${appPort}` },
-    optEnv
-  )
+  appPort = await findPort()
+  const env = {
+    ...clone(process.env),
+    PORT: `${appPort}`,
+    ...optEnv
+  }
 
   server = await initNextServerScript(scriptPath, /Ready on/, env)
 }
@@ -67,27 +64,37 @@ describe('Custom Server', () => {
       expect($normal('img').attr('src')).toBe('/static/myimage.png')
 
       const $dynamic = cheerio.load(await renderViaHTTP(appPort, '/asset?setAssetPrefix=1'))
-      expect($dynamic('img').attr('src')).toBe(`http://127.0.0.1:${context.appPort}/static/myimage.png`)
+      expect($dynamic('img').attr('src')).toBe(`http://127.0.0.1:${appPort}/static/myimage.png`)
     })
 
     it('should support next/asset in client side', async () => {
-      const browser = await webdriver(context.appPort, '/')
+      const browser = await webdriver(appPort, '/')
       await browser
         .elementByCss('#go-asset').click()
         .waitForElementByCss('#asset-page')
 
-      expect(await browser.elementByCss('img').getAttribute('src'))
-        .toBe(`http://localhost:${context.appPort}/static/myimage.png`)
-      browser.close()
+      const imgSrc = await browser
+        .elementByCss('img')
+        .getAttribute('src')
 
-      const browser2 = await webdriver(context.appPort, '/?setAssetPrefix=1')
+      expect(imgSrc).toBe(`http://localhost:${appPort}/static/myimage.png`)
+
+      await browser.close()
+
+      const browser2 = await webdriver(appPort, '/?setAssetPrefix=1')
+
       await browser2
-        .elementByCss('#go-asset').click()
+        .elementByCss('#go-asset')
+        .click()
         .waitForElementByCss('#asset-page')
 
-      expect(await browser2.elementByCss('img').getAttribute('src'))
-        .toBe(`http://127.0.0.1:${context.appPort}/static/myimage.png`)
-      browser2.close()
+      const imgSrc2 = await browser2
+        .elementByCss('img')
+        .getAttribute('src')
+
+      expect(imgSrc2).toBe(`http://127.0.0.1:${appPort}/static/myimage.png`)
+
+      return browser2.close()
     })
   })
 

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -1,12 +1,12 @@
 /* global jasmine, describe, it, expect, beforeAll, afterAll */
 
 import { join } from 'path'
-import getPort from 'get-port'
 import clone from 'clone'
 import cheerio from 'cheerio'
 import {
   initNextServerScript,
   killApp,
+  findPort,
   renderViaHTTP,
   fetchViaHTTP
 } from 'next-test-utils'
@@ -21,7 +21,7 @@ const context = {}
 
 const startServer = async (optEnv = {}) => {
   const scriptPath = join(appDir, 'server.js')
-  context.appPort = appPort = await getPort()
+  context.appPort = appPort = await findPort()
   const env = Object.assign(
     {},
     clone(process.env),

--- a/test/integration/export/test/dev.js
+++ b/test/integration/export/test/dev.js
@@ -12,15 +12,13 @@ export default function (context) {
   describe('Render in development mode', () => {
     it('should render the home page', async () => {
       const browser = await webdriver(context.port, '/')
-
       await check(() => getBrowserBodyText(browser), /This is the home page/)
+      browser.close()
     })
 
     it('should render pages only existent in exportPathMap page', async () => {
       const browser = await webdriver(context.port, '/dynamic/one')
-      const text = await browser
-        .elementByCss('#dynamic-page p').text()
-
+      const text = await browser.elementByCss('#dynamic-page p').text()
       expect(text).toBe('next export is nice')
       browser.close()
     })

--- a/test/integration/filesystempublicroutes/test/index.test.js
+++ b/test/integration/filesystempublicroutes/test/index.test.js
@@ -1,11 +1,11 @@
 /* global jasmine, describe, it, expect, beforeAll, afterAll */
 
 import { join } from 'path'
-import getPort from 'get-port'
 import {
   fetchViaHTTP,
   initNextServerScript,
-  killApp
+  killApp,
+  findPort
 } from 'next-test-utils'
 import clone from 'clone'
 
@@ -18,7 +18,7 @@ const context = {}
 
 const startServer = async (optEnv = {}) => {
   const scriptPath = join(appDir, 'server.js')
-  context.appPort = appPort = await getPort()
+  context.appPort = appPort = await findPort()
   const env = Object.assign(
     {},
     clone(process.env),

--- a/test/integration/production-config/test/index.test.js
+++ b/test/integration/production-config/test/index.test.js
@@ -1,4 +1,5 @@
-/* global jasmine, describe, it, expect, beforeAll, afterAll */
+/* eslint-env jest */
+/* global jasmine */
 
 import { join } from 'path'
 import {
@@ -9,51 +10,39 @@ import {
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
-const appDir = join(__dirname, '../')
-let server
-let app
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 
-const context = {}
+let server
 
 describe('Production Config Usage', () => {
   beforeAll(async () => {
+    const appDir = join(__dirname, '../')
     await nextBuild(appDir)
-    app = nextServer({
+    const app = nextServer({
       dir: join(__dirname, '../'),
       dev: false,
       quiet: true
     })
-
     server = await startApp(app)
-    context.appPort = server.address().port
   })
   afterAll(() => stopApp(server))
 
-  const openBrowser = (args) => webdriver(context.appPort, ...args)
-
   describe('with next-css', () => {
     it('should load styles', async () => {
-      let browser
-
-      async function testBrowser () {
-        browser = await openBrowser('/')
-        const element = await browser.elementByCss('#mounted')
-        const text = await element.text()
-        expect(text).toMatch(/ComponentDidMount executed on client\./)
-        expect(await element.getComputedCss('font-size')).toBe('40px')
-        expect(await element.getComputedCss('color')).toBe('rgba(255, 0, 0, 1)')
-      }
-      try {
-        // Try 3 times as the breaking happens intermittently
-        await testBrowser()
-        await testBrowser()
-        await testBrowser()
-      } finally {
-        if (browser) {
-          browser.close()
-        }
-      }
+      // Try 3 times as the breaking happens intermittently
+      await testBrowser()
+      await testBrowser()
+      await testBrowser()
     })
   })
 })
+
+async function testBrowser () {
+  const browser = await webdriver(server.address().port, '/')
+  const element = await browser.elementByCss('#mounted')
+  const text = await element.text()
+  expect(text).toMatch(/ComponentDidMount executed on client\./)
+  expect(await element.getComputedCss('font-size')).toBe('40px')
+  expect(await element.getComputedCss('color')).toBe('rgba(255, 0, 0, 1)')
+  return browser.close()
+}

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -39,7 +39,7 @@ module.exports = (context) => {
         throw new Error('Vulnerable to XSS attacks')
       }
 
-      browser.close()
+      browser.quit()
     })
   })
 }

--- a/test/lib/next-webdriver.js
+++ b/test/lib/next-webdriver.js
@@ -4,59 +4,9 @@ export default async function (appPort, pathname) {
   if (typeof appPort === 'undefined') {
     throw new Error('appPort is undefined')
   }
-
   const url = `http://localhost:${appPort}${pathname}`
-  console.log(`> Start loading browser with url: ${url}`)
-
-  // Sometimes browser won't initialize due to some random issues.
-  // So, we need to timeout the initialization and retry again.
-  for (let lc = 0; lc < 5; lc++) {
-    try {
-      const browser = await getBrowser(url, 5000)
-      console.log(`> Complete loading browser with url: ${url}`)
-      return browser
-    } catch (ex) {
-      console.warn(`> Error when loading browser with url: ${url}`)
-      if (ex.message === 'TIMEOUT') continue
-      throw ex
-    }
-  }
-
-  console.error(`> Tried 5 times. Cannot load the browser for url: ${url}`)
-  throw new Error(`Couldn't start the browser for url: ${url}`)
-}
-
-function getBrowser (url, timeout) {
   const browser = wd.promiseChainRemote('http://localhost:9515/')
-
-  return new Promise((resolve, reject) => {
-    let timeouted = false
-    const timeoutHandler = setTimeout(() => {
-      timeouted = true
-      const error = new Error('TIMEOUT')
-      reject(error)
-    }, timeout)
-
-    browser.init({browserName: 'chrome'}).get(url, err => {
-      if (timeouted) {
-        try {
-          browser.close(() => {
-            // Ignore errors
-          })
-        } catch (err) {
-          // Ignore
-        }
-        return
-      }
-
-      clearTimeout(timeoutHandler)
-
-      if (err) {
-        reject(err)
-        return
-      }
-
-      resolve(browser)
-    })
-  })
+  await browser.init({ browserName: 'chrome' })
+  await browser.get(url)
+  return browser
 }


### PR DESCRIPTION
This PR fixes common test issues:

1. `browser.close()` was not called after test
2. `target="_blank"` caused `wd` to open a second chrome window, wich was not closed by `browser.close()`
3. Factory test only closed last instance of `browser`

