### PR TITLE
refactor(on-demand-entries): extract method: setupPing

### DIFF
--- a/packages/next/client/on-demand-entries-client.js
+++ b/packages/next/client/on-demand-entries-client.js
@@ -5,7 +5,10 @@ import { setupPing, currentPage } from './on-demand-entries-utils'
 
 export default async ({ assetPrefix }) => {
   Router.ready(() => {
-    Router.events.on('routeChangeComplete', setupPing)
+    Router.events.on(
+      'routeChangeComplete',
+      setupPing.bind(this, assetPrefix, () => Router.pathname)
+    )
   })
 
   setupPing(assetPrefix, () => Router.pathname, currentPage)

--- a/packages/next/client/on-demand-entries-client.js
+++ b/packages/next/client/on-demand-entries-client.js
@@ -1,57 +1,12 @@
-/* global window, location */
+/* global window */
 
 import Router from 'next/router'
-import fetch from 'unfetch'
-
-let evtSource
-let currentPage
-let retryTimeout
-const retryWait = 5000
+import { setupPing, currentPage } from './on-demand-entries-utils'
 
 export default async ({ assetPrefix }) => {
   Router.ready(() => {
     Router.events.on('routeChangeComplete', setupPing)
   })
 
-  function setupPing (retry) {
-    // Make sure to only create new EventSource request if page has changed
-    if (Router.pathname === currentPage && !retry) return
-    // close current EventSource connection
-    if (evtSource) {
-      evtSource.close()
-    }
-    currentPage = Router.pathname
-
-    const url = `${assetPrefix}/_next/on-demand-entries-ping?page=${currentPage}`
-    evtSource = new window.EventSource(url)
-
-    evtSource.onerror = () => {
-      retryTimeout = setTimeout(() => setupPing(true), retryWait)
-    }
-
-    evtSource.onopen = () => {
-      clearTimeout(retryTimeout)
-    }
-
-    evtSource.onmessage = event => {
-      try {
-        const payload = JSON.parse(event.data)
-        if (payload.invalid) {
-          // Payload can be invalid even if the page does not exist.
-          // So, we need to make sure it exists before reloading.
-          fetch(location.href, {
-            credentials: 'same-origin'
-          }).then(pageRes => {
-            if (pageRes.status === 200) {
-              location.reload()
-            }
-          })
-        }
-      } catch (err) {
-        console.error('on-demand-entries failed to parse response', err)
-      }
-    }
-  }
-
-  setupPing(currentPage)
+  setupPing(assetPrefix, () => Router.pathname, currentPage)
 }

--- a/packages/next/client/on-demand-entries-utils.js
+++ b/packages/next/client/on-demand-entries-utils.js
@@ -1,0 +1,53 @@
+/* global window, location */
+
+import fetch from 'unfetch'
+
+let evtSource
+export let currentPage
+let retryTimeout
+const retryWait = 5000
+
+export function setupPing (assetPrefix, pathnameFn, retry) {
+  const pathname = pathnameFn()
+
+  // Make sure to only create new EventSource request if page has changed
+  if (pathname === currentPage && !retry) return
+  // close current EventSource connection
+  if (evtSource) {
+    evtSource.close()
+  }
+  currentPage = pathname
+
+  const url = `${assetPrefix}/_next/on-demand-entries-ping?page=${currentPage}`
+  evtSource = new window.EventSource(url)
+
+  evtSource.onerror = () => {
+    retryTimeout = setTimeout(
+      () => setupPing(assetPrefix, pathnameFn, true),
+      retryWait
+    )
+  }
+
+  evtSource.onopen = () => {
+    clearTimeout(retryTimeout)
+  }
+
+  evtSource.onmessage = event => {
+    try {
+      const payload = JSON.parse(event.data)
+      if (payload.invalid) {
+        // Payload can be invalid even if the page does not exist.
+        // So, we need to make sure it exists before reloading.
+        fetch(location.href, {
+          credentials: 'same-origin'
+        }).then(pageRes => {
+          if (pageRes.status === 200) {
+            location.reload()
+          }
+        })
+      }
+    } catch (err) {
+      console.error('on-demand-entries failed to parse response', err)
+    }
+  }
+}


### PR DESCRIPTION
This refactors the `setupPing` method so it can be used for the `amp-dev` entry point.

I tried to keep the behavior identical (thus the live binding for `currentPage` and a `pathnameFn` instead of `pathname`).

We can change the behavior post-merge if we'd like, but I tried to keep behavior identical for this change.