### PR TITLE
Use var as libraryTarget

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -209,7 +209,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
         }
         return '[name]'
       },
-      libraryTarget: isServer ? 'commonjs2' : 'jsonp',
+      libraryTarget: isServer ? 'commonjs2' : 'var',
       hotUpdateChunkFilename: 'static/webpack/[id].[hash].hot-update.js',
       hotUpdateMainFilename: 'static/webpack/[hash].hot-update.json',
       // This saves chunks with the name given via `import()`


### PR DESCRIPTION
By using `var` we opt-out of the LibraryTemplatePlugin. Considering we have our own loader for registering pages this makes sense.

https://github.com/webpack/webpack/blob/7ed1a8f/lib/WebpackOptionsApply.js#L196-L204