### PR TITLE
Update/fix "examples/with-firebase-hosting"

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -24,7 +24,6 @@ const {
     props,
     err,
     page,
-    pathname,
     query,
     buildId,
     assetPrefix,
@@ -83,7 +82,7 @@ export default async ({
     Component = await pageLoader.loadPage(page)
 
     if (typeof Component !== 'function') {
-      throw new Error(`The default export is not a React Component in page: "${pathname}"`)
+      throw new Error(`The default export is not a React Component in page: "${page}"`)
     }
   } catch (error) {
     // This catches errors like throwing in the top level of a module
@@ -92,7 +91,7 @@ export default async ({
 
   await Loadable.preloadReady(dynamicIds || [])
 
-  router = createRouter(pathname, query, asPath, {
+  router = createRouter(page, query, asPath, {
     initialProps: props,
     pageLoader,
     App,
@@ -141,7 +140,7 @@ export async function renderError (props) {
   // Otherwise, we need to call `getInitialProps` on `App` before mounting.
   const initProps = props.props
     ? props.props
-    : await loadGetInitialProps(App, {Component: ErrorComponent, router, ctx: {err, pathname, query, asPath}})
+    : await loadGetInitialProps(App, {Component: ErrorComponent, router, ctx: {err, pathname: page, query, asPath}})
 
   await doRender({...props, err, Component: ErrorComponent, props: initProps})
 }

--- a/examples/svg-components/package.json
+++ b/examples/svg-components/package.json
@@ -12,6 +12,6 @@
     "react-dom": "latest"
   },
   "devDependencies": {
-    "babel-plugin-inline-react-svg": "^0.2.0"
+    "babel-plugin-inline-react-svg": "^1.0.1"
   }
 }

--- a/examples/with-apollo-and-redux/README.md
+++ b/examples/with-apollo-and-redux/README.md
@@ -41,7 +41,7 @@ now
 ## The idea behind the example
 This example serves as a conduit if you were using Apollo 1.X with Redux, and are migrating to Apollo 2.x, however, you have chosen not to manage your entire application state within Apollo (`apollo-link-state`).
 
-In 2.0.0, Apollo severs out-of-the-box support for redux in favor of Apollo's state management. This example aims to be an amalgamation of the [`with-apollo`](https://github.com/zeit/next.js/tree/master/examples/with-apollo) and [`with-redux`](https://github.com/zeit/next.js/tree/master/examples/with-redux) examples.
+In 2.0.0, Apollo servers out-of-the-box support for redux in favor of Apollo's state management. This example aims to be an amalgamation of the [`with-apollo`](https://github.com/zeit/next.js/tree/master/examples/with-apollo) and [`with-redux`](https://github.com/zeit/next.js/tree/master/examples/with-redux) examples.
 
 Note that you can access the redux store like you normally would using `react-redux`'s `connect`. Here's a quick example:
 

--- a/examples/with-firebase-hosting/.gitignore
+++ b/examples/with-firebase-hosting/.gitignore
@@ -1,1 +1,4 @@
 dist/
+
+# Firebase cache
+.firebase/

--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -80,6 +80,9 @@ If you're having issues, feel free to tag @jthegedus in the [issue you create on
 
 * The empty `placeholder.html` file is so Firebase Hosting does not error on an empty `public/` folder and still hosts at the Firebase project URL.
 * `firebase.json` outlines the catchall rewrite rule for our Cloud Function.
+* Specifying [`"engines": {"node": "8"}`](package.json#L5-L7) in the `package.json` is required for firebase functions
+  to be deployed on Node 8 rather than Node 6.
+  ([Firebase Blog Announcement](https://firebase.googleblog.com/2018/08/cloud-functions-for-firebase-config-node-8-timeout-memory-region.html))
 
 ### Customization
 

--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -80,7 +80,6 @@ If you're having issues, feel free to tag @jthegedus in the [issue you create on
 
 * The empty `placeholder.html` file is so Firebase Hosting does not error on an empty `public/` folder and still hosts at the Firebase project URL.
 * `firebase.json` outlines the catchall rewrite rule for our Cloud Function.
-* The [Firebase predeploy](https://firebase.google.com/docs/cli/#predeploy_and_postdeploy_hooks) hooks run most of the npm scripts when `npm run deploy` runs `firebase deploy`. The only scripts you should need are `clean`, `dev`, `serve` and `deploy`.
 
 ### Customization
 

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -20,16 +20,16 @@
     "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {
-    "firebase-admin": "^5.12.1",
-    "firebase-functions": "^1.0.2",
-    "next": "^6.0.3",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "firebase-admin": "^6.3.0",
+    "firebase-functions": "^2.1.0",
+    "next": "^7.0.2",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-rc.1",
-    "cpx": "1.5.0",
-    "firebase-tools": "3.18.4",
-    "rimraf": "2.6.2"
+    "@babel/cli": "^7.2.0",
+    "cpx": "^1.5.0",
+    "firebase-tools": "^6.1.1",
+    "rimraf": "^2.6.2"
   }
 }

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -30,7 +30,6 @@
     "@babel/cli": "^7.0.0-rc.1",
     "cpx": "1.5.0",
     "firebase-tools": "3.18.4",
-    "prettier": "1.12.1",
     "rimraf": "2.6.2"
   }
 }

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -1,22 +1,18 @@
 {
   "name": "with-firebase-hosting",
   "version": "4.0.1",
-  "description":
-    "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
+  "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
   "scripts": {
     "dev": "next \"src/app/\"",
-    "preserve":
-      "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",
+    "preserve": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",
     "serve": "NODE_ENV=production firebase serve",
-    "predeploy":
-      "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps",
+    "predeploy": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps",
     "deploy": "firebase deploy",
     "clean": "rimraf \"dist/functions/**\" && rimraf \"dist/public\"",
     "build-public": "cpx \"src/public/**/*.*\" \"dist/public\" -C",
     "build-funcs": "babel \"src/functions\" --out-dir \"dist/functions\"",
     "build-app": "next build \"src/app/\"",
-    "copy-deps":
-      "cpx \"*{package.json,package-lock.json,yarn.lock}\" \"dist/functions\" -C",
+    "copy-deps": "cpx \"*{package.json,package-lock.json,yarn.lock}\" \"dist/functions\" -C",
     "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -2,6 +2,9 @@
   "name": "with-firebase-hosting",
   "version": "4.0.1",
   "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
+  "engines": {
+    "node": "8"
+  },
   "scripts": {
     "dev": "next \"src/app/\"",
     "preserve": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next \"src/app/\"",
     "preserve": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",
-    "serve": "NODE_ENV=production firebase serve",
+    "serve": "cross-env NODE_ENV=production firebase serve",
     "predeploy": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps",
     "deploy": "firebase deploy",
     "clean": "rimraf \"dist/functions/**\" && rimraf \"dist/public\"",
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/cli": "^7.2.0",
     "cpx": "^1.5.0",
+    "cross-env": "^5.2.0",
     "firebase-tools": "^6.1.1",
     "rimraf": "^2.6.2"
   }

--- a/examples/with-firebase-hosting/src/app/.babelrc
+++ b/examples/with-firebase-hosting/src/app/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": [["next/babel"]]
-}

--- a/examples/with-firebase-hosting/src/functions/.babelrc
+++ b/examples/with-firebase-hosting/src/functions/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "6.11.5"
+          "node": "8.14"
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Minimalistic framework for server-rendered React applications",
   "main": "./dist/server/next.js",
   "license": "MIT",

--- a/server/document.js
+++ b/server/document.js
@@ -101,8 +101,8 @@ export class Head extends Component {
 
   render () {
     const { head, styles, assetPrefix, __NEXT_DATA__ } = this.context._documentProps
-    const { page, pathname, buildId } = __NEXT_DATA__
-    const pagePathname = getPagePathname(pathname)
+    const { page, buildId } = __NEXT_DATA__
+    const pagePathname = getPagePathname(page)
 
     let children = this.props.children
     // show a warning if Head contains <title> (only in development)
@@ -186,21 +186,21 @@ export class NextScript extends Component {
 
   static getInlineScriptSource (documentProps) {
     const { __NEXT_DATA__ } = documentProps
-    const { page, pathname } = __NEXT_DATA__
-    return `__NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)};__NEXT_LOADED_PAGES__=[];__NEXT_REGISTER_PAGE=function(r,f){__NEXT_LOADED_PAGES__.push([r, f])}${page === '/_error' ? `;__NEXT_REGISTER_PAGE(${htmlescape(pathname)},function(){var e = new Error('Page does not exist: ${htmlescape(pathname)}');e.statusCode=404;return {error:e}})`:''}`
+    const { page } = __NEXT_DATA__
+    return `__NEXT_DATA__ = ${htmlescape(__NEXT_DATA__)};__NEXT_LOADED_PAGES__=[];__NEXT_REGISTER_PAGE=function(r,f){__NEXT_LOADED_PAGES__.push([r, f])}`
   }
 
   render () {
     const { staticMarkup, assetPrefix, devFiles, __NEXT_DATA__ } = this.context._documentProps
-    const { page, pathname, buildId } = __NEXT_DATA__
-    const pagePathname = getPagePathname(pathname)
+    const { page, buildId } = __NEXT_DATA__
+    const pagePathname = getPagePathname(page)
 
     return <Fragment>
       {devFiles ? devFiles.map((file) => <script key={file} src={`${assetPrefix}/_next/${file}`} nonce={this.props.nonce} />) : null}
       {staticMarkup ? null : <script nonce={this.props.nonce} dangerouslySetInnerHTML={{
         __html: NextScript.getInlineScriptSource(this.context._documentProps)
       }} />}
-      {page !== '/_error' && <script async id={`__NEXT_PAGE__${pathname}`} src={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} nonce={this.props.nonce} />}
+      {page !== '/_error' && <script async id={`__NEXT_PAGE__${page}`} src={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} nonce={this.props.nonce} />}
       <script async id={`__NEXT_PAGE__/_app`} src={`${assetPrefix}/_next/static/${buildId}/pages/_app.js`} nonce={this.props.nonce} />
       <script async id={`__NEXT_PAGE__/_error`} src={`${assetPrefix}/_next/static/${buildId}/pages/_error.js`} nonce={this.props.nonce} />
       {staticMarkup ? null : this.getDynamicChunks()}
@@ -209,10 +209,10 @@ export class NextScript extends Component {
   }
 }
 
-function getPagePathname (pathname) {
-  if (pathname === '/') {
+function getPagePathname (page) {
+  if (page === '/') {
     return '/index.js'
   }
 
-  return `${pathname}.js`
+  return `${page}.js`
 }

--- a/server/render.js
+++ b/server/render.js
@@ -89,14 +89,14 @@ async function doRender (req, res, pathname, query, {
   Component = Component.default || Component
 
   if (typeof Component !== 'function') {
-    throw new Error(`The default export is not a React Component in page: "${pathname}"`)
+    throw new Error(`The default export is not a React Component in page: "${page}"`)
   }
 
   App = App.default || App
   Document = Document.default || Document
   const asPath = req.url
-  const ctx = { err, req, res, pathname, query, asPath }
-  const router = new Router(pathname, query, asPath)
+  const ctx = { err, req, res, pathname: page, query, asPath }
+  const router = new Router(page, query, asPath)
   const props = await loadGetInitialProps(App, {Component, router, ctx})
   const devFiles = buildManifest.devFiles
   const files = [
@@ -168,7 +168,6 @@ async function doRender (req, res, pathname, query, {
     __NEXT_DATA__: {
       props, // The result of getInitialProps
       page, // The rendered page
-      pathname, // The requested path
       query, // querystring parsed / passed by the user
       buildId, // buildId is used to facilitate caching of page bundles, we send it to the client so that pageloader knows where to load bundles
       assetPrefix: assetPrefix === '' ? undefined : assetPrefix, // send assetPrefix to the client side when configured, otherwise don't sent in the resulting HTML

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -3,8 +3,20 @@
 
 import { readFileSync } from 'fs'
 import { join } from 'path'
-import { renderViaHTTP, waitFor } from 'next-test-utils'
+import { renderViaHTTP, getBrowserBodyText, waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
+
+// Does the same evaluation checking for INJECTED for 15 seconds, triggering every 500ms
+async function checkInjected (browser) {
+  const start = Date.now()
+  while (Date.now() - start < 15000) {
+    const bodyText = await getBrowserBodyText(browser)
+    if (/INJECTED/.test(bodyText)) {
+      throw new Error('Vulnerable to XSS attacks')
+    }
+    await waitFor(500)
+  }
+}
 
 module.exports = (context) => {
   describe('With Security Related Issues', () => {
@@ -28,17 +40,55 @@ module.exports = (context) => {
     })
 
     it('should prevent URI based XSS attacks', async () => {
-      const browser = await webdriver(context.appPort, '/\',document.body.innerHTML="HACKED",\'')
-      // Wait 5 secs to make sure we load all the client side JS code
-      await waitFor(5000)
+      const browser = await webdriver(context.appPort, '/\',document.body.innerHTML="INJECTED",\'')
+      await checkInjected(browser)
+      browser.quit()
+    })
 
-      const bodyText = await browser
-        .elementByCss('body').text()
+    it('should prevent URI based XSS attacks using single quotes', async () => {
+      const browser = await webdriver(context.appPort, `/'-(document.body.innerHTML='INJECTED')-'`)
+      await checkInjected(browser)
+      browser.close()
+    })
 
-      if (/HACKED/.test(bodyText)) {
-        throw new Error('Vulnerable to XSS attacks')
-      }
+    it('should prevent URI based XSS attacks using double quotes', async () => {
+      const browser = await webdriver(context.appPort, `/"-(document.body.innerHTML='INJECTED')-"`)
+      await checkInjected(browser)
 
+      browser.close()
+    })
+
+    it('should prevent URI based XSS attacks using semicolons and double quotes', async () => {
+      const browser = await webdriver(context.appPort, `/;"-(document.body.innerHTML='INJECTED')-"`)
+      await checkInjected(browser)
+
+      browser.close()
+    })
+
+    it('should prevent URI based XSS attacks using semicolons and single quotes', async () => {
+      const browser = await webdriver(context.appPort, `/;'-(document.body.innerHTML='INJECTED')-'`)
+      await checkInjected(browser)
+
+      browser.close()
+    })
+
+    it('should prevent URI based XSS attacks using src', async () => {
+      const browser = await webdriver(context.appPort, `/javascript:(document.body.innerHTML='INJECTED')`)
+      await checkInjected(browser)
+
+      browser.close()
+    })
+
+    it('should prevent URI based XSS attacks using querystring', async () => {
+      const browser = await webdriver(context.appPort, `/?javascript=(document.body.innerHTML='INJECTED')`)
+      await checkInjected(browser)
+
+      browser.close()
+    })
+
+    it('should prevent URI based XSS attacks using querystring and quotes', async () => {
+      const browser = await webdriver(context.appPort, `/?javascript="(document.body.innerHTML='INJECTED')"`)
+      await checkInjected(browser)
       browser.close()
     })
   })


### PR DESCRIPTION
Hello! 
I was looking at the [`with-firebase-hosting`](/zeit/next.js/tree/canary/examples/with-firebase-hosting) example and was having some various issues running it:

* `npm run serve` will choke on windows because trying to set enviroment variables with `NODE_ENV=production`
* `npm run build-funcs` failing because of babeljs mismatches between `@babel/cli@^7.0.0-rc.1` and `next@^6.0.3`np
* Not being able to deploy because `firebase-tools` being a deprecated version.

I remedied this and also improved some other factors:

* Remove "prettier" as a devDependency as there is no use of it in the example and most other examples does not have it as a dependency. (902b4e11974e3fa2fba6958877fcbd018759b893)
* Update all dependencies. The simple usecase in this example didn't really require any changes to the code. (89a4a74a4390febb2cb291b4d8b10ce1ecbdbdea)
  * [`firebase-admin@6`](https://github.com/firebase/firebase-admin-node/releases/tag/v6.0.0)
  * [`firebase-functions@2`](https://github.com/firebase/firebase-functions/releases/tag/v2.0.0) 
  * [`firebase-tools@4`](https://github.com/firebase/firebase-tools/releases/tag/v4.0.0)
  * [`firebase-tools@5`](https://github.com/firebase/firebase-tools/releases/tag/v5.0.0)
  * [`firebase-tools@6`](https://github.com/firebase/firebase-tools/releases/tag/v6.0.0)
* Use standard JSON formatting on `package.json` so that `npm install` doesn't cause changes on every run. (5b96aa2167a35fe4ac2cba18a411d49fcf74fc41)
* Make `npm run serve` runnable on windows using [`cross-env`](https://www.npmjs.com/package/cross-env). (9a5dd9faed4e31990f613f04044ff0b7b40f7d7e)
* Update `.gitignore` to ignore firebase cache (cc79a7908d913c56341b80df826ed132b7e2da36)
* Remove `src/app/.babelrc` that seems to have been added as a previous bugfix but doesn't seem to do anything currently. (5b96b753f43ea3ca7a9d47a2f47947f06cad6857)
* Use the possibility added by upgrading `firebase-tools` to [`>=4.0.0`](https://github.com/firebase/firebase-tools/releases/tag/v4.0.0) and `firebase-functions` to [`>=2.0.0`](https://github.com/firebase/firebase-functions/releases/tag/v2.0.0) to make the deployable functions use node 8 rather than node 6. Also make babel compile with node 8 as target for less polyfills etc. (0ee2369279ff257c0a617e39568a9155a8b14460)

This was tested to `serve` on windows, linux(WSL) and on mac. Deploy was tested on linux(WSL) and mac.