### PR TITLE
Remove resolve rule

### DIFF
--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -181,7 +181,6 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
     // Disable .mjs for node_modules bundling
     extensions: isServer ? ['.wasm', '.js', '.mjs', '.jsx', '.json'] : ['.wasm', '.mjs', '.js', '.jsx', '.json'],
     modules: [
-      NEXT_PROJECT_ROOT_NODE_MODULES,
       'node_modules',
       ...nodePathList // Support for NODE_PATH environment variable
     ],


### PR DESCRIPTION
Fixes #6117

I'm not entirely sure why we had this rule in the first place. I think for some tests related things when we didn't have a monorepo yet. However it could also be related to bundle sizes. I'll compare that when the build finishes.

The reason for #6117 is that we added `react-is` to the dependency tree of Next.js to check valid elements. react-redux uses hoist-non-react-statics which ships a different version of react-is in this case, one that has `ReactIs.isMemo`