### PR TITLE
Only check if BUILD_ID exists when reading throws error

### DIFF
--- a/packages/next-server/server/next-server.js
+++ b/packages/next-server/server/next-server.js
@@ -254,9 +254,14 @@ export default class Server {
 
   readBuildId () {
     const buildIdFile = join(this.distDir, BUILD_ID_FILE)
-    if (!fs.existsSync(buildIdFile)) {
-      throw new Error(`Could not find a valid build in the '${this.distDir}' directory! Try building your app with 'next build' before starting the server.`)
+    try {
+      return fs.readFileSync(buildIdFile, 'utf8').trim()
+    } catch (err) {
+      if (!fs.existsSync(buildIdFile)) {
+        throw new Error(`Could not find a valid build in the '${this.distDir}' directory! Try building your app with 'next build' before starting the server.`)
+      }
+
+      throw err
     }
-    return fs.readFileSync(buildIdFile, 'utf8').trim()
   }
 }

--- a/packages/next-server/server/next-server.js
+++ b/packages/next-server/server/next-server.js
@@ -253,9 +253,10 @@ export default class Server {
   }
 
   readBuildId () {
-    if (!fs.existsSync(resolve(this.distDir, BUILD_ID_FILE))) {
+    const buildIdFile = join(this.distDir, BUILD_ID_FILE)
+    if (!fs.existsSync(buildIdFile)) {
       throw new Error(`Could not find a valid build in the '${this.distDir}' directory! Try building your app with 'next build' before starting the server.`)
     }
-    return fs.readFileSync(join(this.distDir, BUILD_ID_FILE), 'utf8').trim()
+    return fs.readFileSync(buildIdFile, 'utf8').trim()
   }
 }


### PR DESCRIPTION
We don't have to check if the file already exists here, since it's always in production mode (dev overrides the readBuildId method to always be `development`) If the file is not found (error is thrown) we check if the file exists. If not we throw a helpful error. In other cases we throw the original error.