### PR TITLE
Fix firefox bug in next/dynamic

### DIFF
--- a/packages/next-server/lib/dynamic.tsx
+++ b/packages/next-server/lib/dynamic.tsx
@@ -109,8 +109,8 @@ export default function dynamic<P = {}>(
       const loadModules: LoaderMap = {}
       const modules = dynamicOptions.modules()
       Object.keys(modules).forEach((key) => {
-        const value = modules[key]
-        if (value instanceof Promise) {
+        const value: any = modules[key]
+        if (typeof value.then === 'function') {
           loadModules[key] = () => value.then((mod: any) => mod.default || mod)
           return
         }


### PR DESCRIPTION
`value instanceof Promise` was returning false in firefox causing dynamic components using `modules` to not load right. 