### PR TITLE
Pass mapDispatchToProps as an object

### DIFF
--- a/examples/with-redux/pages/index.js
+++ b/examples/with-redux/pages/index.js
@@ -1,21 +1,21 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
 import { startClock, serverRenderClock } from '../store'
 import Examples from '../components/examples'
 
 class Index extends React.Component {
   static getInitialProps ({ reduxStore, req }) {
     const isServer = !!req
+    // DISPATCH ACTIONS HERE ONLY WITH `reduxStore.dispatch`
     reduxStore.dispatch(serverRenderClock(isServer))
 
     return {}
   }
 
   componentDidMount () {
-    const { dispatch } = this.props
+    // DISPATCH ACTIONS HERE FROM `mapDispatchToProps`
     // TO TICK THE CLOCK
-    this.timer = setInterval(() => this.props.startClock(dispatch), 1000)
+    this.timer = setInterval(() => this.props.startClock(), 1000)
   }
 
   componentWillUnmount () {
@@ -26,5 +26,7 @@ class Index extends React.Component {
     return <Examples />
   }
 }
-const mapDispatchToProps = dispatch => bindActionCreators({ startClock }, dispatch)
+const mapDispatchToProps = {
+  startClock
+};
 export default connect(null, mapDispatchToProps)(Index)

--- a/examples/with-redux/pages/index.js
+++ b/examples/with-redux/pages/index.js
@@ -26,7 +26,5 @@ class Index extends React.Component {
     return <Examples />
   }
 }
-const mapDispatchToProps = {
-  startClock
-};
+const mapDispatchToProps = { startClock };
 export default connect(null, mapDispatchToProps)(Index)

--- a/examples/with-redux/pages/index.js
+++ b/examples/with-redux/pages/index.js
@@ -26,5 +26,5 @@ class Index extends React.Component {
     return <Examples />
   }
 }
-const mapDispatchToProps = { startClock };
+const mapDispatchToProps = { startClock }
 export default connect(null, mapDispatchToProps)(Index)


### PR DESCRIPTION
wrapping `startClock` in `bindActionsCreator` there's no need to pass `dispatch` in:
```
this.props.startClock(dispatch)
```
Furthermore `bindActionsCreator` is not needed because following already bind actions:
```
const mapDispatchToProps = {
  startClock
};
```