### PR TITLE
Don’t prefetch outside of production

### DIFF
--- a/packages/next-server/lib/router/router.js
+++ b/packages/next-server/lib/router/router.js
@@ -377,7 +377,7 @@ export default class Router {
   async prefetch (url) {
     // We don't add support for prefetch in the development mode.
     // If we do that, our on-demand-entries optimization won't performs better
-    if (process.env.NODE_ENV === 'development') return
+    if (process.env.NODE_ENV !== 'production') return
 
     const { pathname } = parse(url)
     const route = toRoute(pathname)

--- a/test/unit/router.test.js
+++ b/test/unit/router.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import Router from 'next-server/dist/lib/router/router'
+process.env.NODE_ENV = 'production'
 
 class PageLoader {
   constructor (options = {}) {


### PR DESCRIPTION
Fixes #1827 

This doesn't affect integration tests as they'd use `next build` which forces production mode. Development forces `development`.

