### PR TITLE
Improve with-google-analytics example

### DIFF
--- a/examples/with-google-analytics/components/Page.js
+++ b/examples/with-google-analytics/components/Page.js
@@ -1,10 +1,5 @@
 import React from 'react'
-import Router from 'next/router'
 import Header from './Header'
-
-import * as gtag from '../lib/gtag'
-
-Router.events.on('routeChangeComplete', url => gtag.pageview(url))
 
 export default ({ children }) => (
   <div>

--- a/examples/with-google-analytics/lib/gtag.js
+++ b/examples/with-google-analytics/lib/gtag.js
@@ -3,7 +3,7 @@ export const GA_TRACKING_ID = '<YOUR_GA_TRACKING_ID>'
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = url => {
   window.gtag('config', GA_TRACKING_ID, {
-    page_location: url
+    page_path: url
   })
 }
 

--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -1,0 +1,8 @@
+import App from 'next/app'
+import Router from 'next/router'
+
+import * as gtag from '../lib/gtag'
+
+Router.events.on('routeChangeComplete', url => gtag.pageview(url))
+
+export default App

--- a/examples/with-google-analytics/pages/_document.js
+++ b/examples/with-google-analytics/pages/_document.js
@@ -1,16 +1,9 @@
 import React from 'react'
 import Document, { Head, Main, NextScript } from 'next/document'
-import flush from 'styled-jsx/server'
 
 import { GA_TRACKING_ID } from '../lib/gtag'
 
 export default class extends Document {
-  static getInitialProps ({ renderPage }) {
-    const { html, head, errorHtml, chunks } = renderPage()
-    const styles = flush()
-    return { html, head, errorHtml, chunks, styles }
-  }
-
   render () {
     return (
       <html>

--- a/examples/with-google-analytics/pages/contact.js
+++ b/examples/with-google-analytics/pages/contact.js
@@ -29,7 +29,7 @@ export default class extends Component {
         <form onSubmit={this.handleSubmit}>
           <label>
             <span>Message:</span>
-            <textarea onInput={this.handleInput} value={this.state.message} />
+            <textarea onChange={this.handleInput} value={this.state.message} />
           </label>
           <button type='submit'>submit</button>
         </form>


### PR DESCRIPTION
The with-google-analytics example had the "routeChangeComplete" event listener set up in components/Page.js, but that the event listener would only be set up if the user visited a page using that component. From the example, it's not clear if google analytics can be used without making every page use a component like components/Page.js. Someone following the example may make pages that don't use components/Page.js and fail to have page views reported, or feel compelled to force a shared component into their design unnecessarily, or might even make a mistake by making multiple different components like Page.js which each add a new "routeChangeComplete" event listener, causing page views to be over-reported when the user navigates between pages using the different components.

This PR moves the "routeChangeComplete" event listener into _app.js, where it's guaranteed to be executed for every page and is more obviously decoupled from page-layout-related components.

This PR also fixes a React warning about the lack of an onChange handler on an input tag, and removes the unnecessary implementation of `getInitialProps` in _document.js (the default implementation is inherited if not present, there's nothing this example needs to do with `getInitialProps` specifically, and the body of the method seems to have been based on an old version of next's internal implementation).

This PR also fixes the url being passed to google tag manager incorrectly. It looks like page_path should be used instead of page_location because the `url` value only has the path, not the full url with the domain name, etc. (https://developers.google.com/analytics/devguides/collection/gtagjs/pages)