### PR TITLE
Introduce env to next.config.js for build-time configuration

### DIFF
--- a/errors/serverless-publicRuntimeConfig.md
+++ b/errors/serverless-publicRuntimeConfig.md
@@ -1,0 +1,18 @@
+# Using `publicRuntimeConfig` with `target` set to `serverless`
+
+#### Why This Error Occurred
+
+Due to the way that Next.js seperates pages into their own lambdas, `publicRuntimeConfig` will not function when `target` is set to `serverless`.
+
+#### Possible Ways to Fix It
+
+Use config option `buildVars` to set build time variables like such:
+
+```js
+// next.config.js
+module.exports = {
+  buildVars: {
+    'process.special': "'value'"
+  }
+}
+```

--- a/errors/serverless-publicRuntimeConfig.md
+++ b/errors/serverless-publicRuntimeConfig.md
@@ -6,13 +6,18 @@ Due to the way that Next.js seperates pages into their own lambdas, `publicRunti
 
 #### Possible Ways to Fix It
 
-Use config option `buildVars` to set build time variables like such:
+Use config option `env` to set **build time** variables like such:
 
 ```js
 // next.config.js
 module.exports = {
-  buildVars: {
-    'process.special': "'value'"
+  env: {
+    special: "value"
   }
 }
+```
+
+```js
+// index.js
+console.log(process.special) // value
 ```

--- a/errors/serverless-publicRuntimeConfig.md
+++ b/errors/serverless-publicRuntimeConfig.md
@@ -2,8 +2,7 @@
 
 #### Why This Error Occurred
 
-Due to the way that Next.js seperates pages into their own lambdas, `publicRuntimeConfig` will not function when `target` is set to `serverless`.
-
+In the `serverless` target environment `next.config.js` is not loaded, so we don't support `publicRuntimeConfig`.
 #### Possible Ways to Fix It
 
 Use config option `env` to set **build time** variables like such:
@@ -18,6 +17,6 @@ module.exports = {
 ```
 
 ```js
-// index.js
+// pages/index.js
 console.log(process.env.special) // value
 ```

--- a/errors/serverless-publicRuntimeConfig.md
+++ b/errors/serverless-publicRuntimeConfig.md
@@ -19,5 +19,5 @@ module.exports = {
 
 ```js
 // index.js
-console.log(process.special) // value
+console.log(process.env.special) // value
 ```

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1551,18 +1551,17 @@ The `modules` option on `"preset-env"` should be kept to `false` otherwise webpa
 
 ### Exposing configuration to the server / client side
 
-Configuration values can be replaced by Webpack at build time.
+Configuration values can be replaced by webpack at build time.
 
 ```js
 // next.config.js
 module.exports = {
   env: {
-    customKey: "value",
-    _globalVar: "value"
+    customKey: "value"
   }
 }
 ```
-This will be set to `proccess.env.customKey` and `globalVar`, respectively.
+This will be set to `proccess.env.customKey`.
 
 #### When configuration must be dynamic
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1551,6 +1551,22 @@ The `modules` option on `"preset-env"` should be kept to `false` otherwise webpa
 
 ### Exposing configuration to the server / client side
 
+Configuration values can be replaced by webpack at build time.
+
+```js
+// next.config.js
+module.exports = {
+  env: {
+    customKey: "value"
+  }
+}
+```
+This will be set to `proccess.env.customKey`.
+
+#### When configuration must be dynamic
+
+This is not compatible with `target=serverless`
+
 The `next/config` module gives your app access to runtime configuration stored in your `next.config.js`. Place any server-only runtime config under a `serverRuntimeConfig` property and anything accessible to both client and server-side code under `publicRuntimeConfig`.
 
 ```js

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1551,17 +1551,18 @@ The `modules` option on `"preset-env"` should be kept to `false` otherwise webpa
 
 ### Exposing configuration to the server / client side
 
-Configuration values can be replaced by webpack at build time.
+Configuration values can be replaced by Webpack at build time.
 
 ```js
 // next.config.js
 module.exports = {
   env: {
-    customKey: "value"
+    customKey: "value",
+    _globalVar: "value"
   }
 }
 ```
-This will be set to `proccess.env.customKey`.
+This will be set to `proccess.env.customKey` and `globalVar`, respectively.
 
 #### When configuration must be dynamic
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1551,23 +1551,49 @@ The `modules` option on `"preset-env"` should be kept to `false` otherwise webpa
 
 ### Exposing configuration to the server / client side
 
-Configuration values can be replaced by webpack at build time.
+There is a common need in applications to provide configuration values.
+
+Next.js supports 2 ways of providing configuration:
+
+- Build-time configuration
+- Runtime configuration
+
+#### Build time configuration
+
+The way build-time configuration works is by inlining the provided values into the Javascript bundle.
+
+You can add the `env` key in `next.config.js`:
 
 ```js
 // next.config.js
 module.exports = {
   env: {
-    customKey: "value"
+    customKey: 'value'
   }
 }
 ```
-This will be set to `proccess.env.customKey`.
 
-#### When configuration must be dynamic
+This will allow you to use `process.env.customKey` in your code. For example:
 
-This is not compatible with `target=serverless`
+```jsx
+// pages/index.js
+export default function Index() {
+  return <h1>The value of customEnv is: {process.env.customEnv}</h1>
+}
+```
 
-The `next/config` module gives your app access to runtime configuration stored in your `next.config.js`. Place any server-only runtime config under a `serverRuntimeConfig` property and anything accessible to both client and server-side code under `publicRuntimeConfig`.
+#### Runtime configuration
+
+> :warning: Note that this option is not available when using `target: 'serverless'`
+
+> :warning: Generally you want to use build-time configuration to provide your configuration. 
+The reason for this is that runtime configuration adds a small rendering / initialization overhead.
+
+The `next/config` module gives your app access to the `publicRuntimeConfig` and `serverRuntimeConfig` stored in your `next.config.js`. 
+
+Place any server-only runtime config under a `serverRuntimeConfig` property.
+
+Anything accessible to both client and server-side code should be under `publicRuntimeConfig`.
 
 ```js
 // next.config.js

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -48,6 +48,8 @@ export default async function build (dir: string, conf = null): Promise<void> {
 
   let result: CompilerResult = {warnings: [], errors: []}
   if (config.target === 'serverless') {
+    if (config.publicRuntimeConfig) throw new Error('Cannot use publicRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig')
+
     const clientResult = await runCompiler([configs[0]])
     // Fail build if clientResult contains errors
     if(clientResult.errors.length > 0) {

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -296,7 +296,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
         config.env ? Object.keys(config.env)
           .reduce((acc, key) => ({
             ...acc,
-            ...{ [`process.${key}`]: JSON.stringify(config.env[key]) }
+            ...{ [`process.env.${key}`]: JSON.stringify(config.env[key]) }
           }), {}) : {},
         {
           'process.crossOrigin': JSON.stringify(config.crossOrigin),

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -294,10 +294,13 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       new webpack.DefinePlugin(Object.assign(
         {},
         config.env ? Object.keys(config.env)
-          .reduce((acc, key) => ({
-            ...acc,
-            ...{ [`process.env.${key}`]: JSON.stringify(config.env[key]) }
-          }), {}) : {},
+          .reduce((acc, key) => {
+            const selector = key.match(/^(_?)(.+)$/)
+            return {
+              ...acc,
+              ...{ [`${selector[1] ? '' : 'process.env.'}${selector[2]}`]: JSON.stringify(config.env[key]) }
+            }
+          }, {}) : {},
         {
           'process.crossOrigin': JSON.stringify(config.crossOrigin),
           'process.browser': JSON.stringify(!isServer)

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -294,13 +294,10 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       new webpack.DefinePlugin(Object.assign(
         {},
         config.env ? Object.keys(config.env)
-          .reduce((acc, key) => {
-            const selector = key.match(/^(_?)(.+)$/)
-            return {
-              ...acc,
-              ...{ [`${selector[1] ? '' : 'process.env.'}${selector[2]}`]: JSON.stringify(config.env[key]) }
-            }
-          }, {}) : {},
+          .reduce((acc, key) => ({
+            ...acc,
+            ...{ [`process.env.${key}`]: JSON.stringify(config.env[key]) }
+          }), {}) : {},
         {
           'process.crossOrigin': JSON.stringify(config.crossOrigin),
           'process.browser': JSON.stringify(!isServer)

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -291,10 +291,10 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       dev && new CaseSensitivePathPlugin(), // Since on macOS the filesystem is case-insensitive this will make sure your path are case-sensitive
       !dev && new webpack.HashedModuleIdsPlugin(),
       // Removes server/client code by minifier
-      new webpack.DefinePlugin({
+      new webpack.DefinePlugin(Object.assign({}, config.buildVars, {
         'process.crossOrigin': JSON.stringify(config.crossOrigin),
         'process.browser': JSON.stringify(!isServer)
-      }),
+      })),
       // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
       !isServer && dev && new webpack.DefinePlugin({
         'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -291,10 +291,18 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       dev && new CaseSensitivePathPlugin(), // Since on macOS the filesystem is case-insensitive this will make sure your path are case-sensitive
       !dev && new webpack.HashedModuleIdsPlugin(),
       // Removes server/client code by minifier
-      new webpack.DefinePlugin(Object.assign({}, config.buildVars, {
-        'process.crossOrigin': JSON.stringify(config.crossOrigin),
-        'process.browser': JSON.stringify(!isServer)
-      })),
+      new webpack.DefinePlugin(Object.assign(
+        {},
+        config.env ? Object.keys(config.env)
+          .reduce((acc, key) => ({
+            ...acc,
+            ...{ [`process.${key}`]: JSON.stringify(config.env[key]) }
+          }), {}) : {},
+        {
+          'process.crossOrigin': JSON.stringify(config.crossOrigin),
+          'process.browser': JSON.stringify(!isServer)
+        }
+      )),
       // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
       !isServer && dev && new webpack.DefinePlugin({
         'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)

--- a/test/integration/config/next.config.js
+++ b/test/integration/config/next.config.js
@@ -15,6 +15,10 @@ module.exports = withCSS(withSass({
   publicRuntimeConfig: {
     staticFolder: '/static'
   },
+  env: {
+    customVar: 'hello',
+    _globalVar: 'world'
+  },
   webpack (config, {buildId}) {
     // When next-css is `npm link`ed we have to solve loaders from the project root
     const nextLocation = path.join(require.resolve('next/package.json'), '../')

--- a/test/integration/config/next.config.js
+++ b/test/integration/config/next.config.js
@@ -16,8 +16,7 @@ module.exports = withCSS(withSass({
     staticFolder: '/static'
   },
   env: {
-    customVar: 'hello',
-    _globalVar: 'world'
+    customVar: 'hello'
   },
   webpack (config, {buildId}) {
     // When next-css is `npm link`ed we have to solve loaders from the project root

--- a/test/integration/config/pages/next-config.js
+++ b/test/integration/config/pages/next-config.js
@@ -1,5 +1,3 @@
-/* global globalVar */
-
 import getConfig from 'next/config'
 const {serverRuntimeConfig, publicRuntimeConfig} = getConfig()
 
@@ -7,5 +5,4 @@ export default () => <div>
   <p id='server-only'>{serverRuntimeConfig.mySecret}</p>
   <p id='server-and-client'>{publicRuntimeConfig.staticFolder}</p>
   <p id='env'>{process.env.customVar}</p>
-  <p id='env-global'>{globalVar}</p>
 </div>

--- a/test/integration/config/pages/next-config.js
+++ b/test/integration/config/pages/next-config.js
@@ -1,7 +1,11 @@
+/* global globalVar */
+
 import getConfig from 'next/config'
 const {serverRuntimeConfig, publicRuntimeConfig} = getConfig()
 
 export default () => <div>
   <p id='server-only'>{serverRuntimeConfig.mySecret}</p>
   <p id='server-and-client'>{publicRuntimeConfig.staticFolder}</p>
+  <p id='env'>{process.env.customVar}</p>
+  <p id='env-global'>{globalVar}</p>
 </div>

--- a/test/integration/config/test/client.js
+++ b/test/integration/config/test/client.js
@@ -14,9 +14,13 @@ export default (context, render) => {
 
       const serverText = await browser.elementByCss('#server-only').text()
       const serverClientText = await browser.elementByCss('#server-and-client').text()
+      const envValue = await browser.elementByCss('#env').text()
+      const globalEnvValue = await browser.elementByCss('#env-global').text()
 
       expect(serverText).toBe('')
       expect(serverClientText).toBe('/static')
+      expect(envValue).toBe('hello')
+      expect(globalEnvValue).toBe('world')
       browser.close()
     })
 

--- a/test/integration/config/test/client.js
+++ b/test/integration/config/test/client.js
@@ -15,12 +15,10 @@ export default (context, render) => {
       const serverText = await browser.elementByCss('#server-only').text()
       const serverClientText = await browser.elementByCss('#server-and-client').text()
       const envValue = await browser.elementByCss('#env').text()
-      const globalEnvValue = await browser.elementByCss('#env-global').text()
 
       expect(serverText).toBe('')
       expect(serverClientText).toBe('/static')
       expect(envValue).toBe('hello')
-      expect(globalEnvValue).toBe('world')
       browser.close()
     })
 


### PR DESCRIPTION
#### Build time configuration

 The way build-time configuration works is by inlining the provided values into the Javascript bundle.

 You can add the `env` key in `next.config.js`:

 ```js
// next.config.js
module.exports = {
  env: {
    customKey: 'value'
  }
}
```

 This will allow you to use `process.env.customKey` in your code. For example:

 ```jsx
// pages/index.js
export default function Index() {
  return <h1>The value of customEnv is: {process.env.customEnv}</h1>
}
```

Also adds an error when `publicRuntimeConfig` / `serverRuntimeConfig` is used in combination with `target: 'serverless'`