### PR TITLE
Remove deprecated useBuiltIns from .babelrc

### DIFF
--- a/examples/with-configured-preset-env/.babelrc
+++ b/examples/with-configured-preset-env/.babelrc
@@ -15,8 +15,7 @@
               }
             },
             "transform-runtime": {
-              "regenerator": false,
-              "useBuiltIns": true
+              "regenerator": false
             }
           }
         ]


### PR DESCRIPTION
The `useBuiltIns` [has been removed](https://babeljs.io/docs/en/babel-plugin-transform-runtime#usebuiltins) in v7 of `@babel/plugin-transform-runtime` and causes an error when attempting to run the current `with-configured-preset-env` example. This PR removes that option and fixes the error.