### PR TITLE
Fix css on with-semantic-ui example

### DIFF
--- a/examples/with-semantic-ui/next.config.js
+++ b/examples/with-semantic-ui/next.config.js
@@ -3,13 +3,13 @@ const withCss = require('@zeit/next-css')
 module.exports = withCss({
   webpack (config) {
     config.module.rules.push({
-      test: /\.(png|svg|eot|otf|ttf|woff|woff2)$/,
+      test: /\.(png|svg|eot|otf|ttf|woff|woff2)$/i,
       use: {
         loader: 'url-loader',
         options: {
-          limit: 100000,
+          limit: 8192,
           publicPath: './',
-          outputPath: 'static/',
+          outputPath: 'static/css/',
           name: '[name].[ext]'
         }
       }


### PR DESCRIPTION
# Changes

* Test file extension using a case insensitive expression.
We never know when someone will screw our workload because they named a file using uppercase.

* Fixes assets output folder.
If `limit` is set to a small number (closer to 1), the `file-loader` can't find the files to import.

![image](https://user-images.githubusercontent.com/2457338/47966720-d28e4980-e03c-11e8-82c3-cc1c30a12af4.png)

* Reduce `limit` so we can use `file-loader` on larger files.
This will save a few kilobytes, since the old behavior is to inline the content using base64 (33% overhead).
Since HTTP/2 with multiplexing, there is not much vantage to inline all resources, specially when you set the number to 100000 bytes (~97KB).

Refer: https://github.com/webpack-contrib/url-loader#limit