### PR TITLE
Extra chunks shouldn't deopt Flying Shuttle

### DIFF
--- a/packages/next/build/flying-shuttle.ts
+++ b/packages/next/build/flying-shuttle.ts
@@ -252,10 +252,6 @@ export class FlyingShuttle {
     const nextManifest = JSON.parse(
       await fsReadFile(nextManifestPath, 'utf8')
     ) as ChunkGraphManifest
-    if (nextManifest.chunks && Object.keys(nextManifest.chunks).length) {
-      Log.warn('build emitted assets that cannot fit in flying shuttle')
-      return
-    }
 
     const storeManifest: ChunkGraphManifest = {
       pages: Object.assign(


### PR DESCRIPTION
Extra chunks shouldn't cause Flying Shuttle to bail out -- this was more important when our goal was to avoid running webpack at all.

As it stands, a build is always ran (even if no pages are emitted) -- this would cause these additional entry points to be built.