### PR TITLE
Remove dynamic-import-node from the preset

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -74,8 +74,6 @@ module.exports = (api: any, options: NextBabelPresetOptions = {}): BabelPreset =
     plugins: [
       require('babel-plugin-react-require'),
       require('@babel/plugin-syntax-dynamic-import'),
-      // Transform dynamic import to require
-      isTest && require('babel-plugin-dynamic-import-node'),
       require('./plugins/react-loadable-plugin'),
       [require('@babel/plugin-proposal-class-properties'), options['class-properties'] || {}],
       [require('@babel/plugin-proposal-object-rest-spread'), {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -55,7 +55,6 @@
     "autodll-webpack-plugin": "0.4.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.2",
-    "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-react-require": "3.0.0",
     "babel-plugin-transform-async-to-promises": "0.8.9",
     "babel-plugin-transform-react-remove-prop-types": "0.4.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,13 +2576,6 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-dynamic-import-node@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz#c0adfb07d95f4a4495e9aaac6ec386c4d7c2524e"
-  integrity sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==
-  dependencies:
-    object.assign "^4.1.0"
-
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
Related to [this spectrum post](https://spectrum.chat/next-js/general/next-8-minor-update-breaks-dynamic-import-in-jest-tests~1e7b58e7-e301-4ef9-9de4-eef6ed3639d4).

I'm not removing the `babel-plugin-dynamic-import-node` package as it's going to be used by #7016

