### PR TITLE
Correct page search order

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1,5 +1,6 @@
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
+
 import { recursiveReadDir } from '../lib/recursive-readdir'
 
 export function collectPages(
@@ -36,9 +37,10 @@ function flatten<T>(arr: T[][]): T[] {
 
 function getPossibleFiles(pageExtensions: string[], pages: string[]) {
   const res = pages.map(page =>
-    [page]
-      .concat(pageExtensions.map(e => `${page}.${e}`))
+    pageExtensions
+      .map(e => `${page}.${e}`)
       .concat(pageExtensions.map(e => `${path.join(page, 'index')}.${e}`))
+      .concat(page)
   )
   return flatten<string>(res)
 }


### PR DESCRIPTION
This fixes a case where a user has a page named `next.js.js` and `next.js`.