### PR TITLE
Remove client bundles for AMP only pages

### DIFF
--- a/packages/next-server/lib/amp.ts
+++ b/packages/next-server/lib/amp.ts
@@ -27,6 +27,7 @@ export function withAmp(
     return React.createElement(Component, props)
   }
 
+  WithAmpWrapper.__nextAmpOnly = !hybrid
   WithAmpWrapper.getInitialProps = Component.getInitialProps
   return WithAmpWrapper
 }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -197,7 +197,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   result = formatWebpackMessages(result)
 
   const pages = Object.keys(mappedPages)
-  const sema = new Sema(50, { capacity: pages.length })
+  const sema = new Sema(20, { capacity: pages.length })
 
   await Promise.all(pages.map(async page => {
     await sema.acquire()

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -217,7 +217,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
         await unlink(clientPage)
       }
     } catch (err) {
-      if (err.code !== 'ENOENT' || (err.message && !err.message.includes('Cannot find module'))) {
+      if (err.code !== 'ENOENT' && err.code !== 'MODULE_NOT_FOUND') {
         throw err
       }
     }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -215,7 +215,11 @@ export default async function build(dir: string, conf = null): Promise<void> {
       if (mod && mod.__nextAmpOnly) {
         await unlink(clientPage)
       }
-    } catch (_) {}
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err
+      }
+    }
     sema.release()
   }))
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -210,13 +210,14 @@ export default async function build(dir: string, conf = null): Promise<void> {
     const clientPage = path.join(distDir, 'static', buildId, 'pages', page + '.js')
 
     try {
+      require('next/config').setConfig({})
       let mod = require(serverPage)
       mod = mod.default || mod
       if (mod && mod.__nextAmpOnly) {
         await unlink(clientPage)
       }
     } catch (err) {
-      if (err.code !== 'ENOENT') {
+      if (err.code !== 'ENOENT' || (err.message && !err.message.includes('Cannot find module'))) {
         throw err
       }
     }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -136,7 +136,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     }
     pagePaths = [...pageSet]
   }
-  
+
   const mappedPages = createPagesMapping(pagePaths, config.pageExtensions)
   const entrypoints = createEntrypoints(
     mappedPages,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -206,14 +206,16 @@ export default async function build(dir: string, conf = null): Promise<void> {
     if (BLOCKED_PAGES.includes(page)) {
       return sema.release()
     }
-    const serverPage = path.join(dir, config.distDir, config.target === 'serverless' ? 'serverless/pages' : `server/static/${buildId}/pages`, page + '.js')
-    const clientPage = path.join(dir, config.distDir, 'static', buildId, 'pages', page + '.js')
+    const serverPage = path.join(distDir, config.target === 'serverless' ? 'serverless/pages' : `server/static/${buildId}/pages`, page + '.js')
+    const clientPage = path.join(distDir, 'static', buildId, 'pages', page + '.js')
 
-    let mod = require(serverPage)
-    mod = mod.default || mod
-    if (mod && mod.__nextAmpOnly) {
-      await unlink(clientPage)
-    }
+    try {
+      let mod = require(serverPage)
+      mod = mod.default || mod
+      if (mod && mod.__nextAmpOnly) {
+        await unlink(clientPage)
+      }
+    } catch (_) {}
     sema.release()
   }))
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -210,7 +210,10 @@ export default async function build(dir: string, conf = null): Promise<void> {
     const clientPage = path.join(distDir, 'static', buildId, 'pages', page + '.js')
 
     try {
-      require('next/config').setConfig({})
+      require('next/config').setConfig({
+        publicRuntimeConfig: config.publicRuntimeConfig,
+        serverRuntimeConfig: config.serverRuntimeConfig
+      })
       let mod = require(serverPage)
       mod = mod.default || mod
       if (mod && mod.__nextAmpOnly) {

--- a/packages/next/lib/recursive-delete.ts
+++ b/packages/next/lib/recursive-delete.ts
@@ -35,8 +35,8 @@ const unlinkFile = async (p: string, t = 1): Promise<void> => {
  * Recursively delete directory contents
  * @param  {string} dir Directory to delete the contents of
  * @param  {RegExp} [filter] Filter for the relative file path
- * @param  {boolean} [ensure] Esures that parameter dir exists, this is not passed recursively
- * @param  {string} [previousPath] Esures that parameter dir exists, this is not passed recursively
+ * @param  {boolean} [ensure] Ensures that parameter dir exists, this is not passed recursively
+ * @param  {string} [previousPath] Ensures that parameter dir exists, this is not passed recursively
  * @returns Promise void
  */
 export async function recursiveDelete(

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -341,6 +341,7 @@ export default class HotReloader {
     const onDemandEntries = onDemandEntryHandler(webpackDevMiddleware, multiCompiler, {
       dir: this.dir,
       buildId: this.buildId,
+      distDir: this.config.distDir,
       reload: this.reload.bind(this),
       pageExtensions: this.config.pageExtensions,
       ...this.config.onDemandEntries

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -344,6 +344,8 @@ export default class HotReloader {
       distDir: this.config.distDir,
       reload: this.reload.bind(this),
       pageExtensions: this.config.pageExtensions,
+      publicRuntimeConfig: this.config.publicRuntimeConfig,
+      serverRuntimeConfig: this.config.serverRuntimeConfig,
       ...this.config.onDemandEntries
     })
 

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -266,11 +266,13 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
           const { name } = entries[normalizedPage]
           const serverPage = join(dir, distDir, 'server', name)
           const clientPage = join(dir, distDir, name)
-          let mod = require(serverPage)
-          mod = mod.default || mod
-          if (mod && mod.__nextAmpOnly) {
-            fs.unlinkSync(clientPage)
-          }
+          try {
+            let mod = require(serverPage)
+            mod = mod.default || mod
+            if (mod && mod.__nextAmpOnly) {
+              fs.unlinkSync(clientPage)
+            }
+          } catch (_) {}
           resolve()
         }
       })

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -272,7 +272,11 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
             if (mod && mod.__nextAmpOnly) {
               fs.unlinkSync(clientPage)
             }
-          } catch (_) {}
+          } catch (err) {
+            if (err.code !== 'ENOENT') {
+              throw err
+            }
+          }
           resolve()
         }
       })

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -265,7 +265,7 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
           if (err) return reject(err)
           const { name } = entries[normalizedPage]
           const serverPage = join(dir, distDir, 'server', name)
-          const clientPage = join(dir, distDir, 'static', name)
+          const clientPage = join(dir, distDir, name)
           let mod = require(serverPage)
           mod = mod.default || mod
           if (mod && mod.__nextAmpOnly) {

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -275,7 +275,7 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
             }
           } catch (err) {
             if (err.code !== 'ENOENT' && err.code !== 'MODULE_NOT_FOUND') {
-              reject(err)
+              return reject(err)
             }
           }
           resolve()

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -274,7 +274,7 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
               fs.unlinkSync(clientPage)
             }
           } catch (err) {
-            if (err.code !== 'ENOENT' && (err.message && !err.message.includes('Cannot find module'))) {
+            if (err.code !== 'ENOENT' && err.code !== 'MODULE_NOT_FOUND') {
               reject(err)
             }
           }

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -267,13 +267,14 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
           let serverPage = join(dir, distDir, 'server', name)
           const clientPage = join(dir, distDir, name)
           try {
+            require('next/config').setConfig({})
             let mod = require(serverPage)
             mod = mod.default || mod
             if (mod && mod.__nextAmpOnly) {
               fs.unlinkSync(clientPage)
             }
           } catch (err) {
-            if (err.code !== 'ENOENT') {
+            if (err.code !== 'ENOENT' && (err.message && !err.message.includes('Cannot find module'))) {
               reject(err)
             }
           }

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -266,8 +266,9 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
           const { name } = entries[normalizedPage]
           const serverPage = join(dir, distDir, 'server', name)
           const clientPage = join(dir, distDir, 'static', name)
-          const mod = require(serverPage)
-          if (mod.default && mod.default.__nextAmpOnly) {
+          let mod = require(serverPage)
+          mod = mod.default || mod
+          if (mod && mod.__nextAmpOnly) {
             fs.unlinkSync(clientPage)
           }
           resolve()

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -33,7 +33,9 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
   reload,
   pageExtensions,
   maxInactiveAge,
-  pagesBufferLength
+  pagesBufferLength,
+  publicRuntimeConfig,
+  serverRuntimeConfig
 }) {
   const pagesDir = join(dir, 'pages')
   const clients = new Map()
@@ -267,7 +269,10 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
           let serverPage = join(dir, distDir, 'server', name)
           const clientPage = join(dir, distDir, name)
           try {
-            require('next/config').setConfig({})
+            require('next/config').setConfig({
+              serverRuntimeConfig,
+              publicRuntimeConfig
+            })
             let mod = require(serverPage)
             mod = mod.default || mod
             if (mod && mod.__nextAmpOnly) {

--- a/packages/next/server/on-demand-entry-handler.js
+++ b/packages/next/server/on-demand-entry-handler.js
@@ -264,7 +264,7 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
         function handleCallback (err) {
           if (err) return reject(err)
           const { name } = entries[normalizedPage]
-          const serverPage = join(dir, distDir, 'server', name)
+          let serverPage = join(dir, distDir, 'server', name)
           const clientPage = join(dir, distDir, name)
           try {
             let mod = require(serverPage)
@@ -274,7 +274,7 @@ export default function onDemandEntryHandler (devMiddleware, multiCompiler, {
             }
           } catch (err) {
             if (err.code !== 'ENOENT') {
-              throw err
+              reject(err)
             }
           }
           resolve()


### PR DESCRIPTION
Since we don't use the client bundles for AMP only pages we remove them. 