### PR TITLE
Add next export --spa (idea)

### DIFF
--- a/packages/next-server/server/render.js
+++ b/packages/next-server/server/render.js
@@ -66,7 +66,8 @@ async function doRender (req, res, pathname, query, {
   dir,
   dev = false,
   staticMarkup = false,
-  nextExport
+  nextExport,
+  spa
 } = {}) {
   page = page || pathname
 
@@ -89,7 +90,7 @@ async function doRender (req, res, pathname, query, {
   App = App.default || App
   Document = Document.default || Document
   const asPath = req.url
-  const ctx = { err, req, res, pathname: page, query, asPath }
+  const ctx = { err, req, res, pathname: page, query, asPath, nextExport }
   const router = new Router(page, query, asPath)
   const props = await loadGetInitialProps(App, {Component, router, ctx})
   const devFiles = buildManifest.devFiles
@@ -167,7 +168,8 @@ async function doRender (req, res, pathname, query, {
       runtimeConfig, // runtimeConfig if provided, otherwise don't sent in the resulting HTML
       nextExport, // If this is a page exported by `next export`
       dynamicIds: dynamicImportsIds.length === 0 ? undefined : dynamicImportsIds,
-      err: (err) ? serializeError(dev, err) : undefined // Error if one happened, otherwise don't sent in the resulting HTML
+      err: (err) ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
+      spa
     },
     dev,
     dir,

--- a/packages/next/bin/next-export
+++ b/packages/next/bin/next-export
@@ -11,10 +11,11 @@ const argv = parseArgs(process.argv.slice(2), {
     s: 'silent',
     o: 'outdir'
   },
-  boolean: ['h'],
+  boolean: ['h', 'spa'],
   default: {
     s: false,
-    o: null
+    o: null,
+    spa: false
   }
 })
 
@@ -54,7 +55,8 @@ if (!existsSync(join(dir, 'pages'))) {
 
 const options = {
   silent: argv.silent,
-  outdir: argv.outdir ? resolve(argv.outdir) : resolve(dir, 'out')
+  outdir: argv.outdir ? resolve(argv.outdir) : resolve(dir, 'out'),
+  spa: argv.spa
 }
 
 exportApp(dir, options)

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -30,7 +30,8 @@ const {
   buildId,
   assetPrefix,
   runtimeConfig,
-  dynamicIds
+  dynamicIds,
+  spa
 } = data
 
 const prefix = assetPrefix || ''
@@ -107,6 +108,12 @@ export default async ({
   })
 
   render({ App, Component, props, err: initialErr, emitter })
+
+  if (spa) {
+    const ctx = { pathname: page, query, asPath }
+    const _props = await loadGetInitialProps(App, {Component, router, ctx})
+    render({ App, Component, props: _props, err: initialErr, emitter })
+  }
 
   return emitter
 }

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -77,6 +77,11 @@ export default async function (dir, options, configuration) {
     }
   }
 
+  const spa = !!options.spa
+  if (spa) {
+    console.log('> Exporting for Single-Page Application (spa) usage')
+  }
+
   // Start the rendering process
   const renderOpts = {
     dir,
@@ -86,7 +91,8 @@ export default async function (dir, options, configuration) {
     distDir,
     dev: false,
     staticMarkup: false,
-    hotReloader: null
+    hotReloader: null,
+    spa: !!options.spa
   }
 
   const {serverRuntimeConfig, publicRuntimeConfig} = nextConfig


### PR DESCRIPTION
There's already `create-react-app` for SPA with React, but I like the way next.js structures the code, comes with a router, a <Head> component, ... And the next.js is *The React Framework*™.

I tried to change as little as possible in next.js to support exporting as a SPA.

The goal is to make it as easy as adding `--spa` to `next export` to export for an SPA with next.js.

🚧It can be tested with this branch : https://github.com/lucleray/next.js/tree/spa-mode-test/nextjs-spa

Also, to make things easier to handle for the user,`next export`passes down a `nextExport` attribute to `getInitialProps`. It is useful when you want to return specific props only when the app/page is exported, and the app will still work perfectly with `next start` and SSR.

When used in `_app.js`, it looks like this :
```jsx
class MyApp extends App {
  static async getInitialProps({ Component, router, ctx }) {
    if (ctx.nextExport) return { placeholder: true }
    // ...
  }

  render () {
    if (this.props.placeholder) {
      return <Container><div>Loading...</div></Container>
    }
    // ...
  }
}
```

It can also be specific to pages, like this :
```jsx
class IndexPage extends React.Component {
  static async getInitialProps({ nextExport }) {
    if (nextExport) return { placeholder: true }
    // ...
  }

  render() {
    if (this.props.placeholder) {
      return <div>Loading...</div>
    }
    // ...
  }
}
```

⚠️ This is WIP, I suspect it doesn't work with shallow rendering.