### PR TITLE
Run initializeStore() only once per route on server

### DIFF
--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -21,7 +21,10 @@ class MyMobxApp extends App {
 
     constructor(props) {
         super(props)
-        this.mobxStore = initializeStore(props.initialMobxState)
+        const isServer = typeof window === 'undefined'
+        this.mobxStore = isServer ?
+            props.initialMobxState:
+            initializeStore(props.initialMobxState)
     }
 
     render() {


### PR DESCRIPTION
On the server `props.initialMobxState` received by the `constructor` is a fully functioning mobx store that was instantiated by `getInitialProps()` only a few ticks earlier.
Thus, creating a new instance is unneccessary busiwork.

In the browser, however, `props.initialMobxState` is a hydrated plain object and thus the store needs to be initialized.