### PR TITLE
Throw error when Promise is returned in next.config

### DIFF
--- a/errors/promise-in-next-config.md
+++ b/errors/promise-in-next-config.md
@@ -1,0 +1,9 @@
+# Promise In Next Config
+
+#### Why This Error Occurred
+
+A function in `next.config.js` returned a promise which is not supported in Next.js yet
+
+#### Possible Ways to Fix It
+
+Look in your `next.config.js` and make sure you aren't using any asynchronous functions. Also check that any plugins you are using aren't either. 

--- a/errors/promise-in-next-config.md
+++ b/errors/promise-in-next-config.md
@@ -14,4 +14,6 @@ module.exports = {
 
 #### Possible Ways to Fix It
 
-Look in your `next.config.js` and make sure you aren't using any asynchronous functions. Also check that any plugins you are using aren't either. 
+Check your `next.config.js` for `async` or `return Promise`
+
+Potentially a plugin is returning a `Promise` from the webpack function.

--- a/errors/promise-in-next-config.md
+++ b/errors/promise-in-next-config.md
@@ -2,7 +2,15 @@
 
 #### Why This Error Occurred
 
-A function in `next.config.js` returned a promise which is not supported in Next.js yet
+The webpack function in `next.config.js` returned a promise which is not supported in Next.js. For example, below is not supported:
+
+```js
+module.exports = {
+  webpack: async function(config) { 
+    return config
+  }
+}
+```
 
 #### Possible Ways to Fix It
 

--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -41,9 +41,14 @@ function assignDefaults (userConfig) {
 
 function normalizeConfig (phase, config) {
   if (typeof config === 'function') {
-    return config(phase, { defaultConfig })
-  }
+    config = config(phase, { defaultConfig })
 
+    if (typeof config.then === 'function') {
+      throw new Error(
+        '> Promise returned in next config. https://err.sh/zeit/next.js/promise-in-next-config.md'
+      )
+    }
+  }
   return config
 }
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -296,6 +296,13 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
 
   if (typeof config.webpack === 'function') {
     webpackConfig = config.webpack(webpackConfig, { dir, dev, isServer, buildId, config, defaultLoaders, totalPages })
+
+    // @ts-ignore: Property 'then' does not exist on type 'Configuration'
+    if (typeof webpackConfig.then === 'function') {
+      throw new Error(
+        '> Promise returned in next config. https://err.sh/zeit/next.js/promise-in-next-config.md'
+      )
+    }
   }
 
   // Backwards compat for `main.js` entry key

--- a/test/integration/config-promise-error/next.config.js
+++ b/test/integration/config-promise-error/next.config.js
@@ -1,0 +1,5 @@
+module.exports = (phase, { isServer }) => {
+  return new Promise((resolve) => {
+    resolve({ target: 'serverless' })
+  })
+}

--- a/test/integration/config-promise-error/pages/index.js
+++ b/test/integration/config-promise-error/pages/index.js
@@ -1,0 +1,5 @@
+export default function Index (props) {
+  return (
+    <div>Index Page</div>
+  )
+}

--- a/test/integration/config-promise-error/test/index.test.js
+++ b/test/integration/config-promise-error/test/index.test.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  runNextCommand,
+  findPort,
+  File
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 30
+const configFile = new File(join(__dirname, '../next.config.js'))
+
+describe('Promise in next config', () => {
+  afterAll(() => configFile.restore())
+
+  it('should throw error when a promise is return on config', async () => {
+    configFile.write(`
+      module.exports = (phase, { isServer }) => {
+        return new Promise((resolve) => {
+          resolve({ target: 'serverless' })
+        })
+      }
+    `)
+
+    const { stderr } = await runNextCommand(
+      ['dev', join(__dirname, '..'), '-p', await findPort()],
+      { stderr: true }
+    )
+
+    expect(stderr).toMatch(/Error: > Promise returned in next config\. https:\/\/err\.sh\/zeit\/next\.js\/promise-in-next-config\.md/)
+  })
+
+  it('should throw error when a promise is returned on webpack', async () => {
+    configFile.write(`
+      module.exports = (phase, { isServer }) => {
+        return {
+          webpack: async (config) => {
+            return config
+          }
+        }
+      }
+    `)
+
+    const { stderr } = await runNextCommand(
+      ['dev', join(__dirname, '..'), '-p', await findPort()],
+      { stderr: true }
+    )
+
+    expect(stderr).toMatch(/Error: > Promise returned in next config\. https:\/\/err\.sh\/zeit\/next\.js\/promise-in-next-config\.md/)
+  })
+})


### PR DESCRIPTION
After discussion, it was decided we should throw an error when a promise is returned in `next.config.js` as this isn't supported

Fixes: #6416 