### PR TITLE
[WIP] Add passEnv config option

### DIFF
--- a/packages/next-server/lib/pass-env.ts
+++ b/packages/next-server/lib/pass-env.ts
@@ -1,0 +1,8 @@
+export default function passEnv() {
+  let passEnv: { [x: string]: string | undefined } | undefined
+  if (process.env.__NEXT_ENV_PASS) process.env.__NEXT_ENV_PASS.split(',').forEach((key) => {
+    passEnv ? passEnv[key] = process.env[key] : passEnv = {[key]: process.env[key]}
+  })
+
+  return passEnv
+}

--- a/packages/next-server/lib/pass-env.ts
+++ b/packages/next-server/lib/pass-env.ts
@@ -1,6 +1,6 @@
 export default function passEnv() {
   let passEnv: { [x: string]: string | undefined } | undefined
-  if (process.env.__NEXT_ENV_PASS) process.env.__NEXT_ENV_PASS.split(',').forEach((key) => {
+  if (process.env.__NEXT_PASS_ENV) process.env.__NEXT_PASS_ENV.split(',').forEach((key) => {
     passEnv ? passEnv[key] = process.env[key] : passEnv = {[key]: process.env[key]}
   })
 

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -224,7 +224,7 @@ export default class Server {
     }
 
     if (this.nextConfig.poweredByHeader) {
-      res.setHeader('X-Powered-By', 'Next.js ' + process.env.NEXT_VERSION)
+      res.setHeader('X-Powered-By', 'Next.js ' + process.env.__NEXT_VERSION)
     }
     return this.sendHTML(req, res, html)
   }

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -9,6 +9,7 @@ import Loadable from '../lib/loadable'
 import LoadableCapture from '../lib/loadable-capture'
 import {getDynamicImportBundles, Manifest as ReactLoadableManifest, ManifestItem} from './get-dynamic-import-bundles'
 import {getPageFiles, BuildManifest} from './get-page-files'
+import passEnv from '../lib/pass-env'
 
 type Enhancer = (Component: React.ComponentType) => React.ComponentType
 type ComponentsEnhancer = {enhanceApp?: Enhancer, enhanceComponent?: Enhancer}|Enhancer
@@ -95,6 +96,7 @@ function renderDocument(Document: React.ComponentType, {
         buildId, // buildId is used to facilitate caching of page bundles, we send it to the client so that pageloader knows where to load bundles
         assetPrefix: assetPrefix === '' ? undefined : assetPrefix, // send assetPrefix to the client side when configured, otherwise don't sent in the resulting HTML
         runtimeConfig, // runtimeConfig if provided, otherwise don't sent in the resulting HTML
+        passEnv: passEnv(), // when setting config option passEnv
         nextExport, // If this is a page exported by `next export`
         dynamicIds: dynamicImportsIds.length === 0 ? undefined : dynamicImportsIds,
         err: (err) ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML

--- a/packages/next-server/taskfile-typescript.js
+++ b/packages/next-server/taskfile-typescript.js
@@ -35,7 +35,7 @@ try {
       }
 
       // update file's data
-      file.data = Buffer.from(result.outputText.replace(/process\.env\.NEXT_VERSION/, `"${require('./package.json').version}"`), 'utf8')
+      file.data = Buffer.from(result.outputText.replace(/process\.env\.__NEXT_VERSION/, `"${require('./package.json').version}"`), 'utf8')
     })
   }
 } catch (err) {

--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -37,7 +37,7 @@ const args = arg({
 // Version is inlined into the file using taskr build pipeline
 if (args['--version']) {
   // tslint:disable-next-line
-  console.log(`Next.js v${process.env.NEXT_VERSION}`)
+  console.log(`Next.js v${process.env.__NEXT_VERSION}`)
   process.exit(0)
 }
 

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -302,6 +302,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
             }
           }, {}) : {},
         {
+          'process.env.__NEXT_ENV_PASS': JSON.stringify(config.passEnv.join(',')),
           'process.crossOrigin': JSON.stringify(config.crossOrigin),
           'process.browser': JSON.stringify(!isServer)
         }

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -302,7 +302,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
             }
           }, {}) : {},
         {
-          'process.env.__NEXT_ENV_PASS': JSON.stringify(Array.isArray(config.passEnv) ? config.passEnv.join(',') : config.passEnv),
+          'process.env.__NEXT_PASS_ENV': JSON.stringify(Array.isArray(config.passEnv) ? config.passEnv.join(',') : config.passEnv),
           'process.crossOrigin': JSON.stringify(config.crossOrigin),
           'process.browser': JSON.stringify(!isServer)
         }

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -295,14 +295,14 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
         {},
         config.env ? Object.keys(config.env)
           .reduce((acc, key) => {
-            if (/^(?:NODE_.+)|(?:__.+)$/.test(key.toUpperCase())) throw new Error(`Next.js config env cannot have key of ${key}`)
+            if (/^(?:NODE_.+)|(?:__.+)$/.test(key.toUpperCase()) || (config.passEnv && config.passEnv.indexOf(key) > -1)) throw new Error(`Next.js config env cannot have key of ${key}`)
             return {
               ...acc,
               ...{ [`process.env.${key}`]: JSON.stringify(config.env[key]) }
             }
           }, {}) : {},
         {
-          'process.env.__NEXT_ENV_PASS': JSON.stringify(config.passEnv.join(',')),
+          'process.env.__NEXT_ENV_PASS': JSON.stringify(Array.isArray(config.passEnv) ? config.passEnv.join(',') : config.passEnv),
           'process.crossOrigin': JSON.stringify(config.crossOrigin),
           'process.browser': JSON.stringify(!isServer)
         }

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -295,7 +295,7 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
         {},
         config.env ? Object.keys(config.env)
           .reduce((acc, key) => {
-            if (/^(?:NODE_\w+)|(?:NEXT_\w+)|(?:__\w+)|(?:CONFIG_BUILD_ID)|(?:PORT)$/.test(key.toUpperCase())) throw new Error(`Next.js config env cannot have key of ${key}`)
+            if (/^(?:NODE_.+)|(?:__.+)$/.test(key.toUpperCase())) throw new Error(`Next.js config env cannot have key of ${key}`)
             return {
               ...acc,
               ...{ [`process.env.${key}`]: JSON.stringify(config.env[key]) }

--- a/packages/next/build/webpack-config.js
+++ b/packages/next/build/webpack-config.js
@@ -294,10 +294,13 @@ export default async function getBaseWebpackConfig (dir, {dev = false, isServer 
       new webpack.DefinePlugin(Object.assign(
         {},
         config.env ? Object.keys(config.env)
-          .reduce((acc, key) => ({
-            ...acc,
-            ...{ [`process.env.${key}`]: JSON.stringify(config.env[key]) }
-          }), {}) : {},
+          .reduce((acc, key) => {
+            if (/^(?:NODE_\w+)|(?:NEXT_\w+)|(?:__\w+)|(?:CONFIG_BUILD_ID)|(?:PORT)$/.test(key.toUpperCase())) throw new Error(`Next.js config env cannot have key of ${key}`)
+            return {
+              ...acc,
+              ...{ [`process.env.${key}`]: JSON.stringify(config.env[key]) }
+            }
+          }, {}) : {},
         {
           'process.crossOrigin': JSON.stringify(config.crossOrigin),
           'process.browser': JSON.stringify(!isServer)

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -21,6 +21,15 @@ if (!window.Promise) {
 
 const data = JSON.parse(document.getElementById('__NEXT_DATA__').textContent)
 window.__NEXT_DATA__ = data
+if (data && typeof data.passEnv === 'object') {
+  Object.keys(data.passEnv).forEach((key) => {
+    if (typeof global.process === 'undefined') {
+      global.process = {env: {}}
+    }
+
+    process.env[key] = data.passEnv[key]
+  })
+}
 
 const {
   props,

--- a/packages/next/client/on-demand-entries-client.js
+++ b/packages/next/client/on-demand-entries-client.js
@@ -20,7 +20,7 @@ export default async ({ assetPrefix }) => {
     }
 
     return new Promise(resolve => {
-      ws = new WebSocket(`${wsProtocol}://${hostname}:${process.env.NEXT_WS_PORT}${process.env.NEXT_WS_PROXY_PATH}`)
+      ws = new WebSocket(`${wsProtocol}://${hostname}:${process.env.__NEXT_WS_PORT}${process.env.__NEXT_WS_PROXY_PATH}`)
       ws.onopen = () => resolve()
       ws.onclose = () => {
         setTimeout(async () => {

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -167,8 +167,8 @@ export default class HotReloader {
   addWsConfig (configs) {
     const { websocketProxyPath, websocketProxyPort } = this.config.onDemandEntries
     const opts = {
-      'process.env.NEXT_WS_PORT': websocketProxyPort || this.wsPort,
-      'process.env.NEXT_WS_PROXY_PATH': JSON.stringify(websocketProxyPath)
+      'process.env.__NEXT_WS_PORT': websocketProxyPort || this.wsPort,
+      'process.env.__NEXT_WS_PROXY_PATH': JSON.stringify(websocketProxyPath)
     }
     configs[0].plugins.push(new webpack.DefinePlugin(opts))
   }

--- a/packages/next/taskfile-typescript.js
+++ b/packages/next/taskfile-typescript.js
@@ -40,7 +40,7 @@ try {
       if (file.base === 'next-dev.js') result.outputText = result.outputText.replace('// REPLACE_NOOP_IMPORT', `import('./noop');`)
 
       // update file's data
-      file.data = Buffer.from(result.outputText.replace(/process\.env\.NEXT_VERSION/, `"${require('./package.json').version}"`), 'utf8')
+      file.data = Buffer.from(result.outputText.replace(/process\.env\.__NEXT_VERSION/, `"${require('./package.json').version}"`), 'utf8')
     })
   }
 } catch (err) {

--- a/test/integration/serverless/next.config.js
+++ b/test/integration/serverless/next.config.js
@@ -4,5 +4,8 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60
   },
+  passEnv: [
+    'DYNAMIC_RUNTIME'
+  ],
   lambdas: true
 }

--- a/test/integration/serverless/pages/fetch.js
+++ b/test/integration/serverless/pages/fetch.js
@@ -24,6 +24,12 @@ export default class extends React.Component {
       <div id='text'>
         {text}
       </div>
+      <div id='var'>
+        {process.env.DYNAMIC_RUNTIME}
+      </div>
+      <div id='noVar'>
+        {process.env.NO_VAR ? process.env.NO_VAR : 'not here'}
+      </div>
     </div>
   }
 }

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -52,6 +52,8 @@ describe('Serverless', () => {
   })
 
   it('should render correctly when importing isomorphic-unfetch on the client side', async () => {
+    process.env.DYNAMIC_RUNTIME = 'I am dynamic'
+    process.env.NO_VAR = 'I am dynamic'
     const browser = await webdriver(appPort, '/')
     try {
       const text = await browser
@@ -60,6 +62,12 @@ describe('Serverless', () => {
         .elementByCss('#text').text()
 
       expect(text).toMatch(/fetch page/)
+      const passVar = await browser
+        .elementByCss('#var').text()
+      expect(passVar).toMatch(/I am dynamic/)
+      const dontPassVar = await browser
+        .elementByCss('#noVar').text()
+      expect(dontPassVar).toMatch(/not here/)
     } finally {
       browser.close()
     }


### PR DESCRIPTION
Adds config option:
```js
// next.config.js
module.exports = {
  passEnv: [
    'dockerHost',
    'apiEndpoint'
  ]
}
```

Will add support for reading dynamic `process.env.apiEndpoint` on both the server and the client at runtime.

Will also block build time `env` being set to something set in `passEnv`

TODO
---
- [ ] `process.env.__NEXT_ENV_PASS` only seems to be replaced when running serverless :thinking: 
- [x] serverless tests
- [ ] other tests

Note: this PR depends on https://github.com/zeit/next.js/pull/6260 so there are some diffs from that PR in this one (that will disappear once it's merged).