### PR TITLE
Updates Link docs regarding automatically wrapping strings into anchor tag

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -385,7 +385,10 @@ export default () => (
 export default () => <p>Welcome to About!</p>
 ```
 
-__Note: use [`<Link prefetch>`](#prefetching-pages) for maximum performance, to link and prefetch in the background at the same time__
+__Notes:__
+
+  - use [`<Link prefetch>`](#prefetching-pages) for maximum performance, to link and prefetch in the background at the same time
+  - if child of `<Link >` is of type `string` - then `Link` will take care of automatically wrapping it into an `<a>` tag for you
 
 Client-side routing behaves exactly like the browser:
 


### PR DESCRIPTION
[Proposal] Since `Link` component takes care of wrapping its children into `<a>` tag when `typeof children === 'string'` I suggest to add this to the docs. Otherwise docs now imply of redundant usage of empty `<a>` tags on `string` type children. 🙂 

If I'm missing some reasons here, let me know I'll update the PR. 