### PR TITLE
Update/fix "examples/with-firebase-hosting"

### DIFF
--- a/examples/with-firebase-hosting/.gitignore
+++ b/examples/with-firebase-hosting/.gitignore
@@ -1,1 +1,4 @@
 dist/
+
+# Firebase cache
+.firebase/

--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -80,6 +80,9 @@ If you're having issues, feel free to tag @jthegedus in the [issue you create on
 
 * The empty `placeholder.html` file is so Firebase Hosting does not error on an empty `public/` folder and still hosts at the Firebase project URL.
 * `firebase.json` outlines the catchall rewrite rule for our Cloud Function.
+* Specifying [`"engines": {"node": "8"}`](package.json#L5-L7) in the `package.json` is required for firebase functions
+  to be deployed on Node 8 rather than Node 6.
+  ([Firebase Blog Announcement](https://firebase.googleblog.com/2018/08/cloud-functions-for-firebase-config-node-8-timeout-memory-region.html))
 
 ### Customization
 

--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -80,7 +80,6 @@ If you're having issues, feel free to tag @jthegedus in the [issue you create on
 
 * The empty `placeholder.html` file is so Firebase Hosting does not error on an empty `public/` folder and still hosts at the Firebase project URL.
 * `firebase.json` outlines the catchall rewrite rule for our Cloud Function.
-* The [Firebase predeploy](https://firebase.google.com/docs/cli/#predeploy_and_postdeploy_hooks) hooks run most of the npm scripts when `npm run deploy` runs `firebase deploy`. The only scripts you should need are `clean`, `dev`, `serve` and `deploy`.
 
 ### Customization
 

--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -81,8 +81,9 @@ If you're having issues, feel free to tag @jthegedus in the [issue you create on
 * The empty `placeholder.html` file is so Firebase Hosting does not error on an empty `public/` folder and still hosts at the Firebase project URL.
 * `firebase.json` outlines the catchall rewrite rule for our Cloud Function.
 * Specifying [`"engines": {"node": "8"}`](package.json#L5-L7) in the `package.json` is required for firebase functions
-  to be deployed on Node 8 rather than Node 6.
+  to be deployed on Node 8 rather than Node 6
   ([Firebase Blog Announcement](https://firebase.googleblog.com/2018/08/cloud-functions-for-firebase-config-node-8-timeout-memory-region.html))
+  . This is matched in [`src/functions/.babelrc`](src/functions/.babelrc) so that babel output somewhat compacter and moderner code.
 
 ### Customization
 

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -26,7 +26,6 @@
     "@babel/cli": "^7.0.0-rc.1",
     "cpx": "1.5.0",
     "firebase-tools": "3.18.4",
-    "prettier": "1.12.1",
     "rimraf": "2.6.2"
   }
 }

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -1,22 +1,18 @@
 {
   "name": "with-firebase-hosting",
   "version": "4.0.1",
-  "description":
-    "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
+  "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
   "scripts": {
     "dev": "next \"src/app/\"",
-    "preserve":
-      "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",
+    "preserve": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",
     "serve": "NODE_ENV=production firebase serve",
-    "predeploy":
-      "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps",
+    "predeploy": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps",
     "deploy": "firebase deploy",
     "clean": "rimraf \"dist/functions/**\" && rimraf \"dist/public\"",
     "build-public": "cpx \"src/public/**/*.*\" \"dist/public\" -C",
     "build-funcs": "babel \"src/functions\" --out-dir \"dist/functions\"",
     "build-app": "next build \"src/app/\"",
-    "copy-deps":
-      "cpx \"*{package.json,package-lock.json,yarn.lock}\" \"dist/functions\" -C",
+    "copy-deps": "cpx \"*{package.json,package-lock.json,yarn.lock}\" \"dist/functions\" -C",
     "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -2,6 +2,9 @@
   "name": "with-firebase-hosting",
   "version": "4.0.1",
   "description": "Host Next.js SSR app on Firebase Cloud Functions with Firebase Hosting redirects.",
+  "engines": {
+    "node": "8"
+  },
   "scripts": {
     "dev": "next \"src/app/\"",
     "preserve": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next \"src/app/\"",
     "preserve": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps && npm run install-deps",
-    "serve": "NODE_ENV=production firebase serve",
+    "serve": "cross-env NODE_ENV=production firebase serve",
     "predeploy": "npm run build-public && npm run build-funcs && npm run build-app && npm run copy-deps",
     "deploy": "firebase deploy",
     "clean": "rimraf \"dist/functions/**\" && rimraf \"dist/public\"",
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@babel/cli": "^7.2.0",
     "cpx": "^1.5.0",
+    "cross-env": "^5.2.0",
     "firebase-tools": "^6.1.0",
     "rimraf": "^2.6.0"
   }

--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -16,16 +16,16 @@
     "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {
-    "firebase-admin": "^5.12.1",
-    "firebase-functions": "^1.0.2",
-    "next": "^6.0.3",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "firebase-admin": "^6.3.0",
+    "firebase-functions": "^2.1.0",
+    "next": "^7.0.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-rc.1",
-    "cpx": "1.5.0",
-    "firebase-tools": "3.18.4",
-    "rimraf": "2.6.2"
+    "@babel/cli": "^7.2.0",
+    "cpx": "^1.5.0",
+    "firebase-tools": "^6.1.0",
+    "rimraf": "^2.6.0"
   }
 }

--- a/examples/with-firebase-hosting/src/app/.babelrc
+++ b/examples/with-firebase-hosting/src/app/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": [["next/babel"]]
-}

--- a/examples/with-firebase-hosting/src/functions/.babelrc
+++ b/examples/with-firebase-hosting/src/functions/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "6.11.5"
+          "node": "8.14"
         }
       }
     ]


### PR DESCRIPTION
Hello! 
I was looking at the [`with-firebase-hosting`](/zeit/next.js/tree/canary/examples/with-firebase-hosting) example and was having some various issues running it:

* `npm run serve` will choke on windows because trying to set enviroment variables with `NODE_ENV=production`
* `npm run build-funcs` failing because of babeljs mismatches between `@babel/cli@^7.0.0-rc.1` and `next@^6.0.3`
* Not being able to deploy because `firebase-tools` being a deprecated version.

I remedied this and also improved some other factors:

* Use standard JSON formatting on `package.json` so that `npm install` doesn't cause changes on every run. (a83e930)
* Remove "prettier" as a devDependency as there is no use of it in the example and most other examples does not have it as a dependency. (6095663)
* Update all dependencies. The simple usecase in this example didn't really require any changes to the code. (ccde086)
  * [`firebase-admin@6`](https://github.com/firebase/firebase-admin-node/releases/tag/v6.0.0)
  * [`firebase-functions@2`](https://github.com/firebase/firebase-functions/releases/tag/v2.0.0) 
  * [`firebase-tools@4`](https://github.com/firebase/firebase-tools/releases/tag/v4.0.0)
  * [`firebase-tools@5`](https://github.com/firebase/firebase-tools/releases/tag/v5.0.0)
  * [`firebase-tools@6`](https://github.com/firebase/firebase-tools/releases/tag/v6.0.0)
* Make `npm run serve` runnable on windows using [`cross-env`](https://www.npmjs.com/package/cross-env). (b20dda7)
* Update `.gitignore` to ignore firebase cache (bf761b7)
* Remove `src/app/.babelrc` that seems to have been added as a previous bugfix but doesn't seem to do anything currently. (1b02045)
* Remove point from [`README.md`](https://github.com/zeit/next.js/blob/canary/examples/with-firebase-hosting/README.md) that was mentioning any `predeploy` hooks in `firebase.json` as they were removed in 4f4b7a1bce91bd0d9df65c4749bd152ce582c420. (5636d9f)
* Use the possibility added by upgrading `firebase-tools` to [`>=4.0.0`](https://github.com/firebase/firebase-tools/releases/tag/v4.0.0) and `firebase-functions` to [`>=2.0.0`](https://github.com/firebase/firebase-functions/releases/tag/v2.0.0) to make the deployable functions use node 8 rather than node 6. Also make babel compile with node 8 as target for less polyfills etc. (c954cc2)
  * Added comment to [`README.md`](https://github.com/zeit/next.js/blob/canary/examples/with-firebase-hosting/README.md) explaining how firebase deploys to node 8 and that babel will compile code for node 8. (d8b2e65, 91953dc)

This was tested to `serve` on windows, linux(WSL) and on mac. Deploy was tested on linux(WSL) and mac.

---

This PR is a based on #5806 with correct base.

---

🔔 @jthegedus @timneutkens 