### PR TITLE
Update Sentry to v5 and add @sentry/integrations

### DIFF
--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -24,15 +24,12 @@ Install it and run:
 ```bash
 npm install
 npm run dev
-# or
-yarn
-yarn dev
 ```
 
 **yarn**
 ```bash
-npm install
-npm run dev
+yarn
+yarn dev
 ```
 
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))

--- a/examples/with-sentry/package.json
+++ b/examples/with-sentry/package.json
@@ -7,8 +7,9 @@
     "start": "SENTRY_DSN=abc123 NODE_ENV=production node server.js"
   },
   "dependencies": {
-    "@sentry/browser": "^4.6.1",
-    "@sentry/node": "^4.6.1",
+    "@sentry/browser": "^5.0.3",
+    "@sentry/node": "^5.0.3",
+    "@sentry/integrations": "^5.0.3",
     "@zeit/next-source-maps": "0.0.4-canary.1",
     "cookie-parser": "1.4.4",
     "express": "^4.16.4",

--- a/examples/with-sentry/utils/sentry.js
+++ b/examples/with-sentry/utils/sentry.js
@@ -1,6 +1,7 @@
 // NOTE: This require will be replaced with `@sentry/browser` when
 // process.browser === true thanks to the webpack config in next.config.js
 const Sentry = require('@sentry/node')
+const SentryIntegrations = require('@sentry/integrations')
 const Cookie = require('js-cookie')
 
 module.exports = (release = process.env.SENTRY_RELEASE) => {
@@ -22,7 +23,7 @@ module.exports = (release = process.env.SENTRY_RELEASE) => {
 
     // Instead, dump the errors to the console
     sentryOptions.integrations = [
-      new Sentry.Integrations.Debug({
+      new SentryIntegrations.Debug({
         // Trigger DevTools debugger instead of using console.log
         debugger: false
       })


### PR DESCRIPTION
Hi everyone :)
I just updated Sentry to v5 and added @sentry/integrations due to breaking changes :)
I also fix the documentation. npm commands were in yarn section.