### PR TITLE
With apollo auth proxy

### DIFF
--- a/examples/with-apollo-auth/lib/initApollo.js
+++ b/examples/with-apollo-auth/lib/initApollo.js
@@ -41,7 +41,7 @@ export default function initApollo (initialState, options) {
   // isn't shared between connections (which would be bad)
   if (!process.browser) {
     let fetchOptions = {}
-    // If you are using a https_proxy, add fetchOptions with 'https-proxy-agent' agent instance 
+    // If you are using a https_proxy, add fetchOptions with 'https-proxy-agent' agent instance
     // 'https-proxy-agent' is required here because it's a sever-side only module
     if (process.env.https_proxy) {
       fetchOptions = {

--- a/examples/with-apollo-auth/lib/initApollo.js
+++ b/examples/with-apollo-auth/lib/initApollo.js
@@ -39,7 +39,19 @@ export default function initApollo (initialState, options) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (!process.browser) {
-    return create(initialState, options)
+    let fetchOptions = {}
+    // If you are using a https_proxy, add fetchOptions with 'https-proxy-agent' agent instance 
+    // 'https-proxy-agent' is required here because it's a sever-side only module
+    if (process.env.https_proxy) {
+      fetchOptions = {
+        agent: new (require('https-proxy-agent'))(process.env.https_proxy)
+      }
+    }
+    return create(initialState,
+      {
+        ...options,
+        fetchOptions
+      })
   }
 
   // Reuse client on the client-side

--- a/examples/with-apollo-auth/lib/initApollo.js
+++ b/examples/with-apollo-auth/lib/initApollo.js
@@ -10,10 +10,11 @@ if (!process.browser) {
   global.fetch = fetch
 }
 
-function create (initialState, { getToken }) {
+function create (initialState, { getToken, fetchOptions }) {
   const httpLink = createHttpLink({
     uri: 'https://api.graph.cool/simple/v1/cj5geu3slxl7t0127y8sity9r',
-    credentials: 'same-origin'
+    credentials: 'same-origin',
+    fetchOptions
   })
 
   const authLink = setContext((_, { headers }) => {

--- a/examples/with-apollo-auth/package.json
+++ b/examples/with-apollo-auth/package.json
@@ -13,6 +13,7 @@
     "apollo-link-context": "^1.0.8",
     "cookie": "^0.3.1",
     "graphql": "14.0.2",
+    "https-proxy-agent": "^2.2.1",
     "isomorphic-unfetch": "^2.0.0",
     "next": "latest",
     "prop-types": "^15.6.1",


### PR DESCRIPTION
- I had a case where the user is logged in on browser but when i access directly to home page ( going through server ) `checkLoggedIn` return empty `loggedInUser` because there were an exception when trying to call graphcool from server