### PR TITLE
Compute Chunk Graph file hashes on emit

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -272,7 +272,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
       !isServer && new ReactLoadablePlugin({
         filename: REACT_LOADABLE_MANIFEST
       }),
-      !isServer && new ChunkGraphPlugin(path.resolve(dir), { filename: CHUNK_GRAPH_MANIFEST }),
+      !isServer && __selectivePageBuilding && new ChunkGraphPlugin(path.resolve(dir), { filename: CHUNK_GRAPH_MANIFEST }),
       ...(dev ? (() => {
         // Even though require.cache is server only we have to clear assets from both compilations
         // This is because the client compilation generates the build manifest that's used on the server side

--- a/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
+++ b/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
@@ -3,6 +3,8 @@ import path from 'path'
 import { EOL } from 'os'
 import { parse } from 'querystring'
 import { CLIENT_STATIC_FILES_RUNTIME_MAIN } from 'next-server/constants'
+import fs from 'fs'
+import { createHash } from 'crypto'
 
 function getFiles(dir: string, modules: any[]): string[] {
   if (!(modules && modules.length)) {
@@ -57,13 +59,19 @@ export class ChunkGraphPlugin implements Plugin {
     const { dir } = this
     compiler.hooks.emit.tap('ChunkGraphPlugin', compilation => {
       type StringDictionary = { [pageName: string]: string[] }
-      const manifest: { pages: StringDictionary; chunks: StringDictionary } = {
+      const manifest: {
+        pages: StringDictionary
+        chunks: StringDictionary
+        hashes: StringDictionary
+      } = {
         pages: {},
         chunks: {},
+        hashes: {},
       }
 
       let clientRuntime = [] as string[]
       const pages: StringDictionary = {}
+      const allFiles = new Set()
 
       compilation.chunks.forEach(chunk => {
         if (!chunk.hasEntryModule()) {
@@ -94,6 +102,8 @@ export class ChunkGraphPlugin implements Plugin {
           .filter(val => !val.includes('node_modules'))
           .map(f => path.relative(dir, f))
           .sort()
+
+        files.forEach(f => allFiles.add(f))
 
         let pageName: string | undefined
         if (chunk.entryModule && chunk.entryModule.loaders) {
@@ -129,6 +139,21 @@ export class ChunkGraphPlugin implements Plugin {
           manifest.pages[page] = [...pages[page], ...clientRuntime]
         }
       })
+
+      manifest.hashes = ([...allFiles] as string[]).sort().reduce(
+        (acc, cur) =>
+          Object.assign(
+            acc,
+            fs.existsSync(path.join(dir, cur))
+              ? {
+                  [cur]: createHash('sha1')
+                    .update(fs.readFileSync(path.join(dir, cur)))
+                    .digest('hex'),
+                }
+              : undefined
+          ),
+        {}
+      )
 
       const json = JSON.stringify(manifest, null, 2) + EOL
       compilation.assets[this.filename] = {

--- a/test/integration/chunk-graph/next.config.js
+++ b/test/integration/chunk-graph/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60
+  }
+}

--- a/test/integration/chunk-graph/next.config.js
+++ b/test/integration/chunk-graph/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  target: 'serverless',
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60

--- a/test/integration/chunk-graph/pages/index.js
+++ b/test/integration/chunk-graph/pages/index.js
@@ -1,0 +1,3 @@
+export default () => (
+  <div>Hello World</div>
+)

--- a/test/integration/chunk-graph/test/index.test.js
+++ b/test/integration/chunk-graph/test/index.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join, resolve, relative } from 'path'
+import { existsSync, readFileSync } from 'fs'
+import { CHUNK_GRAPH_MANIFEST } from 'next-server/constants'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+describe('Chunk Graph on Build', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir, ['--experimental-page', '/'])
+  })
+
+  describe('Module collection', () => {
+    it('should build a chunk graph file', () => {
+      const cgf = join(__dirname, `/../.next/${CHUNK_GRAPH_MANIFEST}`)
+      expect(existsSync(cgf)).toBeTruthy()
+      expect(
+        JSON.parse(readFileSync(cgf, 'utf8')).pages['/'].includes(
+          relative(appDir, resolve(__dirname, '..', 'pages', 'index.js'))
+        )
+      )
+    })
+  })
+})

--- a/test/integration/dist-dir/test/index.test.js
+++ b/test/integration/dist-dir/test/index.test.js
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 /* global jasmine */
-import { join, resolve, relative } from 'path'
-import { existsSync, readFileSync } from 'fs'
-import { BUILD_ID_FILE, CHUNK_GRAPH_MANIFEST } from 'next-server/constants'
+import { join } from 'path'
+import { existsSync } from 'fs'
+import { BUILD_ID_FILE } from 'next-server/constants'
 import {
   nextServer,
   nextBuild,
@@ -48,18 +48,6 @@ describe('Production Usage', () => {
       expect(
         existsSync(join(__dirname, `/../.next/${BUILD_ID_FILE}`))
       ).toBeFalsy()
-    })
-  })
-
-  describe('Module collection', () => {
-    it('should build a chunk graph file', () => {
-      const cgf = join(__dirname, `/../dist/${CHUNK_GRAPH_MANIFEST}`)
-      expect(existsSync(cgf)).toBeTruthy()
-      expect(
-        JSON.parse(readFileSync(cgf, 'utf8')).pages['/'].includes(
-          relative(appDir, resolve(__dirname, '..', 'pages', 'index.js'))
-        )
-      )
     })
   })
 })


### PR DESCRIPTION
This adds a `hashes` key to the emitted chunk graph containing a hash of all files involved in the build.