### PR TITLE
Take full advantage of caching between builds

### DIFF
--- a/packages/next/build/webpack.js
+++ b/packages/next/build/webpack.js
@@ -94,11 +94,19 @@ function optimizationConfig ({dir, dev, isServer, totalPages}) {
   }
 
   // Terser is a better uglifier
-  config.minimizer = [new TerserPlugin({
-    parallel: true,
-    sourceMap: false,
-    cache: true
-  })]
+  config.minimizer = [
+    new TerserPlugin({
+      parallel: true,
+      sourceMap: false,
+      cache: true,
+      cacheKeys: (keys) => {
+        // path changes per build because we add buildId
+        // because the input is already hashed the path is not needed
+        delete keys.path
+        return keys
+      }
+    })
+  ]
 
   // Only enabled in production
   // This logic will create a commons bundle
@@ -254,6 +262,7 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
       }),
       // This plugin makes sure `output.filename` is used for entry chunks
       new ChunkNamesPlugin(),
+      new webpack.HashedModuleIdsPlugin(),
       !isServer && new ReactLoadablePlugin({
         filename: REACT_LOADABLE_MANIFEST
       }),

--- a/packages/next/build/webpack.js
+++ b/packages/next/build/webpack.js
@@ -262,7 +262,6 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
       }),
       // This plugin makes sure `output.filename` is used for entry chunks
       new ChunkNamesPlugin(),
-      new webpack.HashedModuleIdsPlugin(),
       !isServer && new ReactLoadablePlugin({
         filename: REACT_LOADABLE_MANIFEST
       }),
@@ -277,6 +276,7 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, i
       dev && new webpack.NoEmitOnErrorsPlugin(),
       dev && new UnlinkFilePlugin(),
       dev && new CaseSensitivePathPlugin(), // Since on macOS the filesystem is case-insensitive this will make sure your path are case-sensitive
+      !dev && new webpack.HashedModuleIdsPlugin(),
       // Removes server/client code by minifier
       new webpack.DefinePlugin({
         'process.browser': JSON.stringify(!isServer)

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -12,6 +12,7 @@ module.exports = babelLoader.custom(babel => {
         dev: opts.dev
       }
       const loader = Object.assign({
+        cacheCompression: false,
         cacheDirectory: true
       }, opts)
       delete loader.isServer

--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -66,6 +66,6 @@ describe('Production response size', () => {
     console.log(`Response Sizes:\n${responseSizes.map(obj => ` ${obj.url}: ${obj.bytes} (bytes)`).join('\n')} \nOverall: ${responseSizeKilobytes} KB`)
 
     // These numbers are without gzip compression!
-    expect(responseSizeKilobytes).toBeLessThanOrEqual(203) // Kilobytes
+    expect(responseSizeKilobytes).toBeLessThanOrEqual(207) // Kilobytes
   })
 })


### PR DESCRIPTION
Takes advantage of caching between builds for Terser, also makes writing caches for babel-loader faster by disabling compression.

Results for zeit.co (350 pages):

Without cache:
[4:16:22 PM] Compiled server in 1m
[4:16:57 PM] Compiled client in 2m
✨  Done in 125.83s.

With cache:
[4:19:38 PM] Compiled client in 17s
[4:19:50 PM] Compiled server in 29s
✨  Done in 31.79s.

Note: these results are from my multi-core Macbook Pro 2017, exact specs:
MacBook Pro (13-inch, 2017, Four Thunderbolt 3 Ports)
- 3,3 GHz Intel Core i5
- 16 GB 2133 MHz LPDDR3
- Intel Iris Plus Graphics 650 1536 MB

The `without cache` build runs uglify in parallel, so without cache is likely to take longer on environments where you have only 1 core available.

The `with cache` build however runs in a single thread, so the results should be similar.