### PR TITLE
Optimize with-graphql-hooks example

### DIFF
--- a/examples/with-graphql-hooks/package.json
+++ b/examples/with-graphql-hooks/package.json
@@ -20,5 +20,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.2",
     "react-dom": "^16.8.2"
+  },
+  "browser": {
+    "graphql-hooks-ssr": false
   }
 }


### PR DESCRIPTION
Updated the `with-graphql-hooks` example to exclude an SSR library from the commons chunk and removed a next config file that was preventing the app from building.

The exclusion of the SSR library reduces the commons chunk by 18.8kB (7kB gzipped).