### PR TITLE
Move generating types to before deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ commands:
   generate_types:
     steps:
       - run:
-        name: Generate types
-        command: yarn run types-next-server && yarn run types-next
+          name: Generate types
+          command: yarn run types-next-server && yarn run types-next
   save_npm_token:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,11 @@ commands:
           environment:
             BROWSERSTACK: 'true'
             BROWSER_NAME: 'firefox'
+  generate_types:
+    steps:
+      - run:
+        name: Generate types
+        command: yarn run types-next-server && yarn run types-next
   save_npm_token:
     steps:
       - run:
@@ -129,6 +134,7 @@ jobs:
     steps:
       - *attach_workspace
       - save_npm_token
+      - generate_types
       - publish_canary
       - publish_stable
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "standard --fix && standard --fix --parser typescript-eslint-parser --plugin typescript packages/**/*.ts",
     "prettier": "prettier --single-quote --no-semi --write examples/**/*.js && yarn lint-fix",
     "typescript": "lerna run typescript",
-    "prepublish": "lerna run prepublish && yarn run types-next-server && yarn run types-next",
+    "prepublish": "lerna run prepublish",
     "publish-canary": "lerna version prerelease --preid canary --force-publish && release --pre",
     "publish-stable": "lerna version --force-publish",
     "lint-staged": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "standard --fix && standard --fix --parser typescript-eslint-parser --plugin typescript packages/**/*.ts",
     "prettier": "prettier --single-quote --no-semi --write examples/**/*.js && yarn lint-fix",
     "typescript": "lerna run typescript",
-    "prepublish": "lerna run prepublish",
+    "prepublish": "lerna run prepublish && yarn run types-next-server && yarn run types-next",
     "publish-canary": "lerna version prerelease --preid canary --force-publish && release --pre",
     "publish-stable": "lerna version --force-publish",
     "lint-staged": "lint-staged",


### PR DESCRIPTION
Since the types in `dist` were getting cleared when `release` was run we move generating them to the deploy step to make sure they are present