### PR TITLE
Throw Error When Running `next start` on Serverless Build

### DIFF
--- a/errors/next-start-serverless.md
+++ b/errors/next-start-serverless.md
@@ -1,0 +1,9 @@
+# Using `next start` with `target` not set to `server`
+
+#### Why This Error Occurred
+
+Next.js can only handle running a server when the `target` is set to `server` (this is the default value). A serverless build, for instance, has no handler for requests–this is usually implemented by a hosting provider.
+
+#### Possible Ways to Fix It
+
+Use a different handler than `next start` when testing a serverless **production** build, otherwise just use `next dev`.

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -47,7 +47,9 @@ export default class Server {
 
     // Only serverRuntimeConfig needs the default
     // publicRuntimeConfig gets it's default in client/index.js
-    const {serverRuntimeConfig = {}, publicRuntimeConfig, assetPrefix, generateEtags} = this.nextConfig
+    const {serverRuntimeConfig = {}, publicRuntimeConfig, assetPrefix, generateEtags, target} = this.nextConfig
+
+    if (process.env.NODE_ENV === 'production' && target !== 'server') throw new Error('Cannot start server when target is not server. https://err.sh/zeit/next.js/next-start-serverless')
 
     this.buildId = this.readBuildId()
     this.renderOpts = {


### PR DESCRIPTION
Fixes #6144 