### PR TITLE
[change] Update react-native-web example

### DIFF
--- a/examples/with-react-native-web/.babelrc
+++ b/examples/with-react-native-web/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": [
-    ["react-native-web", { commonjs: true }]
-  ]
-}

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,0 +1,32 @@
+const esNodeModules = /react-native-web(?!.*node_modules)/;
+const cjsNodeModules = /node_modules\/(?!react-native-web(?!.*node_modules))/;
+
+module.exports = {
+  webpack: (config, { buildId, dev, isServer, defaultLoaders }) => {
+    // Alias all `react-native` imports to `react-native-web`
+    config.resolve.alias = {
+      'react-native$': 'react-native-web',
+    };
+
+    // Compile ES modules
+    config.resolve.symlinks = false;
+    config.externals = config.externals.map(
+      external =>
+        typeof external === 'function'
+          ? (ctx, req, cb) => (esNodeModules.test(req) ? cb(null) : external(ctx, req, cb))
+          : external
+    );
+    config.module.rules.push({
+      test: /\.js$/,
+      loader: defaultLoaders.babel,
+      include: [esNodeModules],
+    });
+
+    return config;
+  },
+  webpackDevMiddleware: config => {
+    // Ignore CJS modules
+    config.watchOptions.ignored = [config.watchOptions.ignored[0], cjsNodeModules];
+    return config;
+  },
+};

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,32 +1,32 @@
-const esNodeModules = /react-native-web(?!.*node_modules)/;
-const cjsNodeModules = /node_modules\/(?!react-native-web(?!.*node_modules))/;
+const esNodeModules = /react-native-web(?!.*node_modules)/
+const cjsNodeModules = /node_modules\/(?!react-native-web(?!.*node_modules))/
 
 module.exports = {
   webpack: (config, { buildId, dev, isServer, defaultLoaders }) => {
     // Alias all `react-native` imports to `react-native-web`
     config.resolve.alias = {
-      'react-native$': 'react-native-web',
-    };
+      'react-native$': 'react-native-web'
+    }
 
     // Compile ES modules
-    config.resolve.symlinks = false;
+    config.resolve.symlinks = false
     config.externals = config.externals.map(
       external =>
         typeof external === 'function'
           ? (ctx, req, cb) => (esNodeModules.test(req) ? cb(null) : external(ctx, req, cb))
           : external
-    );
+    )
     config.module.rules.push({
       test: /\.js$/,
       loader: defaultLoaders.babel,
-      include: [esNodeModules],
-    });
+      include: [esNodeModules]
+    })
 
-    return config;
+    return config
   },
   webpackDevMiddleware: config => {
     // Ignore CJS modules
-    config.watchOptions.ignored = [config.watchOptions.ignored[0], cjsNodeModules];
-    return config;
-  },
-};
+    config.watchOptions.ignored = [config.watchOptions.ignored[0], cjsNodeModules]
+    return config
+  }
+}

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,32 +1,13 @@
-const esNodeModules = /react-native-web(?!.*node_modules)/
-const cjsNodeModules = /node_modules\/(?!react-native-web(?!.*node_modules))/
+const withTM = require('next-plugin-transpile-modules')
 
-module.exports = {
-  webpack: (config, { buildId, dev, isServer, defaultLoaders }) => {
+module.exports = withTM({
+  transpileModules: ['react-native-web'],
+  webpack: (config) => {
     // Alias all `react-native` imports to `react-native-web`
     config.resolve.alias = {
       'react-native$': 'react-native-web'
     }
 
-    // Compile ES modules
-    config.resolve.symlinks = false
-    config.externals = config.externals.map(
-      external =>
-        typeof external === 'function'
-          ? (ctx, req, cb) => (esNodeModules.test(req) ? cb(null) : external(ctx, req, cb))
-          : external
-    )
-    config.module.rules.push({
-      test: /\.js$/,
-      loader: defaultLoaders.babel,
-      include: [esNodeModules]
-    })
-
-    return config
-  },
-  webpackDevMiddleware: config => {
-    // Ignore CJS modules
-    config.watchOptions.ignored = [config.watchOptions.ignored[0], cjsNodeModules]
     return config
   }
-}
+})

--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -6,11 +6,10 @@
     "start": "next start"
   },
   "dependencies": {
-    "babel-plugin-react-native-web": "^0.8.8",
-    "next": "latest",
-    "react": "^16.4.1",
-    "react-art": "^16.4.1",
-    "react-dom": "^16.4.1",
-    "react-native-web": "0.9.3"
+    "next": "^7.0.2",
+    "react": "^16.5.2",
+    "react-art": "^16.5.2",
+    "react-dom": "^16.5.2",
+    "react-native-web": "^0.9.3"
   }
 }

--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^7.0.2",
+    "next": "latest",
     "react": "^16.5.2",
     "react-art": "^16.5.2",
     "react-dom": "^16.5.2",

--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "next": "latest",
+    "next-plugin-transpile-modules": "^0.1.3",
     "react": "^16.5.2",
     "react-art": "^16.5.2",
     "react-dom": "^16.5.2",

--- a/examples/with-react-native-web/pages/_document.js
+++ b/examples/with-react-native-web/pages/_document.js
@@ -27,7 +27,6 @@ export default class MyDocument extends Document {
     return (
       <html style={{ height: '100%' }}>
         <Head>
-          <title>react-native-web</title>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
         </Head>
         <body style={{ height: '100%', overflow: 'hidden' }}>


### PR DESCRIPTION
Utilize ES modules, which are now the default export for
`react-native-web`.

_NOTE:_ [This example requires `next@^7.0.0`](https://bit.ly/2PaEhao).