### PR TITLE
ncc nanoid

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import nanoid from 'nanoid'
+import nanoid from 'next/dist/compiled/nanoid/index.js'
 import loadConfig from 'next-server/next-config'
 import { PHASE_PRODUCTION_BUILD } from 'next-server/constants'
 import getBaseWebpackConfig from './webpack-config'

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -67,7 +67,6 @@
     "loader-utils": "1.1.0",
     "magic-string": "0.25.2",
     "mkdirp": "0.5.1",
-    "nanoid": "1.2.1",
     "next-server": "8.0.4-canary.19",
     "prop-types": "15.6.2",
     "prop-types-exact": "1.2.0",
@@ -117,6 +116,7 @@
     "@types/webpack-sources": "0.1.5",
     "@zeit/ncc": "0.15.2",
     "taskr": "1.1.0",
+    "nanoid": "1.2.1",
     "text-table": "0.2.0",
     "typescript": "3.1.6",
     "unistore": "3.2.1"

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -21,6 +21,14 @@ const babelOpts = {
 }
 
 // eslint-disable-next-line camelcase
+export async function ncc_nanoid (task, opts) {
+  await task
+    .source(opts.src || relative(__dirname, require.resolve('nanoid')))
+    .ncc({ packageName: 'nanoid' })
+    .target('dist/compiled/nanoid')
+}
+
+// eslint-disable-next-line camelcase
 export async function ncc_unistore (task, opts) {
   await task
     .source(opts.src || relative(__dirname, require.resolve('unistore')))
@@ -37,7 +45,7 @@ export async function ncc_text_table (task, opts) {
 }
 
 export async function precompile (task) {
-  await task.parallel(['ncc_unistore', 'ncc_text_table'])
+  await task.parallel(['ncc_unistore', 'ncc_nanoid', 'ncc_text_table'])
 }
 
 export async function compile (task) {

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -3,6 +3,13 @@ declare module 'next-server/next-config';
 declare module 'next-server/constants';
 declare module 'webpack/lib/GraphHelpers';
 
+
+declare module 'next/dist/compiled/nanoid/index.js' {
+  function nanoid(size?: number): string;
+
+  export = nanoid;
+}
+
 declare module 'arg' {
   function arg<T extends arg.Spec>(spec: T, options?: {argv?: string[], permissive?: boolean}): arg.Result<T>;
 


### PR DESCRIPTION
We only use a very small subset of nanoid, so the ncc'ed size is 4KB vs 22KB.