### PR TITLE
Add test for instance method on getInitialProps.

### DIFF
--- a/test/integration/basic/pages/instance-get-initial-props.js
+++ b/test/integration/basic/pages/instance-get-initial-props.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default class InstanceInitialPropsPage extends React.Component {
+  async getInitialProps () {
+    return fetchData()
+  }
+
+  render () {
+    return <p>{this.props.name}</p>
+  }
+}
+
+function fetchData () {
+  const p = new Promise(resolve => {
+    setTimeout(() => resolve({ name: 'Anderson Leite' }), 10)
+  })
+  return p
+}

--- a/test/integration/basic/test/rendering.js
+++ b/test/integration/basic/test/rendering.js
@@ -120,6 +120,12 @@ export default function ({ app }, suiteName, render, fetch) {
       expect(link.text()).toBe('About')
     })
 
+    test('getInitialProps should be class method', async () => {
+      const $ = await get$('/instance-get-initial-props')
+      const expectedErrorMessage = '"InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://err.sh/zeit/next.js/get-initial-props-as-an-instance-method for more information.'
+      expect($('pre').text().includes(expectedErrorMessage)).toBeTruthy()
+    })
+
     test('getInitialProps resolves to null', async () => {
       const $ = await get$('/empty-get-initial-props')
       const expectedErrorMessage = '"EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.'


### PR DESCRIPTION
Adding a new test for getInitialProps.
If getInitialProps isn't defined as static (class method) next.js should throw an exception.