### PR TITLE
Removing link ref style.css

### DIFF
--- a/examples/with-semantic-ui/pages/_document.js
+++ b/examples/with-semantic-ui/pages/_document.js
@@ -4,9 +4,7 @@ export default class MyDocument extends Document {
   render () {
     return (
       <html>
-        <Head>
-          <link rel='stylesheet' href='/_next/static/style.css' />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
This link ref is no more necessary to include in the Head Section.  It cause error 404 in the console: http://localhost:3000/_next/static/style.css net::ERR_ABORTED 404 (Not Found)