### PR TITLE
Don't re-use the same page file for error-recovery tests

### DIFF
--- a/test/integration/basic/pages/hmr/about1.js
+++ b/test/integration/basic/pages/hmr/about1.js
@@ -1,0 +1,9 @@
+export default () => {
+  return (
+    <div className='hmr-about-page'>
+      <p>
+        This is the about page.
+      </p>
+    </div>
+  )
+}

--- a/test/integration/basic/pages/hmr/about2.js
+++ b/test/integration/basic/pages/hmr/about2.js
@@ -1,0 +1,9 @@
+export default () => {
+  return (
+    <div className='hmr-about-page'>
+      <p>
+        This is the about page.
+      </p>
+    </div>
+  )
+}

--- a/test/integration/basic/pages/hmr/about3.js
+++ b/test/integration/basic/pages/hmr/about3.js
@@ -1,0 +1,9 @@
+export default () => {
+  return (
+    <div className='hmr-about-page'>
+      <p>
+        This is the about page.
+      </p>
+    </div>
+  )
+}

--- a/test/integration/basic/pages/hmr/about4.js
+++ b/test/integration/basic/pages/hmr/about4.js
@@ -1,0 +1,9 @@
+export default () => {
+  return (
+    <div className='hmr-about-page'>
+      <p>
+        This is the about page.
+      </p>
+    </div>
+  )
+}

--- a/test/integration/basic/pages/hmr/about5.js
+++ b/test/integration/basic/pages/hmr/about5.js
@@ -1,0 +1,9 @@
+export default () => {
+  return (
+    <div className='hmr-about-page'>
+      <p>
+        This is the about page.
+      </p>
+    </div>
+  )
+}

--- a/test/integration/basic/pages/hmr/about6.js
+++ b/test/integration/basic/pages/hmr/about6.js
@@ -1,0 +1,9 @@
+export default () => {
+  return (
+    <div className='hmr-about-page'>
+      <p>
+        This is the about page.
+      </p>
+    </div>
+  )
+}

--- a/test/integration/basic/pages/hmr/about7.js
+++ b/test/integration/basic/pages/hmr/about7.js
@@ -1,0 +1,9 @@
+export default () => {
+  return (
+    <div className='hmr-about-page'>
+      <p>
+        This is the about page.
+      </p>
+    </div>
+  )
+}

--- a/test/integration/basic/test/error-recovery.js
+++ b/test/integration/basic/test/error-recovery.js
@@ -39,10 +39,10 @@ export default (context, renderViaHTTP) => {
 
     it('should have installed the react-overlay-editor editor handler', async () => {
       let browser
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about1.js'))
       try {
         aboutPage.replace('</div>', 'div')
-        browser = await webdriver(context.appPort, '/hmr/about')
+        browser = await webdriver(context.appPort, '/hmr/about1')
 
         // react-error-overlay uses the following inline style if an editorHandler is installed
         expect(await getReactErrorOverlayContent(browser)).toMatch(/style="cursor: pointer;"/)
@@ -72,9 +72,9 @@ export default (context, renderViaHTTP) => {
 
     it('should detect syntax errors and recover', async () => {
       let browser
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about2.js'))
       try {
-        browser = await webdriver(context.appPort, '/hmr/about')
+        browser = await webdriver(context.appPort, '/hmr/about2')
         await check(
           () => getBrowserBodyText(browser),
           /This is the about page/
@@ -108,10 +108,10 @@ export default (context, renderViaHTTP) => {
     })
 
     it('should show the error on all pages', async () => {
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about2.js'))
       let browser
       try {
-        await renderViaHTTP('/hmr/about')
+        await renderViaHTTP('/hmr/about2')
 
         aboutPage.replace('</div>', 'div')
 
@@ -145,9 +145,9 @@ export default (context, renderViaHTTP) => {
 
     it('should detect runtime errors on the module scope', async () => {
       let browser
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about3.js'))
       try {
-        browser = await webdriver(context.appPort, '/hmr/about')
+        browser = await webdriver(context.appPort, '/hmr/about3')
         await check(
           () => getBrowserBodyText(browser),
           /This is the about page/
@@ -173,9 +173,9 @@ export default (context, renderViaHTTP) => {
 
     it('should recover from errors in the render function', async () => {
       let browser
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about4.js'))
       try {
-        browser = await webdriver(context.appPort, '/hmr/about')
+        browser = await webdriver(context.appPort, '/hmr/about4')
         await check(
           () => getBrowserBodyText(browser),
           /This is the about page/
@@ -210,9 +210,9 @@ export default (context, renderViaHTTP) => {
 
     it('should recover after exporting an invalid page', async () => {
       let browser
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about5.js'))
       try {
-        browser = await webdriver(context.appPort, '/hmr/about')
+        browser = await webdriver(context.appPort, '/hmr/about5')
         await check(
           () => getBrowserBodyText(browser),
           /This is the about page/
@@ -251,9 +251,9 @@ export default (context, renderViaHTTP) => {
 
     it('should recover after a bad return from the render function', async () => {
       let browser
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about6.js'))
       try {
-        browser = await webdriver(context.appPort, '/hmr/about')
+        browser = await webdriver(context.appPort, '/hmr/about6')
         await check(
           () => getBrowserBodyText(browser),
           /This is the about page/
@@ -292,9 +292,9 @@ export default (context, renderViaHTTP) => {
 
     it('should recover after undefined exported as default', async () => {
       let browser
-      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about.js'))
+      const aboutPage = new File(join(__dirname, '../', 'pages', 'hmr', 'about7.js'))
       try {
-        browser = await webdriver(context.appPort, '/hmr/about')
+        browser = await webdriver(context.appPort, '/hmr/about7')
         await check(
           () => getBrowserBodyText(browser),
           /This is the about page/


### PR DESCRIPTION
Try to make this test suite less finicky by not sharing the same page file between tests