### PR TITLE
Remove http-status dependency

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -83,7 +83,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
     target: isServer ? 'node' : 'web',
     externals: isServer && target !== 'serverless' ? [
       (context, request, callback) => {
-        const notExternalModules = ['next/app', 'next/document', 'next/link', 'next/router', 'next/error', 'http-status', 'string-hash', 'hoist-non-react-statics', 'htmlescape']
+        const notExternalModules = ['next/app', 'next/document', 'next/link', 'next/router', 'next/error', 'string-hash', 'hoist-non-react-statics', 'htmlescape']
 
         if (notExternalModules.indexOf(request) !== -1) {
           return callback()

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -67,7 +67,6 @@
     "fresh": "0.5.2",
     "glob": "7.1.2",
     "hoist-non-react-statics": "3.2.0",
-    "http-status": "1.0.1",
     "launch-editor": "2.2.1",
     "loader-utils": "1.1.0",
     "mkdirp-then": "1.2.0",

--- a/packages/next/pages/_error.js
+++ b/packages/next/pages/_error.js
@@ -1,7 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import HTTPStatus from 'http-status'
 import Head from 'next-server/head'
+
+const statusCodes = {
+  400: 'Bad Request',
+  404: 'This page could not be found',
+  500: 'Internal Server Error',
+  501: 'Not Implemented'
+}
 
 export default class Error extends React.Component {
   static displayName = 'ErrorPage'
@@ -14,10 +20,7 @@ export default class Error extends React.Component {
 
   render () {
     const { statusCode } = this.props
-    const title =
-      statusCode === 404
-        ? 'This page could not be found'
-        : HTTPStatus[statusCode] || 'An unexpected error has occurred'
+    const title = statusCodes[statusCode] || 'An unexpected error has occurred'
 
     return (
       <div style={styles.error}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,11 +6103,6 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-http-status@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/http-status/-/http-status-1.0.1.tgz#dc43001a8bfc50ac87d485a892f7578964bc94a2"
-  integrity sha1-3EMAGov8UKyH1IWokvdXiWS8lKI=
-
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"


### PR DESCRIPTION
Removes `http-status` as it has a bunch of status codes that will never happen in Next.js. It's 2.7kB: https://bundlephobia.com/result?p=http-status@1.0.1