### PR TITLE
[with-typescript] remove unnecessary `passHref` in `Link` components

### DIFF
--- a/examples/with-typescript/components/ListItem.tsx
+++ b/examples/with-typescript/components/ListItem.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 const ListItem: React.FunctionComponent<Props> = ({ data }) => (
-  <Link href={`/detail?id=${data.id}`} passHref>
+  <Link href={`/detail?id=${data.id}`}>
     <a>{data.id}: {data.name}</a>
   </Link>
 );


### PR DESCRIPTION
As per discussion in #6165, I removed the `passHref` in `Link` as
they're unnecessary.