### PR TITLE
Duplicate meta tag fix

### DIFF
--- a/packages/next-server/lib/head.tsx
+++ b/packages/next-server/lib/head.tsx
@@ -66,6 +66,11 @@ function unique() {
     if (h.key && typeof h.key !== 'number' && h.key.indexOf(".$") === 0) {
       if (keys.has(h.key)) return false;
       keys.add(h.key);
+      if (h.props.name && h.props.name === 'viewport') {
+        metaTypes.add("viewport");
+      } else if (h.props.charSet) {
+        metaTypes.add("charSet");
+      }
       return true;
     }
     switch (h.type) {
@@ -78,6 +83,11 @@ function unique() {
         for (let i = 0, len = METATYPES.length; i < len; i++) {
           const metatype = METATYPES[i];
           if (!h.props.hasOwnProperty(metatype)) continue;
+
+          if (h.props.name && h.props.name === "viewport") {
+            if (metaTypes.has("viewport")) return false;
+            metaTypes.add("viewport");
+          }
 
           if (metatype === "charSet" || metatype === "viewport") {
             if (metaTypes.has(metatype)) return false;

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -181,9 +181,10 @@ export class Head extends Component<IOriginProps> {
     // show a warning if Head contains <title> (only in development)
     if (process.env.NODE_ENV !== 'production') {
       children = React.Children.map(children, (child: any) => {
-        if (child && child.type === 'title') {
+        if (child && (child.type === 'title' || child.props.name === 'viewport' || child.charSet)) {
+          const type = child.type === 'title' ? 'title' : (child.props.name === 'viewport' ? 'viewport meta' : 'charSet meta')
           console.warn(
-            "Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title",
+            `Warning: <${type}> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-${type.replace(' ', '-')}`,
           )
         }
         return child


### PR DESCRIPTION
This PR fix https://github.com/zeit/next.js/issues/6919#issuecomment-486521697
also it rise an error in development mode when viewport or charSet meta tags are used inside _document like for the title