### PR TITLE
Add possible explanation for webpack resolve error

### DIFF
--- a/errors/config-resolve-alias.md
+++ b/errors/config-resolve-alias.md
@@ -1,0 +1,22 @@
+# Invalid webpack resolve alias 
+
+#### Why This Error Occurred
+
+When overriding `config.resolve.alias` incorrectly in `next.config.js` webpack will throw an error because private-next-pages is not defined.
+
+#### Possible Ways to Fix It
+
+This is not a bug in Next.js, it's related to the user adding a custom webpack(config) config to next.config.js and overriding internals by not applying Next.js' aliases. Solution would be:
+
+```js
+webpack(config) {
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    // your aliases
+  }
+}
+```
+
+### Useful Links
+
+- [Related issue](https://github.com/zeit/next.js/issues/6681)

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -105,10 +105,15 @@ export default async function build(dir: string, conf = null): Promise<void> {
     if (result.errors.length > 1) {
       result.errors.length = 1
     }
+    const error = result.errors.join('\n\n')
 
     console.error(chalk.red('Failed to compile.\n'))
-    console.error(result.errors.join('\n\n'))
+    console.error(error)
     console.error()
+
+    if (error.indexOf('private-next-pages') > -1) {
+      throw new Error('> webpack config.resolve.alias was incorrectly overriden. https://err.sh/zeit/next.js/invalid-resolve-alias')
+    }
     throw new Error('> Build failed because of webpack errors')
   } else if (result.warnings.length > 0) {
     console.warn(chalk.yellow('Compiled with warnings.\n'))

--- a/test/integration/config-resolve-alias/next.config.js
+++ b/test/integration/config-resolve-alias/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  webpack (config) {
+    config.resolve.alias = {}
+    return config
+  }
+}

--- a/test/integration/config-resolve-alias/pages/index.js
+++ b/test/integration/config-resolve-alias/pages/index.js
@@ -1,0 +1,5 @@
+export default function Index (props) {
+  return (
+    <div>Index</div>
+  )
+}

--- a/test/integration/config-resolve-alias/test/index.test.js
+++ b/test/integration/config-resolve-alias/test/index.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { runNextCommand } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+describe('Invalid resolve alias', () => {
+  it('should show relevant error when webpack resolve alias is wrong', async () => {
+    const { stderr } = await runNextCommand(
+      ['build', join(__dirname, '..')],
+      { stderr: true }
+    )
+
+    expect(stderr).toMatch(
+      'webpack config.resolve.alias was incorrectly overriden. https://err.sh'
+    )
+  })
+})


### PR DESCRIPTION
When overriding `config.resolve.alias` incorrectly webpack will throw an error because private-next-pages is not defined. This adds a more descriptive error explaining the error better.

Fixes: #6681