### PR TITLE
update package dependencies for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "devDependencies": {
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
     "@babel/preset-react": "7.0.0",
-    "@zeit/next-css": "0.2.1-canary.1",
-    "@zeit/next-sass": "0.2.1-canary.1",
-    "@zeit/next-typescript": "1.1.0",
+    "@zeit/next-css": "1.0.2-canary.2",
+    "@zeit/next-sass": "1.0.2-canary.2",
+    "@zeit/next-typescript": "1.1.2-canary.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",
     "babel-jest": "23.6.0",


### PR DESCRIPTION
> Could you add a test to Next.js (upgrading this dep to canary) and then test/integration/config holds the tests for next-css
@timneutkens https://github.com/zeit/next-plugins/pull/335#issuecomment-438845937

I updated package.json with the canary dep and ran `yarn testonly --testPathPattern "config"`
![image](https://user-images.githubusercontent.com/1892132/48519483-f104f980-e821-11e8-875e-13f9ff5ef1c8.png)
Is that what was requested or did I totally misunderstand?