### PR TITLE
update dependency to fix with-next-page-transitions example

### DIFF
--- a/examples/with-next-page-transitions/package.json
+++ b/examples/with-next-page-transitions/package.json
@@ -10,7 +10,7 @@
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "next-page-transitions": "1.0.0-alpha.2"
+    "next-page-transitions": "1.0.0-beta.2"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
Seeing the following error when running the build example for `with-next-page-transitions`. 
The error can be replicated by going to the example's folder and running `yarn build` `yarn start`

```
TypeError: Cannot read property 'isRequired' of null
    at Object.<anonymous> (/Users/andy.obrien/Sites/next/next.js/examples/with-next-page-transitions/node_modules/next-page-transitions/lib/PageTransition.js:300:37)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/andy.obrien/Sites/next/next.js/examples/with-next-page-transitions/node_modules/next-page-transitions/lib/index.js:3:46)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
TypeError: Cannot read property 'isRequired' of null
    at Object.<anonymous> (/Users/andy.obrien/Sites/next/next.js/examples/with-next-page-transitions/node_modules/next-page-transitions/lib/PageTransition.js:300:37)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/andy.obrien/Sites/next/next.js/examples/with-next-page-transitions/node_modules/next-page-transitions/lib/index.js:3:46)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
```

Updating to the latest `next-page-transitions` removes the error.