### PR TITLE
docs: add lerna badge in README

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://dev.azure.com/nextjs/next.js/_apis/build/status/zeit.next.js)](https://dev.azure.com/nextjs/next.js/_build/latest?definitionId=3)
 [![Coverage Status](https://coveralls.io/repos/zeit/next.js/badge.svg?branch=master)](https://coveralls.io/r/zeit/next.js?branch=master)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/next-js)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 **Visit [nextjs.org/learn](https://nextjs.org/learn) to get started with Next.js.**
 


### PR DESCRIPTION
next.js is using [lerna](https://lernajs.io/) that's why I think we should add lerna badge.