### PR TITLE
Remove arrow functions in dynamic import session from readme file

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -951,7 +951,7 @@ Here are a few ways to use dynamic imports.
 ```jsx
 import dynamic from 'next/dynamic'
 
-const DynamicComponent = dynamic(() => import('../components/hello'))
+const DynamicComponent = dynamic(import('../components/hello'))
 
 export default () => (
   <div>
@@ -967,7 +967,7 @@ export default () => (
 ```jsx
 import dynamic from 'next/dynamic'
 
-const DynamicComponentWithCustomLoading = dynamic(() => import('../components/hello2'), {
+const DynamicComponentWithCustomLoading = dynamic(import('../components/hello2'), {
   loading: () => <p>...</p>
 })
 
@@ -985,7 +985,7 @@ export default () => (
 ```jsx
 import dynamic from 'next/dynamic'
 
-const DynamicComponentWithNoSSR = dynamic(() => import('../components/hello3'), {
+const DynamicComponentWithNoSSR = dynamic(import('../components/hello3'), {
   ssr: false
 })
 


### PR DESCRIPTION
I think you forgot to update that part, I had problems using the `import "next/dynamic"` that was in the documentation and I noticed the Next 7 [ad posting](https://nextjs.org/blog/next-7/#standardized-dynamic-imports) that does not need arrow functions anymore.