### PR TITLE
Fixed auth token not getting refreshed on client cache reset

### DIFF
--- a/examples/with-apollo-auth/lib/withApollo.js
+++ b/examples/with-apollo-auth/lib/withApollo.js
@@ -77,10 +77,15 @@ export default App => {
 
     constructor (props) {
       super(props)
+
+      const { token } = props
       // `getDataFromTree` renders the component first, the client is passed off as a property.
       // After that rendering is done using Next's normal rendering pipeline
       this.apolloClient = initApollo(props.apolloState, {
-        getToken: () => props.token
+        getToken: () => {
+          if (token) { return token }
+          return parseCookies().token
+        }
       })
     }
 


### PR DESCRIPTION
Token was being passed on server render from getInitialProps but if a client side redirect happened the token was not refreshed and thus queries after login were not working without a refresh.

Fixes #5246 