### PR TITLE
Upgrade unfetch to v4.1.0

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -76,7 +76,7 @@
     "styled-jsx": "3.2.1",
     "terser": "3.16.1",
     "tty-aware-progress": "1.0.3",
-    "unfetch": "3.0.0",
+    "unfetch": "4.1.0",
     "url": "0.11.0",
     "webpack": "4.29.0",
     "webpack-dev-middleware": "3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12293,15 +12293,10 @@ umask@^1.1.0:
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
 
-unfetch@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-3.0.0.tgz#8d1e0513a4ecd0e5ff2d41a6ba77771aae8b6482"
-  integrity sha1-jR4FE6Ts0OX/LUGmund3Gq6LZII=
-
-unfetch@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.0.1.tgz#8750c4c7497ade75d40387d7dbc4ba024416b8f6"
-  integrity sha512-HzDM9NgldcRvHVDb/O9vKoUszVij30Yw5ePjOZJig8nF/YisG7QN/9CBXZ8dsHLouXMeLZ82r+Jod9M2wFkEbQ==
+unfetch@4.1.0, unfetch@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
+  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
 
 unherit@^1.0.4:
   version "1.1.1"


### PR DESCRIPTION
`unfetch` ^4.0.0 is already used by `isomorphic-unfetch` so this simplifies the dependency tree a tiny bit.

Release notes
https://github.com/developit/unfetch/releases/tag/4.0.0
https://github.com/developit/unfetch/releases/tag/4.1.0