### PR TITLE
Fix location of production server file

### DIFF
--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "nodemon server/index.ts",
     "build": "next build && tsc --project tsconfig.server.json",
-    "start": "NODE_ENV=production node .next/production-server/server/index.js"
+    "start": "NODE_ENV=production node .next/production-server/index.js"
   },
   "dependencies": {
     "@babel/core": "^7.1.2",


### PR DESCRIPTION
(At least with my set up, mac osx, node 10.13.0, yarn 1.12.1)

Couldn't get the server to start with `npm start`, this appears to fix that