### PR TITLE
Update with-jest example .babelrc config

### DIFF
--- a/examples/with-jest/.babelrc
+++ b/examples/with-jest/.babelrc
@@ -1,13 +1,3 @@
 {
-  "env": {
-    "development": {
-      "presets": ["next/babel"]
-    },
-    "production": {
-      "presets": ["next/babel"]
-    },
-    "test": {
-      "presets": [["next/babel", { "preset-env": { "modules": "commonjs" } }]]
-    }
-  }
+  "presets": ["next/babel"]
 }

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -7,11 +7,12 @@
     "react-dom": "^16.5.0"
   },
   "devDependencies": {
-    "babel-core": "7.0.0-bridge.0",
+    "@babel/core": "^7.1.2",
+    "babel-core": "^7.0.0-bridge",
     "babel-jest": "^23.6.0",
     "enzyme": "3.4.3",
     "enzyme-adapter-react-16": "1.2.0",
-    "jest": "23.5.0",
+    "jest": "^23.6.0",
     "react-addons-test-utils": "15.6.2",
     "react-test-renderer": "16.4.2"
   },

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -16,7 +16,7 @@
     "react-test-renderer": "16.4.2"
   },
   "scripts": {
-    "test": "NODE_ENV=test jest",
+    "test": "jest",
     "dev": "next",
     "build": "next build",
     "start": "next start"


### PR DESCRIPTION
With version 7 :
>  the Next.js Babel preset (next/babel) now defaults to setting the modules option to commonjs when NODE_ENV is set to test.

So .babelrc can be simplified.