### PR TITLE
Follow best SEO practices for 404 page

### DIFF
--- a/packages/next/pages/_error.js
+++ b/packages/next/pages/_error.js
@@ -18,7 +18,7 @@ export default class Error extends React.Component {
     return <div style={styles.error}>
       <Head>
         <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-        {statusCode === 404 ? <meta name="robots" content="noindex" /> : null}
+        {statusCode === 404 ? <meta name='robots' content='noindex' /> : null}
         <title>{statusCode}: {title}</title>
       </Head>
       <div>

--- a/packages/next/pages/_error.js
+++ b/packages/next/pages/_error.js
@@ -18,6 +18,7 @@ export default class Error extends React.Component {
     return <div style={styles.error}>
       <Head>
         <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+        {statusCode === 404 ? <meta name="robots" content="noindex" /> : null}
         <title>{statusCode}: {title}</title>
       </Head>
       <div>


### PR DESCRIPTION
We are running https://www.onepixel.com/ through an SEO audit, I have learned that it's best practice to add a **noindex** on 404 pages.