### PR TITLE
Bump bump-babel-plugin-react-require to 3.0.1

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -51,7 +51,7 @@
     "autodll-webpack-plugin": "0.4.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.2",
-    "babel-plugin-react-require": "3.0.0",
+    "babel-plugin-react-require": "3.0.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.15",
     "case-sensitive-paths-webpack-plugin": "2.1.2",
     "cross-spawn": "5.1.0",


### PR DESCRIPTION
See https://github.com/vslinko/babel-plugin-react-require/pull/18#issuecomment-425996681 🙂

I came across that patch when attempting to use `babel-plugin-inline-react-svg` (https://github.com/airbnb/babel-plugin-inline-react-svg/issues/31)