### PR TITLE
Generate correct 404 on export

### DIFF
--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -104,6 +104,7 @@ export default async function (dir, options, configuration) {
 
   log(`  launching ${threads} threads with concurrency of ${concurrency} per thread`)
   const exportPathMap = await nextConfig.exportPathMap(defaultPathMap, {dev: false, dir, outDir, distDir, buildId})
+  exportPathMap['/404.html'] = exportPathMap['/404.html'] || { page: '/_error' }
   const exportPaths = Object.keys(exportPathMap)
 
   const progress = !options.silent && createProgress(exportPaths.length)

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -28,7 +28,8 @@ process.on(
         await sema.acquire()
         const { page, query = {} } = exportPathMap[path]
         const req = { url: path }
-        const res = {}
+        const res = path === '/404.html' ? { statusCode: 404 } : {}
+
         envConfig.setConfig({
           serverRuntimeConfig,
           publicRuntimeConfig: renderOpts.runtimeConfig

--- a/test/integration/export/test/ssr.js
+++ b/test/integration/export/test/ssr.js
@@ -48,14 +48,12 @@ export default function (context) {
       expect(html).toMatch(/Query is: {}/)
     })
 
-    it('should render _error on 404', async () => {
-      const html = await renderViaHTTP(context.port, '/404')
-      expect(html).toMatch(/404/)
-    })
-
-    it('should export 404.html instead of 404/index.html', async () => {
+    it('should render _error on 404.html even if not provided in exportPathMap', async () => {
       const html = await renderViaHTTP(context.port, '/404.html')
       expect(html).toMatch(/404/)
+      // The static server used in these tests also includes "404" in
+      // its error page, so we also check for text unique to _error
+      expect(html).toMatch(/page.*not.*found/i)
     })
   })
 }


### PR DESCRIPTION
This PR fixes a couple of issues around 404-pages when exporting:

* Default `404.html` when exporting is now a correct 404-page (Fixes #6243)
* If `/404.html` is not provided in `exportPathMap`, add the default one
* Fix one false negative test in `/test/integration/export`
* Remove one false negative test in `/test/integration/export`

The tests matched for `/404/` in the html, but the default error page from the static Express server used in the tests includes this, causing false positives.

The test that was removed was `should export 404.html instead of 404/index.html`. Because this logic only applies to `defaultPathMap` and this test-suite defines a custom configuration, there is to my knowledge currently no way to test this without adding a new test-suite.

The options as I see it:

* Be content with removing the test for now
* Add a new test-suite for `export-default` (Scope-creep for this PR? Won't have time to do it next few days)
* Extend logic to apply to custom `exportPathMap` as well