### PR TITLE
Remove usage of Lerna Bootstrap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ jobs:
           name: Installing dependencies
           command: yarn install
       - run:
-          name: Bootstrapping
-          command: yarn bootstrap
-      - run:
           name: Linting
           command: yarn lint
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@
   before_cache: [
     "rm -rf node_modules/.cache"
   ],
-  before_script: ["npm run bootstrap"],
+  before_script: [],
   after_script: ["npm run coveralls"]
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,9 +20,5 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
-    yarn bootstrap
-  displayName: 'Lerna bootstrap'
-  
-- script: |
     yarn test
   displayName: 'Run tests'

--- a/contributing.md
+++ b/contributing.md
@@ -3,10 +3,9 @@
 Our Commitment to Open Source can be found [here](https://zeit.co/blog/oss)
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
-2. Install yarn: `npm install -g yarn`
-3. Install the dependencies: `yarn`
-4. Run `yarn run bootstrap`, which will link all repositories locally
-5. Run `yarn run dev` to build and watch for code changes
+1. Install yarn: `npm install -g yarn`
+1. Install the dependencies: `yarn`
+1. Run `yarn run dev` to build and watch for code changes
 
 ## To run tests
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   ],
   "scripts": {
     "lerna": "lerna",
-    "bootstrap": "lerna bootstrap",
     "dev": "lerna run build --stream --parallel",
     "testonly": "jest",
     "testall": "yarn check && npm run testonly -- --coverage --forceExit --runInBand --reporters=default --reporters=jest-junit",


### PR DESCRIPTION
Yarn Workspaces and Lerna shouldn't need to compete for local development.
IMO, we should restrict usage of Lerna to just publishing.

Let's see if tests pass 😅.