### PR TITLE
Transpile styled-jsx into server bundle

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -36,7 +36,6 @@
     "path-to-regexp": "2.1.0",
     "prop-types": "15.6.2",
     "send": "0.16.1",
-    "styled-jsx": "3.1.0",
     "url": "0.11.0"
   },
   "peerDependencies": {

--- a/packages/next/build/webpack.js
+++ b/packages/next/build/webpack.js
@@ -31,7 +31,7 @@ function externalsConfig (dir, isServer) {
     return externals
   }
 
-  const notExternalModules = ['next/app', 'next/document', 'next/error', 'http-status', 'styled-jsx']
+  const notExternalModules = ['next/app', 'next/document', 'next/error', 'http-status']
 
   externals.push((context, request, callback) => {
     if (notExternalModules.indexOf(request) !== -1) {
@@ -50,6 +50,11 @@ function externalsConfig (dir, isServer) {
 
       // Webpack itself has to be compiled because it doesn't always use module relative paths
       if (res.match(/node_modules[/\\]webpack/) || res.match(/node_modules[/\\]css-loader/)) {
+        return callback()
+      }
+
+      // styled-jsx has to be transpiled
+      if (res.match(/node_modules[/\\]styled-jsx/)) {
         return callback()
       }
 


### PR DESCRIPTION
Drops an additional 6MB from the next-server node_modules size as there's no lodash