### PR TITLE
Remove node-args in favor of NODE_OPTIONS environment variable

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1340,13 +1340,17 @@ module.exports = {
 
 #### Configuring next process script
 
-You can pass any node arguments to `next` cli command.
-
+You can pass any node arguments to `next` CLI command.
 
 ```bash
-next --node-args="--throw-deprecation"
-next start --node-args="--inspect"
-next build --node-args="-r esm"
+NODE_OPTIONS="--throw-deprecation" next
+NODE_OPTIONS="-r esm" next
+```
+
+`--inspect` is a special case since it binds to a port and can't double-bind to the child process the `next` CLI creates.
+
+```
+next start --inspect
 ```
 
 ### Customizing webpack config

--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -24,7 +24,6 @@ const args = arg({
   // Types
   '--version': Boolean,
   '--help': Boolean,
-  '--node-args': String,
   '--inspect': Boolean,
 
   // Aliases
@@ -55,7 +54,7 @@ if (!foundCommand && args['--help']) {
       
     Options
       --version, -p   Version number
-      --node-args     Node arguments applied to the process
+      --inspect       Enable the Node.js inspector
       --help, -h      Displays this message  
 
     For more information run a command with the --help flag
@@ -64,15 +63,10 @@ if (!foundCommand && args['--help']) {
   process.exit(0)
 }
 
-// Add support for `--node-args` to send Node.js arguments to the spawned process
-const nodeArguments = args['--node-args'] && args['--node-args'] !== '' ? args['--node-args'].split(' ') : []
+const nodeArguments: string[] = []
 if (args['--inspect']) {
-  console.log('The `--inspect` option is deprecated in favor of `--node-args`')
+  console.log('Passing "--inspect" to Node.js')
   nodeArguments.push('--inspect')
-}
-
-if (nodeArguments.length > 0) {
-  console.log(`Passing arguments to Node.js: "${nodeArguments.join(' ')}"`)
 }
 
 const command = foundCommand || defaultCommand

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -45,14 +45,7 @@ describe('CLI Usage', () => {
       const output = await runNextCommand(['build', dir, '--inspect'], {
         stdout: true
       })
-      expect(output.stdout).toMatch(/The `--inspect` option is deprecated/)
-    })
-
-    test('--node-args', async () => {
-      const output = await runNextCommand(['build', dir, '--node-args=--inspect'], {
-        stdout: true
-      })
-      expect(output.stdout).toMatch(/Passing arguments to Node\.js: "--inspect"/)
+      expect(output.stdout).toMatch(/Passing "--inspect" to Node\.js/)
     })
   })
   describe('build', () => {


### PR DESCRIPTION
Since passing `--node-args` gives parsing issues as it takes arguments as argument. And Node.js has a built-in way of providing them through an environment variable called `NODE_OPTIONS` there is no need for us to ship a specific feature to support it.