### PR TITLE
feat: Added react-useragent example

### DIFF
--- a/examples/with-react-useragent/README.md
+++ b/examples/with-react-useragent/README.md
@@ -1,0 +1,47 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-useragent)
+
+# react-useragent example
+
+Show how to setup [@quentin-sommer/react-useragent](https://github.com/quentin-sommer/react-useragent) using next.js client side and server side rendering.
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-react-useragent with-react-useragent-app
+# or
+yarn create next-app --example with-react-useragent with-react-useragent-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-react-useragent
+cd with-react-useragent
+```
+
+Install it
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+## The idea behind the example
+
+This example shows how to add user-agent awarness to your next.js app and set it up for server side rendering. It will enable you to directly detect the device from the server side.
+
+You can then decide what to render depending on the device. For example:
+
+- Smaller image for phones
+- Dedicated download button fos iOS devices.
+
+The example uses the `pages/_app.js` file to automatically injectuser-agent detection in all your pages.

--- a/examples/with-react-useragent/package.json
+++ b/examples/with-react-useragent/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "with-react-useragent",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@quentin-sommer/react-useragent": "2.0.0",
+    "next": "latest",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "license": "ISC"
+}

--- a/examples/with-react-useragent/pages/_app.js
+++ b/examples/with-react-useragent/pages/_app.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import App, {Container} from 'next/app'
+import {UserAgentProvider} from '@quentin-sommer/react-useragent'
+
+const PageWrapper = Comp =>
+  class extends React.Component {
+    /*
+     * Need to use args.ctx
+     * See https://github.com/zeit/next.js#custom-document
+     */
+    static async getInitialProps (args) {
+      return {
+        ua: args.ctx.req
+          ? args.ctx.req.headers['user-agent']
+          : navigator.userAgent,
+        ...(Comp.getInitialProps ? await Comp.getInitialProps(args) : null)
+      }
+    }
+
+    render () {
+      const {ua, ...props} = this.props
+      return (
+        <UserAgentProvider ua={ua}>
+          <Comp {...props} />
+        </UserAgentProvider>
+      )
+    }
+  }
+
+class MyApp extends App {
+  render () {
+    const {Component, pageProps} = this.props
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}
+
+export default PageWrapper(MyApp)

--- a/examples/with-react-useragent/pages/index.js
+++ b/examples/with-react-useragent/pages/index.js
@@ -1,0 +1,47 @@
+import React, {Component} from 'react'
+import {UserAgent} from '@quentin-sommer/react-useragent'
+
+class Index extends Component {
+  render () {
+    return (
+      <div>
+        <p>
+          The following texts render conditionally depending of your user-agent,
+          try visiting with another device or using the chrome dev tools device
+          emulator !
+        </p>
+        <UserAgent android>
+          <div>
+            <p>You seem to be on an android device</p>
+          </div>
+        </UserAgent>
+        <UserAgent ios>
+          <div>
+            <p>You seem to be on an ios device</p>
+          </div>
+        </UserAgent>
+        <UserAgent computer>
+          <div>
+            <p>You seem to be on a computer</p>
+          </div>
+        </UserAgent>
+        <UserAgent linux>
+          <p>Hello Linux!</p>
+        </UserAgent>
+        <UserAgent mac>
+          <p>Hello MacOS!</p>
+        </UserAgent>
+        <UserAgent windows>
+          <p>Hello Windows!</p>
+        </UserAgent>
+        <div>
+          <a href='https://github.com/quentin-sommer/react-useragent'>
+            See full documentation here
+          </a>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Index


### PR DESCRIPTION
Add an example how to use `@quentin-sommer/react-useragent` with next.

I've been asked this https://github.com/quentin-sommer/react-useragent/issues/10 and plan to link this example as reference!

See readme for details