### PR TITLE
Update babel-plugin-react-require for better plugin interoperability

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -54,7 +54,7 @@
     "autodll-webpack-plugin": "0.4.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.2",
-    "babel-plugin-react-require": "3.0.0",
+    "babel-plugin-react-require": "3.0.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.15",
     "cacache": "^11.0.2",
     "case-sensitive-paths-webpack-plugin": "2.1.2",


### PR DESCRIPTION
In an effort to inline some svg assets in my app, I was running into an issue.

`babel-plugin-react-require` will add `import React from "react"` to the top of a component with JSX if it does not explicitly have it stated.

When importing an SVG file, this is happening twice because `babel-plugin-react-require` and `babel-plugin-inline-react-svg` will both try to fix the missing import statement.

It looks like @timneutkens patched this https://github.com/airbnb/babel-plugin-inline-react-svg/issues/31#issuecomment-425996923 but i'm still seeing the issue.

Turns out that next@8.0.0 requires babel-plugin-react-require@3.0.0, but the aforementioned patch didn't land until the 3.0.1 release.

It looks like we'd need to bump this dependency in next@8.0.0.
