### PR TITLE
styled-components example: use a fragment for styles initial prop

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -15,7 +15,7 @@ export default class MyDocument extends Document {
       const initialProps = await Document.getInitialProps(ctx)
       return {
         ...initialProps,
-        styles: [...initialProps.styles, ...sheet.getStyleElement()]
+        styles: <>{initialProps.styles}{sheet.getStyleElement()}</>
       }
     } finally {
       sheet.seal()


### PR DESCRIPTION
`initialProps.styles` is a React node, but it's not guaranteed to be an array, so we can use a fragment to concatenate additional styles.

See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/32932#issuecomment-462372319