### PR TITLE
Update/fix "examples/with-firebase-hosting-and-typescript"

### DIFF
--- a/examples/with-firebase-hosting-and-typescript/.gitignore
+++ b/examples/with-firebase-hosting-and-typescript/.gitignore
@@ -1,1 +1,4 @@
 dist/
+
+# Firebase cache
+.firebase/

--- a/examples/with-firebase-hosting-and-typescript/README.md
+++ b/examples/with-firebase-hosting-and-typescript/README.md
@@ -72,3 +72,6 @@ If you're having issues, feel free to tag @sampsonjoliver in the [issue you crea
 * The empty `placeholder.html` file is so Firebase Hosting does not error on an empty `public/` folder and still hosts at the Firebase project URL.
 * `firebase.json` outlines the catchall rewrite rule for our Cloud Function.
 * The [Firebase predeploy](https://firebase.google.com/docs/cli/#predeploy_and_postdeploy_hooks) hooks defined in `firebase.json` will handle linting and compiling of the next app and the functions sourceswhen `firebase deploy` is invoked. The only scripts you should need are `dev`, `clean` and `deploy`.
+* Specifying [`"engines": {"node": "8"}`](package.json#L5-L7) in the `package.json` is required for firebase functions
+  to be deployed on Node 8 rather than Node 6.
+  ([Firebase Blog Announcement](https://firebase.googleblog.com/2018/08/cloud-functions-for-firebase-config-node-8-timeout-memory-region.html))

--- a/examples/with-firebase-hosting-and-typescript/package.json
+++ b/examples/with-firebase-hosting-and-typescript/package.json
@@ -4,7 +4,7 @@
   "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
   "scripts": {
     "dev": "next src/app",
-    "serve": "NODE_ENV=production firebase serve --only functions,hosting",
+    "serve": "cross-env NODE_ENV=production firebase serve --only functions,hosting",
     "deploy": "firebase deploy",
     "clean": "rimraf \"dist/functions\" && rimraf \"dist/public\"",
     "build-app": "next build \"src/app\"",
@@ -28,6 +28,7 @@
     "@types/next": "^7.0.5",
     "@types/react": "^16.7.13",
     "cpx": "^1.5.0",
+    "cross-env": "^5.2.0",
     "firebase-tools": "^6.1.2",
     "rimraf": "^2.6.2",
     "tslint": "^5.11.0",

--- a/examples/with-firebase-hosting-and-typescript/package.json
+++ b/examples/with-firebase-hosting-and-typescript/package.json
@@ -4,6 +4,7 @@
   "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
   "scripts": {
     "dev": "next src/app",
+    "preserve": "npm run build-public && npm run build-functions && npm run build-app && npm run copy-deps && npm run install-deps",
     "serve": "cross-env NODE_ENV=production firebase serve --only functions,hosting",
     "deploy": "firebase deploy",
     "clean": "rimraf \"dist/functions\" && rimraf \"dist/public\"",

--- a/examples/with-firebase-hosting-and-typescript/package.json
+++ b/examples/with-firebase-hosting-and-typescript/package.json
@@ -29,7 +29,6 @@
     "@types/react": "^16.3.14",
     "cpx": "1.5.0",
     "firebase-tools": "3.18.4",
-    "prettier": "1.12.1",
     "rimraf": "2.6.2",
     "tslint": "^5.8.0",
     "tslint-react": "3.6.0",

--- a/examples/with-firebase-hosting-and-typescript/package.json
+++ b/examples/with-firebase-hosting-and-typescript/package.json
@@ -17,21 +17,21 @@
     "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {
-    "@zeit/next-typescript": "1.1.0",
-    "firebase-admin": "~5.12.1",
-    "firebase-functions": "^1.0.1",
-    "next": "^6.0.3",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "@zeit/next-typescript": "^1.1.1",
+    "firebase-admin": "~6.3.0",
+    "firebase-functions": "^2.0.1",
+    "next": "^7.0.2",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3"
   },
   "devDependencies": {
-    "@types/next": "^2.4.10",
-    "@types/react": "^16.3.14",
-    "cpx": "1.5.0",
-    "firebase-tools": "3.18.4",
-    "rimraf": "2.6.2",
-    "tslint": "^5.8.0",
-    "tslint-react": "3.6.0",
-    "typescript": "^2.5.3"
+    "@types/next": "^7.0.5",
+    "@types/react": "^16.7.13",
+    "cpx": "^1.5.0",
+    "firebase-tools": "^6.1.2",
+    "rimraf": "^2.6.2",
+    "tslint": "^5.11.0",
+    "tslint-react": "^3.6.0",
+    "typescript": "^3.2.1"
   }
 }

--- a/examples/with-firebase-hosting-and-typescript/package.json
+++ b/examples/with-firebase-hosting-and-typescript/package.json
@@ -2,6 +2,9 @@
   "name": "with-firebase-hosting",
   "version": "1.0.0",
   "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
+  "engines": {
+    "node": "8"
+  },
   "scripts": {
     "dev": "next src/app",
     "preserve": "npm run build-public && npm run build-functions && npm run build-app && npm run copy-deps && npm run install-deps",

--- a/examples/with-firebase-hosting-and-typescript/src/functions/index.ts
+++ b/examples/with-firebase-hosting-and-typescript/src/functions/index.ts
@@ -1,11 +1,11 @@
 import * as functions from 'firebase-functions';
-const next = require('next');
+import * as next from 'next';
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev, conf: { distDir: 'next' } });
 const handle = app.getRequestHandler();
 
 export const nextApp = functions.https.onRequest((req, res) => {
-  console.log('File: ' + req.originalUrl);
-  return app.prepare().then(() => handle(req, res));
+    console.log('File: ' + req.originalUrl);
+    return app.prepare().then(() => handle(req, res));
 });

--- a/examples/with-firebase-hosting-and-typescript/src/functions/index.ts
+++ b/examples/with-firebase-hosting-and-typescript/src/functions/index.ts
@@ -6,6 +6,6 @@ const app = next({ dev, conf: { distDir: 'next' } });
 const handle = app.getRequestHandler();
 
 export const nextApp = functions.https.onRequest((req, res) => {
-    console.log('File: ' + req.originalUrl);
-    return app.prepare().then(() => handle(req, res));
+  console.log('File: ' + req.originalUrl);
+  return app.prepare().then(() => handle(req, res));
 });

--- a/examples/with-firebase-hosting-and-typescript/src/functions/src/index.ts
+++ b/examples/with-firebase-hosting-and-typescript/src/functions/src/index.ts
@@ -1,3 +1,0 @@
-import * as functions from 'firebase-functions';
-
-export { nextApp } from './app/next';

--- a/examples/with-firebase-hosting-and-typescript/src/functions/tsconfig.json
+++ b/examples/with-firebase-hosting-and-typescript/src/functions/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "lib": ["es6"],
+    "lib": ["es2017"],
     "module": "commonjs",
     "noImplicitReturns": true,
     "outDir": "../../dist/functions",
     "sourceMap": true,
-    "target": "es6",
+    "target": "es2017",
     "baseUrl": "."
   },
   "compileOnSave": true

--- a/examples/with-firebase-hosting-and-typescript/src/functions/tsconfig.json
+++ b/examples/with-firebase-hosting-and-typescript/src/functions/tsconfig.json
@@ -6,8 +6,7 @@
     "outDir": "../../dist/functions",
     "sourceMap": true,
     "target": "es6",
-    "baseUrl": "./src"
+    "baseUrl": "."
   },
-  "compileOnSave": true,
-  "include": ["src"]
+  "compileOnSave": true
 }


### PR DESCRIPTION
* Update all dependencies. (928a6b7)
* Remove `prettier`, as it was unused in the example. (7a613bd)
* Make `npm run serve` work on windows using `cross-env` (7ad04b9)
* Add `pre`-task to make serve work on its own (dc27212)
* Flatten `src/functions`. It was creating an unnecessarily complicated file structure with `src` inside `src` being kind of confusing. (585fbd9)
* Make use of upgraded upgraded firebase dependencies to deploy functions on Node 8 (71097db, 254220f)
* Add the `.firebase` cache to `.gitignore`. (b78d8df)