### PR TITLE
Added beforeRouteChangeStart

### DIFF
--- a/packages/next-server/lib/router/index.js
+++ b/packages/next-server/lib/router/index.js
@@ -17,7 +17,7 @@ const SingletonRouter = {
 const urlPropertyFields = ['pathname', 'route', 'query', 'asPath']
 const propertyFields = ['components']
 const routerEvents = ['routeChangeStart', 'beforeHistoryChange', 'routeChangeComplete', 'routeChangeError', 'hashChangeStart', 'hashChangeComplete']
-const coreMethodFields = ['push', 'replace', 'reload', 'back', 'prefetch', 'beforePopState']
+const coreMethodFields = ['push', 'replace', 'reload', 'back', 'prefetch', 'beforePopState', 'beforeRouteChangeStart']
 
 // Events is a static property on the router, the router doesn't have to be initialized to use it
 Object.defineProperty(SingletonRouter, 'events', {

--- a/packages/next-server/lib/router/router.js
+++ b/packages/next-server/lib/router/router.js
@@ -38,6 +38,7 @@ export default class Router {
     this.subscriptions = new Set()
     this.componentLoadCancel = null
     this._beforePopState = () => true
+    this._beforeRouteChangeStart = () => true
 
     if (typeof window !== 'undefined') {
       // in order for `e.state` to work on the `onpopstate` event
@@ -140,7 +141,16 @@ export default class Router {
     return this.change('replaceState', url, as, options)
   }
 
+  beforeRouteChangeStart (cb) {
+    this._beforeRouteChangeStart = cb
+  }
+
   async change (method, _url, _as, options) {
+    // Check if there is a false return from the beforeRouteChangeStart callback
+    if (!this._beforeRouteChangeStart()) {
+      return
+    }
+
     // If url and as provided as an object representation,
     // we'll format them into the string version here.
     const url = typeof _url === 'object' ? format(_url) : _url

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -540,6 +540,27 @@ If you return a `false` value from `beforePopState`, `Router` will not handle `p
 you'll be responsible for handling it, in that case.
 See [Disabling File-System Routing](#disabling-file-system-routing).
 
+#### Intercepting `beforeRouteChangeStart`
+
+Similar to the `beforePopState`, this will work if a user clicks on a link to navigate to another page using the router.
+For example, you could confirm changing routes or canceling.
+
+```jsx
+import Router from 'next/router'
+
+class Example extends Component {
+  componentDidMount() {
+    Router.beforeRouteChangeStart(() => window.confirm('Are you sure you want to change pages?'));
+  }
+
+  componentWillUnmount() {
+    Router.beforeRouteChangeStart(() => true)
+  }
+  ...
+}
+```
+Note that in this example, you should also set the beforeRouteChangeStart callback to return true in `componentWillUnmount` if you don't want it to continue confirming route changes.
+
 Above `Router` object comes with the following API:
 
 - `route` - `String` of the current route
@@ -549,6 +570,7 @@ Above `Router` object comes with the following API:
 - `push(url, as=url)` - performs a `pushState` call with the given url
 - `replace(url, as=url)` - performs a `replaceState` call with the given url
 - `beforePopState(cb=function)` - intercept popstate before router processes the event.
+- `beforeRouteChangeStart(cb=function`) - intercept the router change event
 
 The second `as` parameter for `push` and `replace` is an optional _decoration_ of the URL. Useful if you configured custom routes on the server.
 

--- a/test/integration/with-router/components/header-nav.js
+++ b/test/integration/with-router/components/header-nav.js
@@ -4,7 +4,8 @@ import Link from 'next/link'
 
 const pages = {
   '/a': 'Foo',
-  '/b': 'Bar'
+  '/b': 'Bar',
+  '/c': 'Baz'
 }
 
 class HeaderNav extends React.Component {

--- a/test/integration/with-router/pages/c.js
+++ b/test/integration/with-router/pages/c.js
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import Router from 'next/router'
+
+class PageC extends React.Component {
+  componenntWillUnmount () {
+    Router.beforeRouteChangeStart(() => true)
+  }
+
+  goToBFalse () {
+    Router.beforeRouteChangeStart(() => false)
+    return Router.push('/b')
+  }
+
+  goToBTrue () {
+    Router.beforeRouteChangeStart(() => true)
+    return Router.push('/b')
+  }
+
+  render () {
+    return (
+      <div id='page-c'>
+        <button className='false' onClick={() => this.goToBFalse()}>Go to B</button>
+        <button className='true' onClick={() => this.goToBTrue()}>Go to B</button>
+      </div>
+    )
+  }
+}
+
+export default PageC

--- a/test/integration/with-router/test/index.test.js
+++ b/test/integration/with-router/test/index.test.js
@@ -77,4 +77,31 @@ describe('withRouter', () => {
 
     browser.close()
   })
+
+  it('allows Router change to be prevented with beforeRouteChangeStart', async () => {
+    // mock a false return from window.confirm cancel
+    global.confirm = () => false
+
+    const browser = await webdriver(appPort, '/c')
+    await browser.waitForElementByCss('#page-c')
+
+    let activePage = await browser.elementByCss('.active-top-level-router').text()
+    expect(activePage).toBe('Baz')
+
+    // mock beforeRouteChangeStart returns false
+    await browser.elementByCss('button.false').click()
+    await browser.waitForElementByCss('#page-c')
+
+    activePage = await browser.elementByCss('.active-top-level-router').text()
+    expect(activePage).toBe('Baz')
+
+    // mock beforeRouteChangeStart returns true
+    await browser.elementByCss('button.true').click()
+    await browser.waitForElementByCss('#page-b')
+
+    activePage = await browser.elementByCss('.active-top-level-router').text()
+    expect(activePage).toBe('Bar')
+
+    browser.close()
+  })
 })


### PR DESCRIPTION
Added `beforeRouteChangeStart` to router so that you can stop the router from changing if the callback function returns false.

fixes #2694