### PR TITLE
AMP fix escaped rel

### DIFF
--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -444,12 +444,16 @@ export async function renderToHTML(
 
   if (amphtml && html) {
     html = await optimizeAmp(html, { amphtml, query })
-    html = html.replace(/&amp;amp=1/g, '&amp=1')
 
     // don't validate dirty AMP
     if (renderOpts.ampValidator && query.amp) {
       await renderOpts.ampValidator(html, pathname)
     }
+  }
+
+  if (amphtml || hasAmp) {
+    // fix &amp being escaped for amphtml rel link
+    html = html.replace(/&amp;amp=1/g, '&amp=1')
   }
   return html
 }

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -444,6 +444,7 @@ export async function renderToHTML(
 
   if (amphtml && html) {
     html = await optimizeAmp(html, { amphtml, query })
+    html = html.replace(/&amp;amp=1/g, '&amp=1')
 
     // don't validate dirty AMP
     if (renderOpts.ampValidator && query.amp) {

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -152,6 +152,11 @@ describe('AMP Usage', () => {
       ).toBe('/use-amp-hook?amp=1')
     })
 
+    it('should render link rel amphtml with existing query', async () => {
+      const html = await renderViaHTTP(appPort, '/use-amp-hook?hello=1')
+      expect(html).not.toMatch(/&amp;amp=1/)
+    })
+
     it('should render the AMP page that uses the AMP hook', async () => {
       const html = await renderViaHTTP(appPort, '/use-amp-hook?amp=1')
       const $ = cheerio.load(html)


### PR DESCRIPTION
if `&amp=1` is used to point to the `amphtml` version of a page it get's escaped causing it to become `&amp;amp=1` this fixes it to stay as `&amp=1`

Closes: #7038 