### PR TITLE
Added cross-env package for using on Windows

### DIFF
--- a/examples/custom-server-express/package.json
+++ b/examples/custom-server-express/package.json
@@ -4,12 +4,15 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
     "express": "^4.14.0",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
+  },
+  "devDependencies": {
+    "cross-env": "^5.2.0"
   }
 }


### PR DESCRIPTION
Added [cross-env](https://www.npmjs.com/package/cross-env) package for using the command `npm start` on Windows environment.

Tested on:
- [x] Windows version 1809
- [x] Node.js 10.15.3 (LTS version)