### PR TITLE
Add example using lingui.js

### DIFF
--- a/examples/with-lingui/.babelrc
+++ b/examples/with-lingui/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    "macros"
+  ]
+}

--- a/examples/with-lingui/.gitignore
+++ b/examples/with-lingui/.gitignore
@@ -1,0 +1,2 @@
+locale/_build
+locale/*/*.js

--- a/examples/with-lingui/README.md
+++ b/examples/with-lingui/README.md
@@ -1,0 +1,56 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-lingui)
+
+# With Lingui example
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-lingui with-lingui-app
+# or
+yarn create next-app --example with-lingui with-lingui-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-lingui
+cd with-lingui
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example shows a way to use [lingui.js](https://lingui.js.org) with next.js.
+
+It adds a webpack loader for the messages to avoid having to manually compile while developing as well as adds the compile step to the `next build` script for production builds.
+
+The example also uses a Higher order Component which can be added to all pages which will be translated and that checks for a `?lang` query string switch the language. Next.js  will dynamically load in the messages for the locale when navigating using a Next.js `<Link />` component.
+
+### How to add more translated strings
+
+To add new strings use the [react component](https://lingui.js.org/tutorials/react-patterns.html#common-i18n-patterns-in-react) `<Trans />` and then run `yarn export` to export the messages into `locale/{language}/messages.po`.
+
+### How to add another language
+
+To add another language simply run `yarn add-locale <locale ...>` and it will create a new locale in the `locale/messages/` directory.

--- a/examples/with-lingui/components/LangSwitcher.js
+++ b/examples/with-lingui/components/LangSwitcher.js
@@ -1,0 +1,32 @@
+import Router from 'next/router'
+import { I18n } from '@lingui/react'
+import { t, Trans } from '@lingui/macro'
+
+const availableLanguageNames = {
+  'en': t`English`,
+  'sv': t`Swedish`
+}
+const availableLanguages = Object.keys(availableLanguageNames)
+
+export default () => {
+  function onSubmit (evt) {
+    evt.preventDefault()
+    Router.push({
+      pathname: window.location.pathname,
+      query: {lang: evt.currentTarget.lang.value}
+    })
+  }
+
+  return (
+    <I18n>{({i18n}) =>
+      <form onSubmit={onSubmit}>
+        <select key={i18n.language} name='lang' defaultValue={availableLanguages.find(lang => lang !== i18n.language)}>
+          {availableLanguages.map(lang => (
+            <option key={lang} value={lang} disabled={i18n.language === lang}>{i18n._(availableLanguageNames[lang])}</option>
+          ))}
+        </select>
+        <button><Trans>Switch language</Trans></button>
+      </form>
+    }</I18n>
+  )
+}

--- a/examples/with-lingui/components/withLang.js
+++ b/examples/with-lingui/components/withLang.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { I18nProvider } from '@lingui/react'
+
+export default (Component, defaultLang = 'en') => class WithLang extends React.Component {
+  static async getInitialProps (ctx) {
+    const language = ctx.query.lang || defaultLang
+    const [props, catalog] = await Promise.all([
+      Component.getInitialProps ? Component.getInitialProps(ctx) : {},
+      import(`../locale/${language}/messages.po`).then(m => m.default)
+    ])
+
+    return {
+      ...props,
+      language,
+      catalogs: {
+        [language]: catalog
+      }
+    }
+  }
+
+  render () {
+    return (
+      <I18nProvider language={this.props.language} catalogs={this.props.catalogs}>
+        <Component />
+      </I18nProvider>
+    )
+  }
+}

--- a/examples/with-lingui/locale/en/messages.po
+++ b/examples/with-lingui/locale/en/messages.po
@@ -1,0 +1,38 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2019-02-05 13:34+0100\n"
+"Mime-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/LangSwitcher.js:6
+msgid "English"
+msgstr "English"
+
+#: pages/index.js:9
+msgid "Go to page 2"
+msgstr "Go to page 2"
+
+#: pages/index.js:8
+msgid "Hello World."
+msgstr "Hello World. "
+
+#: pages/two.js:8
+msgid "Page two."
+msgstr "Page two."
+
+#: components/LangSwitcher.js:7
+msgid "Swedish"
+msgstr "Swedish"
+
+#: components/LangSwitcher.js:26
+msgid "Switch language"
+msgstr "Switch language"

--- a/examples/with-lingui/locale/sv/messages.po
+++ b/examples/with-lingui/locale/sv/messages.po
@@ -1,0 +1,39 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2019-02-05 13:38+0100\n"
+"Mime-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: sv\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: components/LangSwitcher.js:6
+msgid "English"
+msgstr "Engelska"
+
+#: pages/index.js:9
+msgid "Go to page 2"
+msgstr "Gå till sida 2"
+
+#: pages/index.js:8
+msgid "Hello World."
+msgstr "Hej Världen. "
+
+#: pages/two.js:8
+msgid "Page two."
+msgstr "Sida två."
+
+#: components/LangSwitcher.js:7
+msgid "Swedish"
+msgstr "Svenska"
+
+#: components/LangSwitcher.js:26
+msgid "Switch language"
+msgstr "Byt Språk"
+

--- a/examples/with-lingui/next.config.js
+++ b/examples/with-lingui/next.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  webpack: (config, options) => {
+    config.module.rules.push({
+      test: /\.po/,
+      use: [
+        {
+          loader: '@lingui/loader'
+        }
+      ]
+    })
+    return config
+  }
+}

--- a/examples/with-lingui/package.json
+++ b/examples/with-lingui/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "with-lingui",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "lingui compile && next build",
+    "start": "next start",
+    "add-locale": "lingui add-locale",
+    "extract": "lingui extract"
+  },
+  "dependencies": {
+    "@lingui/react": "latest",
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "devDependencies": {
+    "@lingui/cli": "latest",
+    "@lingui/loader": "latest",
+    "@lingui/macro": "latest",
+    "babel-plugin-macros": "^2.4.0"
+  },
+  "lingui": {
+    "sourceLocale": "en",
+    "localeDir": "./locale",
+    "srcPathDirs": [
+      "./pages/",
+      "./components/"
+    ],
+    "format": "po"
+  },
+  "license": "ISC"
+}

--- a/examples/with-lingui/pages/index.js
+++ b/examples/with-lingui/pages/index.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+import { Trans } from '@lingui/macro'
+import withLang from '../components/withLang'
+import LangSwitcher from '../components/LangSwitcher'
+
+const Index = () =>
+  <div>
+    <Trans>Hello World.</Trans>
+    <Link href='/two'><a><Trans>Go to page 2</Trans></a></Link>
+    <br />
+    <LangSwitcher />
+  </div>
+
+export default withLang(Index)

--- a/examples/with-lingui/pages/two.js
+++ b/examples/with-lingui/pages/two.js
@@ -1,0 +1,12 @@
+import { Trans } from '@lingui/macro'
+import withLang from '../components/withLang'
+import LangSwitcher from '../components/LangSwitcher'
+
+const Two = () =>
+  <div>
+    <Trans>Page two. </Trans>
+    <br />
+    <LangSwitcher />
+  </div>
+
+export default withLang(Two)


### PR DESCRIPTION
## The idea behind the example

This example shows a way to use [lingui.js](https://lingui.js.org) with next.js.

It adds a webpack loader for the messages to avoid having to manually compile while developing as well as adds the compile step to the `next build` script for production builds.

The example also uses a Higher order Component which can be added to all pages which will be translated and that checks for a `?lang` query string switch the language. Next.js  will dynamically load in the messages for the locale when navigating using a Next.js `<Link />` component.

### How to add more translated strings

To add new strings use the [react component](https://lingui.js.org/tutorials/react-patterns.html#common-i18n-patterns-in-react) `<Trans />` and then run `yarn export` to export the messages into `locale/{language}/messages.po`.

### How to add another language

To add another language simply run `yarn add-locale <locale ...>` and it will create a new locale in the `locale/messages/` directory.
