### PR TITLE
MobX example: Use process.browser instead of env probing

### DIFF
--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -21,7 +21,7 @@ class MyMobxApp extends App {
 
   constructor(props) {
     super(props)
-    const isServer = typeof window === 'undefined'
+    const isServer = !process.browser;
     this.mobxStore = isServer
       ? props.initialMobxState
       : initializeStore(props.initialMobxState)

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -1,7 +1,7 @@
 import { action, observable } from 'mobx'
 import { useStaticRendering } from 'mobx-react'
 
-const isServer = typeof window === 'undefined'
+const isServer = !process.browser
 useStaticRendering(isServer)
 
 class Store {
@@ -25,7 +25,8 @@ class Store {
 }
 
 let store = null
-export function initializeStore(initialData) {
+
+export function initializeStore (initialData) {
   // Always make a new store if server, otherwise state is shared between requests
   if (isServer) {
     return new Store(isServer, initialData)


### PR DESCRIPTION
This is a minor change, for newcomers to `Next.js` (like me), it is very important to use the best practices instead of workarounds.