### PR TITLE
Remove leading spaces from server log

### DIFF
--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -30,7 +30,7 @@ store.subscribe(state => {
     console.log(chalk.cyan('Starting the development server ...'))
     if (state.appUrl) {
       console.log()
-      console.log(`  > Waiting on ${state.appUrl!}`)
+      console.log(`> Waiting on ${state.appUrl!}`)
     }
     return
   }
@@ -57,7 +57,7 @@ store.subscribe(state => {
   console.log(chalk.green('Compiled successfully!'))
   if (state.appUrl) {
     console.log()
-    console.log(`  > Ready on ${state.appUrl!}`)
+    console.log(`> Ready on ${state.appUrl!}`)
   }
   console.log()
   console.log('Note that pages will be compiled when you first load them.')


### PR DESCRIPTION
Warning: This is pretty nitpicky...

Currently, the default server info log has two trailing spaces, while other warnings don't. This removes the two leading spaces to correctly align all messages.

Before:

<img width="752" alt="Screenshot 2019-04-01 at 15 38 56" src="https://user-images.githubusercontent.com/1561079/55332225-43734980-5495-11e9-8f30-963eb18366e6.png">

After:

<img width="835" alt="Screenshot 2019-04-01 at 15 47 40" src="https://user-images.githubusercontent.com/1561079/55332368-86352180-5495-11e9-8c58-d0fdfe6a0c43.png">
