### PR TITLE
Use Object.assign instead of object spread for serverless loader

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -51,27 +51,24 @@ const nextServerlessLoader: loader.Loader = function () {
       const parsedUrl = parse(req.url, true)
       try {
         ${page === '/_error' ? `res.statusCode = 404` : ''}
-        const result = await renderToHTML(req, res, "${page}", parsedUrl.query, {
-          ...options,
+        const result = await renderToHTML(req, res, "${page}", parsedUrl.query, Object.assign({}, options, {
           Component
-        })
+        }))
         return result
       } catch (err) {
         if (err.code === 'ENOENT') {
           res.statusCode = 404
-          const result = await renderToHTML(req, res, "/_error", parsedUrl.query, {
-            ...options,
+          const result = await renderToHTML(req, res, "/_error", parsedUrl.query, Object.assign({}, options, {
             Component: Error
-          })
+          }))
           return result
         } else {
           console.error(err)
           res.statusCode = 500
-          const result = await renderToHTML(req, res, "/_error", parsedUrl.query, {
-            ...options,
+          const result = await renderToHTML(req, res, "/_error", parsedUrl.query, Object.assign({}, options, {
             Component: Error,
             err
-          })
+          }))
           return result
         }
       }


### PR DESCRIPTION
Fixes https://github.com/zeit/now-builders/issues/168

For some reason with a certain mix of deps `...` is not supported in webpack's parsing.
By default it is supported as all our tests passed before and we have deployed Next.js apps on v2 already.