### PR TITLE
[with-apollo] Import ApolloClient from apollo-boost directly

### DIFF
--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -1,4 +1,4 @@
-import { ApolloClient, InMemoryCache, HttpLink } from 'apollo-boost'
+import ApolloClient, { InMemoryCache, HttpLink } from 'apollo-boost'
 import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null


### PR DESCRIPTION
In the `with-apollo` example, import `ApolloClient` from `apollo-boost` without destructuring.  The previous example was not compatible with `apollo-link-state` provided by `apollo-boost`

This is also in line with `apollo-boost` documentation:
https://github.com/apollographql/apollo-client/tree/master/packages/apollo-boost