### PR TITLE
Fix issue with HMR not working

### DIFF
--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -309,10 +309,10 @@ export default class HotReloader {
       this.prevChunkHashes = chunkHashes
     })
 
-    // We don’t watch .git .next/ and node_modules for changes
+    // We don’t watch .git/ .next/ and node_modules for changes
     const ignored = [
-      /\.git/,
-      /\.next\//,
+      /\.git[\\/]/,
+      /\.next[\\/]/,
       /node_modules/
     ]
 

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -313,7 +313,7 @@ export default class HotReloader {
     const ignored = [
       /\.git[\\/]/,
       /\.next[\\/]/,
-      /node_modules/
+      /[\\/]node_modules[\\/]/
     ]
 
     let webpackDevMiddlewareConfig = {

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -312,7 +312,7 @@ export default class HotReloader {
     // We don’t watch .git/ .next/ and node_modules for changes
     const ignored = [
       /\.git[\\/]/,
-      /\.next[\\/]/,
+      /[\\/]\.next[\\/]/,
       /[\\/]node_modules[\\/]/
     ]
 

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -311,7 +311,7 @@ export default class HotReloader {
 
     // We don’t watch .git/ .next/ and node_modules for changes
     const ignored = [
-      /\.git[\\/]/,
+      /[\\/]\.git[\\/]/,
       /[\\/]\.next[\\/]/,
       /[\\/]node_modules[\\/]/
     ]


### PR DESCRIPTION
Change the ignore patterns to ignore `.git/` folder.
Add Windows pattern matching for `.next/` and `.git/` folders.

Fixes #5429