### PR TITLE
Warn, don’t crash, when running Next.js inside an IFrame

### DIFF
--- a/packages/next-server/lib/router/router.js
+++ b/packages/next-server/lib/router/router.js
@@ -4,7 +4,7 @@ import { parse, format } from 'url'
 import EventEmitter from '../EventEmitter'
 import shallowEquals from '../shallow-equals'
 import PQueue from '../p-queue'
-import { loadGetInitialProps, getURL } from '../utils'
+import { loadGetInitialProps, getURL, execOnce } from '../utils'
 import { _rewriteUrlForNextExport } from './'
 
 export default class Router {
@@ -224,6 +224,9 @@ export default class Router {
     }
 
     if (method !== 'pushState' || getURL() !== as) {
+    if (window.frameElement) {
+      execOnce(console.warn)(`Warning: You're using Next.js inside an iFrame. Browser history is disabled.`)
+    } else if (method !== 'pushState' || getURL() !== as) {
       window.history[method]({ url, as, options }, null, as)
     }
   }


### PR DESCRIPTION
Checks if Next.js is running inside an IFrame, in which case it doesn’t use `window.history` and throws a warning once.

Previously, this would generate this error:

	Failed to execute 'replaceState' on 'History':
	A history state object with URL 'https://NEXTJS-CHILD-SERVER/path' cannot be created in a document with origin 'https://IFRAME-SERVER.com' and URL 'https://IFRAME-SERVER.com/path'.

This is an update to #3437 (which is a solution for #3118).