### PR TITLE
Replace --target serverless with env var

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -25,7 +25,7 @@ import getBaseWebpackConfig from './webpack-config'
 import { exportManifest } from './webpack/plugins/chunk-graph-plugin'
 import { writeBuildId } from './write-build-id'
 
-export default async function build(dir: string, conf = null, targetFlag?: string): Promise<void> {
+export default async function build(dir: string, conf = null): Promise<void> {
   if (!(await isWriteable(dir))) {
     throw new Error(
       '> Build directory is not writeable. https://err.sh/zeit/next.js/build-dir-not-writeable'
@@ -44,7 +44,6 @@ export default async function build(dir: string, conf = null, targetFlag?: strin
   console.log()
 
   const config = loadConfig(PHASE_PRODUCTION_BUILD, dir, conf)
-  const target = targetFlag ? targetFlag : config.target
   const buildId = debug
     ? 'unoptimized-build'
     : await generateBuildId(config.generateBuildId, nanoid)
@@ -59,7 +58,7 @@ export default async function build(dir: string, conf = null, targetFlag?: strin
     isFlyingShuttle || process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE
   )
 
-  if (selectivePageBuilding && target !== 'serverless') {
+  if (selectivePageBuilding && config.target !== 'serverless') {
     throw new Error(
       `Cannot use ${
         isFlyingShuttle ? 'flying shuttle' : '`now dev`'
@@ -141,7 +140,7 @@ export default async function build(dir: string, conf = null, targetFlag?: strin
   const mappedPages = createPagesMapping(pagePaths, config.pageExtensions)
   const entrypoints = createEntrypoints(
     mappedPages,
-    target,
+    config.target,
     buildId,
     /* dynamicBuildId */ selectivePageBuilding,
     config
@@ -152,7 +151,7 @@ export default async function build(dir: string, conf = null, targetFlag?: strin
       buildId,
       isServer: false,
       config,
-      target,
+      target: config.target,
       entrypoints: entrypoints.client,
       selectivePageBuilding,
     }),
@@ -161,14 +160,14 @@ export default async function build(dir: string, conf = null, targetFlag?: strin
       buildId,
       isServer: true,
       config,
-      target,
+      target: config.target,
       entrypoints: entrypoints.server,
       selectivePageBuilding,
     }),
   ])
 
   let result: CompilerResult = { warnings: [], errors: [] }
-  if (target === 'serverless') {
+  if (config.target === 'serverless') {
     if (config.publicRuntimeConfig)
       throw new Error(
         'Cannot use publicRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -44,6 +44,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   console.log()
 
   const config = loadConfig(PHASE_PRODUCTION_BUILD, dir, conf)
+  const target = process.env.__NEXT_BUILDER_EXPERIMENTAL_TARGET || config.target
   const buildId = debug
     ? 'unoptimized-build'
     : await generateBuildId(config.generateBuildId, nanoid)
@@ -58,7 +59,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     isFlyingShuttle || process.env.__NEXT_BUILDER_EXPERIMENTAL_PAGE
   )
 
-  if (selectivePageBuilding && config.target !== 'serverless') {
+  if (selectivePageBuilding && target !== 'serverless') {
     throw new Error(
       `Cannot use ${
         isFlyingShuttle ? 'flying shuttle' : '`now dev`'
@@ -140,7 +141,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   const mappedPages = createPagesMapping(pagePaths, config.pageExtensions)
   const entrypoints = createEntrypoints(
     mappedPages,
-    config.target,
+    target,
     buildId,
     /* dynamicBuildId */ selectivePageBuilding,
     config
@@ -151,7 +152,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       buildId,
       isServer: false,
       config,
-      target: config.target,
+      target,
       entrypoints: entrypoints.client,
       selectivePageBuilding,
     }),
@@ -160,14 +161,14 @@ export default async function build(dir: string, conf = null): Promise<void> {
       buildId,
       isServer: true,
       config,
-      target: config.target,
+      target,
       entrypoints: entrypoints.server,
       selectivePageBuilding,
     }),
   ])
 
   let result: CompilerResult = { warnings: [], errors: [] }
-  if (config.target === 'serverless') {
+  if (target === 'serverless') {
     if (config.publicRuntimeConfig)
       throw new Error(
         'Cannot use publicRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'

--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -11,7 +11,6 @@ const nextBuild: cliCommand = (argv) => {
     {
       // Types
       '--help': Boolean,
-      '--target': String,
       // Aliases
       '-h': '--help',
     },
@@ -56,7 +55,7 @@ const nextBuild: cliCommand = (argv) => {
     )
   }
 
-  build(dir, null, args['--target']).catch((err) => {
+  build(dir).catch((err) => {
     // tslint:disable-next-line
     console.error('> Build error occurred')
     printAndExit(err)


### PR DESCRIPTION
Reverts zeit/next.js#7141
We can more easily set an env var in the builder