### PR TITLE
Remove <title> in _document.js in examples

### DIFF
--- a/examples/with-aphrodite/pages/_document.js
+++ b/examples/with-aphrodite/pages/_document.js
@@ -27,7 +27,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           <style data-aphrodite dangerouslySetInnerHTML={{ __html: this.props.css.content }} />
         </Head>
         <body>

--- a/examples/with-babel-macros/pages/_document.js
+++ b/examples/with-babel-macros/pages/_document.js
@@ -6,7 +6,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>With babel-macros</title>
           <style dangerouslySetInnerHTML={{__html: this.props.css}} />
         </Head>
         <body>

--- a/examples/with-cxs/pages/_document.js
+++ b/examples/with-cxs/pages/_document.js
@@ -12,7 +12,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           <style id='cxs-style' dangerouslySetInnerHTML={{ __html: this.props.style }} />
         </Head>
         <body>

--- a/examples/with-emotion-fiber/pages/_document.js
+++ b/examples/with-emotion-fiber/pages/_document.js
@@ -20,7 +20,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>With Emotion</title>
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
         </Head>
         <body>

--- a/examples/with-fela/pages/_document.js
+++ b/examples/with-fela/pages/_document.js
@@ -39,7 +39,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           {styleNodes}
         </Head>
         <body>

--- a/examples/with-glamor/pages/_document.js
+++ b/examples/with-glamor/pages/_document.js
@@ -20,7 +20,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
         </Head>
         <body>

--- a/examples/with-glamorous/pages/_document.js
+++ b/examples/with-glamorous/pages/_document.js
@@ -20,7 +20,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>With Glamorous</title>
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
         </Head>
         <body>

--- a/examples/with-react-uwp/pages/_document.js
+++ b/examples/with-react-uwp/pages/_document.js
@@ -14,7 +14,6 @@ export default class MyDocument extends Document {
     return (
       <html lang='en'>
         <Head>
-          <title>My page</title>
           <meta charSet='utf-8' />
           <meta name='viewport' content='user-scalable=0, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height' />
           <meta name='theme-color' content='yellowgreen' />

--- a/examples/with-rebass/pages/_document.js
+++ b/examples/with-rebass/pages/_document.js
@@ -10,7 +10,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           {styleTags}
         </Head>
         <body>

--- a/examples/with-styletron/pages/_document.js
+++ b/examples/with-styletron/pages/_document.js
@@ -13,7 +13,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           {this.props.stylesheets.map((sheet, i) => (
             <style
               className='_styletron_hydrate_'

--- a/examples/with-typestyle/pages/_document.js
+++ b/examples/with-typestyle/pages/_document.js
@@ -12,7 +12,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           <style id='styles-target'>
             {this.props.styleTags}
           </style>


### PR DESCRIPTION
Writing `<title>` in `_document.js` creates a warning :

```
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
```

This PR removes <title> in _document.js in examples.