### PR TITLE
Change redirect status to 302

### DIFF
--- a/examples/with-cookie-auth/www/pages/profile.js
+++ b/examples/with-cookie-auth/www/pages/profile.js
@@ -50,7 +50,7 @@ Profile.getInitialProps = async ctx => {
   const redirectOnError = () =>
     process.browser
       ? Router.push('/login')
-      : ctx.res.writeHead(301, { Location: '/login' }).end()
+      : ctx.res.writeHead(302, { Location: '/login' }).end()
 
   try {
     const response = await fetch(apiUrl, {


### PR DESCRIPTION
As discussed in #6546, changing redirect status to 302, so the redirect is only temporary