### PR TITLE
Remove registration code from initial markup

### DIFF
--- a/packages/next/build/webpack/plugins/pages-plugin.js
+++ b/packages/next/build/webpack/plugins/pages-plugin.js
@@ -41,10 +41,10 @@ export default class PagesPlugin {
         routeName = `/${routeName.replace(/(^|\/)index$/, '')}`
 
         const source = new ConcatSource(
-          `__NEXT_REGISTER_PAGE('${routeName}', function() {\n`,
+          `(window.__NEXT_P=window.__NEXT_P||[]).push(['${routeName}', function() {\n`,
           moduleSourcePostModule,
           '\nreturn { page: module.exports.default }',
-          '});'
+          '}]);'
         )
 
         return source

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -48,11 +48,12 @@ envConfig.setConfig({
 const asPath = getURL()
 
 const pageLoader = new PageLoader(buildId, prefix)
-window.__NEXT_LOADED_PAGES__.forEach(([r, f]) => {
-  pageLoader.registerPage(r, f)
-})
-delete window.__NEXT_LOADED_PAGES__
-window.__NEXT_REGISTER_PAGE = pageLoader.registerPage.bind(pageLoader)
+const register = ([r, f]) => pageLoader.registerPage(r, f)
+if (window.__NEXT_P) {
+  window.__NEXT_P.map(register)
+}
+window.__NEXT_P = []
+window.__NEXT_P.push = register
 
 const headManager = new HeadManager()
 const appContainer = document.getElementById('__next')

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -187,7 +187,7 @@ export class NextScript extends Component {
   static getInlineScriptSource (documentProps) {
     const { __NEXT_DATA__ } = documentProps
     const { page } = __NEXT_DATA__
-    return `__NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)};__NEXT_LOADED_PAGES__=[];__NEXT_REGISTER_PAGE=function(r,f){__NEXT_LOADED_PAGES__.push([r, f])};`
+    return `__NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)};`
   }
 
   render () {


### PR DESCRIPTION
Clears the way a bit for #4943, also makes _document.js less complex, and will allow us to move `__NEXT_DATA__` to a `application/json` script tag.

Also this causes a slightly smaller bundle size 😌 