### PR TITLE
Add --target serverless flag

### DIFF
--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -11,6 +11,7 @@ const nextBuild: cliCommand = (argv) => {
     {
       // Types
       '--help': Boolean,
+      '--target': String,
       // Aliases
       '-h': '--help',
     },
@@ -55,7 +56,7 @@ const nextBuild: cliCommand = (argv) => {
     )
   }
 
-  build(dir).catch((err) => {
+  build(dir, null, args['--target']).catch((err) => {
     // tslint:disable-next-line
     console.error('> Build error occurred')
     printAndExit(err)


### PR DESCRIPTION
Allow enabling serverless mode via the command line without adding a `next.config.js`