### PR TITLE
Ensure all modules are identified

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -11,6 +11,7 @@ import { SERVER_DIRECTORY, REACT_LOADABLE_MANIFEST, CLIENT_STATIC_FILES_RUNTIME_
 import { NEXT_PROJECT_ROOT, NEXT_PROJECT_ROOT_NODE_MODULES, NEXT_PROJECT_ROOT_DIST_CLIENT, PAGES_DIR_ALIAS, DOT_NEXT_ALIAS } from '../lib/constants'
 import {TerserPlugin} from './webpack/plugins/terser-webpack-plugin/src/index'
 import { ServerlessPlugin } from './webpack/plugins/serverless-plugin'
+import { AllModulesIdentifiedPlugin } from './webpack/plugins/all-modules-identified-plugin'
 import { WebpackEntrypoints } from './entries'
 type ExcludesFalse = <T>(x: T | false) => x is T
 
@@ -282,6 +283,9 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
         return devPlugins
       })() : []),
       !dev && new webpack.HashedModuleIdsPlugin(),
+      // This must come after HashedModuleIdsPlugin (it sets any modules that
+      // were missed by HashedModuleIdsPlugin)
+      !dev && new AllModulesIdentifiedPlugin(),
       !dev && new webpack.IgnorePlugin({
         checkResource: (resource: string) => {
           return /react-is/.test(resource)

--- a/packages/next/build/webpack/plugins/all-modules-identified-plugin.ts
+++ b/packages/next/build/webpack/plugins/all-modules-identified-plugin.ts
@@ -1,0 +1,22 @@
+import { Compiler } from 'webpack'
+
+export class AllModulesIdentifiedPlugin {
+  apply(compiler: Compiler) {
+    compiler.hooks.compilation.tap(
+      'AllModulesIdentifiedPlugin',
+      compilation => {
+        compilation.hooks.beforeModuleIds.tap(
+          'AllModulesIdentifiedPlugin',
+          modules => {
+            ;(modules as any[]).forEach(module => {
+              if (module.id != null || !module.identifier) {
+                return
+              }
+              module.id = module.identifier()
+            })
+          }
+        )
+      }
+    )
+  }
+}

--- a/packages/next/build/webpack/plugins/all-modules-identified-plugin.ts
+++ b/packages/next/build/webpack/plugins/all-modules-identified-plugin.ts
@@ -1,6 +1,6 @@
-import { Compiler } from 'webpack'
+import { Compiler, Plugin } from 'webpack'
 
-export class AllModulesIdentifiedPlugin {
+export class AllModulesIdentifiedPlugin implements Plugin {
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(
       'AllModulesIdentifiedPlugin',


### PR DESCRIPTION
Not all modules get IDs from `HashedModuleIdsPlugin`, it looks like webpack 5 does something similar to this so we can remove this in the future.