### PR TITLE
Update custom-server-typescript example

### DIFF
--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -1,21 +1,21 @@
 {
   "scripts": {
     "dev": "nodemon",
-    "build": "next build && tsc --project tsconfig.server.json",
-    "start": "cross-env NODE_ENV=production node dist/index.js"
+    "build": "next build && tsc && tsc --project tsconfig.server.json",
+    "start": "cross-env NODE_ENV=production node .next/server"
   },
   "dependencies": {
-    "@zeit/next-typescript": "^1.1.0",
-    "next": "^7.0.0",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "@zeit/next-typescript": "^1.1.1",
+    "next": "^8.0.3",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
   },
   "devDependencies": {
-    "@types/next": "^7.0.0",
-    "@types/react": "^16.6.0",
+    "@types/next": "^7.0.9",
+    "@types/react": "^16.8.7",
     "cross-env": "^5.2.0",
-    "nodemon": "^1.18.8",
+    "nodemon": "^1.18.10",
     "ts-node": "^7.0.1",
-    "typescript": "^3.2.0"
+    "typescript": "^3.3.3333"
   }
 }

--- a/examples/custom-server-typescript/server/index.ts
+++ b/examples/custom-server-typescript/server/index.ts
@@ -21,8 +21,7 @@ app.prepare()
       handle(req, res, parsedUrl)
     }
   })
-  .listen(port, (err) => {
-    if (err) throw err
+  .listen(port, () => {
     console.log(`> Ready on http://localhost:${port}`)
   })
 })

--- a/examples/custom-server-typescript/tsconfig.json
+++ b/examples/custom-server-typescript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "noEmit": true,
     "target": "esnext",
     "module": "esnext",
     "jsx": "preserve",
@@ -21,6 +22,8 @@
       "dom",
       "es2015",
       "es2016"
-    ]
-  }
+    ],
+    "outDir": ".next"
+  },
+  "exclude": [".next", "server/**/*.*"]
 }

--- a/examples/custom-server-typescript/tsconfig.server.json
+++ b/examples/custom-server-typescript/tsconfig.server.json
@@ -1,12 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "module": "commonjs",
-    "outDir": "dist",
     "target": "es2017",
-    "lib": [
-      "es2017"
-    ]
+    "lib": ["es2017"],
+    "outDir": ".next/server"
   },
-  "include": ["server/**/*.ts"]
+  "include": ["server/**/*.ts"],
+  "exclude": [".next"]
 }


### PR DESCRIPTION
* Typecheck server vs. client code independently, ensuring that each respects its own tsconfig.
* Use nextjs default distDir in tsconfig
* Update packages
* Fix type error in server.listen callback