### PR TITLE
Update docs: change prop name in `Reusing the built-in error page` code example

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1196,15 +1196,15 @@ import fetch from 'isomorphic-unfetch'
 export default class Page extends React.Component {
   static async getInitialProps() {
     const res = await fetch('https://api.github.com/repos/zeit/next.js')
-    const statusCode = res.statusCode > 200 ? res.statusCode : false
+    const errorCode = res.statusCode > 200 ? res.statusCode : false
     const json = await res.json()
 
-    return { statusCode, stars: json.stargazers_count }
+    return { errorCode, stars: json.stargazers_count }
   }
 
   render() {
-    if (this.props.statusCode) {
-      return <Error statusCode={this.props.statusCode} />
+    if (this.props.errorCode) {
+      return <Error statusCode={this.props.errorCode} />
     }
 
     return (


### PR DESCRIPTION
For this code snippet, we only store the status code as Integer itself if it's not `200 OK` so using `errorCode` as a prop name here is better to self-explain the code and help the example easier to understand.