### PR TITLE
Make HMR still apply updates when there is a webpack warning

### DIFF
--- a/packages/next/client/dev-error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev-error-overlay/hot-dev-client.js
@@ -216,7 +216,6 @@ function processMessage (e) {
 
       if (obj.warnings.length > 0) {
         handleWarnings(obj.warnings)
-        break
       }
 
       if (obj.errors.length > 0) {

--- a/test/integration/basic/next.config.js
+++ b/test/integration/basic/next.config.js
@@ -1,6 +1,15 @@
+const path = require('path')
 module.exports = {
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60
+  },
+  webpack (config) {
+    config.module.rules.push({
+      test: /pages[\\/]hmr/,
+      loader: path.join(__dirname, 'warning-loader.js')
+    })
+
+    return config
   }
 }

--- a/test/integration/basic/warning-loader.js
+++ b/test/integration/basic/warning-loader.js
@@ -1,0 +1,4 @@
+module.exports = function (source) {
+  this.emitWarning(new Error('This is an expected warning added by warning-loader.js'))
+  return source
+}


### PR DESCRIPTION
Fixes #5363

I noticed this happening when making some changes on the nextjs.org/learn app. Basically we didn't apply updates when a warning was emitted from webpack. This would cause issues for users using eslint-loader or similar too.