### PR TITLE
Update contributing.md to use yarn.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -3,9 +3,10 @@
 Our Commitment to Open Source can be found [here](https://zeit.co/blog/oss)
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
-2. Install the dependencies: `npm install`
-3. Run `npm run bootstrap`, which will link all repositories locally
-4. Run `npm run dev` to build and watch for code changes
+2. Install yarn: `npm install -g yarn`
+3. Install the dependencies: `yarn`
+4. Run `yarn run bootstrap`, which will link all repositories locally
+5. Run `yarn run dev` to build and watch for code changes
 
 ## To run tests
 


### PR DESCRIPTION
The current contributing.md instructions are outdated since the project uses yarn.

The problem:
Without installing yarn we have the following error/output:

`lerna ERR! yarn run prepublish exited ENOENT in 'next-server'`

Adding new instructions on how to install and run the project.