### PR TITLE
Update to have default value for renderToHTML

### DIFF
--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -114,7 +114,7 @@ export default class DevServer extends Server {
     return !snippet.includes('data-amp-development-mode-only')
   }
 
-  async renderToHTML (req, res, pathname, query, options) {
+  async renderToHTML (req, res, pathname, query, options = {}) {
     const compilationErr = await this.getCompilationError(pathname)
     if (compilationErr) {
       res.statusCode = 500

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -32,7 +32,7 @@ const startServer = async (optEnv = {}) => {
     optEnv
   )
 
-  server = await initNextServerScript(scriptPath, /Ready on/, env)
+  server = await initNextServerScript(scriptPath, /Ready on/, env, /ReferenceError: options is not defined/)
 }
 
 describe('Custom Server', () => {

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -17,7 +17,7 @@ import _pkg from 'next/package.json'
 export const nextServer = server
 export const pkg = _pkg
 
-export function initNextServerScript (scriptPath, successRegexp, env) {
+export function initNextServerScript (scriptPath, successRegexp, env, failRegexp) {
   return new Promise((resolve, reject) => {
     const instance = spawn('node', [scriptPath], { env })
 
@@ -30,7 +30,12 @@ export function initNextServerScript (scriptPath, successRegexp, env) {
     }
 
     function handleStderr (data) {
-      process.stderr.write(data.toString())
+      const message = data.toString()
+      if (failRegexp && failRegexp.test(message)) {
+        instance.kill()
+        return reject(new Error('received failRegexp'))
+      }
+      process.stderr.write(message)
     }
 
     instance.stdout.on('data', handleStdout)


### PR DESCRIPTION
Looks like `next-dev-server` was missing a default value for `options` in `renderToHTML`