### PR TITLE
Make sure to 404 for AMP client bundles in dev mode

### DIFF
--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -12,6 +12,11 @@ import { createPagesMapping, createEntrypoints } from '../build/entries'
 import { watchCompiler } from '../build/output'
 import { findPageFile } from './lib/find-page-file'
 import { recursiveDelete } from '../lib/recursive-delete'
+import { promisify } from 'util'
+import fs from 'fs'
+
+const access = promisify(fs.access)
+const readFile = promisify(fs.readFile)
 
 export async function renderScriptError (res, error) {
   // Asks CDNs and others to not to cache the errored page
@@ -127,6 +132,23 @@ export default class HotReloader {
 
       const page = `/${params.path.join('/')}`
       if (page === '/_error' || BLOCKED_PAGES.indexOf(page) === -1) {
+        const bundlePath = join(
+          this.dir,
+          this.config.distDir,
+          'static/development/pages', page + '.js'
+        )
+
+        // make sure to 404 for AMP bundles in case they weren't removed
+        try {
+          await access(bundlePath)
+          const data = await readFile(bundlePath, 'utf8')
+          if (data.includes('__NEXT_DROP_CLIENT_FILE__')) {
+            res.statusCode = 404
+            res.end()
+            return { finished: true }
+          }
+        } catch (_) {}
+
         try {
           await this.ensurePage(page)
         } catch (error) {

--- a/packages/next/server/hot-reloader.js
+++ b/packages/next/server/hot-reloader.js
@@ -132,6 +132,13 @@ export default class HotReloader {
 
       const page = `/${params.path.join('/')}`
       if (page === '/_error' || BLOCKED_PAGES.indexOf(page) === -1) {
+        try {
+          await this.ensurePage(page)
+        } catch (error) {
+          await renderScriptError(res, error)
+          return { finished: true }
+        }
+
         const bundlePath = join(
           this.dir,
           this.config.distDir,
@@ -148,13 +155,6 @@ export default class HotReloader {
             return { finished: true }
           }
         } catch (_) {}
-
-        try {
-          await this.ensurePage(page)
-        } catch (error) {
-          await renderScriptError(res, error)
-          return { finished: true }
-        }
 
         const errors = await this.getCompilationErrors(page)
         if (errors.length > 0) {

--- a/test/integration/amphtml/pages/normal.js
+++ b/test/integration/amphtml/pages/normal.js
@@ -1,1 +1,10 @@
-export default () => <div>No AMP for me...</div>
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <p>No AMP for me...</p>
+    <Link href='/only-amp'>
+      <a id='to-amp'>To AMP page!</a>
+    </Link>
+  </div>
+)

--- a/test/integration/amphtml/pages/only-amp.js
+++ b/test/integration/amphtml/pages/only-amp.js
@@ -1,3 +1,7 @@
 import { withAmp } from 'next/amp'
 
-export default withAmp(() => <div>Only AMP for me...</div>)
+export default withAmp(() => (
+  <div>
+    <p id='only-amp'>Only AMP for me...</p>
+  </div>
+))

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -256,7 +256,7 @@ describe('AMP Usage', () => {
     })
   })
 
-  describe('editing a page', () => {
+  describe('AMP dev mode', () => {
     let dynamicAppPort
     let ampDynamic
 
@@ -266,6 +266,13 @@ describe('AMP Usage', () => {
     })
 
     afterAll(() => killApp(ampDynamic))
+
+    it('should navigate from non-AMP to AMP without error', async () => {
+      const browser = await webdriver(dynamicAppPort, '/normal')
+      await browser.elementByCss('#to-amp').click()
+      await browser.waitForElementByCss('#only-amp')
+      expect(await browser.elementByCss('#only-amp').text()).toMatch(/Only AMP/)
+    })
 
     it('should detect the changes and display it', async () => {
       let browser


### PR DESCRIPTION
While debugging, I noticed that client bundles aren't always able to be disposed of in dev mode so this just adds a last check to make sure we 404 when an AMP bundle is requested in dev mode. Also added a test for this. 