### PR TITLE
SSR for styled-components babel plugin (fixes #5988)

### DIFF
--- a/examples/with-styled-components/.babelrc
+++ b/examples/with-styled-components/.babelrc
@@ -1,8 +1,4 @@
 {
-  "presets": [
-    "next/babel"
-  ],
-  "plugins": [
-    "styled-components"
-  ]
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true }]]
 }


### PR DESCRIPTION
fixes #5988

Enables SSR for styled-components babel-plugin to prevent HTML attribute mismatch warnings during rehydration.

https://www.styled-components.com/docs/tooling#serverside-rendering