### PR TITLE
Add a space on README

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -676,7 +676,7 @@ import { withRouter } from 'next/router'
 const ActiveLink = ({ children, router, href }) => {
   const style = {
     marginRight: 10,
-    color: router.pathname === href? 'red' : 'black'
+    color: router.pathname === href ? 'red' : 'black'
   }
 
   const handleClick = (e) => {


### PR DESCRIPTION
Hi
Just add a space on README. I suppose that line should be same as [here](https://github.com/zeit/next.js/blob/canary/examples/using-with-router/components/ActiveLink.js#L10).