### PR TITLE
fixed mobx example where initialProp wouldn’t match client prop

### DIFF
--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -9,7 +9,7 @@ class MyMobxApp extends App {
     // This allows you to set a custom default initialState
     const mobxStore = initializeStore()
     // Provide the store to getInitialProps of pages
-    appContext.ctx.mobxStore = mobxStore
+    appContext.ctx.store = mobxStore
 
     let appProps = await App.getInitialProps(appContext)
 


### PR DESCRIPTION
I believe there's a typo in this example. The Provider receives a prop named `store`:

```javascript
<Provider store={this.mobxStore}>
```

and subsequent components can get "store" injected, but the parameter given to the props in `getInitialProps()` is named "mobxStore"