### PR TITLE
📦️ lint:fix => !global standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "npm run testall || npm run testall",
     "coveralls": "cat ./test/coverage/lcov.info | coveralls",
     "lint": "standard",
+    "lint:fix": "standard --fix",
     "prepublish": "lerna run prepublish",
     "publish-canary": "lerna version prerelease --preid canary --force-publish",
     "lint-staged": "lint-staged"


### PR DESCRIPTION
Add a script  call (`yarn lint:fix`) to run `standard --fix` so
 `standard` does not need to be installed globally.

```bash
standard: Use JavaScript Standard Style (https://standardjs.com)
standard: Run `standard --fix` to automatically fix some problems.
```