### PR TITLE
Remove outdated note from with-jest example

### DIFF
--- a/examples/with-jest/README.md
+++ b/examples/with-jest/README.md
@@ -46,5 +46,3 @@ yarn test
 This example features:
 
 * An app with jest tests
-
-> A very important part of this example is the `.babelrc` file which configures the `test` environment to use `babel-preset-env` and configures it to transpile modules to `commonjs`). [Learn more](https://github.com/zeit/next.js/issues/2895).


### PR DESCRIPTION
Thanks to recent updates of Next.js and #5414, `.babelrc` of the example of with-jest is simplified.

> the Next.js Babel preset (next/babel) now defaults to setting the modules option to commonjs when NODE_ENV is set to test.

Therefore, the note added by #2911 is now outdated and confusing users.