### PR TITLE
Update using emotion example (fix: Warning: <title> should not be used in …)

### DIFF
--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -20,7 +20,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>With Emotion</title>
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
         </Head>
         <body>

--- a/examples/with-emotion/pages/index.js
+++ b/examples/with-emotion/pages/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Head from 'next/head'
 import styled, { hydrate, keyframes, css, injectGlobal } from 'react-emotion'
 
 // Adds server generated styles to emotion cache.
@@ -68,12 +69,17 @@ const Animated = styled.div`
 
 export default () => {
   return (
-    <div>
-      <Basic>Cool Styles</Basic>
-      <Combined>
-        With <code>:hover</code>.
-      </Combined>
-      <Animated animation={bounce}>Let's bounce.</Animated>
-    </div>
+    <>
+      <Head>
+        <title>With Emotion</title>
+      </Head>
+      <div>
+        <Basic>Cool Styles</Basic>
+        <Combined>
+          With <code>:hover</code>.
+        </Combined>
+        <Animated animation={bounce}>Let's bounce.</Animated>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
Update using emotion example to omit:

```bash
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
```