### PR TITLE
Fix getSpecifiedPages not filtering right on windows

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -111,7 +111,7 @@ export async function getSpecifiedPages(
 
     resolvedPagePaths
       .filter(p => p.ignore)
-      .forEach(p => pageSet.delete(p.pathname))
+      .forEach(p => pageSet.delete(p.pathname.replace('/', path.sep)))
 
     pagePaths = [...pageSet]
   } else {


### PR DESCRIPTION
Since we weren't using the right separator in one place they were mismatching causing them to not be filtered.

