### PR TITLE
Fix with-jest-typescript example to keep babel-jest in sync with jest

### DIFF
--- a/examples/with-jest-typescript/package.json
+++ b/examples/with-jest-typescript/package.json
@@ -19,10 +19,10 @@
     "@types/react-dom": "^16.0.4",
     "@zeit/next-typescript": "1.1.0",
     "babel-core": "^7.0.0-bridge.0",
-    "babel-jest": "23.0.1",
+    "babel-jest": "^23.6.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jest": "^23.1.0",
+    "jest": "^23.6.0",
     "react-addons-test-utils": "^15.6.2",
     "react-test-renderer": "^16.2.0",
     "typescript": "^2.7.2"


### PR DESCRIPTION
This fixes the `with-jest-typescript` example to keep jest in sync with babel-jest (also updated to the latest of both). Having them resolve to different versions was resulting in weird errors.

When attempting to update the `transform` property in `jest.setup.js` to add babel-jest support to *.js/jsx files, it would throw:

> Plugin 0 specified in "node_modules/next/babel.js" provided an invalid property of "default" (While processing preset: "node_modules/next/babel.js")

Indirectly, this will fix https://github.com/zeit/next.js/issues/5917, once the author updates `jest.setup.js` to have:
```js
  transform: {
    '^.+\\.(js|tsx)?$': 'babel-jest',
  },
```

