### PR TITLE
Update to render directly to body in AMP mode

### DIFF
--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -444,6 +444,9 @@ export async function renderToHTML(
   })
 
   if (amphtml && html) {
+    // use replace to allow rendering directly to body in AMP mode
+    html = html.replace('__NEXT_AMP_RENDER_TARGET__', docProps.html)
+
     if (ampMode.hasQuery) {
       html = await optimizeAmp(html, { amphtml, query })
     }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -346,7 +346,8 @@ export class Main extends Component {
   context!: IDocumentComponentContext
 
   render() {
-    const { html } = this.context._documentProps
+    const { amphtml, html } = this.context._documentProps
+    if (amphtml) return '__NEXT_AMP_RENDER_TARGET__'
     return <div id="__next" dangerouslySetInnerHTML={{ __html: html }} />
   }
 }


### PR DESCRIPTION
Since some AMP components require being directly under the body element, this removes the `<div id='__next'>` wrapper element in AMP mode