### PR TITLE
Friendly type names

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -3,7 +3,7 @@
 import { ComponentType } from 'react';
 import { parse } from 'url';
 import mitt, {MittEmitter} from '../mitt';
-import { formatWithValidation, getURL, loadGetInitialProps, IContext, AppContextType } from '../utils';
+import { formatWithValidation, getURL, loadGetInitialProps, NextPageContext, AppContextType } from '../utils';
 import {rewriteUrlForNextExport} from './rewrite-url-for-export'
 
 function toRoute(path: string): string {
@@ -423,7 +423,7 @@ export default class Router implements BaseRouter {
     return Component
   }
 
-  async getInitialProps(Component: ComponentType, ctx: IContext): Promise<any> {
+  async getInitialProps(Component: ComponentType, ctx: NextPageContext): Promise<any> {
     let cancelled = false
     const cancel = () => { cancelled = true }
     this.componentLoadCancel = cancel

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -8,7 +8,7 @@ import { BaseRouter } from './router/router'
 /**
  * Types used by both next and next-server
  */
-export type NextComponentType<C extends BaseContext = IContext, IP = {}, P = {}> = ComponentType<P> & {
+export type NextComponentType<C extends BaseContext = NextPageContext, IP = {}, P = {}> = ComponentType<P> & {
   getInitialProps?(context: C): Promise<IP>,
 }
 
@@ -31,7 +31,7 @@ export type BaseContext = {
   [k: string]: any,
 }
 
-export type INEXTDATA = {
+export type NEXT_DATA = {
   dataManager: string
   props: any
   page: string
@@ -45,7 +45,8 @@ export type INEXTDATA = {
   err?: Error & { statusCode?: number },
 }
 
-export interface IContext {
+// tslint:disable-next-line interface-name
+export interface NextPageContext {
   err?: Error & { statusCode?: number } | null
   req?: IncomingMessage
   res?: ServerResponse
@@ -55,9 +56,9 @@ export interface IContext {
 }
 
 export type AppContextType<R extends BaseRouter = BaseRouter> = {
-  Component: NextComponentType<IContext>
+  Component: NextComponentType<NextPageContext>
   router: R
-  ctx: IContext,
+  ctx: NextPageContext,
 }
 
 export type AppInitialProps = {
@@ -65,11 +66,11 @@ export type AppInitialProps = {
 }
 
 export type AppPropsType<R extends BaseRouter = BaseRouter, P = {}> = AppInitialProps & {
-  Component: NextComponentType<IContext, any, P>
+  Component: NextComponentType<NextPageContext, any, P>
   router: R,
 }
 
-export type DocumentContext = IContext & {
+export type DocumentContext = NextPageContext & {
   renderPage: RenderPage,
 }
 
@@ -78,7 +79,7 @@ export type DocumentInitialProps = RenderPageResult & {
 }
 
 export type DocumentProps = DocumentInitialProps & {
-  __NEXT_DATA__: INEXTDATA
+  __NEXT_DATA__: NEXT_DATA
   dangerousAsPath: string
   ampPath: string
   amphtml: boolean

--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { NextComponentType, IContext } from 'next-server/dist/lib/utils'
+import { NextComponentType, NextPageContext } from 'next-server/dist/lib/utils'
 import { PublicRouterInstance } from './router';
 
 export type WithRouterProps = {
@@ -9,7 +9,9 @@ export type WithRouterProps = {
 
 export type ExcludeRouterProps<P> = Pick<P, Exclude<keyof P, keyof WithRouterProps>>
 
-export default function withRouter<P extends WithRouterProps, C = IContext>(ComposedComponent: NextComponentType<C, any, P>): React.ComponentClass<ExcludeRouterProps<P>> {
+export default function withRouter<P extends WithRouterProps, C = NextPageContext>(
+  ComposedComponent: NextComponentType<C, any, P>,
+): React.ComponentClass<ExcludeRouterProps<P>> {
   class WithRouteWrapper extends React.Component<ExcludeRouterProps<P>> {
     static displayName?: string
     static getInitialProps?: any

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -1,9 +1,9 @@
 import React, {ErrorInfo} from 'react'
 import PropTypes from 'prop-types'
-import { execOnce, loadGetInitialProps, NextComponentType, IContext, AppContextType, AppInitialProps, AppPropsType } from 'next-server/dist/lib/utils'
+import { execOnce, loadGetInitialProps, AppContextType, AppInitialProps, AppPropsType } from 'next-server/dist/lib/utils'
 import { Router, makePublicRouterInstance } from '../client/router'
 
-export { NextComponentType, IContext, AppInitialProps }
+export { AppInitialProps }
 
 export type AppContext = AppContextType<Router>
 

--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Head from 'next-server/head'
-import { IContext } from 'next-server/dist/lib/utils'
+import { NextPageContext } from 'next-server/dist/lib/utils'
 
 const statusCodes: { [code: number]: string } = {
   400: 'Bad Request',
@@ -16,7 +16,7 @@ export type ErrorProps = {
 export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   static displayName = 'ErrorPage'
 
-  static getInitialProps({ res, err }: IContext) {
+  static getInitialProps({ res, err }: NextPageContext) {
     const statusCode =
       res && res.statusCode ? res.statusCode : err ? err.statusCode : 404
     return { statusCode }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IContext } from 'next-server/dist/lib/utils';
+import { NextPageContext, NextComponentType } from 'next-server/dist/lib/utils';
 
 // Extend the React types with missing properties
 declare module 'react' {
@@ -20,11 +20,9 @@ declare module 'react' {
   }
 }
 
-export type NextPageContext = IContext
-
 export type NextPage<P = {}> = {
   (props: P): JSX.Element;
   getInitialProps?(ctx: NextPageContext): Promise<P>;
 }
 
-export { IContext }
+export { NextPageContext, NextComponentType }


### PR DESCRIPTION
This PR renames `IContext` to be `NextPageContext` and `INEXTDATA` to `NEXT_DATA`

Related to #7235 