### PR TITLE
Don't bundle next/asset if it's not used

### DIFF
--- a/packages/next-server/lib/asset.js
+++ b/packages/next-server/lib/asset.js
@@ -1,4 +1,4 @@
-let assetPrefix
+let assetPrefix = typeof window !== 'undefined' ? (window.__NEXT_DATA__.assetPrefix) : undefined
 
 export default function asset (path) {
   // If the URL starts with http, we assume it's an

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -5,7 +5,6 @@ import { createRouter } from 'next/router'
 import EventEmitter from 'next-server/dist/lib/event-emitter'
 import {loadGetInitialProps, getURL} from 'next-server/dist/lib/utils'
 import PageLoader from './page-loader'
-import * as asset from 'next-server/asset'
 import * as envConfig from 'next-server/config'
 import ErrorBoundary from './error-boundary'
 import Loadable from 'next-server/dist/lib/loadable'
@@ -38,8 +37,6 @@ const prefix = assetPrefix || ''
 // With dynamic assetPrefix it's no longer possible to set assetPrefix at the build time
 // So, this is how we do it in the client side at runtime
 __webpack_public_path__ = `${prefix}/_next/` //eslint-disable-line
-// Initialize next/asset with the assetPrefix
-asset.setAssetPrefix(prefix)
 // Initialize next/config with the environment configuration
 envConfig.setConfig({
   serverRuntimeConfig: {},


### PR DESCRIPTION
This solves part of #5970 by not requiring `next/asset` when it's not used in pages.

However I still want to drop this API as it's not documented.