### PR TITLE
Make sure Cache-Control header is set when no getInitialProps

### DIFF
--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -1,6 +1,6 @@
 import React, {ErrorInfo} from 'react'
 import PropTypes from 'prop-types'
-import { execOnce, NextComponentType, IContext, AppContextType, AppInitialProps, AppPropsType } from 'next-server/dist/lib/utils'
+import { execOnce, loadGetInitialProps, NextComponentType, IContext, AppContextType, AppInitialProps, AppPropsType } from 'next-server/dist/lib/utils'
 import { Router, makePublicRouterInstance } from '../client/router'
 
 export { NextComponentType, IContext, AppInitialProps }
@@ -15,12 +15,7 @@ export default class App<P = {}, CP = P> extends React.Component<P & AppProps<CP
   }
 
   static async getInitialProps({ Component, ctx }: AppContext): Promise<AppInitialProps> {
-    let pageProps = {}
-
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx)
-    }
-
+    const pageProps = await loadGetInitialProps(Component, ctx)
     return { pageProps }
   }
 

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -1,6 +1,6 @@
 import React, {ErrorInfo} from 'react'
 import PropTypes from 'prop-types'
-import { execOnce, loadGetInitialProps, NextComponentType, IContext, AppContextType, AppInitialProps, AppPropsType } from 'next-server/dist/lib/utils'
+import { execOnce, NextComponentType, IContext, AppContextType, AppInitialProps, AppPropsType } from 'next-server/dist/lib/utils'
 import { Router, makePublicRouterInstance } from '../client/router'
 
 export { NextComponentType, IContext, AppInitialProps }
@@ -15,7 +15,12 @@ export default class App<P = {}, CP = P> extends React.Component<P & AppProps<CP
   }
 
   static async getInitialProps({ Component, ctx }: AppContext): Promise<AppInitialProps> {
-    const pageProps = await loadGetInitialProps(Component, ctx)
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
     return { pageProps }
   }
 

--- a/test/integration/serverless/pages/_app.js
+++ b/test/integration/serverless/pages/_app.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import App, { Container } from 'next/app'
+
+class MyApp extends App {
+  static async getInitialProps ({ Component, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps }
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}
+
+export default MyApp

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -29,6 +29,14 @@ describe('Serverless', () => {
     expect(html).toMatch(/Hello World/)
   })
 
+  it('should set cache-control header', async () => {
+    const header = (
+      await fetch(`http://localhost:${appPort}/`)
+    ).headers.get('Cache-Control')
+
+    expect(header).toBe('s-maxage=86400, stale-while-revalidate')
+  })
+
   it('should render the page with dynamic import', async () => {
     const html = await renderViaHTTP(appPort, '/dynamic')
     expect(html).toMatch(/Hello!/)


### PR DESCRIPTION
Also, removed the extra usage of `loadGetInitialProps` from `_app` since it's not what we have documented to use. 