### PR TITLE
Remove <link ...style.css"> from next-sass example

### DIFF
--- a/examples/with-next-sass/pages/_document.js
+++ b/examples/with-next-sass/pages/_document.js
@@ -1,21 +1,10 @@
-/*
-In production the stylesheet is compiled to .next/static/style.css.
-The file will be served from /_next/static/style.css
-You could include it into the page using either next/head or a custom _document.js.
-*/
-
 import Document, { Head, Main, NextScript } from 'next/document'
 
 export default class MyDocument extends Document {
   render () {
     return (
       <html>
-        <Head>
-          <link
-            rel='stylesheet'
-            href='/_next/static/style.css'
-          />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
It seems that we don't need to put ```<link rel="stylesheet" href="/_next/static/style.css" />``` in ```<Head>...</Head>``` after Next 7+.
But still need to have ```<Head />``` itself when customizing _document.

refer:
https://github.com/zeit/next-plugins/issues/290