### PR TITLE
Disable flying shuttle when building for `now dev`

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1,16 +1,17 @@
-import path from 'path'
-import nanoid from 'next/dist/compiled/nanoid/index.js'
-import loadConfig from 'next-server/next-config'
-import { PHASE_PRODUCTION_BUILD } from 'next-server/constants'
-import getBaseWebpackConfig from './webpack-config'
-import { generateBuildId } from './generate-build-id'
-import { writeBuildId } from './write-build-id'
-import { isWriteable } from './is-writeable'
-import { runCompiler, CompilerResult } from './compiler'
-import { createPagesMapping, createEntrypoints } from './entries'
-import formatWebpackMessages from '../client/dev-error-overlay/format-webpack-messages'
 import chalk from 'chalk'
-import { collectPages, printTreeView, getSpecifiedPages } from './utils'
+import { PHASE_PRODUCTION_BUILD } from 'next-server/constants'
+import loadConfig from 'next-server/next-config'
+import nanoid from 'next/dist/compiled/nanoid/index.js'
+import path from 'path'
+
+import formatWebpackMessages from '../client/dev-error-overlay/format-webpack-messages'
+import { CompilerResult, runCompiler } from './compiler'
+import { createEntrypoints, createPagesMapping } from './entries'
+import { generateBuildId } from './generate-build-id'
+import { isWriteable } from './is-writeable'
+import { collectPages, getSpecifiedPages, printTreeView } from './utils'
+import getBaseWebpackConfig from './webpack-config'
+import { writeBuildId } from './write-build-id'
 
 export default async function build(dir: string, conf = null): Promise<void> {
   if (!(await isWriteable(dir))) {
@@ -37,15 +38,18 @@ export default async function build(dir: string, conf = null): Promise<void> {
   const distDir = path.join(dir, config.distDir)
   const pagesDir = path.join(dir, 'pages')
 
-  const flyingShuttle = Boolean(config.experimental.flyingShuttle)
+  const isFlyingShuttle = Boolean(
+    config.experimental.flyingShuttle &&
+      !process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE
+  )
   const selectivePageBuilding = Boolean(
-    flyingShuttle || process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE
+    isFlyingShuttle || process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE
   )
 
   if (selectivePageBuilding && config.target !== 'serverless') {
     throw new Error(
       `Cannot use ${
-        flyingShuttle ? 'flying shuttle' : '`now dev`'
+        isFlyingShuttle ? 'flying shuttle' : '`now dev`'
       } without the serverless target.`
     )
   }

--- a/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
+++ b/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
@@ -1,10 +1,10 @@
-import { Compiler, Plugin } from 'webpack'
-import path from 'path'
-import { EOL } from 'os'
-import { parse } from 'querystring'
-import { CLIENT_STATIC_FILES_RUNTIME_MAIN } from 'next-server/constants'
-import fs from 'fs'
 import { createHash } from 'crypto'
+import fs from 'fs'
+import { CLIENT_STATIC_FILES_RUNTIME_MAIN } from 'next-server/constants'
+import { EOL } from 'os'
+import path from 'path'
+import { parse } from 'querystring'
+import { Compiler, Plugin } from 'webpack'
 
 function getFiles(dir: string, modules: any[]): string[] {
   if (!(modules && modules.length)) {

--- a/packages/next/build/write-build-id.ts
+++ b/packages/next/build/write-build-id.ts
@@ -1,11 +1,15 @@
 import fs from 'fs'
-import {promisify} from 'util'
-import {join} from 'path'
-import {BUILD_ID_FILE, HEAD_BUILD_ID_FILE} from 'next-server/constants'
+import { promisify } from 'util'
+import { join } from 'path'
+import { BUILD_ID_FILE, HEAD_BUILD_ID_FILE } from 'next-server/constants'
 
 const writeFile = promisify(fs.writeFile)
 
-export async function writeBuildId (distDir: string, buildId: string, headBuildId: boolean): Promise<void> {
+export async function writeBuildId(
+  distDir: string,
+  buildId: string,
+  headBuildId: boolean
+): Promise<void> {
   const buildIdPath = join(distDir, BUILD_ID_FILE)
   await writeFile(buildIdPath, buildId, 'utf8')
 


### PR DESCRIPTION
`now dev` is going to roll it's own watching / rebuilding soon. Also, flying shuttle won't work without compiling all pages.