### PR TITLE
Remove deploy to now button from all examples

### DIFF
--- a/examples/active-class-name/README.md
+++ b/examples/active-class-name/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/active-class-name)
-
 # activeClassName example
 
 ## How to use

--- a/examples/amp/README.md
+++ b/examples/amp/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/amp)
-
 # Google AMP
 
 ## How to use
@@ -41,4 +39,4 @@ now
 
 ## The idea behind the example
 
-This example shows how to create AMP pages using Next.js and the experimental AMP feature. It shows a normal page (non-AMP), an AMP only page, and a hybrid AMP page. 
+This example shows how to create AMP pages using Next.js and the experimental AMP feature. It shows a normal page (non-AMP), an AMP only page, and a hybrid AMP page.

--- a/examples/analyze-bundles/README.md
+++ b/examples/analyze-bundles/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/analyze-bundles)
-
 # Analyzer Bundles example
 
 ## How to use

--- a/examples/basic-css/README.md
+++ b/examples/basic-css/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/basic-css)
-
 # Basic CSS example
 
 ## How to use

--- a/examples/basic-export/README.md
+++ b/examples/basic-export/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/basic-export)
-
 # Basic export example
 
 ## How to use

--- a/examples/custom-charset/README.md
+++ b/examples/custom-charset/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-charset)
-
 # Custom server example
 
 ## How to use

--- a/examples/custom-server-express/README.md
+++ b/examples/custom-server-express/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-express)
-
 # Custom Express Server example
 
 ## How to use

--- a/examples/custom-server-fastify/README.md
+++ b/examples/custom-server-fastify/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-fastify)
-
 # Custom Fastify Server example
 
 ## How to use
@@ -32,6 +30,7 @@ npm run dev
 yarn
 yarn dev
 ```
+
 Fastify
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
 

--- a/examples/custom-server-hapi/README.md
+++ b/examples/custom-server-hapi/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-hapi)
-
 # Custom server using Hapi example
 
 ## How to use

--- a/examples/custom-server-koa/README.md
+++ b/examples/custom-server-koa/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-koa)
-
 # Custom Koa Server example
 
 ## How to use
@@ -47,7 +45,6 @@ Because the Next.js server is just a node.js module you can combine it with any 
 
 The example shows a server that serves the component living in `pages/a.js` when the route `/b` is requested and `pages/b.js` when the route `/a` is accessed. This is obviously a non-standard routing strategy. You can see how this custom routing is being made inside `server.js`.
 
-
 ## Side note: Enabling gzip compression
 
 The most common Koa middleware for handling the gzip compression is [compress](https://github.com/koajs/compress), but unfortunately it is currently not compatible with Next.<br>
@@ -56,10 +53,8 @@ The most common Koa middleware for handling the gzip compression is [compress](h
 If you need to enable the gzip compression, the most simple way to do so is by wrapping the express-middleware [compression](https://github.com/expressjs/compression) with [koa-connect](https://github.com/vkurchatkin/koa-connect):
 
 ```javascript
-const compression = require('compression');
-const koaConnect = require('koa-connect');
-
+const compression = require("compression");
+const koaConnect = require("koa-connect");
 
 server.use(koaConnect(compression()));
-
 ```

--- a/examples/custom-server-micro/README.md
+++ b/examples/custom-server-micro/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-micro)
-
 # Custom Micro Server example
 
 ## How to use

--- a/examples/custom-server-nodemon/README.md
+++ b/examples/custom-server-nodemon/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-nodemon)
-
 # Custom server with Nodemon example
 
 ## How to use

--- a/examples/custom-server-polka/README.md
+++ b/examples/custom-server-polka/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-polka)
-
 # Custom [Polka](https://github.com/lukeed/polka) Server example
 
 ## How to use

--- a/examples/custom-server-typescript/README.md
+++ b/examples/custom-server-typescript/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server-typescript)
-
 # Custom server with TypeScript + Nodemon example
 
 ## How to use

--- a/examples/custom-server/README.md
+++ b/examples/custom-server/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/custom-server)
-
 # Custom server example
 
 ## How to use

--- a/examples/data-fetch/README.md
+++ b/examples/data-fetch/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/data-fetch)
-
 # Data fetch example
 
 ## How to use

--- a/examples/form-handler/README.md
+++ b/examples/form-handler/README.md
@@ -1,6 +1,4 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/form-handler)
-
-# Form Handler
+# Form Handler example
 
 ## How to use
 

--- a/examples/head-elements/README.md
+++ b/examples/head-elements/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/head-elements)
-
 # Head elements example
 
 ## How to use

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/hello-world)
-
 # Hello World example
 
 ## How to use

--- a/examples/layout-component/README.md
+++ b/examples/layout-component/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/layout-component)
-
 # Layout component example
 
 ## How to use

--- a/examples/nested-components/README.md
+++ b/examples/nested-components/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/nested-components)
-
 # Example app using nested components
 
 ## How to use

--- a/examples/only-client-render-external-dependencies/README.md
+++ b/examples/only-client-render-external-dependencies/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/only-client-render-external-dependencies)
-
 # Only client render for external dependencies
 
 ## How to use

--- a/examples/parameterized-routing/README.md
+++ b/examples/parameterized-routing/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/parameterized-routing)
-
 # Parametrized routes example (dynamic routing)
 
 ## How to use
@@ -34,7 +32,6 @@ yarn dev
 ```
 
 See now documentation [here](https://zeit.co/docs/v2/deployments/routes/) and Next.js example [here](https://zeit.co/examples/nextjs/) for info on deploying with [now](https://zeit.co/now) ([download](https://zeit.co/download))
-
 
 ## The idea behind the example
 

--- a/examples/pass-server-data/README.md
+++ b/examples/pass-server-data/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/pass-server-data)
-
 # Pass Server Data Directly to a Next.js Page during SSR
 
 ## How to use
@@ -59,7 +57,7 @@ The server knows whether or not to use next.js to render the route based on the 
 
 Take a look at the following files:
 
-* server.js
-* routes/item.js
-* pages/item.js
-* operations/get-item.js
+- server.js
+- routes/item.js
+- pages/item.js
+- operations/get-item.js

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/progressive-render)
 # Example app implementing progressive server-side render
 
 ## How to use
@@ -46,5 +45,5 @@ In that case you can wrap the component in `react-no-ssr` which will only render
 
 This example features:
 
-* An app with a component that must only be rendered in the client
-* A loading component that will be displayed before rendering the client-only component
+- An app with a component that must only be rendered in the client
+- A loading component that will be displayed before rendering the client-only component

--- a/examples/root-static-files/README.md
+++ b/examples/root-static-files/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/root-static-files)
-
 # Root static files example
 
 ## How to use

--- a/examples/shared-modules/README.md
+++ b/examples/shared-modules/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/shared-modules)
 # Example app using shared modules
 
 ## How to use
@@ -42,5 +41,5 @@ now
 
 This example features:
 
-* An app with two pages which has a common Counter component
-* That Counter component maintain the counter inside its module. This is used primarily to illustrate that modules get initialized once and their state variables persist in runtime
+- An app with two pages which has a common Counter component
+- That Counter component maintain the counter inside its module. This is used primarily to illustrate that modules get initialized once and their state variables persist in runtime

--- a/examples/ssr-caching/README.md
+++ b/examples/ssr-caching/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/ssr-caching)
-
 # Example app where it caches SSR'ed pages in the memory
 
 ## How to use

--- a/examples/svg-components/README.md
+++ b/examples/svg-components/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/svg-components)
-
 # SVG components example
 
 ## How to use

--- a/examples/using-inferno/README.md
+++ b/examples/using-inferno/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/using-inferno)
-
 # Hello World example
 
 ## How to use
@@ -45,4 +43,4 @@ This example uses [Inferno](https://github.com/infernojs/inferno), an insanely f
 
 Here's how we did it:
 
-* Use `next.config.js` to customize our webpack config to support [inferno-compat](https://www.npmjs.com/package/inferno-compat)
+- Use `next.config.js` to customize our webpack config to support [inferno-compat](https://www.npmjs.com/package/inferno-compat)

--- a/examples/using-nerv/README.md
+++ b/examples/using-nerv/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/using-nerv)
-
 # Hello World example
 
 ## How to use
@@ -45,4 +43,4 @@ This example uses [Nerv](https://nerv.aotu.io/) instead of React. It's a "blazin
 
 Here's how we did it:
 
-* Use `next.config.js` to customize our webpack config to support [Nerv](https://nerv.aotu.io/)
+- Use `next.config.js` to customize our webpack config to support [Nerv](https://nerv.aotu.io/)

--- a/examples/using-preact/README.md
+++ b/examples/using-preact/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/using-preact)
-
 # Hello World example
 
 ## How to use
@@ -45,4 +43,4 @@ This example uses [Preact](https://github.com/developit/preact) instead of React
 
 Here's how we did it:
 
-* Use `next.config.js` to customize our webpack config to support [preact-compat](https://github.com/developit/preact-compat)
+- Use `next.config.js` to customize our webpack config to support [preact-compat](https://github.com/developit/preact-compat)

--- a/examples/using-router/README.md
+++ b/examples/using-router/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/using-router)
 # Example app utilizing next/router for routing
 
 ## How to use
@@ -42,5 +41,5 @@ now
 
 This example features:
 
-* An app linking pages using `next/router` instead of `<Link>` component.
-* Access the pathname using `next/router` and render it in a component
+- An app linking pages using `next/router` instead of `<Link>` component.
+- Access the pathname using `next/router` and render it in a component

--- a/examples/using-with-router/README.md
+++ b/examples/using-with-router/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/using-with-router)
 # Example app utilizing `withRouter` utility for routing
 
 ## How to use

--- a/examples/with-algolia-react-instantsearch/README.md
+++ b/examples/with-algolia-react-instantsearch/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-algolia-react-instantsearch)
-
 # With Algolia React InstantSearch example
 
 ## How to use
@@ -24,6 +22,7 @@ cd with-algolia-react-instantsearch
 ```
 
 Set up Algolia:
+
 - create an [algolia](https://www.algolia.com/) account or use this already [configured index](https://community.algolia.com/react-instantsearch/Getting_started.html#before-we-start)
 - update the appId, apikey and indexName you want to search on in components/app.js
 
@@ -44,6 +43,7 @@ now
 ```
 
 ## The idea behind the example
+
 The goal of this example is to illustrate how you can use [Algolia React InstantSearch](https://community.algolia.com/react-instantsearch/) to perform
 your search with a Server-rendered application developed with Next.js. It also illustrates how you
 can keep in sync the Url with the search.

--- a/examples/with-ant-design-less/README.md
+++ b/examples/with-ant-design-less/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-ant-design-less)
-
 # Ant Design example
 
 ## How to use

--- a/examples/with-ant-design/README.md
+++ b/examples/with-ant-design/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-ant-design)
-
 # Ant Design example
 
 ## How to use

--- a/examples/with-antd-mobile/README.md
+++ b/examples/with-antd-mobile/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-antd-mobile)
 # Ant Design Mobile example
 
 ## How to use

--- a/examples/with-aphrodite/README.md
+++ b/examples/with-aphrodite/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-aphrodite)
-
 # Example app with aphrodite
 
 ## How to use

--- a/examples/with-apollo-and-redux-saga/README.md
+++ b/examples/with-apollo-and-redux-saga/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-apollo-and-redux-saga)
 # Apollo & Redux Saga Example
 
 ## How to use
@@ -39,19 +38,26 @@ now
 ```
 
 ## The idea behind the example
+
 In 2.0.0, Apollo Client severs out-of-the-box support for redux in favor of Apollo's client side state management. This example aims to be an amalgamation of the [`with-apollo`](https://github.com/zeit/next.js/tree/master/examples/with-apollo) and [`with-redux-saga`](https://github.com/zeit/next.js/tree/master/examples/with-redux-saga) examples.
 
 Note that you can access the redux store like you normally would using `react-redux`'s `connect`. Here's a quick example:
 
 ```js
 const mapStateToProps = state => ({
-  location: state.form.location,
+  location: state.form.location
 });
 
-export default withReduxSaga(connect(mapStateToProps, null)(Index));
+export default withReduxSaga(
+  connect(
+    mapStateToProps,
+    null
+  )(Index)
+);
 ```
 
 `connect` must go inside `withReduxSaga` otherwise `connect` will not be able to find the store.
 
 ### Note:
-In these *with-apollo* examples, the ```withData()``` HOC must wrap a top-level component from within the ```pages``` directory. Wrapping a child component with the HOC will result in a ```Warning: Failed prop type: The prop 'serverState' is marked as required in 'WithData(Apollo(Component))', but its value is 'undefined'``` error. Down-tree child components will have access to Apollo, and can be wrapped with any other sort of ```graphql()```, ```compose()```, etc HOC's.
+
+In these _with-apollo_ examples, the `withData()` HOC must wrap a top-level component from within the `pages` directory. Wrapping a child component with the HOC will result in a `Warning: Failed prop type: The prop 'serverState' is marked as required in 'WithData(Apollo(Component))', but its value is 'undefined'` error. Down-tree child components will have access to Apollo, and can be wrapped with any other sort of `graphql()`, `compose()`, etc HOC's.

--- a/examples/with-apollo-and-redux/README.md
+++ b/examples/with-apollo-and-redux/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-apollo-and-redux)
 # Apollo & Redux Example
 
 ## How to use
@@ -39,6 +38,7 @@ now
 ```
 
 ## The idea behind the example
+
 This example serves as a conduit if you were using Apollo 1.X with Redux, and are migrating to Apollo 2.x, however, you have chosen not to manage your entire application state within Apollo (`apollo-link-state`).
 
 In 2.0.0, Apollo serves out-of-the-box support for redux in favor of Apollo's state management. This example aims to be an amalgamation of the [`with-apollo`](https://github.com/zeit/next.js/tree/master/examples/with-apollo) and [`with-redux`](https://github.com/zeit/next.js/tree/master/examples/with-redux) examples.
@@ -47,11 +47,17 @@ Note that you can access the redux store like you normally would using `react-re
 
 ```js
 const mapStateToProps = state => ({
-  location: state.form.location,
+  location: state.form.location
 });
 
-export default withRedux(connect(mapStateToProps, null)(Index));
+export default withRedux(
+  connect(
+    mapStateToProps,
+    null
+  )(Index)
+);
 ```
 
 ### Note:
-In these *with-apollo* examples, the ```withData()``` HOC must wrap a top-level component from within the ```pages``` directory. Wrapping a child component with the HOC will result in a ```Warning: Failed prop type: The prop 'serverState' is marked as required in 'WithData(Apollo(Component))', but its value is 'undefined'``` error. Down-tree child components will have access to Apollo, and can be wrapped with any other sort of ```graphql()```, ```compose()```, etc HOC's.
+
+In these _with-apollo_ examples, the `withData()` HOC must wrap a top-level component from within the `pages` directory. Wrapping a child component with the HOC will result in a `Warning: Failed prop type: The prop 'serverState' is marked as required in 'WithData(Apollo(Component))', but its value is 'undefined'` error. Down-tree child components will have access to Apollo, and can be wrapped with any other sort of `graphql()`, `compose()`, etc HOC's.

--- a/examples/with-apollo-auth/README.md
+++ b/examples/with-apollo-auth/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-apollo-auth)
 # Apollo With Authentication Example
 
 ## How to use
@@ -44,13 +43,13 @@ This is an extention of the _[with Apollo](https://github.com/zeit/next.js/tree/
 
 > [Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run, fetching more results from the server.
 >
-> In this simple example, we integrate Apollo seamlessly with Next by wrapping our *pages* inside a [higher-order component (HOC)](https://facebook.github.io/react/docs/higher-order-components.html). Using the HOC pattern we're able to pass down a central store of query result data created by Apollo into our React component hierarchy defined inside each page of our Next application.
+> In this simple example, we integrate Apollo seamlessly with Next by wrapping our _pages_ inside a [higher-order component (HOC)](https://facebook.github.io/react/docs/higher-order-components.html). Using the HOC pattern we're able to pass down a central store of query result data created by Apollo into our React component hierarchy defined inside each page of our Next application.
 >
-> On initial page load, while on the server and inside `getInitialProps`, we invoke the Apollo method,  [`getDataFromTree`](https://www.apollographql.com/docs/react/features/server-side-rendering.html#getDataFromTree). This method returns a promise; at the point in which the promise resolves, our Apollo Client store is completely initialized.
+> On initial page load, while on the server and inside `getInitialProps`, we invoke the Apollo method, [`getDataFromTree`](https://www.apollographql.com/docs/react/features/server-side-rendering.html#getDataFromTree). This method returns a promise; at the point in which the promise resolves, our Apollo Client store is completely initialized.
 >
 > This example relies on [graph.cool](https://www.graph.cool) for its GraphQL backend.
 >
-> *Note: If you're interested in integrating the client with your existing Redux store check out the [`with-apollo-and-redux`](https://github.com/zeit/next.js/tree/master/examples/with-apollo-and-redux) example.*
+> _Note: If you're interested in integrating the client with your existing Redux store check out the [`with-apollo-and-redux`](https://github.com/zeit/next.js/tree/master/examples/with-apollo-and-redux) example._
 
 [graph.cool](https://www.graph.cool) can be setup with many different
 [authentication providers](https://www.graph.cool/docs/reference/integrations/overview-seimeish6e/#authentication-providers), the most basic of which is [email-password authentication](https://www.graph.cool/docs/reference/simple-api/user-authentication-eixu9osueb/#email-and-password). Once email-password authentication is enabled for your graph.cool project, you are provided with 2 useful mutations: `createUser` and `signinUser`.
@@ -66,6 +65,6 @@ It is important to note the use of Apollo's `resetStore()` method after signing 
 To get this example running locally, you will need to create a graph.cool
 account, and provide [the `project.graphcool` schema](https://github.com/zeit/next.js/blob/master/examples/with-apollo-auth/project.graphcool).
 
-
 ### Note:
-In these *with-apollo* examples, the ```withData()``` HOC must wrap a top-level component from within the ```pages``` directory. Wrapping a child component with the HOC will result in a ```Warning: Failed prop type: The prop 'serverState' is marked as required in 'WithData(Apollo(Component))', but its value is 'undefined'``` error. Down-tree child components will have access to Apollo, and can be wrapped with any other sort of ```graphql()```, ```compose()```, etc HOC's.
+
+In these _with-apollo_ examples, the `withData()` HOC must wrap a top-level component from within the `pages` directory. Wrapping a child component with the HOC will result in a `Warning: Failed prop type: The prop 'serverState' is marked as required in 'WithData(Apollo(Component))', but its value is 'undefined'` error. Down-tree child components will have access to Apollo, and can be wrapped with any other sort of `graphql()`, `compose()`, etc HOC's.

--- a/examples/with-apollo/README.md
+++ b/examples/with-apollo/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-apollo)
 # Apollo Example
 
 ## Demo
@@ -46,12 +45,11 @@ now
 
 [Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run, fetching more results from the server.
 
-In this simple example, we integrate Apollo seamlessly with Next by wrapping our *pages/_app.js* inside a [higher-order component (HOC)](https://facebook.github.io/react/docs/higher-order-components.html). Using the HOC pattern we're able to pass down a central store of query result data created by Apollo into our React component hierarchy defined inside each page of our Next application.
+In this simple example, we integrate Apollo seamlessly with Next by wrapping our _pages/\_app.js_ inside a [higher-order component (HOC)](https://facebook.github.io/react/docs/higher-order-components.html). Using the HOC pattern we're able to pass down a central store of query result data created by Apollo into our React component hierarchy defined inside each page of our Next application.
 
-On initial page load, while on the server and inside `getInitialProps`, we invoke the Apollo method,  [`getDataFromTree`](https://www.apollographql.com/docs/react/features/server-side-rendering.html#getDataFromTree). This method returns a promise; at the point in which the promise resolves, our Apollo Client store is completely initialized.
+On initial page load, while on the server and inside `getInitialProps`, we invoke the Apollo method, [`getDataFromTree`](https://www.apollographql.com/docs/react/features/server-side-rendering.html#getDataFromTree). This method returns a promise; at the point in which the promise resolves, our Apollo Client store is completely initialized.
 
 This example relies on [graph.cool](https://www.graph.cool) for its GraphQL backend.
 
-
-Note: Do not be alarmed that you see two renders being executed.  Apollo recursively traverses the React render tree looking for Apollo query components. When it has done that, it fetches all these queries and then passes the result to a cache. This cache is then used to render the data on the server side (another React render).
+Note: Do not be alarmed that you see two renders being executed. Apollo recursively traverses the React render tree looking for Apollo query components. When it has done that, it fetches all these queries and then passes the result to a cache. This cache is then used to render the data on the server side (another React render).
 https://www.apollographql.com/docs/react/features/server-side-rendering.html#getDataFromTree

--- a/examples/with-app-layout/readme.md
+++ b/examples/with-app-layout/readme.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-app-layout)
-
 # With `App` layout example
 
 ## How to use
@@ -41,4 +39,4 @@ now
 
 ## The idea behind the example
 
-Shows how to use _app.js to implement a global layout for all pages.
+Shows how to use \_app.js to implement a global layout for all pages.

--- a/examples/with-astroturf/README.md
+++ b/examples/with-astroturf/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-astroturf)
-
 # Example app with [astroturf](https://github.com/4Catalyzer/astroturf)
 
 ## How to use

--- a/examples/with-babel-macros/README.md
+++ b/examples/with-babel-macros/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-babel-macros)
-
 # Example app with [babel-macros](https://github.com/kentcdodds/babel-macros)
 
 ## How to use

--- a/examples/with-cerebral/README.md
+++ b/examples/with-cerebral/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-cerebral)
-
 # Declarative State & Side-effect management with [CerebralJS](https://cerebraljs.com/)
 
 ## How to use
@@ -51,9 +49,9 @@ Declarative CerebralJS:
   getUser,
   {
     success: setUser,
-    error: setError,
+    error: setError
   },
-  setLoading(false),
+  setLoading(false)
 ];
 ```
 

--- a/examples/with-componentdidcatch/readme.md
+++ b/examples/with-componentdidcatch/readme.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-componentdidcatch)
-
 # With `componentDidCatch` example
 
 ## How to use

--- a/examples/with-configured-preset-env/README.md
+++ b/examples/with-configured-preset-env/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-configured-preset-env)
-
 # Example preconfigured Babel [preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env)
 
 ## How to use

--- a/examples/with-context-api/README.md
+++ b/examples/with-context-api/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-context-api)
-
 # Hello World example
 
 ## How to use
@@ -39,7 +37,7 @@ Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.
 now
 ```
 
-## The idea behind the example*
+## The idea behind the example\*
 
 This example shows how to use react context api in our app.
 
@@ -49,5 +47,4 @@ The `pages/index.js` shows how to, from the home page, increment and decrement t
 
 The `pages/about.js` shows how to, from the about page, how to pass an increment value from the about page into the context provider itself.
 
-
-**Based on WesBos example*.
+\*_Based on WesBos example_.

--- a/examples/with-cookie-auth/README.md
+++ b/examples/with-cookie-auth/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-cookie-auth)
-
 # Example app utilizing cookie-based authentication
 
 ## How to use

--- a/examples/with-custom-babel-config/README.md
+++ b/examples/with-custom-babel-config/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-custom-babel-config)
-
 # Using a custom Babel config
 
 ## How to use
@@ -43,8 +41,8 @@ now
 
 This example features:
 
-* An app using proposed [do expressions](https://babeljs.io/docs/plugins/transform-do-expressions/).
-* It uses babel-preset-stage-0, which allows us to use above JavaScript feature.
-* It uses '.babelrc' file in the app directory to add above preset.
+- An app using proposed [do expressions](https://babeljs.io/docs/plugins/transform-do-expressions/).
+- It uses babel-preset-stage-0, which allows us to use above JavaScript feature.
+- It uses '.babelrc' file in the app directory to add above preset.
 
 > Most of the time, when writing a custom `.babelrc` file, you need to add `next/babel` as a preset.

--- a/examples/with-cxs/README.md
+++ b/examples/with-cxs/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-cxs)
-
 # Example app with cxs
 
 ## How to use

--- a/examples/with-data-prefetch/README.md
+++ b/examples/with-data-prefetch/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-data-prefetch)
 # Example app with prefetching data
 
 ## How to use

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-docker&env=API_URL&docker=true)
-
 # With Docker
 
 ## How to use
@@ -49,7 +47,7 @@ now --docker -e API_URL="https://example.com"
 
 ## The idea behind the example
 
-This example show how to set custom environment variables for your __docker application__ at runtime.
+This example show how to set custom environment variables for your **docker application** at runtime.
 
 The `dockerfile` is the simplest way to run Next.js app in docker, and the size of output image is `173MB`. However, for an even smaller build, you can do multi-stage builds with `dockerfile.multistage`. The size of output image is `85MB`.
 

--- a/examples/with-dotenv/README.md
+++ b/examples/with-dotenv/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-dotenv)
-
 # With Dotenv example
 
 ## How to use
@@ -45,7 +43,7 @@ This example shows how to inline env vars.
 
 **Please note**:
 
-* It is a bad practice to commit env vars to a repository. Thats why you should normally [gitignore](https://git-scm.com/docs/gitignore) your `.env` file.
-* In this example, as soon as you reference an env var in your code it will be automatically be publicly available and exposed to the client.
-* If you want to have more centralized control of what is exposed to the client check out the example [with-universal-configuration-build-time](../with-universal-configuration-build-time).
-* Env vars are set (inlined) at build time. If you need to configure your app on rutime check out [examples/with-universal-configuration-runtime](../with-universal-configuration-runtime).
+- It is a bad practice to commit env vars to a repository. Thats why you should normally [gitignore](https://git-scm.com/docs/gitignore) your `.env` file.
+- In this example, as soon as you reference an env var in your code it will be automatically be publicly available and exposed to the client.
+- If you want to have more centralized control of what is exposed to the client check out the example [with-universal-configuration-build-time](../with-universal-configuration-build-time).
+- Env vars are set (inlined) at build time. If you need to configure your app on rutime check out [examples/with-universal-configuration-runtime](../with-universal-configuration-runtime).

--- a/examples/with-draft-js/README.md
+++ b/examples/with-draft-js/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-draft-js)
 # DraftJS Medium editor inspiration
 
 ## How to use

--- a/examples/with-dynamic-app-layout/readme.md
+++ b/examples/with-dynamic-app-layout/readme.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-dynamic-app-layout)
-
 # With dynamic `App` layout example
 
 ## How to use
@@ -41,5 +39,5 @@ now
 
 ## The idea behind the example
 
-Shows how to use _app.js to implement _dynamic_ layouts for pages.
+Shows how to use _app.js to implement \_dynamic_ layouts for pages.
 This is achieved by attaching a static `Layout` property to each page that needs a different layout. In that way, once we use `_app.js` to wrap our pages, we can get it from `Component.Layout` and render it accordingly.

--- a/examples/with-emotion-fiber/README.md
+++ b/examples/with-emotion-fiber/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-emotion-fiber)
-
 # Pass Server Data Directly to a Next.js Page during SSR
 
 ## How to use

--- a/examples/with-emotion/README.md
+++ b/examples/with-emotion/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-emotion)
-
 # Example app with [emotion](https://github.com/tkh44/emotion)
 
 ## How to use
@@ -44,6 +42,5 @@ now
 This example features how to use [emotion](https://github.com/tkh44/emotion) as the styling solution instead of [styled-jsx](https://github.com/zeit/styled-jsx).
 
 We are creating three `div` elements with custom styles being shared across the elements. The styles includes the use of pseedo-selector and CSS animations.
-
 
 This is based off the with-glamorous example.

--- a/examples/with-env-from-next-config-js/README.md
+++ b/examples/with-env-from-next-config-js/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-dotenv)
-
 # With env From next.js.config
 
 ## How to use
@@ -46,14 +44,14 @@ More specifically, what that means, is that environmental variables are programm
 returned to your react components (including `getInitialProps`) when the program is built with `next build`.
 
 As the build process (`next build`) is proceeding, `next.config.js` is processed and passed in as a parameter is the variable `phase`.
-`phase` can have the values `PHASE_DEVELOPMENT_SERVER` or `PHASE_PRODUCTION_BUILD` (as defined in `next\constants`).  Based on the variable
-`phase`, different environmental variables can be set for use in your react app.  That is, if you reference `process.env.RESTURL_SPEAKERS`
+`phase` can have the values `PHASE_DEVELOPMENT_SERVER` or `PHASE_PRODUCTION_BUILD` (as defined in `next\constants`). Based on the variable
+`phase`, different environmental variables can be set for use in your react app. That is, if you reference `process.env.RESTURL_SPEAKERS`
 in your react app, whatever is returned by `next.config.js` as the variable `env`, (or `env.RESTURL_SPEAKERS`) will be accessible in your
 app as `process.env.RESTURL_SPEAKERS`.
 
 > ## Special note
 >
-> `next build` does a hard coded variable substitution into your JavaScript before the final bundle is created.  This means
+> `next build` does a hard coded variable substitution into your JavaScript before the final bundle is created. This means
 > that if you change your environmental variables outside of your running app, such as in windows with `set` or lunix with `setenv`
 > those changes will not be reflected in your running application until a build happens again (with `next build`).
 
@@ -63,8 +61,8 @@ This example is not meant to be a reference standard for how to do development, 
 production builds with Next. This is just one possible scenario that could be used if you want the
 following behavior while you are doing development.
 
-* When your run `next dev` or `npm run dev`, you will always use the environmental variables assigned when `isDev` is true in the example.
-* When you run `next build` then `next start`, assuming you set externally the environmental variable STAGING to anything but 1, you will get the results assuming `isProd` is true.
-* When your run `next build` or `npm run build` in production, if the environmental variable `STAGING` is set to `1`, `isStaging` will be set and you will get those values returned.
+- When your run `next dev` or `npm run dev`, you will always use the environmental variables assigned when `isDev` is true in the example.
+- When you run `next build` then `next start`, assuming you set externally the environmental variable STAGING to anything but 1, you will get the results assuming `isProd` is true.
+- When your run `next build` or `npm run build` in production, if the environmental variable `STAGING` is set to `1`, `isStaging` will be set and you will get those values returned.
 
 You can read more about this feature in thie blog post <a href="https://zeit.co/blog/next5-1" target="_blank">Next.js 5.1: Faster Page Resolution, Environment Config and More</a> (under Environment Config).

--- a/examples/with-external-scoped-css/README.md
+++ b/examples/with-external-scoped-css/README.md
@@ -1,4 +1,3 @@
-
 # With external scoped css
 
 This example has been deprecated in favor of [@zeit/next-css](https://github.com/zeit/next-plugins/tree/master/packages/next-css).

--- a/examples/with-external-styled-jsx-sass/README.md
+++ b/examples/with-external-styled-jsx-sass/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-external-styled-jsx-sass)
-
 # Example app with next-sass
 
 ## How to use

--- a/examples/with-fela/README.md
+++ b/examples/with-fela/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-fela)
-
 # Example app with Fela
 
 ## How to use

--- a/examples/with-firebase-authentication/README.md
+++ b/examples/with-firebase-authentication/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-firebase-authentication)
-
 # With Firebase Authentication example
 
 ## How to use
@@ -24,11 +22,12 @@ cd with-firebase-authentication
 ```
 
 Set up firebase:
+
 - Create a project at the [Firebase console](https://console.firebase.google.com/).
-- Get your account credentials from the Firebase console at *settings>service accounts*, where you can click on *generate new private key* and download the credentials as a json file. It will contain keys such as `project_id`, `client_email` and `client id`. Now copy them into your project in the `credentials/server.js` file.
-- Get your authentication credentials  from the Firebase console under *authentication>users>web setup*. It will include keys like `apiKey`, `authDomain` and `databaseUrl` and it goes into your project in `credentials/client.js`.
+- Get your account credentials from the Firebase console at _settings>service accounts_, where you can click on _generate new private key_ and download the credentials as a json file. It will contain keys such as `project_id`, `client_email` and `client id`. Now copy them into your project in the `credentials/server.js` file.
+- Get your authentication credentials from the Firebase console under _authentication>users>web setup_. It will include keys like `apiKey`, `authDomain` and `databaseUrl` and it goes into your project in `credentials/client.js`.
 - Copy the `databaseUrl` key you got in the last step into `server.js` in the corresponding line.
-- Back at the Firebase web console, go to *authentication>signup method* and select *Google*.
+- Back at the Firebase web console, go to _authentication>signup method_ and select _Google_.
 - Create a database in the "Database" tab and select the realtime database. Then go to "rules" and set up your write, read rules. Examples can be found here: https://firebase.google.com/docs/database/security/quickstart#sample-rules
 
 Install it and run:
@@ -48,4 +47,5 @@ now
 ```
 
 ## The idea behind the example
+
 The goal is to authenticate users with firebase and store their auth token in sessions. A logged in user will see their messages on page load and then be able to post new messages.

--- a/examples/with-firebase-cloud-messaging/README.md
+++ b/examples/with-firebase-cloud-messaging/README.md
@@ -1,4 +1,4 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-firebase-cloud-messaging)
+# With Firebase Cloud Messaging example
 
 ## How to run
 

--- a/examples/with-flow/README.md
+++ b/examples/with-flow/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-flow)
 # Example app with [Flow](https://flowtype.org/)
 
 ## How to use

--- a/examples/with-freactal/README.md
+++ b/examples/with-freactal/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-freactal)
-
 # Freactal example
 
 ## How to use
@@ -43,11 +41,11 @@ now
 
 When it comes to state management of the React webapp, Redux is the most popular solution. However it brings lots of boilerplate code and fiddling aroud multiple files when tracing even simplest state change.
 
-[Freactal](https://github.com/FormidableLabs/freactal) is a state management library that put this disadvantages away. With very little setup code your components' `props` are enhanced with two key ingredients: `state` and `effects`. Another benefit of Freactal is that you don't need to place *state* at some special place (global store). You can even have multiple state roots and compose them together - just like your components (this is true also for `effects`).
+[Freactal](https://github.com/FormidableLabs/freactal) is a state management library that put this disadvantages away. With very little setup code your components' `props` are enhanced with two key ingredients: `state` and `effects`. Another benefit of Freactal is that you don't need to place _state_ at some special place (global store). You can even have multiple state roots and compose them together - just like your components (this is true also for `effects`).
 
 ### example app
 
-In this example the `index` page renders list of public repos on GitHub for selected username. It fetches list of repos from public gihub api. First page of this list is rendered by SSR. *serverState* is then hydrated into the `Index` page. Button at the end of the list allows to load next page of repos list from the API on the client.
+In this example the `index` page renders list of public repos on GitHub for selected username. It fetches list of repos from public gihub api. First page of this list is rendered by SSR. _serverState_ is then hydrated into the `Index` page. Button at the end of the list allows to load next page of repos list from the API on the client.
 
 ![](https://i.imgur.com/JFU0YUt.png)
 

--- a/examples/with-glamor/README.md
+++ b/examples/with-glamor/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-glamor)
-
 # Example app with glamor
 
 ## How to use

--- a/examples/with-glamorous/README.md
+++ b/examples/with-glamorous/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-glamorous)
-
 # Example app with [glamorous](https://github.com/kentcdodds/glamorous)
 
 ## How to use

--- a/examples/with-google-analytics/README.md
+++ b/examples/with-google-analytics/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-google-analytics)
-
 # Example app with analytics
 
 ## How to use

--- a/examples/with-graphql-hooks/README.md
+++ b/examples/with-graphql-hooks/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-graphql-hooks)
-
 # GraphQL Hooks Example
 
 This started life as a copy of the `with-apollo` example. We then stripped out Apollo and replaced it with `graphql-hooks`. This was mostly as an exercise in ensuring basic functionality could be achieved in a similar way to Apollo. The [bundle size](https://bundlephobia.com/result?p=graphql-hooks@3.2.1) of `graphql-hooks` is tiny in comparison to Apollo and should cover a fair amount of use cases.

--- a/examples/with-graphql-react/README.md
+++ b/examples/with-graphql-react/README.md
@@ -32,7 +32,3 @@ See how it can be used in a Next.js app for GraphQL queries with server side ren
    ```sh
    npm run dev
    ```
-
-## Deploy
-
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-graphl-react)

--- a/examples/with-grommet/README.md
+++ b/examples/with-grommet/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-grommet)
-
 # Example app with Grommet
 
 ## How to use

--- a/examples/with-higher-order-component/README.md
+++ b/examples/with-higher-order-component/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-higher-order-component)
-
 # Higher Order Component example
 
 ## How to use

--- a/examples/with-http2/README.md
+++ b/examples/with-http2/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-http2)
-
 # HTTP2 server example
 
 ## How to use

--- a/examples/with-immutable-redux-wrapper/README.md
+++ b/examples/with-immutable-redux-wrapper/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-immutable-redux-wrapper)
-
 # Immutable Redux Example
 
 > This example and documentation is based on the [with-redux](https://github.com/zeit/next.js/tree/master/examples/with-redux) example.

--- a/examples/with-ioc/README.md
+++ b/examples/with-ioc/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-ioc)
 # Dependency Injection (IoC) example ([ioc](https://github.com/alexindigo/ioc))
 
 ## How to use

--- a/examples/with-jest-react-testing-library/README.md
+++ b/examples/with-jest-react-testing-library/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-jest-react-testing-library)
-
 # Example app with React Testing Library and Jest
 
 ## How to use
@@ -47,5 +45,4 @@ This library encourages your applications to be more accessible and allows you t
 
 This example features:
 
-* An app with [react testing library](https://github.com/kentcdodds/react-testing-library) by [Kent Dodds](https://github.com/kentcdodds/)
-
+- An app with [react testing library](https://github.com/kentcdodds/react-testing-library) by [Kent Dodds](https://github.com/kentcdodds/)

--- a/examples/with-jest/README.md
+++ b/examples/with-jest/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-jest)
-
 # Example app with Jest tests
 
 ## How to use
@@ -45,4 +43,4 @@ yarn test
 
 This example features:
 
-* An app with jest tests
+- An app with jest tests

--- a/examples/with-kea/README.md
+++ b/examples/with-kea/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-kea)
-
 # kea example
 
 ## How to use

--- a/examples/with-linaria/README.md
+++ b/examples/with-linaria/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-linaria)
-
 # Example app with [linaria](https://linaria.now.sh/)
 
 ## How to use

--- a/examples/with-lingui/README.md
+++ b/examples/with-lingui/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-lingui)
-
 # With Lingui example
 
 ## How to use
@@ -45,7 +43,7 @@ This example shows a way to use [lingui.js](https://lingui.js.org) with next.js.
 
 It adds a webpack loader for the messages to avoid having to manually compile while developing as well as adds the compile step to the `next build` script for production builds.
 
-The example also uses a Higher order Component which can be added to all pages which will be translated and that checks for a `?lang` query string switch the language. Next.js  will dynamically load in the messages for the locale when navigating using a Next.js `<Link />` component.
+The example also uses a Higher order Component which can be added to all pages which will be translated and that checks for a `?lang` query string switch the language. Next.js will dynamically load in the messages for the locale when navigating using a Next.js `<Link />` component.
 
 ### How to add more translated strings
 

--- a/examples/with-loading/README.md
+++ b/examples/with-loading/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-loading)
 # Example app with page loading indicator
 
 ## How to use
@@ -46,6 +45,6 @@ We can simply fix this issue by showing a loading indicator. That's what this ex
 
 It features:
 
-* An app with two pages which uses a common [Header](./components/Header.js) component for navigation links.
-* Using `next/router` to identify different router events
-* Uses [nprogress](https://github.com/rstacruz/nprogress) as the loading indicator.
+- An app with two pages which uses a common [Header](./components/Header.js) component for navigation links.
+- Using `next/router` to identify different router events
+- Uses [nprogress](https://github.com/rstacruz/nprogress) as the loading indicator.

--- a/examples/with-markdown/README.md
+++ b/examples/with-markdown/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-markdown)
-
 # With Markdown example
 
 ## How to use

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mdx)
-
 # Example app with MDX
 
 ## How to use

--- a/examples/with-mobx-react-lite/README.md
+++ b/examples/with-mobx-react-lite/README.md
@@ -1,6 +1,4 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mobx-react-lite)
-
-# MobX example
+# MobX React Lite example
 
 ## How to use
 
@@ -61,49 +59,52 @@ The initial store data is returned from the `initializeData` function that recyc
 
 ```jsx
 function initializeData(initialData = store || {}) {
-  const { lastUpdate = Date.now(), light } = initialData
+  const { lastUpdate = Date.now(), light } = initialData;
   return {
     lastUpdate,
-    light: Boolean(light),
-  }
+    light: Boolean(light)
+  };
 }
 ```
 
 The observable store is created in a function component by passing a plain JavaScript object to the `useObservable` hook. Actions on the observable store (`start` and `stop`) are created in the same scope as the `store` in `store.js` and exported as named exports.
 
 ```js
-store = useObservable(initializeData(props.initialData))
+store = useObservable(initializeData(props.initialData));
 
-start = useCallback(action(() => {
-  // Async operation that mutates the store
-}))
+start = useCallback(
+  action(() => {
+    // Async operation that mutates the store
+  })
+);
 
 stop = () => {
   // Does not mutate the store
-}
+};
 ```
 
 The component creates and exports a new React context provider that will make the store accessible to all of its descendents.
 
 ```jsx
-return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
+return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>;
 ```
 
 The store is accessible at any depth by using the `StoreContext`.
 
 ```js
-const store = useContext(StoreContext)
+const store = useContext(StoreContext);
 ```
 
 The clock, under `components/Clock.js`, reacts to changes in the observable `store` by means of the `useObserver` hook.
 
 ```jsx
-return <div>
-  // ...
-  {useObserver(() => <Clock
-    lastUpdate={store.lastUpdate}
-    light={store.light}
-  />)}
-  // ...
-</div>
+return (
+  <div>
+    // ...
+    {useObserver(() => (
+      <Clock lastUpdate={store.lastUpdate} light={store.light} />
+    ))}
+    // ...
+  </div>
+);
 ```

--- a/examples/with-mobx-state-tree-typescript/README.md
+++ b/examples/with-mobx-state-tree-typescript/README.md
@@ -1,6 +1,4 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mobx-state-tree)
-
-# MobX State Tree example
+# MobX State Tree TypeScript example
 
 ## How to use
 

--- a/examples/with-mobx-state-tree/README.md
+++ b/examples/with-mobx-state-tree/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mobx-state-tree)
-
 # MobX State Tree example
 
 ## How to use

--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mobx)
-
 # MobX example
 
 ## How to use
@@ -38,14 +36,14 @@ Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.
 ```bash
 now
 ```
+
 ## Notes
+
 This example is a mobx port of the [with-redux](https://github.com/zeit/next.js/tree/master/examples/with-redux) example. Decorator support is activated by adding a `.babelrc` file at the root of the project:
 
 ```json
 {
-  "presets": [
-    "next/babel"
-  ],
+  "presets": ["next/babel"],
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }]
@@ -54,6 +52,7 @@ This example is a mobx port of the [with-redux](https://github.com/zeit/next.js/
 ```
 
 ### Rehydrating with server data
+
 Be aware that data that was used on the server (and provided via `getInitialProps`) will be stringified in order to rehydrate the client with it. That means, if you create a store that is, say, an `ObservableMap` and give it as prop to a page, then the server will render appropriately. But stringifying it for the client will turn the `ObservableMap` to an ordinary JavaScript object (which does not have `Map`-style methods and is not an observable). So it is better to create the store as a normal object and turn it into a `Observable` in the `render()` method. This way both sides have an `Observable` to work with.
 
 ## The idea behind the example

--- a/examples/with-mocha/README.md
+++ b/examples/with-mocha/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-mocha)
-
 # Example app with Mocha tests
 
 ## How to use
@@ -45,6 +43,6 @@ yarn test
 
 This example features:
 
-* An app with Mocha tests
+- An app with Mocha tests
 
 > A very important part of this example is the `.babelrc` file which configures the `test` environment to use `babel-preset-env` and configures it to transpile modules to `commonjs`). [Learn more](https://github.com/zeit/next.js/issues/2895).

--- a/examples/with-next-css/README.md
+++ b/examples/with-next-css/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-next-css)
-
 # next-css example
 
 ## How to use

--- a/examples/with-next-less/README.md
+++ b/examples/with-next-less/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-next-less)
-
 # Example App with next-less
 
 ## How to use

--- a/examples/with-next-page-transitions/README.md
+++ b/examples/with-next-page-transitions/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-next-page-transitions)
-
 # next-page-transitions example
 
 ## How to use
@@ -42,4 +40,3 @@ now
 The [`next-page-transitions`](https://github.com/illinois/next-page-transitions) library is a component that sits at the app level and allows you to animate page changes. It works especially nicely with apps with a shared layout element, like a navbar. This component will ensure that only one page is ever mounted at a time, and manages the timing of animations for you. This component works similarly to [`react-transition-group`](https://github.com/reactjs/react-transition-group) in that it applies classes to a container around your page; it's up to you to write the CSS transitions or animations to make things pretty!
 
 This example includes two pages with links between them. The "About" page demonstrates how `next-page-transitions` makes it easy to add a loading state when navigating to a page: it will wait for the page to "load" its content (in this examples, that's simulated with a timeout) and then hide the loading indicator and animate in the page when it's done.
-

--- a/examples/with-next-routes/README.md
+++ b/examples/with-next-routes/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-next-routes)
 # Named routes example ([next-routes](https://github.com/fridays/next-routes))
 
 ## How to use

--- a/examples/with-next-sass/README.md
+++ b/examples/with-next-sass/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-next-sass)
-
 # Example app with next-sass
 
 ## How to use
@@ -47,7 +45,7 @@ yarn start
 
 This example features:
 
-* An app with next-sass
+- An app with next-sass
 
 This example uses next-sass without css-modules. The config can be found in `next.config.js`, change `withSass()` to `withSass({cssModules: true})` if you use css-modules. Then in the code, you import the stylesheet as `import style from '../styles/style.scss'` and use it like `<div className={style.example}>`.
 

--- a/examples/with-next-seo/README.md
+++ b/examples/with-next-seo/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-next-seo)
-
 # Next SEO example
 
 ## How to use

--- a/examples/with-noscript/README.md
+++ b/examples/with-noscript/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-noscript)
-
 # Noscript example
 
 ## How to use
@@ -19,9 +17,11 @@ yarn create next-app --example with-noscript with-noscript-app
 Download the example:
 
 ## Development
+
 Install it and run:
 
 **npm**
+
 ```bash
 npm install
 npm run dev
@@ -31,13 +31,16 @@ yarn dev
 ```
 
 **yarn**
+
 ```bash
 yarn install
 yarn run dev
 ```
 
 ## Production
+
 **npm**
+
 ```bash
 npm install
 npm run build
@@ -45,6 +48,7 @@ npm start
 ```
 
 **yarn**
+
 ```bash
 yarn install
 yarn run build

--- a/examples/with-now-env/README.md
+++ b/examples/with-now-env/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-now-env)
-
 # Now-env example
 
 ## How to use

--- a/examples/with-office-ui-fabric-react/README.md
+++ b/examples/with-office-ui-fabric-react/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-office-ui-fabric-react)
-
 # Office UI Fabric React example
 
 ## How to use

--- a/examples/with-orbit-components/README.md
+++ b/examples/with-orbit-components/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-orbit-components)
-
 # Example app with styled-components
 
 ## How to use
@@ -40,9 +38,9 @@ now
 ```
 
 ## The idea behind the example
+
 [Orbit-components](https://orbit.kiwi) is a React component library which provides developers with the easiest possible way of building Kiwi.com’s products.
 
 For this purpose we are extending `<App />` of injected `<ThemeProvider/>`, and also adding `@kiwicom/babel-plugin-orbit-components`
 
 This fork comes from [styled-components-example](https://github.com/zeit/next.js/tree/canary/examples/with-styled-components)
-

--- a/examples/with-overmind/README.md
+++ b/examples/with-overmind/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-overmind)
-
 # Overmind example
 
 ## How to use

--- a/examples/with-polyfills/README.md
+++ b/examples/with-polyfills/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-polyfills)
-
 # Example app with polyfills
 
 ## How to use

--- a/examples/with-prefetching/README.md
+++ b/examples/with-prefetching/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-prefetching)
 # Example app with prefetching pages
 
 ## How to use
@@ -42,6 +41,6 @@ now
 
 This example features:
 
-* An app with four simple pages
-* The "about" page uses the imperative (i.e.: "manual") prefetching API to prefetch on hover
-* It will prefetch all the pages in the background except the "contact" page
+- An app with four simple pages
+- The "about" page uses the imperative (i.e.: "manual") prefetching API to prefetch on hover
+- It will prefetch all the pages in the background except the "contact" page

--- a/examples/with-pretty-url-routing/README.md
+++ b/examples/with-pretty-url-routing/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-pretty-url-routing)
-
 # Example app with pretty url routing
 
 ## How to use
@@ -42,5 +40,6 @@ now
 ## The idea behind the example
 
 This example features:
+
 - route customisation and parameterization
 - reverse routing

--- a/examples/with-react-esi/README.md
+++ b/examples/with-react-esi/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-esi)
 # React ESI example
 
 # Example app with prefetching pages

--- a/examples/with-react-ga/README.md
+++ b/examples/with-react-ga/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-ga)
-
 # React-GA example
 
 ## How to use

--- a/examples/with-react-helmet/README.md
+++ b/examples/with-react-helmet/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-helmet)
-
 # react-helmet example
 
 ## How to use

--- a/examples/with-react-intl/README.md
+++ b/examples/with-react-intl/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-intl)
 # Example app with [React Intl][]
 
 ## How to use
@@ -65,4 +64,4 @@ $ npm start
 
 You can then switch your browser's language preferences to French and refresh the page to see the UI update accordingly.
 
-[React Intl]: https://github.com/yahoo/react-intl
+[react intl]: https://github.com/yahoo/react-intl

--- a/examples/with-react-jss/README.md
+++ b/examples/with-react-jss/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-jss)
-
 # react-jss example
 
 ## How to use

--- a/examples/with-react-md/README.md
+++ b/examples/with-react-md/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-md)
-
 # Example app with react-md
 
 ![Screenshot](https://cloud.githubusercontent.com/assets/304265/22472564/b2e04ff0-e7de-11e6-921e-d0c9833ac805.png)

--- a/examples/with-react-native-web/README.md
+++ b/examples/with-react-native-web/README.md
@@ -1,4 +1,4 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-native-web)
+# React Native Web example
 
 ## How to use
 

--- a/examples/with-react-relay-network-modern/README.md
+++ b/examples/with-react-relay-network-modern/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-relay-modern)
-
 # Relay Modern Example
 
 ## How to use

--- a/examples/with-react-toolbox/README.md
+++ b/examples/with-react-toolbox/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-toolbox)
-
 # With react-toolbox example
 
 ## How to use

--- a/examples/with-react-useragent/README.md
+++ b/examples/with-react-useragent/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-useragent)
-
 # react-useragent example
 
 Show how to setup [@quentin-sommer/react-useragent](https://github.com/quentin-sommer/react-useragent) using next.js client side and server side rendering.

--- a/examples/with-react-uwp/README.md
+++ b/examples/with-react-uwp/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-uwp)
 # React-UWP example
 
 ## How to use

--- a/examples/with-react-with-styles/README.md
+++ b/examples/with-react-with-styles/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-react-with-styles)
-
 # Example app with react-with-styles
 
 ## How to use

--- a/examples/with-reasonml/README.md
+++ b/examples/with-reasonml/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-reasonml)
-
 # Example app using ReasonML & ReasonReact components
 
 ## How to use
@@ -62,8 +60,8 @@ experience that ReasonML can offer, don't miss it!
 
 This example features:
 
-* An app that mixes together JavaScript and ReasonML components and functions
-* An app with two pages which has a common Counter component
-* That Counter component maintain the counter inside its module. This is used
+- An app that mixes together JavaScript and ReasonML components and functions
+- An app with two pages which has a common Counter component
+- That Counter component maintain the counter inside its module. This is used
   primarily to illustrate that modules get initialized once and their state
   variables persist in runtime

--- a/examples/with-rebass/README.md
+++ b/examples/with-rebass/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-rebass)
-
 # Example app with Rebass
 
 ![Screenshot](https://cloud.githubusercontent.com/assets/304265/22472564/b2e04ff0-e7de-11e6-921e-d0c9833ac805.png)

--- a/examples/with-recompose/README.md
+++ b/examples/with-recompose/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-recompose)
-
 # Recompose example
 
 ## How to use

--- a/examples/with-redux-code-splitting/README.md
+++ b/examples/with-redux-code-splitting/README.md
@@ -1,6 +1,3 @@
-
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-redux-code-splitting)
-
 # Redux with code splitting example
 
 ## How to use

--- a/examples/with-redux-reselect-recompose/README.md
+++ b/examples/with-redux-reselect-recompose/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-redux-reselect-recompose)
-
 # Redux with reselect and recompose example
 
 ## How to use
@@ -40,7 +38,6 @@ yarn
 yarn dev
 ```
 
-
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
 
 ```bash
@@ -48,4 +45,5 @@ now
 ```
 
 ## The idea behind the example
+
 This example is based on the great work of [with-redux](https://github.com/zeit/next.js/blob/master/examples/with-redux/) example with the addition of [reselect](https://github.com/reactjs/reselect) and [recompose](https://github.com/acdlite/recompose)

--- a/examples/with-redux-saga/README.md
+++ b/examples/with-redux-saga/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-redux-saga)
-
 # redux-saga example
 
 > This example and documentation is based on the [with-redux](https://github.com/zeit/next.js/tree/master/examples/with-redux) example.
@@ -70,12 +68,12 @@ The digital clock is updated every second using the `runClockSaga` found in `sag
 All pages are also being wrapped by `next-redux-saga` using a helper function from `store.js`:
 
 ```js
-import withRedux from 'next-redux-wrapper'
-import nextReduxSaga from 'next-redux-saga'
-import configureStore from './store'
+import withRedux from "next-redux-wrapper";
+import nextReduxSaga from "next-redux-saga";
+import configureStore from "./store";
 
 export function withReduxSaga(BaseComponent) {
-  return withRedux(configureStore)(nextReduxSaga(BaseComponent))
+  return withRedux(configureStore)(nextReduxSaga(BaseComponent));
 }
 
 /**
@@ -92,12 +90,13 @@ export function withReduxSaga(BaseComponent) {
 If you need to pass `react-redux` connect args to your page, you could use the following helper instead:
 
 ```js
-import withRedux from 'next-redux-wrapper'
-import nextReduxSaga from 'next-redux-saga'
-import configureStore from './store'
+import withRedux from "next-redux-wrapper";
+import nextReduxSaga from "next-redux-saga";
+import configureStore from "./store";
 
 export function withReduxSaga(...connectArgs) {
-  return BaseComponent => withRedux(configureStore, ...connectArgs)(nextReduxSaga(BaseComponent))
+  return BaseComponent =>
+    withRedux(configureStore, ...connectArgs)(nextReduxSaga(BaseComponent));
 }
 
 /**
@@ -111,6 +110,6 @@ export function withReduxSaga(...connectArgs) {
  */
 ```
 
-Since `redux-saga` is like a separate thread in your application, we need to tell the server to END the running saga when all asynchronous actions are complete. This is automatically handled for you by wrapping your components in `next-redux-saga`. To illustrate this, `pages/index.js` loads placeholder JSON data on the server from [https://jsonplaceholder.typicode.com/users](https://jsonplaceholder.typicode.com/users). If you refresh `pages/other.js`, the placeholder JSON data will **NOT** be loaded on the server, however, the saga is running on the client. When you click *Navigate*, you will be taken to `pages/index.js` and the placeholder JSON data will be fetched from the client. The placeholder JSON data will only be fetched **once** from the client or the server.
+Since `redux-saga` is like a separate thread in your application, we need to tell the server to END the running saga when all asynchronous actions are complete. This is automatically handled for you by wrapping your components in `next-redux-saga`. To illustrate this, `pages/index.js` loads placeholder JSON data on the server from [https://jsonplaceholder.typicode.com/users](https://jsonplaceholder.typicode.com/users). If you refresh `pages/other.js`, the placeholder JSON data will **NOT** be loaded on the server, however, the saga is running on the client. When you click _Navigate_, you will be taken to `pages/index.js` and the placeholder JSON data will be fetched from the client. The placeholder JSON data will only be fetched **once** from the client or the server.
 
 After introducing `redux-saga` there was too much code in `store.js`. For simplicity and readability, the actions, reducers, sagas, and store creators have been split into seperate files: `actions.js`, `reducer.js`, `saga.js`, `store.js`

--- a/examples/with-redux-thunk/README.md
+++ b/examples/with-redux-thunk/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-redux-thunk)
-
 # Redux Thunk example
 
 ## How to use

--- a/examples/with-redux-wrapper/README.md
+++ b/examples/with-redux-wrapper/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-redux-wrapper)
-
 # Redux example
 
 ## How to use

--- a/examples/with-redux/README.md
+++ b/examples/with-redux/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-redux)
-
 # Redux example
 
 ## How to use

--- a/examples/with-reflux/README.md
+++ b/examples/with-reflux/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-reflux)
-
 # Pass Server Data Directly to a Next.js Page during SSR
 
 ## How to use

--- a/examples/with-refnux/README.md
+++ b/examples/with-refnux/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-refnux)
-
 # Refnux example
 
 ## How to use
@@ -39,7 +37,6 @@ Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.
 now
 ```
 
-
 ## The idea behind the example
 
 This example, just like `with-redux` and `with-mobx` examples, shows how to manage a global state in your web-application.
@@ -50,11 +47,10 @@ We have two very similar pages (page1.js, page2.js). They both
 - show the current application state, including a simple counter value
 - have a link to jump from one page to the other
 - have an 'increment' button to increment the state of the counter
-(it triggers the `counterIncrement` action)
+  (it triggers the `counterIncrement` action)
 
 When running the example, please, increment the counter and note how moving from page 1 to page 2 and back the state is persisted.
 Reloading any of the pages will restore the initial state coming from the server.
-
 
 ### Implementation details
 

--- a/examples/with-relay-modern-server-express/README.md
+++ b/examples/with-relay-modern-server-express/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-relay-modern)
-
 # Relay Modern Server Express Example
 
 ## How to use

--- a/examples/with-relay-modern/README.md
+++ b/examples/with-relay-modern/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-relay-modern)
-
 # Relay Modern Example
 
 ## How to use

--- a/examples/with-rematch/README.md
+++ b/examples/with-rematch/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-rematch)
-
 # Rematch example
 
 ## How to use
@@ -48,6 +46,6 @@ Besides the `pages` directory, there is a directory called shared which holds al
 
 Some features of this example are :
 
-* Pages are connected to rematch using `withRematch` util. These pages are capable of accessing values from the store and dispatching changes
-* Components are inside the `shared/components` folder. The `counter-display` component is connected to the store using the `connect` function to show how components which are not pages, can connect with Rematch.
-* The file `shared/store` exports an initStore function which is used by `withRematch` to create store universally on the server and on the client.
+- Pages are connected to rematch using `withRematch` util. These pages are capable of accessing values from the store and dispatching changes
+- Components are inside the `shared/components` folder. The `counter-display` component is connected to the store using the `connect` function to show how components which are not pages, can connect with Rematch.
+- The file `shared/store` exports an initStore function which is used by `withRematch` to create store universally on the server and on the client.

--- a/examples/with-segment-analytics/README.md
+++ b/examples/with-segment-analytics/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-segment-analytics)
-
 # Example app with analytics
 
 ## How to use

--- a/examples/with-semantic-ui/README.md
+++ b/examples/with-semantic-ui/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-semantic-ui)
-
 # Semantic UI example
 
 ## How to use

--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-sentry)
-
 # Sentry example
 
 ## How to use
@@ -21,12 +19,14 @@ Download the example:
 Install it and run:
 
 **npm**
+
 ```bash
 npm install
 npm run dev
 ```
 
 **yarn**
+
 ```bash
 yarn
 yarn dev

--- a/examples/with-shallow-routing/README.md
+++ b/examples/with-shallow-routing/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-shallow-routing)
-
 # Shallow Routing Example
 
 ## How to use

--- a/examples/with-sitemap-and-robots-express-server-typescript/README.md
+++ b/examples/with-sitemap-and-robots-express-server-typescript/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-sitemap-and-robots-typescript)
-
 # Example with sitemap.xml and robots.txt using Express server and typescript
 
 ## How to use
@@ -47,15 +45,18 @@ The app is deployed at: https://sitemap-robots.now.sh. Open the page and click t
 ![sitemap-robots](https://user-images.githubusercontent.com/26158226/38786210-4d0c3f70-40db-11e8-8e44-b2c90cfd1b74.png)
 
 Notes:
+
 - routes `/a` and `/b` are added to sitemap manually
 - routes that start with `/posts` are added automatically to sitemap; in a real application, you will get post slugs from a database
 
 When you start this example locally:
+
 - your app with run at https://localhost:8000
 - sitemap.xml will be located at http://localhost:8000/sitemap.xml
 - robots.txt will be located at http://localhost:8000/robots.txt
 
 In case you want to deploy this example, replace the URL in the following locations with your own domain:
+
 - `hostname` in `src/server/sitemapAndRobots.ts`
 - `ROOT_URL` in `src/server/app.ts`
 - `Sitemap` at the bottom of `src/server/robots.txt`
@@ -65,10 +66,10 @@ Deploy with `now` or with `yarn now` if you specified `alias` in `now.json`
 
 ## Typescript notes
 
-express.js and next.js require slighty different forms of javascript (es5 vs. es6, es6 modules vs commonjs modules, that sort of thing) so there are two tsconfig files that are used to generate the appropriate *.js and *.jsx files in dist from the *.ts and *.tsx files in src (`tsconfig.next.json` and `tsconfig.server.json`). Any files under /src/server are assumed to be for express, any other files under /src are assumed to be for next. To keep things simple the two typescript transpiles using these two config files are run directly from npm commands in package.json so all you need to run the example are simple commands like
+express.js and next.js require slighty different forms of javascript (es5 vs. es6, es6 modules vs commonjs modules, that sort of thing) so there are two tsconfig files that are used to generate the appropriate _.js and _.jsx files in dist from the _.ts and _.tsx files in src (`tsconfig.next.json` and `tsconfig.server.json`). Any files under /src/server are assumed to be for express, any other files under /src are assumed to be for next. To keep things simple the two typescript transpiles using these two config files are run directly from npm commands in package.json so all you need to run the example are simple commands like
 
 `npm run start`
 or
 `npm run dev`
 
-This example has most of the hot module reload plumbing setup for both express- and next-related source files when you use `npm run dev` but it's currently only watching the *.js and *.jsx files in /dist for changes. You will need to manually `npm run build-ts` in another window to transpile your modified typescript files in `src` into the watched javascript files in `dist` (it should be possible to have tsc watch the src folder and auto compile on save but that isn't wired up yet in this example). This example does also have tslint support though `npm run tslint`.
+This example has most of the hot module reload plumbing setup for both express- and next-related source files when you use `npm run dev` but it's currently only watching the _.js and _.jsx files in /dist for changes. You will need to manually `npm run build-ts` in another window to transpile your modified typescript files in `src` into the watched javascript files in `dist` (it should be possible to have tsc watch the src folder and auto compile on save but that isn't wired up yet in this example). This example does also have tslint support though `npm run tslint`.

--- a/examples/with-sitemap-and-robots-express-server/README.md
+++ b/examples/with-sitemap-and-robots-express-server/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-sitemap-and-robots)
-
 # Example with sitemap.xml and robots.txt using Express server
 
 ## How to use
@@ -47,16 +45,19 @@ The app is deployed at: https://sitemap-robots.now.sh. Open the page and click t
 ![sitemap-robots](https://user-images.githubusercontent.com/26158226/38786210-4d0c3f70-40db-11e8-8e44-b2c90cfd1b74.png)
 
 Notes:
+
 - routes `/a` and `/b` are added to sitemap manually
 - routes that start with `/posts` are added automatically to sitemap; the current example creates an array of posts (see `server/posts.js`), but in a production-level web app, you would want to update `sitemap.xml` dynamically by getting posts from a database:
   - see [this app](https://github.com/builderbook/builderbook/blob/5f33772b8896d646cff89493853f34e61de6179a/server/sitemapAndRobots.js#L11) in which posts are fetched from a database
 
 When you start this example locally:
+
 - your app with run at https://localhost:8000
 - sitemap.xml will be located at http://localhost:8000/sitemap.xml
 - robots.txt will be located at http://localhost:8000/robots.txt
 
 In case you want to deploy this example, replace the URL in the following locations with your own domain:
+
 - `hostname` in `server/sitemapAndRobots.js`
 - `ROOT_URL` in `server/app.js`
 - `Sitemap` at the bottom of `robots.txt`

--- a/examples/with-slate/README.md
+++ b/examples/with-slate/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-slate)
-
 # slate.js example
 
 ## How to use

--- a/examples/with-socket.io/README.md
+++ b/examples/with-socket.io/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-socket.io)
-
 # Socket.io example
 
 ## How to use

--- a/examples/with-storybook/README.md
+++ b/examples/with-storybook/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-storybook)
-
 # Example app with Storybook
 
 ## How to use

--- a/examples/with-strict-csp-hash/README.md
+++ b/examples/with-strict-csp-hash/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-strict-csp-hash)
-
 # Example app with strict CSP generating script hash
 
 ## How to use

--- a/examples/with-strict-csp/README.md
+++ b/examples/with-strict-csp/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-strict-csp)
-
 # Strict CSP example
 
 ## How to use

--- a/examples/with-style-sheet/README.md
+++ b/examples/with-style-sheet/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-style-sheet)
-
 # Using the style-sheet CSS in JS library and extract CSS to file.
 
 ## How to use

--- a/examples/with-styled-components/README.md
+++ b/examples/with-styled-components/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-styled-components)
-
 # Example app with styled-components
 
 ## How to use

--- a/examples/with-styled-jsx-plugins/README.md
+++ b/examples/with-styled-jsx-plugins/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-styled-jsx-plugins)
-
 # With styled-jsx plugins
 
 ## How to use

--- a/examples/with-styled-jsx-scss/README.md
+++ b/examples/with-styled-jsx-scss/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-styled-jsx-scss)
-
 # With styled-jsx SASS / SCSS
 
 ## How to use

--- a/examples/with-styletron/README.md
+++ b/examples/with-styletron/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-styletron)
-
 # Example app with styletron
 
 ## How to use

--- a/examples/with-sw-precache/README.md
+++ b/examples/with-sw-precache/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-sw-precache)
-
 # sw-precache example
 
 ## How to use

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-tailwindcss)
-
 # Tailwind CSS example
 
 This is an example of how you can include a global stylesheet in a next.js webapp.
@@ -49,12 +47,12 @@ now
 
 In the `package.json` you'll see some extra commands.
 
-* `yarn dev:css`
-  * used by `yarn dev` generate css bundle and watch css files for changes
-  * includes css imported into `index.css`
-  * will **not** autoreload browser when css changes
-* `yarn build:css`
-  * used by `yarn build` to generate css bundle
+- `yarn dev:css`
+  - used by `yarn dev` generate css bundle and watch css files for changes
+  - includes css imported into `index.css`
+  - will **not** autoreload browser when css changes
+- `yarn build:css`
+  - used by `yarn build` to generate css bundle
 
 These can be used manually but using the usual commands will run them anyways.
 
@@ -70,8 +68,8 @@ some webpack loaders. If you are curious about using loaders with next look at t
 
 This project shows how you can set it up. Have a look at:
 
-* pages/\_document.js
-* styles/config/postcss.config.js
-* styles/config/tailwind.config.js
-* styles/index.css
-* styles/button.css
+- pages/\_document.js
+- styles/config/postcss.config.js
+- styles/config/tailwind.config.js
+- styles/index.css
+- styles/button.css

--- a/examples/with-ts-node/README.md
+++ b/examples/with-ts-node/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-ts-node)
-
 # Custom server with fully TypeScript + ts-node example (without babel and tsc), require next js 7+
 
 ## How to use

--- a/examples/with-typescript-styled-components/README.md
+++ b/examples/with-typescript-styled-components/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-typescript-styled-components)
-
 # TypeScript & Styled Components Next.js example
 
 This is a really simple project that show the usage of Next.js with TypeScript and Styled Components.
@@ -39,5 +37,5 @@ yarn dev
 
 This is an amalgamation of the 2 existing examples:
 
-* [with-typescript](https://github.com/zeit/next.js/tree/canary/examples/with-typescript)
-* [with-styled-components](https://github.com/zeit/next.js/tree/canary/examples/with-styled-components)
+- [with-typescript](https://github.com/zeit/next.js/tree/canary/examples/with-typescript)
+- [with-styled-components](https://github.com/zeit/next.js/tree/canary/examples/with-styled-components)

--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-typescript)
-
 # TypeScript Next.js example
 
 This is a really simple project that show the usage of Next.js with TypeScript.

--- a/examples/with-typestyle/README.md
+++ b/examples/with-typestyle/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-typestyle)
-
 # Example app with typestyle
 
 ## How to use

--- a/examples/with-typings-for-css-modules/README.md
+++ b/examples/with-typings-for-css-modules/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-typings-for-css-modules)
-
 # Typings for CSS Modules example
 
 ## How to use

--- a/examples/with-universal-configuration-build-time/README.md
+++ b/examples/with-universal-configuration-build-time/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-universal-configuration-build-time)
-
 # With universal configuration
 
 ## How to use

--- a/examples/with-universal-configuration-runtime/README.md
+++ b/examples/with-universal-configuration-runtime/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-universal-configuration-runtime)
-
 # With universal runtime configuration
 
 ## How to use

--- a/examples/with-unstated/README.md
+++ b/examples/with-unstated/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/canary/examples/with-unstated)
-
 # Unstated example
 
 ## How to use

--- a/examples/with-url-object-routing/README.md
+++ b/examples/with-url-object-routing/README.md
@@ -1,4 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-url-object-routing)
 # URL object routing
 
 ## How to use

--- a/examples/with-videojs/README.md
+++ b/examples/with-videojs/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-videojs)
-
 # video.js example
 
 ## How to use

--- a/examples/with-webassembly/readme.md
+++ b/examples/with-webassembly/readme.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-webassembly)
-
 # WebAssembly example
 
 ## How to use

--- a/examples/with-webpack-bundle-size-analyzer/README.md
+++ b/examples/with-webpack-bundle-size-analyzer/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-webpack-bundle-size-analyzer)
-
 # Webpack Bundle Size Analyzer
 
 ## How to use

--- a/examples/with-yarn-workspaces/README.md
+++ b/examples/with-yarn-workspaces/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-yarn-workspaces)
-
 # Yarn workspaces example
 
 ## How to use
@@ -42,13 +40,13 @@ Workspaces are a new way to setup your package architecture that’s available b
 
 In this example we have three workspaces:
 
-* **web-app**: A Next.js app
-* **foo**: A normal node module
-* **bar**: A react component, that gets compiled by Next.js (see [packages/web-app/next.config.js](./packages/web-app/next.config.js) for more info)
+- **web-app**: A Next.js app
+- **foo**: A normal node module
+- **bar**: A react component, that gets compiled by Next.js (see [packages/web-app/next.config.js](./packages/web-app/next.config.js) for more info)
 
 ## Useful Links
 
-* [Documentation](https://yarnpkg.com/en/docs/workspaces)
-* [yarn workspaces](https://yarnpkg.com/lang/en/docs/cli/workspace)
-* [yarn workspace](https://yarnpkg.com/lang/en/docs/cli/workspaces)
-* [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules)
+- [Documentation](https://yarnpkg.com/en/docs/workspaces)
+- [yarn workspaces](https://yarnpkg.com/lang/en/docs/cli/workspace)
+- [yarn workspace](https://yarnpkg.com/lang/en/docs/cli/workspaces)
+- [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules)

--- a/examples/with-zones/README.md
+++ b/examples/with-zones/README.md
@@ -1,5 +1,3 @@
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-zones)
-
 # Using multiple zones
 
 ## How to use
@@ -79,16 +77,16 @@ These rules are based on ZEIT now v1 [path alias](https://zeit.co/docs/features/
 
 ## Special Notes
 
-* All pages should be unique across zones. A page with the same name should not exist in multiple zones. Otherwise, there'll be unexpected behaviour in client side navigation.
-  * According to the above example, a page named `blog` should not be exist in the `home` zone.
+- All pages should be unique across zones. A page with the same name should not exist in multiple zones. Otherwise, there'll be unexpected behaviour in client side navigation.
+  - According to the above example, a page named `blog` should not be exist in the `home` zone.
 
 ## Production Deployment
 
 Here's how are going to deploy this application into production.
 
-* Open the `now.json` and `next.config.js` files in both `blog` and `home` directories and change the aliases as you wish.
-* Then update `routes` in `home/now.json` accordingly.
-* Now deploy both apps:
+- Open the `now.json` and `next.config.js` files in both `blog` and `home` directories and change the aliases as you wish.
+- Then update `routes` in `home/now.json` accordingly.
+- Now deploy both apps:
 
 ```bash
 cd home


### PR DESCRIPTION
Currently, nearly all examples have a 'Deploy to now' button which is currently broken. This PR removes this button from all examples, in addition to this it also:

- Adds example titles where previously missing
- Makes example titles more descriptive
- Corrects duplicated example titles