### PR TITLE
Print list of pages when building

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -17,6 +17,17 @@ function collectPages (directory: string, pageExtensions: string[]): Promise<str
   return glob(`**/*.+(${pageExtensions.join('|')})`, {cwd: directory})
 }
 
+function printTreeView(list) {
+  list
+    .sort((a, b) => a > b ? 1 : -1)
+    .forEach((item, i) => {
+      const corner = i === 0 ? list.length === 1 ? '─' : '┌' : i === list.length - 1 ? '└' : '├'
+      console.log(` \x1b[90m${corner}\x1b[39m ${item}`)
+    })
+
+  console.log()
+}
+
 export default async function build (dir: string, conf = null): Promise<void> {
   if (!await isWriteable(dir)) {
     throw new Error('> Build directory is not writeable. https://err.sh/zeit/next.js/build-dir-not-writeable')
@@ -58,5 +69,8 @@ export default async function build (dir: string, conf = null): Promise<void> {
     result.errors.forEach((error) => console.error(error))
     throw new Error('> Build failed because of webpack errors')
   }
+
+  printTreeView(Object.keys(pages))
+
   await writeBuildId(distDir, buildId)
 }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -17,7 +17,7 @@ function collectPages (directory: string, pageExtensions: string[]): Promise<str
   return glob(`**/*.+(${pageExtensions.join('|')})`, {cwd: directory})
 }
 
-function printTreeView(list) {
+function printTreeView(list: string[]) {
   list
     .sort((a, b) => a > b ? 1 : -1)
     .forEach((item, i) => {


### PR DESCRIPTION
Based on @timneutkens 's comment here : https://github.com/zeit/next.js/pull/6122

Print a list of pages when running `next build`

![capture d ecran 2019-01-25 a 17 37 49](https://user-images.githubusercontent.com/6616955/51737813-7893a200-20c8-11e9-8401-5d3a695663ba.png)