### PR TITLE
feat: add dynamic layouts with _app.js example

### DIFF
--- a/examples/with-dynamic-app-layout/layouts/BlueLayout.js
+++ b/examples/with-dynamic-app-layout/layouts/BlueLayout.js
@@ -1,0 +1,5 @@
+export default ({ children }) => {
+  return <main style={{ border: '4px dashed blue' }}>
+    {children}
+  </main>
+}

--- a/examples/with-dynamic-app-layout/layouts/GreenLayout.js
+++ b/examples/with-dynamic-app-layout/layouts/GreenLayout.js
@@ -1,0 +1,5 @@
+export default ({ children }) => {
+  return <main style={{ border: '4px dashed green' }}>
+    {children}
+  </main>
+}

--- a/examples/with-dynamic-app-layout/layouts/RedLayout.js
+++ b/examples/with-dynamic-app-layout/layouts/RedLayout.js
@@ -1,0 +1,5 @@
+export default ({ children }) => {
+  return <main style={{ border: '4px dashed red' }}>
+    {children}
+  </main>
+}

--- a/examples/with-dynamic-app-layout/pages/_app.js
+++ b/examples/with-dynamic-app-layout/pages/_app.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import App, { Container } from 'next/app'
+
+export default class MyApp extends App {
+  render () {
+    const { Component, pageProps } = this.props
+    return <Container>
+      <Component.Layout>
+        <Component {...pageProps} />
+      </Component.Layout>
+    </Container>
+  }
+}

--- a/examples/with-dynamic-app-layout/pages/green.js
+++ b/examples/with-dynamic-app-layout/pages/green.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import Link from 'next/link'
+
+import GreenLayout from '../layouts/GreenLayout'
+
+const GreenPage = () => {
+  return <p>
+    This is the <strong style={{ color: 'green' }}>Green</strong> page, it's borders are green<br /><br />
+    Go back to the <Link href='/'><a style={{ color: 'blue' }}>Blue Page</a></Link>
+  </p>
+}
+
+GreenPage.Layout = GreenLayout
+
+export default GreenPage

--- a/examples/with-dynamic-app-layout/pages/index.js
+++ b/examples/with-dynamic-app-layout/pages/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import Link from 'next/link'
+
+import BlueLayout from '../layouts/BlueLayout'
+
+const BluePage = () => {
+  return <p>
+    This is the <strong style={{ color: 'blue' }}>Blue</strong> page, it's borders are blue<br /><br />
+    Go to the <Link href='/red'><a style={{ color: 'red' }}>Red Page</a></Link><br /><br />
+    Go to the <Link href='/green'><a style={{ color: 'green' }} >Green Page</a></Link>
+  </p>
+}
+
+BluePage.Layout = BlueLayout
+
+export default BluePage

--- a/examples/with-dynamic-app-layout/pages/red.js
+++ b/examples/with-dynamic-app-layout/pages/red.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import Link from 'next/link'
+
+import RedLayout from '../layouts/RedLayout'
+
+const RedPage = () => {
+  return <p>
+    This is the <strong style={{ color: 'red' }} >Red</strong> page, it's borders are red<br /><br />
+    Go back to the <Link href='/'><a>Blue Page</a></Link>
+  </p>
+}
+
+RedPage.Layout = RedLayout
+
+export default RedPage

--- a/examples/with-dynamic-app-layout/readme.md
+++ b/examples/with-dynamic-app-layout/readme.md
@@ -1,0 +1,45 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-dynamic-app-layout)
+
+# With dynamic `App` layout example
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-dynamic-app-layout with-dynamic-app-layout-app
+# or
+yarn create next-app --example with-dynamic-app-layout with-dynamic-app-layout-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-dynamic-app-layout
+cd with-dynamic-app-layout
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+Shows how to use _app.js to implement _dynamic_ layouts for pages.
+This is achieved by attaching a static `Layout` property to each page that needs a different layout. In that way, once we use `_app.js` to wrap our pages, we can get it from `Component.Layout` and render it accordingly.


### PR DESCRIPTION
Regarding a question about having different global layouts via `_app.js` usage, it came up that we could use a static property in the page that needed a different one(Thanks @timneutkens )

Link to the Spectrum post: https://spectrum.chat/?t=af6ca794-5420-4780-abd8-96f085a19e09

This PR adds an example called `with-dynamic-app-layout`, that showcases that use case in the simplest way I could think of.

Let me know if there's changes or improvements to be made. :tada: 
