### PR TITLE
Add tests for AMP style tags

### DIFF
--- a/test/integration/amphtml/components/Bar.js
+++ b/test/integration/amphtml/components/Bar.js
@@ -1,0 +1,12 @@
+export default function Bar() {
+  return (
+    <>
+      <span>Bar!</span>
+      <style jsx>{`
+        div {
+          color: blue;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/test/integration/amphtml/components/Bar.js
+++ b/test/integration/amphtml/components/Bar.js
@@ -1,12 +1,12 @@
-export default function Bar() {
+export default function Bar () {
   return (
-    <>
+    <div>
       <span>Bar!</span>
       <style jsx>{`
-        div {
+        span {
           color: blue;
         }
       `}</style>
-    </>
+    </div>
   )
 }

--- a/test/integration/amphtml/components/Foo.js
+++ b/test/integration/amphtml/components/Foo.js
@@ -1,12 +1,12 @@
-export default function Foo() {
+export default function Foo () {
   return (
-    <>
+    <div>
       <div>Foo!</div>
       <style jsx>{`
         div {
           color: red;
         }
       `}</style>
-    </>
+    </div>
   )
 }

--- a/test/integration/amphtml/components/Foo.js
+++ b/test/integration/amphtml/components/Foo.js
@@ -1,0 +1,12 @@
+export default function Foo() {
+  return (
+    <>
+      <div>Foo!</div>
+      <style jsx>{`
+        div {
+          color: red;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/test/integration/amphtml/pages/styled.js
+++ b/test/integration/amphtml/pages/styled.js
@@ -1,0 +1,14 @@
+import Foo from '../components/Foo'
+import Bar from '../components/Bar'
+
+export default () => (
+  <>
+    <Foo />
+    <Bar />
+    <style jsx global>{`
+      body {
+        background-color: green;
+      }
+    `}</style>
+  </>
+)

--- a/test/integration/amphtml/pages/styled.js
+++ b/test/integration/amphtml/pages/styled.js
@@ -2,7 +2,7 @@ import Foo from '../components/Foo'
 import Bar from '../components/Bar'
 
 export default () => (
-  <>
+  <div>
     <Foo />
     <Bar />
     <style jsx global>{`
@@ -10,5 +10,5 @@ export default () => (
         background-color: green;
       }
     `}</style>
-  </>
+  </div>
 )

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -145,7 +145,7 @@ describe('AMP Usage', () => {
           .first()
           .text()
       ).toMatch(
-        /div.jsx-\d+{color:\w+;}div.jsx-\d+{color:\w+;}body{background-color:\w+;}/
+        /div.jsx-\d+{color:\w+;}span.jsx-\d+{color:\w+;}body{background-color:\w+;}/
       )
     })
   })

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -135,4 +135,18 @@ describe('AMP Usage', () => {
       ).toBe('/use-amp-hook')
     })
   })
+
+  describe('combined styles', () => {
+    it('should combine style tags', async () => {
+      const html = await renderViaHTTP(appPort, '/styled?amp=1')
+      const $ = cheerio.load(html)
+      expect(
+        $('style[amp-custom]')
+          .first()
+          .text()
+      ).toMatch(
+        /div.jsx-\d+{color:\w+;}div.jsx-\d+{color:\w+;}body{background-color:\w+;}/
+      )
+    })
+  })
 })

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -145,7 +145,7 @@ describe('AMP Usage', () => {
           .first()
           .text()
       ).toMatch(
-        /div.jsx-\d+{color:\w+;}span.jsx-\d+{color:\w+;}body{background-color:\w+;}/
+        /div.jsx-\d+{color:red;}span.jsx-\d+{color:blue;}body{background-color:green;}/
       )
     })
   })


### PR DESCRIPTION
Relevant commit: https://github.com/zeit/next.js/commit/f913aabe163aebfbe57a2c407be5e7108559cc3a

~~I needed to upgrade Standard to work with JSX fragment syntax.~~ This caused too much noise so I just stopped using Fragments.