### PR TITLE
fix(examples/with-react-intl): Bug when accept-language is not 'en'

### DIFF
--- a/examples/with-react-intl/server.js
+++ b/examples/with-react-intl/server.js
@@ -42,7 +42,7 @@ const getMessages = (locale) => {
 app.prepare().then(() => {
   createServer((req, res) => {
     const accept = accepts(req)
-    const locale = accept.language(dev ? ['en'] : languages)
+    const locale = accept.language(languages) || 'en'
     req.locale = locale
     req.localeDataScript = getLocaleDataScript(locale)
     req.messages = dev ? {} : getMessages(locale)


### PR DESCRIPTION
## Expected Behaviour

When you run `npm run dev` and visit the http://localhost:3000 with browser with locale other then 'en' in development you should be served eng version of the app.

![image](https://user-images.githubusercontent.com/3077558/47258900-a56d6300-d4a2-11e8-9735-305a9d709469.png)

### Also expected in dev in console per explanation in readme ( & after fix is applyed)
![image](https://user-images.githubusercontent.com/3077558/47258916-df3e6980-d4a2-11e8-8d88-57ec7e01a617.png)

## Actual Behaviour
When you visit app in dev mode & in production, app crashes 
![image](https://user-images.githubusercontent.com/3077558/47258895-8cfd4880-d4a2-11e8-9c8a-b08ef1303a70.png)


## Reason
package 'accept' returns false if can't find language in offered list of languages, then later on
bool is attempted to be split, and app crashes in prod & dev. 
