### PR TITLE
Enable strict type checking on custom-server-typescript example

### DIFF
--- a/examples/custom-server-typescript/server/index.ts
+++ b/examples/custom-server-typescript/server/index.ts
@@ -2,7 +2,7 @@ import { createServer } from 'http'
 import { parse } from 'url'
 import * as next from 'next'
 
-const port = parseInt(process.env.PORT, 10) || 3000
+const port = parseInt(process.env.PORT || '3000', 10)
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const handle = app.getRequestHandler()
@@ -10,7 +10,7 @@ const handle = app.getRequestHandler()
 app.prepare()
 .then(() => {
   createServer((req, res) => {
-    const parsedUrl = parse(req.url, true)
+    const parsedUrl = parse(req.url!, true)
     const { pathname, query } = parsedUrl
 
     if (pathname === '/a') {

--- a/examples/custom-server-typescript/tsconfig.json
+++ b/examples/custom-server-typescript/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "noEmit": true,
+    "strict": true,
     "target": "esnext",
     "module": "esnext",
     "jsx": "preserve",


### PR DESCRIPTION
After enabling "strict": true in tsconfig.json, two errors in index.ts where reported by typescript.

Those errors where fixed by adding ! operator to req.url! and moving default value of process.env.PORT || '3000'.
