### PR TITLE
Update cache-control header when no getInitialProps

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -133,7 +133,9 @@ export async function loadGetInitialProps<C extends BaseContext, IP = {}, P = {}
 
   if (!Component.getInitialProps) {
     if (ctx.res && ctx.res.setHeader) {
-      ctx.res.setHeader('Cache-Control', 'stale-while-revalidate=30')
+      ctx.res.setHeader(
+        'Cache-Control', 's-maxage=86400, stale-while-revalidate',
+      )
     }
     return null
   }

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -62,6 +62,13 @@ describe('Production Usage', () => {
       expect(header).toBe('Next.js')
     })
 
+    it('should set correct cache-control header when no GIP', async () => {
+      const url = `http://localhost:${appPort}/`
+      const header = (await fetch(url)).headers.get('Cache-Control')
+
+      expect(header).toBe('s-maxage=86400, stale-while-revalidate')
+    })
+
     it('should render 404 for routes that do not exist', async () => {
       const url = `http://localhost:${appPort}/abcdefghijklmno`
       const res = await fetch(url)


### PR DESCRIPTION
Fixes invalid `Cache-Control` header used when no `getInitialProps`. Also added test making sure header is set. 