### PR TITLE
Export 404 even if undefined in exportPathMap

### DIFF
--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -42,13 +42,9 @@ export default async function (dir, options, configuration) {
   const defaultPathMap = {}
 
   for (const page of pages) {
-    // _document and _app are not real pages.
-    if (page === '/_document' || page === '/_app') {
-      continue
-    }
-
-    if (page === '/_error') {
-      defaultPathMap['/404.html'] = { page }
+    // _document and _app are not real pages
+    // _error is exported as 404.html later on
+    if (page === '/_document' || page === '/_app' || page === '/_error') {
       continue
     }
 
@@ -146,6 +142,7 @@ export default async function (dir, options, configuration) {
 
   log(`  launching ${threads} threads with concurrency of ${concurrency} per thread`)
   const exportPathMap = await nextConfig.exportPathMap(defaultPathMap, { dev: false, dir, outDir, distDir, buildId })
+  exportPathMap['/404.html'] = exportPathMap['/404.html'] || { page: '/_error' }
   const exportPaths = Object.keys(exportPathMap)
 
   const progress = !options.silent && createProgress(exportPaths.length)

--- a/test/integration/export/test/ssr.js
+++ b/test/integration/export/test/ssr.js
@@ -48,14 +48,18 @@ export default function (context) {
       expect(html).toMatch(/Query is: {}/)
     })
 
-    it('should render _error on 404', async () => {
-      const html = await renderViaHTTP(context.port, '/404')
-      expect(html).toMatch(/404/)
+    it('should render _error on 404.html even if not provided in exportPathMap', async () => {
+      const html = await renderViaHTTP(context.port, '/404.html')
+      // The default error page from the test server
+      // contains "404", so need to be specific here
+      expect(html).toMatch(/404.*page.*not.*found/i)
     })
 
-    it('should export 404.html instead of 404/index.html', async () => {
-      const html = await renderViaHTTP(context.port, '/404.html')
-      expect(html).toMatch(/404/)
+    it('should not render _error on /404/index.html', async () => {
+      const html = await renderViaHTTP(context.port, '/404/index.html')
+      // The default error page from the test server
+      // contains "404", so need to be specific here
+      expect(html).not.toMatch(/404.*page.*not.*found/i)
     })
   })
 }


### PR DESCRIPTION
This PR adds the `_error`-page as an `404.html`-export, even when it is not explicitly defined in a custom `exportPathMap`.

It also fixes two false negative tests related to this. Previously the tests were matching the fallback 404-page from the test-server, rather than the `404.html`-page from next, which was actually not being generated. The test server is also not set up to serve `/404.html` as `/404` which the tests now reflect.

**Caveat**

In its current state, this PR removes `/404.html` from the `defaultPathMap` passed to the custom `exportPathMap`-functions, since it instead adds it after that function is run. While it is possible that someone is relying on this to exist, it is to my knowledge undocumented and also unlikely to be used for anything but merging it into the custom pathMap.

Since this would now merge `undefined` which would result in it being added later on anyway, I deemed it safe, but would be happy to undo that part of the PR if necessary as it was only cleanup.

**Examples**

As a way to demonstrate what this PR does, this is how examples changed:

* `basic-export` - Behaviour is unchanged, still has a `404.html`
* `with-static-export` - Now has a `404.html`