### PR TITLE
Remove sourceMaps from amp styles to not go over limit

### DIFF
--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -197,7 +197,9 @@ export class Head extends Component {
                 dangerouslySetInnerHTML={{
                   __html: styles
                     .map(style => style.props.dangerouslySetInnerHTML.__html)
-                    .join(''),
+                    .join('')
+                    .replace(/\/\*# sourceMappingURL=.*\*\//g, '')
+                    .replace(/\/\*@ sourceURL=.*?\*\//g, '')
                 }}
               />
             )}

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -158,6 +158,15 @@ describe('AMP Usage', () => {
         /div.jsx-\d+{color:red;}span.jsx-\d+{color:blue;}body{background-color:green;}/
       )
     })
+
+    it('should remove sourceMaps from styles', async () => {
+      const html = await renderViaHTTP(appPort, '/styled?amp=1')
+      const $ = cheerio.load(html)
+      const styles = $('style[amp-custom]').first().text()
+
+      expect(styles).not.toMatch(/\/\*@ sourceURL=.*?\*\//)
+      expect(styles).not.toMatch(/\/\*# sourceMappingURL=.*\*\//)
+    })
   })
 
   describe('editing a page', () => {


### PR DESCRIPTION
Since amp limits styles to 50K we remove the `sourceMaps` as they are not critical

Fixes: #6570 