### PR TITLE
Fix nesting level of client page scripts

### DIFF
--- a/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
+++ b/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
@@ -163,7 +163,7 @@ export class ChunkGraphPlugin implements Plugin {
       const getLambdaChunk = (name: string) =>
         name.includes(this.buildId)
           ? name
-              .replace(new RegExp(`${this.buildId}[\\/\\\\]`), '')
+              .replace(new RegExp(`${this.buildId}[\\/\\\\]`), 'client/')
               .replace(/[.]js$/, `.${this.buildId}.js`)
           : name
 

--- a/packages/next/build/webpack/plugins/serverless-plugin.ts
+++ b/packages/next/build/webpack/plugins/serverless-plugin.ts
@@ -94,7 +94,7 @@ export class ServerlessPlugin {
         for (const name of assetNames) {
           compilation.assets[
             name
-              .replace(new RegExp(`${this.buildId}[\\/\\\\]`), '')
+              .replace(new RegExp(`${this.buildId}[\\/\\\\]`), 'client/')
               .replace(/[.]js$/, `.${this.buildId}.js`)
           ] = compilation.assets[name]
         }

--- a/packages/next/pages/_document.js
+++ b/packages/next/pages/_document.js
@@ -258,7 +258,7 @@ export class Head extends Component {
                 href={
                   assetPrefix +
                   (dynamicBuildId
-                    ? `/_next/static/pages${getPageFile(page, buildId)}`
+                    ? `/_next/static/client/pages${getPageFile(page, buildId)}`
                     : `/_next/static/${buildId}/pages${getPageFile(page)}`) +
                   _devOnlyInvalidateCacheQueryString
                 }
@@ -272,7 +272,7 @@ export class Head extends Component {
               href={
                 assetPrefix +
                 (dynamicBuildId
-                  ? `/_next/static/pages/_app.${buildId}.js`
+                  ? `/_next/static/client/pages/_app.${buildId}.js`
                   : `/_next/static/${buildId}/pages/_app.js`) +
                 _devOnlyInvalidateCacheQueryString
               }
@@ -467,7 +467,7 @@ export class NextScript extends Component {
             src={
               assetPrefix +
               (dynamicBuildId
-                ? `/_next/static/pages${getPageFile(page, buildId)}`
+                ? `/_next/static/client/pages${getPageFile(page, buildId)}`
                 : `/_next/static/${buildId}/pages${getPageFile(page)}`) +
               _devOnlyInvalidateCacheQueryString
             }
@@ -481,7 +481,7 @@ export class NextScript extends Component {
           src={
             assetPrefix +
             (dynamicBuildId
-              ? `/_next/static/pages/_app.${buildId}.js`
+              ? `/_next/static/client/pages/_app.${buildId}.js`
               : `/_next/static/${buildId}/pages/_app.js`) +
             _devOnlyInvalidateCacheQueryString
           }


### PR DESCRIPTION
Webpack chunk loading relies on relative paths, so we cannot remove directories.