### PR TITLE
Fix dynamic require breaking after updating to v8

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -93,7 +93,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
           return callback()
         }
     
-        resolve(request, { basedir: context, preserveSymlinks: true }, (err, res) => {
+        resolve(request, { basedir: dir, preserveSymlinks: true }, (err, res) => {
           if (err) {
             return callback()
           }

--- a/test/integration/dynamic-require/locales/en.js
+++ b/test/integration/dynamic-require/locales/en.js
@@ -1,0 +1,3 @@
+(function en (props) {
+  // no-nop
+})()

--- a/test/integration/dynamic-require/locales/ru.js
+++ b/test/integration/dynamic-require/locales/ru.js
@@ -1,0 +1,3 @@
+(function en (props) {
+  // no-nop
+})()

--- a/test/integration/dynamic-require/pages/index.js
+++ b/test/integration/dynamic-require/pages/index.js
@@ -1,0 +1,7 @@
+const locale = 'ru'
+
+console.log(require(`../locales/${locale}`))
+
+export default () => (
+  <p>If you can see this then we are good 👍</p>
+)

--- a/test/integration/dynamic-require/test/index.test.js
+++ b/test/integration/dynamic-require/test/index.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  renderViaHTTP,
+  launchApp,
+  findPort,
+  killApp
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 30
+
+let server
+let appPort
+
+describe('Dynamic require', () => {
+  beforeAll(async () => {
+    appPort = await findPort()
+    server = await launchApp(join(__dirname, '../'), appPort)
+  })
+  afterAll(() => killApp(server))
+
+  it('should not throw error when dynamic require is used', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    expect(html).toMatch(/If you can see this then we are good/)
+  })
+})


### PR DESCRIPTION
Changing `dir` to `context` breaks dynamic requires. Reverted to fix.

Fixes: #6469 