### PR TITLE
fix: add repository metadata to next-server package.json

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -3,6 +3,7 @@
   "version": "8.1.1-canary.1",
   "main": "./index.js",
   "license": "MIT",
+  "repository": "zeit/next.js",
   "files": [
     "dist",
     "index.js",


### PR DESCRIPTION
This PR adds the `repository` field so that npmjs.com and others can correctly resolve the source GitHub repo for this package.