### PR TITLE
Add checking for corresponding pages for link tags

### DIFF
--- a/packages/next-server/server/load-components.ts
+++ b/packages/next-server/server/load-components.ts
@@ -20,7 +20,7 @@ export async function loadComponents(distDir: string, buildId: string, pathname:
   ])
 
   const Component = interopDefault(pageData.mod)
-  const { hasAmp, hasCanonical } = pageData
+  const { hasAmp } = pageData
 
-  return {buildManifest, reactLoadableManifest, Component, Document, App, hasAmp, hasCanonical}
+  return {buildManifest, reactLoadableManifest, Component, Document, App, hasAmp}
 }

--- a/packages/next-server/server/load-components.ts
+++ b/packages/next-server/server/load-components.ts
@@ -11,13 +11,16 @@ export async function loadComponents(distDir: string, buildId: string, pathname:
   const documentPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_document')
   const appPath = join(distDir, SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH, buildId, 'pages', '_app')
 
-  const [buildManifest, reactLoadableManifest, Component, Document, App] = await Promise.all([
+  const [buildManifest, reactLoadableManifest, pageData, Document, App] = await Promise.all([
     require(join(distDir, BUILD_MANIFEST)),
     require(join(distDir, REACT_LOADABLE_MANIFEST)),
-    interopDefault(requirePage(pathname, distDir, opts)),
+    requirePage(pathname, distDir, opts),
     interopDefault(require(documentPath)),
     interopDefault(require(appPath)),
   ])
 
-  return {buildManifest, reactLoadableManifest, Component, Document, App}
+  const Component = interopDefault(pageData.mod)
+  const { hasAmp, hasCanonical } = pageData
+
+  return {buildManifest, reactLoadableManifest, Component, Document, App, hasAmp, hasCanonical}
 }

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -285,7 +285,9 @@ export default class Server {
     query: ParsedUrlQuery = {},
     opts: any,
   ) {
-    const result = await loadComponents(this.distDir, this.buildId, pathname, { amphtml: !!opts.amphtml })
+    const loadOpts = { amphtml: !!opts.amphtml }
+    const result = await loadComponents(this.distDir, this.buildId, pathname, loadOpts)
+    opts.amphtml = loadOpts.amphtml
     return renderToHTML(req, res, pathname, query, { ...opts, ...result  })
   }
 

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -296,10 +296,9 @@ export default class Server {
     res: ServerResponse,
     pathname: string,
     query: ParsedUrlQuery = {},
-    { amphtml, hasAmp, hasCanonical }: {
+    { amphtml, hasAmp }: {
       amphtml?: boolean,
       hasAmp?: boolean,
-      hasCanonical?: boolean,
     } = {},
   ): Promise<string | null> {
     try {
@@ -309,7 +308,7 @@ export default class Server {
         res,
         pathname,
         query,
-        { ...this.renderOpts, amphtml, hasAmp, hasCanonical },
+        { ...this.renderOpts, amphtml, hasAmp },
       )
       return html
     } catch (err) {

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -285,9 +285,7 @@ export default class Server {
     query: ParsedUrlQuery = {},
     opts: any,
   ) {
-    const loadOpts = { amphtml: Boolean(opts.amphtml) }
-    const result = await loadComponents(this.distDir, this.buildId, pathname, loadOpts)
-    opts.amphtml = loadOpts.amphtml
+    const result = await loadComponents(this.distDir, this.buildId, pathname, opts)
     return renderToHTML(req, res, pathname, query, { ...opts, ...result  })
   }
 

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -286,7 +286,7 @@ export default class Server {
     opts: any,
   ) {
     const result = await loadComponents(this.distDir, this.buildId, pathname, { amphtml: !!opts.amphtml })
-    return renderToHTML(req, res, pathname, query, { ...result, ...opts })
+    return renderToHTML(req, res, pathname, query, { ...opts, ...result  })
   }
 
   public async renderToHTML(
@@ -294,7 +294,11 @@ export default class Server {
     res: ServerResponse,
     pathname: string,
     query: ParsedUrlQuery = {},
-    { amphtml }: { amphtml?: boolean } = {},
+    { amphtml, hasAmp, hasCanonical }: {
+      amphtml?: boolean,
+      hasAmp?: boolean,
+      hasCanonical?: boolean,
+    } = {},
   ): Promise<string | null> {
     try {
       // To make sure the try/catch is executed
@@ -303,7 +307,7 @@ export default class Server {
         res,
         pathname,
         query,
-        { ...this.renderOpts, amphtml },
+        { ...this.renderOpts, amphtml, hasAmp, hasCanonical },
       )
       return html
     } catch (err) {

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -286,7 +286,7 @@ export default class Server {
     opts: any,
   ) {
     const result = await loadComponents(this.distDir, this.buildId, pathname, opts)
-    return renderToHTML(req, res, pathname, query, { ...opts, ...result  })
+    return renderToHTML(req, res, pathname, query, { ...result, ...opts, hasAmp: result.hasAmp  })
   }
 
   public async renderToHTML(

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -285,7 +285,7 @@ export default class Server {
     query: ParsedUrlQuery = {},
     opts: any,
   ) {
-    const loadOpts = { amphtml: !!opts.amphtml }
+    const loadOpts = { amphtml: Boolean(opts.amphtml) }
     const result = await loadComponents(this.distDir, this.buildId, pathname, loadOpts)
     opts.amphtml = loadOpts.amphtml
     return renderToHTML(req, res, pathname, query, { ...opts, ...result  })

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -117,7 +117,6 @@ type RenderOpts = {
   dev?: boolean
   amphtml?: boolean
   hasAmp?: boolean
-  hasCanonical?: boolean
   buildManifest: BuildManifest
   reactLoadableManifest: ReactLoadableManifest
   Component: React.ComponentType
@@ -143,7 +142,6 @@ function renderDocument(
     dev,
     amphtml,
     hasAmp,
-    hasCanonical,
     staticMarkup,
     devFiles,
     files,
@@ -155,7 +153,6 @@ function renderDocument(
     query: ParsedUrlQuery
     amphtml: boolean
     hasAmp: boolean,
-    hasCanonical: boolean
     dynamicImportsIds: string[]
     dynamicImports: ManifestItem[]
     files: string[]
@@ -182,7 +179,6 @@ function renderDocument(
           ampEnabled={ampEnabled}
           amphtml={amphtml}
           hasAmp={hasAmp}
-          hasCanonical={hasCanonical}
           staticMarkup={staticMarkup}
           devFiles={devFiles}
           files={files}
@@ -209,7 +205,6 @@ export async function renderToHTML(
     staticMarkup = false,
     amphtml = false,
     hasAmp = false,
-    hasCanonical = false,
     App,
     Document,
     Component,
@@ -321,7 +316,6 @@ export async function renderToHTML(
     pathname,
     amphtml,
     hasAmp,
-    hasCanonical,
     query,
     dynamicImportsIds,
     dynamicImports,

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -116,6 +116,8 @@ type RenderOpts = {
   nextExport?: boolean
   dev?: boolean
   amphtml?: boolean
+  hasAmp?: boolean
+  hasCanonical?: boolean
   buildManifest: BuildManifest
   reactLoadableManifest: ReactLoadableManifest
   Component: React.ComponentType
@@ -140,6 +142,8 @@ function renderDocument(
     err,
     dev,
     amphtml,
+    hasAmp,
+    hasCanonical,
     staticMarkup,
     devFiles,
     files,
@@ -150,6 +154,8 @@ function renderDocument(
     pathname: string
     query: ParsedUrlQuery
     amphtml: boolean
+    hasAmp: boolean,
+    hasCanonical: boolean
     dynamicImportsIds: string[]
     dynamicImports: ManifestItem[]
     files: string[]
@@ -175,6 +181,8 @@ function renderDocument(
           }}
           ampEnabled={ampEnabled}
           amphtml={amphtml}
+          hasAmp={hasAmp}
+          hasCanonical={hasCanonical}
           staticMarkup={staticMarkup}
           devFiles={devFiles}
           files={files}
@@ -200,6 +208,8 @@ export async function renderToHTML(
     dev = false,
     staticMarkup = false,
     amphtml = false,
+    hasAmp = false,
+    hasCanonical = false,
     App,
     Document,
     Component,
@@ -310,6 +320,8 @@ export async function renderToHTML(
     docProps,
     pathname,
     amphtml,
+    hasAmp,
+    hasCanonical,
     query,
     dynamicImportsIds,
     dynamicImports,

--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -51,7 +51,18 @@ export function getPagePath(page: string, distDir: string, opts: PagePathOptions
   return join(serverBuildPath, pagesManifest[page])
 }
 
-export function requirePage(page: string, distDir: string, opts?: PagePathOptions): any {
+export function requirePage(page: string, distDir: string, opts: PagePathOptions = {}): any {
   const pagePath = getPagePath(page, distDir, opts)
-  return require(pagePath)
+  const isAmp = pagePath.indexOf('.amp.') > -1
+  let hasAmpCanonical = false
+  try {
+    hasAmpCanonical = Boolean(
+      getPagePath(page, distDir, { amphtml: !isAmp }),
+    )
+  } catch (_) {}
+
+  return {
+    mod: require(pagePath),
+    [isAmp ? 'hasCanonical' : 'hasAmp']: hasAmpCanonical,
+  }
 }

--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -54,6 +54,7 @@ export function getPagePath(page: string, distDir: string, opts: PagePathOptions
 export function requirePage(page: string, distDir: string, opts: PagePathOptions = {}): any {
   const pagePath = getPagePath(page, distDir, opts)
   const isAmp = pagePath.indexOf('.amp.') > -1
+  opts.amphtml = isAmp
   let hasAmpCanonical = false
   try {
     hasAmpCanonical = Boolean(

--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -55,15 +55,18 @@ export function requirePage(page: string, distDir: string, opts: PagePathOptions
   const pagePath = getPagePath(page, distDir, opts)
   const isAmp = pagePath.indexOf('.amp.') > -1
   opts.amphtml = isAmp
-  let hasAmpCanonical = false
-  try {
-    hasAmpCanonical = Boolean(
-      getPagePath(page, distDir, { amphtml: !isAmp }),
-    )
-  } catch (_) {}
+  let hasAmp = false
+
+  if (!isAmp) {
+    try {
+      hasAmp = Boolean(
+        getPagePath(page, distDir, { amphtml: false }),
+      )
+    } catch (_) {}
+  }
 
   return {
+    hasAmp,
     mod: require(pagePath),
-    [isAmp ? 'hasCanonical' : 'hasAmp']: hasAmpCanonical,
   }
 }

--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -54,16 +54,16 @@ export function getPagePath(page: string, distDir: string, opts: PagePathOptions
 export function requirePage(page: string, distDir: string, opts: PagePathOptions = {}): any {
   const pagePath = getPagePath(page, distDir, opts)
   const isAmp = pagePath.indexOf('.amp.') > -1
-  opts.amphtml = isAmp
   let hasAmp = false
 
-  if (!isAmp) {
+  if (!isAmp && opts.amphtml) {
     try {
       hasAmp = Boolean(
         getPagePath(page, distDir, { amphtml: false }),
       )
     } catch (_) {}
   }
+  opts.amphtml = isAmp
 
   return {
     hasAmp,

--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -56,14 +56,13 @@ export function requirePage(page: string, distDir: string, opts: PagePathOptions
   const isAmp = pagePath.indexOf('.amp.') > -1
   let hasAmp = false
 
-  if (!isAmp && opts.amphtml) {
+  if (!isAmp) {
     try {
-      hasAmp = Boolean(
-        getPagePath(page, distDir, { amphtml: false }),
-      )
+      const ampPage = getPagePath(page, distDir, { amphtml: true })
+      hasAmp = Boolean(ampPage && ampPage.indexOf('.amp') > -1)
     } catch (_) {}
   }
-  opts.amphtml = isAmp
+  opts.amphtml = opts.amphtml || isAmp
 
   return {
     hasAmp,

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -203,7 +203,7 @@ export class Head extends Component {
               name="viewport"
               content="width=device-width,minimum-scale=1,initial-scale=1"
             />
-            {<link rel="canonical" href={page.split('.amp')[0] + (hasCanonical ? '' : '?amp=1')} />}
+            {hasCanonical && <link rel="canonical" href={page} />}
             {/* https://www.ampproject.org/docs/fundamentals/optimize_amp#optimize-the-amp-runtime-loading */}
             <link
               rel="preload"

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -151,7 +151,7 @@ export class Head extends Component {
       styles,
       amphtml,
       hasAmp,
-      hasCanonical,
+      // hasCanonical,
       assetPrefix,
       __NEXT_DATA__,
     } = this.context._documentProps
@@ -203,7 +203,7 @@ export class Head extends Component {
               name="viewport"
               content="width=device-width,minimum-scale=1,initial-scale=1"
             />
-            {hasCanonical && <link rel="canonical" href={page} />}
+            <link rel="canonical" href={page.split('.amp')[0]} />
             {/* https://www.ampproject.org/docs/fundamentals/optimize_amp#optimize-the-amp-runtime-loading */}
             <link
               rel="preload"

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -150,6 +150,8 @@ export class Head extends Component {
       ampEnabled,
       styles,
       amphtml,
+      hasAmp,
+      hasCanonical,
       assetPrefix,
       __NEXT_DATA__,
     } = this.context._documentProps
@@ -201,7 +203,7 @@ export class Head extends Component {
               name="viewport"
               content="width=device-width,minimum-scale=1,initial-scale=1"
             />
-            <link rel="canonical" href={page} />
+            {<link rel="canonical" href={page.split('.amp')[0] + (hasCanonical ? '' : '?amp=1')} />}
             {/* https://www.ampproject.org/docs/fundamentals/optimize_amp#optimize-the-amp-runtime-loading */}
             <link
               rel="preload"
@@ -240,7 +242,7 @@ export class Head extends Component {
         )}
         {!amphtml && (
           <>
-            {ampEnabled && <link rel="amphtml" href={`${page}?amp=1`} />}
+            {ampEnabled && hasAmp && <link rel="amphtml" href={`${page}?amp=1`} />}
             {page !== '/_error' && (
               <link
                 rel="preload"

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -203,7 +203,7 @@ export class Head extends Component {
               name="viewport"
               content="width=device-width,minimum-scale=1,initial-scale=1"
             />
-            {hasCanonical && <link rel="canonical" href={page} />}
+            <link rel="canonical" href={page.split('.amp')[0]} />
             {/* https://www.ampproject.org/docs/fundamentals/optimize_amp#optimize-the-amp-runtime-loading */}
             <link
               rel="preload"

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -151,7 +151,6 @@ export class Head extends Component {
       styles,
       amphtml,
       hasAmp,
-      // hasCanonical,
       assetPrefix,
       __NEXT_DATA__,
     } = this.context._documentProps

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -126,6 +126,8 @@ export default class DevServer extends Server {
       const result = await this.hotReloader.ensurePage(pathname, options.amphtml, this.nextConfig.experimental.amp)
       pathname = result.pathname
       options.amphtml = options.amphtml || result.isAmp
+      options.hasAmp = result.hasAmp
+      options.hasCanonical = result.hasCanonical
     } catch (err) {
       if (err.code === 'ENOENT') {
         res.statusCode = 404

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -127,7 +127,6 @@ export default class DevServer extends Server {
       pathname = result.pathname
       options.amphtml = options.amphtml || result.isAmp
       options.hasAmp = result.hasAmp
-      options.hasCanonical = result.hasCanonical
     } catch (err) {
       if (err.code === 'ENOENT') {
         res.statusCode = 404

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -234,7 +234,11 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
       const absolutePagePath = pagePath.startsWith('next/dist/pages') ? require.resolve(pagePath) : join(pagesDir, pagePath)
 
       page = posix.normalize(pageUrl)
-      const result = { isAmp, pathname: page }
+      const result = {
+        isAmp,
+        pathname: page,
+        [isAmp ? 'hasCanonical' : 'hasAmp']: Boolean(await findPageFile(pagesDir, normalizedPagePath, pageExtensions, !isAmp, ampEnabled))
+      }
 
       await new Promise((resolve, reject) => {
         // Makes sure the page that is being kept in on-demand-entries matches the webpack output

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -237,7 +237,7 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
       const result = {
         isAmp,
         pathname: page,
-        [isAmp ? 'hasCanonical' : 'hasAmp']: Boolean(await findPageFile(pagesDir, normalizedPagePath, pageExtensions, !isAmp, ampEnabled))
+        hasAmp: !isAmp && await findPageFile(pagesDir, normalizedPagePath, pageExtensions, !isAmp, ampEnabled)
       }
 
       await new Promise((resolve, reject) => {

--- a/test/integration/amphtml/pages/normal.js
+++ b/test/integration/amphtml/pages/normal.js
@@ -1,3 +1,1 @@
-export default () => (
-  <div>No AMP for me...</div>
-)
+export default () => <div>No AMP for me...</div>

--- a/test/integration/amphtml/pages/normal.js
+++ b/test/integration/amphtml/pages/normal.js
@@ -1,0 +1,3 @@
+export default () => (
+  <div>No AMP for me...</div>
+)

--- a/test/integration/amphtml/pages/only-amp.amp.js
+++ b/test/integration/amphtml/pages/only-amp.amp.js
@@ -1,0 +1,1 @@
+export default () => <div>Only AMP for me...</div>

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -166,28 +166,6 @@ describe('AMP Usage', () => {
       ).not.toBeTruthy()
     })
 
-    it('should not render canonical link to page with AMP only (implicit)', async () => {
-      const html = await renderViaHTTP(appPort, '/styled')
-      const $ = cheerio.load(html)
-      await validateAMP(html)
-      expect(
-        $('link[rel=canonical]')
-          .first()
-          .attr('href')
-      ).not.toBeTruthy()
-    })
-
-    it('should not render canonical link to page with AMP only (explicit)', async () => {
-      const html = await renderViaHTTP(appPort, '/styled?amp=1')
-      const $ = cheerio.load(html)
-      await validateAMP(html)
-      expect(
-        $('link[rel=canonical]')
-          .first()
-          .attr('href')
-      ).not.toBeTruthy()
-    })
-
     it('should remove conflicting amp tags', async () => {
       const html = await renderViaHTTP(appPort, '/conflicting-tag?amp=1')
       const $ = cheerio.load(html)

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -156,6 +156,28 @@ describe('AMP Usage', () => {
       ).toBe('/use-amp-hook')
     })
 
+    it('should render a canonical regardless of amp-only status (implicit)', async () => {
+      const html = await renderViaHTTP(appPort, '/only-amp')
+      const $ = cheerio.load(html)
+      await validateAMP(html)
+      expect(
+        $('link[rel=canonical]')
+          .first()
+          .attr('href')
+      ).toBe('/only-amp')
+    })
+
+    it('should render a canonical regardless of amp-only status (explicit)', async () => {
+      const html = await renderViaHTTP(appPort, '/only-amp?amp=1')
+      const $ = cheerio.load(html)
+      await validateAMP(html)
+      expect(
+        $('link[rel=canonical]')
+          .first()
+          .attr('href')
+      ).toBe('/only-amp')
+    })
+
     it('should not render amphtml link tag with no AMP page', async () => {
       const html = await renderViaHTTP(appPort, '/normal')
       const $ = cheerio.load(html)

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -166,8 +166,19 @@ describe('AMP Usage', () => {
       ).not.toBeTruthy()
     })
 
-    it('should not render canonical link to page with AMP only', async () => {
+    it('should not render canonical link to page with AMP only (implicit)', async () => {
       const html = await renderViaHTTP(appPort, '/styled')
+      const $ = cheerio.load(html)
+      await validateAMP(html)
+      expect(
+        $('link[rel=canonical]')
+          .first()
+          .attr('href')
+      ).not.toBeTruthy()
+    })
+
+    it('should not render canonical link to page with AMP only (explicit)', async () => {
+      const html = await renderViaHTTP(appPort, '/styled?amp=1')
       const $ = cheerio.load(html)
       await validateAMP(html)
       expect(

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -160,6 +160,17 @@ describe('AMP Usage', () => {
       const html = await renderViaHTTP(appPort, '/normal')
       const $ = cheerio.load(html)
       expect(
+        $('link[rel=amphtml]')
+          .first()
+          .attr('href')
+      ).not.toBeTruthy()
+    })
+
+    it('should not render canonical link to page with AMP only', async () => {
+      const html = await renderViaHTTP(appPort, '/styled')
+      const $ = cheerio.load(html)
+      await validateAMP(html)
+      expect(
         $('link[rel=canonical]')
           .first()
           .attr('href')
@@ -170,9 +181,7 @@ describe('AMP Usage', () => {
       const html = await renderViaHTTP(appPort, '/conflicting-tag?amp=1')
       const $ = cheerio.load(html)
       await validateAMP(html)
-      expect(
-        $('meta[name=viewport]').attr('content')
-      ).not.toBe('something :p')
+      expect($('meta[name=viewport]').attr('content')).not.toBe('something :p')
     })
   })
 
@@ -192,7 +201,9 @@ describe('AMP Usage', () => {
     it('should remove sourceMaps from styles', async () => {
       const html = await renderViaHTTP(appPort, '/styled?amp=1')
       const $ = cheerio.load(html)
-      const styles = $('style[amp-custom]').first().text()
+      const styles = $('style[amp-custom]')
+        .first()
+        .text()
 
       expect(styles).not.toMatch(/\/\*@ sourceURL=.*?\*\//)
       expect(styles).not.toMatch(/\/\*# sourceMappingURL=.*\*\//)

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -156,6 +156,16 @@ describe('AMP Usage', () => {
       ).toBe('/use-amp-hook')
     })
 
+    it('should not render amphtml link tag with no AMP page', async () => {
+      const html = await renderViaHTTP(appPort, '/normal')
+      const $ = cheerio.load(html)
+      expect(
+        $('link[rel=canonical]')
+          .first()
+          .attr('href')
+      ).not.toBeTruthy()
+    })
+
     it('should remove conflicting amp tags', async () => {
       const html = await renderViaHTTP(appPort, '/conflicting-tag?amp=1')
       const $ = cheerio.load(html)

--- a/test/isolated/require-page.test.js
+++ b/test/isolated/require-page.test.js
@@ -59,17 +59,17 @@ describe('getPagePath', () => {
 
 describe('requirePage', () => {
   it('Should require /index.js when using /', async () => {
-    const page = await requirePage('/', distDir)
+    const page = (await requirePage('/', distDir)).mod
     expect(page.test).toBe('hello')
   })
 
   it('Should require /index.js when using /index', async () => {
-    const page = await requirePage('/index', distDir)
+    const page = (await requirePage('/index', distDir)).mod
     expect(page.test).toBe('hello')
   })
 
   it('Should require /world.js when using /world', async () => {
-    const page = await requirePage('/world', distDir)
+    const page = (await requirePage('/world', distDir)).mod
     expect(page.test).toBe('world')
   })
 


### PR DESCRIPTION
This adds a check for correspondings pages e.g. `dog.js` and `dog.amp.js` so we can create the correct `rel="canonical"` and only add `rel="amphtml"` when an AMP page is present. 

Closes: #6710 