### PR TITLE
Local variable 'out' is redundant

### DIFF
--- a/packages/next-server/server/next-server.js
+++ b/packages/next-server/server/next-server.js
@@ -194,8 +194,7 @@ export default class Server {
 
   async renderToHTML (req, res, pathname, query) {
     try {
-      const out = await renderToHTML(req, res, pathname, query, this.renderOpts)
-      return out
+      return await renderToHTML(req, res, pathname, query, this.renderOpts)
     } catch (err) {
       if (err.code === 'ENOENT') {
         res.statusCode = 404


### PR DESCRIPTION
Removing the variable "out" since it's not used for anything after assigning it a value besides returning it. 