### PR TITLE
Rename EventEmitter.test.js -> mitt.test.js

### DIFF
--- a/test/unit/mitt.test.js
+++ b/test/unit/mitt.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import mitt from 'next-server/dist/lib/mitt'
 
-describe('EventEmitter', () => {
+describe('mitt', () => {
   describe('With listeners', () => {
     it('should listen to a event', (done) => {
       const ev = mitt()


### PR DESCRIPTION
Following https://github.com/zeit/next.js/pull/5987