### PR TITLE
Change React version of examples to latest

### DIFF
--- a/examples/custom-server-polka/package.json
+++ b/examples/custom-server-polka/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "next": "latest",
     "polka": "0.5.1",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   }
 }

--- a/examples/custom-server-polka/package.json
+++ b/examples/custom-server-polka/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "next": "latest",
     "polka": "0.5.1",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   }
 }

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -12,9 +12,9 @@
     "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "prop-types": "^15.6.2",
-    "react": "latest",
+    "react": "^16.7.0",
     "react-apollo": "^2.1.11",
-    "react-dom": "latest"
+    "react-dom": "^16.7.0"
   },
   "author": "",
   "license": "ISC"

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -12,9 +12,9 @@
     "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "prop-types": "^15.6.2",
-    "react": "^16.5.2",
+    "react": "latest",
     "react-apollo": "^2.1.11",
-    "react-dom": "^16.5.2"
+    "react-dom": "latest"
   },
   "author": "",
   "license": "ISC"

--- a/examples/with-cerebral/package.json
+++ b/examples/with-cerebral/package.json
@@ -14,7 +14,7 @@
     "@cerebral/react": "^2.1.0",
     "cerebral": "^3.1.0",
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   }
 }

--- a/examples/with-cerebral/package.json
+++ b/examples/with-cerebral/package.json
@@ -14,7 +14,7 @@
     "@cerebral/react": "^2.1.0",
     "cerebral": "^3.1.0",
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   }
 }

--- a/examples/with-custom-reverse-proxy/package.json
+++ b/examples/with-custom-reverse-proxy/package.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "express": "^4.15.3",
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   },
   "devDependencies": {
     "cross-env": "^5.0.1",

--- a/examples/with-custom-reverse-proxy/package.json
+++ b/examples/with-custom-reverse-proxy/package.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "express": "^4.15.3",
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "devDependencies": {
     "cross-env": "^5.0.1",

--- a/examples/with-draft-js/package.json
+++ b/examples/with-draft-js/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "draft-js": "0.10.5",
     "next": "5.0.0",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   }
 }

--- a/examples/with-draft-js/package.json
+++ b/examples/with-draft-js/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "draft-js": "0.10.5",
     "next": "5.0.0",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   }
 }

--- a/examples/with-glamorous/package.json
+++ b/examples/with-glamorous/package.json
@@ -10,8 +10,8 @@
     "glamor": "^2.20.24",
     "glamorous": "^4.11.0",
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "license": "ISC"
 }

--- a/examples/with-glamorous/package.json
+++ b/examples/with-glamorous/package.json
@@ -10,8 +10,8 @@
     "glamor": "^2.20.24",
     "glamorous": "^4.11.0",
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   },
   "license": "ISC"
 }

--- a/examples/with-hashed-statics/package.json
+++ b/examples/with-hashed-statics/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "babel-plugin-transform-assets": "^0.2.0",
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "devDependencies": {
     "file-loader": "2.0.0"

--- a/examples/with-hashed-statics/package.json
+++ b/examples/with-hashed-statics/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "babel-plugin-transform-assets": "^0.2.0",
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   },
   "devDependencies": {
     "file-loader": "2.0.0"

--- a/examples/with-higher-order-component/package.json
+++ b/examples/with-higher-order-component/package.json
@@ -10,8 +10,8 @@
     "accepts": "1.3.4",
     "lodash.flowright": "3.5.0",
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "license": "ISC"
 }

--- a/examples/with-higher-order-component/package.json
+++ b/examples/with-higher-order-component/package.json
@@ -10,8 +10,8 @@
     "accepts": "1.3.4",
     "lodash.flowright": "3.5.0",
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   },
   "license": "ISC"
 }

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "dependencies": {
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "dependencies": {
     "next": "latest",
-    "react": "^16.5.0",
-    "react-dom": "^16.5.0"
+    "react": "latest",
+    "react-dom": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/examples/with-next-css/package.json
+++ b/examples/with-next-css/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@zeit/next-css": "^1.0.1",
     "next": "latest",
-    "react": "16.4.2",
-    "react-dom": "16.4.2"
+    "react": "latest",
+    "react-dom": "latest"
   }
 }

--- a/examples/with-next-css/package.json
+++ b/examples/with-next-css/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@zeit/next-css": "^1.0.1",
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   }
 }

--- a/examples/with-pkg/package.json
+++ b/examples/with-pkg/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "devDependencies": {
     "pkg": "^4.2.2"

--- a/examples/with-pkg/package.json
+++ b/examples/with-pkg/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   },
   "devDependencies": {
     "pkg": "^4.2.2"

--- a/examples/with-styled-jsx-plugins/package.json
+++ b/examples/with-styled-jsx-plugins/package.json
@@ -10,8 +10,8 @@
     "lost": "8.2.0",
     "next": "latest",
     "postcss-nested": "2.1.2",
-    "react": "16.0.0",
-    "react-dom": "16.0.0",
+    "react": "latest",
+    "react-dom": "latest",
     "styled-jsx-plugin-postcss": "0.1.0"
   },
   "license": "ISC",

--- a/examples/with-styled-jsx-plugins/package.json
+++ b/examples/with-styled-jsx-plugins/package.json
@@ -10,8 +10,8 @@
     "lost": "8.2.0",
     "next": "latest",
     "postcss-nested": "2.1.2",
-    "react": "latest",
-    "react-dom": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0",
     "styled-jsx-plugin-postcss": "0.1.0"
   },
   "license": "ISC",

--- a/examples/with-styled-jsx-scss/package.json
+++ b/examples/with-styled-jsx-scss/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "next": "latest",
     "node-sass": "4.5.3",
-    "react": "16.0.0",
-    "react-dom": "16.0.0",
+    "react": "latest",
+    "react-dom": "latest",
     "styled-jsx-plugin-sass": "0.2.0"
   },
   "license": "ISC"

--- a/examples/with-styled-jsx-scss/package.json
+++ b/examples/with-styled-jsx-scss/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "next": "latest",
     "node-sass": "4.5.3",
-    "react": "latest",
-    "react-dom": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0",
     "styled-jsx-plugin-sass": "0.2.0"
   },
   "license": "ISC"

--- a/examples/with-universal-configuration-runtime/package.json
+++ b/examples/with-universal-configuration-runtime/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   }
 }

--- a/examples/with-universal-configuration-runtime/package.json
+++ b/examples/with-universal-configuration-runtime/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   }
 }

--- a/examples/with-zones/blog/package.json
+++ b/examples/with-zones/blog/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "license": "ISC"
 }

--- a/examples/with-zones/home/package.json
+++ b/examples/with-zones/home/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "license": "ISC"
 }

--- a/examples/with-zones/package.json
+++ b/examples/with-zones/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "micro-proxy": "^1.0.0",
     "next": "5.0.0-universal-alpha.15",
-    "react": "16.2.0",
-    "react-dom": "16.2.0"
+    "react": "latest",
+    "react-dom": "latest"
   },
   "license": "ISC"
 }

--- a/examples/with-zones/package.json
+++ b/examples/with-zones/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "micro-proxy": "^1.0.0",
     "next": "5.0.0-universal-alpha.15",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
I changed the version to the following files:

- [x] - examples/with-next-css/package.json
- [x] - examples/with-draft-js/package.json
- [x] - examples/custom-server-polka/package.json
- [x] - examples/with-cerebral/package.json
- [x] - examples/with-zones/package.json
- [x] - examples/with-universal-configuration-runtime/package.json
- [x] - examples/with-apollo/package.json
- [x] - examples/with-higher-order-component/package.json
- [x] - examples/with-hashed-statics/package.json
- [x] - examples/with-pkg/package.json
- [x] - examples/with-jest/package.json
- [x] - examples/with-glamorous/package.json
- [x] - examples/with-custom-reverse-proxy/package.json
- [ ] - examples/with-emotion/package.json
- [x] - examples/with-styled-jsx-scss/package.json
- [x] - examples/with-styled-jsx-plugins/package.json

`with-emotion/package.json` already has the latest, so I guess it's other packabe. BUT I think we need to update this example with the latest version of `emotion` since it changed a little bit (for better).