### PR TITLE
Catch errors when loading a page in case a script 404s

### DIFF
--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -156,11 +156,11 @@ export default class PageLoader {
     }
 
     if (document.readyState === 'complete') {
-      await this.loadPage(route)
+      await this.loadPage(route).catch(() => {})
     } else {
       return new Promise((resolve, reject) => {
         window.addEventListener('load', () => {
-          this.loadPage(route).then(() => resolve(), reject)
+          this.loadPage(route).then(resolve, resolve)
         })
       })
     }

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -156,11 +156,11 @@ export default class PageLoader {
     }
 
     if (document.readyState === 'complete') {
-      await this.loadPage(route).catch(() => {})
+      return this.loadPage(route).catch((e) => {})
     } else {
       return new Promise((resolve, reject) => {
         window.addEventListener('load', () => {
-          this.loadPage(route).then(resolve, resolve)
+          this.loadPage(route).then(() => resolve(), () => resolve())
         })
       })
     }


### PR DESCRIPTION
Firefox changes `<link rel="preload">` tags into script tags and causes a nondescript error if failing to load `<Link preload />`