### PR TITLE
Remove 'acorn' dependency

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -48,7 +48,6 @@
     "@babel/runtime": "7.1.2",
     "@babel/runtime-corejs2": "7.1.2",
     "@babel/template": "7.1.2",
-    "acorn": "^6.0.5",
     "ansi-html": "0.0.7",
     "arg": "3.0.0",
     "async-sema": "2.1.4",


### PR DESCRIPTION
The dependency was added as a workaround for npm bug (mentioned [here](https://github.com/webpack/webpack/issues/8656#issuecomment-456713191)). It looks like it should rather be added by the project that uses Next.js. `acorn` is not used directly by Next.js.

Fixes #6189.