### PR TITLE
Add stale-while-revalidate when no getInitialProps

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -132,7 +132,7 @@ export async function loadGetInitialProps<C extends IBaseContext, P = any, CP = 
   }
 
   if (!Component.getInitialProps) {
-    if (ctx.res) {
+    if (ctx.res && ctx.res.setHeader) {
       ctx.res.setHeader('Cache-Control', 'stale-while-revalidate=30')
     }
     return null

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -131,7 +131,12 @@ export async function loadGetInitialProps<C extends IBaseContext, P = any, CP = 
     }
   }
 
-  if (!Component.getInitialProps) return null
+  if (!Component.getInitialProps) {
+    if (ctx.res) {
+      ctx.res.setHeader('Cache-Control', 'stale-while-revalidate=30')
+    }
+    return null
+  }
 
   const props = await Component.getInitialProps(ctx)
 


### PR DESCRIPTION
just adds the `stale-while-revalidate` Cache-Control header in production if the page doesn't have `getInitialProps`