### PR TITLE
Bug fix for #6181 #6384 #6181 v8.0.3 export issue

### DIFF
--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -9,6 +9,9 @@ import { loadComponents } from 'next-server/dist/server/load-components'
 const envConfig = require('next-server/config')
 const mkdirp = promisify(mkdirpModule)
 
+import loadConfig from 'next-server/next-config'      // Needed for extension support (ie., less) #6181 #6384 #6181
+import { PHASE_EXPORT } from 'next-server/constants'  // Needed for call to loadConfig()
+
 global.__NEXT_DATA__ = {
   nextExport: true
 }
@@ -36,6 +39,8 @@ process.on(
           serverRuntimeConfig,
           publicRuntimeConfig: renderOpts.runtimeConfig
         })
+
+        const nextConfig = loadConfig(PHASE_EXPORT)     // Needed for extension support (ie., less) #6181 #6384 #6181
 
         let htmlFilename = `${path}${sep}index.html`
         const pageExt = extname(page)


### PR DESCRIPTION
When using .less files as in the with-ant-design-less example, next v8.0.3 export will fail as per #6181 #6384 #6181 issues. The cause is due to the worker.js call running parallel export jobs not having the proper JS extensions. Namely, the `config.next.js` file contains the following code which needs to be called:

```
// fix: prevents error when .less files are required by node
if (typeof require !== 'undefined') {
  require.extensions['.less'] = file => {}
}
```

Modifying the worker.js file to explicitly call the configuration `loadConfig(PHASE_EXPORT)` fixes the problem.

Note, it's not clear if the `dir` parameter is needed or not. For example, should the call be `loadConfig(PHASE_EXPORT,dir)`?