### PR TITLE
Improve lint-staged for TypeScript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,8 @@
       "standard --fix",
       "git add"
     ],
-    "*.ts": [
-      "tslint -c tslint.json 'packages/**/*.ts' --fix",
-      "git add"
-    ],
-    "*.tsx": [
-      "tslint -c tslint.json 'packages/**/*.ts' --fix",
+    "*.{ts,tsx}": [
+      "tslint -c tslint.json --fix",
       "git add"
     ],
     "packages/**/bin/*": [


### PR DESCRIPTION
Remove unnecessary check for files to be linted and combine the ts & tsx commands.