### PR TITLE
Use more recent version of svg plugin

### DIFF
--- a/examples/svg-components/package.json
+++ b/examples/svg-components/package.json
@@ -12,6 +12,6 @@
     "react-dom": "latest"
   },
   "devDependencies": {
-    "babel-plugin-inline-react-svg": "^0.2.0"
+    "babel-plugin-inline-react-svg": "^1.0.1"
   }
 }


### PR DESCRIPTION
The demo did not work. Updating to babel-plugin-inline-react-svg v1.0.1 did work.