### PR TITLE
Fix edge case where file had `module.export` in the content

### DIFF
--- a/packages/next/build/babel/plugins/commonjs.ts
+++ b/packages/next/build/babel/plugins/commonjs.ts
@@ -1,0 +1,34 @@
+import {PluginObj} from '@babel/core'
+import {NodePath} from '@babel/traverse'
+import {Program} from '@babel/types'
+import commonjsPlugin from '@babel/plugin-transform-modules-commonjs'
+// Rewrite imports using next/<something> to next-server/<something>
+export default function NextToNextServer (...args: any): PluginObj {
+  const commonjs = commonjsPlugin(...args)
+  return {
+    visitor: {
+      Program: {
+        exit (path: NodePath<Program>, state) {
+          let foundModuleExports = false
+          path.traverse({
+            MemberExpression (
+              path: any
+            ) {
+              if (path.node.object.name !== 'module') return
+              if (path.node.property.name !== 'exports') return
+              foundModuleExports = true
+              console.log('FOUND', state.file.opts.filename)
+            }
+          })
+
+          if (!foundModuleExports) {
+            console.log('NOT FOUND', state.file.opts.filename)
+            return
+          }
+
+          commonjs.visitor.Program.exit.call(this, path, state)
+        }
+      }
+    }
+  }
+}

--- a/test/integration/basic/pages/exports.js
+++ b/test/integration/basic/pages/exports.js
@@ -1,0 +1,3 @@
+export default () => {
+  return <div>module.exports</div>
+}

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -131,6 +131,11 @@ export default function ({ app }, suiteName, render, fetch) {
       expect(res.status).toBe(404)
     })
 
+    test('should render page that has module.exports anywhere', async () => {
+      const res = await fetch('/exports')
+      expect(res.status).toBe(200)
+    })
+
     test('should expose the compiled page file in development', async () => {
       await fetch('/stateless') // make sure the stateless page is built
       const clientSideJsRes = await fetch('/_next/development/static/development/pages/stateless.js')


### PR DESCRIPTION
We ran into this eg on hyper-site, which has `module.exports` in the content.