### PR TITLE
Use correct default for query

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -205,7 +205,7 @@ export default class Server {
     return sendHTML(req, res, html, {generateEtags})
   }
 
-  public async render (req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery, parsedUrl: UrlWithParsedQuery): Promise<void> {
+  public async render (req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery = {}, parsedUrl?: UrlWithParsedQuery): Promise<void> {
     const url: any = req.url
     if (isInternalUrl(url)) {
       return this.handleRequest(req, res, parsedUrl)
@@ -227,7 +227,7 @@ export default class Server {
     return this.sendHTML(req, res, html)
   }
 
-  public async renderToHTML (req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery): Promise<string|null> {
+  public async renderToHTML (req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery = {}): Promise<string|null> {
     try {
       // To make sure the try/catch is executed
       const html = await renderToHTML(req, res, pathname, query, this.renderOpts)
@@ -243,13 +243,13 @@ export default class Server {
     }
   }
 
-  public async renderError (err: Error|null, req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery): Promise<void> {
+  public async renderError (err: Error|null, req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery = {}): Promise<void> {
     res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
     const html = await this.renderErrorToHTML(err, req, res, pathname, query)
     return this.sendHTML(req, res, html)
   }
 
-  public async renderErrorToHTML (err: Error|null, req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery) {
+  public async renderErrorToHTML (err: Error|null, req: IncomingMessage, res: ServerResponse, pathname: string, query: ParsedUrlQuery = {}) {
     return renderErrorToHTML(err, req, res, pathname, query, this.renderOpts)
   }
 

--- a/test/integration/custom-server/pages/no-query.js
+++ b/test/integration/custom-server/pages/no-query.js
@@ -1,0 +1,1 @@
+export default () => 'test'

--- a/test/integration/custom-server/server.js
+++ b/test/integration/custom-server/server.js
@@ -10,6 +10,10 @@ const handleNextRequests = app.getRequestHandler()
 
 app.prepare().then(() => {
   const server = new http.Server((req, res) => {
+    if (req.url === '/no-query') {
+      return app.render(req, res, '/no-query')
+    }
+
     if (/setAssetPrefix/.test(req.url)) {
       app.setAssetPrefix(`http://127.0.0.1:${port}`)
     } else if (/setEmptyAssetPrefix/.test(req.url)) {

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -37,6 +37,10 @@ describe('Custom Server', () => {
     beforeAll(() => startServer())
     afterAll(() => killApp(server))
 
+    it('should handle render with undefined query', async () => {
+      expect(await renderViaHTTP(appPort, '/no-query')).toMatch(/"query":/)
+    })
+
     it('should set the assetPrefix dynamically', async () => {
       const normalUsage = await renderViaHTTP(appPort, '/asset')
       expect(normalUsage).not.toMatch(/127\.0\.0\.1/)


### PR DESCRIPTION
Fixes #2943
Fixes #4341

The backwards-compatible version of this fix. It's basically the same as with router.js, where we always know the query will be at least `{}` 