### PR TITLE
Fix #7167: React Context Consumer value

### DIFF
--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -11,12 +11,6 @@ import arg from 'next/dist/compiled/arg/index.js'
   }
 })
 
-const React = require('react')
-
-if (typeof React.Suspense === 'undefined') {
-  throw new Error(`The version of React you are using is lower than the minimum required version needed for Next.js. Please upgrade "react" and "react-dom": "npm install --save react react-dom" https://err.sh/zeit/next.js/invalid-react-version`)
-}
-
 const defaultCommand = 'dev'
 export type cliCommand = (argv?: string[]) => void
 const commands: {[command: string]: () => Promise<cliCommand>} = {
@@ -73,6 +67,13 @@ if (!foundCommand && args['--help']) {
 
 const command = foundCommand ? args._[0] : defaultCommand
 const forwardedArgs = foundCommand ? args._.slice(1) : args._
+
+if (command !== 'start') {
+  const React = require('react')
+  if (typeof React.Suspense === 'undefined') {
+    throw new Error(`The version of React you are using is lower than the minimum required version needed for Next.js. Please upgrade "react" and "react-dom": "npm install --save react react-dom" https://err.sh/zeit/next.js/invalid-react-version`)
+  }
+}
 
 if (args['--inspect']) throw new Error(`Use env variable NODE_OPTIONS instead: NODE_OPTIONS="--inspect" next ${command}`)
 


### PR DESCRIPTION
fix https://github.com/zeit/next.js/issues/7167 this PR check the version of React only when running `next build` and `next dev`