### PR TITLE
Updated entries to not output _app and _document in serverless

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -48,7 +48,7 @@ export function createEntrypoints(pages: PagesMapping, target: 'server'|'serverl
     const absolutePagePath = pages[page]
     const bundleFile = page === '/' ? '/index.js' : `${page}.js`
     const bundlePath = join('static', buildId, 'pages', bundleFile)
-    if(target === 'serverless') {
+    if(target === 'serverless' && page !== '/_app' && page !== '/_document') {
       const serverlessLoaderOptions: ServerlessLoaderQuery = {page, absolutePagePath, ...defaultServerlessOptions}
       server[join('pages', bundleFile)] = `next-serverless-loader?${stringify(serverlessLoaderOptions)}!`
     } else if(target === 'server') {

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 /* global jasmine, test */
 import { join } from 'path'
+import { existsSync } from 'fs'
 import {
   nextBuild,
   stopApp,
@@ -63,6 +64,12 @@ describe('Serverless', () => {
     } finally {
       browser.close()
     }
+  })
+
+  it('should not output _app.js and _document.js to serverless build', () => {
+    const serverlessDir = join(appDir, '.next/serverless/pages')
+    expect(existsSync(join(serverlessDir, '_app.js'))).toBeFalsy()
+    expect(existsSync(join(serverlessDir, '_document.js'))).toBeFalsy()
   })
 
   describe('With basic usage', () => {


### PR DESCRIPTION
Since `_app` and `_document` are already bundled in each page in a serverless build they do not need to be outputted to serverless. 