### PR TITLE
Improve contributing guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -3,52 +3,90 @@
 Our Commitment to Open Source can be found [here](https://zeit.co/blog/oss)
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
-1. Install yarn: `npm install -g yarn`
-1. Install the dependencies: `yarn`
-1. Run `yarn run dev` to build and watch for code changes
+2. Install yarn: `npm install -g yarn`
+3. Install the dependencies: `yarn`
+4. Run `yarn run dev` to build and watch for code changes
+5. The development branch is `canary`. On a release, the relevant parts of the changes in the `canary` branch are rebased into `master`.
 
 ## To run tests
 
 Running all tests:
 
-```
+```sh
 yarn testonly
 ```
 
 Running a specific test suite inside of the `test/integration` directory:
 
-```
+```sh
 yarn testonly --testPathPattern "production"
 ```
 
 Running just one test in the `production` test suite:
 
-```
+```sh
 yarn testonly --testPathPattern "production" -t "should allow etag header support"
 ```
 
-## Running the integration test apps without running tests
+## Running the integration apps
 
-```
-./node_modules/.bin/next ./test/integration/basic
-```
+The correct path to the compiled `next` binary can be discovered by running:
 
-## Testing in your own app
-
-Because of the way Node.js resolves modules the easiest way to test your own application is copying it into the `test` directory.
-
-```
-cp -r yourapp <next.js directory>/test/integration/yourapp
+```sh
+find . -name next -perm -u=x -type f
 ```
 
-Make sure you remove `react` `react-dom` and `next` from `test/integration/yourapp/node_modules` as otherwise they will be overwritten.
+Running examples can be done with:
 
-```bash
-rm -rf <next.js directory>/test/integration/yourapp/{react,react-dom,next,next-server}
+```sh
+./packages/next/dist/bin/next ./test/integration/basic
+# OR
+./packages/next/dist/bin/next ./examples/basic-css/
 ```
 
-Then run your app using:
+To figure out which pages are available for the given example, you can run:
 
+```sh
+EXAMPLE=./test/integration/basic
+(\
+  cd $EXAMPLE/pages; \
+  find . -type f \
+  | grep -v '\.next' \
+  | sed 's#^\.##' \
+  | sed 's#index\.js##' \
+  | sed 's#\.js$##' \
+  | xargs -I{} echo localhost:3000{} \
+)
 ```
-./node_modules/.bin/next ./test/integration/yourapp
-```
+
+## Running your own app with locally compiled version of Next.js
+
+1. In your app's `package.json`, replace:
+
+   ```json
+   "next": "<next-version>",
+   ```
+
+   with:
+
+   ```json
+   "next": "file:<local-path-to-cloned-nextjs-repo>/packages/next",
+   ```
+
+2. In your app's root directory, make sure to remove `next` from `node_modules` with:
+
+   ```sh
+   rm -rf ./node_modules/next
+   ```
+
+3. In your app's root directory, run:
+
+   ```sh
+   yarn
+   ```
+
+   to re-install all of the dependencies.
+
+   Note that Next will be copied from the locally compiled version as opposed to from being downloaded from the NPM registry.
+
+4. Run your application as you normally would.


### PR DESCRIPTION
- Correct the path to the compiled Next binary
- Code to reveal which pages are avaliable within an example
- Preferred way of testing an external application with a locally compiled Next
- Add markdown code annotations