### PR TITLE
Bring back module.exports because of backwards compat

### DIFF
--- a/packages/next/link.js
+++ b/packages/next/link.js
@@ -1,1 +1,1 @@
-export {default} from './dist/client/link'
+module.exports = require('./dist/client/link')

--- a/packages/next/router.js
+++ b/packages/next/router.js
@@ -1,2 +1,1 @@
-export * from './dist/client/router'
-export {default} from './dist/client/router'
+module.exports = require('./dist/client/router')


### PR DESCRIPTION
Unfortunately this is needed because of next-routes importing link in the custom server.