### PR TITLE
Check if esmodules is supported before enabling useESModules

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -47,11 +47,18 @@ type BabelPreset = {
   plugins?: PluginItem[] | null
 }
 
-module.exports = (context: any, options: NextBabelPresetOptions = {}): BabelPreset => {
+// Taken from https://github.com/babel/babel/commit/d60c5e1736543a6eac4b549553e107a9ba967051#diff-b4beead8ad9195361b4537601cc22532R158
+function supportsStaticESM(caller: any) {
+  return !!(caller && caller.supportsStaticESM);
+}
+
+module.exports = (api: any, options: NextBabelPresetOptions = {}): BabelPreset => {
+  const supportsESM = api.caller(supportsStaticESM)
+  console.log({supportsESM})
   const presetEnvConfig = {
     // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
     // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
-    modules: isDevelopment || isProduction ? false : 'auto',
+    modules: 'auto',
     ...options['preset-env']
   }
   return {
@@ -74,7 +81,7 @@ module.exports = (context: any, options: NextBabelPresetOptions = {}): BabelPres
         corejs: 2,
         helpers: true,
         regenerator: true,
-        useESModules: !isTest && presetEnvConfig.modules !== 'commonjs',
+        useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
         ...options['transform-runtime']
       }],
       [require('styled-jsx/babel'), styledJsxOptions(options['styled-jsx'])],

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -54,7 +54,6 @@ function supportsStaticESM(caller: any) {
 
 module.exports = (api: any, options: NextBabelPresetOptions = {}): BabelPreset => {
   const supportsESM = api.caller(supportsStaticESM)
-  console.log({supportsESM})
   const presetEnvConfig = {
     // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
     // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking


### PR DESCRIPTION
Fixes #6273

This checks if esmodules is supported using the same detection login that @babel/preset-env uses. babel-loader sets the esmodule support flag automatically. This way it will still work with jest etc, but this will allow compilation using the `babel` cli etc that uses next/babel to work.