### PR TITLE
Remove Typescript helpers in favor of babel helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint-plugin-typescript": "0.14.0",
     "express": "4.16.3",
     "fkill": "5.1.0",
-    "flatten": "1.0.2",
     "get-port": "3.2.0",
     "isomorphic-unfetch": "3.0.0",
     "jest-cli": "23.6.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",
     "babel-jest": "23.6.0",
-    "babel-plugin-transform-define": "1.3.0",
     "benchmark": "2.1.4",
     "cheerio": "0.22.0",
     "chromedriver": "2.42.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -32,7 +32,8 @@
   },
   "taskr": {
     "requires": [
-      "./taskfile-typescript.js"
+      "./taskfile-typescript.js",
+      "./taskfile-babel.js"
     ]
   },
   "dependencies": {

--- a/packages/next/taskfile-babel.js
+++ b/packages/next/taskfile-babel.js
@@ -1,0 +1,23 @@
+// taskr babel plugin with Babel 7 support
+// https://github.com/lukeed/taskr/pull/305
+'use strict'
+
+const transform = require('@babel/core').transform
+
+module.exports = function (task) {
+  task.plugin('babel', {}, function * (file, opts) {
+    const options = {
+      ...opts
+    }
+    options.filename = file.base
+    options.plugins = [
+      require('@babel/plugin-syntax-dynamic-import'),
+      ...(options.plugins || [])
+    ]
+    options.babelrc = false
+    options.configFile = false
+    options.babelrcRoots = false
+    const output = transform(file.data, options)
+    file.data = Buffer.from(output.code)
+  })
+}

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2,7 +2,10 @@ const notifier = require('node-notifier')
 const babelOpts = {
   presets: [
     ['@babel/preset-env', {
-      modules: 'commonjs'
+      modules: 'commonjs',
+      'targets': {
+        'browsers': ['IE 11']
+      }
     }]
   ],
   plugins: [

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1,7 +1,11 @@
 const notifier = require('node-notifier')
 const babelOpts = {
+  presets: [
+    ['@babel/preset-env', {
+      modules: 'commonjs'
+    }]
+  ],
   plugins: [
-    '@babel/plugin-transform-modules-commonjs',
     ['@babel/plugin-transform-runtime', {
       corejs: 2,
       helpers: true,

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1,4 +1,15 @@
 const notifier = require('node-notifier')
+const babelOpts = {
+  plugins: [
+    '@babel/plugin-transform-modules-commonjs',
+    ['@babel/plugin-transform-runtime', {
+      corejs: 2,
+      helpers: true,
+      regenerator: true,
+      useESModules: false
+    }]
+  ]
+}
 
 export async function compile (task) {
   await task.parallel(['bin', 'server', 'nextbuild', 'nextbuildstatic', 'pages', 'lib', 'client'])
@@ -25,7 +36,7 @@ export async function nextbuild (task, opts) {
 }
 
 export async function client (task, opts) {
-  await task.source(opts.src || 'client/**/*.+(js|ts|tsx)').typescript({module: 'commonjs', target: 'es5'}).target('dist/client')
+  await task.source(opts.src || 'client/**/*.+(js|ts|tsx)').typescript({module: 'commonjs'}).babel(babelOpts).target('dist/client')
   notify('Compiled client files')
 }
 
@@ -36,7 +47,7 @@ export async function nextbuildstatic (task, opts) {
 }
 
 export async function pages (task, opts) {
-  await task.source(opts.src || 'pages/**/*.+(js|ts|tsx)').typescript({module: 'commonjs', target: 'es5'}).target('dist/pages')
+  await task.source(opts.src || 'pages/**/*.+(js|ts|tsx)').typescript({module: 'commonjs'}).babel(babelOpts).target('dist/pages')
 }
 
 export async function build (task) {


### PR DESCRIPTION
There's still a few Typescript helpers in use, but regenerator is added by Babel after this change, as it was already in the bundle it'll drop bundle sizes by quite a bit, eg _app.js becomes half the size.