### PR TITLE
Refine selective page building

### DIFF
--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -30,8 +30,7 @@ const defaultConfig = {
     ),
     ampBindInitData: false,
     exportTrailingSlash: true,
-    profiling: false,
-    sharedRuntime: false
+    profiling: false
   }
 }
 


### PR DESCRIPTION
This drops the `experimental` setting for `sharedRuntime` and automatically toggles it when you utilize the `--experimental-flag` option on `next build`.

Using these changes, users can build bundles for specific subsets of page(s) and stitch the applications together.