### PR TITLE
Use a query parameter for AMP pages instead of new route

### DIFF
--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -85,7 +85,6 @@ function renderDocument(
     props,
     docProps,
     pathname,
-    asPath,
     query,
     buildId,
     assetPrefix,
@@ -103,7 +102,6 @@ function renderDocument(
     props: any
     docProps: any
     pathname: string
-    asPath: string | undefined
     query: ParsedUrlQuery
     amphtml: boolean
     dynamicImportsIds: string[]
@@ -130,7 +128,6 @@ function renderDocument(
             err: err ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
           }}
           ampEnabled={ampEnabled}
-          asPath={encodeURI(asPath || '')}
           amphtml={amphtml}
           staticMarkup={staticMarkup}
           devFiles={devFiles}
@@ -249,7 +246,6 @@ export async function renderToHTML(
     ...renderOpts,
     props,
     docProps,
-    asPath,
     pathname,
     amphtml,
     query,

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -111,7 +111,7 @@ export class Head extends Component {
   }
 
   render () {
-    const { asPath, ampEnabled, head, styles, amphtml, assetPrefix, __NEXT_DATA__ } = this.context._documentProps
+    const { ampEnabled, head, styles, amphtml, assetPrefix, __NEXT_DATA__ } = this.context._documentProps
     const { _devOnlyInvalidateCacheQueryString } = this.context
     const { page, buildId } = __NEXT_DATA__
 
@@ -131,7 +131,7 @@ export class Head extends Component {
       {head}
       {amphtml && <>
         <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/>
-        <link rel="canonical" href={asPath === '/amp' ? '/' : asPath.replace(/\/amp$/, '')} />
+        <link rel="canonical" href={page} />
         {/* https://www.ampproject.org/docs/fundamentals/optimize_amp#optimize-the-amp-runtime-loading */}
         <link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js" />
         {/* Add custom styles before AMP styles to prevent accidental overrides */}
@@ -141,7 +141,7 @@ export class Head extends Component {
         <script async src="https://cdn.ampproject.org/v0.js"></script>
       </>}
       {!amphtml && <>
-      {ampEnabled && <link rel="amphtml" href={asPath === '/' ? '/amp' : (asPath.replace(/\/$/, '') + '/amp')} />}
+      {ampEnabled && <link rel="amphtml" href={`${page}?amp=1`} />}
       {page !== '/_error' && <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages${getPagePathname(page)}${_devOnlyInvalidateCacheQueryString}`} as='script' nonce={this.props.nonce} crossOrigin={this.props.crossOrigin || process.crossOrigin} />}
       <link rel='preload' href={`${assetPrefix}/_next/static/${buildId}/pages/_app.js${_devOnlyInvalidateCacheQueryString}`} as='script' nonce={this.props.nonce} crossOrigin={this.props.crossOrigin || process.crossOrigin} />
       {this.getPreloadDynamicChunks()}

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -24,11 +24,12 @@ async function validateAMP (html) {
   if (result.status !== 'PASS') {
     for (let ii = 0; ii < result.errors.length; ii++) {
       const error = result.errors[ii]
-      let msg = 'line ' + error.line + ', col ' + error.col + ': ' + error.message
+      let msg =
+        'line ' + error.line + ', col ' + error.col + ': ' + error.message
       if (error.specUrl !== null) {
         msg += ' (see ' + error.specUrl + ')'
       }
-      ((error.severity === 'ERROR') ? console.error : console.warn)(msg)
+      ;(error.severity === 'ERROR' ? console.error : console.warn)(msg)
     }
   }
   expect(result.status).toBe('PASS')
@@ -57,33 +58,45 @@ describe('AMP Usage', () => {
 
   describe('With basic AMP usage', () => {
     it('should render the page as valid AMP', async () => {
-      const html = await renderViaHTTP(appPort, '/amp')
+      const html = await renderViaHTTP(appPort, '/?amp=1')
       await validateAMP(html)
       expect(html).toMatch(/Hello World/)
     })
 
     it('should add link preload for amp script', async () => {
-      const html = await renderViaHTTP(appPort, '/amp')
+      const html = await renderViaHTTP(appPort, '/?amp=1')
       await validateAMP(html)
       const $ = cheerio.load(html)
-      expect($($('link[rel=preload]').toArray().find(i => $(i).attr('href') === 'https://cdn.ampproject.org/v0.js')).attr('href')).toBe('https://cdn.ampproject.org/v0.js')
+      expect(
+        $(
+          $('link[rel=preload]')
+            .toArray()
+            .find(i => $(i).attr('href') === 'https://cdn.ampproject.org/v0.js')
+        ).attr('href')
+      ).toBe('https://cdn.ampproject.org/v0.js')
     })
 
     it('should add custom styles before amp boilerplate styles', async () => {
-      const html = await renderViaHTTP(appPort, '/amp')
+      const html = await renderViaHTTP(appPort, '/?amp=1')
       await validateAMP(html)
       const $ = cheerio.load(html)
       const order = []
-      $('style').toArray().forEach((i) => {
-        if ($(i).attr('amp-custom') === '') {
-          order.push('amp-custom')
-        }
-        if ($(i).attr('amp-boilerplate') === '') {
-          order.push('amp-boilerplate')
-        }
-      })
+      $('style')
+        .toArray()
+        .forEach(i => {
+          if ($(i).attr('amp-custom') === '') {
+            order.push('amp-custom')
+          }
+          if ($(i).attr('amp-boilerplate') === '') {
+            order.push('amp-boilerplate')
+          }
+        })
 
-      expect(order).toEqual(['amp-custom', 'amp-boilerplate', 'amp-boilerplate'])
+      expect(order).toEqual([
+        'amp-custom',
+        'amp-boilerplate',
+        'amp-boilerplate'
+      ])
     })
   })
 
@@ -94,7 +107,7 @@ describe('AMP Usage', () => {
     })
 
     it('should render the AMP page that uses the AMP hook', async () => {
-      const html = await renderViaHTTP(appPort, '/use-amp-hook/amp')
+      const html = await renderViaHTTP(appPort, '/use-amp-hook?amp=1')
       await validateAMP(html)
       expect(html).toMatch(/Hello AMP/)
     })
@@ -104,14 +117,22 @@ describe('AMP Usage', () => {
     it('should render link rel amphtml', async () => {
       const html = await renderViaHTTP(appPort, '/use-amp-hook')
       const $ = cheerio.load(html)
-      expect($('link[rel=amphtml]').first().attr('href')).toBe('/use-amp-hook/amp')
+      expect(
+        $('link[rel=amphtml]')
+          .first()
+          .attr('href')
+      ).toBe('/use-amp-hook?amp=1')
     })
 
     it('should render the AMP page that uses the AMP hook', async () => {
-      const html = await renderViaHTTP(appPort, '/use-amp-hook/amp')
+      const html = await renderViaHTTP(appPort, '/use-amp-hook?amp=1')
       const $ = cheerio.load(html)
       await validateAMP(html)
-      expect($('link[rel=canonical]').first().attr('href')).toBe('/use-amp-hook')
+      expect(
+        $('link[rel=canonical]')
+          .first()
+          .attr('href')
+      ).toBe('/use-amp-hook')
     })
   })
 })


### PR DESCRIPTION
Per consensus in a mixed-application scenario, we'll use the `amp` query parameter convention.

This has a nice side effect of reducing duplication! 😄 