### PR TITLE
Prefer type over interface

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -3,18 +3,18 @@
 import { ComponentType } from 'react';
 import { parse } from 'url';
 import mitt, {MittEmitter} from '../mitt';
-import { formatWithValidation, getURL, loadGetInitialProps, IContext, IAppContext } from '../utils';
+import { formatWithValidation, getURL, loadGetInitialProps, IContext, AppContextType } from '../utils';
 import {rewriteUrlForNextExport} from './rewrite-url-for-export'
 
 function toRoute(path: string): string {
   return path.replace(/\/$/, '') || '/'
 }
 
-export interface IRouterInterface {
+export type BaseRouter = {
   route: string
   pathname: string
   query: string
-  asPath: string
+  asPath: string,
 }
 
 type RouteInfo = {
@@ -28,7 +28,7 @@ type Subscription = (data: {App?: ComponentType} & RouteInfo) => void
 
 type BeforePopStateCallback = (state: any) => boolean
 
-export default class Router implements IRouterInterface {
+export default class Router implements BaseRouter {
   route: string
   pathname: string
   query: string
@@ -460,7 +460,7 @@ export default class Router implements IRouterInterface {
     this.componentLoadCancel = cancel
     const { Component: App } = this.components['/_app']
 
-    const props = await loadGetInitialProps<IAppContext<Router>>(App, { Component, router: this, ctx })
+    const props = await loadGetInitialProps<AppContextType<Router>>(App, { Component, router: this, ctx })
 
     if (cancel === this.componentLoadCancel) {
       this.componentLoadCancel = null

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -3,18 +3,18 @@ import { ServerResponse, IncomingMessage } from 'http';
 import { ComponentType } from 'react'
 import { ParsedUrlQuery } from 'querystring'
 import { ManifestItem } from '../server/get-dynamic-import-bundles'
-import { IRouterInterface } from './router/router'
+import { BaseRouter } from './router/router'
 
 /**
  * Types used by both next and next-server
  */
-export type NextComponentType<C extends IBaseContext = any, P = any, CP = {}> = ComponentType<CP> & {
+export type NextComponentType<C extends BaseContext = any, P = any, CP = {}> = ComponentType<CP> & {
   getInitialProps?(context: C): Promise<P>,
 }
 
-export type DocumentType = NextComponentType<IDocumentContext, IDocumentInitialProps, IDocumentProps>
+export type DocumentType = NextComponentType<DocumentContext, DocumentInitialProps, DocumentProps>
 
-export type AppType = NextComponentType<IAppContext, IAppInitialProps, IAppProps>
+export type AppType = NextComponentType<AppContextType, AppInitialProps, AppPropsType>
 
 export type Enhancer<C> = (Component: C) => C
 
@@ -26,12 +26,12 @@ export type RenderPageResult = { html: string, head?: Array<JSX.Element | null>,
 
 export type RenderPage = (options?: ComponentsEnhancer) => RenderPageResult | Promise<RenderPageResult>
 
-export interface IBaseContext {
+export type BaseContext = {
   res?: ServerResponse
-  [k: string]: any
+  [k: string]: any,
 }
 
-export interface INEXTDATA {
+export type INEXTDATA = {
   dataManager: string
   props: any
   page: string
@@ -42,7 +42,7 @@ export interface INEXTDATA {
   runtimeConfig?: { [key: string]: any }
   nextExport?: boolean
   dynamicIds?: string[]
-  err?: Error & { statusCode?: number }
+  err?: Error & { statusCode?: number },
 }
 
 export interface IContext {
@@ -54,30 +54,30 @@ export interface IContext {
   asPath?: string
 }
 
-export interface IAppContext<R extends IRouterInterface = IRouterInterface> {
+export type AppContextType<R extends BaseRouter = BaseRouter> = {
   Component: NextComponentType<IContext>
   router: R
-  ctx: IContext
+  ctx: IContext,
 }
 
-export interface IAppInitialProps {
-  pageProps: any
+export type AppInitialProps = {
+  pageProps: any,
 }
 
-export interface IAppProps<R extends IRouterInterface = IRouterInterface> extends IAppInitialProps {
+export type AppPropsType<R extends BaseRouter = BaseRouter> = AppInitialProps & {
   Component: NextComponentType<IContext>
-  router: R
+  router: R,
 }
 
-export interface IDocumentContext extends IContext {
-  renderPage: RenderPage
+export type DocumentContext = IContext & {
+  renderPage: RenderPage,
 }
 
-export interface IDocumentInitialProps extends RenderPageResult {
-  styles?: React.ReactElement[]
+export type DocumentInitialProps = RenderPageResult & {
+  styles?: React.ReactElement[],
 }
 
-export interface IDocumentProps extends IDocumentInitialProps {
+export type DocumentProps = DocumentInitialProps & {
   __NEXT_DATA__: INEXTDATA
   dangerousAsPath: string
   ampPath: string
@@ -87,7 +87,7 @@ export interface IDocumentProps extends IDocumentInitialProps {
   devFiles: string[]
   files: string[]
   dynamicImports: ManifestItem[]
-  assetPrefix?: string
+  assetPrefix?: string,
 }
 
 /**
@@ -123,7 +123,7 @@ export function isResSent(res: ServerResponse) {
   return res.finished || res.headersSent
 }
 
-export async function loadGetInitialProps<C extends IBaseContext, P = any, CP = {}>(Component: NextComponentType<C, P, CP>, ctx: C): Promise<P | null> {
+export async function loadGetInitialProps<C extends BaseContext, P = any, CP = {}>(Component: NextComponentType<C, P, CP>, ctx: C): Promise<P | null> {
   if (process.env.NODE_ENV !== 'production') {
     if (Component.prototype && Component.prototype.getInitialProps) {
       const message = `"${getDisplayName(Component)}.getInitialProps()" is defined as an instance method - visit https://err.sh/zeit/next.js/get-initial-props-as-an-instance-method for more information.`

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -2,9 +2,9 @@ import { IncomingMessage, ServerResponse } from 'http'
 import { ParsedUrlQuery } from 'querystring'
 import React from 'react'
 import { renderToString, renderToStaticMarkup } from 'react-dom/server'
-import { IRouterInterface } from '../lib/router/router'
+import { BaseRouter } from '../lib/router/router'
 import mitt, { MittEmitter } from '../lib/mitt';
-import { loadGetInitialProps, isResSent, getDisplayName, ComponentsEnhancer, RenderPage, IDocumentInitialProps, NextComponentType, DocumentType, AppType } from '../lib/utils'
+import { loadGetInitialProps, isResSent, getDisplayName, ComponentsEnhancer, RenderPage, DocumentInitialProps, NextComponentType, DocumentType, AppType } from '../lib/utils'
 import Head, { defaultHead } from '../lib/head'
 // @ts-ignore types will be added later as it's an internal module
 import Loadable from '../lib/loadable'
@@ -28,7 +28,7 @@ function noRouter() {
   throw new Error(message)
 }
 
-class ServerRouter implements IRouterInterface {
+class ServerRouter implements BaseRouter {
   route: string
   pathname: string
   query: string
@@ -160,7 +160,7 @@ function renderDocument(
   }: RenderOpts & {
     dataManagerData: string,
     props: any
-    docProps: IDocumentInitialProps
+    docProps: DocumentInitialProps
     pathname: string
     query: ParsedUrlQuery
     dangerousAsPath: string

--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { NextComponentType, IContext } from 'next-server/dist/lib/utils'
-import { IPublicRouterInstance } from './router';
+import { PublicRouterInstance } from './router';
 
 export type WithRouterProps = {
-  router: IPublicRouterInstance,
+  router: PublicRouterInstance,
 }
 
 export type ExcludeRouterProps<P> = Pick<P, Exclude<keyof P, keyof WithRouterProps>>

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -1,22 +1,22 @@
 import React, {ErrorInfo} from 'react'
 import PropTypes from 'prop-types'
-import { execOnce, loadGetInitialProps, NextComponentType, IContext, IAppContext, IAppInitialProps, IAppProps } from 'next-server/dist/lib/utils'
+import { execOnce, loadGetInitialProps, NextComponentType, IContext, AppContextType, AppInitialProps, AppPropsType } from 'next-server/dist/lib/utils'
 import { makePublicRouterInstance } from '../client/router'
 
-export { NextComponentType, IContext, IAppContext, IAppInitialProps, IAppProps }
+export { NextComponentType, IContext, AppInitialProps }
 
 type Router = import('next-server/dist/lib/router/router').default
 
-export type AppClientContext = IAppContext<Router>
+export type AppContext = AppContextType<Router>
 
-export type AppProps = IAppProps<Router>
+export type AppProps = AppPropsType<Router>
 
 export default class App extends React.Component<AppProps> {
   static childContextTypes = {
     router: PropTypes.object,
   }
 
-  static async getInitialProps({ Component, ctx }: AppClientContext): Promise<IAppInitialProps> {
+  static async getInitialProps({ Component, ctx }: AppContext): Promise<AppInitialProps> {
     const pageProps = await loadGetInitialProps(Component, ctx)
     return { pageProps }
   }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { cleanAmpPath } from 'next-server/dist/server/utils'
-import { IDocumentContext, IDocumentInitialProps, IDocumentProps } from 'next-server/dist/lib/utils'
+import { DocumentContext, DocumentInitialProps, DocumentProps } from 'next-server/dist/lib/utils'
 import { htmlEscapeJsonString } from '../server/htmlescape'
 import flush from 'styled-jsx/server'
 import {
@@ -10,33 +10,33 @@ import {
   CLIENT_STATIC_FILES_RUNTIME_WEBPACK,
 } from 'next-server/constants'
 
-export { IDocumentContext, IDocumentInitialProps, IDocumentProps }
+export { DocumentContext, DocumentInitialProps, DocumentProps }
 
-export interface IOriginProps {
+export type OriginProps = {
   nonce?: string
-  crossOrigin?: string
+  crossOrigin?: string,
 }
 
-export interface IDocumentComponentContext {
-  readonly _documentProps: IDocumentProps
-  readonly _devOnlyInvalidateCacheQueryString: string
+export type DocumentComponentContext = {
+  readonly _documentProps: DocumentProps
+  readonly _devOnlyInvalidateCacheQueryString: string,
 }
 
-export default class Document extends Component<IDocumentProps> {
+export default class Document extends Component<DocumentProps> {
   static childContextTypes = {
     _documentProps: PropTypes.any,
     _devOnlyInvalidateCacheQueryString: PropTypes.string,
   }
 
-  static async getInitialProps({ renderPage }: IDocumentContext): Promise<IDocumentInitialProps> {
+  static async getInitialProps({ renderPage }: DocumentContext): Promise<DocumentInitialProps> {
     const { html, head, dataOnly } = await renderPage()
     const styles = flush()
     return { html, head, styles, dataOnly }
   }
 
-  context!: IDocumentComponentContext
+  context!: DocumentComponentContext
 
-  getChildContext(): IDocumentComponentContext {
+  getChildContext(): DocumentComponentContext {
     return {
       _documentProps: this.props,
       // In dev we invalidate the cache by appending a timestamp to the resource URL.
@@ -69,7 +69,7 @@ export class Html extends Component {
     children: PropTypes.node.isRequired,
   }
 
-  context!: IDocumentComponentContext
+  context!: DocumentComponentContext
 
   render() {
     const { amphtml } = this.context._documentProps
@@ -79,7 +79,7 @@ export class Html extends Component {
   }
 }
 
-export class Head extends Component<IOriginProps> {
+export class Head extends Component<OriginProps> {
   static contextTypes = {
     _documentProps: PropTypes.any,
     _devOnlyInvalidateCacheQueryString: PropTypes.string,
@@ -90,7 +90,7 @@ export class Head extends Component<IOriginProps> {
     crossOrigin: PropTypes.string,
   }
 
-  context!: IDocumentComponentContext
+  context!: DocumentComponentContext
 
   getCssLinks() {
     const { assetPrefix, files } = this.context._documentProps
@@ -343,7 +343,7 @@ export class Main extends Component {
     _devOnlyInvalidateCacheQueryString: PropTypes.string,
   }
 
-  context!: IDocumentComponentContext
+  context!: DocumentComponentContext
 
   render() {
     const { amphtml, html } = this.context._documentProps
@@ -352,7 +352,7 @@ export class Main extends Component {
   }
 }
 
-export class NextScript extends Component<IOriginProps> {
+export class NextScript extends Component<OriginProps> {
   static contextTypes = {
     _documentProps: PropTypes.any,
     _devOnlyInvalidateCacheQueryString: PropTypes.string,
@@ -363,7 +363,7 @@ export class NextScript extends Component<IOriginProps> {
     crossOrigin: PropTypes.string,
   }
 
-  context!: IDocumentComponentContext
+  context!: DocumentComponentContext
 
   getDynamicChunks() {
     const { dynamicImports, assetPrefix } = this.context._documentProps
@@ -409,7 +409,7 @@ export class NextScript extends Component<IOriginProps> {
     })
   }
 
-  static getInlineScriptSource(documentProps: IDocumentProps) {
+  static getInlineScriptSource(documentProps: DocumentProps) {
     const { __NEXT_DATA__ } = documentProps
     try {
       const data = JSON.stringify(__NEXT_DATA__)

--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -9,11 +9,11 @@ const statusCodes: { [code: number]: string } = {
   501: 'Not Implemented',
 }
 
-export interface IErrorProps {
-  statusCode: number
+export type ErrorProps = {
+  statusCode: number,
 }
 
-export default class Error<P = {}> extends React.Component<P & IErrorProps> {
+export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   static displayName = 'ErrorPage'
 
   static getInitialProps({ res, err }: IContext) {


### PR DESCRIPTION
As interfaces can be merged that allow for use cases where a user can extend one of our core interfaces just for the sake of doing it, with types this should not be a problem and will allow us to properly differentiate them by their only real difference: interfaces can be merged while types can't.