### PR TITLE
Explicitly set NODE_ENV

### DIFF
--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -75,8 +75,7 @@ if (args['--help']) {
   forwardedArgs.push('--help')
 }
 
-const defaultEnv = command === 'dev' ? 'development' : 'production'
-process.env.NODE_ENV = process.env.NODE_ENV || defaultEnv
+process.env.NODE_ENV = command === 'dev' ? 'development' : 'production'
 
 commands[command]().then((exec) => exec(forwardedArgs))
 


### PR DESCRIPTION
We shouldn't allow `NODE_ENV` to be overwritten because it can interfere with internal processes