### PR TITLE
merge to redux-saga 1.0.0, api breaking changes included.

### DIFF
--- a/examples/with-redux-saga/package.json
+++ b/examples/with-redux-saga/package.json
@@ -8,18 +8,18 @@
     "start": "next start"
   },
   "dependencies": {
-    "es6-promise": "4.1.1",
-    "isomorphic-unfetch": "2.0.0",
+    "es6-promise": "4.2.5",
+    "isomorphic-unfetch": "3.0.0",
     "next": "latest",
     "next-redux-saga": "3.0.0",
-    "next-redux-wrapper": "2.0.0",
+    "next-redux-wrapper": "2.1.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "react-redux": "5.0.7",
-    "redux": "4.0.0",
-    "redux-saga": "0.16.0"
+    "react-redux": "6.0.0",
+    "redux": "4.0.1",
+    "redux-saga": "1.0.0"
   },
   "devDependencies": {
-    "redux-devtools-extension": "2.13.2"
+    "redux-devtools-extension": "2.13.7"
   }
 }

--- a/examples/with-redux-saga/saga.js
+++ b/examples/with-redux-saga/saga.js
@@ -1,7 +1,6 @@
 /* global fetch */
 
-import { delay } from 'redux-saga/effects'
-import { all, call, put, take, takeLatest } from 'redux-saga/effects'
+import { all, call, delay, put, take, takeLatest } from 'redux-saga/effects'
 import es6promise from 'es6-promise'
 import 'isomorphic-unfetch'
 

--- a/examples/with-redux-saga/saga.js
+++ b/examples/with-redux-saga/saga.js
@@ -1,6 +1,6 @@
 /* global fetch */
 
-import { delay } from 'redux-saga'
+import { delay } from 'redux-saga/effects'
 import { all, call, put, take, takeLatest } from 'redux-saga/effects'
 import es6promise from 'es6-promise'
 import 'isomorphic-unfetch'
@@ -13,7 +13,7 @@ function * runClockSaga () {
   yield take(actionTypes.START_CLOCK)
   while (true) {
     yield put(tickClock(false))
-    yield call(delay, 1000)
+    yield delay(1000)
   }
 }
 


### PR DESCRIPTION
Fixes #6134

Hi there
I noticed you have not yet included the api breaking changes in `"redux-saga": "1.0.0"`. Therefore I felt free to upgrade the dependencies in `examples/with-redux-saga`.
I do not know anything about apollo nor graphql, that is why I did not upgrade `examples/with-apollo-and-redux-saga`. But, I think you should do this on occasion.
Keep the great work up.
Regards
