### PR TITLE
Add Html tag for custom Document

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1235,7 +1235,7 @@ Pages in `Next.js` skip the definition of the surrounding document's markup. For
 // Event handlers like onClick can't be added to this file
 
 // ./pages/_document.js
-import Document, { Head, Main, NextScript } from 'next/document'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
@@ -1245,7 +1245,7 @@ class MyDocument extends Document {
 
   render() {
     return (
-      <html>
+      <Html>
         <Head>
           <style>{`body { margin: 0 } /* custom! */`}</style>
         </Head>
@@ -1253,7 +1253,7 @@ class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     )
   }
 }

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -26,14 +26,31 @@ export default class Document extends Component {
     }
   }
 
-  render () {
-    return <html amp={this.props.amphtml ? '' : null}>
-      <Head />
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </html>
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export class Html extends Component {
+  static contextTypes = {
+    _documentProps: PropTypes.any,
+  }
+
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  }
+
+  render() {
+    const { amphtml } = this.context._documentProps
+    return <html amp={amphtml ? '' : null}>{this.props.children}</html>
   }
 }
 


### PR DESCRIPTION
This introduces a new `<Html>` tag for a custom `Document` so that we can correctly toggle the `amp` flag (among other things in the future ... maybe).

This is already "tested" through every other test & the AMP validator -- but let me know if we want explicit tests.