### PR TITLE
Apply babel to .mjs files

### DIFF
--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -242,7 +242,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
     module: {
       rules: [
         {
-          test: /\.(js|jsx)$/,
+          test: /\.(js|mjs|jsx)$/,
           include: [dir, /next-server[\\/]dist[\\/]lib/],
           exclude: (path) => {
             if (/next-server[\\/]dist[\\/]lib/.exec(path)) {


### PR DESCRIPTION
Noticed this - seems like .mjs files are included for module resolution, but weren't being transpiled by Babel.