### PR TITLE
Styled Components example that more closely matches default create-next-app

### DIFF
--- a/examples/with-styled-components/.babelrc
+++ b/examples/with-styled-components/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["next/babel"],
-  "plugins": [["styled-components", { "ssr": true }]]
+  "plugins": [
+    ["styled-components", { 
+      "ssr": true, 
+      "displayName": true 
+    }]
+  ]
 }

--- a/examples/with-styled-components/components/head.js
+++ b/examples/with-styled-components/components/head.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import NextHead from 'next/head'
+import { string } from 'prop-types'
+
+const defaultDescription = ''
+const defaultOGURL = ''
+const defaultOGImage = ''
+
+const Head = props => (
+  <NextHead>
+    <meta charSet="UTF-8" />
+    <title>{props.title || ''}</title>
+    <meta
+      name="description"
+      content={props.description || defaultDescription}
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" sizes="192x192" href="/static/touch-icon.png" />
+    <link rel="apple-touch-icon" href="/static/touch-icon.png" />
+    <link rel="mask-icon" href="/static/favicon-mask.svg" color="#49B882" />
+    <link rel="icon" href="/static/favicon.ico" />
+    <meta property="og:url" content={props.url || defaultOGURL} />
+    <meta property="og:title" content={props.title || ''} />
+    <meta
+      property="og:description"
+      content={props.description || defaultDescription}
+    />
+    <meta name="twitter:site" content={props.url || defaultOGURL} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content={props.ogImage || defaultOGImage} />
+    <meta property="og:image" content={props.ogImage || defaultOGImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+  </NextHead>
+)
+
+Head.propTypes = {
+  title: string,
+  description: string,
+  url: string,
+  ogImage: string
+}
+
+export default Head

--- a/examples/with-styled-components/components/head.js
+++ b/examples/with-styled-components/components/head.js
@@ -8,29 +8,29 @@ const defaultOGImage = ''
 
 const Head = props => (
   <NextHead>
-    <meta charSet="UTF-8" />
+    <meta charSet='UTF-8' />
     <title>{props.title || ''}</title>
     <meta
-      name="description"
+      name='description'
       content={props.description || defaultDescription}
     />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" sizes="192x192" href="/static/touch-icon.png" />
-    <link rel="apple-touch-icon" href="/static/touch-icon.png" />
-    <link rel="mask-icon" href="/static/favicon-mask.svg" color="#49B882" />
-    <link rel="icon" href="/static/favicon.ico" />
-    <meta property="og:url" content={props.url || defaultOGURL} />
-    <meta property="og:title" content={props.title || ''} />
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <link rel='icon' sizes='192x192' href='/static/touch-icon.png' />
+    <link rel='apple-touch-icon' href='/static/touch-icon.png' />
+    <link rel='mask-icon' href='/static/favicon-mask.svg' color='#49B882' />
+    <link rel='icon' href='/static/favicon.ico' />
+    <meta property='og:url' content={props.url || defaultOGURL} />
+    <meta property='og:title' content={props.title || ''} />
     <meta
-      property="og:description"
+      property='og:description'
       content={props.description || defaultDescription}
     />
-    <meta name="twitter:site" content={props.url || defaultOGURL} />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content={props.ogImage || defaultOGImage} />
-    <meta property="og:image" content={props.ogImage || defaultOGImage} />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta name='twitter:site' content={props.url || defaultOGURL} />
+    <meta name='twitter:card' content='summary_large_image' />
+    <meta name='twitter:image' content={props.ogImage || defaultOGImage} />
+    <meta property='og:image' content={props.ogImage || defaultOGImage} />
+    <meta property='og:image:width' content='1200' />
+    <meta property='og:image:height' content='630' />
   </NextHead>
 )
 

--- a/examples/with-styled-components/components/nav.js
+++ b/examples/with-styled-components/components/nav.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import styled, { createGlobalStyle } from 'styled-components'
+import styled from 'styled-components'
 
 const StyledNav = styled.nav`
   text-align: center;
@@ -18,7 +18,7 @@ const StyledNav = styled.nav`
     text-decoration: none;
     font-size: 13px;
   }
-` 
+`
 
 const links = [
   { href: 'https://github.com/segmentio/create-next-app', label: 'Github' }

--- a/examples/with-styled-components/components/nav.js
+++ b/examples/with-styled-components/components/nav.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import Link from 'next/link'
+import styled, { createGlobalStyle } from 'styled-components'
+
+const StyledNav = styled.nav`
+  text-align: center;
+  ul {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 16px;
+    li {
+      display: flex;
+      padding: 6px 8px;
+    }
+  }
+  a {
+    color: #067df7;
+    text-decoration: none;
+    font-size: 13px;
+  }
+` 
+
+const links = [
+  { href: 'https://github.com/segmentio/create-next-app', label: 'Github' }
+].map(link => {
+  link.key = `nav-link-${link.href}-${link.label}`
+  return link
+})
+
+const Nav = () => (
+  <StyledNav>
+    <ul>
+      <li>
+        <Link prefetch href="/">
+          <a>Home</a>
+        </Link>
+      </li>
+      <ul>
+        {links.map(({ key, href, label }) => (
+          <li key={key}>
+            <Link href={href}>
+              <a>{label}</a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </ul>
+  </StyledNav>
+)
+
+export default Nav

--- a/examples/with-styled-components/components/nav.js
+++ b/examples/with-styled-components/components/nav.js
@@ -31,7 +31,7 @@ const Nav = () => (
   <StyledNav>
     <ul>
       <li>
-        <Link prefetch href="/">
+        <Link prefetch href='/'>
           <a>Home</a>
         </Link>
       </li>

--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -1,5 +1,12 @@
 import Document from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
+import { ServerStyleSheet, createGlobalStyle } from 'styled-components'
+
+const GlobalStyles = createGlobalStyle`
+  html, body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, Avenir Next, Avenir, Helvetica, sans-serif;
+  }
+`
 
 export default class MyDocument extends Document {
   static async getInitialProps (ctx) {
@@ -9,7 +16,11 @@ export default class MyDocument extends Document {
     try {
       ctx.renderPage = () =>
         originalRenderPage({
-          enhanceApp: App => props => sheet.collectStyles(<App {...props} />)
+          enhanceApp: App => props => sheet.collectStyles(
+          <React.Fragment>
+            <GlobalStyles />
+            <App {...props} />
+          </React.Fragment>)
         })
 
       const initialProps = await Document.getInitialProps(ctx)

--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -17,10 +17,10 @@ export default class MyDocument extends Document {
       ctx.renderPage = () =>
         originalRenderPage({
           enhanceApp: App => props => sheet.collectStyles(
-            <React.Fragment>
+            <>
               <GlobalStyles />
               <App {...props} />
-            </React.Fragment>)
+            </>)
         })
 
       const initialProps = await Document.getInitialProps(ctx)

--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -17,10 +17,10 @@ export default class MyDocument extends Document {
       ctx.renderPage = () =>
         originalRenderPage({
           enhanceApp: App => props => sheet.collectStyles(
-          <React.Fragment>
-            <GlobalStyles />
-            <App {...props} />
-          </React.Fragment>)
+            <React.Fragment>
+              <GlobalStyles />
+              <App {...props} />
+            </React.Fragment>)
         })
 
       const initialProps = await Document.getInitialProps(ctx)

--- a/examples/with-styled-components/pages/index.js
+++ b/examples/with-styled-components/pages/index.js
@@ -1,9 +1,93 @@
 import React from 'react'
+import Link from 'next/link'
+import Head from '../components/head'
+import Nav from '../components/nav'
 import styled from 'styled-components'
 
+const Hero = styled.div`
+  width: 100%;
+  color: #333;
+`
 const Title = styled.h1`
-  color: red;
-  font-size: 50px;
+  margin: 0;
+  width: 100%;
+  padding-top: 80px;
+  line-height: 1.15;
+  font-size: 48px;
+  text-align: center;
+`
+const Description = styled.p`
+  text-align: center;
+`
+const Row = styled.div`
+  max-width: 880px;
+  margin: 80px auto 40px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+`
+const Card = styled.a`
+  padding: 18px 18px 24px;
+  width: 220px;
+  text-align: left;
+  text-decoration: none;
+  color: #434343;
+  border: 1px solid #9b9b9b;
+
+  &:hover {
+    border-color: #067df7;
+  }
+
+  h3 {
+    margin: 0;
+    color: #067df7;
+    font-size: 18px;
+  }
+
+  p {
+    margin: 0;
+    padding: 12px 0 0;
+    font-size: 13px;
+    color: #333;
+  }
 `
 
-export default () => <Title>My page</Title>
+const Home = () => (
+  <div>
+    <Head title="Home" />
+    <Nav />
+
+    <Hero>
+      <Title>Welcome to Next!</Title>
+      <Description>
+        To get started, edit <code>pages/index.js</code> and save to reload.
+      </Description>
+
+      <Row>
+        <Link href="https://github.com/zeit/next.js#getting-started">
+          <Card>
+            <h3>Getting Started &rarr;</h3>
+            <p>Learn more about Next on Github and in their examples</p>
+          </Card>
+        </Link>
+        <Link href="https://open.segment.com/create-next-app">
+          <Card>
+            <h3>Examples &rarr;</h3>
+            <p>
+              Find other example boilerplates on the{' '}
+              <code>create-next-app</code> site
+            </p>
+          </Card>
+        </Link>
+        <Link href="https://github.com/segmentio/create-next-app">
+          <Card>
+            <h3>Create Next App &rarr;</h3>
+            <p>Was this tool helpful? Let us know how we can improve it</p>
+          </Card>
+        </Link>
+      </Row>
+    </Hero>
+  </div>
+)
+
+export default Home

--- a/examples/with-styled-components/pages/index.js
+++ b/examples/with-styled-components/pages/index.js
@@ -54,7 +54,7 @@ const Card = styled.a`
 
 const Home = () => (
   <div>
-    <Head title="Home" />
+    <Head title='Home' />
     <Nav />
 
     <Hero>
@@ -64,13 +64,13 @@ const Home = () => (
       </Description>
 
       <Row>
-        <Link href="https://github.com/zeit/next.js#getting-started">
+        <Link href='https://github.com/zeit/next.js#getting-started'>
           <Card>
             <h3>Getting Started &rarr;</h3>
             <p>Learn more about Next on Github and in their examples</p>
           </Card>
         </Link>
-        <Link href="https://open.segment.com/create-next-app">
+        <Link href='https://open.segment.com/create-next-app'>
           <Card>
             <h3>Examples &rarr;</h3>
             <p>
@@ -79,7 +79,7 @@ const Home = () => (
             </p>
           </Card>
         </Link>
-        <Link href="https://github.com/segmentio/create-next-app">
+        <Link href='https://github.com/segmentio/create-next-app'>
           <Card>
             <h3>Create Next App &rarr;</h3>
             <p>Was this tool helpful? Let us know how we can improve it</p>


### PR DESCRIPTION
I'm just getting started with NextJS, and wanted to use styled-components instead of the default styled-jsx. I thought it would be a useful example for me to make the styled-components example more closely match the default `create-next-app` to hopefully make for a better example to anyone else getting started with this. 

Note, the one thing I deviated a bit from the default `create-next-app` is in putting the global body styling within `_document.js`, based on [this spectrum discussion](https://spectrum.chat/next-js/general/ssr-global-styles-with-styled-components-v4~605fa241-b194-4c6b-b071-1816fb96074b)