### PR TITLE
Move serve-static to typescript

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@taskr/clear": "1.1.0",
     "@taskr/watch": "1.1.0",
+    "@types/send": "0.14.4",
     "taskr": "1.1.0",
     "typescript": "3.1.6"
   },

--- a/packages/next-server/server/next-server.js
+++ b/packages/next-server/server/next-server.js
@@ -6,9 +6,9 @@ import fs from 'fs'
 import {
   renderToHTML,
   renderErrorToHTML,
-  sendHTML,
-  serveStatic
+  sendHTML
 } from './render'
+import {serveStatic} from './serve-static'
 import Router, {route} from './router'
 import { isInternalUrl, isBlockedPage } from './utils'
 import loadConfig from 'next-server/next-config'

--- a/packages/next-server/server/render.js
+++ b/packages/next-server/server/render.js
@@ -1,7 +1,6 @@
 import { join } from 'path'
 import React from 'react'
 import { renderToString, renderToStaticMarkup } from 'react-dom/server'
-import send from 'send'
 import generateETag from 'etag'
 import fresh from 'fresh'
 import requirePage, {normalizePagePath} from './require'
@@ -22,9 +21,6 @@ function getDynamicImportBundles (manifest, moduleIds) {
     return bundles.concat(manifest[moduleId])
   }, [])
 }
-
-// since send doesn't support wasm yet
-send.mime.define({ 'application/wasm': ['wasm'] })
 
 export async function render (req, res, pathname, query, opts) {
   const html = await renderToHTML(req, res, pathname, query, opts)
@@ -244,19 +240,4 @@ function serializeError (dev, err) {
   }
 
   return { message: '500 - Internal Server Error.' }
-}
-
-export function serveStatic (req, res, path) {
-  return new Promise((resolve, reject) => {
-    send(req, path)
-      .on('directory', () => {
-      // We don't allow directories to be read.
-        const err = new Error('No directory access')
-        err.code = 'ENOENT'
-        reject(err)
-      })
-      .on('error', reject)
-      .pipe(res)
-      .on('finish', resolve)
-  })
 }

--- a/packages/next-server/server/serve-static.ts
+++ b/packages/next-server/server/serve-static.ts
@@ -1,0 +1,20 @@
+import {IncomingMessage, ServerResponse} from 'http'
+import send from 'send'
+
+// since send doesn't support wasm yet
+send.mime.define({ 'application/wasm': ['wasm'] })
+
+export function serveStatic (req: IncomingMessage, res: ServerResponse, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    send(req, path)
+      .on('directory', () => {
+      // We don't allow directories to be read.
+        const err: any = new Error('No directory access')
+        err.code = 'ENOENT'
+        reject(err)
+      })
+      .on('error', reject)
+      .pipe(res)
+      .on('finish', resolve)
+  })
+}


### PR DESCRIPTION
Since this method has nothing to do with rendering of the page it makes sense to move it out. It also allowed for easily adding typings.