### PR TITLE
Add Error for Exporting When Target Is Not Server

### DIFF
--- a/errors/next-export-serverless.md
+++ b/errors/next-export-serverless.md
@@ -1,0 +1,9 @@
+# Using `next export` with `target` not set to `server`
+
+#### Why This Error Occurred
+
+Next.js can only handle exporting when the `target` is set to `server` (this is the default value). A serverless build, for instance, has no handler for requests–this is usually implemented by a hosting provider.
+
+#### Possible Ways to Fix It
+
+Change `target` to `server`, run `next build`, then run `next export` again.

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -25,6 +25,8 @@ export default async function (dir, options, configuration) {
   const threads = options.threads || Math.max(cpus().length - 1, 1)
   const distDir = join(dir, nextConfig.distDir)
 
+  if (nextConfig.target !== 'server') throw new Error('Cannot export when target is not server. https://err.sh/zeit/next.js/next-export-serverless')
+
   log(`> using build directory: ${distDir}`)
 
   if (!existsSync(distDir)) {


### PR DESCRIPTION
This adds an error (and err.sh page) when exporting when `target` isn't set to `server`

Fixes: #6449 