### PR TITLE
Remove broken link from progressive-render example

### DIFF
--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -48,5 +48,3 @@ This example features:
 
 * An app with a component that must only be rendered in the client
 * A loading component that will be displayed before rendering the client-only component
-
-**Example**: https://progressive-render-raceuevkqw.now.sh/


### PR DESCRIPTION
- Looks like no other example provides a link to a hosted demo
- There is the "Deploy to now" badge, so it can be deployed on demand when needed
- The link is broken anyway
- Probably any example hosted by an individual contributor sooner or later will be cleaned up, doesn't feel like a reliable way to provide a live demo