### PR TITLE
Add an experimental mode for flyingShuttle

### DIFF
--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -30,7 +30,8 @@ const defaultConfig = {
     ),
     ampBindInitData: false,
     exportTrailingSlash: true,
-    profiling: false
+    profiling: false,
+    flyingShuttle: false
   }
 }
 


### PR DESCRIPTION
This PR adds a new `experimental` setting called `flyingShuttle`.

All pages will be built in a standalone mode when `flyingShuttle` is enabled.