### PR TITLE
Add AMP label to AMP only pages in build tree

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -222,7 +222,16 @@ export default async function build(dir: string, conf = null): Promise<void> {
     console.log(chalk.green('Compiled successfully.\n'))
   }
 
-  printTreeView(Object.keys(mappedPages))
+  let ampPages = new Set()
+
+  if (Array.isArray(configs[0].plugins)) {
+    configs[0].plugins.some((plugin: any) => {
+      if (plugin.ampPages) ampPages = plugin.ampPages
+      return Boolean(plugin.ampPages)
+    })
+  }
+
+  printTreeView(Object.keys(mappedPages), ampPages)
 
   if (flyingShuttle) {
     await flyingShuttle.save()

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -19,7 +19,7 @@ export function collectPages(
   )
 }
 
-export function printTreeView(list: string[]) {
+export function printTreeView(list: string[], ampPages: Set<string>) {
   list
     .sort((a, b) => (a > b ? 1 : -1))
     .forEach((item, i) => {
@@ -31,7 +31,7 @@ export function printTreeView(list: string[]) {
           : i === list.length - 1
           ? '└'
           : '├'
-      console.log(` \x1b[90m${corner}\x1b[39m ${item}`)
+      console.log(` \x1b[90m${corner}\x1b[39m ${item}${ampPages.has(item) ? ' (AMP)' : ''}`)
     })
 
   console.log()

--- a/packages/next/build/webpack/plugins/next-drop-client-page-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-drop-client-page-plugin.ts
@@ -1,13 +1,20 @@
 import { Compiler, Plugin } from 'webpack'
+import { extname } from 'path'
 
 // Prevents outputting client pages when they are not needed
 export class DropClientPage implements Plugin {
+  ampPages = new Set();
+
   apply(compiler: Compiler) {
     compiler.hooks.emit.tap('DropClientPage', compilation => {
       Object.keys(compilation.assets).forEach(assetKey => {
         const asset = compilation.assets[assetKey]
 
         if (asset && asset._value && asset._value.includes('__NEXT_DROP_CLIENT_FILE__')) {
+          const page = '/' + assetKey.split('pages/')[1]
+          const pageNoExt = page.split(extname(page))[0]
+
+          this.ampPages.add(pageNoExt.replace(/\/index$/, '') || '/')
           delete compilation.assets[assetKey]
         }
       })


### PR DESCRIPTION
Adds `(AMP)` in build tree for AMP-first pages

<img width="532" alt="Screen Shot 2019-04-23 at 3 30 09 PM" src="https://user-images.githubusercontent.com/22380829/56613668-bbd4b280-65dc-11e9-8c05-e210bc577cf3.png">

Closes: #7086 