### PR TITLE
Add engines to next and next-server

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -53,5 +53,8 @@
     "@taskr/clear": "1.1.0",
     "@taskr/watch": "1.1.0",
     "taskr": "1.1.0"
+  },
+  "engines": {
+    "node": ">= 8.0.0"
   }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -94,5 +94,8 @@
     "@taskr/esnext": "1.1.0",
     "@taskr/watch": "1.1.0",
     "taskr": "1.1.0"
+  },
+  "engines": {
+    "node": ">= 8.0.0"
   }
 }


### PR DESCRIPTION
Fixes #5520 #5508

Decided against adding runtime checks for Node.js version, especially in production it'd be a slight slowdown on bootup. Package managers handle engines already, so this would be the correct solution.