### PR TITLE
add theme to styled-components example

### DIFF
--- a/examples/with-styled-components/README.md
+++ b/examples/with-styled-components/README.md
@@ -45,4 +45,4 @@ now
 
 This example features how you use a different styling solution than [styled-jsx](https://github.com/zeit/styled-jsx) that also supports universal styles. That means we can serve the required styles for the first render within the HTML and then load the rest in the client. In this case we are using [styled-components](https://github.com/styled-components/styled-components).
 
-For this purpose we are extending the `<Document />` and injecting the server side rendered styles into the `<head>`, and also adding the `babel-plugin-styled-components`. (which is required for server side rendering)
+For this purpose we are extending the `<Document />` and injecting the server side rendered styles into the `<head>`, and also adding the `babel-plugin-styled-components` (which is required for server side rendering). Additionally we set up a global [theme](https://www.styled-components.com/docs/advanced#theming) for styled-components using NextJS custom [`<App>`](https://nextjs.org/docs#custom-app) component.

--- a/examples/with-styled-components/pages/_app.js
+++ b/examples/with-styled-components/pages/_app.js
@@ -1,0 +1,32 @@
+import App, { Container } from 'next/app'
+import React from 'react'
+import { ThemeProvider } from 'styled-components'
+
+const theme = {
+  colors: {
+    primary: '#0070f3'
+  }
+}
+
+export default class MyApp extends App {
+  static async getInitialProps ({ Component, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps }
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+    return (
+      <Container>
+        <ThemeProvider theme={theme}>
+          <Component {...pageProps} />
+        </ThemeProvider>
+      </Container>
+    )
+  }
+}

--- a/examples/with-styled-components/pages/index.js
+++ b/examples/with-styled-components/pages/index.js
@@ -2,8 +2,8 @@ import React from 'react'
 import styled from 'styled-components'
 
 const Title = styled.h1`
-  color: red;
   font-size: 50px;
+  color: ${({ theme }) => theme.colors.primary};
 `
 
 export default () => <Title>My page</Title>


### PR DESCRIPTION
Seems that to some it is still unclear how to add theme when working with styled-components. 
I thought it would be good to have it set up in the example.