### PR TITLE
Use alternate screen buffer if terminal supports it

### DIFF
--- a/packages/next/build/output/clearConsole.ts
+++ b/packages/next/build/output/clearConsole.ts
@@ -2,12 +2,12 @@
 // https://github.com/facebook/jest/blob/d9d501ac342212b8a58ddb23a31518beb7b56f47/packages/jest-util/src/specialChars.ts#L18
 
 const isWindows = process.platform === 'win32'
-const isInteractive = process.stdout.isTTY
+const isInteractive = process.stderr.isTTY
 
 export function clearConsole() {
   if (!isInteractive) {
     return
   }
 
-  process.stdout.write(isWindows ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H')
+  process.stderr.write(isWindows ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H')
 }

--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import createStore from 'unistore'
+import onExit from 'signal-exit'
 
 import { clearConsole } from './clearConsole'
 
@@ -15,7 +16,18 @@ export type OutputState =
 
 export const store = createStore<OutputState>({ appUrl: null, bootstrap: true })
 
+let registered = false
+
 store.subscribe(state => {
+  if (!registered) {
+    registered = true
+
+    process.stderr.write('\u001B[?1049h')
+    onExit(function() {
+      process.stderr.write('\u001B[?1049l')
+    })
+  }
+
   clearConsole()
 
   if (state.bootstrap) {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -82,6 +82,7 @@
     "resolve": "1.5.0",
     "schema-utils": "1.0.0",
     "serialize-javascript": "1.4.0",
+    "signal-exit": "3.0.2",
     "source-map": "0.6.1",
     "strip-ansi": "3.0.1",
     "styled-jsx": "3.2.1",
@@ -119,6 +120,7 @@
     "@types/nanoid": "1.2.0",
     "@types/node-fetch": "2.1.4",
     "@types/rimraf": "2.0.2",
+    "@types/signal-exit": "3.0.0",
     "@types/webpack": "4.4.22",
     "taskr": "1.1.0",
     "typescript": "3.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,6 +1512,11 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/signal-exit@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/signal-exit/-/signal-exit-3.0.0.tgz#75e3b17660cf1f6c6cb8557675b4e680e43bbf36"
+  integrity sha512-MaJ+16SOXz0Z27EMf3d88+B6UDglq1sn140a+5X/ROLkIcEfRq0CPg+1B2efF1GXQn4n+aKH4ti2hHG4Ya+Dzg==
+
 "@types/tapable@*":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
@@ -10651,7 +10656,7 @@ shellwords@^0.1.0, shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@3.0.2, signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=


### PR DESCRIPTION
![](https://file-dslgszwdjp.nextjs.org)

This uses the xterm optional / extension ANSI code (which is implemented by most terminals) to switch to the "Alternate Screen".

This behavior is that `less`, `vim`, `nano`, etc use.

I brought in `signal-exit` because it's really hard to execute something when the program exits _no matter what_ (or so people say).

This also switches us to use `stderr` over `stdout` which appears to be the preferred way of using ANSI control codes.