### PR TITLE
Fix GitHub spelling

### DIFF
--- a/examples/form-handler/components/Social.js
+++ b/examples/form-handler/components/Social.js
@@ -16,7 +16,7 @@ const Social = () => {
           <Input controlLabel='Twitter' title='social' name='twitter' />
         </Col>
         <Col lg={8}>
-          <Input controlLabel='Github' title='social' name='github' />
+          <Input controlLabel='GitHub' title='social' name='github' />
         </Col>
       </Row>
     </div>

--- a/examples/with-cloud9/README.md
+++ b/examples/with-cloud9/README.md
@@ -3,7 +3,7 @@
 ## Install NVM and set node to the latest version ##
 
 Cloud 9 environment comes with a preinstalled nvm, but its better to use the latest
-version - follow the install instructions from the [NVM Github page](https://github.com/creationix/nvm)
+version - follow the install instructions from the [NVM GitHub page](https://github.com/creationix/nvm)
 
 Then download nvm package for the latest available node version and set it as default.
 For example, if the latest is 10.12.0, use the following commands:

--- a/examples/with-freactal/README.md
+++ b/examples/with-freactal/README.md
@@ -47,7 +47,7 @@ When it comes to state management of the React webapp, Redux is the most popular
 
 ### example app
 
-In this example the `index` page renders list of public repos on Github for selected username. It fetches list of repos from public gihub api. First page of this list is rendered by SSR. *serverState* is then hydrated into the `Index` page. Button at the end of the list allows to load next page of repos list from the API on the client.
+In this example the `index` page renders list of public repos on GitHub for selected username. It fetches list of repos from public gihub api. First page of this list is rendered by SSR. *serverState* is then hydrated into the `Index` page. Button at the end of the list allows to load next page of repos list from the API on the client.
 
 ![](https://i.imgur.com/JFU0YUt.png)
 

--- a/examples/with-tailwindcss/components/nav.js
+++ b/examples/with-tailwindcss/components/nav.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 const links = [
-  { href: 'https://github.com/zeit/next.js', label: 'Github' },
+  { href: 'https://github.com/zeit/next.js', label: 'GitHub' },
   { href: 'https://nextjs.org/docs', label: 'Docs' }
 ]
 


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.