### PR TITLE
Fix examples/with-redux-saga

### DIFF
--- a/examples/with-redux-saga/store.js
+++ b/examples/with-redux-saga/store.js
@@ -1,10 +1,8 @@
-import { createStore, applyMiddleware } from 'redux'
+import { applyMiddleware, createStore } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 
 import rootReducer, { exampleInitialState } from './reducer'
 import rootSaga from './saga'
-
-const sagaMiddleware = createSagaMiddleware()
 
 const bindMiddleware = middleware => {
   if (process.env.NODE_ENV !== 'production') {
@@ -15,17 +13,15 @@ const bindMiddleware = middleware => {
 }
 
 function configureStore (initialState = exampleInitialState) {
+  const sagaMiddleware = createSagaMiddleware()
   const store = createStore(
     rootReducer,
     initialState,
     bindMiddleware([sagaMiddleware])
   )
 
-  store.runSagaTask = () => {
-    store.sagaTask = sagaMiddleware.run(rootSaga)
-  }
+  store.sagaTask = sagaMiddleware.run(rootSaga)
 
-  store.runSagaTask()
   return store
 }
 


### PR DESCRIPTION
When dispatching `dispatch(END)` to redux-saga the corresponding stdChannel is closed. It was possible to restart it in version `"redux-saga": "0.16.2"` but is no longer possible on the current release. Therefore the server was unable to run sagas on multiple requests.
**Edit:** And of course if we recreate the middleware a new stdChannel is opened and we can continue running sagas.
The bug was reported in #6308.