### PR TITLE
Fix wrong task name on watch for next/export files

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -153,7 +153,7 @@ export default async function (task) {
   await task.watch('pages/**/*.+(js|ts|tsx)', 'pages')
   await task.watch('server/**/*.+(js|ts|tsx)', 'server')
   await task.watch('build/**/*.+(js|ts|tsx)', 'nextbuild')
-  await task.watch('export/**/*.+(js|ts|tsx)', 'nextexport')
+  await task.watch('export/**/*.+(js|ts|tsx)', 'nextbuildstatic')
   await task.watch('client/**/*.+(js|ts|tsx)', 'client')
   await task.watch('lib/**/*.+(js|ts|tsx)', 'lib')
   await task.watch('cli/**/*.+(js|ts|tsx)', 'cli')


### PR DESCRIPTION
This was causing the taskr watch process to crash since it tried to run an invalid task. 