### PR TITLE
Revert weird firefox workaround

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -75,18 +75,6 @@ export default class Router implements IRouterInterface {
       this.changeState('replaceState', formatWithValidation({ pathname, query }), as)
 
       window.addEventListener('popstate', this.onPopState)
-
-      // Workaround for weird Firefox bug, see below links
-      // https://github.com/zeit/next.js/issues/3817
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1422334
-      // TODO: let's remove this once the Firefox bug is resolved
-      if (navigator.userAgent && navigator.userAgent.match(/firefox/i)) {
-        window.addEventListener('unload', () => {
-          try {
-            if (window.location.search) window.location.replace(window.location.toString())
-          } catch (_) {/* since it's a workaround, ignore */}
-        })
-      }
     }
   }
 


### PR DESCRIPTION
This workaround originally addressed #3817 which is an edge case but introduced #6882 which is much worse so this reverts it. 

Closes: #3817 