### PR TITLE
with-apollo example: explicitly pass fetch to HttpLink

### DIFF
--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -3,11 +3,6 @@ import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null
 
-// Polyfill fetch() on the server (used by apollo-client)
-if (!process.browser) {
-  global.fetch = fetch
-}
-
 function create (initialState) {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
   return new ApolloClient({
@@ -15,7 +10,9 @@ function create (initialState) {
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
-      credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
+      credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
+      // Use fetch() polyfill on the server
+      fetch: !process.browser && fetch
     }),
     cache: new InMemoryCache().restore(initialState || {})
   })


### PR DESCRIPTION
instead of letting apollo rely on a global variable, we pass it explicitly to the HttpLink constructor.