### PR TITLE
Add types for getInitialProps

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -8,8 +8,8 @@ import { IRouterInterface } from './router/router'
 /**
  * Types used by both next and next-server
  */
-export type NextComponentType<C extends IBaseContext = any, P = any, CP = {}> = ComponentType<CP> & {
-  getInitialProps?(context: C): Promise<P>,
+export type NextComponentType<C extends IBaseContext = IContext, IP = {}, P = {}> = ComponentType<P> & {
+  getInitialProps?(context: C): Promise<IP>,
 }
 
 export type DocumentType = NextComponentType<IDocumentContext, IDocumentInitialProps, IDocumentProps>
@@ -123,7 +123,7 @@ export function isResSent(res: ServerResponse) {
   return res.finished || res.headersSent
 }
 
-export async function loadGetInitialProps<C extends IBaseContext, P = any, CP = {}>(Component: NextComponentType<C, P, CP>, ctx: C): Promise<P | null> {
+export async function loadGetInitialProps<C extends IBaseContext, IP = {}, P = {}>(Component: NextComponentType<C, IP, P>, ctx: C): Promise<IP | null> {
   if (process.env.NODE_ENV !== 'production') {
     if (Component.prototype && Component.prototype.getInitialProps) {
       const message = `"${getDisplayName(Component)}.getInitialProps()" is defined as an instance method - visit https://err.sh/zeit/next.js/get-initial-props-as-an-instance-method for more information.`

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -20,11 +20,14 @@ declare module 'react' {
   }
 }
 
-export type GetInitialProps<P = {}> = (context: IContext) => Promise<P>
+
+export type GetInitialProps<P = {}> = (context: NextPageContext) => Promise<P>
+
+export type NextPageContext = IContext
 
 export type NextPage<P = {}> = {
   (props: P): JSX.Element;
-  getInitialProps?(ctx: IContext): Promise<P>;
+  getInitialProps?(ctx: NextPageContext): Promise<P>;
 }
 
 export { IContext }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -22,9 +22,9 @@ declare module 'react' {
 
 export type GetInitialProps<P = {}> = (context: IContext) => Promise<P>
 
-export type NextPage<P = {}, IP = {}> = {
+export type NextPage<P = {}> = {
   (props: P): JSX.Element;
-  getInitialProps?(ctx: IContext): Promise<IP>;
+  getInitialProps?(ctx: IContext): Promise<P>;
 }
 
 export { IContext }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -1,4 +1,5 @@
 import React from 'react'
+import { IContext } from 'next-server/dist/lib/utils';
 
 // Extend the React types with missing properties
 declare module 'react' {
@@ -18,3 +19,12 @@ declare module 'react' {
     global?: boolean;
   }
 }
+
+export type GetInitialProps<P = {}, C = IContext> = (context: C) => Promise<P>
+
+export type NextPage<P = {}, IP = {}> = {
+  (props: P): JSX.Element;
+  getInitialProps?(ctx: IContext): Promise<IP>;
+}
+
+export { IContext }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -20,7 +20,7 @@ declare module 'react' {
   }
 }
 
-export type GetInitialProps<P = {}, C = IContext> = (context: C) => Promise<P>
+export type GetInitialProps<P = {}> = (context: IContext) => Promise<P>
 
 export type NextPage<P = {}, IP = {}> = {
   (props: P): JSX.Element;

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -20,9 +20,6 @@ declare module 'react' {
   }
 }
 
-
-export type GetInitialProps<P = {}> = (context: NextPageContext) => Promise<P>
-
 export type NextPageContext = IContext
 
 export type NextPage<P = {}> = {


### PR DESCRIPTION
This PR adds support for:

```tsx
import React from 'react'
import { NextPage } from 'next'

const Page: NextPage<{ world: string }> = ({ world }) => <h1>Hello {world}</h1>

Page.getInitialProps = async (ctx) => ({ world: 'world' })
```

The same in a class:
```tsx
import React from 'react'
import { NextPageContext } from 'next'

export default class Page extends React.Component<{ world: string }> {
  static async getInitialProps(ctx: NextPageContext) {
    return { world: 'test' }
  }

  render() {
    return <h1>Hello {this.props.world}</h1>
  }
}
```

**We should probably document this somehow.**