### PR TITLE
Show that <Head /> is needed for custom document

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1108,9 +1108,12 @@ export default class MyDocument extends Document {
   }
 
   render() {
+    // Important: All of Head, Main, and NextScript are required to be rendered
     return (
       <html>
-        <Head />
+        <Head>
+          <style>{`body { margin: 0 } /* custom! */`}</style>
+        </Head>
         <body className="custom_class">
           <Main />
           <NextScript />

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1110,9 +1110,7 @@ export default class MyDocument extends Document {
   render() {
     return (
       <html>
-        <Head>
-          <style>{`body { margin: 0 } /* custom! */`}</style>
-        </Head>
+        <Head />
         <body className="custom_class">
           <Main />
           <NextScript />

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1108,7 +1108,6 @@ export default class MyDocument extends Document {
   }
 
   render() {
-    // Important: All of Head, Main, and NextScript are required to be rendered
     return (
       <html>
         <Head>
@@ -1123,6 +1122,8 @@ export default class MyDocument extends Document {
   }
 }
 ```
+
+All of `<Head />`, `<Main />` and `<NextScript />` are required for page to be properly rendered.
 
 The `ctx` object is equivalent to the one received in all [`getInitialProps`](#fetching-data-and-component-lifecycle) hooks, with one addition:
 


### PR DESCRIPTION
This prevents others doing mistake I made and not including Head at all in custom document like so:

```
      <html lang={get(__NEXT_DATA__, 'props.i18n.language', 'en')}>
        <body>
          <Main />
          <NextScript />
        </body>
      </html>
```