### PR TITLE
Fix link to constants (for phases) in next readme

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1213,7 +1213,7 @@ module.exports = (phase, {defaultConfig}) => {
 }
 ```
 
-`phase` is the current context in which the configuration is loaded. You can see all phases here: [constants](/packages/next/lib/constants.js)
+`phase` is the current context in which the configuration is loaded. You can see all phases here: [constants](/packages/next-server/lib/constants.js)
 Phases can be imported from `next/constants`:
 
 ```js


### PR DESCRIPTION
The `PHASE_*` constants seem to have moved, so I'm updating this link in the readme.