### PR TITLE
Cache Babel and AutoDll plugin in `dirDir/cache`

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -16,6 +16,7 @@ import { SharedRuntimePlugin } from './webpack/plugins/shared-runtime-plugin'
 import { HashedChunkIdsPlugin } from './webpack/plugins/hashed-chunk-ids-plugin'
 import { ChunkGraphPlugin } from './webpack/plugins/chunk-graph-plugin'
 import { DropClientPage } from './webpack/plugins/next-drop-client-page-plugin'
+import { importAutoDllPlugin } from './webpack/plugins/dll-import'
 import { WebpackEntrypoints } from './entries'
 type ExcludesFalse = <T>(x: T | false) => x is T
 
@@ -295,33 +296,7 @@ export default function getBaseWebpackConfig (dir: string, {dev = false, debug =
         ]
 
         if (!isServer) {
-          // BEGIN: Hijack autodll-webpack-plugin cache path
-          const autodllPaths = path.join(
-            path.dirname(require.resolve('autodll-webpack-plugin')),
-            'paths.js'
-          )
-          require(autodllPaths)
-
-          const autodllCachePath = path.resolve(
-            path.join(distDir, 'cache', 'autodll-webpack-plugin')
-          );
-          require.cache[autodllPaths] = Object.assign(
-            {},
-            require.cache[autodllPaths],
-            {
-              exports: Object.assign(
-                {},
-                require.cache[autodllPaths].exports,
-                {
-                  cacheDir: autodllCachePath,
-                  getManifestPath: (hash: string) => (bundleName: string) => path.resolve(autodllCachePath, hash, `${bundleName}.manifest.json`)
-                }
-              ),
-            }
-          )
-          // END: Hijack autodll-webpack-plugin cache path
-
-          const AutoDllPlugin = require('autodll-webpack-plugin')
+          const AutoDllPlugin = importAutoDllPlugin({ distDir })
           devPlugins.push(
             new AutoDllPlugin({
               filename: '[name]_[hash].js',

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -21,7 +21,7 @@ module.exports = babelLoader.custom(babel => {
       const filename = join(opts.cwd, 'noop.js')
       const loader = Object.assign({
         cacheCompression: false,
-        cacheDirectory: true,
+        cacheDirectory: join(opts.distDir, 'cache', 'next-babel-loader'),
         cacheIdentifier: cacheKey + JSON.stringify(
           babel.loadPartialConfig({
             filename,
@@ -33,6 +33,7 @@ module.exports = babelLoader.custom(babel => {
 
       delete loader.isServer
       delete loader.asyncToPromises
+      delete loader.distDir
       return { loader, custom }
     },
     config (cfg, { source, customOptions: { isServer, asyncToPromises } }) {

--- a/packages/next/build/webpack/plugins/dll-import.ts
+++ b/packages/next/build/webpack/plugins/dll-import.ts
@@ -1,0 +1,23 @@
+import path from 'path'
+
+export function importAutoDllPlugin({ distDir }: { distDir: string }) {
+  const autodllPaths = path.join(
+    path.dirname(require.resolve('autodll-webpack-plugin')),
+    'paths.js'
+  )
+  require(autodllPaths)
+
+  const autodllCachePath = path.resolve(
+    path.join(distDir, 'cache', 'autodll-webpack-plugin')
+  )
+  require.cache[autodllPaths] = Object.assign({}, require.cache[autodllPaths], {
+    exports: Object.assign({}, require.cache[autodllPaths].exports, {
+      cacheDir: autodllCachePath,
+      getManifestPath: (hash: string) => (bundleName: string) =>
+        path.resolve(autodllCachePath, hash, `${bundleName}.manifest.json`),
+    }),
+  })
+
+  const AutoDllPlugin = require('autodll-webpack-plugin')
+  return AutoDllPlugin
+}


### PR DESCRIPTION
This moves the `babel-loader` and `autodll-webpack-plugin` cache folders to `.next/cache/`.