### PR TITLE
Remove _error page from blocked pages

### DIFF
--- a/packages/next-server/lib/constants.js
+++ b/packages/next-server/lib/constants.js
@@ -10,8 +10,7 @@ export const CONFIG_FILE = 'next.config.js'
 export const BUILD_ID_FILE = 'BUILD_ID'
 export const BLOCKED_PAGES = [
   '/_document',
-  '/_app',
-  '/_error'
+  '/_app'
 ]
 export const CLIENT_STATIC_FILES_PATH = 'static'
 export const CLIENT_STATIC_FILES_RUNTIME = 'runtime'

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -132,7 +132,7 @@ describe('Production Usage', () => {
     })
 
     it('should block special pages', async () => {
-      const urls = ['/_document', '/_error']
+      const urls = ['/_document', '/_app']
       for (const url of urls) {
         const html = await renderViaHTTP(appPort, url)
         expect(html).toMatch(/404/)


### PR DESCRIPTION
This allows rendering the `_error` component with a custom `statusCode` using a custom server.
Fixes: #6442 