### PR TITLE
Only compile /_error when /_error is needed

### DIFF
--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -128,7 +128,7 @@ export default class HotReloader {
       }
 
       const page = `/${params.path.join('/')}`
-      if (BLOCKED_PAGES.indexOf(page) === -1) {
+      if (page === '/_error' || BLOCKED_PAGES.indexOf(page) === -1) {
         try {
           await this.ensurePage(page)
         } catch (error) {
@@ -174,7 +174,7 @@ export default class HotReloader {
   }
 
   async getWebpackConfig () {
-    const pagePaths = await glob(`+(_app|_document|_error).+(${this.config.pageExtensions.join('|')})`, {cwd: join(this.dir, 'pages')})
+    const pagePaths = await glob(`+(_app|_document).+(${this.config.pageExtensions.join('|')})`, {cwd: join(this.dir, 'pages')})
     const pages = createPagesMapping(pagePaths, this.config.pageExtensions)
     const entrypoints = createEntrypoints(pages, 'server', this.buildId, this.config)
     return Promise.all([
@@ -410,7 +410,7 @@ export default class HotReloader {
 
   async ensurePage (page) {
     // Make sure we don't re-build or dispose prebuilt pages
-    if (BLOCKED_PAGES.indexOf(page) !== -1) {
+    if (page !== '/_error' && BLOCKED_PAGES.indexOf(page) !== -1) {
       return
     }
     await this.onDemandEntries.ensurePage(page)

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -113,6 +113,8 @@ export default class DevServer extends Server {
   }
 
   async renderErrorToHTML (err, req, res, pathname, query) {
+    await this.hotReloader.ensurePage('/_error')
+
     const compilationErr = await this.getCompilationError(pathname)
     if (compilationErr) {
       res.statusCode = 500

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -236,7 +236,12 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
           return sendJson(ws, { invalid: true })
         }
 
-        sendJson(ws, { success: true })
+        // 404 is an on demand entry but when a new page is added we have to refresh the page
+        if (page === '/_error') {
+          sendJson(ws, { invalid: true })
+        } else {
+          sendJson(ws, { success: true })
+        }
 
         // We don't need to maintain active state of anything other than BUILT entries
         if (entryInfo.status !== BUILT) return

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -175,7 +175,13 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
 
       const extensions = pageExtensions.join('|')
       const pagesDir = join(dir, 'pages')
-      const paths = await glob(`{${normalizedPagePath.slice(1)}/index,${normalizedPagePath.slice(1)}}.+(${extensions})`, {cwd: pagesDir})
+
+      let paths = await glob(`{${normalizedPagePath.slice(1)}/index,${normalizedPagePath.slice(1)}}.+(${extensions})`, {cwd: pagesDir})
+
+      // Default the /_error route to the Next.js provided default page
+      if (page === '/_error' && paths.length === 0) {
+        paths = ['next/dist/pages/_error']
+      }
 
       if (paths.length === 0) {
         throw pageNotFoundError(normalizedPagePath)
@@ -186,7 +192,7 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
       pageUrl = pageUrl === '' ? '/' : pageUrl
       const bundleFile = pageUrl === '/' ? '/index.js' : `${pageUrl}.js`
       const name = join('static', buildId, 'pages', bundleFile)
-      const absolutePagePath = join(pagesDir, pagePath)
+      const absolutePagePath = pagePath.startsWith('next/dist/pages') ? require.resolve(pagePath) : join(pagesDir, pagePath)
 
       await new Promise((resolve, reject) => {
         const entryInfo = entries[page]


### PR DESCRIPTION
Followup to removing the /_error in the initial markup we can now compile it using on-demand-entries only when it's needed.