### PR TITLE
🐳️ multistage: remove devDependencies

### DIFF
--- a/examples/with-docker/Dockerfile.multistage
+++ b/examples/with-docker/Dockerfile.multistage
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY package.json .
 RUN yarn install
 COPY . .
-RUN yarn build
+RUN yarn build && yarn --production
 
 # And then copy over node_modules, etc from that stage to the smaller base image
 FROM mhart/alpine-node:base

--- a/examples/with-docker/package.json
+++ b/examples/with-docker/package.json
@@ -11,5 +11,8 @@
     "react": "16.2.0",
     "react-dom": "16.2.0"
   },
+  "devDependencies": {
+    "isomorphic-unfetch": "^3.0.0"
+  },
   "license": "ISC"
 }


### PR DESCRIPTION
🐳️ `examples/with-docker`: Multistage

Remove `devDependencies` from `./node_modules` in `builder` after build for faster copy to `base`

* Added `isomorphic-unfetch` to show it not being copied over to `base`

* `isomorphic-fetch` will still show from `next`