### PR TITLE
Fix/update "examples/custom-server-typescript"

### DIFF
--- a/examples/custom-server-typescript/.gitignore
+++ b/examples/custom-server-typescript/.gitignore
@@ -1,0 +1,5 @@
+# Dependency directories
+node_modules/
+
+# next.js build output
+.next

--- a/examples/custom-server-typescript/.gitignore
+++ b/examples/custom-server-typescript/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 
 # next.js build output
 .next
+
+# typescript build output
+dist

--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,6 +1,4 @@
 {
   "watch": ["server/**/*.ts"],
-  "execMap": {
-    "ts": "ts-node --typeCheck --compilerOptions '{\"module\":\"commonjs\"}'"
-  }
+  "exec": "ts-node --project tsconfig.server.json server/index.ts"
 }

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -5,19 +5,16 @@
     "start": "NODE_ENV=production node .next/production-server/index.js"
   },
   "dependencies": {
-    "@babel/core": "^7.1.2",
-    "@zeit/next-typescript": "1.1.1",
-    "babel-loader": "^8.0.4",
-    "next": "latest",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2",
-    "typescript": "latest",
-    "typescript-babel-jest": "^1.0.5"
+    "@zeit/next-typescript": "^1.1.0",
+    "next": "^7.0.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0"
   },
   "devDependencies": {
-    "@types/next": "^7.0.1",
-    "@types/react": "^16.4.16",
-    "nodemon": "^1.18.4",
-    "ts-node": "^7.0.1"
+    "@types/next": "^7.0.0",
+    "@types/react": "^16.6.0",
+    "nodemon": "^1.18.8",
+    "ts-node": "^7.0.1",
+    "typescript": "^3.2.0"
   }
 }

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "nodemon",
     "build": "next build && tsc --project tsconfig.server.json",
-    "start": "cross-env NODE_ENV=production node .next/production-server/index.js"
+    "start": "cross-env NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
     "@zeit/next-typescript": "^1.1.0",

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dev": "nodemon",
     "build": "next build && tsc --project tsconfig.server.json",
-    "start": "NODE_ENV=production node .next/production-server/index.js"
+    "start": "cross-env NODE_ENV=production node .next/production-server/index.js"
   },
   "dependencies": {
     "@zeit/next-typescript": "^1.1.0",
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@types/next": "^7.0.0",
     "@types/react": "^16.6.0",
+    "cross-env": "^5.2.0",
     "nodemon": "^1.18.8",
     "ts-node": "^7.0.1",
     "typescript": "^3.2.0"

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "nodemon server/index.ts",
+    "dev": "nodemon",
     "build": "next build && tsc --project tsconfig.server.json",
     "start": "NODE_ENV=production node .next/production-server/index.js"
   },

--- a/examples/custom-server-typescript/tsconfig.server.json
+++ b/examples/custom-server-typescript/tsconfig.server.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "dist",
+    "target": "es2017",
+    "lib": [
+      "es2017"
+    ]
   },
   "include": ["server/**/*.ts"]
 }

--- a/examples/custom-server-typescript/tsconfig.server.json
+++ b/examples/custom-server-typescript/tsconfig.server.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": ".next/production-server/"
+    "outDir": "dist"
   },
   "include": ["server/**/*.ts"]
 }


### PR DESCRIPTION
* Update all dependencies and remove redundant ones from package.json. (60f9ee5)
* Fixes #5596 by adjusting nodemon scripts (d4b7d3a)
* Fixes `npm start` on windows by using `cross-env` (9555217)
* Move compiled server out from `.next`. Compiling other JS into `.next` seems incorrect. (79fce02, 
9ce7086)
* Partly fixes #5753 by making sure typescript compiles with `es2017` as target, at least ensuring code is runnable on node 8. Previously it was compiled with `esnext`. (9176e92)

--- 

I tried improving the structure by keeping source in `src/app` and `src/server` and then building to `dist/server` and `dist/app` but I didn't really get it to work and made most configs more complicated. Moved the built server out from `.next` anyway.