### PR TITLE
Upgrade styled-jsx

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -78,7 +78,7 @@
     "recursive-copy": "2.0.6",
     "resolve": "1.5.0",
     "strip-ansi": "3.0.1",
-    "styled-jsx": "3.1.3",
+    "styled-jsx": "3.2.0",
     "terser-webpack-plugin": "1.1.0",
     "tty-aware-progress": "1.0.3",
     "unfetch": "3.0.0",


### PR DESCRIPTION
Introduces full support for Babel 7 including JSX Fragments shorthand. 
Switched to visiting the `Program` path and then start a traversal manually to solve conflicts with other Babel plugins.