### PR TITLE
Add an experimental debug mode to builds

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -123,6 +123,9 @@ export default async function build(
   )
   const configs = await Promise.all([
     getBaseWebpackConfig(dir, {
+      __debug:
+        process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG === 'true' ||
+        process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG === '1',
       buildId,
       isServer: false,
       config,
@@ -131,6 +134,9 @@ export default async function build(
       __selectivePageBuilding: pages && Boolean(pages.length),
     }),
     getBaseWebpackConfig(dir, {
+      __debug:
+        process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG === 'true' ||
+        process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG === '1',
       buildId,
       isServer: true,
       config,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -264,7 +264,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, __debug
         'process.crossOrigin': JSON.stringify(config.crossOrigin),
         'process.browser': JSON.stringify(!isServer),
         // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
-        ...((dev || __debug) && !isServer ? {
+        ...(dev && !isServer ? {
           'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)
         } : {}),
         'process.env.__NEXT_EXPORT_TRAILING_SLASH': JSON.stringify(config.experimental.exportTrailingSlash)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -18,7 +18,7 @@ import { ChunkGraphPlugin } from './webpack/plugins/chunk-graph-plugin'
 import { WebpackEntrypoints } from './entries'
 type ExcludesFalse = <T>(x: T | false) => x is T
 
-export default function getBaseWebpackConfig (dir: string, {dev = false, isServer = false, buildId, config, target = 'server', entrypoints, __selectivePageBuilding = false}: {dev?: boolean, isServer?: boolean, buildId: string, config: any, target?: string, entrypoints: WebpackEntrypoints, __selectivePageBuilding?: boolean}): webpack.Configuration {
+export default function getBaseWebpackConfig (dir: string, {dev = false, __debug = false, isServer = false, buildId, config, target = 'server', entrypoints, __selectivePageBuilding = false}: {dev?: boolean, __debug?: boolean, isServer?: boolean, buildId: string, config: any, target?: string, entrypoints: WebpackEntrypoints, __selectivePageBuilding?: boolean}): webpack.Configuration {
   const defaultLoaders = {
     babel: {
       loader: 'next-babel-loader',
@@ -77,7 +77,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
 
   let webpackConfig: webpack.Configuration = {
     mode: webpackMode,
-    devtool: dev ? 'cheap-module-source-map' : false,
+    devtool: (dev || __debug) ? 'cheap-module-source-map' : false,
     name: isServer ? 'server' : 'client',
     target: isServer ? 'node' : 'web',
     externals: isServer && target !== 'serverless' ? [
@@ -178,8 +178,8 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
           }
         }
       },
-      minimize: !dev,
-      minimizer: !dev ? [
+      minimize: !(dev || __debug),
+      minimizer: !(dev || __debug) ? [
         new TerserPlugin({...terserPluginConfig,
           terserOptions: {
             safari10: true
@@ -264,7 +264,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, isServe
         'process.crossOrigin': JSON.stringify(config.crossOrigin),
         'process.browser': JSON.stringify(!isServer),
         // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
-        ...(dev && !isServer ? {
+        ...((dev || __debug) && !isServer ? {
           'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir)
         } : {}),
         'process.env.__NEXT_EXPORT_TRAILING_SLASH': JSON.stringify(config.experimental.exportTrailingSlash)


### PR DESCRIPTION
This pull request introduces a way for the builder to request a debug-enabled build. This is useful for initiatives like `now dev`, et al.