### PR TITLE
Purge Terser Cache When Using Flying Shuttle

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -80,6 +80,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     console.log()
 
     await recursiveDelete(distDir, /^(?!cache(?:[\/\\]|$)).*$/)
+    await recursiveDelete(path.join(distDir, 'cache', 'next-minifier'))
 
     flyingShuttle = new FlyingShuttle({
       buildId,


### PR DESCRIPTION
Users who are first-time users of flying shuttle will need their cache purged -- this is really useful for CI systems that don't allow you to clear your cache.