### PR TITLE
Convert router/router.js to typescript

### DIFF
--- a/packages/next-server/lib/mitt.ts
+++ b/packages/next-server/lib/mitt.ts
@@ -16,7 +16,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 type Handler = (...evts: any[]) => void
 
-export default function mitt() {
+export type MittEmitter = {
+  on(type: string, handler: Handler): void
+  off(type: string, handler: Handler): void
+  emit(type: string, ...evts: any[]): void,
+}
+
+export default function mitt(): MittEmitter {
   const all: { [s: string]: Handler[] } = Object.create(null)
 
   return {

--- a/packages/next-server/lib/router/to-route.ts
+++ b/packages/next-server/lib/router/to-route.ts
@@ -1,0 +1,3 @@
+export function toRoute(path: string): string {
+  return path.replace(/\/$/, '') || '/'
+}

--- a/test/unit/router.test.js
+++ b/test/unit/router.test.js
@@ -17,7 +17,7 @@ class PageLoader {
     }
   }
 
-  prefetch (route) {
+  async prefetch (route) {
     this.prefetched[route] = true
   }
 }


### PR DESCRIPTION
- Removed `fetchRoute` as it was only used once (internal method, non-breaking)
- Convert files to TypeScript
- Don't extend `ServerRouter` from `Router` as it introduces unneeded overhead, we only have to provide `pathname` `asPath` and `query` for `withRouter`. Also added `events` even though it shouldn't be called on SSR, just making sure we don't break things.