### PR TITLE
Set descriptive displayName on withRouter HOC

### DIFF
--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -18,8 +18,10 @@ export default function withRouter(ComposedComponent: React.ComponentType<any> &
   }
 
   WithRouteWrapper.getInitialProps = ComposedComponent.getInitialProps
-  const name = ComposedComponent.displayName || ComposedComponent.name || 'Unknown'
-  WithRouteWrapper.displayName = `withRouter(${name})`
+  if (process.env.NODE_ENV !== 'production') {
+    const name = ComposedComponent.displayName || ComposedComponent.name || 'Unknown'
+    WithRouteWrapper.displayName = `withRouter(${name})`
+  }
 
   return WithRouteWrapper
 }

--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 export default function withRouter(ComposedComponent: React.ComponentType<any> & {getInitialProps?: any}) {
   class WithRouteWrapper extends React.Component {
+    static displayName?: string
     static getInitialProps?: any
     static contextTypes = {
       router: PropTypes.object,
@@ -17,6 +18,8 @@ export default function withRouter(ComposedComponent: React.ComponentType<any> &
   }
 
   WithRouteWrapper.getInitialProps = ComposedComponent.getInitialProps
+  const name = ComposedComponent.displayName || ComposedComponent.name || 'Unknown'
+  WithRouteWrapper.displayName = `withRouter(${name})`
 
   return WithRouteWrapper
 }


### PR DESCRIPTION
Not sure when it was introduced, but on the latest Next v8.0.4, there's no descriptive name attached to the component returns from `withRouter`.

This makes it harder to debug and write test cases for components wrapped by `withRouter`.