### PR TITLE
Small improvements to the babel config

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -72,12 +72,14 @@ module.exports = (api: any, options: NextBabelPresetOptions = {}): BabelPreset =
         // This adds @babel/plugin-transform-react-jsx-source and
         // @babel/plugin-transform-react-jsx-self automatically in development
         development: isDevelopment || isTest,
+        useBuiltIns: true,
         ...options['preset-react']
       }]
     ],
     plugins: [
       ['babel-plugin-transform-async-to-promises', {
-        inlineHelpers: true
+        inlineHelpers: true,
+        externalHelpers: true
       }],
       require('babel-plugin-react-require'),
       require('@babel/plugin-syntax-dynamic-import'),

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -8,7 +8,11 @@ const babelOpts = {
       'targets': {
         'browsers': ['IE 11']
       },
-      exclude: ['transform-typeof-symbol']
+      exclude: [
+        'transform-typeof-symbol',
+        'transform-regenerator',
+        'transform-async-to-generator'
+      ]
     }]
   ],
   plugins: [
@@ -19,7 +23,8 @@ const babelOpts = {
       useESModules: false
     }],
     ['babel-plugin-transform-async-to-promises', {
-      inlineHelpers: true
+      inlineHelpers: true,
+      externalHelpers: true
     }]
   ]
 }


### PR DESCRIPTION
This PR adds some excluded transform in the client config to the core babel config too, `useBuiltIns` to the react preset and `externalHelpers` to `transform-async-to-promises`