### PR TITLE
Fix HMR with HTTPS

### DIFF
--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -27,6 +27,23 @@ const defaultConfig = {
   }
 }
 
+function assignDefaults (userConfig) {
+  if (userConfig.experimental) {
+    userConfig.experimental = {
+      ...defaultConfig.experimental,
+      ...userConfig.experimental
+    }
+  }
+  if (userConfig.onDemandEntries) {
+    userConfig.onDemandEntries = {
+      ...defaultConfig.onDemandEntries,
+      ...userConfig.onDemandEntries
+    }
+  }
+
+  return {...defaultConfig, ...userConfig}
+}
+
 function normalizeConfig (phase, config) {
   if (typeof config === 'function') {
     return config(phase, {defaultConfig})
@@ -37,7 +54,7 @@ function normalizeConfig (phase, config) {
 
 export default function loadConfig (phase, dir, customConfig) {
   if (customConfig) {
-    return {...defaultConfig, configOrigin: 'server', ...customConfig}
+    return assignDefaults({configOrigin: 'server', ...customConfig})
   }
   const path = findUp.sync(CONFIG_FILE, {
     cwd: dir
@@ -50,19 +67,7 @@ export default function loadConfig (phase, dir, customConfig) {
     if (userConfig.target && !targets.includes(userConfig.target)) {
       throw new Error(`Specified target is invalid. Provided: "${userConfig.target}" should be one of ${targets.join(', ')}`)
     }
-    if (userConfig.experimental) {
-      userConfig.experimental = {
-        ...defaultConfig.experimental,
-        ...userConfig.experimental
-      }
-    }
-    if (userConfig.onDemandEntries) {
-      userConfig.onDemandEntries = {
-        ...defaultConfig.onDemandEntries,
-        ...userConfig.onDemandEntries
-      }
-    }
-    return {...defaultConfig, configOrigin: CONFIG_FILE, ...userConfig}
+    return assignDefaults({configOrigin: CONFIG_FILE, ...userConfig})
   }
 
   return defaultConfig

--- a/packages/next/client/on-demand-entries-client.js
+++ b/packages/next/client/on-demand-entries-client.js
@@ -4,7 +4,16 @@ import Router from 'next/router'
 import fetch from 'unfetch'
 
 const { hostname, protocol } = location
-const wsProtocol = protocol.includes('https') ? 'wss' : 'ws'
+const isHttps = protocol.includes('https')
+
+//
+// Cannot use `wss` until we can spin up ws server with ssl certs
+//
+const wsProtocol = 'ws'
+//
+// If developing under https, use ws://localhost
+//
+const wsHostname = isHttps ? 'localhost' : hostname
 const retryTime = 5000
 let ws = null
 let lastHref = null
@@ -20,7 +29,7 @@ export default async ({ assetPrefix }) => {
     }
 
     return new Promise(resolve => {
-      ws = new WebSocket(`${wsProtocol}://${hostname}:${process.env.NEXT_WS_PORT}${process.env.NEXT_WS_PROXY_PATH}`)
+      ws = new WebSocket(`${wsProtocol}://${wsHostname}:${process.env.NEXT_WS_PORT}${process.env.NEXT_WS_PROXY_PATH}`)
       ws.onopen = () => resolve()
       ws.onclose = () => {
         setTimeout(async () => {

--- a/test/isolated/config.test.js
+++ b/test/isolated/config.test.js
@@ -23,6 +23,12 @@ describe('config', () => {
     expect(config.defaultConfig).toBeDefined()
   })
 
+  it('Should assign defaults deeply to user config', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
+    expect(config.distDir).toEqual('.next')
+    expect(config.onDemandEntries.websocketPort).toBeDefined()
+  })
+
   it('Should pass the customConfig correctly', () => {
     const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, {customConfig: true})
     expect(config.customConfig).toBe(true)
@@ -31,6 +37,12 @@ describe('config', () => {
   it('Should not pass the customConfig when it is null', () => {
     const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, null)
     expect(config.webpack).toBe(null)
+  })
+
+  it('Should assign defaults deeply to customConfig', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, {customConfig: true})
+    expect(config.customConfig).toBe(true)
+    expect(config.onDemandEntries.websocketPort).toBeDefined()
   })
 
   it('Should throw when an invalid target is provided', () => {


### PR DESCRIPTION
This PR fixes 2 issues found while upgrading our apps to 8.x:
- Fixes HMR with HTTPS by always using `ws://localhost` https://github.com/zeit/next.js/issues/6296
- Fixes deep defaults not being included when using customConfig