### PR TITLE
Browserstack optimisations

### DIFF
--- a/test/jest-environment.js
+++ b/test/jest-environment.js
@@ -44,7 +44,8 @@ if (isBrowserStack) {
   }
   const sharedOpts = {
     'browserstack.local': true,
-    'browserstack.video': false
+    'browserstack.video': false,
+    'browserstack.localIdentifier': global.browserStackLocal.localIdentifierFlag
   }
 
   browserOptions = {

--- a/test/jest-global-setup.js
+++ b/test/jest-global-setup.js
@@ -5,7 +5,8 @@ if (process.env.BROWSERSTACK) {
   const { Local } = require('browserstack-local')
   const browserStackLocal = new Local()
   const localBrowserStackOpts = {
-    key: process.env.BROWSERSTACK_ACCESS_KEY
+    key: process.env.BROWSERSTACK_ACCESS_KEY,
+    localIdentifier: new Date().getTime() //Adding a unique local identifier to run parallel tests on BrowserStack
   }
   global.browserStackLocal = browserStackLocal
 

--- a/test/jest-global-setup.js
+++ b/test/jest-global-setup.js
@@ -6,7 +6,7 @@ if (process.env.BROWSERSTACK) {
   const browserStackLocal = new Local()
   const localBrowserStackOpts = {
     key: process.env.BROWSERSTACK_ACCESS_KEY,
-    localIdentifier: new Date().getTime() //Adding a unique local identifier to run parallel tests on BrowserStack
+    localIdentifier: new Date().getTime() // Adding a unique local identifier to run parallel tests on BrowserStack
   }
   global.browserStackLocal = browserStackLocal
 

--- a/test/jest-global-teardown.js
+++ b/test/jest-global-teardown.js
@@ -11,8 +11,7 @@ if (process.env.BROWSERSTACK) {
 }
 
 module.exports = async () => {
-  await globalTeardown()
-
+  
   if (browser) {
     // Close all remaining browser windows
     try {
@@ -21,7 +20,11 @@ module.exports = async () => {
         if (!window) continue
         await browser.window(window)
         await browser.origClose()
+        await browser.quit()
+        await globalTeardown()
       }
     } catch (_) {}
+  } else {
+    await globalTeardown()
   }
 }

--- a/test/jest-global-teardown.js
+++ b/test/jest-global-teardown.js
@@ -11,7 +11,6 @@ if (process.env.BROWSERSTACK) {
 }
 
 module.exports = async () => {
-  
   if (browser) {
     // Close all remaining browser windows
     try {


### PR DESCRIPTION
So actually there problems was as follows - 
The driver was not being stopped, so it kept the test in running state until the BrowserStack 90 seconds Timeout and the BrowserStack Binary was being killed before the drive was being quit. Hence, some of the requests in the test were failing.

Sometimes, in case of sessions running in parallel with same key, it cannot spawn two different binaries with only ``` key ``` parameter, user needs to use ``` local-identifier ``` for each instance of binary.



