### PR TITLE
Update error handling in with-cookie-auth example

### DIFF
--- a/examples/with-cookie-auth/www/pages/login.js
+++ b/examples/with-cookie-auth/www/pages/login.js
@@ -28,6 +28,7 @@ class Login extends Component {
 
   async handleSubmit (event) {
     event.preventDefault()
+    this.setState({ error: '' })
     const username = this.state.username
     const url = this.props.apiUrl
 
@@ -45,14 +46,14 @@ class Login extends Component {
         // https://github.com/developit/unfetch#caveats
         let error = new Error(response.statusText)
         error.response = response
-        return Promise.reject(error)
+        throw error
       }
     } catch (error) {
       console.error(
         'You have an error in your code or there are Network issues.',
         error
       )
-      throw new Error(error)
+      this.setState({ error: error.message })
     }
   }
 


### PR DESCRIPTION
Playing with this example, I realized that it was not doing what I expected in case of an error coming back from the API (e.g : throw the error to catch it, save it in the state and eventually display it) so I took the liberty to submit some minor changes. 

Thanks for the great work !