### PR TITLE
Update env variables for CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
       - run:
           name: Production Tests
           command: '[[ ! -z $BROWSERSTACK_USERNAME ]] && yarn testall test/integration/production/ || echo "Not running for PR"'
+          environment:
+            BROWSERSTACK: 'true'
+            BROWSER_NAME: 'ie'
   deploy:
     docker:
       - image: circleci/node:8-browsers


### PR DESCRIPTION
This got dropped off the BrowserStack PR when reverting so it just ran with chromedriver on merge