### PR TITLE
Remove conflicting <head> tags in amp mode

### DIFF
--- a/errors/conflicting-amp-tag.md
+++ b/errors/conflicting-amp-tag.md
@@ -1,0 +1,9 @@
+# Conflicting AMP Tag
+
+#### Why This Error Occurred
+
+In AMP mode Next.js adds certain necessary tags automatically to comply with the AMP standard. You added a tag using `next/head` that conflicts with one of these automatically added tags. 
+
+#### Possible Ways to Fix It
+
+Remove the tag mentioned in the error message from any `<Head></Head>` elements

--- a/test/integration/amphtml/pages/conflicting-tag.js
+++ b/test/integration/amphtml/pages/conflicting-tag.js
@@ -1,0 +1,10 @@
+import Head from 'next/head'
+
+export default () => (
+  <amp-layout className='abc' layout='responsive' width='1' height='1'>
+    <Head>
+      <meta name='viewport' content='something :p' />
+    </Head>
+    <span>Hello World</span>
+  </amp-layout>
+)

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -144,6 +144,15 @@ describe('AMP Usage', () => {
           .attr('href')
       ).toBe('/use-amp-hook')
     })
+
+    it('should remove conflicting amp tags', async () => {
+      const html = await renderViaHTTP(appPort, '/conflicting-tag?amp=1')
+      const $ = cheerio.load(html)
+      await validateAMP(html)
+      expect(
+        $('meta[name=viewport]').attr('content')
+      ).not.toBe('something :p')
+    })
   })
 
   describe('combined styles', () => {


### PR DESCRIPTION
In AMP mode Next.js adds certain necessary tags automatically to comply with AMP. This adds a check to see if a user added a tag using `next/head` that conflicts with one of these automatically added tags. 

Fixes: #6689 