### PR TITLE
Fix react-helmet example

### DIFF
--- a/examples/with-react-helmet/pages/_app.js
+++ b/examples/with-react-helmet/pages/_app.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import App, { Container } from 'next/app'
+import Helmet from 'react-helmet'
+
+export default class MyApp extends App {
+  static async getInitialProps (...args) {
+    return App.getInitialProps(...args)
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+
+    return (
+      <Container>
+        <Helmet
+          htmlAttributes={{ lang: 'en' }}
+          title='Hello next.js!'
+          meta={[
+            {
+              name: 'viewport',
+              content: 'width=device-width, initial-scale=1'
+            },
+            { property: 'og:title', content: 'Hello next.js!' }
+          ]}
+        />
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}

--- a/examples/with-react-helmet/pages/_document.js
+++ b/examples/with-react-helmet/pages/_document.js
@@ -26,21 +26,9 @@ export default class extends Document {
       .map(el => this.props.helmet[el].toComponent())
   }
 
-  get helmetJsx () {
-    return (<Helmet
-      htmlAttributes={{lang: 'en'}}
-      title='Hello next.js!'
-      meta={[
-        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        { property: 'og:title', content: 'Hello next.js!' }
-      ]}
-    />)
-  }
-
   render () {
     return (<html {...this.helmetHtmlAttrComponents}>
       <Head>
-        { this.helmetJsx }
         { this.helmetHeadComponents }
       </Head>
       <body {...this.helmetBodyAttrComponents}>

--- a/examples/with-react-helmet/pages/_document.js
+++ b/examples/with-react-helmet/pages/_document.js
@@ -3,36 +3,33 @@ import Helmet from 'react-helmet'
 
 export default class extends Document {
   static async getInitialProps (...args) {
-    const documentProps = await super.getInitialProps(...args)
+    const documentProps = await Document.getInitialProps(...args)
     // see https://github.com/nfl/react-helmet#server-usage for more information
     // 'head' was occupied by 'renderPage().head', we cannot use it
     return { ...documentProps, helmet: Helmet.renderStatic() }
   }
 
-  // should render on <html>
-  get helmetHtmlAttrComponents () {
-    return this.props.helmet.htmlAttributes.toComponent()
-  }
-
-  // should render on <body>
-  get helmetBodyAttrComponents () {
-    return this.props.helmet.bodyAttributes.toComponent()
-  }
-
-  // should render on <head>
-  get helmetHeadComponents () {
-    return Object.keys(this.props.helmet)
-      .filter(el => el !== 'htmlAttributes' && el !== 'bodyAttributes')
-      .map(el => this.props.helmet[el].toComponent())
-  }
-
   render () {
-    return (<html {...this.helmetHtmlAttrComponents}>
-      <head>{this.helmetHeadComponents}</head>
-      <body {...this.helmetBodyAttrComponents}>
-        <Main />
-        <NextScript />
-      </body>
-    </html>)
+    const { htmlAttributes, bodyAttributes, ...helmet } = this.props.helmet
+
+    const htmlAttrs = htmlAttributes.toComponent()
+    const bodyAttrs = bodyAttributes.toComponent()
+
+    // we replace next's <Head> component and build our own <head> here
+    // we could rearrange the head tags in a better order
+    // (first meta charset, then title, ...)
+    const headComponent = (
+      <head>{Object.values(helmet).map(el => el.toComponent())}</head>
+    )
+
+    return (
+      <html {...htmlAttrs}>
+        {headComponent}
+        <body {...bodyAttrs}>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
   }
 }

--- a/examples/with-react-helmet/pages/_document.js
+++ b/examples/with-react-helmet/pages/_document.js
@@ -1,4 +1,4 @@
-import Document, { Head, Main, NextScript } from 'next/document'
+import Document, { Main, NextScript } from 'next/document'
 import Helmet from 'react-helmet'
 
 export default class extends Document {
@@ -28,9 +28,7 @@ export default class extends Document {
 
   render () {
     return (<html {...this.helmetHtmlAttrComponents}>
-      <Head>
-        { this.helmetHeadComponents }
-      </Head>
+      <head>{this.helmetHeadComponents}</head>
       <body {...this.helmetBodyAttrComponents}>
         <Main />
         <NextScript />


### PR DESCRIPTION
This PR fix the example with react-helmet printing warnings : 

```
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
```

The key is to replace next's `<Head>` component and build our own `<head>` tags in `_document.js`.

Fix https://github.com/zeit/next.js/issues/5668