### PR TITLE
Make sure WebSocket server port is always detected

### DIFF
--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -172,11 +172,18 @@ export default class HotReloader {
   async start () {
     await this.clean()
 
-    await new Promise(resolve => {
+    this.wsPort = await new Promise((resolve, reject) => {
       // create dynamic entries WebSocket
-      this.wss = new WebSocket.Server({ port: 0 }, () => {
-        this.wsPort = this.wss.address().port
-        resolve()
+      this.wss = new WebSocket.Server({ port: 0 }, function (err) {
+        if (err) {
+          return reject(err)
+        }
+
+        const {port} = this.address()
+        if (!port) {
+          return reject(new Error('No websocket port could be detected'))
+        }
+        resolve(port)
       })
     })
 


### PR DESCRIPTION
Ran into this when upgrading zeit.co:

```
TypeError: this.wss.address is not a function
    at Server.wss.ws_1.default.Server (/Users/timneutkens/projects/front/node_modules/next/dist/server/hot-reloader.js:162:40)
    at Object.onceWrapper (events.js:273:13)
    at Server.emit (events.js:187:15)
    at Server.EventEmitter.emit (domain.js:442:20)
    at emitListeningNT (net.js:1370:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
Uncaught Exception TypeError: this.wss.address is not a function
    at Server.wss.ws_1.default.Server (/Users/timneutkens/projects/front/node_modules/next/dist/server/hot-reloader.js:162:40)
    at Object.onceWrapper (events.js:273:13)
    at Server.emit (events.js:187:15)
    at Server.EventEmitter.emit (domain.js:442:20)
    at emitListeningNT (net.js:1370:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

I'm not sure why the tests didn't catch this before :thinking: