### PR TITLE
Close #5607 -  Bug in examples/with-data-prefetch

### DIFF
--- a/examples/with-data-prefetch/components/link.js
+++ b/examples/with-data-prefetch/components/link.js
@@ -11,18 +11,16 @@ export const prefetch = async href => {
 
   const url = typeof href !== 'string' ? format(href) : href
 
-  const { pathname } = window.location
+  const parsedHref = resolve(window.location.pathname, url)
 
-  const parsedHref = resolve(pathname, url)
-
-  const { query } = typeof href !== 'string' ? href : parse(url, true)
+  const { query, pathname } = typeof href !== 'string' ? href : parse(url, true)
 
   const Component = await Router.prefetch(parsedHref)
 
   // if Component exists and has getInitialProps
   // fetch the component props (the component should save it in cache)
   if (Component && Component.getInitialProps) {
-    const ctx = { pathname: href, query, isVirtualCall: true }
+    const ctx = { pathname, query, isVirtualCall: true }
     await Component.getInitialProps(ctx)
   }
 }


### PR DESCRIPTION
ctx.pathname was set to href (including the query) of the page to prefetch
therefore the page was cached with the wrong key (article%3Fid=1?id=1),
and that's why the cache didn't work (right key: article?id=1)