### PR TITLE
Fix paths when built on windows

### DIFF
--- a/build/webpack/plugins/pages-manifest-plugin.js
+++ b/build/webpack/plugins/pages-manifest-plugin.js
@@ -24,7 +24,7 @@ export default class PagesManifestPlugin {
         }
 
         const {name} = entry
-        pages[`/${pagePath.replace(/\\/g, '/')}`] = name
+        pages[`/${pagePath.replace(/\\/g, '/')}`] = name.replace(/\\/g, '/')
       }
 
       if (typeof pages['/index'] !== 'undefined') {

--- a/build/webpack/plugins/pages-manifest-plugin.js
+++ b/build/webpack/plugins/pages-manifest-plugin.js
@@ -24,6 +24,7 @@ export default class PagesManifestPlugin {
         }
 
         const {name} = entry
+        // Write filename, replace any backslashes in path (on windows) with forwardslashes for cross-platform consistency.
         pages[`/${pagePath.replace(/\\/g, '/')}`] = name.replace(/\\/g, '/')
       }
 

--- a/server/require.js
+++ b/server/require.js
@@ -42,7 +42,7 @@ export function getPagePath (page, {distDir}) {
     throw pageNotFoundError(page)
   }
 
-  return join(serverBuildPath, pagesManifest[page].replace(/(\/|\\)/, sep))
+  return join(serverBuildPath, pagesManifest[page].replace(/(\/|\\)/g, sep))
 }
 
 export default async function requirePage (page, {distDir}) {

--- a/server/require.js
+++ b/server/require.js
@@ -42,7 +42,7 @@ export function getPagePath (page, {distDir}) {
     throw pageNotFoundError(page)
   }
 
-  return join(serverBuildPath, pagesManifest[page].replace(/\//, sep))
+  return join(serverBuildPath, pagesManifest[page].replace(/(\/|\\)/, sep))
 }
 
 export default async function requirePage (page, {distDir}) {

--- a/server/require.js
+++ b/server/require.js
@@ -42,6 +42,7 @@ export function getPagePath (page, {distDir}) {
     throw pageNotFoundError(page)
   }
 
+  // Replace any separators with the current platform separator
   return join(serverBuildPath, pagesManifest[page].replace(/(\/|\\)/g, sep))
 }
 

--- a/server/require.js
+++ b/server/require.js
@@ -1,4 +1,4 @@
-import {join, posix} from 'path'
+import {join, posix, sep} from 'path'
 import {PAGES_MANIFEST, SERVER_DIRECTORY} from '../lib/constants'
 
 export function pageNotFoundError (page) {
@@ -42,7 +42,7 @@ export function getPagePath (page, {distDir}) {
     throw pageNotFoundError(page)
   }
 
-  return join(serverBuildPath, pagesManifest[page])
+  return join(serverBuildPath, pagesManifest[page].replace(/\//, sep))
 }
 
 export default async function requirePage (page, {distDir}) {

--- a/server/require.js
+++ b/server/require.js
@@ -1,4 +1,4 @@
-import {join, posix, sep} from 'path'
+import {join, posix} from 'path'
 import {PAGES_MANIFEST, SERVER_DIRECTORY} from '../lib/constants'
 
 export function pageNotFoundError (page) {
@@ -42,8 +42,7 @@ export function getPagePath (page, {distDir}) {
     throw pageNotFoundError(page)
   }
 
-  // Replace any separators with the current platform separator
-  return join(serverBuildPath, pagesManifest[page].replace(/(\/|\\)/g, sep))
+  return join(serverBuildPath, pagesManifest[page])
 }
 
 export default async function requirePage (page, {distDir}) {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -16,7 +16,7 @@ import fetch from 'node-fetch'
 import dynamicImportTests from './dynamic'
 import processEnv from './process-env'
 import security from './security'
-import {BUILD_MANIFEST, REACT_LOADABLE_MANIFEST} from 'next/constants'
+import {BUILD_MANIFEST, REACT_LOADABLE_MANIFEST, PAGES_MANIFEST} from 'next/constants'
 
 const appDir = join(__dirname, '../')
 let appPort
@@ -274,6 +274,17 @@ describe('Production Usage', () => {
     expect(serverSideJsRes.status).toBe(404)
     const serverSideJsBody = await serverSideJsRes.text()
     expect(serverSideJsBody).toMatch(/404/)
+  })
+
+  it('should not put backslashes in pages-manifest.json', () => {
+    // Whatever platform you build on, pages-manifest.json should use forward slash (/)
+    // See: https://github.com/zeit/next.js/issues/4920
+    const pagesManifest = require(join('..', '.next', 'server', PAGES_MANIFEST))
+
+    for (let key of Object.keys(pagesManifest)) {
+      expect(key).not.toMatch(/\\/)
+      expect(pagesManifest[key]).not.toMatch(/\\/)
+    }
   })
 
   dynamicImportTests(context, (p, q) => renderViaHTTP(context.appPort, p, q))


### PR DESCRIPTION
This PR Fixes #4920

So the problem is that when a next.js application is built on windows, the `pages-manifest.json` file is created with backslashes. If this built application is deployed to a linux hosting enviroment, the server will fail when trying to load the modules.

```
Error: Cannot find module '/user_code/next/server/bundles\pages\index.js
```

My simple solution is to modify the `pages-manifest.json` to always use linux separator (`/`), then also 
modify `server/require.js` to, when requiring page, replace any separator (`\` or `/`) with current platform-specific file separator (`require('path').sep`).

The fix in `server/require.js` would be sufficient, but my opinion is that having some cross-platform consistency is nice.

This change was tested by bulding an application in windows and running it in linux and windows, aswell as building an application in linux and running it in linux and windows. The related tests was also run.