### PR TITLE
Make sure error isn't swallowed for test-production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           at: .
       - run:
           name: Production Tests
-          command: '[[ ! -z $BROWSERSTACK_USERNAME ]] && yarn testall test/integration/production/ || echo "Not running for PR"'
+          command: 'if [[ ! -z $BROWSERSTACK_USERNAME ]]; then yarn testall test/integration/production/; else echo "Not running for PR"; fi'
           environment:
             BROWSERSTACK: 'true'
             BROWSER_NAME: 'ie'

--- a/test/lib/next-webdriver.js
+++ b/test/lib/next-webdriver.js
@@ -87,5 +87,7 @@ function getBrowser (url, timeout) {
   })
 }
 
-if (global.isBrowserStack) webdriver = global.bsBrowser
+if (global.isBrowserStack) {
+  webdriver = (...args) => global.bsWd(...args)
+}
 export default webdriver


### PR DESCRIPTION
Tweaked the CircleCi `test-production` command to make sure if the tests fail the error isn't swallowed