### PR TITLE
updated module and removed old example in socket.io example

### DIFF
--- a/examples/with-socket.io/README.md
+++ b/examples/with-socket.io/README.md
@@ -36,5 +36,3 @@ yarn dev
 ## The idea behind the example
 
 This example show how to use [socket.io](https://socket.io/) inside a Next.js application. It uses `getInitialProps` to fetch the old messages from a HTTP endpoint as if it was a Rest API. The example combine the WebSocket server with the Next server, in a production application you should split them as different services.
-
-**Example:** [https://next-socket-io.now.sh/](https://next-socket-io.now.sh/)

--- a/examples/with-socket.io/package.json
+++ b/examples/with-socket.io/package.json
@@ -7,8 +7,8 @@
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "socket.io": "^1.7.3",
-    "socket.io-client": "^1.7.3"
+    "socket.io": "^2.2.0",
+    "socket.io-client": "^2.2.0"
   },
   "scripts": {
     "dev": "node server.js",


### PR DESCRIPTION
I tried socket.io example and found socket.io@1.7.3 & socket.io-client@1.7.3 have some vulnerabilities.
Also I noticed the example link written in README.md is an old one. (that is, it doesn't catch up with this commit https://github.com/zeit/next.js/commit/6ed2da4575d946e80da36acf7d2e7cc9ef6c8c3b. ) so I just removed it.