### PR TITLE
Remove trailing spaces

### DIFF
--- a/errors/cant-override-next-props.md
+++ b/errors/cant-override-next-props.md
@@ -6,7 +6,7 @@ In your `pages/_app.js` you returned an object from `getInitialProps` that conta
 
 #### Possible Ways to Fix It
 
-Look in your _app.js component's `getInitialProps` function and make sure neither of these property names are present in the object returned. 
+Look in your _app.js component's `getInitialProps` function and make sure neither of these property names are present in the object returned.
 
 ### Useful Links
 

--- a/errors/circular-structure.md
+++ b/errors/circular-structure.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-`getInitialProps` is serialized to JSON using `JSON.stringify` and sent to the client side for hydrating the page. 
+`getInitialProps` is serialized to JSON using `JSON.stringify` and sent to the client side for hydrating the page.
 
 However, the result returned from `getInitialProps` can't be serialized when it has a circular structure.
 

--- a/errors/multi-tabs.md
+++ b/errors/multi-tabs.md
@@ -8,6 +8,6 @@ More info here: https://tools.ietf.org/html/rfc6202#section-5.1
 
 #### Possible Ways to Fix It
 
-- Don't have too many tabs open to the same Next.js site open in development in the same browser at the same time. 
+- Don't have too many tabs open to the same Next.js site open in development in the same browser at the same time.
 - If using Firefox you can increase this limit by navigating to `about:config` and setting `network.http.max-persistent-connections-per-server` to a higher number
 

--- a/errors/popstate-state-empty.md
+++ b/errors/popstate-state-empty.md
@@ -2,12 +2,12 @@
 
 #### Why This Error Occurred
 
-When using the browser back button the popstate event is triggered. Next.js sets 
+When using the browser back button the popstate event is triggered. Next.js sets
 `popstate` event triggered but `event.state` did not have `url` or `as`, causing a route change failure
 
 #### Possible Ways to Fix It
 
-The only known cause of this issue is manually manipulating `window.history` instead of using `next/router` 
+The only known cause of this issue is manually manipulating `window.history` instead of using `next/router`
 
 ### Useful Links
 

--- a/errors/promise-in-next-config.md
+++ b/errors/promise-in-next-config.md
@@ -6,7 +6,7 @@ The webpack function in `next.config.js` returned a promise which is not support
 
 ```js
 module.exports = {
-  webpack: async function(config) { 
+  webpack: async function(config) {
     return config
   }
 }

--- a/examples/custom-server-actionhero/README.md
+++ b/examples/custom-server-actionhero/README.md
@@ -1,6 +1,6 @@
 # Running Next.JS and React /inside/ of ActionHero
 
-This server will render dynamic next.js/react pages on some routes, and normal ActionHero API requests on others.  
+This server will render dynamic next.js/react pages on some routes, and normal ActionHero API requests on others.<br>
 This configuration works with both Next and ActionHero hot reloading of code.
 
 A more detailed example showcasing how to use fetch and web sockets to interact with your API can be found here: https://github.com/actionhero/next-in-actionhero
@@ -100,7 +100,7 @@ module.exports = class CreateChatRoom extends Action {
 
 3. Tell ActionHero to use the api rather than the file server as the top-level route in `api.config.servers.web.rootEndpointType = 'api'`.  This will allows "/" to listen to API requests.  Also update `api.config.general.paths.public = [ path.join(__dirname, '/../static') ]`.  In this configuration, the next 'static' renderer will take priority over the ActionHero 'public file' api.  Note that any static assets (CSS, fonts, etc) will need to be in "./static" rather than "./public".
 
-Note that this is where the websocket server, if you enable it, will place the `ActionheroWebsocketClient` libraray.  
+Note that this is where the websocket server, if you enable it, will place the `ActionheroWebsocketClient` libraray.<br>
 
 4.  Configure a wild-card route at the lowest priority of your GET handler to catch all web requests that aren't caught by other actions:
 

--- a/examples/custom-server-koa/README.md
+++ b/examples/custom-server-koa/README.md
@@ -50,10 +50,10 @@ The example shows a server that serves the component living in `pages/a.js` when
 
 ## Side note: Enabling gzip compression
 
-The most common Koa middleware for handling the gzip compression is [compress](https://github.com/koajs/compress), but unfortunately it is currently not compatible with Next.  
-`koa-compress` handles the compression of the response body by checking `res.body`, which will be empty in the case of the routes handled by Next (because Next sends and ends the response by itself). 
+The most common Koa middleware for handling the gzip compression is [compress](https://github.com/koajs/compress), but unfortunately it is currently not compatible with Next.<br>
+`koa-compress` handles the compression of the response body by checking `res.body`, which will be empty in the case of the routes handled by Next (because Next sends and ends the response by itself).
 
-If you need to enable the gzip compression, the most simple way to do so is by wrapping the express-middleware [compression](https://github.com/expressjs/compression) with [koa-connect](https://github.com/vkurchatkin/koa-connect):  
+If you need to enable the gzip compression, the most simple way to do so is by wrapping the express-middleware [compression](https://github.com/expressjs/compression) with [koa-connect](https://github.com/vkurchatkin/koa-connect):
 
 ```javascript
 const compression = require('compression');

--- a/examples/root-static-files/static/sitemap.xml
+++ b/examples/root-static-files/static/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> 
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>http://www.example.com/foo.html</loc> 
+    <loc>http://www.example.com/foo.html</loc>
   </url>
 </urlset>

--- a/examples/using-with-router/README.md
+++ b/examples/using-with-router/README.md
@@ -40,6 +40,6 @@ now
 
 ## The idea behind the example
 
-Sometimes, we want to use the `router` inside component of our app without using the singleton `next/router` API. 
+Sometimes, we want to use the `router` inside component of our app without using the singleton `next/router` API.
 
 You can do that by creating a React Higher Order Component with the help of the `withRouter` utility.

--- a/examples/with-algolia-react-instantsearch/README.md
+++ b/examples/with-algolia-react-instantsearch/README.md
@@ -45,5 +45,5 @@ now
 
 ## The idea behind the example
 The goal of this example is to illustrate how you can use [Algolia React InstantSearch](https://community.algolia.com/react-instantsearch/) to perform
-your search with a Server-rendered application developed with Next.js. It also illustrates how you 
-can keep in sync the Url with the search. 
+your search with a Server-rendered application developed with Next.js. It also illustrates how you
+can keep in sync the Url with the search.

--- a/examples/with-cloud9/README.md
+++ b/examples/with-cloud9/README.md
@@ -22,18 +22,18 @@ nvm use node
     const { createServer } = require('http')
     const { parse } = require('url')
     const next = require('next')
-    
+
     const dev = process.env.NODE_ENV !== 'production'
     const app = next({ dev })
     const handle = app.getRequestHandler()
-    
+
     app.prepare().then(() => {
       let server = createServer((req, res) => {
         // Be sure to pass `true` as the second argument to `url.parse`.
         // This tells it to parse the query portion of the URL.
         const parsedUrl = parse(req.url, true)
         const { pathname, query } = parsedUrl
-    
+
         handle(req, res, parsedUrl)
       }).listen(process.env.PORT, process.env.IP || "0.0.0.0", err => {
         if (err) throw err
@@ -41,7 +41,7 @@ nvm use node
         console.log("> Ready on http://", addr.address + ":" + addr.port);
       })
     })
-    
+
 ## Change 'package.json' scripts to use that file ##
 
     "scripts": {
@@ -52,7 +52,7 @@ nvm use node
 
 ## Use dev preview within the Cloud9 VM IDE ##
 
-After starting up the server (by using 'Run' button while having server.js open 
+After starting up the server (by using 'Run' button while having server.js open
 in the IDE editor or by using "npm run dev" in terminal) you should be able to access web server by
 clicking on "Preview" -> "Preview running application" next to 'Run' button in
 the top menu in Cloud9 IDE.

--- a/examples/with-context-api/README.md
+++ b/examples/with-context-api/README.md
@@ -41,7 +41,7 @@ now
 
 ## The idea behind the example*
 
-This example shows how to use react context api in our app. 
+This example shows how to use react context api in our app.
 
 It provides an example of using `pages/_app.js` to include include the context api provider and then shows how both the `pages/index.js` and `pages/about.js` can both share the same data using the context api consumer.
 

--- a/examples/with-dotenv/README.md
+++ b/examples/with-dotenv/README.md
@@ -41,7 +41,7 @@ now
 
 ## The idea behind the example
 
-This example shows how to inline env vars. 
+This example shows how to inline env vars.
 
 **Please note**:
 

--- a/examples/with-env-from-next-config-js/README.md
+++ b/examples/with-env-from-next-config-js/README.md
@@ -46,13 +46,13 @@ More specifically, what that means, is that environmental variables are programm
 returned to your react components (including `getInitialProps`) when the program is built with `next build`.
 
 As the build process (`next build`) is proceeding, `next.config.js` is processed and passed in as a parameter is the variable `phase`.
-`phase` can have the values `PHASE_DEVELOPMENT_SERVER` or `PHASE_PRODUCTION_BUILD` (as defined in `next\constants`).  Based on the variable 
+`phase` can have the values `PHASE_DEVELOPMENT_SERVER` or `PHASE_PRODUCTION_BUILD` (as defined in `next\constants`).  Based on the variable
 `phase`, different environmental variables can be set for use in your react app.  That is, if you reference `process.env.RESTURL_SPEAKERS`
 in your react app, whatever is returned by `next.config.js` as the variable `env`, (or `env.RESTURL_SPEAKERS`) will be accessible in your
 app as `process.env.RESTURL_SPEAKERS`.
 
 > ## Special note
-> 
+>
 > `next build` does a hard coded variable substitution into your JavaScript before the final bundle is created.  This means
 > that if you change your environmental variables outside of your running app, such as in windows with `set` or lunix with `setenv`
 > those changes will not be reflected in your running application until a build happens again (with `next build`).
@@ -63,8 +63,8 @@ This example is not meant to be a reference standard for how to do development, 
 production builds with Next. This is just one possible scenario that could be used if you want the
 following behavior while you are doing development.
 
-* When your run `next dev` or `npm run dev`, you will always use the environmental variables assigned when `isDev` is true in the example. 
-* When you run `next build` then `next start`, assuming you set externally the environmental variable STAGING to anything but 1, you will get the results assuming `isProd` is true. 
+* When your run `next dev` or `npm run dev`, you will always use the environmental variables assigned when `isDev` is true in the example.
+* When you run `next build` then `next start`, assuming you set externally the environmental variable STAGING to anything but 1, you will get the results assuming `isProd` is true.
 * When your run `next build` or `npm run build` in production, if the environmental variable `STAGING` is set to `1`, `isStaging` will be set and you will get those values returned.
 
 You can read more about this feature in thie blog post <a href="https://zeit.co/blog/next5-1" target="_blank">Next.js 5.1: Faster Page Resolution, Environment Config and More</a> (under Environment Config).

--- a/examples/with-firebase-authentication/README.md
+++ b/examples/with-firebase-authentication/README.md
@@ -48,4 +48,4 @@ now
 ```
 
 ## The idea behind the example
-The goal is to authenticate users with firebase and store their auth token in sessions. A logged in user will see their messages on page load and then be able to post new messages. 
+The goal is to authenticate users with firebase and store their auth token in sessions. A logged in user will see their messages on page load and then be able to post new messages.

--- a/examples/with-firebase-hosting-and-typescript/firebase.json
+++ b/examples/with-firebase-hosting-and-typescript/firebase.json
@@ -8,7 +8,7 @@
         "npm run build-functions",
         "npm run build-app",
         "npm run copy-deps",
-        "npm run install-deps"        
+        "npm run install-deps"
     ]
   },
   "hosting": {

--- a/examples/with-mobx-state-tree-typescript/tslint.json
+++ b/examples/with-mobx-state-tree-typescript/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "tslint-config-standard",
-    "tslint:latest", 
+    "tslint:latest",
     "tslint-react"
   ],
   "rules": {
@@ -12,7 +12,7 @@
     "no-console": false,
     "no-object-literal-type-assertion": false,
     "no-submodule-imports": [
-      true, 
+      true,
       "next"
     ],
     "no-unused-variable": false,

--- a/examples/with-next-css/style.css
+++ b/examples/with-next-css/style.css
@@ -4,13 +4,13 @@
 }
 
 /* Post-CSS */
-/* 
+/*
 :root {
   --some-color: red;
 }
 
 .example {
   color: var(--some-color);
-} 
+}
 
 */

--- a/examples/with-next-less/README.md
+++ b/examples/with-next-less/README.md
@@ -41,5 +41,5 @@ now
 
 ## The idea behind the example
 
-This example demonstrates how to use the [next-less plugin](https://github.com/zeit/next-plugins/tree/master/packages/next-less).  
+This example demonstrates how to use the [next-less plugin](https://github.com/zeit/next-plugins/tree/master/packages/next-less).<br>
 It includes patterns for with and without CSS Modules, with PostCSS and with additional webpack configurations on top of the next-less plugin.

--- a/examples/with-react-ga/README.md
+++ b/examples/with-react-ga/README.md
@@ -41,5 +41,5 @@ now
 
 ## The idea behind the example
 
-This example shows the most basic way to use [react-ga](https://github.com/react-ga/react-ga) using custom [App](https://github.com/zeit/next.js#custom-app) 
+This example shows the most basic way to use [react-ga](https://github.com/react-ga/react-ga) using custom [App](https://github.com/zeit/next.js#custom-app)
 component with NextJs. Modify `Tracking ID` in `utils/analytics.js` file for testing this example.

--- a/examples/with-react-with-styles/README.md
+++ b/examples/with-react-with-styles/README.md
@@ -41,10 +41,10 @@ now
 
 ## The idea behind the example
 
-This example features how you use a different styling solution than [styled-jsx](https://github.com/zeit/styled-jsx) that also supports universal styles. 
-That means we can serve the required styles for the first render within the HTML and then load the rest in the client. 
+This example features how you use a different styling solution than [styled-jsx](https://github.com/zeit/styled-jsx) that also supports universal styles.
+That means we can serve the required styles for the first render within the HTML and then load the rest in the client.
 In this case we are using [react-with-styles](https://github.com/airbnb/react-with-styles).
 
 For this purpose we are extending the `<Document />` and injecting the server side rendered styles into the `<head>`.
 
-We are using `pages/_index.js` from this example [with-aphrodite](https://github.com/zeit/next.js/tree/master/examples/with-aphrodite). 
+We are using `pages/_index.js` from this example [with-aphrodite](https://github.com/zeit/next.js/tree/master/examples/with-aphrodite).

--- a/examples/with-redux-observable/README.md
+++ b/examples/with-redux-observable/README.md
@@ -67,13 +67,13 @@ the default export from
 
 We transform the Observable we get from `ajax` into a Promise in order to await
 its resolution. That resolution should be a action (since the epic returns
-Observables of actions). We immediately dispatch that action to the store. 
+Observables of actions). We immediately dispatch that action to the store.
 
 This server-side solution allows compatibility with Next. It may not be
 something you wish to emulate. In other situations, calling or awaiting epics
 directly and passing their result to the store would be an anti-pattern. You
 should only trigger epics by dispatching actions. This solution may not
-generalise to resolving more complicated sets of actions. 
+generalise to resolving more complicated sets of actions.
 
 The layout of the redux related functionality is split between:
 
@@ -85,5 +85,5 @@ The layout of the redux related functionality is split between:
 and organized in `redux/index.js`.
 
 Excepting in those manners discussed above, the configuration is similar the
-configuration found in [with-redux example](https://github.com/zeit/next.js/tree/canary/examples/with-redux) 
-and [redux-observable docs](https://redux-observable.js.org/). 
+configuration found in [with-redux example](https://github.com/zeit/next.js/tree/canary/examples/with-redux)
+and [redux-observable docs](https://redux-observable.js.org/).

--- a/examples/with-refnux/README.md
+++ b/examples/with-refnux/README.md
@@ -42,17 +42,17 @@ now
 
 ## The idea behind the example
 
-This example, just like `with-redux` and `with-mobx` examples, shows how to manage a global state in your web-application. 
+This example, just like `with-redux` and `with-mobx` examples, shows how to manage a global state in your web-application.
 In this case we are using [refnux](https://github.com/algesten/refnux) which is an alternative, simpler, purely functional store state manager.
 
 We have two very similar pages (page1.js, page2.js). They both
 
 - show the current application state, including a simple counter value
 - have a link to jump from one page to the other
-- have an 'increment' button to increment the state of the counter 
+- have an 'increment' button to increment the state of the counter
 (it triggers the `counterIncrement` action)
 
-When running the example, please, increment the counter and note how moving from page 1 to page 2 and back the state is persisted. 
+When running the example, please, increment the counter and note how moving from page 1 to page 2 and back the state is persisted.
 Reloading any of the pages will restore the initial state coming from the server.
 
 

--- a/examples/with-sitemap-and-robots-express-server-typescript/tslint.json
+++ b/examples/with-sitemap-and-robots-express-server-typescript/tslint.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "tslint-config-standard",
-    "tslint:latest", 
+    "tslint:latest",
     "tslint-react"
   ],
   "rules": {
@@ -12,7 +12,7 @@
     "no-console": false,
     "no-object-literal-type-assertion": false,
     "no-submodule-imports": [
-      true, 
+      true,
       "next"
     ],
     "no-unused-variable": false,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -86,35 +86,35 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
         if (notExternalModules.indexOf(request) !== -1) {
           return callback()
         }
-    
+
         resolve(request, { basedir: dir, preserveSymlinks: true }, (err, res) => {
           if (err) {
             return callback()
           }
-    
+
           if (!res) {
             return callback()
           }
-    
+
           // Default pages have to be transpiled
           if (res.match(/next[/\\]dist[/\\]/) || res.match(/node_modules[/\\]@babel[/\\]runtime[/\\]/) || res.match(/node_modules[/\\]@babel[/\\]runtime-corejs2[/\\]/)) {
             return callback()
           }
-    
+
           // Webpack itself has to be compiled because it doesn't always use module relative paths
           if (res.match(/node_modules[/\\]webpack/) || res.match(/node_modules[/\\]css-loader/)) {
             return callback()
           }
-    
+
           // styled-jsx has to be transpiled
           if (res.match(/node_modules[/\\]styled-jsx/)) {
             return callback()
           }
-    
+
           if (res.match(/node_modules[/\\].*\.js$/)) {
             return callback(undefined, `commonjs ${request}`)
           }
-    
+
           callback()
         })
       }

--- a/packages/next/types/webpack.d.ts
+++ b/packages/next/types/webpack.d.ts
@@ -18,7 +18,7 @@
 //                 Grgur Grisogono <https://github.com/grgur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
-  
+
 /// <reference types="node" />
 
 declare module 'webpack' {

--- a/test/integration/basic/pages/dynamic/bundle.js
+++ b/test/integration/basic/pages/dynamic/bundle.js
@@ -25,7 +25,7 @@ const HelloBundle = dynamic({
 
 export default class Bundle extends React.Component {
   static childContextTypes = {
-    data: PropTypes.object 
+    data: PropTypes.object
   }
 
   static getInitialProps ({ query }) {

--- a/test/integration/production/pages/dynamic/bundle.js
+++ b/test/integration/production/pages/dynamic/bundle.js
@@ -24,7 +24,7 @@ const HelloBundle = dynamic({
 
 export default class Bundle extends React.Component {
   static childContextTypes = {
-    data: PropTypes.object 
+    data: PropTypes.object
   }
 
   static getInitialProps ({ query }) {


### PR DESCRIPTION
### changes
#### remove trailing spaces

When I was using example I noticed trailing spaces.
So, this PR removes the trailing spaces of json file, README, and others.

`examples/with-jest-typescript/src/modules/cars/Overview.tsx` also has it, but this time it did not change as tslint error occurs at commit.