### PR TITLE
Remove prop-types import in the build

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -85,7 +85,9 @@ module.exports = (api: any, options: NextBabelPresetOptions = {}): BabelPreset =
       }],
       [require('styled-jsx/babel'), styledJsxOptions(options['styled-jsx'])],
       require('./plugins/amp-attributes'),
-      isProduction && require('babel-plugin-transform-react-remove-prop-types')
+      isProduction && [require('babel-plugin-transform-react-remove-prop-types'), {
+        removeImport: true
+      }]
     ].filter(Boolean)
   }
 }


### PR DESCRIPTION
Tests don't catch this change because `isProduction &&` is always false so I tested it with a local build