### PR TITLE
Use webpack IgnorePlugin to exclude 'react-is' from production build

### DIFF
--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -291,6 +291,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       dev && new UnlinkFilePlugin(),
       dev && new CaseSensitivePathPlugin(), // Since on macOS the filesystem is case-insensitive this will make sure your path are case-sensitive
       !dev && new webpack.HashedModuleIdsPlugin(),
+      process.env.NODE_ENV === 'production' && new webpack.IgnorePlugin(/^react-is$/),
       // Removes server/client code by minifier
       new webpack.DefinePlugin({
         'process.crossOrigin': JSON.stringify(config.crossOrigin),

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -291,7 +291,6 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       dev && new UnlinkFilePlugin(),
       dev && new CaseSensitivePathPlugin(), // Since on macOS the filesystem is case-insensitive this will make sure your path are case-sensitive
       !dev && new webpack.HashedModuleIdsPlugin(),
-      process.env.NODE_ENV === 'production' && new webpack.IgnorePlugin(/^react-is$/),
       // Removes server/client code by minifier
       new webpack.DefinePlugin({
         'process.crossOrigin': JSON.stringify(config.crossOrigin),
@@ -305,7 +304,15 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       !isServer && new BuildManifestPlugin(),
       isServer && new NextJsSsrImportPlugin(),
       target !== 'serverless' && isServer && new NextJsSSRModuleCachePlugin({outputPath}),
-      target !== 'serverless' && !isServer && !dev && new AssetsSizePlugin(buildId, distDir)
+      target !== 'serverless' && !isServer && !dev && new AssetsSizePlugin(buildId, distDir),
+      !dev && new webpack.IgnorePlugin({
+        checkResource: (resource) => {
+          return /react-is/.test(resource)
+        },
+        checkContext: (context) => {
+          return /next-server[\\/]dist[\\/]/.test(context) || /next[\\/]dist[\\/]/.test(context)
+        }
+      })
     ].filter(Boolean)
   }
 


### PR DESCRIPTION
`react-is` isn't used in production, so we shouldn't bundle it.

Note: most of those plugins are using the `dev` variable, but in case someone runs `NODE_ENV=development next build`, they would need a copy of `react-is` because the conditional use of `react-is` checks `NODE_ENV` — not whether or not HMR is being used (what what the `dev` variable is based on).