### PR TITLE
Migrate HeadManager to use React.createContext

### DIFF
--- a/packages/next-server/lib/head.js
+++ b/packages/next-server/lib/head.js
@@ -2,10 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import sideEffect from './side-effect'
 
+const HeadManagerContext = React.createContext()
+
 class Head extends React.Component {
-  static contextTypes = {
-    headManager: PropTypes.object
-  }
+  static contextType = HeadManagerContext
 
   render () {
     return null
@@ -47,8 +47,8 @@ function mapOnServer (head) {
 }
 
 function onStateChange (head) {
-  if (this.context && this.context.headManager) {
-    this.context.headManager.updateHead(head)
+  if (this.context) {
+    this.context.updateHead(head)
   }
 }
 

--- a/packages/next-server/lib/head.js
+++ b/packages/next-server/lib/head.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import sideEffect from './side-effect'
 
-const HeadManagerContext = React.createContext()
+export const HeadManagerContext = React.createContext()
 
 class Head extends React.Component {
   static contextType = HeadManagerContext

--- a/packages/next-server/lib/side-effect.js
+++ b/packages/next-server/lib/side-effect.js
@@ -37,6 +37,7 @@ export default function withSideEffect (reduceComponentsToState, handleStateChan
       static canUseDOM = typeof window !== 'undefined'
 
       static contextTypes = WrappedComponent.contextTypes
+      static contextType = WrappedComponent.contextType
 
       // Try to use displayName of wrapped component
       static displayName = `SideEffect(${getDisplayName(WrappedComponent)})`

--- a/packages/next/pages/_app.js
+++ b/packages/next/pages/_app.js
@@ -27,9 +27,9 @@ export default class App extends Component {
   }
 
   render () {
-    const {router, Component, pageProps} = this.props
+    const {router, Component, pageProps, headManager} = this.props
     const url = createUrl(router)
-    return <HeadManagerContext.Provider value={this.props.headManager}>
+    return <HeadManagerContext.Provider value={headManager}>
       <Container>
         <Component {...pageProps} url={url} />
       </Container>

--- a/packages/next/pages/_app.js
+++ b/packages/next/pages/_app.js
@@ -2,10 +2,10 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { execOnce, loadGetInitialProps } from 'next-server/dist/lib/utils'
 import { makePublicRouterInstance } from 'next/router'
+import { HeadManagerContext } from 'next-server/dist/lib/head'
 
 export default class App extends Component {
   static childContextTypes = {
-    headManager: PropTypes.object,
     router: PropTypes.object
   }
 
@@ -15,9 +15,7 @@ export default class App extends Component {
   }
 
   getChildContext () {
-    const { headManager } = this.props
     return {
-      headManager,
       router: makePublicRouterInstance(this.props.router)
     }
   }
@@ -31,9 +29,11 @@ export default class App extends Component {
   render () {
     const {router, Component, pageProps} = this.props
     const url = createUrl(router)
-    return <Container>
-      <Component {...pageProps} url={url} />
-    </Container>
+    return <HeadManagerContext.Provider value={this.props.headManager}>
+      <Container>
+        <Component {...pageProps} url={url} />
+      </Container>
+    </HeadManagerContext.Provider>
   }
 }
 


### PR DESCRIPTION
A more focused PR from #5935 and responding to #5716. Converts HeadManager to use the new [React.createContext](https://reactjs.org/docs/context.html#reactcreatecontext) api.