### PR TITLE
Ensure browser gets closed during testing

### DIFF
--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -230,29 +230,44 @@ describe('AMP Usage', () => {
     })
     afterAll(() => killApp(ampDynamic))
     it('should detect the changes and display it', async () => {
-      let browser = await webdriver(dynamicAppPort, '/hmr/test')
-      const text = await browser.elementByCss('p').text()
-      expect(text).toBe('This is the hot AMP page.')
+      let browser
+      try {
+        browser = await webdriver(dynamicAppPort, '/hmr/test')
+        const text = await browser.elementByCss('p').text()
+        expect(text).toBe('This is the hot AMP page.')
 
-      const hmrTestPagePath = join(__dirname, '../', 'pages', 'hmr', 'test.js')
+        const hmrTestPagePath = join(
+          __dirname,
+          '../',
+          'pages',
+          'hmr',
+          'test.js'
+        )
 
-      const originalContent = readFileSync(hmrTestPagePath, 'utf8')
-      const editedContent = originalContent.replace(
-        'This is the hot AMP page',
-        'This is a cold AMP page'
-      )
+        const originalContent = readFileSync(hmrTestPagePath, 'utf8')
+        const editedContent = originalContent.replace(
+          'This is the hot AMP page',
+          'This is a cold AMP page'
+        )
 
-      // change the content
-      writeFileSync(hmrTestPagePath, editedContent, 'utf8')
+        // change the content
+        writeFileSync(hmrTestPagePath, editedContent, 'utf8')
 
-      await check(() => getBrowserBodyText(browser), /This is a cold AMP page/)
+        await check(
+          () => getBrowserBodyText(browser),
+          /This is a cold AMP page/
+        )
 
-      // add the original content
-      writeFileSync(hmrTestPagePath, originalContent, 'utf8')
+        // add the original content
+        writeFileSync(hmrTestPagePath, originalContent, 'utf8')
 
-      await check(() => getBrowserBodyText(browser), /This is the hot AMP page/)
-
-      await browser.close()
+        await check(
+          () => getBrowserBodyText(browser),
+          /This is the hot AMP page/
+        )
+      } finally {
+        await browser.close()
+      }
     })
   })
 })

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -230,46 +230,29 @@ describe('AMP Usage', () => {
     })
     afterAll(() => killApp(ampDynamic))
     it('should detect the changes and display it', async () => {
-      let browser
-      try {
-        browser = await webdriver(dynamicAppPort, '/hmr/test')
-        const text = await browser.elementByCss('p').text()
-        expect(text).toBe('This is the hot AMP page.')
+      let browser = await webdriver(dynamicAppPort, '/hmr/test')
+      const text = await browser.elementByCss('p').text()
+      expect(text).toBe('This is the hot AMP page.')
 
-        const hmrTestPagePath = join(
-          __dirname,
-          '../',
-          'pages',
-          'hmr',
-          'test.js'
-        )
+      const hmrTestPagePath = join(__dirname, '../', 'pages', 'hmr', 'test.js')
 
-        const originalContent = readFileSync(hmrTestPagePath, 'utf8')
-        const editedContent = originalContent.replace(
-          'This is the hot AMP page',
-          'This is a cold AMP page'
-        )
+      const originalContent = readFileSync(hmrTestPagePath, 'utf8')
+      const editedContent = originalContent.replace(
+        'This is the hot AMP page',
+        'This is a cold AMP page'
+      )
 
-        // change the content
-        writeFileSync(hmrTestPagePath, editedContent, 'utf8')
+      // change the content
+      writeFileSync(hmrTestPagePath, editedContent, 'utf8')
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is a cold AMP page/
-        )
+      await check(() => getBrowserBodyText(browser), /This is a cold AMP page/)
 
-        // add the original content
-        writeFileSync(hmrTestPagePath, originalContent, 'utf8')
+      // add the original content
+      writeFileSync(hmrTestPagePath, originalContent, 'utf8')
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is the hot AMP page/
-        )
-      } finally {
-        if (browser) {
-          browser.close()
-        }
-      }
+      await check(() => getBrowserBodyText(browser), /This is the hot AMP page/)
+
+      await browser.close()
     })
   })
 })

--- a/test/integration/app-aspath/test/index.test.js
+++ b/test/integration/app-aspath/test/index.test.js
@@ -48,6 +48,6 @@ describe('App asPath', () => {
 
     // Change back to the original content
     writeFileSync(appPath, originalContent, 'utf8')
-    browser.quit()
+    await browser.close()
   })
 })

--- a/test/integration/app-document/test/client.js
+++ b/test/integration/app-document/test/client.js
@@ -35,7 +35,7 @@ export default (context, render) => {
       } finally {
         writeFileSync(appPath, originalContent, 'utf8')
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -70,7 +70,7 @@ export default (context, render) => {
       } finally {
         writeFileSync(appPath, originalContent, 'utf8')
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -86,7 +86,7 @@ export default (context, render) => {
         .elementByCss('#random-number').text()
 
       expect(switchedRandomNumer).toBe(randomNumber)
-      browser.close()
+      await browser.close()
     })
 
     it('It should share module state with pages', async () => {
@@ -94,7 +94,7 @@ export default (context, render) => {
 
       const text = await browser.elementByCss('#currentstate').text()
       expect(text).toBe('UPDATED CLIENT')
-      browser.close()
+      await browser.close()
     })
   })
 }

--- a/test/integration/app-document/test/csp.js
+++ b/test/integration/app-document/test/csp.js
@@ -8,14 +8,14 @@ export default (context, render) => {
       const browser = await webdriver(context.appPort, '/?withCSP=hash')
       const errLog = await browser.log('browser')
       expect(errLog.filter((e) => e.source === 'security')).toEqual([])
-      browser.close()
+      await browser.close()
     })
 
     it('should load inline script by nonce', async () => {
       const browser = await webdriver(context.appPort, '/?withCSP=nonce')
       const errLog = await browser.log('browser')
       expect(errLog.filter((e) => e.source === 'security')).toEqual([])
-      browser.close()
+      await browser.close()
     })
   })
 }

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -14,7 +14,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the about page.')
-        browser.close()
+        await browser.close()
       })
 
       it('should navigate via the client side', async () => {
@@ -29,7 +29,7 @@ export default (context) => {
           .elementByCss('#counter').text()
 
         expect(counterText).toBe('Counter: 1')
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -43,7 +43,7 @@ export default (context) => {
         expect(JSON.parse(urlResult)).toMatchObject({ 'query': { 'added': 'yes' }, 'pathname': '/nav/url-prop-change', 'asPath': '/nav/url-prop-change?added=yes' })
         expect(JSON.parse(previousUrlResult)).toMatchObject({ 'query': {}, 'pathname': '/nav/url-prop-change', 'asPath': '/nav/url-prop-change' })
 
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -56,7 +56,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the home.')
-        browser.quit()
+        await browser.close()
       })
 
       it('should not navigate if the <a/> tag has a target', async () => {
@@ -68,7 +68,7 @@ export default (context) => {
           .elementByCss('#counter').text()
 
         expect(counterText).toBe('Counter: 1')
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -81,7 +81,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the passHref prop page.')
-        browser.close()
+        await browser.close()
       })
 
       it('should redirect if passHref prop is defined in Link', async () => {
@@ -92,7 +92,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the home.')
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -110,7 +110,7 @@ export default (context) => {
           )
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -125,7 +125,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('2')
-        browser.close()
+        await browser.close()
       })
 
       it('should remove querystring', async () => {
@@ -136,7 +136,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('0')
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -151,7 +151,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(countAfterClicked).toBe('COUNT: 1')
-        browser.close()
+        await browser.close()
       })
 
       it('should always replace the state', async () => {
@@ -172,7 +172,7 @@ export default (context) => {
           .back()
           .waitForElementByCss('.nav-home')
 
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -194,7 +194,7 @@ export default (context) => {
           expect(countStateAfterClicked).toBe('STATE COUNT: 1')
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -223,7 +223,7 @@ export default (context) => {
           expect(countStateAfterClickedAgain).toBe('STATE COUNT: 2')
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -248,7 +248,7 @@ export default (context) => {
           await browser.back().waitForElementByCss('.nav-home')
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -265,7 +265,7 @@ export default (context) => {
 
           expect(counter).toBe('COUNT: 0')
 
-          browser.close()
+          await browser.close()
         })
 
         it('should scroll to the specified position on the same page', async () => {
@@ -288,7 +288,7 @@ export default (context) => {
             expect(scrollPositionAfterEmptyHash).toBe(0)
           } finally {
             if (browser) {
-              browser.close()
+              await browser.close()
             }
           }
         })
@@ -315,7 +315,7 @@ export default (context) => {
             expect(scrollPositionAfterEmptyHash).toBe(0)
           } finally {
             if (browser) {
-              browser.close()
+              await browser.close()
             }
           }
         })
@@ -334,7 +334,7 @@ export default (context) => {
             expect(scrollPosition).toBe(7258)
           } finally {
             if (browser) {
-              browser.close()
+              await browser.close()
             }
           }
         })
@@ -350,7 +350,7 @@ export default (context) => {
 
           expect(counter).toBe('COUNT: 0')
 
-          browser.close()
+          await browser.close()
         })
       })
 
@@ -365,7 +365,7 @@ export default (context) => {
 
           expect(counter).toBe('COUNT: 1')
 
-          browser.close()
+          await browser.close()
         })
       })
 
@@ -380,7 +380,7 @@ export default (context) => {
 
           expect(counter).toBe('COUNT: 0')
 
-          browser.close()
+          await browser.close()
         })
       })
 
@@ -395,7 +395,7 @@ export default (context) => {
 
           expect(counter).toBe('COUNT: 0')
 
-          browser.close()
+          await browser.close()
         })
       })
     })
@@ -413,7 +413,7 @@ export default (context) => {
           .elementByCss('#get-initial-props-run-count').text()
         expect(getInitialPropsRunCount).toBe('getInitialProps run count: 1')
 
-        browser.close()
+        await browser.close()
       })
 
       it('should handle the back button and should not run getInitialProps', async () => {
@@ -433,7 +433,7 @@ export default (context) => {
           .elementByCss('#get-initial-props-run-count').text()
         expect(getInitialPropsRunCount).toBe('getInitialProps run count: 1')
 
-        browser.close()
+        await browser.close()
       })
 
       it('should run getInitialProps always when rending the page to the screen', async () => {
@@ -453,7 +453,7 @@ export default (context) => {
           .elementByCss('#get-initial-props-run-count').text()
         expect(getInitialPropsRunCount).toBe('getInitialProps run count: 2')
 
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -468,7 +468,7 @@ export default (context) => {
 
         expect(await browser.url())
           .toBe(`http://localhost:${context.appPort}/nav/querystring/10#10`)
-        browser.close()
+        await browser.close()
       })
 
       it('should work with "Router.push"', async () => {
@@ -481,7 +481,7 @@ export default (context) => {
 
         expect(await browser.url())
           .toBe(`http://localhost:${context.appPort}/nav/querystring/10#10`)
-        browser.close()
+        await browser.close()
       })
 
       it('should work with the "replace" prop', async () => {
@@ -515,7 +515,7 @@ export default (context) => {
 
         expect(stackLength).toBe(3)
 
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -528,7 +528,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the about page.')
-        browser.close()
+        await browser.close()
       })
 
       it('should redirect the page when loading', async () => {
@@ -538,7 +538,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the about page.')
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -548,7 +548,7 @@ export default (context) => {
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
+        await browser.close()
       })
 
       it('should work with dir/ page', async () => {
@@ -556,7 +556,7 @@ export default (context) => {
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
+        await browser.close()
       })
 
       it('should work with /index page', async () => {
@@ -564,7 +564,7 @@ export default (context) => {
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
+        await browser.close()
       })
 
       it('should work with / page', async () => {
@@ -572,7 +572,7 @@ export default (context) => {
         const text = await browser.elementByCss('p').text()
 
         expect(text).toBe('ComponentDidMount executed on client.')
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -592,7 +592,7 @@ export default (context) => {
           .elementByCss('p').text()
 
         expect(text).toBe('This is the home.')
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -606,7 +606,7 @@ export default (context) => {
             .elementByCss('.as-path-content').text()
 
           expect(asPath).toBe('/as/path')
-          browser.close()
+          await browser.close()
         })
 
         it('should show the correct asPath with a Link without the as prop', async () => {
@@ -617,7 +617,7 @@ export default (context) => {
             .elementByCss('.as-path-content').text()
 
           expect(asPath).toBe('/nav/as-path')
-          browser.close()
+          await browser.close()
         })
       })
 
@@ -630,7 +630,7 @@ export default (context) => {
             .elementByCss('.as-path-content').text()
 
           expect(asPath).toBe('/nav/as-path-using-router')
-          browser.close()
+          await browser.close()
         })
       })
 
@@ -655,7 +655,7 @@ export default (context) => {
             expect(queryFour.something).toBe(undefined)
           } finally {
             if (browser) {
-              browser.close()
+              await browser.close()
             }
           }
         })
@@ -672,7 +672,7 @@ export default (context) => {
             expect(queryTwo.something).toBe('else')
           } finally {
             if (browser) {
-              browser.close()
+              await browser.close()
             }
           }
         })
@@ -690,7 +690,7 @@ export default (context) => {
           expect(text).toMatch(/pages\/error-inside-browser-page\.js:5/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -705,7 +705,7 @@ export default (context) => {
           expect(text).toMatch(/error-in-the-browser-global-scope\.js:2/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -716,14 +716,14 @@ export default (context) => {
         const browser = await webdriver(context.appPort, '/non-existent')
         expect(await browser.elementByCss('h1').text()).toBe('404')
         expect(await browser.elementByCss('h2').text()).toBe('This page could not be found.')
-        browser.close()
+        await browser.close()
       })
 
-      it('should 404 for <page>/', async () => {
+      fit('should 404 for <page>/', async () => {
         const browser = await webdriver(context.appPort, '/nav/about/')
         expect(await browser.elementByCss('h1').text()).toBe('404')
         expect(await browser.elementByCss('h2').text()).toBe('This page could not be found.')
-        browser.close()
+        await browser.close()
       })
 
       it('should should not contain a page script in a 404 page', async () => {
@@ -733,7 +733,7 @@ export default (context) => {
           const src = await script.getAttribute('src')
           expect(src.includes('/non-existent')).toBeFalsy()
         }
-        browser.close()
+        await browser.close()
       })
     })
 
@@ -749,7 +749,7 @@ export default (context) => {
           expect(await browser.elementByCss('meta[name="description"]').getAttribute('content')).toBe('Head One')
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -762,7 +762,7 @@ export default (context) => {
         expect(await browser.elementByCss('body').text()).toBe('this is just a placeholder component')
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -770,7 +770,7 @@ export default (context) => {
     it('should work on nested /index/index.js', async () => {
       const browser = await webdriver(context.appPort, '/nested-index/index')
       expect(await browser.elementByCss('p').text()).toBe('This is an index.js nested in an index/ folder.')
-      browser.close()
+      await browser.close()
     })
   })
 }

--- a/test/integration/basic/test/client-navigation.js
+++ b/test/integration/basic/test/client-navigation.js
@@ -719,7 +719,7 @@ export default (context) => {
         await browser.close()
       })
 
-      fit('should 404 for <page>/', async () => {
+      it('should 404 for <page>/', async () => {
         const browser = await webdriver(context.appPort, '/nav/about/')
         expect(await browser.elementByCss('h1').text()).toBe('404')
         expect(await browser.elementByCss('h2').text()).toBe('This page could not be found.')

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -32,7 +32,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Welcome, dynamic/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -52,7 +52,7 @@ export default (context, render) => {
           })
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -68,7 +68,7 @@ export default (context, render) => {
           expect(backgroundColor).toBe('rgba(0, 128, 0, 1)')
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -87,7 +87,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Hello World 1/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -107,7 +107,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Hello World 1/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -127,7 +127,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /test chunkfilename/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -146,7 +146,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Hello World 1/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -169,7 +169,7 @@ export default (context, render) => {
           expect(html).not.toMatch(/hello2\.js/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -218,7 +218,7 @@ export default (context, render) => {
           await waitFor(1000)
         }
 
-        browser.close()
+        await browser.close()
       })
 
       it('should render support React context', async () => {
@@ -233,7 +233,7 @@ export default (context, render) => {
           await waitFor(1000)
         }
 
-        browser.close()
+        await browser.close()
       })
 
       it('should load new components and render for prop changes', async () => {
@@ -254,7 +254,7 @@ export default (context, render) => {
           await waitFor(1000)
         }
 
-        browser.close()
+        await browser.close()
       })
     })
   })

--- a/test/integration/basic/test/error-recovery.js
+++ b/test/integration/basic/test/error-recovery.js
@@ -32,7 +32,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -66,7 +66,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -101,7 +101,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -137,7 +137,7 @@ export default (context, renderViaHTTP) => {
       } finally {
         aboutPage.restore()
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -164,7 +164,7 @@ export default (context, renderViaHTTP) => {
       } finally {
         aboutPage.restore()
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -200,7 +200,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -239,7 +239,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -278,7 +278,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -321,7 +321,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -362,7 +362,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -403,7 +403,7 @@ export default (context, renderViaHTTP) => {
         throw err
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })

--- a/test/integration/basic/test/hmr.js
+++ b/test/integration/basic/test/hmr.js
@@ -36,7 +36,7 @@ export default (context, renderViaHTTP) => {
           )
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
           if (existsSync(newContactPagePath)) {
             renameSync(newContactPagePath, contactPagePath)
@@ -76,7 +76,7 @@ export default (context, renderViaHTTP) => {
           )
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -111,7 +111,7 @@ export default (context, renderViaHTTP) => {
           writeFileSync(aboutPagePath, originalContent, 'utf8')
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -151,7 +151,7 @@ export default (context, renderViaHTTP) => {
           }
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -183,7 +183,7 @@ export default (context, renderViaHTTP) => {
           expect(editedFontSize).toBe('200px')
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
           writeFileSync(pagePath, originalContent, 'utf8')
         }
@@ -243,7 +243,7 @@ export default (context, renderViaHTTP) => {
           writeFileSync(pagePath, originalContent, 'utf8')
 
           if (browser) {
-            browser.close()
+            await browser.close()
           }
 
           if (secondBrowser) {

--- a/test/integration/basic/test/process-env.js
+++ b/test/integration/basic/test/process-env.js
@@ -7,7 +7,7 @@ export default (context) => {
       const browser = await webdriver(context.appPort, '/process-env')
       const nodeEnv = await browser.elementByCss('#node-env').text()
       expect(nodeEnv).toBe('development')
-      browser.close()
+      await browser.close()
     })
   })
 }

--- a/test/integration/client-404/test/client-navigation.js
+++ b/test/integration/client-404/test/client-navigation.js
@@ -20,7 +20,7 @@ export default (context) => {
           serverCode: '404',
           clientCode: '404'
         })
-        browser.close()
+        await browser.close()
       })
     })
   })

--- a/test/integration/config/test/client.js
+++ b/test/integration/config/test/client.js
@@ -19,7 +19,7 @@ export default (context, render) => {
       expect(serverText).toBe('')
       expect(serverClientText).toBe('/static')
       expect(envValue).toBe('hello')
-      browser.close()
+      await browser.close()
     })
 
     it('should update css styles using hmr', async () => {
@@ -54,7 +54,7 @@ export default (context, render) => {
         }
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -103,7 +103,7 @@ export default (context, render) => {
     //     throw err
     //   } finally {
     //     if (browser) {
-    //       browser.close()
+    //       await browser.close()
     //     }
     //   }
     // })

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -112,7 +112,7 @@ describe('Custom Server', () => {
         )
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })

--- a/test/integration/export/test/browser.js
+++ b/test/integration/export/test/browser.js
@@ -10,7 +10,7 @@ export default function (context) {
         .elementByCss('#home-page p').text()
 
       expect(text).toBe('This is the home page')
-      browser.close()
+      await browser.close()
     })
 
     it('should add trailing slash on Link', async () => {
@@ -39,7 +39,7 @@ export default function (context) {
         .elementByCss('#about-page p').text()
 
       expect(text).toBe('This is the About page foo')
-      browser.close()
+      await browser.close()
     })
 
     it('should do navigations via Router', async () => {
@@ -50,7 +50,7 @@ export default function (context) {
         .elementByCss('#about-page p').text()
 
       expect(text).toBe('This is the About page foo')
-      browser.close()
+      await browser.close()
     })
 
     it('should do run client side javascript', async () => {
@@ -63,7 +63,7 @@ export default function (context) {
         .elementByCss('#counter-page p').text()
 
       expect(text).toBe('Counter: 2')
-      browser.close()
+      await browser.close()
     })
 
     it('should render pages using getInitialProps', async () => {
@@ -74,7 +74,7 @@ export default function (context) {
         .elementByCss('#dynamic-page p').text()
 
       expect(text).toBe('cool dynamic text')
-      browser.close()
+      await browser.close()
     })
 
     it('should render dynamic pages with custom urls', async () => {
@@ -85,7 +85,7 @@ export default function (context) {
         .elementByCss('#dynamic-page p').text()
 
       expect(text).toBe('next export is nice')
-      browser.close()
+      await browser.close()
     })
 
     it('should support client side naviagtion', async () => {
@@ -109,7 +109,7 @@ export default function (context) {
 
       expect(textNow).toBe('Counter: 2')
 
-      browser.close()
+      await browser.close()
     })
 
     it('should render dynamic import components in the client', async () => {
@@ -123,7 +123,7 @@ export default function (context) {
         /Welcome to dynamic imports/
       )
 
-      browser.close()
+      await browser.close()
     })
 
     it('should render pages with url hash correctly', async () => {
@@ -145,7 +145,7 @@ export default function (context) {
         )
       } finally {
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })
@@ -159,7 +159,7 @@ export default function (context) {
         .elementByCss('#home-page p').text()
 
       expect(text).toBe('This is the home page')
-      browser.close()
+      await browser.close()
     })
 
     describe('pages in the nested level: level1', () => {
@@ -170,7 +170,7 @@ export default function (context) {
 
         await check(() => getBrowserBodyText(browser), /This is the Level1 home page/)
 
-        browser.close()
+        await browser.close()
       })
 
       it('should render the about page', async () => {
@@ -180,7 +180,7 @@ export default function (context) {
 
         await check(() => getBrowserBodyText(browser), /This is the Level1 about page/)
 
-        browser.close()
+        await browser.close()
       })
     })
   })

--- a/test/integration/export/test/dev.js
+++ b/test/integration/export/test/dev.js
@@ -13,14 +13,14 @@ export default function (context) {
     it('should render the home page', async () => {
       const browser = await webdriver(context.port, '/')
       await check(() => getBrowserBodyText(browser), /This is the home page/)
-      browser.close()
+      await browser.close()
     })
 
     it('should render pages only existent in exportPathMap page', async () => {
       const browser = await webdriver(context.port, '/dynamic/one')
       const text = await browser.elementByCss('#dynamic-page p').text()
       expect(text).toBe('next export is nice')
-      browser.close()
+      await browser.close()
     })
   })
 

--- a/test/integration/ondemand/test/index.test.js
+++ b/test/integration/ondemand/test/index.test.js
@@ -99,7 +99,7 @@ describe('On Demand Entries', () => {
       }, /Hello/)
     } finally {
       if (browser) {
-        browser.close()
+        await browser.close()
       }
     }
   })

--- a/test/integration/page-extensions/test/hmr.js
+++ b/test/integration/page-extensions/test/hmr.js
@@ -32,7 +32,7 @@ export default (context, renderViaHTTP) => {
         // restore the about page content.
         writeFileSync(pagePath, originalContent, 'utf8')
         if (browser) {
-          browser.close()
+          await browser.close()
         }
       }
     })

--- a/test/integration/production-config/test/index.test.js
+++ b/test/integration/production-config/test/index.test.js
@@ -75,7 +75,7 @@ describe('Production Config Usage', () => {
 
       const html = await browser.elementByCss('html').getAttribute('innerHTML')
       expect(html).toMatch('custom-buildid')
-      return browser.close()
+      await browser.close()
     })
   })
 })
@@ -87,5 +87,5 @@ async function testBrowser () {
   expect(text).toMatch(/ComponentDidMount executed on client\./)
   expect(await element.getComputedCss('font-size')).toBe('40px')
   expect(await element.getComputedCss('color')).toBe('rgba(255, 0, 0, 1)')
-  return browser.close()
+  await browser.close()
 }

--- a/test/integration/production/test/dynamic.js
+++ b/test/integration/production/test/dynamic.js
@@ -24,7 +24,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Welcome, dynamic/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -42,7 +42,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Hello World 1/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -61,7 +61,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Hello World 1/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -80,7 +80,7 @@ export default (context, render) => {
           await check(() => browser.elementByCss('body').text(), /Hello World 1/)
         } finally {
           if (browser) {
-            browser.close()
+            await browser.close()
           }
         }
       })
@@ -117,7 +117,7 @@ export default (context, render) => {
           await waitFor(1000)
         }
 
-        browser.close()
+        await browser.close()
       })
 
       it('should render support React context', async () => {
@@ -132,7 +132,7 @@ export default (context, render) => {
           await waitFor(1000)
         }
 
-        browser.close()
+        await browser.close()
       })
 
       it('should load new components and render for prop changes', async () => {
@@ -153,7 +153,7 @@ export default (context, render) => {
           await waitFor(1000)
         }
 
-        browser.close()
+        await browser.close()
       })
     })
   })

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -151,7 +151,7 @@ describe('Production Usage', () => {
         .elementByCss('div').text()
 
       expect(text).toBe('About Page')
-      browser.close()
+      await browser.close()
     })
 
     it('should navigate to nested index via client side', async () => {
@@ -162,7 +162,7 @@ describe('Production Usage', () => {
         .elementByCss('p').text()
 
       expect(text).toBe('Hello World')
-      browser.close()
+      await browser.close()
     })
   })
 
@@ -176,7 +176,7 @@ describe('Production Usage', () => {
       const headingText = await browser.elementByCss('h1').text()
       // This makes sure we render statusCode on the client side correctly
       expect(headingText).toBe('500')
-      browser.close()
+      await browser.close()
     })
 
     it('should render a client side component error', async () => {
@@ -184,7 +184,7 @@ describe('Production Usage', () => {
       await waitFor(2000)
       const text = await browser.elementByCss('body').text()
       expect(text).toMatch(/An unexpected error has occurred\./)
-      browser.close()
+      await browser.close()
     })
 
     it('should call getInitialProps on _error page during a client side component error', async () => {
@@ -192,7 +192,7 @@ describe('Production Usage', () => {
       await waitFor(2000)
       const text = await browser.elementByCss('body').text()
       expect(text).toMatch(/This page could not be found\./)
-      browser.close()
+      await browser.close()
     })
   })
 
@@ -236,7 +236,7 @@ describe('Production Usage', () => {
         .elementByCss('#counter').text()
       expect(counterAfter404Page).toBe('Counter: 0')
 
-      browser.close()
+      await browser.close()
     })
 
     it('should add preload tags when Link prefetch prop is used', async () => {
@@ -251,7 +251,7 @@ describe('Production Usage', () => {
           expect(as).toBe('script')
         })
       )
-      browser.close()
+      await browser.close()
     })
 
     // This is a workaround to fix https://github.com/zeit/next.js/issues/5860
@@ -272,7 +272,7 @@ describe('Production Usage', () => {
           expect(src).not.toMatch(/\?ts=/)
         })
       )
-      browser.close()
+      await browser.close()
     })
 
     it('should reload the page on page script error with prefetch', async () => {
@@ -306,7 +306,7 @@ describe('Production Usage', () => {
         .elementByCss('#counter').text()
       expect(counterAfter404Page).toBe('Counter: 0')
 
-      browser.close()
+      await browser.close()
     })
   })
 

--- a/test/integration/production/test/process-env.js
+++ b/test/integration/production/test/process-env.js
@@ -13,7 +13,7 @@ export default (context) => {
       const browser = await webdriver(context.appPort, '/process-env')
       const nodeEnv = await browser.elementByCss('#node-env').text()
       expect(nodeEnv).toBe('production')
-      browser.close()
+      await browser.close()
     })
   })
 

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -74,54 +74,54 @@ module.exports = (context) => {
     it('should prevent URI based XSS attacks', async () => {
       const browser = await webdriver(context.appPort, '/\',document.body.innerHTML="INJECTED",\'')
       await checkInjected(browser)
-      browser.quit()
+      await browser.close()
     })
 
     it('should prevent URI based XSS attacks using single quotes', async () => {
       const browser = await webdriver(context.appPort, `/'-(document.body.innerHTML='INJECTED')-'`)
       await checkInjected(browser)
-      browser.close()
+      await browser.close()
     })
 
     it('should prevent URI based XSS attacks using double quotes', async () => {
       const browser = await webdriver(context.appPort, `/"-(document.body.innerHTML='INJECTED')-"`)
       await checkInjected(browser)
 
-      browser.close()
+      await browser.close()
     })
 
     it('should prevent URI based XSS attacks using semicolons and double quotes', async () => {
       const browser = await webdriver(context.appPort, `/;"-(document.body.innerHTML='INJECTED')-"`)
       await checkInjected(browser)
 
-      browser.close()
+      await browser.close()
     })
 
     it('should prevent URI based XSS attacks using semicolons and single quotes', async () => {
       const browser = await webdriver(context.appPort, `/;'-(document.body.innerHTML='INJECTED')-'`)
       await checkInjected(browser)
 
-      browser.close()
+      await browser.close()
     })
 
     it('should prevent URI based XSS attacks using src', async () => {
       const browser = await webdriver(context.appPort, `/javascript:(document.body.innerHTML='INJECTED')`)
       await checkInjected(browser)
 
-      browser.close()
+      await browser.close()
     })
 
     it('should prevent URI based XSS attacks using querystring', async () => {
       const browser = await webdriver(context.appPort, `/?javascript=(document.body.innerHTML='INJECTED')`)
       await checkInjected(browser)
 
-      browser.close()
+      await browser.close()
     })
 
     it('should prevent URI based XSS attacks using querystring and quotes', async () => {
       const browser = await webdriver(context.appPort, `/?javascript="(document.body.innerHTML='INJECTED')"`)
       await checkInjected(browser)
-      browser.close()
+      await browser.close()
     })
   })
 }

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -62,7 +62,7 @@ describe('Serverless', () => {
 
       expect(text).toMatch(/fetch page/)
     } finally {
-      browser.close()
+      await browser.close()
     }
   })
 

--- a/test/integration/with-router/test/index.test.js
+++ b/test/integration/with-router/test/index.test.js
@@ -48,7 +48,7 @@ describe('withRouter', () => {
     activePage = await browser.elementByCss('.active').text()
     expect(activePage).toBe('Bar')
 
-    browser.close()
+    await browser.close()
   })
 
   it('allows observation of navigation events using top level Router', async () => {
@@ -64,7 +64,7 @@ describe('withRouter', () => {
     activePage = await browser.elementByCss('.active-top-level-router').text()
     expect(activePage).toBe('Bar')
 
-    browser.close()
+    await browser.close()
   })
 
   it('allows observation of navigation events using top level Router deprecated behavior', async () => {
@@ -80,7 +80,7 @@ describe('withRouter', () => {
     activePage = await browser.elementByCss('.active-top-level-router-deprecated-behavior').text()
     expect(activePage).toBe('Bar')
 
-    browser.close()
+    await browser.close()
   })
 })
 
@@ -99,6 +99,6 @@ describe('withRouter SSR', async () => {
   it('should show an error when trying to use router methods during SSR', async () => {
     const browser = await webdriver(port, '/router-method-ssr')
     expect(await getReactErrorOverlayContent(browser)).toMatch(`No router instance found. you should only use "next/router" inside the client side of your app. https://err.sh/`)
-    browser.close()
+    await browser.close()
   })
 })


### PR DESCRIPTION
The Jest worker will exit before the browser is closed, leaving Chrome processes orphaned / running. This eventually leads to OOM.