### PR TITLE
Stabilize Chunk ID generation

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -12,6 +12,7 @@ import { NEXT_PROJECT_ROOT, NEXT_PROJECT_ROOT_NODE_MODULES, NEXT_PROJECT_ROOT_DI
 import {TerserPlugin} from './webpack/plugins/terser-webpack-plugin/src/index'
 import { ServerlessPlugin } from './webpack/plugins/serverless-plugin'
 import { AllModulesIdentifiedPlugin } from './webpack/plugins/all-modules-identified-plugin'
+import { HashedChunkIdsPlugin } from './webpack/plugins/hashed-chunk-ids-plugin'
 import { WebpackEntrypoints } from './entries'
 type ExcludesFalse = <T>(x: T | false) => x is T
 
@@ -286,6 +287,9 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
       // This must come after HashedModuleIdsPlugin (it sets any modules that
       // were missed by HashedModuleIdsPlugin)
       !dev && new AllModulesIdentifiedPlugin(),
+      // This sets chunk ids to be hashed versions of their names to reduce
+      // bundle churn
+      !dev && new HashedChunkIdsPlugin(buildId),
       !dev && new webpack.IgnorePlugin({
         checkResource: (resource: string) => {
           return /react-is/.test(resource)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -170,7 +170,6 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
         })
       ] : undefined,
     },
-    recordsPath: path.join(outputPath, 'records.json'),
     context: dir,
     // Kept as function to be backwards compatible
     entry: async () => {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -170,6 +170,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
         })
       ] : undefined,
     },
+    recordsPath: path.join(outputPath, 'records.json'),
     context: dir,
     // Kept as function to be backwards compatible
     entry: async () => {

--- a/packages/next/build/webpack/plugins/hashed-chunk-ids-plugin.ts
+++ b/packages/next/build/webpack/plugins/hashed-chunk-ids-plugin.ts
@@ -1,0 +1,27 @@
+import { Compiler, Plugin } from 'webpack'
+import { createHash } from 'crypto'
+
+export class HashedChunkIdsPlugin implements Plugin {
+  buildId: string
+
+  constructor(buildId: string) {
+    this.buildId = buildId
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.compilation.tap('HashedChunkIdsPlugin', compilation => {
+      compilation.hooks.beforeChunkIds.tap('HashedChunkIdsPlugin', chunks => {
+        for (const chunk of chunks) {
+          if (chunk.id === null && chunk.name) {
+            const id = chunk.name.replace(this.buildId, '')
+
+            chunk.id = createHash('md4')
+              .update(id)
+              .digest('hex')
+              .substr(0, 4)
+          }
+        }
+      })
+    })
+  }
+}

--- a/packages/next/types/webpack.d.ts
+++ b/packages/next/types/webpack.d.ts
@@ -705,6 +705,8 @@ declare module 'webpack' {
                 minimizer?: Array<Plugin | Tapable.Plugin>;
                 /** Generate records with relative paths to be able to move the context folder". */
                 portableRecords?: boolean;
+                /** Tells webpack which algorithm to use when choosing chunk ids. */
+                chunkIds: false | 'natural' | 'named'| 'size' | 'total-size'
             }
         }
 

--- a/packages/next/types/webpack.d.ts
+++ b/packages/next/types/webpack.d.ts
@@ -706,7 +706,7 @@ declare module 'webpack' {
                 /** Generate records with relative paths to be able to move the context folder". */
                 portableRecords?: boolean;
                 /** Tells webpack which algorithm to use when choosing chunk ids. */
-                chunkIds: false | 'natural' | 'named'| 'size' | 'total-size'
+                chunkIds?: false | 'natural' | 'named'| 'size' | 'total-size'
             }
         }
 

--- a/packages/next/types/webpack.d.ts
+++ b/packages/next/types/webpack.d.ts
@@ -705,8 +705,6 @@ declare module 'webpack' {
                 minimizer?: Array<Plugin | Tapable.Plugin>;
                 /** Generate records with relative paths to be able to move the context folder". */
                 portableRecords?: boolean;
-                /** Tells webpack which algorithm to use when choosing chunk ids. */
-                chunkIds: false | 'natural' | 'named'| 'size' | 'total-size'
             }
         }
 


### PR DESCRIPTION
This is as effective as `NamedChunksPlugin` but more space efficient. This will prevent chunk IDs from changing between builds.