### PR TITLE
Simplify styled-components example

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -1,25 +1,16 @@
-import Document, { Head, Main, NextScript } from 'next/document'
+import Document from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
 export default class MyDocument extends Document {
-  static getInitialProps ({ renderPage }) {
+  static async getInitialProps (ctx) {
     const sheet = new ServerStyleSheet()
-    const page = renderPage(App => props => sheet.collectStyles(<App {...props} />))
-    const styleTags = sheet.getStyleElement()
-    return { ...page, styleTags }
-  }
 
-  render () {
-    return (
-      <html>
-        <Head>
-          {this.props.styleTags}
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </html>
-    )
+    const originalRenderPage = ctx.renderPage
+    ctx.renderPage = () => originalRenderPage({
+      enhanceApp: App => props => sheet.collectStyles(<App {...props} />)
+    })
+
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps, styles: [...initialProps.styles, ...sheet.getStyleElement()] }
   }
 }


### PR DESCRIPTION
- use `enhanceApp` so that styled-components used in _app.js are server rendered
- call parent getInitialProps, fixes #5629
- return `styles`, making the render() method obsolete.

cc @mxstbr @probablyup