### PR TITLE
Disable Terser Cache When Using Flying Shuttle

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -73,7 +73,7 @@ export default async function getBaseWebpackConfig (dir: string, {dev = false, d
   const terserPluginConfig = {
     parallel: true,
     sourceMap: false,
-    cache: true,
+    cache: !selectivePageBuilding,
     cpus: config.experimental.cpus,
     distDir: distDir
   }

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/TaskRunner.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/TaskRunner.js
@@ -12,8 +12,10 @@ const writeFileP = promisify(writeFile)
 const readFileP = promisify(readFile)
 
 export default class TaskRunner {
-  constructor(distDir, cpus) {
-    mkdirp.sync((this.cacheDir = join(distDir, 'cache', 'next-minifier')))
+  constructor({ distDir, cpus, cache }) {
+    if (cache) {
+      mkdirp.sync((this.cacheDir = join(distDir, 'cache', 'next-minifier')))
+    }
 
     // In some cases cpus() returns undefined
     // https://github.com/nodejs/node/issues/19022
@@ -68,7 +70,7 @@ export default class TaskRunner {
     }
 
     tasks.forEach((task, index) => {
-      const cachePath = join(this.cacheDir, task.cacheKey)
+      const cachePath = this.cacheDir && join(this.cacheDir, task.cacheKey)
 
       const enqueue = () => {
         this.boundWorkers(task, (error, data) => {

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -129,7 +129,11 @@ export class TerserPlugin {
 
   apply(compiler) {
     const optimizeFn = (compilation, chunks, callback) => {
-      const taskRunner = new TaskRunner(this.distDir, this.cpus)
+      const taskRunner = new TaskRunner({
+        distDir: this.distDir,
+        cpus: this.cpus,
+        cache: this.options.cache,
+      })
 
       const processedAssets = new WeakSet()
       const tasks = []
@@ -285,7 +289,7 @@ export class TerserPlugin {
         template.hooks.hashForChunk.tap(plugin, hash => {
           // Terser version
           // Has to be updated when options change too
-          hash.update('3.17.0');
+          hash.update('3.17.0')
           return hash
         })
       }


### PR DESCRIPTION
JavaScript is only ever emitted when changed, so caching these files is meaningless.

Also, it'd grow unbounded since people have incentive to never delete `.next/` now.