### PR TITLE
fix custom-server-express example routes mismatch

### DIFF
--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -11,11 +11,11 @@ app.prepare()
     const server = express()
 
     server.get('/a', (req, res) => {
-      return app.render(req, res, '/b', req.query)
+      return app.render(req, res, '/a', req.query)
     })
 
     server.get('/b', (req, res) => {
-      return app.render(req, res, '/a', req.query)
+      return app.render(req, res, '/b', req.query)
     })
 
     server.get('/posts/:id', (req, res) => {


### PR DESCRIPTION
Simple fix for routes mismatch in `custom-server-express` example.