### PR TITLE
Make calling .prepare() optional

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -49,6 +49,7 @@ export default class Server {
     assetPrefix?: string,
   }
   router: Router
+  ready: Promise<void> | boolean
 
   public constructor({
     dir = '.',
@@ -61,6 +62,7 @@ export default class Server {
     const phase = this.currentPhase()
     this.nextConfig = loadConfig(phase, this.dir, conf)
     this.distDir = join(this.dir, this.nextConfig.distDir)
+    this.ready = false
     // this.pagesDir = join(this.dir, 'pages')
     this.publicDir = join(this.dir, CLIENT_PUBLIC_FILES_PATH)
 
@@ -116,11 +118,18 @@ export default class Server {
     console.error(...args)
   }
 
-  private handleRequest(
+  private async handleRequest(
     req: IncomingMessage,
     res: ServerResponse,
     parsedUrl?: UrlWithParsedQuery,
   ): Promise<void> {
+    if (this.ready !== true) {
+      if (this.ready === false) {
+        this.ready = this.prepare()
+      }
+      await this.ready
+    }
+
     // Parse url if parsedUrl not provided
     if (!parsedUrl || typeof parsedUrl !== 'object') {
       const url: any = req.url

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -960,24 +960,22 @@ const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const handle = app.getRequestHandler()
 
-app.prepare().then(() => {
-  createServer((req, res) => {
-    // Be sure to pass `true` as the second argument to `url.parse`.
-    // This tells it to parse the query portion of the URL.
-    const parsedUrl = parse(req.url, true)
-    const { pathname, query } = parsedUrl
+createServer((req, res) => {
+  // Be sure to pass `true` as the second argument to `url.parse`.
+  // This tells it to parse the query portion of the URL.
+  const parsedUrl = parse(req.url, true)
+  const { pathname, query } = parsedUrl
 
-    if (pathname === '/a') {
-      app.render(req, res, '/b', query)
-    } else if (pathname === '/b') {
-      app.render(req, res, '/a', query)
-    } else {
-      handle(req, res, parsedUrl)
-    }
-  }).listen(3000, err => {
-    if (err) throw err
-    console.log('> Ready on http://localhost:3000')
-  })
+  if (pathname === '/a') {
+    app.render(req, res, '/b', query)
+  } else if (pathname === '/b') {
+    app.render(req, res, '/a', query)
+  } else {
+    handle(req, res, parsedUrl)
+  }
+}).listen(3000, err => {
+  if (err) throw err
+  console.log('> Ready on http://localhost:3000')
 })
 ```
 
@@ -1031,25 +1029,23 @@ const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const handleNextRequests = app.getRequestHandler()
 
-app.prepare().then(() => {
-  const server = new http.Server((req, res) => {
-    // Add assetPrefix support based on the hostname
-    if (req.headers.host === 'my-app.com') {
-      app.setAssetPrefix('http://cdn.com/myapp')
-    } else {
-      app.setAssetPrefix('')
-    }
+const server = new http.Server((req, res) => {
+  // Add assetPrefix support based on the hostname
+  if (req.headers.host === 'my-app.com') {
+    app.setAssetPrefix('http://cdn.com/myapp')
+  } else {
+    app.setAssetPrefix('')
+  }
 
-    handleNextRequests(req, res)
-  })
+  handleNextRequests(req, res)
+})
 
-  server.listen(port, err => {
-    if (err) {
-      throw err
-    }
+server.listen(port, err => {
+  if (err) {
+    throw err
+  }
 
-    console.log(`> Ready on http://localhost:${port}`)
-  })
+  console.log(`> Ready on http://localhost:${port}`)
 })
 ```
 

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -63,9 +63,6 @@ const nextDev: cliCommand = (argv) => {
   startedDevelopmentServer(appUrl)
 
   startServer({dir, dev: true}, port, args['--hostname'])
-    .then(async (app) => {
-      await app.prepare()
-    })
     .catch((err) => {
       if (err.code === 'EADDRINUSE') {
         let errorMessage = `Port ${port} is already in use.`

--- a/packages/next/cli/next-start.ts
+++ b/packages/next/cli/next-start.ts
@@ -47,7 +47,6 @@ const nextStart: cliCommand = (argv) => {
     .then(async (app) => {
       // tslint:disable-next-line
       console.log(`> Ready on http://${args['--hostname'] || 'localhost'}:${port}`)
-      await app.prepare()
     })
     .catch((err) => {
       // tslint:disable-next-line


### PR DESCRIPTION
I see my [other PR](https://github.com/zeit/next.js/pull/6922) meets some kind of silent resistance, so I'm sending this one that incorporates major part of original but without introducing any new feature so it should be easier to review.

The only purpose of this PR is to make `.prepare()` call optional when creating custom server (without it development server doesn't work). This change is 100% backward compatible and doesn't introduce any new features. I can update other custom server examples if you agree to merge this.

EDIT:

This PR makes development server to accept connections instantly, the same way production does