### PR TITLE
Remove serialize-javascript

### DIFF
--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/TaskRunner.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/TaskRunner.js
@@ -4,7 +4,6 @@ import { promisify } from 'util';
 import workerFarm from 'worker-farm';
 import { writeFile, readFile } from 'fs';
 import findCacheDir from 'find-cache-dir';
-import serialize from 'serialize-javascript';
 
 const worker = require.resolve('./worker');
 const writeFileP = promisify(writeFile)
@@ -36,7 +35,7 @@ export default class TaskRunner {
       this.workers = workerFarm(workerOptions, worker);
       this.boundWorkers = (options, cb) => {
         try {
-          this.workers(serialize(options), cb);
+          this.workers(options, cb);
         } catch (error) {
           // worker-farm can fail with ENOMEM or something else
           cb(error);
@@ -65,7 +64,7 @@ export default class TaskRunner {
 
     tasks.forEach((task, index) => {
       const cachePath = join(
-        this.cacheDir, 
+        this.cacheDir,
         task.cacheKey
       )
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -74,7 +74,6 @@
     "react-error-overlay": "5.1.4",
     "react-is": "16.8.6",
     "recursive-copy": "2.0.6",
-    "serialize-javascript": "1.6.1",
     "source-map": "0.6.1",
     "string-hash": "1.1.3",
     "strip-ansi": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11292,7 +11292,7 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
-serialize-javascript@1.6.1, serialize-javascript@^1.4.0:
+serialize-javascript@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
   integrity sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==


### PR DESCRIPTION
`serialize-javascript` causes excessive heap allocations, eventually leading to an OOM event on large builds.
We don't even need this because we pass plain objects. 😄 