### PR TITLE
Disable terser for server build

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -130,18 +130,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
     ],
     optimization: isServer ? {
       splitChunks: false,
-      minimize: target === 'serverless',
-      minimizer: target === 'serverless' ? [
-        new TerserPlugin({...terserPluginConfig,
-          terserOptions: {
-            compress: false,
-            mangle: false,
-            module: false,
-            keep_classnames: true,
-            keep_fnames: true
-          }
-        })
-      ] : undefined
+      minimize: false
     } : Object.assign({
       runtimeChunk: __selectivePageBuilding ? false : {
         name: CLIENT_STATIC_FILES_RUNTIME_WEBPACK


### PR DESCRIPTION
Checking the stats first. But at least until https://github.com/zeit/next.js/issues/6950 is figured out we should disable it for serverless builds as it's also disabled for zeit.co serverless builds.