### PR TITLE
Small fix to example custom-server-typescript

### DIFF
--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,5 +1,5 @@
 {
   "watch": ["server"],
-	"ext": "ts",
-	"exec": "ts-node --project tsconfig.server.json server/index.ts"
+  "ext": "ts",
+  "exec": "ts-node --project tsconfig.server.json server/index.ts"
 }

--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,4 +1,5 @@
 {
-  "watch": ["server/**/*.ts"],
-  "exec": "ts-node --project tsconfig.server.json server/index.ts"
+  "watch": ["server"],
+	"ext": "ts",
+	"exec": "ts-node --project tsconfig.server.json server/index.ts"
 }


### PR DESCRIPTION
I noticed that the nodemon.json file was not watching for all file changes in the correct location for filetype .ts (typescript). After some research I found that the "ext" option in the nodemon.json fixes the issue and should work across all operating systems. 