### PR TITLE
Fix attempting to observe non-DOM refs in Link

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -113,8 +113,8 @@ class Link extends Component<LinkProps> {
     this.cleanUpListeners()
   }
 
-  handleRef(ref: any) {
-    if (IntersectionObserver && ref) {
+  handleRef(ref: Element) {
+    if (IntersectionObserver && ref && ref.tagName) {
       this.cleanUpListeners = listenToIntersections(ref, () => {
         this.prefetch()
       })
@@ -193,11 +193,15 @@ class Link extends Component<LinkProps> {
     // This will return the first child, if multiple are provided it will throw an error
     const child: any = Children.only(children)
     const props: {
+      onMouseEnter: React.MouseEventHandler,
       onClick: React.MouseEventHandler,
       href?: string,
       ref?: any,
     } = {
       ref: (el: any) => this.handleRef(el),
+      onMouseEnter: () => {
+        this.prefetch()
+      },
       onClick: (e: React.MouseEvent) => {
         if (child.props && typeof child.props.onClick === 'function') {
           child.props.onClick(e)


### PR DESCRIPTION
Since we can only observer DOM elements with `IntersectionObserver` this adds a check for that. Also, added prefetching `onMouseEnter` for fallback. 

Fixes: #7242 