### PR TITLE
Separate toRoute function

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -4,7 +4,10 @@ import { ComponentType } from 'react';
 import { parse } from 'url';
 import mitt, {MittEmitter} from '../mitt';
 import { formatWithValidation, getURL, loadGetInitialProps } from '../utils';
-import {toRoute} from './to-route'
+
+function toRoute(path: string): string {
+  return path.replace(/\/$/, '') || '/'
+}
 
 export interface IRouterInterface {
   route: string

--- a/packages/next-server/lib/router/to-route.ts
+++ b/packages/next-server/lib/router/to-route.ts
@@ -1,3 +1,0 @@
-export function toRoute(path: string): string {
-  return path.replace(/\/$/, '') || '/'
-}

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -3,7 +3,6 @@ import { ParsedUrlQuery } from 'querystring'
 import React from 'react'
 import { renderToString, renderToStaticMarkup } from 'react-dom/server'
 import {IRouterInterface} from '../lib/router/router'
-import {toRoute} from '../lib/router/to-route'
 import mitt, {MittEmitter} from '../lib/mitt';
 import { loadGetInitialProps, isResSent } from '../lib/utils'
 import Head, { defaultHead } from '../lib/head'
@@ -36,7 +35,7 @@ class ServerRouter implements IRouterInterface {
   static events: MittEmitter = mitt()
 
   constructor(pathname: string, query: any, as: string) {
-    this.route = toRoute(pathname)
+    this.route = pathname.replace(/\/$/, '') || '/'
     this.pathname = pathname
     this.query = query
     this.asPath = as

--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -1,13 +1,14 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
-export default function withRouter (ComposedComponent) {
-  class WithRouteWrapper extends Component {
+export default function withRouter(ComposedComponent: React.ComponentType<any> & {getInitialProps?: any}) {
+  class WithRouteWrapper extends React.Component {
+    static getInitialProps?: any
     static contextTypes = {
-      router: PropTypes.object
+      router: PropTypes.object,
     }
 
-    render () {
+    render() {
       return <ComposedComponent
         router={this.context.router}
         {...this.props}


### PR DESCRIPTION
Because Typescript output is turned to commonjs for these modules currently it’s better to do this. Also convert withRouter to typescript, making it smaller.