### PR TITLE
Sort pages between bundles

### DIFF
--- a/packages/next/build/webpack/plugins/build-manifest-plugin.js
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.js
@@ -65,6 +65,10 @@ export default class BuildManifestPlugin {
         assetMap.pages['/'] = assetMap.pages['/index']
       }
 
+      assetMap.pages = Object.keys(assetMap.pages)
+        .sort()
+        .reduce((a, c) => Object.assign(a, { [c]: assetMap.pages[c] }), {})
+
       compilation.assets[BUILD_MANIFEST] = new RawSource(JSON.stringify(assetMap, null, 2))
       callback()
     })


### PR DESCRIPTION
`assetMap`'s `pages` key would change every build, causing bundle invalidation. This ensures we sort the pages to achieve stable ordering: reducing bundle invalidation.