### PR TITLE
Remove title from _document.js

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -13,7 +13,6 @@ export default class MyDocument extends Document {
     return (
       <html>
         <Head>
-          <title>My page</title>
           {this.props.styleTags}
         </Head>
         <body>


### PR DESCRIPTION
This produces an error:

Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title

and should be done in either individual page components, or at _app.js