### PR TITLE
fixed typo in code comment

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1315,7 +1315,7 @@ class MyDocument extends Document {
     ctx.renderPage = () => originalRenderPage({
       // useful for wrapping the whole react tree
       enhanceApp: App => App,
-      // userful for wrapping in a per-page basis
+      // useful for wrapping in a per-page basis
       enhanceComponent: Component => Component
     })
 


### PR DESCRIPTION
This PR fixes a typo in one of the comments in the "Customizing renderPage" code example. 