### PR TITLE
Add export to example, to highlight failure

### DIFF
--- a/examples/with-ant-design-less/package.json
+++ b/examples/with-ant-design-less/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "deploy": "next build && next export -o dist"
   },
   "dependencies": {
     "@zeit/next-less": "^1.0.1",


### PR DESCRIPTION
This example breaks on export, see issue #6727. Adding this deploy script to highlight the error.