### PR TITLE
add extra info to authentication

### DIFF
--- a/examples/with-cookie-auth/www/utils/auth.js
+++ b/examples/with-cookie-auth/www/utils/auth.js
@@ -63,12 +63,20 @@ export const withAuthSync = WrappedComponent =>
 export const auth = ctx => {
   const { token } = nextCookie(ctx)
 
+  /*
+   * This happens on server only, ctx.req is available means it's being
+   * rendered on server. If we are on server and token is not available,
+   * means user is not logged in.
+   */
   if (ctx.req && !token) {
     ctx.res.writeHead(302, { Location: '/login' })
     ctx.res.end()
     return
   }
 
+  /*
+   * We already checked for server. This should only happen on client.
+   */
   if (!token) {
     Router.push('/login')
   }

--- a/examples/with-cookie-auth/www/utils/auth.js
+++ b/examples/with-cookie-auth/www/utils/auth.js
@@ -74,9 +74,7 @@ export const auth = ctx => {
     return
   }
 
-  /*
-   * We already checked for server. This should only happen on client.
-   */
+  // We already checked for server. This should only happen on client.
   if (!token) {
     Router.push('/login')
   }


### PR DESCRIPTION
- add extra information to cookie-auth example.

The render happens on server and client. So, based on where the page is being rendered, the logic for retrieving token varies. The comment will be helpful for people who are just starting with next.js authentication flow.