### PR TITLE
Remove unnecessary type from LinkProps

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -43,7 +43,6 @@ function formatUrl(url: Url) {
 }
 
 type LinkProps = {
-  elRef: any,
   href: Url,
   as?: Url|undefined,
   replace?: boolean,


### PR DESCRIPTION
This prop isn't needed