### PR TITLE
Disable assetSizePlugin in serverless target

### DIFF
--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -292,7 +292,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       !isServer && new BuildManifestPlugin(),
       isServer && new NextJsSsrImportPlugin(),
       target !== 'serverless' && isServer && new NextJsSSRModuleCachePlugin({outputPath}),
-      !isServer && !dev && new AssetsSizePlugin(buildId, distDir)
+      target !== 'serverless' && !isServer && !dev && new AssetsSizePlugin(buildId, distDir)
     ].filter(Boolean)
   }
 


### PR DESCRIPTION
Temporarily disable this plugin to optimize.