### PR TITLE
Remove experimental amp config

### DIFF
--- a/packages/next-server/server/config.js
+++ b/packages/next-server/server/config.js
@@ -22,7 +22,6 @@ const defaultConfig = {
     pagesBufferLength: 2
   },
   experimental: {
-    amp: false,
     cpus: Math.max(
       1,
       (Number(process.env.CIRCLE_NODE_TOTAL) ||

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -59,9 +59,6 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
       'next/router': 'next/dist/client/router.js',
       'next/config': 'next-server/dist/lib/runtime-config.js',
       'next/dynamic': 'next-server/dist/lib/dynamic.js',
-       ...(config.experimental.amp ? {} : {
-        'next/amp': 'you-must-enable-experimental-amp',
-      }),
       next: NEXT_PROJECT_ROOT,
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,


### PR DESCRIPTION
This just removes the need for setting the experimental amp option