### PR TITLE
Bug #6350 - TypeError: sheet.seal is not a function error

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -18,7 +18,7 @@ export default class MyDocument extends Document {
         styles: <>{initialProps.styles}{sheet.getStyleElement()}</>
       }
     } finally {
-      sheet.seal()
+      Object.seal(sheet)
     }
   }
 }


### PR DESCRIPTION
Fix sheet.seal error when using the code example file for the _document.js file.