### PR TITLE
Make sure not to trigger getInitialProps on nav back from hash

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -215,6 +215,7 @@ export default class Router implements BaseRouter {
       // If the url change is only related to a hash change
       // We should not proceed. We should only change the state.
       if (this.onlyAHashChange(as)) {
+        this.asPath = as
         Router.events.emit('hashChangeStart', as)
         this.changeState(method, url, as)
         this.scrollToHash(as)

--- a/test/integration/client-navigation/test/index.test.js
+++ b/test/integration/client-navigation/test/index.test.js
@@ -420,6 +420,18 @@ describe('Client Navigation', () => {
 
         await browser.close()
       })
+
+      it('should not run getInitialProps when removing via back', async () => {
+        const browser = await webdriver(context.appPort, '/nav/hash-changes')
+
+        const counter = await browser
+          .elementByCss('#scroll-to-item-400').click()
+          .back()
+          .elementByCss('p').text()
+
+        expect(counter).toBe('COUNT: 0')
+        await browser.close()
+      })
     })
 
     describe('when hash set to empty', () => {


### PR DESCRIPTION
As mentioned in the thread `this.asPath` wasn't being set on a hash only change causing successive checks for hash only changes to return `false`. I added another test to the client-navigation suite to make sure this doesn't regress. 

Fixes: #2825
Closes: #5519
