### PR TITLE
Firebase auth example _app

### DIFF
--- a/examples/with-firebase-authentication/env/auth-context.js
+++ b/examples/with-firebase-authentication/env/auth-context.js
@@ -1,0 +1,55 @@
+import React, {Component} from 'react'
+import firebase from 'firebase/app'
+import 'firebase/auth'
+
+const INITIAL_STATE = {
+    user: null,
+    handleLogin: () => firebase.auth().signInWithPopup(new firebase.auth.GoogleAuthProvider()),
+    handleLogout: () => firebase.auth().signOut()
+}
+
+export const AuthContext = React.createContext(INITIAL_STATE)
+
+export default class Provider extends Component{
+    constructor(props){
+        super(props)
+
+        this.state = {
+            ...INITIAL_STATE,
+            ...props.initialState
+        }
+
+        firebase.auth().onAuthStateChanged(user => {
+            if (user) {
+              this.setState({ user: user })
+              return user
+                .getIdToken()
+                .then(token => {
+                  // eslint-disable-next-line no-undef
+                  return fetch('/api/login', {
+                    method: 'POST',
+                    // eslint-disable-next-line no-undef
+                    headers: new Headers({ 'Content-Type': 'application/json' }),
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ token })
+                  })
+                })
+            } else {
+              this.setState({ user: null })
+              // eslint-disable-next-line no-undef
+              fetch('/api/logout', {
+                method: 'POST',
+                credentials: 'same-origin'
+              })
+            }
+          })
+    }
+
+    render() {
+        return (
+            <AuthContext.Provider value={this.state}>
+                {this.props.children}
+            </AuthContext.Provider>
+        )
+    }
+}

--- a/examples/with-firebase-authentication/pages/_app.js
+++ b/examples/with-firebase-authentication/pages/_app.js
@@ -1,0 +1,44 @@
+import App, {Container} from 'next/app'
+import Head from 'next/head'
+import firebase from 'firebase/app'
+import clientCredentials from '../credentials/client'
+import AuthProvider, { AuthContext } from '../env/auth-context';
+
+class MyApp extends App{
+    static async getInitialProps({ctx: {req}}) {
+        const user = req && req.session ? req.session.decodedToken : null
+        return { user }
+    }
+
+    constructor() {
+        super()
+        // firebase is stateful so we have to prevent reinitialization
+        if (!firebase.apps.length)
+            firebase.initializeApp(clientCredentials)
+    }
+
+    render() {
+        const {Component, user} = this.props;
+        return (
+            <Container>
+                <Head>
+                    <title>Firebase auth example</title>
+                </Head>
+                <AuthProvider initialState={{user}}>
+                    {/*
+                    The user is now passed to every single page.
+                    This is probably not what you want in a production app:
+                    Try to place the consumer as close as possible to where you need it.
+                     */}
+                    <AuthContext.Consumer>
+                        {({user}) => (
+                            <Component user={user}/>
+                        )}
+                    </AuthContext.Consumer>
+                </AuthProvider>
+            </Container>
+        )
+    }
+}
+
+export default MyApp;

--- a/examples/with-firebase-authentication/pages/index.js
+++ b/examples/with-firebase-authentication/pages/index.js
@@ -7,12 +7,11 @@ import {AuthContext} from '../env/auth-context'
 
 export default class Index extends Component {
   static async getInitialProps ({ req, query }) {
-    const user = req && req.session ? req.session.decodedToken : null
     // don't fetch anything from firebase if the user is not found
     // const snap = user && await req.firebaseServer.database().ref('messages').once('value')
     // const messages = snap && snap.val()
     const messages = null
-    return { user, messages }
+    return { messages }
   }
 
   constructor (props) {

--- a/examples/with-firebase-authentication/pages/whoami.js
+++ b/examples/with-firebase-authentication/pages/whoami.js
@@ -1,0 +1,5 @@
+const WhoAmI = ({user}) => (
+    <div>{JSON.stringify(user)}</div>
+)
+
+export default WhoAmI


### PR DESCRIPTION
refactored firebase-auth example to use `_app` and a reusable `AuthContext`

I also tried to refactor it to be compatible with now 2 with no success.
Serverless/Lambda is pretty new for me... can `session-file-store` even work in a serverless context?
As i get it there's no way to persist files/or ensure a users call are processed by the same server so i guess the answer is no.

What would be the preferred way to use an auth middleware on now 2 in front of next?

Thanks, in advance for any help/hint