### PR TITLE
Add AMP validation on export

### DIFF
--- a/errors/amp-export-validation.md
+++ b/errors/amp-export-validation.md
@@ -1,0 +1,13 @@
+# AMP Export Validation
+
+#### Why This Error Occurred
+
+During export we validate AMP pages using [amphtml-validator](https://www.npmjs.com/package/amphtml-validator), when we receive an error is received from the validator that means an AMP page is invalid an the export is not valid.
+
+#### Possible Ways to Fix It
+
+Look at the error messages telling you the reasons for the error and update it to make the AMP page that caused the error to validate. 
+
+### Useful Links
+
+- [AMP HTML Specification](https://www.ampproject.org/docs/fundamentals/spec)

--- a/errors/amp-export-validation.md
+++ b/errors/amp-export-validation.md
@@ -4,7 +4,7 @@
 
 During export we validate AMP pages using [amphtml-validator](https://www.npmjs.com/package/amphtml-validator). Errors received from the validator will fail the export.
 
-Validation errors mean your page is not valid AMP HTML and will not be [indexed by AMP Caches](https://www.ampproject.org/docs/fundamentals/how_cached).
+Validation errors will cause pages to not be [indexed by AMP Caches](https://www.ampproject.org/docs/fundamentals/how_cached).
 
 #### Possible Ways to Fix It
 

--- a/errors/amp-export-validation.md
+++ b/errors/amp-export-validation.md
@@ -2,7 +2,9 @@
 
 #### Why This Error Occurred
 
-During export we validate AMP pages using [amphtml-validator](https://www.npmjs.com/package/amphtml-validator), when we receive an error from the validator that means an AMP page is invalid so the export is not valid.
+During export we validate AMP pages using [amphtml-validator](https://www.npmjs.com/package/amphtml-validator). Errors received from the validator will fail the export.
+
+Validation errors mean your page is not valid AMP HTML and will not be [indexed by AMP Caches](https://www.ampproject.org/docs/fundamentals/how_cached).
 
 #### Possible Ways to Fix It
 

--- a/errors/amp-export-validation.md
+++ b/errors/amp-export-validation.md
@@ -6,7 +6,7 @@ During export we validate AMP pages using [amphtml-validator](https://www.npmjs.
 
 #### Possible Ways to Fix It
 
-Look at the error messages telling you the reasons for the error and update it to make the AMP page that caused the error to validate. 
+Look at the error messages and follow their appropriate links to learn more about the error and how to correct the problem.
 
 ### Useful Links
 

--- a/errors/amp-export-validation.md
+++ b/errors/amp-export-validation.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-During export we validate AMP pages using [amphtml-validator](https://www.npmjs.com/package/amphtml-validator), when we receive an error is received from the validator that means an AMP page is invalid an the export is not valid.
+During export we validate AMP pages using [amphtml-validator](https://www.npmjs.com/package/amphtml-validator), when we receive an error from the validator that means an AMP page is invalid so the export is not valid.
 
 #### Possible Ways to Fix It
 

--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -58,7 +58,7 @@ function getWebpackStatusPhase(status: WebpackStatus): WebpackStatusPhase {
   return WebpackStatusPhase.COMPILED
 }
 
-function formatAmpMessages(amp: AmpPageStatus) {
+export function formatAmpMessages(amp: AmpPageStatus) {
   let output = chalk.bold('Amp Validation') + '\n\n'
   let messages: string[][] = []
 

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -184,7 +184,7 @@ export default async function (dir, options, configuration) {
     console.log(formatAmpMessages(ampValidations))
   }
   if (hadValidationError) {
-    throw new Error(`AMP Validation received an error. https://err.sh/zeit/next.js/amp-export-validation`)
+    throw new Error(`AMP Validation caused the export to fail. https://err.sh/zeit/next.js/amp-export-validation`)
   }
 
   // Add an empty line to the console for the better readability.

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -11,6 +11,7 @@ import { PHASE_EXPORT, SERVER_DIRECTORY, PAGES_MANIFEST, CONFIG_FILE, BUILD_ID_F
 import createProgress from 'tty-aware-progress'
 import { promisify } from 'util'
 import { recursiveDelete } from '../lib/recursive-delete'
+import { formatAmpMessages } from '../build/output/index'
 
 const mkdirp = promisify(mkdirpModule)
 
@@ -143,6 +144,9 @@ export default async function (dir, options, configuration) {
     return result
   }, [])
 
+  const ampValidations = {}
+  let hadValidationError = false
+
   await Promise.all(
     chunks.map(
       chunk =>
@@ -167,11 +171,21 @@ export default async function (dir, options, configuration) {
               reject(payload)
             } else if (type === 'done') {
               resolve()
+            } else if (type === 'amp-validation') {
+              ampValidations[payload.page] = payload.result
+              hadValidationError = hadValidationError || payload.result.errors.length
             }
           })
         })
     )
   )
+
+  if (Object.keys(ampValidations).length) {
+    console.log(formatAmpMessages(ampValidations))
+  }
+  if (hadValidationError) {
+    throw new Error(`AMP Validation received an error. https://err.sh/zeit/next.js/amp-export-validation`)
+  }
 
   // Add an empty line to the console for the better readability.
   log('')

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -6,7 +6,6 @@ import { renderToHTML } from 'next-server/dist/server/render'
 import { writeFile } from 'fs'
 import Sema from 'async-sema'
 import AmpHtmlValidator from 'amphtml-validator'
-import { formatAmpMessages } from '../build/output/index'
 import { loadComponents } from 'next-server/dist/server/load-components'
 
 const envConfig = require('next-server/config')
@@ -77,17 +76,16 @@ process.on(
           const warnings = result.errors.filter(e => e.severity !== 'ERROR')
 
           if (warnings.length || errors.length) {
-            console.log(
-              formatAmpMessages({
-                [page]: {
+            process.send({
+              type: 'amp-validation',
+              payload: {
+                page,
+                result: {
                   errors,
                   warnings
                 }
-              })
-            )
-            if (errors.length) {
-              throw new Error('AMP validation had error')
-            }
+              }
+            })
           }
         }
 

--- a/test/integration/amp-export-validation/next.config.js
+++ b/test/integration/amp-export-validation/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // exportPathMap
+  experimental: {
+    amp: true
+  }
+}

--- a/test/integration/amp-export-validation/pages/cat.amp.js
+++ b/test/integration/amp-export-validation/pages/cat.amp.js
@@ -1,0 +1,6 @@
+export default () => (
+  <div>
+    {/* I show a warning since the amp-video script isn't added */}
+    <amp-video src='/cats.mp4' height={400} width={800} />
+  </div>
+)

--- a/test/integration/amp-export-validation/pages/dog-cat.amp.js
+++ b/test/integration/amp-export-validation/pages/dog-cat.amp.js
@@ -1,0 +1,8 @@
+export default () => (
+  <div>
+    {/* I throw an error since <amp-img/> should be used instead */}
+    <img src='/dog.gif' height={400} width={800} />
+    {/* I show a warning since the amp-video script isn't added */}
+    <amp-video src='/cats.mp4' height={400} width={800} />
+  </div>
+)

--- a/test/integration/amp-export-validation/pages/dog.amp.js
+++ b/test/integration/amp-export-validation/pages/dog.amp.js
@@ -1,0 +1,6 @@
+export default () => (
+  <div>
+    {/* I throw an error since <amp-img/> should be used instead */}
+    <img src='/dog.gif' height={400} width={800} />
+  </div>
+)

--- a/test/integration/amp-export-validation/test/index.test.js
+++ b/test/integration/amp-export-validation/test/index.test.js
@@ -1,0 +1,93 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs'
+import { join } from 'path'
+import { promisify } from 'util'
+import {
+  File,
+  nextBuild,
+  runNextCommand
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const access = promisify(fs.access)
+const appDir = join(__dirname, '../')
+const outDir = join(appDir, 'out')
+const nextConfig = new File(join(appDir, 'next.config.js'))
+
+describe('AMP Validation on Export', () => {
+  beforeAll(() => nextBuild(appDir))
+
+  it('shows AMP warning without throwing error', async () => {
+    nextConfig.replace('// exportPathMap',
+      `exportPathMap: function(defaultMap) {
+      return {
+        '/cat': defaultMap['/cat.amp'],
+      }
+    },`)
+
+    let stdout = ''
+    try {
+      await runNextCommand(['export', appDir], {
+        instance: child => {
+          child.stdout.on('data', chunk => {
+            stdout += chunk.toString()
+          })
+        }
+      })
+    } finally {
+      nextConfig.restore()
+      expect(stdout).toMatch(/warn.*The tag 'amp-video extension \.js script' is missing/)
+      await expect(access(join(outDir, 'cat/index.html'))).resolves.toBe(undefined)
+    }
+  })
+
+  it('throws error on AMP error', async () => {
+    nextConfig.replace('// exportPathMap',
+      `exportPathMap: function(defaultMap) {
+      return {
+        '/dog': defaultMap['/dog.amp'],
+      }
+    },`)
+
+    let stdout = ''
+    try {
+      await runNextCommand(['export', appDir], {
+        instance: child => {
+          child.stdout.on('data', chunk => {
+            stdout += chunk.toString()
+          })
+        }
+      })
+    } finally {
+      nextConfig.restore()
+      expect(stdout).toMatch(/error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/)
+      await expect(access(join(outDir, 'dog/index.html'))).rejects.toBeTruthy()
+    }
+  })
+
+  it('shows warning and error when throwing error', async () => {
+    nextConfig.replace('// exportPathMap',
+      `exportPathMap: function(defaultMap) {
+      return {
+        '/dog-cat': defaultMap['/dog-cat.amp'],
+      }
+    },`)
+
+    let stdout = ''
+    try {
+      await runNextCommand(['export', appDir], {
+        instance: child => {
+          child.stdout.on('data', chunk => {
+            stdout += chunk.toString()
+          })
+        }
+      })
+    } finally {
+      nextConfig.restore()
+      expect(stdout).toMatch(/warn.*The tag 'amp-video extension \.js script' is missing/)
+      expect(stdout).toMatch(/error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/)
+      await expect(access(join(outDir, 'dog-cat/index.html'))).rejects.toBeTruthy()
+    }
+  })
+})

--- a/test/integration/amp-export-validation/test/index.test.js
+++ b/test/integration/amp-export-validation/test/index.test.js
@@ -35,10 +35,10 @@ describe('AMP Validation on Export', () => {
           })
         }
       })
-    } finally {
-      nextConfig.restore()
       expect(stdout).toMatch(/warn.*The tag 'amp-video extension \.js script' is missing/)
       await expect(access(join(outDir, 'cat/index.html'))).resolves.toBe(undefined)
+    } finally {
+      nextConfig.restore()
     }
   })
 
@@ -59,10 +59,10 @@ describe('AMP Validation on Export', () => {
           })
         }
       })
+      expect(stdout).toMatch(/error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/)
+      await expect(access(join(outDir, 'dog/index.html'))).resolves.toBe(undefined)
     } finally {
       nextConfig.restore()
-      expect(stdout).toMatch(/error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/)
-      await expect(access(join(outDir, 'dog/index.html'))).rejects.toBeTruthy()
     }
   })
 
@@ -83,11 +83,11 @@ describe('AMP Validation on Export', () => {
           })
         }
       })
-    } finally {
-      nextConfig.restore()
       expect(stdout).toMatch(/warn.*The tag 'amp-video extension \.js script' is missing/)
       expect(stdout).toMatch(/error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/)
-      await expect(access(join(outDir, 'dog-cat/index.html'))).rejects.toBeTruthy()
+      await expect(access(join(outDir, 'dog-cat/index.html'))).resolves.toBe(undefined)
+    } finally {
+      nextConfig.restore()
     }
   })
 })


### PR DESCRIPTION
When exporting an AMP page we validate it and when an error is returned we abort the export after logging the errors. If just a warning is shown we log the warning but don't abort the export. 

Closes: #6792 