### PR TITLE
Show error when `router` or `Component` are returned in _app.js

### DIFF
--- a/errors/cant-override-next-props.md
+++ b/errors/cant-override-next-props.md
@@ -1,0 +1,13 @@
+# Can't Override Next Props
+
+#### Why This Error Occurred
+
+In your `pages/_app.js` you returned an object from `getInitialProps` that contained a `router` or `Component` value. These property names are used by Next.js and can not be overwritten.
+
+#### Possible Ways to Fix It
+
+Look in your _app.js component's `getInitialProps` function and make sure neither of these property names are present in the object returned. 
+
+### Useful Links
+
+- [The issue this was reported in: #6480](https://github.com/zeit/next.js/issues/6480)

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -212,6 +212,10 @@ export async function renderToHTML(
       return render(renderElementToString, <ErrorDebug error={err} />)
     }
 
+    if ((props.router || props.Component) && ErrorDebug) {
+      throw new Error(`'router' and 'Component' can not be returned in getInitialProps from _app.js https://err.sh/zeit/next.js/cant-override-next-props.md`)
+    }
+
     const {
       App: EnhancedApp,
       Component: EnhancedComponent,

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -212,7 +212,7 @@ export async function renderToHTML(
       return render(renderElementToString, <ErrorDebug error={err} />)
     }
 
-    if ((props.router || props.Component) && ErrorDebug) {
+    if ((props.router || props.Component) && dev) {
       throw new Error(`'router' and 'Component' can not be returned in getInitialProps from _app.js https://err.sh/zeit/next.js/cant-override-next-props.md`)
     }
 

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -212,7 +212,7 @@ export async function renderToHTML(
       return render(renderElementToString, <ErrorDebug error={err} />)
     }
 
-    if ((props.router || props.Component) && dev) {
+    if (dev && (props.router || props.Component)) {
       throw new Error(`'router' and 'Component' can not be returned in getInitialProps from _app.js https://err.sh/zeit/next.js/cant-override-next-props.md`)
     }
 

--- a/test/integration/no-override-next-props/pages/_app.js
+++ b/test/integration/no-override-next-props/pages/_app.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import App, { Container } from 'next/app'
+
+class MyApp extends App {
+  static async getInitialProps ({ Component, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps, router: () => {} }
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}
+
+export default MyApp

--- a/test/integration/no-override-next-props/pages/index.js
+++ b/test/integration/no-override-next-props/pages/index.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello there 👋</p>
+)

--- a/test/integration/no-override-next-props/test/index.test.js
+++ b/test/integration/no-override-next-props/test/index.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  renderViaHTTP,
+  launchApp,
+  findPort,
+  killApp
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 30
+
+let server
+let appPort
+
+describe('Dynamic require', () => {
+  beforeAll(async () => {
+    appPort = await findPort()
+    server = await launchApp(join(__dirname, '../'), appPort)
+  })
+  afterAll(() => killApp(server))
+
+  it('should show error when a Next prop is returned in _app.getInitialProps', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    expect(html).toMatch(/https:\/\/err\.sh\/zeit\/next\.js\/cant-override-next-props\.md/)
+  })
+})


### PR DESCRIPTION
Fixes: #6480 