### PR TITLE
Fix initialNow in react-intl example

### DIFF
--- a/examples/with-react-intl/pages/_app.js
+++ b/examples/with-react-intl/pages/_app.js
@@ -23,17 +23,17 @@ export default class MyApp extends App {
     // In the browser, use the same values that the server serialized.
     const { req } = ctx
     const { locale, messages } = req || window.__NEXT_DATA__.props
+    const initialNow = Date.now()
 
-    return { pageProps, locale, messages }
+    return { pageProps, locale, messages, initialNow }
   }
 
   render () {
-    const { Component, pageProps, locale, messages } = this.props
-    const now = Date.now()
+    const { Component, pageProps, locale, messages, initialNow } = this.props
 
     return (
       <Container>
-        <IntlProvider locale={locale} messages={messages} initialNow={now}>
+        <IntlProvider locale={locale} messages={messages} initialNow={initialNow}>
           <Component {...pageProps} />
         </IntlProvider>
       </Container>


### PR DESCRIPTION
The `initialNow` prop is used to avoid content mismatches when Universal/SSR apps render date values using components like `<FormattedRelative>`.

If this value is created in `render()`, then the server and client will both run it and generate two different values, resulting in content mismatches like:

> Warning: Text content did not match. Server: "in 1,741,545 seconds" Client: "in 1,741,543 seconds"

If the value is instead generated in `getInitialProps`, then the client's initial rendering will match because it will use the same value sent down by the server.