### PR TITLE
Move nanoid dependency

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -33,6 +33,7 @@
     "hoist-non-react-statics": "^3.0.1",
     "htmlescape": "1.1.1",
     "http-errors": "1.6.2",
+    "nanoid": "1.2.1",
     "path-to-regexp": "2.1.0",
     "prop-types": "15.6.2",
     "send": "0.16.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -80,7 +80,6 @@
     "loader-utils": "1.1.0",
     "minimist": "1.2.0",
     "mkdirp-then": "1.2.0",
-    "nanoid": "1.2.1",
     "next-server": "^7.0.2-canary.9",
     "path-to-regexp": "2.1.0",
     "prop-types": "15.6.2",


### PR DESCRIPTION
I was curious of the size of the new next-server package so tried to [run it through bundlephobia](https://bundlephobia.com/result?p=next-server@canary) but it failed with this message:

![image](https://user-images.githubusercontent.com/5991/46802072-9c6eea00-cd5c-11e8-95a3-c7b690f7606e.png)

So I figured I'd have a shot at a PR :)