### PR TITLE
Export render instead of default for serverless target

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -39,7 +39,7 @@ const nextServerlessLoader: loader.Loader = function () {
     import Error from '${absoluteErrorPath}';
     import App from '${absoluteAppPath}';
     import Component from '${absolutePagePath}';
-    async function render(req, res) {
+    async function renderReqToHTML(req, res) {
       const options = {
         App,
         Document,
@@ -76,9 +76,9 @@ const nextServerlessLoader: loader.Loader = function () {
         }
       }
     }
-    export default async (req, res) => {
+    export async function render (req, res) {
       try {
-        const html = await render(req, res)
+        const html = await renderReqToHTML(req, res)
         sendHTML(req, res, html, {generateEtags: ${generateEtags}})
       } catch(err) {
         console.error(err)

--- a/test/integration/serverless/server.js
+++ b/test/integration/serverless/server.js
@@ -8,22 +8,22 @@ module.exports = function start (port = 0) {
     const nextStaticDir = path.join(__dirname, '.next', 'static')
     app.use('/_next/static', express.static(nextStaticDir))
     app.get('/', (req, res) => {
-      require('./.next/serverless/pages/index.js').default(req, res)
+      require('./.next/serverless/pages/index.js').render(req, res)
     })
     app.get('/abc', (req, res) => {
-      require('./.next/serverless/pages/abc.js').default(req, res)
+      require('./.next/serverless/pages/abc.js').render(req, res)
     })
     app.get('/fetch', (req, res) => {
-      require('./.next/serverless/pages/fetch.js').default(req, res)
+      require('./.next/serverless/pages/fetch.js').render(req, res)
     })
     app.get('/dynamic', (req, res) => {
-      require('./.next/serverless/pages/dynamic.js').default(req, res)
+      require('./.next/serverless/pages/dynamic.js').render(req, res)
     })
     app.get('/dynamic-two', (req, res) => {
-      require('./.next/serverless/pages/dynamic-two.js').default(req, res)
+      require('./.next/serverless/pages/dynamic-two.js').render(req, res)
     })
     app.get('/404', (req, res) => {
-      require('./.next/serverless/pages/_error.js').default(req, res)
+      require('./.next/serverless/pages/_error.js').render(req, res)
     })
     const server = new http.Server(app)
 


### PR DESCRIPTION
Extends on #5927, instead of `.default` we'll expose `.render` which is semantically more correct / mirrors the naming of the custom server API.

I've updated the spec in #5927 to reflect this change.

(copied from #5927):

```js
const http = require('http')
const page = require('./.next/serverless/about.js')
const server = new http.Server((req, res) => page.render(req, res))
server.listen(3000, () => console.log('Listening on http://localhost:3000'))
```