### PR TITLE
Update readme with ZEIT Now deployment guide link

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1761,7 +1761,7 @@ next build
 next start
 ```
 
-To deploy with [ZEIT Now](https://zeit.co/now), see the [Serverless deployment section](#serverless-deployment).
+To deploy Next.js with [ZEIT Now](https://zeit.co/now) see the [ZEIT Guide for Deploying Next.js with Now](https://zeit.co/guides/deploying-nextjs-with-now/).
 
 Next.js can be deployed to other hosting solutions too. Please have a look at the ['Deployment'](https://github.com/zeit/next.js/wiki/Deployment) section of the wiki.
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1808,7 +1808,7 @@ export function render(req: http.IncomingMessage, res: http.ServerResponse) => v
 - [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse)
 - `void` refers to the function not having a return value and is equivalent to JavaScript's `undefined`. Calling the function will finish the request.
 
-Using the serverless, you can deploy Next.js to [ZEIT Now](https://zeit.co/now) with all of the benefits and added ease of control like for example; [custom routes](https://zeit.co/guides/custom-next-js-server-to-routes/) and caching headers. See the [ZEIT Guide for Deploying Next.js with Now](https://zeit.co/guides/deploying-nextjs-with-now/) for more information.
+Using the serverless target, you can deploy Next.js to [ZEIT Now](https://zeit.co/now) with all of the benefits and added ease of control like for example; [custom routes](https://zeit.co/guides/custom-next-js-server-to-routes/) and caching headers. See the [ZEIT Guide for Deploying Next.js with Now](https://zeit.co/guides/deploying-nextjs-with-now/) for more information.
 
 #### One Level Lower
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1761,23 +1761,7 @@ next build
 next start
 ```
 
-For example, to deploy with [`now`](https://zeit.co/now) a `package.json` like follows is recommended:
-
-```json
-{
-  "name": "my-app",
-  "dependencies": {
-    "next": "latest"
-  },
-  "scripts": {
-    "dev": "next",
-    "build": "next build",
-    "start": "next start"
-  }
-}
-```
-
-Then run `now` and enjoy!
+To deploy with [ZEIT Now](https://zeit.co/now), see the [Serverless deployment section](#serverless-deployment).
 
 Next.js can be deployed to other hosting solutions too. Please have a look at the ['Deployment'](https://github.com/zeit/next.js/wiki/Deployment) section of the wiki.
 
@@ -1823,6 +1807,8 @@ export function render(req: http.IncomingMessage, res: http.ServerResponse) => v
 - [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
 - [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse)
 - `void` refers to the function not having a return value and is equivalent to JavaScript's `undefined`. Calling the function will finish the request.
+
+Using the serverless, you can deploy Next.js to [ZEIT Now](https://zeit.co/now) with all of the benefits and added ease of control like for example; [custom routes](https://zeit.co/guides/custom-next-js-server-to-routes/) and caching headers. See the [ZEIT Guide for Deploying Next.js with Now](https://zeit.co/guides/deploying-nextjs-with-now/) for more information.
 
 #### One Level Lower
 


### PR DESCRIPTION
This pull request updates the Next.js readme with the removal of an old ZEIT Now deployment guide and the addition of a link to an external ZEIT Now deployment guide.