### PR TITLE
Add more export tests for AMP

### DIFF
--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -6,6 +6,7 @@ import { resolve, join } from 'path'
 import { existsSync, readFileSync } from 'fs'
 import loadConfig from 'next-server/next-config'
 import { tryAmp } from 'next-server/dist/server/require'
+import { cleanAmpPath } from 'next-server/dist/server/utils'
 import { PHASE_EXPORT, SERVER_DIRECTORY, PAGES_MANIFEST, CONFIG_FILE, BUILD_ID_FILE, CLIENT_STATIC_FILES_PATH } from 'next-server/constants'
 import createProgress from 'tty-aware-progress'
 import { promisify } from 'util'
@@ -58,7 +59,8 @@ export default async function (dir, options, configuration) {
 
     if (isAmp) {
       defaultPathMap[path].query = { amp: 1 }
-      if (!defaultPathMap[path.split('.amp')[0]]) {
+      const nonAmp = cleanAmpPath(path).replace(/\/$/, '')
+      if (!defaultPathMap[nonAmp]) {
         defaultPathMap[path].query.ampOnly = true
       }
     } else {

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -64,7 +64,6 @@ process.on(
         const baseDir = join(outDir, dirname(htmlFilename))
         const htmlFilepath = join(outDir, htmlFilename)
 
-        console.log('export', path)
 
         await mkdirp(baseDir)
         const components = await loadComponents(distDir, buildId, page)

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -64,7 +64,6 @@ process.on(
         const baseDir = join(outDir, dirname(htmlFilename))
         const htmlFilepath = join(outDir, htmlFilename)
 
-
         await mkdirp(baseDir)
         const components = await loadComponents(distDir, buildId, page)
         const html = await renderToHTML(req, res, page, query, { ...components, ...renderOpts, ...ampOpts })

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -47,6 +47,9 @@ process.on(
           path = cleanAmpPath(path)
         }
 
+        // replace /docs/index.amp with /docs.amp
+        path = path.replace(/(?<!^)\/index\.amp$/, '.amp')
+
         let htmlFilename = `${path}${sep}index.html`
         const pageExt = extname(page)
         const pathExt = extname(path)
@@ -60,6 +63,8 @@ process.on(
         }
         const baseDir = join(outDir, dirname(htmlFilename))
         const htmlFilepath = join(outDir, htmlFilename)
+
+        console.log('export', path)
 
         await mkdirp(baseDir)
         const components = await loadComponents(distDir, buildId, page)

--- a/test/integration/export-default-map/pages/docs/index.amp.js
+++ b/test/integration/export-default-map/pages/docs/index.amp.js
@@ -1,3 +1,1 @@
-export default () => (
-  <p>I'm an AMP page</p>
-)
+export { default } from './index'

--- a/test/integration/export-default-map/pages/docs/index.js
+++ b/test/integration/export-default-map/pages/docs/index.js
@@ -1,0 +1,5 @@
+import { useAmp } from 'next/amp'
+
+export default () => (
+  <p>I'm an {useAmp() ? 'AMP' : 'normal'} page</p>
+)

--- a/test/integration/export-default-map/pages/info.js
+++ b/test/integration/export-default-map/pages/info.js
@@ -1,0 +1,5 @@
+import { useAmp } from 'next/amp'
+
+export default () => (
+  <p>I'm an {useAmp() ? 'AMP' : 'normal'} page</p>
+)

--- a/test/integration/export-default-map/pages/info/index.amp.js
+++ b/test/integration/export-default-map/pages/info/index.amp.js
@@ -1,0 +1,1 @@
+export { default } from '../info'

--- a/test/integration/export-default-map/pages/just-amp/index.amp.js
+++ b/test/integration/export-default-map/pages/just-amp/index.amp.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>I am an AMP only page</p>
+)

--- a/test/integration/export-default-map/test/index.test.js
+++ b/test/integration/export-default-map/test/index.test.js
@@ -34,4 +34,16 @@ describe('Export with default map', () => {
     await expect(access(join(outdir, 'some/index.html'))).resolves.toBe(undefined)
     await expect(access(join(outdir, 'some.amp/index.html'))).resolves.toBe(undefined)
   })
+
+  it('should export nested hybrid amp page correctly', async () => {
+    expect.assertions(2)
+    await expect(access(join(outdir, 'docs/index.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'docs.amp/index.html'))).resolves.toBe(undefined)
+  })
+
+  it('should export nested hybrid amp page correctly with folder', async () => {
+    expect.assertions(2)
+    await expect(access(join(outdir, 'info/index.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'info.amp/index.html'))).resolves.toBe(undefined)
+  })
 })


### PR DESCRIPTION
These tests make sure we support `/info.js` -> `/info/index.amp.js` and `/docs/index.js` -> `/docs/index.amp.js` not colliding