### PR TITLE
Test Reducing CircleCI Parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - yarn_lint
       - *persist_to_workspace
   test:
-    parallelism: 4
+    parallelism: 3
     executor: node
     steps:
       - *attach_workspace


### PR DESCRIPTION
This will free up more capacity for the ZEIT organization. It shouldn't affect our wait times too significantly.