### PR TITLE
Fix export not checking amp right for /index.amp

### DIFF
--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -14,6 +14,7 @@ export function pageNotFoundError(page: string): Error {
 }
 
 export const tryAmp = (manifest: any, page: string) => {
+  page = page === '/' ? '/index' : page
   const hasAmp = manifest[page + '.amp']
   if (hasAmp) {
     page += '.amp'

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -59,7 +59,7 @@ export default async function (dir, options, configuration) {
 
     if (isAmp) {
       defaultPathMap[path].query = { amp: 1 }
-      const nonAmp = cleanAmpPath(path).replace(/\/$/, '')
+      const nonAmp = cleanAmpPath(path).replace(/\/$/, '') || '/'
       if (!defaultPathMap[nonAmp]) {
         defaultPathMap[path].query.ampOnly = true
       }

--- a/test/integration/export-default-map/pages/index.amp.js
+++ b/test/integration/export-default-map/pages/index.amp.js
@@ -1,0 +1,1 @@
+export { default } from './index'

--- a/test/integration/export-default-map/pages/index.js
+++ b/test/integration/export-default-map/pages/index.js
@@ -1,0 +1,3 @@
+export default () => (
+  <p>Simple hybrid amp/non-amp page</p>
+)

--- a/test/integration/export-default-map/test/index.test.js
+++ b/test/integration/export-default-map/test/index.test.js
@@ -56,4 +56,14 @@ describe('Export with default map', () => {
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/info.amp')
   })
+
+  it('should export hybrid index amp page correctly', async () => {
+    expect.assertions(3)
+    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'index.amp/index.html'))).resolves.toBe(undefined)
+
+    const html = await readFile(join(outdir, 'index.html'))
+    const $ = cheerio.load(html)
+    expect($('link[rel=amphtml]').attr('href')).toBe('/index.amp')
+  })
 })


### PR DESCRIPTION
Fixes `/` not being checked for non-amp counterpart during export. Also added test for this. 