### PR TITLE
fix(example): fixes styled-components example

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -18,7 +18,7 @@ export default class MyDocument extends Document {
         styles: [...initialProps.styles, ...sheet.getStyleElement()]
       }
     } finally {
-      sheet.seal()
+      Object.seal(sheet)
     }
   }
 }


### PR DESCRIPTION
currently gives `TypeError: sheet.seal is not a function` as `Object.seal()` needs the desired object passed in I believe. This seemed to work so submitting the fix 👍 