### PR TITLE
Avoid "ad" anywhere in the biuldId

### DIFF
--- a/packages/next/build/generate-build-id.ts
+++ b/packages/next/build/generate-build-id.ts
@@ -3,7 +3,7 @@ export async function generateBuildId (generate: () => string|null, fallback: ()
   // If there's no buildId defined we'll fall back
   if (buildId === null) {
     // We also create a new buildId if it starts with ad_ to avoid ad blockers
-    while (!buildId || buildId.startsWith('ad_')) {
+    while (!buildId || buildId.startsWith('ad')) {
       buildId = fallback()
     }
   }

--- a/packages/next/build/generate-build-id.ts
+++ b/packages/next/build/generate-build-id.ts
@@ -2,7 +2,8 @@ export async function generateBuildId (generate: () => string|null, fallback: ()
   let buildId = await generate()
   // If there's no buildId defined we'll fall back
   if (buildId === null) {
-    // We also create a new buildId if it starts with ad_ to avoid ad blockers
+    // We also create a new buildId if it starts with `ad` to avoid false 
+    // positives with ad blockers
     while (!buildId || buildId.startsWith('ad')) {
       buildId = fallback()
     }

--- a/packages/next/build/generate-build-id.ts
+++ b/packages/next/build/generate-build-id.ts
@@ -4,7 +4,7 @@ export async function generateBuildId (generate: () => string|null, fallback: ()
   if (buildId === null) {
     // We also create a new buildId if it starts with `ad` to avoid false 
     // positives with ad blockers
-    while (!buildId || buildId.includes('ad')) {
+    while (!buildId || /ad/i.test(buildId)) {
       buildId = fallback()
     }
   }

--- a/packages/next/build/generate-build-id.ts
+++ b/packages/next/build/generate-build-id.ts
@@ -4,7 +4,7 @@ export async function generateBuildId (generate: () => string|null, fallback: ()
   if (buildId === null) {
     // We also create a new buildId if it starts with `ad` to avoid false 
     // positives with ad blockers
-    while (!buildId || buildId.startsWith('ad')) {
+    while (!buildId || buildId.includes('ad')) {
       buildId = fallback()
     }
   }

--- a/packages/next/build/generate-build-id.ts
+++ b/packages/next/build/generate-build-id.ts
@@ -2,7 +2,10 @@ export async function generateBuildId (generate: () => string|null, fallback: ()
   let buildId = await generate()
   // If there's no buildId defined we'll fall back
   if (buildId === null) {
-    buildId = fallback()
+    // We also create a new buildId if it starts with ad_ to avoid ad blockers
+    while (!buildId || buildId.startsWith('ad_')) {
+      buildId = fallback()
+    }
   }
 
   if (typeof buildId !== 'string') {


### PR DESCRIPTION
In response to the comment created here:

https://github.com/zeit/next.js/pull/6851/files/a3d7fab3f181d310673af31b7ac14522856e219f#diff-76c9c0ae51cc93af6d31aae67d12a4c2R7