### PR TITLE
Remove hoist-non-react-statics from with-router

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -78,7 +78,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
       (context, request, callback) => {
         const notExternalModules = [
           'next/app', 'next/document', 'next/link', 'next/router', 'next/error',
-          'string-hash', 'hoist-non-react-statics', 'htmlescape','next/dynamic',
+          'string-hash', 'htmlescape','next/dynamic',
           'next/constants', 'next/config', 'next/head'
         ]
 

--- a/packages/next/client/with-router.js
+++ b/packages/next/client/with-router.js
@@ -1,17 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import hoistStatics from 'hoist-non-react-statics'
-import { getDisplayName } from 'next-server/dist/lib/utils'
 
 export default function withRouter (ComposedComponent) {
-  const displayName = getDisplayName(ComposedComponent)
-
   class WithRouteWrapper extends Component {
     static contextTypes = {
       router: PropTypes.object
     }
-
-    static displayName = `withRouter(${displayName})`
 
     render () {
       return <ComposedComponent
@@ -21,5 +15,7 @@ export default function withRouter (ComposedComponent) {
     }
   }
 
-  return hoistStatics(WithRouteWrapper, ComposedComponent)
+  WithRouteWrapper.getInitialProps = ComposedComponent.getInitialProps
+
+  return WithRouteWrapper
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -62,7 +62,6 @@
     "find-cache-dir": "2.0.0",
     "find-up": "2.1.0",
     "fresh": "0.5.2",
-    "hoist-non-react-statics": "3.2.0",
     "imurmurhash": "0.1.4",
     "launch-editor": "2.2.1",
     "loader-utils": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6131,13 +6131,6 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoist-non-react-statics@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz#d21b9fc72b50fdc38c5d88f6e2c52f2c2dbe5ee2"
-  integrity sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==
-  dependencies:
-    react-is "^16.3.2"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -10257,7 +10250,7 @@ react-is@16.6.3:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
-react-is@^16.3.2, react-is@^16.8.1:
+react-is@^16.8.1:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
   integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==


### PR DESCRIPTION
hoist-non-react-statics ships `react-is`, making it rather large for what it does.

It also causes non-standard behavior as the static properties are copied over implicly instead of explicitly. I've left `getInitialProps` as that is the main reason it was added, for backwards compat.

Besides bundle size this also brings down install size 💯 