### PR TITLE
Update Hapi example

### DIFF
--- a/examples/custom-server-hapi/next-wrapper.js
+++ b/examples/custom-server-hapi/next-wrapper.js
@@ -1,5 +1,3 @@
-const { parse } = require('url')
-
 const nextHandlerWrapper = app => {
   const handler = app.getRequestHandler()
   return async ({ raw, url }, h) => {
@@ -8,7 +6,7 @@ const nextHandlerWrapper = app => {
   }
 }
 const defaultHandlerWrapper = app => async ({ raw: { req, res }, url }) => {
-  const { pathname, query } = parse(url, true)
+  const { pathname, query } = url
   return app.renderToHTML(req, res, pathname, query)
 }
 

--- a/examples/custom-server-hapi/package.json
+++ b/examples/custom-server-hapi/package.json
@@ -7,7 +7,7 @@
     "start": "NODE_ENV=production node server.js"
   },
   "dependencies": {
-    "hapi": "^17.1.1",
+    "hapi": "^18.1.0",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"


### PR DESCRIPTION
Since version 18 (released in January), Hapi's `request.url` returns the parsed URL, so `parse` is not needed.

Ref:
- https://hapijs.com/api#-requesturl
- https://github.com/hapijs/hapi/pull/3822