### PR TITLE
Fix rtl-test example & add Snapshot testing

### DIFF
--- a/examples/with-jest-react-testing-library/__tests__/__snapshots__/index.test.js.snap
+++ b/examples/with-jest-react-testing-library/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`With React Testing Library Snapshot Should match Snapshot 1`] = `
+<DocumentFragment>
+  <div>
+    <p>
+      Hello World!
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/examples/with-jest-react-testing-library/__tests__/index.test.js
+++ b/examples/with-jest-react-testing-library/__tests__/index.test.js
@@ -12,3 +12,11 @@ describe('With React Testing Library', () => {
     expect(getByText('Hello World!')).not.toBeNull()
   })
 })
+
+describe('With React Testing Library Snapshot', () => {
+  it('Should match Snapshot', () => {
+    const { asFragment } = render(<App />)
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/examples/with-jest-react-testing-library/package.json
+++ b/examples/with-jest-react-testing-library/package.json
@@ -7,6 +7,9 @@
     "react-dom": "latest"
   },
   "devDependencies": {
+    "@babel/core": "^7.1.2",
+    "babel-core": "^7.0.0-bridge",
+    "babel-jest": "^23.6.0",
     "react-testing-library": "^5.4.2",
     "jest": "^23.6.0"
   },


### PR DESCRIPTION
Fix #5980 

I've also added a snapshot test 🎉 

```
C:\Users\Skaronator\Documents\GitHub\next.js\examples\with-jest-react-testing-library>del node_modules

C:\Users\Skaronator\Documents\GitHub\next.js\examples\with-jest-react-testing-library>yarn
yarn install v1.12.3
warning package.json: No license field
warning with-jest-react-testing-library@1.0.0: No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 2.18s.

C:\Users\Skaronator\Documents\GitHub\next.js\examples\with-jest-react-testing-library>yarn test
yarn run v1.12.3
warning package.json: No license field
$ jest
 PASS  __tests__/index.test.js
  With React Testing Library
    √ Shows "Hello world!" (17ms)
  With React Testing Library Snapshot
    √ Should match Snapshot (5ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   1 passed, 1 total
Time:        1.166s
Ran all test suites.
Done in 1.81s.
```