### PR TITLE
Custom hapi server example handle static files

### DIFF
--- a/examples/custom-server-hapi/server.js
+++ b/examples/custom-server-hapi/server.js
@@ -31,7 +31,7 @@ app.prepare().then(async () => {
     path: '/_next/{p*}' /* next specific routes */,
     handler: nextHandlerWrapper(app)
   })
-  
+
   server.route({
     method: 'GET',
     path: '/static/{p*}' /* use next to handle static files */,

--- a/examples/custom-server-hapi/server.js
+++ b/examples/custom-server-hapi/server.js
@@ -31,6 +31,12 @@ app.prepare().then(async () => {
     path: '/_next/{p*}' /* next specific routes */,
     handler: nextHandlerWrapper(app)
   })
+  
+  server.route({
+    method: 'GET',
+    path: '/static/{p*}' /* use next to handle static files */,
+    handler: nextHandlerWrapper(app)
+  })
 
   server.route({
     method: 'GET',


### PR DESCRIPTION
While implementing hapi as a custom server, I found a minor issue. The example provided isn't showing that we also need to serve static files using next. This change should fix that. Thanks!