### PR TITLE
Add experimental profiling flag

### DIFF
--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -21,6 +21,7 @@ const defaultConfig = {
     pagesBufferLength: 2
   },
   experimental: {
+    profiling: false,
     amp: false
   }
 }

--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -28,7 +28,7 @@ const defaultConfig = {
       (Number(process.env.CIRCLE_NODE_TOTAL) ||
         (os.cpus() || { length: 1 }).length) - 1
     ),
-    profiling: false,
+    profiling: false
   }
 }
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -292,6 +292,9 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
       target !== 'serverless' && isServer && new NextJsSSRModuleCachePlugin({ outputPath }),
       isServer && new NextJsSsrImportPlugin(),
       !isServer && new BuildManifestPlugin(),
+      config.experimental.profiling && new webpack.debug.ProfilingPlugin({
+        outputPath: path.join(distDir, `profile-events-${isServer ? 'server' : 'client'}.json`)
+      })
     ].filter(Boolean as any as ExcludesFalse)
   }
 

--- a/test/integration/profiling/components/hello-context.js
+++ b/test/integration/profiling/components/hello-context.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class extends React.Component {
+  static contextTypes = {
+    data: PropTypes.object
+  }
+
+  render () {
+    const { data } = this.context
+    return (
+      <div>{data.title}</div>
+    )
+  }
+}

--- a/test/integration/profiling/components/hello1.js
+++ b/test/integration/profiling/components/hello1.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello World 1</p>
+)

--- a/test/integration/profiling/components/hello2.js
+++ b/test/integration/profiling/components/hello2.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Hello World 2</p>
+)

--- a/test/integration/profiling/components/welcome.js
+++ b/test/integration/profiling/components/welcome.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default class Welcome extends React.Component {
+  state = { name: null }
+
+  componentDidMount () {
+    const { name } = this.props
+    this.setState({ name })
+  }
+
+  render () {
+    const { name } = this.state
+    if (!name) return null
+
+    return (
+      <p>Welcome, {name}</p>
+    )
+  }
+}

--- a/test/integration/profiling/next.config.js
+++ b/test/integration/profiling/next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  experimental: {
+    profiling: true
+  },
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60
+  }
+}

--- a/test/integration/profiling/pages/about.js
+++ b/test/integration/profiling/pages/about.js
@@ -1,0 +1,3 @@
+export default () => (
+  <div className='about-page'>About Page</div>
+)

--- a/test/integration/profiling/pages/another.js
+++ b/test/integration/profiling/pages/another.js
@@ -1,0 +1,8 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/'><a>Index Page</a></Link>
+    <p>Another</p>
+  </div>
+)

--- a/test/integration/profiling/pages/counter.js
+++ b/test/integration/profiling/pages/counter.js
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+import { Component } from 'react'
+import Router from 'next/router'
+
+let counter = 0
+
+export default class extends Component {
+  increase () {
+    counter++
+    this.forceUpdate()
+  }
+
+  visitQueryStringPage () {
+    const href = { pathname: '/nav/querystring', query: { id: 10 } }
+    const as = { pathname: '/nav/querystring/10', hash: '10' }
+    Router.push(href, as)
+  }
+
+  render () {
+    return (
+      <div id='counter-page'>
+        <Link href='/no-such-page'><a id='no-such-page'>No Such Page</a></Link>
+        <br />
+        <Link href='/no-such-page' prefetch><a id='no-such-page-prefetch'>No Such Page (with prefetch)</a></Link>
+        <p>This is the home.</p>
+        <div id='counter'>
+          Counter: {counter}
+        </div>
+        <button id='increase' onClick={() => this.increase()}>Increase</button>
+      </div>
+    )
+  }
+}

--- a/test/integration/profiling/pages/dynamic/bundle.js
+++ b/test/integration/profiling/pages/dynamic/bundle.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import dynamic from 'next/dynamic'
+import Router from 'next/router'
+import PropTypes from 'prop-types'
+
+const HelloBundle = dynamic({
+  modules: () => {
+    const components = {
+      HelloContext: import('../../components/hello-context'),
+      Hello1: import('../../components/hello1'),
+      Hello2: import('../../components/hello2')
+    }
+    return components
+  },
+  render: (props, { HelloContext, Hello1, Hello2 }) => (
+    <div>
+      <h1>{props.title}</h1>
+      <HelloContext />
+      <Hello1 />
+      {props.showMore ? <Hello2 /> : null}
+    </div>
+  )
+})
+
+export default class Bundle extends React.Component {
+  static childContextTypes = {
+    data: PropTypes.object
+  }
+
+  static getInitialProps ({ query }) {
+    return { showMore: Boolean(query.showMore) }
+  }
+
+  getChildContext () {
+    return {
+      data: { title: 'ZEIT Rocks' }
+    }
+  }
+
+  toggleShowMore () {
+    if (this.props.showMore) {
+      Router.push('/dynamic/bundle')
+      return
+    }
+
+    Router.push('/dynamic/bundle?showMore=1')
+  }
+
+  render () {
+    const { showMore } = this.props
+
+    return (
+      <div>
+        <HelloBundle showMore={showMore} title="Dynamic Bundle"/>
+        <button
+          id="toggle-show-more"
+          onClick={() => this.toggleShowMore()}
+        >
+          Toggle Show More
+        </button>
+      </div>
+    )
+  }
+}

--- a/test/integration/profiling/pages/dynamic/index.js
+++ b/test/integration/profiling/pages/dynamic/index.js
@@ -1,0 +1,7 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/dynamic/no-chunk'><a>No Chunk</a></Link>
+  </div>
+)

--- a/test/integration/profiling/pages/dynamic/no-chunk.js
+++ b/test/integration/profiling/pages/dynamic/no-chunk.js
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic'
+import Welcome from '../../components/welcome'
+
+const Welcome2 = dynamic(import('../../components/welcome'))
+
+export default () => (
+  <div>
+    <Welcome name='normal' />
+    <Welcome2 name='dynamic' />
+  </div>
+)

--- a/test/integration/profiling/pages/dynamic/no-ssr-custom-loading.js
+++ b/test/integration/profiling/pages/dynamic/no-ssr-custom-loading.js
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(import('../../components/hello1'), {
+  ssr: false,
+  loading: () => (<p>LOADING</p>)
+})
+
+export default Hello

--- a/test/integration/profiling/pages/dynamic/no-ssr.js
+++ b/test/integration/profiling/pages/dynamic/no-ssr.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(import('../../components/hello1'), { ssr: false })
+
+export default Hello

--- a/test/integration/profiling/pages/dynamic/ssr-true.js
+++ b/test/integration/profiling/pages/dynamic/ssr-true.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(import('../../components/hello1'), { ssr: true })
+
+export default Hello

--- a/test/integration/profiling/pages/dynamic/ssr.js
+++ b/test/integration/profiling/pages/dynamic/ssr.js
@@ -1,0 +1,5 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(import('../../components/hello1'))
+
+export default Hello

--- a/test/integration/profiling/pages/error-in-browser-render-status-code.js
+++ b/test/integration/profiling/pages/error-in-browser-render-status-code.js
@@ -1,0 +1,13 @@
+import React from 'react'
+export default class ErrorInRenderPage extends React.Component {
+  render () {
+    if (typeof window !== 'undefined') {
+      const error = new Error('An Expected error occurred')
+      // This will be extracted by getInitialProps in the _error page,
+      // which will result in a different error message being rendered.
+      error.statusCode = 404
+      throw error
+    }
+    return <div />
+  }
+}

--- a/test/integration/profiling/pages/error-in-browser-render.js
+++ b/test/integration/profiling/pages/error-in-browser-render.js
@@ -1,0 +1,9 @@
+import React from 'react'
+export default class ErrorInRenderPage extends React.Component {
+  render () {
+    if (typeof window !== 'undefined') {
+      throw new Error('An Expected error occured')
+    }
+    return <div />
+  }
+}

--- a/test/integration/profiling/pages/error-in-ssr-render.js
+++ b/test/integration/profiling/pages/error-in-ssr-render.js
@@ -1,0 +1,6 @@
+import React from 'react'
+export default class ErrorInRenderPage extends React.Component {
+  render () {
+    throw new Error('An Expected error occured')
+  }
+}

--- a/test/integration/profiling/pages/finish-response.js
+++ b/test/integration/profiling/pages/finish-response.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class extends Component {
+  static getInitialProps ({ res }) {
+    res.end('hi')
+  }
+
+  render () {
+    return <div>hi</div>
+  }
+}

--- a/test/integration/profiling/pages/index/index.js
+++ b/test/integration/profiling/pages/index/index.js
@@ -1,0 +1,8 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href='/about'><a>About Page</a></Link>
+    <p className='index-page'>Hello World</p>
+  </div>
+)

--- a/test/integration/profiling/pages/prefetch.js
+++ b/test/integration/profiling/pages/prefetch.js
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export default () => {
+  return <div>
+    <ul>
+      <li>
+        <Link href='/' prefetch>
+          <a>index</a>
+        </Link>
+      </li>
+      <li>
+        <Link href='/process-env' prefetch>
+          <a>process env</a>
+        </Link>
+      </li>
+      <li>
+        <Link href='/counter' prefetch>
+          <a>counter</a>
+        </Link>
+      </li>
+      <li>
+        <Link href='/about' prefetch>
+          <a>about</a>
+        </Link>
+      </li>
+    </ul>
+  </div>
+}

--- a/test/integration/profiling/pages/process-env.js
+++ b/test/integration/profiling/pages/process-env.js
@@ -1,0 +1,12 @@
+
+if (process.browser) {
+  global.__THIS_SHOULD_ONLY_BE_DEFINED_IN_BROWSER_CONTEXT__ = true
+}
+
+if (!process.browser) {
+  global.__THIS_SHOULD_ONLY_BE_DEFINED_IN_SERVER_CONTEXT__ = true
+}
+
+export default () => (
+  <div id='node-env'>{process.env.NODE_ENV}</div>
+)

--- a/test/integration/profiling/test/index.test.js
+++ b/test/integration/profiling/test/index.test.js
@@ -1,0 +1,42 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  nextServer,
+  nextBuild,
+  startApp,
+  stopApp,
+  renderViaHTTP
+} from 'next-test-utils'
+import fs from 'fs'
+const appDir = join(__dirname, '../')
+let appPort
+let server
+let app
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+const context = {}
+
+describe('Profiling Usage', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    app = nextServer({
+      dir: join(__dirname, '../'),
+      dev: false,
+      quiet: true
+    })
+
+    server = await startApp(app)
+    context.appPort = appPort = server.address().port
+  })
+  afterAll(() => stopApp(server))
+
+  describe('With basic usage', () => {
+    it('should render the page', async () => {
+      expect(fs.existsSync(join(appDir, '.next', 'profile-events-server.json'))).toBe(true)
+      expect(fs.existsSync(join(appDir, '.next', 'profile-events-client.json'))).toBe(true)
+      const html = await renderViaHTTP(appPort, '/')
+      expect(html).toMatch(/Hello World/)
+    })
+  })
+})


### PR DESCRIPTION
Allows for setting:

```
module.exports = {
  experimental: { profiling: true }
}
```

Which will enable `webpack.debug.ProfilingPlugin` for now.

The events.json is output into `.next` as `.next/profile-events-server.json` and `.next/profile-events-client.json`.

These can be dropped into the Chrome devtools performance window to see timings around webpack plugins.

This is currently only useful for the Next.js team to track down performance related things.