### PR TITLE
added cachedAssets config for cached headers on /_next/static/* assets.

### DIFF
--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -9,6 +9,7 @@ const defaultConfig = {
   poweredByHeader: true,
   distDir: '.next',
   assetPrefix: '',
+  cachedAssets: [],
   configOrigin: 'default',
   useFileSystemPublicRoutes: true,
   generateBuildId: () => null,


### PR DESCRIPTION
Hello all!

Been looking at ways to allow for caching of image/fonts without having to use a custom server and decided to propose this idea. It will allow for the user to add the config option, `cachedAssets`, to next.config.js via an array of folder names, which will set the cache headers for assets that proceed the directory `/_next/static/:cachedAssetsFolder`. This proposal was done fairly quick to show the logic so im probably missing something.

The reason for proposing this was because I've been using next-optimized-images that allows for hashed statics via /_next/static/images/* directory which makes immutability feasible. They did not have cache headers that i saw (I could be blind though). 

Open for discussion or other proposals, but feel as though this is fairly necessary for non custom server users.  Would this or a similar logical implementation be feasible?