### PR TITLE
Add a missing hyphen in a snippet using `create-next-app`

### DIFF
--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -13,7 +13,7 @@ Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [
 ```bash
 npx create-next-app --example with-typescript with-typescript-app
 # or
-yarn create next-app --example with-typescript with-typescript-app
+yarn create-next-app --example with-typescript with-typescript-app
 ```
 
 ### Download manually


### PR DESCRIPTION
Change `create next-app` to `create-next-app`