### PR TITLE
Fix Head.propTypes

### DIFF
--- a/packages/next-server/lib/head.js
+++ b/packages/next-server/lib/head.js
@@ -104,7 +104,7 @@ if (process.env.NODE_ENV === 'development') {
   const exact = require('prop-types-exact')
 
   Head.propTypes = exact({
-    children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired
+    children: PropTypes.node.isRequired
   })
 }
 


### PR DESCRIPTION
This PR fixes the buggy `Head.propTypes` here:

https://github.com/zeit/next.js/blob/v8.0.0-canary.3/packages/next-server/lib/head.js#L107

Currently, `Head.propTypes` allows one child node like this:

```jsx
import Head from 'next/head'

// …

<Head>
  <title>Title</title>
</Head>
```

But more than one child node mistakenly causes a prop type error like this:

```jsx
<Head>
  <title>Title</title>
  <meta name="description" content="Description." />
</Head>
```

```
Warning: Failed prop type: Invalid prop `children` supplied to `Head`.
```