### PR TITLE
Fix hot reloading in the yarn workspaces example

### DIFF
--- a/examples/with-yarn-workspaces/README.md
+++ b/examples/with-yarn-workspaces/README.md
@@ -51,4 +51,4 @@ In this example we have three workspaces:
 * [Documentation](https://yarnpkg.com/en/docs/workspaces)
 * [yarn workspaces](https://yarnpkg.com/lang/en/docs/cli/workspace)
 * [yarn workspace](https://yarnpkg.com/lang/en/docs/cli/workspaces)
-* [next-plugin-transpile-modules](https://www.npmjs.com/package/next-plugin-transpile-modules)
+* [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules)

--- a/examples/with-yarn-workspaces/packages/web-app/next.config.js
+++ b/examples/with-yarn-workspaces/packages/web-app/next.config.js
@@ -1,7 +1,7 @@
-const withTM = require('next-plugin-transpile-modules')
+const withTM = require('next-transpile-modules')
 
 // Tell webpack to compile the "bar" package
-// https://www.npmjs.com/package/next-plugin-transpile-modules
+// https://www.npmjs.com/package/next-transpile-modules
 module.exports = withTM({
   transpileModules: ['bar']
 })

--- a/examples/with-yarn-workspaces/packages/web-app/package.json
+++ b/examples/with-yarn-workspaces/packages/web-app/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "next": "latest",
-    "next-plugin-transpile-modules": "0.1.1",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "next-transpile-modules": "^2.0.0",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
Next.js 8 introduced some internal changes that broke hot reloading for packages transpiled via `next-transpile-modules` (previously `next-plugin-transpile-modules`).

This PR should fix it.

More details about the bug itself: https://github.com/martpie/next-transpile-modules/blob/master/index.js#L65