### PR TITLE
Add Grommet example

### DIFF
--- a/examples/with-grommet/.babelrc
+++ b/examples/with-grommet/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true }]]
+}

--- a/examples/with-grommet/README.md
+++ b/examples/with-grommet/README.md
@@ -1,0 +1,50 @@
+[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-grommet)
+
+# Example app with Grommet
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-grommet with-grommet-app
+# or
+yarn create next-app --example with-grommet with-grommet-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-grommet
+cd with-grommet
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+### Try it on CodeSandbox
+
+[Open this example on CodeSandbox](https://codesandbox.io/s/github/zeit/next.js/tree/canary/examples/with-grommet)
+
+## The idea behind the example
+
+This example shows how to use the [Grommet UI library](https://grommet.io/) with Next.js.
+
+It works by extending the `<Document />` to enable server-side rendering of `styled-components`, which are used by Grommet, and extending `<App />` to provide a Grommet context (and optionally a theme) for all child pages and components.

--- a/examples/with-grommet/package.json
+++ b/examples/with-grommet/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "with-grommet",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "grommet": "^2.5.5",
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0",
+    "styled-components": "^4.0.0"
+  },
+  "devDependencies": {
+    "babel-plugin-styled-components": "^1.8.0"
+  },
+  "license": "ISC"
+}

--- a/examples/with-grommet/pages/_app.js
+++ b/examples/with-grommet/pages/_app.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import App, { Container } from 'next/app'
+import { Grommet, grommet as grommetTheme } from 'grommet'
+
+export default class MyApp extends App {
+  render () {
+    const { Component, pageProps } = this.props
+    return (
+      <Container>
+        <Grommet theme={grommetTheme}>
+          <Component {...pageProps} />
+        </Grommet>
+      </Container>
+    )
+  }
+}

--- a/examples/with-grommet/pages/_document.js
+++ b/examples/with-grommet/pages/_document.js
@@ -1,0 +1,24 @@
+import Document from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
+
+export default class MyDocument extends Document {
+  static async getInitialProps (ctx) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: App => props => sheet.collectStyles(<App {...props} />)
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: <>{initialProps.styles}{sheet.getStyleElement()}</>
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+}

--- a/examples/with-grommet/pages/index.js
+++ b/examples/with-grommet/pages/index.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Anchor, Box, Heading, Paragraph } from 'grommet'
+
+export default () => (
+  <Box align='center' margin='large'>
+    <Heading>Grommet is awesome!</Heading>
+    <Paragraph>
+      Find out more at <Anchor href='https://v2.grommet.io/'>https://v2.grommet.io/</Anchor>
+    </Paragraph>
+  </Box>
+)


### PR DESCRIPTION
Adds a new example showing how to use the [Grommet UI library](https://grommet.io/) with Next.js.