### PR TITLE
Use relative paths instead of absolute for entry

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -40,7 +40,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
     // Backwards compatibility
     'main.js': [],
     [CLIENT_STATIC_FILES_RUNTIME_MAIN]: [
-      path.join(NEXT_PROJECT_ROOT_DIST_CLIENT, (dev ? `next-dev` : 'next'))
+      path.relative(dir, path.join(NEXT_PROJECT_ROOT_DIST_CLIENT, (dev ? `next-dev` : 'next')))
     ].filter(Boolean)
   } : undefined
 

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -1,4 +1,4 @@
-import { join, normalize } from 'path'
+import { relative as relativePath, join, normalize } from 'path'
 import WebpackDevMiddleware from 'webpack-dev-middleware'
 import WebpackHotMiddleware from 'webpack-hot-middleware'
 import errorOverlayMiddleware from './lib/error-overlay-middleware'
@@ -174,7 +174,7 @@ export default class HotReloader {
 
     let additionalClientEntrypoints = {}
     if (this.config.experimental.amp) {
-      additionalClientEntrypoints[CLIENT_STATIC_FILES_RUNTIME_AMP] = join(NEXT_PROJECT_ROOT_DIST_CLIENT, 'amp-dev')
+      additionalClientEntrypoints[CLIENT_STATIC_FILES_RUNTIME_AMP] = relativePath(this.dir, join(NEXT_PROJECT_ROOT_DIST_CLIENT, 'amp-dev'))
     }
 
     return [


### PR DESCRIPTION
This ensures all of our entry points are relative paths instead of absolute.

Don't merge this until a test comes through that looks for a user's home directory in our build output.