### PR TITLE
Turn off module opts when selective page building

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -142,7 +142,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
           }
         })
       ] : undefined
-    } : {
+    } : Object.assign({
       runtimeChunk: __selectivePageBuilding ? false : {
         name: CLIENT_STATIC_FILES_RUNTIME_WEBPACK
       },
@@ -186,7 +186,11 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
           }
         })
       ] : undefined,
-    },
+    }, __selectivePageBuilding ? {
+      providedExports: false,
+      usedExports: false,
+      concatenateModules: false,
+    } : undefined),
     recordsPath: path.join(outputPath, 'records.json'),
     context: dir,
     // Kept as function to be backwards compatible


### PR DESCRIPTION
Webpack will non-deterministically assign export IDs prior to this change:
```js
/***/ "2oF8":
/***/ (function(module, __webpack_exports__, __webpack_require__) {

"use strict";
/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return FONT_FAMILY_SANS; });
/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "c", function() { return FONT_FAMILY_MONO; });
```

```js
/***/ "2oF8":
/***/ (function(module, __webpack_exports__, __webpack_require__) {

"use strict";
/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "e", function() { return FONT_FAMILY_SANS; });
/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "d", function() { return FONT_FAMILY_MONO; });
/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "b", function() { return COLOR_ERROR; });
```

----


After this PR:
```js
/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "FONT_FAMILY_MONO", function() { return FONT_FAMILY_MONO; });
```