### PR TITLE
push redux-saga to major release 1.0.1.

### DIFF
--- a/examples/with-redux-saga/package.json
+++ b/examples/with-redux-saga/package.json
@@ -11,13 +11,13 @@
     "es6-promise": "4.1.1",
     "isomorphic-unfetch": "2.0.0",
     "next": "latest",
-    "next-redux-saga": "3.0.0",
+    "next-redux-saga": "4.0.0",
     "next-redux-wrapper": "2.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "5.0.7",
-    "redux": "4.0.0",
-    "redux-saga": "0.16.0"
+    "redux": "4.0.1",
+    "redux-saga": "1.0.1"
   },
   "devDependencies": {
     "redux-devtools-extension": "2.13.2"

--- a/examples/with-redux-saga/pages/_app.js
+++ b/examples/with-redux-saga/pages/_app.js
@@ -29,4 +29,4 @@ class MyApp extends App {
   }
 }
 
-export default withRedux(createStore)(withReduxSaga({ async: true })(MyApp))
+export default withRedux(createStore)(withReduxSaga(MyApp))

--- a/examples/with-redux-saga/saga.js
+++ b/examples/with-redux-saga/saga.js
@@ -1,7 +1,6 @@
 /* global fetch */
 
-import { delay } from 'redux-saga'
-import { all, call, put, take, takeLatest } from 'redux-saga/effects'
+import { all, call, delay, put, take, takeLatest } from 'redux-saga/effects'
 import es6promise from 'es6-promise'
 import 'isomorphic-unfetch'
 
@@ -13,7 +12,7 @@ function * runClockSaga () {
   yield take(actionTypes.START_CLOCK)
   while (true) {
     yield put(tickClock(false))
-    yield call(delay, 1000)
+    yield delay(1000)
   }
 }
 


### PR DESCRIPTION
Hi there
We finally managed to match `next-redux-saga` with `"redux-saga": "1.x"` 🥇 
Therefore I'm proud to submit you this pull-request: Updating the example `with-redux-saga`.
Best regards