### PR TITLE
Ensure the promise returned by loadPage eventually gets resolved

### DIFF
--- a/packages/next/lib/page-loader.js
+++ b/packages/next/lib/page-loader.js
@@ -58,13 +58,13 @@ export default class PageLoader {
 
       // Load the script if not asked to load yet.
       if (!this.loadingRoutes[route]) {
-        this.loadScript(route)
+        this.loadScript(route, resolve, reject)
         this.loadingRoutes[route] = true
       }
     })
   }
 
-  loadScript (route) {
+  loadScript (route, resolve, reject) {
     route = this.normalizeRoute(route)
     const scriptRoute = route === '/' ? '/index.js' : `${route}.js`
 
@@ -75,6 +75,14 @@ export default class PageLoader {
       const error = new Error(`Error when loading route: ${route}`)
       error.code = 'PAGE_LOAD_ERROR'
       this.pageRegisterEvents.emit(route, { error })
+      reject(error)
+    }
+    script.onload = () => {
+      if (this.pageCache[route]) {
+        resolve(this.pageCache[route])
+      } else {
+        reject({code: 'PAGE_LOAD_ERROR'})
+      }
     }
 
     document.body.appendChild(script)


### PR DESCRIPTION
If the page js loads but doesn't register for some reason, the promise
will instead reject with PAGE_LOAD_ERROR, which forces a full page
load.

See discussion of what I was running into here: https://spectrum.chat/thread/5c3bc952-1cc5-4010-a001-781d8ebc8594

I can't test that this still helps my specific problem on the latest canary because the [contributing.md](https://github.com/zeit/next.js/blob/canary/packages/next/contributing.md) is now out of date. I'm opening this PR to hopefully get some more visibility and start some discussion. 

Edit: not sure, but this may be related to #5291