### PR TITLE
Refactor rendor verification to validate if it's a blocked page.

### DIFF
--- a/packages/next-server/server/next-server.js
+++ b/packages/next-server/server/next-server.js
@@ -10,9 +10,9 @@ import {
   serveStatic
 } from './render'
 import Router, {route} from './router'
-import { isInternalUrl } from './utils'
+import { isInternalUrl, isBlockedPage } from './utils'
 import loadConfig from 'next-server/next-config'
-import {PHASE_PRODUCTION_SERVER, BLOCKED_PAGES, BUILD_ID_FILE, CLIENT_STATIC_FILES_PATH, CLIENT_STATIC_FILES_RUNTIME} from 'next-server/constants'
+import {PHASE_PRODUCTION_SERVER, BUILD_ID_FILE, CLIENT_STATIC_FILES_PATH, CLIENT_STATIC_FILES_RUNTIME} from 'next-server/constants'
 import * as asset from '../lib/asset'
 import * as envConfig from '../lib/runtime-config'
 import { isResSent } from '../lib/utils'
@@ -177,7 +177,7 @@ export default class Server {
       return this.handleRequest(req, res, parsedUrl)
     }
 
-    if (BLOCKED_PAGES.indexOf(pathname) !== -1) {
+    if (isBlockedPage(pathname)) {
       return await this.render404(req, res, parsedUrl)
     }
 

--- a/packages/next-server/server/utils.js
+++ b/packages/next-server/server/utils.js
@@ -1,3 +1,5 @@
+import { BLOCKED_PAGES } from 'next-server/constants'
+
 const internalPrefixes = [
   /^\/_next\//,
   /^\/static\//
@@ -11,4 +13,8 @@ export function isInternalUrl (url) {
   }
 
   return false
+}
+
+export function isBlockedPage (pathname) {
+  return (BLOCKED_PAGES.indexOf(pathname) !== -1)
 }


### PR DESCRIPTION
Extracting the logic that defines if a page is blocked to utils.

If that refactor make sense, I will create a next PR to cover both of the functions inside utils with tests.