### PR TITLE
Add a build all but specified pages mode

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -52,6 +52,73 @@ function getPossibleFiles(pageExtensions: string[], pages: string[]) {
   return flatten<string>(res)
 }
 
+export async function getSpecifiedPages(
+  dir: string,
+  pages: string[],
+  pageExtensions: string[]
+) {
+  const pagesDir = path.join(dir, 'pages')
+
+  const reservedPages = ['/_app', '/_document', '/_error']
+  pages.push(...reservedPages)
+
+  const searchAllPages = pages.some(p => p.includes('**'))
+
+  let pagePaths: string[]
+  const explodedPages = [
+    ...new Set(
+      flatten<string>(pages.map(p => p.split(',').filter(p => p !== '**')))
+    ),
+  ].map(p => {
+    let removePage = false
+    if (p.startsWith('-')) {
+      p = p.substring(1)
+      removePage = true
+    }
+
+    let resolvedPage: string | undefined
+    if (path.isAbsolute(p)) {
+      resolvedPage = getPossibleFiles(pageExtensions, [
+        path.join(pagesDir, p),
+        p,
+      ]).find(f => fs.existsSync(f))
+    } else {
+      resolvedPage = getPossibleFiles(pageExtensions, [
+        path.join(pagesDir, p),
+        path.join(dir, p),
+      ]).find(f => fs.existsSync(f))
+    }
+    return { original: p, resolved: resolvedPage || null, removePage }
+  })
+
+  const missingPage = explodedPages.find(
+    ({ original, resolved }) => !resolved && !reservedPages.includes(original)
+  )
+  if (missingPage) {
+    throw new Error(`Unable to identify page: ${missingPage.original}`)
+  }
+  const resolvedPagePaths = explodedPages
+    .filter(page => page.resolved)
+    .map(page => ({
+      ignore: page.removePage,
+      pathname: '/' + path.relative(pagesDir, page.resolved!),
+    }))
+
+  if (searchAllPages) {
+    const pageSet = new Set(await collectPages(pagesDir, pageExtensions))
+
+    resolvedPagePaths
+      .filter(p => p.ignore)
+      .forEach(p => pageSet.delete(p.pathname))
+
+    pagePaths = [...pageSet]
+  } else {
+    pagePaths = resolvedPagePaths.filter(p => !p.ignore).map(p => p.pathname)
+  }
+
+  return pagePaths.sort()
+}
+
 export default async function build(
   dir: string,
   conf = null,
@@ -96,66 +163,9 @@ export default async function build(
     )
   }
 
-  const reservedPages = ['/_app', '/_document', '/_error']
-
   let pagePaths
   if (__selectivePageBuilding) {
-    pages.push(...reservedPages)
-
-    const searchAllPages = pages.some(p => p.includes('**'))
-
-    const explodedPages = [
-      ...new Set(
-        flatten<string>(pages.map(p => p.split(',').filter(p => p !== '**')))
-      ),
-    ].map(p => {
-      let removePage = false
-      if (p.startsWith('-')) {
-        p = p.substring(1)
-        removePage = true
-      }
-
-      let resolvedPage: string | undefined
-      if (path.isAbsolute(p)) {
-        resolvedPage = getPossibleFiles(config.pageExtensions, [
-          path.join(pagesDir, p),
-          p,
-        ]).find(f => fs.existsSync(f))
-      } else {
-        resolvedPage = getPossibleFiles(config.pageExtensions, [
-          path.join(pagesDir, p),
-          path.join(dir, p),
-        ]).find(f => fs.existsSync(f))
-      }
-      return { original: p, resolved: resolvedPage || null, removePage }
-    })
-
-    const missingPage = explodedPages.find(
-      ({ original, resolved }) => !resolved && !reservedPages.includes(original)
-    )
-    if (missingPage) {
-      throw new Error(`Unable to identify page: ${missingPage.original}`)
-    }
-    const resolvedPagePaths = explodedPages
-      .filter(page => page.resolved)
-      .map(page => ({
-        ignore: page.removePage,
-        pathname: '/' + path.relative(pagesDir, page.resolved!),
-      }))
-
-    if (searchAllPages) {
-      const pageSet = new Set(
-        await collectPages(pagesDir, config.pageExtensions)
-      )
-
-      resolvedPagePaths
-        .filter(p => p.ignore)
-        .forEach(p => pageSet.delete(p.pathname))
-
-      pagePaths = [...pageSet]
-    } else {
-      pagePaths = resolvedPagePaths.filter(p => !p.ignore).map(p => p.pathname)
-    }
+    pagePaths = await getSpecifiedPages(dir, pages, config.pageExtensions)
   } else {
     pagePaths = await collectPages(pagesDir, config.pageExtensions)
   }

--- a/test/unit/select-pages/__snapshots__/select-pages.test.js.snap
+++ b/test/unit/select-pages/__snapshots__/select-pages.test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSpecifiedPages should filter pages 1`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+]
+`;
+
+exports[`getSpecifiedPages should filter pages 2`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/b.jsx",
+  "/c.mdx",
+]
+`;
+
+exports[`getSpecifiedPages should filter pages 3`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/b.jsx",
+]
+`;
+
+exports[`getSpecifiedPages should only choose selected 1`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/a.js",
+]
+`;
+
+exports[`getSpecifiedPages should only choose selected 2`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/a.js",
+  "/b.jsx",
+]
+`;
+
+exports[`getSpecifiedPages should only choose selected 3`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/a.js",
+  "/b.jsx",
+]
+`;
+
+exports[`getSpecifiedPages should only choose selected 4`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/a.js",
+  "/b.jsx",
+  "/c.mdx",
+]
+`;
+
+exports[`getSpecifiedPages should select all 1`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/a.js",
+]
+`;
+
+exports[`getSpecifiedPages should select all 2`] = `
+Array [
+  "/_app.js",
+  "/_document.js",
+  "/a.js",
+  "/b.jsx",
+  "/c.mdx",
+]
+`;

--- a/test/unit/select-pages/pages/_app.js
+++ b/test/unit/select-pages/pages/_app.js
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/test/unit/select-pages/pages/_document.js
+++ b/test/unit/select-pages/pages/_document.js
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/test/unit/select-pages/pages/a.js
+++ b/test/unit/select-pages/pages/a.js
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/test/unit/select-pages/pages/b.jsx
+++ b/test/unit/select-pages/pages/b.jsx
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/test/unit/select-pages/pages/c.mdx
+++ b/test/unit/select-pages/pages/c.mdx
@@ -1,0 +1,1 @@
+# intentionally empty

--- a/test/unit/select-pages/select-pages.test.js
+++ b/test/unit/select-pages/select-pages.test.js
@@ -1,0 +1,63 @@
+/* eslint-env jest */
+import { getSpecifiedPages } from 'next/dist/build'
+
+describe('getSpecifiedPages', () => {
+  it('should only choose selected', async () => {
+    expect(await getSpecifiedPages(__dirname, ['a'], ['js'])).toMatchSnapshot()
+
+    let err
+    try {
+      await getSpecifiedPages(__dirname, ['a', 'b'], ['js'])
+    } catch (e) {
+      err = e
+    }
+    expect(err).toBeTruthy()
+
+    expect(
+      await getSpecifiedPages(__dirname, ['a', 'b'], ['js', 'jsx'])
+    ).toMatchSnapshot()
+
+    expect(
+      await getSpecifiedPages(__dirname, ['a', 'b'], ['js', 'jsx', 'mdx'])
+    ).toMatchSnapshot()
+
+    expect(
+      await getSpecifiedPages(__dirname, ['a', 'b', 'c'], ['js', 'jsx', 'mdx'])
+    ).toMatchSnapshot()
+
+    expect(
+      await getSpecifiedPages(__dirname, ['a', 'b', 'c'], ['js', 'jsx', 'mdx'])
+    ).toEqual(
+      await getSpecifiedPages(__dirname, ['a,b,c'], ['js', 'jsx', 'mdx'])
+    )
+    expect(
+      await getSpecifiedPages(__dirname, ['a', 'b', 'c'], ['js', 'jsx', 'mdx'])
+    ).toEqual(
+      await getSpecifiedPages(__dirname, ['a,c', 'b'], ['js', 'jsx', 'mdx'])
+    )
+    expect(
+      await getSpecifiedPages(__dirname, ['a', 'b', 'c'], ['js', 'jsx', 'mdx'])
+    ).toEqual(
+      await getSpecifiedPages(__dirname, ['a', 'c,b'], ['js', 'jsx', 'mdx'])
+    )
+  })
+
+  it('should select all', async () => {
+    expect(await getSpecifiedPages(__dirname, ['**'], ['js'])).toMatchSnapshot()
+    expect(
+      await getSpecifiedPages(__dirname, ['**'], ['js', 'mdx', 'jsx'])
+    ).toMatchSnapshot()
+  })
+
+  it('should filter pages', async () => {
+    expect(
+      await getSpecifiedPages(__dirname, ['**', '-a'], ['js'])
+    ).toMatchSnapshot()
+    expect(
+      await getSpecifiedPages(__dirname, ['**', '-a'], ['js', 'mdx', 'jsx'])
+    ).toMatchSnapshot()
+    expect(
+      await getSpecifiedPages(__dirname, ['**,-a', '-c'], ['js', 'mdx', 'jsx'])
+    ).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
This allows the user to utilize syntax like the following:
```sh
--experimental-page='**,-/oss,-/blog/api-2,-/tv,-/about'
```

---

~This code~ needs refactored ~and tested before merging. 🙏~
~Original code made it through without tests b/c it was needed for `now dev`, but it _really_ needs coverage now. 😄~

---

This PR must land for https://github.com/zeit/now-builders/pull/357 to continue.