### PR TITLE
WIP: Using React.createContext instead of ChildContext

### DIFF
--- a/packages/next-server/lib/head.js
+++ b/packages/next-server/lib/head.js
@@ -2,10 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import sideEffect from './side-effect'
 
+export const HeadManagerContext = React.createContext()
+
 class Head extends React.Component {
-  static contextTypes = {
-    headManager: PropTypes.object
-  }
+  static contextType = HeadManagerContext
 
   render () {
     return null
@@ -47,8 +47,8 @@ function mapOnServer (head) {
 }
 
 function onStateChange (head) {
-  if (this.context && this.context.headManager) {
-    this.context.headManager.updateHead(head)
+  if (this.context) {
+    this.context.updateHead(head)
   }
 }
 

--- a/packages/next-server/lib/side-effect.js
+++ b/packages/next-server/lib/side-effect.js
@@ -36,7 +36,9 @@ export default function withSideEffect (reduceComponentsToState, handleStateChan
       // Expose canUseDOM so tests can monkeypatch it
       static canUseDOM = typeof window !== 'undefined'
 
+      // Both of these are needed for React 16/17 interop
       static contextTypes = WrappedComponent.contextTypes
+      static contextType = WrappedComponent.contextType
 
       // Try to use displayName of wrapped component
       static displayName = `SideEffect(${getDisplayName(WrappedComponent)})`

--- a/packages/next/pages/_app.js
+++ b/packages/next/pages/_app.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { execOnce, loadGetInitialProps } from 'next-server/dist/lib/utils'
+import { HeadManagerContext } from 'next-server/dist/lib/head'
 import { makePublicRouterInstance } from 'next/router'
 
 export default class App extends Component {
   static childContextTypes = {
-    headManager: PropTypes.object,
     router: PropTypes.object
   }
 
@@ -15,9 +15,7 @@ export default class App extends Component {
   }
 
   getChildContext () {
-    const { headManager } = this.props
     return {
-      headManager,
       router: makePublicRouterInstance(this.props.router)
     }
   }
@@ -31,9 +29,11 @@ export default class App extends Component {
   render () {
     const {router, Component, pageProps} = this.props
     const url = createUrl(router)
-    return <Container>
-      <Component {...pageProps} url={url} />
-    </Container>
+    return <HeadManagerContext.Provider value={this.props.headManager}>
+      <Container>
+        <Component {...pageProps} url={url} />
+      </Container>
+    </HeadManagerContext.Provider>
   }
 }
 

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -3,12 +3,11 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import htmlescape from 'htmlescape'
 import flush from 'styled-jsx/server'
+import { DocumentPropsContext } from 'next-server/dist/server/render';
 
 const Fragment = React.Fragment || function Fragment ({ children }) {
   return <div>{children}</div>
 }
-
-const DocumentPropsContext = React.createContext();
 
 export default class Document extends Component {
 
@@ -19,15 +18,13 @@ export default class Document extends Component {
   }
 
   render () {
-    return <DocumentPropsContext.Provider value={this.props}>
-      <html>
-        <Head />
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </html>
-    </DocumentPropsContext.Provider>
+    return <html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </html>
   }
 }
 
@@ -149,7 +146,7 @@ export class NextScript extends Component {
   }
 
   getDynamicChunks () {
-    const { dynamicImports, assetPrefix } = this.context._documentProps
+    const { dynamicImports, assetPrefix } = this.context
     return dynamicImports.map((bundle) => {
       return <script
         async
@@ -162,7 +159,7 @@ export class NextScript extends Component {
   }
 
   getScripts () {
-    const { assetPrefix, files } = this.context._documentProps
+    const { assetPrefix, files } = this.context
     if(!files || files.length === 0) {
       return null
     }
@@ -189,7 +186,7 @@ export class NextScript extends Component {
   }
 
   render () {
-    const { staticMarkup, assetPrefix, devFiles, __NEXT_DATA__ } = this.context._documentProps
+    const { staticMarkup, assetPrefix, devFiles, __NEXT_DATA__ } = this.context
     const { page, buildId } = __NEXT_DATA__
     const pagePathname = getPagePathname(page)
 
@@ -200,7 +197,7 @@ export class NextScript extends Component {
     return <Fragment>
       {devFiles ? devFiles.map((file) => <script key={file} src={`${assetPrefix}/_next/${file}`} nonce={this.props.nonce} crossOrigin={this.props.crossOrigin || process.crossOrigin} />) : null}
       {staticMarkup ? null : <script id="__NEXT_DATA__" type="application/json" nonce={this.props.nonce} crossOrigin={this.props.crossOrigin || process.crossOrigin} dangerouslySetInnerHTML={{
-        __html: NextScript.getInlineScriptSource(this.context._documentProps)
+        __html: NextScript.getInlineScriptSource(this.context)
       }} />}
       {page !== '/_error' && <script async id={`__NEXT_PAGE__${page}`} src={`${assetPrefix}/_next/static/${buildId}/pages${pagePathname}`} nonce={this.props.nonce} crossOrigin={this.props.crossOrigin || process.crossOrigin} />}
       <script async id={`__NEXT_PAGE__/_app`} src={`${assetPrefix}/_next/static/${buildId}/pages/_app.js`} nonce={this.props.nonce} crossOrigin={this.props.crossOrigin || process.crossOrigin} />

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -8,10 +8,9 @@ const Fragment = React.Fragment || function Fragment ({ children }) {
   return <div>{children}</div>
 }
 
+const DocumentPropsContext = React.createContext();
+
 export default class Document extends Component {
-  static childContextTypes = {
-    _documentProps: PropTypes.any
-  }
 
   static getInitialProps ({ renderPage }) {
     const { html, head } = renderPage()
@@ -19,25 +18,21 @@ export default class Document extends Component {
     return { html, head, styles }
   }
 
-  getChildContext () {
-    return { _documentProps: this.props }
-  }
-
   render () {
-    return <html>
-      <Head />
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </html>
+    return <DocumentPropsContext.Provider value={this.props}>
+      <html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    </DocumentPropsContext.Provider>
   }
 }
 
 export class Head extends Component {
-  static contextTypes = {
-    _documentProps: PropTypes.any
-  }
+  static contextType = DocumentPropsContext
 
   static propTypes = {
     nonce: PropTypes.string,
@@ -45,7 +40,7 @@ export class Head extends Component {
   }
 
   getCssLinks () {
-    const { assetPrefix, files } = this.context._documentProps
+    const { assetPrefix, files } = this.context
     if(!files || files.length === 0) {
       return null
     }
@@ -67,7 +62,7 @@ export class Head extends Component {
   }
 
   getPreloadDynamicChunks () {
-    const { dynamicImports, assetPrefix } = this.context._documentProps
+    const { dynamicImports, assetPrefix } = this.context
     return dynamicImports.map((bundle) => {
       return <link
         rel='preload'
@@ -81,7 +76,7 @@ export class Head extends Component {
   }
 
   getPreloadMainLinks () {
-    const { assetPrefix, files } = this.context._documentProps
+    const { assetPrefix, files } = this.context
     if(!files || files.length === 0) {
       return null
     }
@@ -104,7 +99,7 @@ export class Head extends Component {
   }
 
   render () {
-    const { head, styles, assetPrefix, __NEXT_DATA__ } = this.context._documentProps
+    const { head, styles, assetPrefix, __NEXT_DATA__ } = this.context
     const { page, buildId } = __NEXT_DATA__
     const pagePathname = getPagePathname(page)
 
@@ -135,12 +130,10 @@ export class Head extends Component {
 }
 
 export class Main extends Component {
-  static contextTypes = {
-    _documentProps: PropTypes.any
-  }
+  static contextType = DocumentPropsContext
 
   render () {
-    const { html } = this.context._documentProps
+    const { html } = this.context
     return (
       <div id='__next' dangerouslySetInnerHTML={{ __html: html }} />
     )
@@ -148,9 +141,7 @@ export class Main extends Component {
 }
 
 export class NextScript extends Component {
-  static contextTypes = {
-    _documentProps: PropTypes.any
-  }
+  static contextType = DocumentPropsContext
 
   static propTypes = {
     nonce: PropTypes.string,


### PR DESCRIPTION
This is in respose to #5716. I'm tackling some of the smaller instances first just to get a sense of the project, coding style, tests etc.

It seemed like there was a little discussion about whether this change would alienate Preact and Inferno users however that's a decision for somebody else to make - I for one would prefer to take advantage of the latest and greatest React features.

The test plan is pretty simple - it's a refactoring so existing tests shouldn't break. Also completion milestone is removing `prop-types` as a dependency.

### TODO

- [x] `headManager`
- [ ] `loadable`
- [ ] `router`
- [x] `_documentProps`

Note: I'm going to ignore the usage of legacy `contextTypes` in the examples as they don't add directly to Next's bundle size and I'm sure that each example library will have different best practices on how to update to React 17.
