### PR TITLE
[with-sentry] Use env config instead of webpack where possible

### DIFF
--- a/examples/with-sentry/next.config.js
+++ b/examples/with-sentry/next.config.js
@@ -2,10 +2,12 @@ const webpack = require('webpack')
 const nextSourceMaps = require('@zeit/next-source-maps')()
 
 module.exports = nextSourceMaps({
+  env: {
+    SENTRY_DSN: process.env.SENTRY_DSN
+  },
   webpack: (config, { isServer, buildId }) => {
     config.plugins.push(
       new webpack.DefinePlugin({
-        'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN),
         'process.env.SENTRY_RELEASE': JSON.stringify(buildId)
       })
     )


### PR DESCRIPTION
Based on feedback in original PR: https://github.com/zeit/next.js/pull/6362#discussion_r