### PR TITLE
Update with-react-native-web example to use babel

### DIFF
--- a/examples/with-react-native-web/.babelrc
+++ b/examples/with-react-native-web/.babelrc
@@ -1,0 +1,16 @@
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "root": ["./"],
+        "alias": {
+          "^react-native$": "react-native-web"
+        }
+      }
+    ]
+  ]
+}

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,13 +1,11 @@
-const withTM = require('next-plugin-transpile-modules')
-
-module.exports = withTM({
-  transpileModules: ['react-native-web'],
+module.exports = {
   webpack: config => {
     // Alias all `react-native` imports to `react-native-web`
     config.resolve.alias = {
+      ...(config.resolve.alias || {}),
       'react-native$': 'react-native-web'
     }
 
     return config
   }
-})
+}

--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -6,8 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
+    "babel-plugin-module-resolver": "^3.1.2",
     "next": "latest",
-    "next-plugin-transpile-modules": "^0.1.3",
     "react": "^16.7.0",
     "react-art": "^16.5.2",
     "react-dom": "^16.7.0",


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/6138

Tested with both latest and 8.0.0-canary.17