### PR TITLE
Fix incorrect path for ts server example

### DIFF
--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "nodemon server/index.ts",
     "build": "next build && tsc --project tsconfig.server.json",
-    "start": "NODE_ENV=production node .next/production-server/index.js"
+    "start": "NODE_ENV=production node .next/production-server/server/index.js"
   },
   "dependencies": {
     "@babel/core": "^7.1.2",


### PR DESCRIPTION
The customer-server-typescript example has a bug where the `yarn start` command has the incorrect path to the server entry point file.