### PR TITLE
make static css immutable

### DIFF
--- a/packages/next-server/server/next-server.js
+++ b/packages/next-server/server/next-server.js
@@ -105,7 +105,7 @@ export default class Server {
           // The commons folder holds commonschunk files
           // The chunks folder holds dynamic entries
           // The buildId folder holds pages and potentially other assets. As buildId changes per build it can be long-term cached.
-          if (params.path[0] === CLIENT_STATIC_FILES_RUNTIME || params.path[0] === 'chunks' || params.path[0] === this.buildId) {
+          if (params.path[0] === CLIENT_STATIC_FILES_RUNTIME || params.path[0] === 'chunks' || params.path[0] === 'css' || params.path[0] === this.buildId) {
             this.setImmutableAssetCacheControl(res)
           }
           const p = join(this.distDir, CLIENT_STATIC_FILES_PATH, ...(params.path || []))


### PR DESCRIPTION
css is currently max-age 0 which means it won't be cached by cdn.  This fixes that along with 

Related: https://github.com/zeit/next-plugins/pull/335

Fixes #5464 
Fixes zeit/next-plugins#243
