### PR TITLE
Optimize resolve configuration

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -47,7 +47,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
 
   const resolveConfig = {
     // Disable .mjs for node_modules bundling
-    extensions: isServer ? ['.wasm', '.js', '.mjs', '.jsx', '.json'] : ['.wasm', '.mjs', '.js', '.jsx', '.json'],
+    extensions: isServer ? ['.js', '.mjs', '.jsx', '.json', '.wasm'] : ['.mjs', '.js', '.jsx', '.json', '.wasm'],
     modules: [
       'node_modules',
       ...nodePathList // Support for NODE_PATH environment variable

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -223,9 +223,8 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
     resolve: resolveConfig,
     resolveLoader: {
       modules: [
-        NEXT_PROJECT_ROOT_NODE_MODULES,
-        'node_modules',
         path.join(__dirname, 'webpack', 'loaders'), // The loaders Next.js provides
+        'node_modules',
         ...nodePathList // Support for NODE_PATH environment variable
       ]
     },


### PR DESCRIPTION
Next.js loaders should be resolved first, then node_modules. There is no
need for NEXT_PROJECT_ROOT_NODE_MODULES anymore since all our loaders are internal

Since wasm isn't the main target for Next.js it shouldn't be the first value to be resolved, as it would incur a file not found for nearly all files in the compilation.