### PR TITLE
Add workflow with next-stats-action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,9 @@
+workflow "Generate pull request stats" {
+  on = "pull_request"
+  resolves = ["PR Stats"]
+}
+
+action "PR Stats" {
+  uses = "zeit/next-stats-action@master"
+  secrets = ["GITHUB_TOKEN"]
+}


### PR DESCRIPTION
Adds GitHub action to repo that will generate stats for PRs comparing them to the current canary branch