### PR TITLE
Revert "Detect built ins in externals"

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -90,9 +90,8 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, d
           'string-hash',
           'next/constants'
         ]
-        const nodeBuiltins = new Set([...require("repl")._builtinLibs, "constants", "module", "timers", "console", "_stream_writable", "_stream_readable", "_stream_duplex"])
 
-        if (notExternalModules.indexOf(request) !== -1 || nodeBuiltins.has(request)) {
+        if (notExternalModules.indexOf(request) !== -1) {
           return callback()
         }
 


### PR DESCRIPTION
Reverts zeit/next.js#7083

This pull request adjusted built-ins for the server target, not serverless.

Also, it'd probably be more appropriate to make this change under the `.node` key, e.g.:
```js
    node: {
      module: 'empty',
      dgram: 'empty',
      dns: 'mock',
      fs: 'empty',
      http2: 'empty',
      net: 'empty',
      tls: 'empty',
      child_process: 'empty',
    },
```