### PR TITLE
Corrects Typo from next-bundle-analyzer/readme.md

### DIFF
--- a/examples/analyze-bundles/next.config.js
+++ b/examples/analyze-bundles/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
     },
     browser: {
       analyzerMode: 'static',
-      reportFilename: './bundles/client.html'
+      reportFilename: '../bundles/client.html'
     }
   },
   webpack (config) {


### PR DESCRIPTION
c.f. https://github.com/zeit/next-plugins/blob/master/packages/next-bundle-analyzer/readme.md