### PR TITLE
Run optimizer after validating in dirty AMP mode

### DIFF
--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -443,11 +443,16 @@ export async function renderToHTML(
   })
 
   if (amphtml && html) {
-    html = await optimizeAmp(html, { amphtml, query })
+    if (ampMode.hasQuery) {
+      html = await optimizeAmp(html, { amphtml, query })
+    }
 
-    // don't validate dirty AMP
-    if (renderOpts.ampValidator && query.amp) {
+    if (renderOpts.ampValidator) {
       await renderOpts.ampValidator(html, pathname)
+    }
+    // run optimize after validating in dirty mode
+    if (!ampMode.hasQuery) {
+      html = await optimizeAmp(html, { amphtml, query })
     }
   }
 


### PR DESCRIPTION
This makes sure we still show validation errors in dirty AMP mode but not the irrelevant ones caused by the dirty optimizations