### PR TITLE
Move ensurePage to DevServer

### DIFF
--- a/packages/next-server/server/render.js
+++ b/packages/next-server/server/render.js
@@ -24,8 +24,6 @@ function getDynamicImportBundles (manifest, moduleIds) {
   }, [])
 }
 
-const logger = console
-
 // since send doesn't support wasm yet
 send.mime.define({ 'application/wasm': ['wasm'] })
 
@@ -203,7 +201,7 @@ export async function renderScriptError (req, res, page, error) {
     return
   }
 
-  logger.error(error.stack)
+  console.error(error.stack)
   res.statusCode = 500
   res.end('500 - Internal Error')
 }

--- a/packages/next-server/server/render.js
+++ b/packages/next-server/server/render.js
@@ -24,8 +24,6 @@ function getDynamicImportBundles (manifest, moduleIds) {
   }, [])
 }
 
-const logger = console
-
 // since send doesn't support wasm yet
 send.mime.define({ 'application/wasm': ['wasm'] })
 
@@ -63,7 +61,6 @@ async function doRender (req, res, pathname, query, {
   err,
   page,
   buildId,
-  hotReloader,
   assetPrefix,
   runtimeConfig,
   distDir,
@@ -73,11 +70,6 @@ async function doRender (req, res, pathname, query, {
   nextExport
 } = {}) {
   page = page || pathname
-
-  // In dev mode we use on demand entries to compile the page before rendering
-  if (hotReloader) {
-    await hotReloader.ensurePage(page)
-  }
 
   const documentPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_document')
   const appPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_app')
@@ -167,7 +159,7 @@ async function doRender (req, res, pathname, query, {
   if (isResSent(res)) return
 
   if (!Document.prototype || !Document.prototype.isReactComponent) throw new Error('_document.js is not exporting a React component')
-  const doc = <Document {...{
+  const documentProps = {
     __NEXT_DATA__: {
       props, // The result of getInitialProps
       page, // The rendered page
@@ -188,7 +180,8 @@ async function doRender (req, res, pathname, query, {
     dynamicImports,
     assetPrefix, // We always pass assetPrefix as a top level property since _document needs it to render, even though the client side might not need it
     ...docProps
-  }} />
+  }
+  const doc = <Document {...documentProps} />
 
   return '<!DOCTYPE html>' + renderToStaticMarkup(doc)
 }
@@ -203,7 +196,7 @@ export async function renderScriptError (req, res, page, error) {
     return
   }
 
-  logger.error(error.stack)
+  console.error(error.stack)
   res.statusCode = 500
   res.end('500 - Internal Error')
 }

--- a/packages/next-server/server/render.js
+++ b/packages/next-server/server/render.js
@@ -61,7 +61,6 @@ async function doRender (req, res, pathname, query, {
   err,
   page,
   buildId,
-  hotReloader,
   assetPrefix,
   runtimeConfig,
   distDir,
@@ -71,11 +70,6 @@ async function doRender (req, res, pathname, query, {
   nextExport
 } = {}) {
   page = page || pathname
-
-  // In dev mode we use on demand entries to compile the page before rendering
-  if (hotReloader) {
-    await hotReloader.ensurePage(page)
-  }
 
   const documentPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_document')
   const appPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_app')

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -90,9 +90,6 @@ export default class DevServer extends Server {
       return this.renderErrorToHTML(compilationErr, req, res, pathname, query)
     }
 
-    // In dev mode we use on demand entries to compile the page before rendering
-    await this.hotReloader.ensurePage(pathname)
-
     return super.renderToHTML(req, res, pathname, query)
   }
 

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -90,6 +90,9 @@ export default class DevServer extends Server {
       return this.renderErrorToHTML(compilationErr, req, res, pathname, query)
     }
 
+    // In dev mode we use on demand entries to compile the page before rendering
+    await this.hotReloader.ensurePage(pathname)
+
     return super.renderToHTML(req, res, pathname, query)
   }
 


### PR DESCRIPTION
It's no longer needed inside the `render()` function since we have a separate devServer