### PR TITLE
[withApollo example] include async get token example

### DIFF
--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -18,11 +18,11 @@ function create (initialState) {
       credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
       fetch: async (uri, options) => { // Computes token on every request and adds it to Authorization header
         if (typeof window !== 'undefined') {
-          const token = await window.localStorage.getItem('token');
-          if (token) options.headers.Authorization = `Bearer ${token}`;
+          const token = await window.localStorage.getItem('token')
+          if (token) options.headers.Authorization = `Bearer ${token}`
         }
-        return fetch(uri, options);
-      },
+        return fetch(uri, options)
+      }
     }),
     cache: new InMemoryCache().restore(initialState || {})
   })

--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -15,7 +15,14 @@ function create (initialState) {
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
-      credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
+      credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
+      fetch: async (uri, options) => { // Computes token on every request and adds it to Authorization header
+        if (typeof window !== 'undefined') {
+          const token = await window.localStorage.getItem('token');
+          if (token) options.headers.Authorization = `Bearer ${token}`;
+        }
+        return fetch(uri, options);
+      },
     }),
     cache: new InMemoryCache().restore(initialState || {})
   })


### PR DESCRIPTION
Most users that are integrating `apollo` will need authentication at some point. Sometimes it can get confusing since there are some different ways of doing it.

This PR adds an asynchronous function on every `ApolloClient` request to potentially get a token stored on `localStorage` — or somewhere else — and add it in the `Authorization` header.