### PR TITLE
Disable webpack minifier

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -120,6 +120,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
     ],
     optimization: isServer ? {
       splitChunks: false,
+      minimize: target === 'serverless',
       minimizer: target === 'serverless' ? [
         new TerserPlugin({...terserPluginConfig,
           terserOptions: {
@@ -157,6 +158,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
           }
         }
       },
+      minimize: !dev,
       minimizer: !dev ? [
         new TerserPlugin({...terserPluginConfig,
           terserOptions: {


### PR DESCRIPTION
When the webpack `mode` is set to `production`, `minimizer: undefined` means "use the default webpack minifier."

We need to explicitly disable the webpack minifier via `minimize: false`. This should speed up non-serverless builds. 😄 

This doesn't affect dev, but I added the toggle there for consistency.