### PR TITLE
Assign deep defaults for custom config

### DIFF
--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -36,7 +36,7 @@ function assignDefaults (userConfig) {
     }
   })
 
-  return {...defaultConfig, ...userConfig}
+  return { ...defaultConfig, ...userConfig }
 }
 
 function normalizeConfig (phase, config) {

--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -26,18 +26,15 @@ const defaultConfig = {
 }
 
 function assignDefaults (userConfig) {
-  if (userConfig.experimental) {
-    userConfig.experimental = {
-      ...defaultConfig.experimental,
-      ...userConfig.experimental
+  Object.keys(userConfig).forEach(key => {
+    const maybeObject = userConfig[key]
+    if ((!!maybeObject) && (maybeObject.constructor === Object)) {
+      userConfig[key] = {
+        ...(defaultConfig[key] || {}),
+        ...userConfig[key]
+      }
     }
-  }
-  if (userConfig.onDemandEntries) {
-    userConfig.onDemandEntries = {
-      ...defaultConfig.onDemandEntries,
-      ...userConfig.onDemandEntries
-    }
-  }
+  })
 
   return {...defaultConfig, ...userConfig}
 }

--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -25,6 +25,23 @@ const defaultConfig = {
   }
 }
 
+function assignDefaults (userConfig) {
+  if (userConfig.experimental) {
+    userConfig.experimental = {
+      ...defaultConfig.experimental,
+      ...userConfig.experimental
+    }
+  }
+  if (userConfig.onDemandEntries) {
+    userConfig.onDemandEntries = {
+      ...defaultConfig.onDemandEntries,
+      ...userConfig.onDemandEntries
+    }
+  }
+
+  return {...defaultConfig, ...userConfig}
+}
+
 function normalizeConfig (phase, config) {
   if (typeof config === 'function') {
     return config(phase, { defaultConfig })
@@ -35,7 +52,7 @@ function normalizeConfig (phase, config) {
 
 export default function loadConfig (phase, dir, customConfig) {
   if (customConfig) {
-    return { ...defaultConfig, configOrigin: 'server', ...customConfig }
+    return assignDefaults({ configOrigin: 'server', ...customConfig })
   }
   const path = findUp.sync(CONFIG_FILE, {
     cwd: dir
@@ -48,19 +65,7 @@ export default function loadConfig (phase, dir, customConfig) {
     if (userConfig.target && !targets.includes(userConfig.target)) {
       throw new Error(`Specified target is invalid. Provided: "${userConfig.target}" should be one of ${targets.join(', ')}`)
     }
-    if (userConfig.experimental) {
-      userConfig.experimental = {
-        ...defaultConfig.experimental,
-        ...userConfig.experimental
-      }
-    }
-    if (userConfig.onDemandEntries) {
-      userConfig.onDemandEntries = {
-        ...defaultConfig.onDemandEntries,
-        ...userConfig.onDemandEntries
-      }
-    }
-    return { ...defaultConfig, configOrigin: CONFIG_FILE, ...userConfig }
+    return assignDefaults({ configOrigin: CONFIG_FILE, ...userConfig })
   }
 
   return defaultConfig

--- a/test/isolated/config.test.js
+++ b/test/isolated/config.test.js
@@ -23,6 +23,12 @@ describe('config', () => {
     expect(config.defaultConfig).toBeDefined()
   })
 
+  it('Should assign defaults deeply to user config', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
+    expect(config.distDir).toEqual('.next')
+    expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
+  })
+
   it('Should pass the customConfig correctly', () => {
     const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, { customConfig: true })
     expect(config.customConfig).toBe(true)
@@ -31,6 +37,12 @@ describe('config', () => {
   it('Should not pass the customConfig when it is null', () => {
     const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, null)
     expect(config.webpack).toBe(null)
+  })
+
+  it('Should assign defaults deeply to customConfig', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, {customConfig: true})
+    expect(config.customConfig).toBe(true)
+    expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
   })
 
   it('Should throw when an invalid target is provided', () => {

--- a/test/isolated/config.test.js
+++ b/test/isolated/config.test.js
@@ -23,7 +23,7 @@ describe('config', () => {
     expect(config.defaultConfig).toBeDefined()
   })
 
-  it('Should assign defaults deeply to user config', () => {
+  it('Should assign object defaults deeply to user config', () => {
     const config = loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
     expect(config.distDir).toEqual('.next')
     expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
@@ -39,10 +39,21 @@ describe('config', () => {
     expect(config.webpack).toBe(null)
   })
 
-  it('Should assign defaults deeply to customConfig', () => {
-    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, {customConfig: true})
+  it('Should assign object defaults deeply to customConfig', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, { customConfig: true, onDemandEntries: { custom: true } })
     expect(config.customConfig).toBe(true)
     expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
+  })
+
+  it('Should allow setting objects which do not have defaults', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, { bogusSetting: { custom: true } })
+    expect(config.bogusSetting).toBeDefined()
+    expect(config.bogusSetting.custom).toBe(true)
+  })
+
+  it('Should override defaults for arrays from user arrays', () => {
+    const config = loadConfig(PHASE_DEVELOPMENT_SERVER, null, { pageExtensions: ['.bogus'] })
+    expect(config.pageExtensions).toEqual(['.bogus'])
   })
 
   it('Should throw when an invalid target is provided', () => {


### PR DESCRIPTION
* Fixes deep defaults not being included when using customConfig.
Carried over from https://github.com/zeit/next.js/pull/6305