### PR TITLE
Fix webpack fetch error

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -147,10 +147,11 @@ export default async function getBaseWebpackConfig(
     cpus: config.experimental.cpus,
     distDir: distDir,
   }
+  const devtool = dev || debug ? 'cheap-module-source-map' : false
 
   let webpackConfig: webpack.Configuration = {
+    devtool,
     mode: webpackMode,
-    devtool: dev || debug ? 'cheap-module-source-map' : false,
     name: isServer ? 'server' : 'client',
     target: isServer ? 'node' : 'web',
     externals: !isServer
@@ -451,6 +452,7 @@ export default async function getBaseWebpackConfig(
                     dll: ['react', 'react-dom'],
                   },
                   config: {
+                    devtool,
                     mode: webpackMode,
                     resolve: resolveConfig,
                   },

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -490,7 +490,7 @@ export class NextScript extends Component<OriginProps> {
     return (
       <>
         {devFiles
-          ? devFiles.map((file: string) => (
+          ? devFiles.map((file: string) => !file.match(/\.js\.map/) && (
               <script
                 key={file}
                 src={`${assetPrefix}/_next/${file}${_devOnlyInvalidateCacheQueryString}`}


### PR DESCRIPTION
Since the `AutoDllPlugin` didn't have source maps enabled, when an error was encountered and `react-error-overlay` would try to get the source maps for a module in it e.g. `react`, it would throw an error since it was trying to fetch `webpack://` which is not a valid URL. 


Fixes: #6374 