### PR TITLE
Add Babel plugin that fixes className for Amp elements

### DIFF
--- a/packages/next/build/babel/plugins/amp-attributes.ts
+++ b/packages/next/build/babel/plugins/amp-attributes.ts
@@ -1,15 +1,12 @@
 import { PluginObj } from '@babel/core'
 import { NodePath } from '@babel/traverse'
-import { JSXElement } from '@babel/types'
+import { JSXOpeningElement } from '@babel/types'
 
 export default function AmpAttributePatcher(...args: any): PluginObj {
   return {
     visitor: {
-      JSXElement(path: NodePath<JSXElement>) {
-        const { openingElement } = path.node
-        if (!openingElement) {
-          return
-        }
+      JSXOpeningElement(path: NodePath<JSXOpeningElement>) {
+        const openingElement = path.node
 
         const { name, attributes } = openingElement
         if (!(name && name.type === 'JSXIdentifier')) {

--- a/packages/next/build/babel/plugins/amp-attributes.ts
+++ b/packages/next/build/babel/plugins/amp-attributes.ts
@@ -1,0 +1,43 @@
+import { PluginObj } from '@babel/core'
+import { NodePath } from '@babel/traverse'
+import { JSXElement } from '@babel/types'
+
+export default function AmpAttributePatcher(...args: any): PluginObj {
+  return {
+    visitor: {
+      JSXElement(path: NodePath<JSXElement>) {
+        const { openingElement } = path.node
+        if (!openingElement) {
+          return
+        }
+
+        const { name, attributes } = openingElement
+        if (!(name && name.type === 'JSXIdentifier')) {
+          return
+        }
+
+        if (!name.name.startsWith('amp-')) {
+          return
+        }
+
+        for (const attribute of attributes) {
+          if (
+            attribute.type !== 'JSXAttribute' ||
+            typeof attribute.name.name !== 'string'
+          ) {
+            continue
+          }
+
+          switch (attribute.name.name) {
+            case 'className':
+              attribute.name.name = 'class'
+              break
+            case 'htmlFor':
+              attribute.name.name = 'for'
+              break
+          }
+        }
+      },
+    },
+  }
+}

--- a/packages/next/build/babel/plugins/amp-attributes.ts
+++ b/packages/next/build/babel/plugins/amp-attributes.ts
@@ -18,20 +18,12 @@ export default function AmpAttributePatcher(...args: any): PluginObj {
         }
 
         for (const attribute of attributes) {
-          if (
-            attribute.type !== 'JSXAttribute' ||
-            typeof attribute.name.name !== 'string'
-          ) {
+          if (attribute.type !== 'JSXAttribute') {
             continue
           }
 
-          switch (attribute.name.name) {
-            case 'className':
-              attribute.name.name = 'class'
-              break
-            case 'htmlFor':
-              attribute.name.name = 'for'
-              break
+          if (attribute.name.name === 'className') {
+            attribute.name.name = 'class'
           }
         }
       },

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -78,6 +78,7 @@ module.exports = (context: any, options: NextBabelPresetOptions = {}): BabelPres
         ...options['transform-runtime']
       }],
       [require('styled-jsx/babel'), styledJsxOptions(options['styled-jsx'])],
+      require('./plugins/amp-attributes'),
       isProduction && require('babel-plugin-transform-react-remove-prop-types')
     ].filter(Boolean)
   }

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -1,9 +1,21 @@
 import babelLoader from 'babel-loader'
 
 module.exports = babelLoader.custom(babel => {
-  const presetItem = babel.createConfigItem(require('../../babel/preset'), { type: 'preset' })
-  const applyCommonJs = babel.createConfigItem(require('../../babel/plugins/commonjs'), { type: 'plugin' })
-  const commonJsItem = babel.createConfigItem(require('@babel/plugin-transform-modules-commonjs'), { type: 'plugin' })
+  const presetItem = babel.createConfigItem(require('../../babel/preset'), {
+    type: 'preset'
+  })
+  const applyCommonJs = babel.createConfigItem(
+    require('../../babel/plugins/commonjs'),
+    { type: 'plugin' }
+  )
+  const applyAmpAttributes = babel.createConfigItem(
+    require('../../babel/plugins/amp-attributes'),
+    { type: 'plugin' }
+  )
+  const commonJsItem = babel.createConfigItem(
+    require('@babel/plugin-transform-modules-commonjs'),
+    { type: 'plugin' }
+  )
 
   const configs = new Set()
 
@@ -13,16 +25,25 @@ module.exports = babelLoader.custom(babel => {
         isServer: opts.isServer,
         dev: opts.dev
       }
-      const loader = Object.assign({
-        cacheCompression: false,
-        cacheDirectory: true
-      }, opts)
+      const loader = Object.assign(
+        {
+          cacheCompression: false,
+          cacheDirectory: true
+        },
+        opts
+      )
       delete loader.isServer
       delete loader.dev
 
       return { loader, custom }
     },
-    config (cfg, { source, customOptions: { isServer, dev } }) {
+    config (
+      cfg,
+      {
+        source,
+        customOptions: { isServer, dev }
+      }
+    ) {
       const options = Object.assign({}, cfg.options)
       if (cfg.hasFilesystemConfig()) {
         for (const file of [cfg.babelrc, cfg.config]) {
@@ -38,10 +59,12 @@ module.exports = babelLoader.custom(babel => {
         options.presets = [...options.presets, presetItem]
       }
 
+      options.plugins = options.plugins || []
+      options.plugins.push(applyAmpAttributes)
+
       // If the file has `module.exports` we have to transpile commonjs because Babel adds `import` statements
       // That break webpack, since webpack doesn't support combining commonjs and esmodules
       if (source.indexOf('module.exports') !== -1) {
-        options.plugins = options.plugins || []
         options.plugins.push(applyCommonJs)
       }
 
@@ -50,9 +73,7 @@ module.exports = babelLoader.custom(babel => {
         ...(options.overrides || []),
         {
           test: /next-server[\\/]dist[\\/]lib/,
-          plugins: [
-            commonJsItem
-          ]
+          plugins: [commonJsItem]
         }
       ]
 

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -1,21 +1,9 @@
 import babelLoader from 'babel-loader'
 
 module.exports = babelLoader.custom(babel => {
-  const presetItem = babel.createConfigItem(require('../../babel/preset'), {
-    type: 'preset'
-  })
-  const applyCommonJs = babel.createConfigItem(
-    require('../../babel/plugins/commonjs'),
-    { type: 'plugin' }
-  )
-  const applyAmpAttributes = babel.createConfigItem(
-    require('../../babel/plugins/amp-attributes'),
-    { type: 'plugin' }
-  )
-  const commonJsItem = babel.createConfigItem(
-    require('@babel/plugin-transform-modules-commonjs'),
-    { type: 'plugin' }
-  )
+  const presetItem = babel.createConfigItem(require('../../babel/preset'), { type: 'preset' })
+  const applyCommonJs = babel.createConfigItem(require('../../babel/plugins/commonjs'), { type: 'plugin' })
+  const commonJsItem = babel.createConfigItem(require('@babel/plugin-transform-modules-commonjs'), { type: 'plugin' })
 
   const configs = new Set()
 
@@ -25,25 +13,16 @@ module.exports = babelLoader.custom(babel => {
         isServer: opts.isServer,
         dev: opts.dev
       }
-      const loader = Object.assign(
-        {
-          cacheCompression: false,
-          cacheDirectory: true
-        },
-        opts
-      )
+      const loader = Object.assign({
+        cacheCompression: false,
+        cacheDirectory: true
+      }, opts)
       delete loader.isServer
       delete loader.dev
 
       return { loader, custom }
     },
-    config (
-      cfg,
-      {
-        source,
-        customOptions: { isServer, dev }
-      }
-    ) {
+    config (cfg, { source, customOptions: { isServer, dev } }) {
       const options = Object.assign({}, cfg.options)
       if (cfg.hasFilesystemConfig()) {
         for (const file of [cfg.babelrc, cfg.config]) {
@@ -59,12 +38,10 @@ module.exports = babelLoader.custom(babel => {
         options.presets = [...options.presets, presetItem]
       }
 
-      options.plugins = options.plugins || []
-      options.plugins.push(applyAmpAttributes)
-
       // If the file has `module.exports` we have to transpile commonjs because Babel adds `import` statements
       // That break webpack, since webpack doesn't support combining commonjs and esmodules
       if (source.indexOf('module.exports') !== -1) {
+        options.plugins = options.plugins || []
         options.plugins.push(applyCommonJs)
       }
 
@@ -73,7 +50,9 @@ module.exports = babelLoader.custom(babel => {
         ...(options.overrides || []),
         {
           test: /next-server[\\/]dist[\\/]lib/,
-          plugins: [commonJsItem]
+          plugins: [
+            commonJsItem
+          ]
         }
       ]
 

--- a/test/integration/amphtml/pages/index.js
+++ b/test/integration/amphtml/pages/index.js
@@ -1,1 +1,5 @@
-export default () => 'Hello World'
+export default () => (
+  <amp-layout className='abc' layout='responsive' width='1' height='1'>
+    <span>Hello World</span>
+  </amp-layout>
+)

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -68,6 +68,9 @@ describe('AMP Usage', () => {
       const html = await renderViaHTTP(appPort, '/?amp=1')
       await validateAMP(html)
       expect(html).toMatch(/Hello World/)
+
+      const $ = cheerio.load(html)
+      expect($('.abc').length === 1)
     })
 
     it('should add link preload for amp script', async () => {


### PR DESCRIPTION
This is a simple Babel plugin that overwrites certain attributes for `amp-` elements.