### PR TITLE
Add workflow to generate stats for release

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,6 +3,11 @@ workflow "Generate pull request stats" {
   resolves = ["PR Stats"]
 }
 
+workflow "Generate release stats" {
+  on = "release"
+  resolve = ["PR Stats"]
+}
+
 action "PR Stats" {
   uses = "zeit/next-stats-action@master"
   secrets = ["GITHUB_TOKEN"]


### PR DESCRIPTION
This adds triggering the PR Stats GitHub Action for a canary release. It compares the latest canary release with the last stable release and posts it as a comment to the commit. 