### PR TITLE
Update types for with-router

### DIFF
--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -1,18 +1,28 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { NextComponentType, IContext } from 'next-server/dist/lib/utils'
+import { IPublicRouterInstance } from './router';
 
-export default function withRouter(ComposedComponent: React.ComponentType<any> & {getInitialProps?: any}) {
-  class WithRouteWrapper extends React.Component {
+export type WithRouterProps = {
+  router: IPublicRouterInstance,
+}
+
+export type ExcludeRouterProps<P> = Pick<P, Exclude<keyof P, keyof WithRouterProps>>
+
+export default function withRouter<P extends WithRouterProps, C = IContext>(ComposedComponent: NextComponentType<C, any, P>): React.ComponentClass<ExcludeRouterProps<P>> {
+  class WithRouteWrapper extends React.Component<ExcludeRouterProps<P>> {
     static displayName?: string
     static getInitialProps?: any
     static contextTypes = {
       router: PropTypes.object,
     }
 
+    context!: WithRouterProps
+
     render() {
       return <ComposedComponent
         router={this.context.router}
-        {...this.props}
+        {...this.props as any}
       />
     }
   }

--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -22,7 +22,7 @@ export default function withRouter<P extends WithRouterProps, C = IContext>(Comp
     render() {
       return <ComposedComponent
         router={this.context.router}
-        {...this.props as P}
+        {...this.props as any}
       />
     }
   }

--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -22,7 +22,7 @@ export default function withRouter<P extends WithRouterProps, C = IContext>(Comp
     render() {
       return <ComposedComponent
         router={this.context.router}
-        {...this.props as any}
+        {...this.props as P}
       />
     }
   }


### PR DESCRIPTION
The current types don't really work for Typescript projects, with this changes the following code will now be possible with Typescript:

```ts
import { withRouter, WithRouterProps } from 'next/router'

const H1 = ({ router, title }: { title: string } & WithRouterProps) => <h1>{title} - {router.pathname}</h1>
const Title = withRouter(H1)

// Trying to add `router=""` here will report an error as it's a prop set by withRouter
const Page = () => (
  <Title title="Hello World" />
)
```