### PR TITLE
Adding in `@tailwind components;`

### DIFF
--- a/examples/with-tailwindcss/styles/index.css
+++ b/examples/with-tailwindcss/styles/index.css
@@ -1,6 +1,7 @@
 @import "./button.css";
 
 @tailwind preflight;
+@tailwind components;
 @tailwind utilities;
 
 .hero {


### PR DESCRIPTION
Without `@tailwind components;` plugins (like container which is added by default) will not work.
See: https://github.com/tailwindcss/tailwindcss/issues/446#issuecomment-378792892 for details