### PR TITLE
Fix for locale.split is not a function.

### DIFF
--- a/examples/with-react-intl/server.js
+++ b/examples/with-react-intl/server.js
@@ -17,7 +17,7 @@ const app = next({dev})
 const handle = app.getRequestHandler()
 
 // Get the supported languages by looking for translations in the `lang/` dir.
-const languages = glob.sync('./lang/*.json').map((f) => basename(f, '.json'))
+const supportedLanguages = glob.sync('./lang/*.json').map((f) => basename(f, '.json'))
 
 // We need to expose React Intl's locale data on the request for the user's
 // locale. This function will also cache the scripts by lang in memory.
@@ -42,7 +42,7 @@ const getMessages = (locale) => {
 app.prepare().then(() => {
   createServer((req, res) => {
     const accept = accepts(req)
-    const locale = accept.language(languages) || 'en'
+    const locale = accept.language(accept.languages(languages)) || 'en'
     req.locale = locale
     req.localeDataScript = getLocaleDataScript(locale)
     req.messages = dev ? {} : getMessages(locale)

--- a/examples/with-react-intl/server.js
+++ b/examples/with-react-intl/server.js
@@ -42,7 +42,7 @@ const getMessages = (locale) => {
 app.prepare().then(() => {
   createServer((req, res) => {
     const accept = accepts(req)
-    const locale = accept.language(accept.languages(languages)) || 'en'
+    const locale = accept.language(accept.languages(supportedLanguages)) || 'en'
     req.locale = locale
     req.localeDataScript = getLocaleDataScript(locale)
     req.messages = dev ? {} : getMessages(locale)


### PR DESCRIPTION
Following from https://github.com/zeit/next.js/pull/5488

- Renamed languages to supportedLanguages
- Firstly, accept languages based on supportedLanguages
- And finally, accept a single language, if it returns false, the default of 'en' is used.

I looked at the navigator library, which is used by 'accept', this should be a more solid solution, since we can now know that `const locale` is always a string.

// Before (Sometimes returns an array as `const local`)
const locale = accept.language(languages) || 'en' 

// After (Always returns a string)
const locale = accept.language(accept.languages(supportedLanguages)) || 'en';