### PR TITLE
Disable terser on .min.js input files

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -226,7 +226,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
       rules: [
         selectivePageBuilding && !isServer && {
           test: /\.(js|mjs|jsx)$/,
-          exclude: /\.min.(js|mjs|jsx)$/,
+          exclude: /\.min\.(js|mjs|jsx)$/,
           use: {
             loader: 'next-minify-loader',
             options: { terserOptions: { safari10: true, compress: true, mangle: false } }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -226,6 +226,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
       rules: [
         selectivePageBuilding && !isServer && {
           test: /\.(js|mjs|jsx)$/,
+          exclude: /\.min.(js|mjs|jsx)$/,
           use: {
             loader: 'next-minify-loader',
             options: { terserOptions: { safari10: true, compress: true, mangle: false } }


### PR DESCRIPTION
This skips re-compressing already minified files.