### PR TITLE
Bring back "module" to server mainFields

### DIFF
--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -189,7 +189,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir
     },
-    mainFields: isServer ? ['main'] : ['browser', 'module', 'main']
+    mainFields: isServer ? ['module', 'main'] : ['browser', 'module', 'main']
   }
 
   const webpackMode = dev ? 'development' : 'production'


### PR DESCRIPTION
Brings back the behavior of v7 and the default behavior of webpack according to https://webpack.js.org/configuration/resolve/#resolve-mainfields

Fixes #6246