### PR TITLE
Exclude webpack files from next export.

### DIFF
--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -70,7 +70,7 @@ export default async function (dir, options, configuration) {
     await cp(
       join(distDir, CLIENT_STATIC_FILES_PATH),
       join(outDir, '_next', CLIENT_STATIC_FILES_PATH),
-      {filter: ['!.hot-update.json']}
+      { filter: ['!.hot-update.json'] }
     )
   }
 

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -69,7 +69,8 @@ export default async function (dir, options, configuration) {
     log('  copying "static build" directory')
     await cp(
       join(distDir, CLIENT_STATIC_FILES_PATH),
-      join(outDir, '_next', CLIENT_STATIC_FILES_PATH)
+      join(outDir, '_next', CLIENT_STATIC_FILES_PATH),
+      {filter: ['!.hot-update.json']}
     )
   }
 


### PR DESCRIPTION
All `hot-update.json` files are now excluded when running `export`

<img width="250" alt="screen shot 2019-01-06 at 5 26 41 pm" src="https://user-images.githubusercontent.com/52427/50744478-4f25db80-11d8-11e9-8182-076e3f590443.png">

Fix #5554 