### PR TITLE
Fix duplicate React declaration error when interoping with other plugins

### DIFF
--- a/packages/next/build/babel/preset.js
+++ b/packages/next/build/babel/preset.js
@@ -44,6 +44,7 @@ module.exports = (context, opts = {}) => ({
     }]
   ],
   plugins: [
+    process.env.NODE_ENV === 'production' && require('babel-plugin-transform-react-remove-prop-types'),
     require('babel-plugin-react-require'),
     require('@babel/plugin-syntax-dynamic-import'),
     require('./plugins/react-loadable-plugin'),
@@ -55,7 +56,6 @@ module.exports = (context, opts = {}) => ({
       regenerator: true,
       ...opts['transform-runtime']
     }],
-    [require('styled-jsx/babel'), styledJsxOptions(opts['styled-jsx'])],
-    process.env.NODE_ENV === 'production' && require('babel-plugin-transform-react-remove-prop-types')
+    [require('styled-jsx/babel'), styledJsxOptions(opts['styled-jsx'])]
   ].filter(Boolean)
 })


### PR DESCRIPTION
When trying to upgrade a project from next 6 to 7, I hit a series of errors like `Duplicate declaration "React"` caused by babel transforms.

This prevented me from building my next.js app (with `next build`) while importing SVGs (using either `babel-plugin-inline-react-svg` or `@svgr/webpack`) and MDX files (using `@zeit/next-mdx`).

After much digging, was able to pinpoint the culprit to `babel-plugin-transform-react-remove-prop-types` running after `babel-plugin-react-require`.

Changing the order of plugins fixes the issue and does run, build and export without errors.