### PR TITLE
Disable `recordsPath` for selective page building

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -184,7 +184,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
       usedExports: false,
       concatenateModules: false,
     } : undefined),
-    recordsPath: path.join(outputPath, 'records.json'),
+    recordsPath: selectivePageBuilding ? undefined : path.join(outputPath, 'records.json'),
     context: dir,
     // Kept as function to be backwards compatible
     entry: async () => {


### PR DESCRIPTION
We cannot rely on `recordsPath` when using selective page mode. All modules must be identified.