### PR TITLE
Hydrate query prop for static export

### DIFF
--- a/examples/basic-export/pages/about.js
+++ b/examples/basic-export/pages/about.js
@@ -1,3 +1,5 @@
 export default () => (
-  <div>About us</div>
+  <div>
+    <h1>About us</h1>
+  </div>
 )

--- a/examples/basic-export/pages/about2.js
+++ b/examples/basic-export/pages/about2.js
@@ -1,3 +1,0 @@
-export default () => (
-  <div>About 2</div>
-)

--- a/examples/basic-export/pages/day/index.js
+++ b/examples/basic-export/pages/day/index.js
@@ -1,3 +1,5 @@
 export default () => (
-  <div>Hello Day</div>
+  <div>
+    <h1>Hello Day</h1>
+  </div>
 )

--- a/examples/basic-export/pages/index.js
+++ b/examples/basic-export/pages/index.js
@@ -1,4 +1,11 @@
 import Link from 'next/link'
 export default () => (
-  <div>Hello World. <Link href='/about'><a>About</a></Link></div>
+  <div>
+    <h1>Hello World.</h1>
+    <ol>
+      <li><Link href='/about'><a>About</a></Link></li>
+      <li><Link href='/withQuery?some=query&in=here'><a>About 2: A link with query</a></Link></li>
+      <li><Link href='/day'><a>Day: A folder with index.js</a></Link></li>
+    </ol>
+  </div>
 )

--- a/examples/basic-export/pages/withQuery.js
+++ b/examples/basic-export/pages/withQuery.js
@@ -1,0 +1,7 @@
+export default (props) => (
+  <div>
+    <h1>Route with query</h1>
+    <p>props.url.query</p>
+    <pre>{JSON.stringify(props.url.query, null, '  ')}</pre>
+  </div>
+)

--- a/packages/next-server/lib/utils.js
+++ b/packages/next-server/lib/utils.js
@@ -1,3 +1,5 @@
+import { parse as parseQs } from 'querystring'
+
 export function execOnce (fn) {
   let used = false
   return (...args) => {
@@ -17,6 +19,11 @@ export function getURL () {
   const { href } = window.location
   const origin = getLocationOrigin()
   return href.substring(origin.length)
+}
+
+export function getQuery () {
+  const { search } = window.location
+  return parseQs(search.replace(/^\?/, ''))
 }
 
 export function getDisplayName (Component) {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import HeadManager from './head-manager'
 import { createRouter } from 'next-server/dist/lib/router'
 import EventEmitter from 'next-server/dist/lib/EventEmitter'
-import {loadGetInitialProps, getURL} from 'next-server/dist/lib/utils'
+import {loadGetInitialProps, getURL, getQuery} from 'next-server/dist/lib/utils'
 import PageLoader from '../lib/page-loader'
 import * as asset from 'next-server/asset'
 import * as envConfig from 'next-server/config'
@@ -30,7 +30,8 @@ const {
   buildId,
   assetPrefix,
   runtimeConfig,
-  dynamicIds
+  dynamicIds,
+  nextExport
 } = data
 
 const prefix = assetPrefix || ''
@@ -93,14 +94,18 @@ export default async ({
 
   await Loadable.preloadReady(dynamicIds || [])
 
-  router = createRouter(page, query, asPath, {
-    initialProps: props,
-    pageLoader,
-    App,
-    Component,
-    ErrorComponent,
-    err: initialErr
-  })
+  router = createRouter(
+    page,
+    nextExport ? getQuery() : query,
+    asPath, {
+      initialProps: props,
+      pageLoader,
+      App,
+      Component,
+      ErrorComponent,
+      err: initialErr
+    }
+  )
 
   router.subscribe(({ App, Component, props, err }) => {
     render({ App, Component, props, err, emitter })


### PR DESCRIPTION
When you load a route with a querystring the query prop would always be undefined.

fixes #4804 #4403 #3304 #3313