### PR TITLE
fix: pass full path to `launch-editor` from `error-overlay-middleware`

### DIFF
--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -253,7 +253,7 @@ export default class HotReloader {
     this.middlewares = [
       webpackDevMiddleware,
       webpackHotMiddleware,
-      errorOverlayMiddleware,
+      errorOverlayMiddleware({ dir: this.dir }),
       onDemandEntries.middleware()
     ]
   }

--- a/packages/next/server/lib/error-overlay-middleware.js
+++ b/packages/next/server/lib/error-overlay-middleware.js
@@ -1,17 +1,19 @@
 import url from 'url'
 import launchEditor from 'launch-editor'
+import fs from 'fs'
 import path from 'path'
 
-export default function errorOverlayMiddleware(req, res, next) {
-
-  const srcRoot = process.cwd()
-
+export default function errorOverlayMiddleware (req, res, next) {
   if (req.url.startsWith('/_next/development/open-stack-frame-in-editor')) {
     const query = url.parse(req.url, true).query
     const lineNumber = parseInt(query.lineNumber, 10) || 1
     const colNumber = parseInt(query.colNumber, 10) || 1
 
-    const resolvedFileName = path.join(srcRoot, query.fileName)
+    let resolvedFileName = query.fileName
+
+    if (!fs.existsSync(resolvedFileName)) {
+      resolvedFileName = path.join(process.cwd(), resolvedFileName)
+    }
 
     launchEditor(`${resolvedFileName}:${lineNumber}:${colNumber}`)
     res.end()

--- a/packages/next/server/lib/error-overlay-middleware.js
+++ b/packages/next/server/lib/error-overlay-middleware.js
@@ -3,21 +3,23 @@ import launchEditor from 'launch-editor'
 import fs from 'fs'
 import path from 'path'
 
-export default function errorOverlayMiddleware (req, res, next) {
-  if (req.url.startsWith('/_next/development/open-stack-frame-in-editor')) {
-    const query = url.parse(req.url, true).query
-    const lineNumber = parseInt(query.lineNumber, 10) || 1
-    const colNumber = parseInt(query.colNumber, 10) || 1
+export default function errorOverlayMiddleware (options) {
+  return (req, res, next) => {
+    if (req.url.startsWith('/_next/development/open-stack-frame-in-editor')) {
+      const query = url.parse(req.url, true).query
+      const lineNumber = parseInt(query.lineNumber, 10) || 1
+      const colNumber = parseInt(query.colNumber, 10) || 1
 
-    let resolvedFileName = query.fileName
+      let resolvedFileName = query.fileName
 
-    if (!fs.existsSync(resolvedFileName)) {
-      resolvedFileName = path.join(process.cwd(), resolvedFileName)
+      if (!fs.existsSync(resolvedFileName)) {
+        resolvedFileName = path.join(options.dir, resolvedFileName)
+      }
+
+      launchEditor(`${resolvedFileName}:${lineNumber}:${colNumber}`)
+      res.end()
+    } else {
+      next()
     }
-
-    launchEditor(`${resolvedFileName}:${lineNumber}:${colNumber}`)
-    res.end()
-  } else {
-    next()
   }
 }

--- a/packages/next/server/lib/error-overlay-middleware.js
+++ b/packages/next/server/lib/error-overlay-middleware.js
@@ -1,12 +1,19 @@
 import url from 'url'
 import launchEditor from 'launch-editor'
+import path from 'path'
 
-export default function errorOverlayMiddleware (req, res, next) {
+export default function errorOverlayMiddleware(req, res, next) {
+
+  const srcRoot = process.cwd()
+
   if (req.url.startsWith('/_next/development/open-stack-frame-in-editor')) {
     const query = url.parse(req.url, true).query
     const lineNumber = parseInt(query.lineNumber, 10) || 1
     const colNumber = parseInt(query.colNumber, 10) || 1
-    launchEditor(`${query.fileName}:${lineNumber}:${colNumber}`)
+
+    const resolvedFileName = path.join(srcRoot, query.fileName)
+
+    launchEditor(`${resolvedFileName}:${lineNumber}:${colNumber}`)
     res.end()
   } else {
     next()


### PR DESCRIPTION
This PR:
- Includes `cwd` via `process.cwd()` in the resolved filename passed as argument to `launch-editor` when clicking the links on `react-error-overlay`

In the below folder structure:
![image](https://user-images.githubusercontent.com/4474353/52811211-8b175080-3062-11e9-8e89-7c1a77c3b952.png)

I have intentionally left a bug to pop `react-error-overlay`:
![image](https://user-images.githubusercontent.com/4474353/52811454-21e40d00-3063-11e9-925a-ce6ab8697a48.png)

When I click on the link that's supposed to launch the editor,the `error-overlay-middleware` passes the filename along to `launch-editor`

![image](https://user-images.githubusercontent.com/4474353/52811519-4dff8e00-3063-11e9-8b0e-fdefd0bf89e7.png)

*Since `launch-editor` uses a check like this*
```js
  if (!fs.existsSync(fileName)) {
    return
  }
```

It never launches my editor :disappointed: 

After the changes in this PR, the filename is correct:

![image](https://user-images.githubusercontent.com/4474353/52811625-88692b00-3063-11e9-840c-1770c8c57977.png)

And my editor is succesfully launched :tada: 



