### PR TITLE
Replace path-to-regexp with regexparam

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -30,8 +30,8 @@
     "etag": "1.8.1",
     "find-up": "3.0.0",
     "fresh": "0.5.2",
-    "path-to-regexp": "2.1.0",
     "prop-types": "15.6.2",
+    "regexparam": "1.2.0",
     "send": "0.16.1",
     "url": "0.11.0"
   },

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -151,7 +151,7 @@ export default class Server {
   private generateRoutes(): Route[] {
     const routes: Route[] = [
       {
-        match: route('/_next/static/:path*'),
+        match: route('/_next/static/*'),
         fn: async (req, res, params, parsedUrl) => {
           // The commons folder holds commonschunk files
           // The chunks folder holds dynamic entries
@@ -172,7 +172,7 @@ export default class Server {
         },
       },
       {
-        match: route('/_next/:path*'),
+        match: route('/_next/*'),
         // This path is needed because `render()` does a check for `/_next` and the calls the routing again
         fn: async (req, res, _params, parsedUrl) => {
           await this.render404(req, res, parsedUrl)
@@ -183,7 +183,7 @@ export default class Server {
         // (but it should support as many params as needed, separated by '/')
         // Otherwise this will lead to a pretty simple DOS attack.
         // See more: https://github.com/zeit/next.js/issues/2617
-        match: route('/static/:path*'),
+        match: route('/static/*'),
         fn: async (req, res, params, parsedUrl) => {
           const p = join(this.dir, 'static', ...(params.path || []))
           await this.serveStatic(req, res, p, parsedUrl)
@@ -197,7 +197,7 @@ export default class Server {
       // Otherwise this will lead to a pretty simple DOS attack.
       // See more: https://github.com/zeit/next.js/issues/2617
       routes.push({
-        match: route('/:path*'),
+        match: route('/*'),
         fn: async (req, res, _params, parsedUrl) => {
           const { pathname, query } = parsedUrl
           if (!pathname) {

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -49,7 +49,7 @@ function addCorsSupport (req, res) {
   return { preflight: false }
 }
 
-const matchNextPageBundleRequest = route('/_next/static/:buildId/pages/:path*.js(.map)?')
+const matchNextPageBundleRequest = route('/_next/static/:buildId/pages/*.js(.map)?')
 
 // Recursively look up the issuer till it ends up at the root
 function findEntryModule (issuer) {
@@ -125,6 +125,7 @@ export default class HotReloader {
         return
       }
 
+      console.log(params.path)
       const page = `/${params.path.join('/')}`
       if (page === '/_error' || BLOCKED_PAGES.indexOf(page) === -1) {
         try {

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -125,7 +125,6 @@ export default class HotReloader {
         return
       }
 
-      console.log(params.path)
       const page = `/${params.path.join('/')}`
       if (page === '/_error' || BLOCKED_PAGES.indexOf(page) === -1) {
         try {

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -81,7 +81,7 @@ export default class DevServer extends Server {
     // In development we expose all compiled files for react-error-overlay's line show feature
     // We use unshift so that we're sure the routes is defined before Next's default routes
     routes.unshift({
-      match: route('/_next/development/:path*'),
+      match: route('/_next/development/*'),
       fn: async (req, res, params) => {
         const p = join(this.distDir, ...(params.path || []))
         await this.serveStatic(req, res, p)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9371,11 +9371,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.1.0.tgz#7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b"
-  integrity sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==
-
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -10416,6 +10411,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexparam@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/regexparam/-/regexparam-1.2.0.tgz#c447c5c947ea2c823669c0578d3424808b84aae8"
+  integrity sha512-uSDJXp9qGMcTQpYkzK8xb1qc3n5l7y/bed2GO4fXDiiLcMSUSeUYhrzJirnFte1nd153+krKErlTa0c6nyQoMw==
 
 regexpp@^2.0.0, regexpp@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Hi,

I'm trying to replace [path-to-regexp](https://github.com/pillarjs/path-to-regexp) with [regexparam](https://github.com/lukeed/regexparam). The idea is to reduce the size since the former is [1.4kb](https://bundlephobia.com/result?p=path-to-regexp@3.0.0) compared to `regexparam` which is [371b](https://bundlephobia.com/result?p=regexparam@1.2.0).

I encounter some issue when I launch an example in `development`: I get a `404` error on resources with `?ts=...` in the url.

Anyway, I'm not sure to not have broken anything and even not sure that it will reduce the size at the end.

So I would like to have your opinion on this before continuing 😆 

