### PR TITLE
Experimental API support

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@babel/preset-flow": "7.0.0",
     "@babel/preset-react": "7.0.0",
     "@mdx-js/loader": "0.18.0",
+    "@types/jest": "24.0.12",
     "@types/string-hash": "1.1.1",
     "@zeit/next-css": "1.0.2-canary.2",
     "@zeit/next-sass": "1.0.2-canary.2",

--- a/packages/next-server/server/load-components.ts
+++ b/packages/next-server/server/load-components.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 import { requirePage } from './require';
 
-function interopDefault(mod: any) {
+export function interopDefault(mod: any) {
   return mod.default || mod
 }
 

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -243,7 +243,7 @@ export default class Server {
   private async handleApiRequest(req: IncomingMessage, res: ServerResponse, pathname: string) {
     const resolverFunction = await this.resolveApiRequest(pathname)
     if (resolverFunction === null) {
-      res.statusCode = 501
+      res.statusCode = 404
       res.end('Not Implemented')
       return
     }

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -22,6 +22,7 @@ import {
 } from '../lib/constants'
 import * as envConfig from '../lib/runtime-config'
 import { loadComponents } from './load-components'
+import { getPagePath, requireResolver } from './require';
 
 type NextConfig = any
 
@@ -199,6 +200,13 @@ export default class Server {
           await this.serveStatic(req, res, p, parsedUrl)
         },
       },
+      {
+        match: route('/api/:path*'),
+        fn: async (req, res, params, parsedUrl) => {
+          const { pathname } = parsedUrl
+          await this.handleApiRequest(req, res, pathname!)
+        },
+      },
     ]
 
     if (fs.existsSync(this.publicDir)) {
@@ -224,6 +232,32 @@ export default class Server {
     }
 
     return routes
+  }
+
+  /**
+   * Resolves `API` request, in development builds on demand
+   * @param req http request
+   * @param res http response
+   * @param pathname path of request
+   */
+  private async handleApiRequest(req: IncomingMessage, res: ServerResponse, pathname: string) {
+    const resolverFunction = await this.resolveApiRequest(pathname)
+    if (resolverFunction === null) {
+      res.statusCode = 501
+      res.end('Not Implemented')
+      return
+    }
+
+    const resolver = requireResolver(resolverFunction)
+    resolver(req, res)
+  }
+
+  /**
+   * Resolves path to resolver function
+   * @param pathname path of request
+   */
+  private resolveApiRequest(pathname: string) {
+    return getPagePath(pathname, this.distDir)
   }
 
   private generatePublicRoutes(): Route[] {

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -244,7 +244,7 @@ export default class Server {
     const resolverFunction = await this.resolveApiRequest(pathname)
     if (resolverFunction === null) {
       res.statusCode = 404
-      res.end('Not Implemented')
+      res.end('Not Found')
       return
     }
 

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -21,8 +21,8 @@ import {
   PAGES_MANIFEST,
 } from '../lib/constants'
 import * as envConfig from '../lib/runtime-config'
-import { loadComponents } from './load-components'
-import { getPagePath, requireResolver } from './require';
+import { loadComponents, interopDefault } from './load-components'
+import { getPagePath } from './require';
 
 type NextConfig = any
 
@@ -248,7 +248,7 @@ export default class Server {
       return
     }
 
-    const resolver = requireResolver(resolverFunction)
+    const resolver = interopDefault(require(resolverFunction))
     resolver(req, res)
   }
 

--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -36,3 +36,9 @@ export function requirePage(page: string, distDir: string): any {
   const pagePath = getPagePath(page, distDir)
   return require(pagePath)
 }
+
+export function requireResolver(path: string): any {
+  const resolver = require(path)
+
+  return resolver.default
+}

--- a/packages/next-server/server/require.ts
+++ b/packages/next-server/server/require.ts
@@ -36,9 +36,3 @@ export function requirePage(page: string, distDir: string): any {
   const pagePath = getPagePath(page, distDir)
   return require(pagePath)
 }
-
-export function requireResolver(path: string): any {
-  const resolver = require(path)
-
-  return resolver.default
-}

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -146,7 +146,7 @@ export default class DevServer extends Server {
     try {
       await this.hotReloader.ensurePage(pathname)
     } catch (err) {
-      // API route dosn't exist => return 503
+      // API route dosn't exist => return 404
       if (err.code === 'ENOENT') {
         return null
       }

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -138,6 +138,23 @@ export default class DevServer extends Server {
     return !snippet.includes('data-amp-development-mode-only')
   }
 
+  /**
+   * Check if resolver function is build or request new build for this function
+   * @param {string} pathname
+   */
+  async resolveApiRequest (pathname) {
+    try {
+      await this.hotReloader.ensurePage(pathname)
+    } catch (err) {
+      // API route dosn't exist => return 503
+      if (err.code === 'ENOENT') {
+        return null
+      }
+    }
+    const resolvedPath = await super.resolveApiRequest(pathname)
+    return resolvedPath
+  }
+
   async renderToHTML (req, res, pathname, query, options = {}) {
     const compilationErr = await this.getCompilationError(pathname)
     if (compilationErr) {

--- a/test/integration/api-support/pages/api/posts/index.js
+++ b/test/integration/api-support/pages/api/posts/index.js
@@ -1,0 +1,6 @@
+export default (req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+
+  const json = JSON.stringify([{ title: 'Cool Post!' }])
+  res.end(json)
+}

--- a/test/integration/api-support/pages/api/users.js
+++ b/test/integration/api-support/pages/api/users.js
@@ -1,0 +1,15 @@
+import url from 'url'
+
+export default (req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+
+  const { query } = url.parse(req.url, true)
+
+  const users = [{ name: 'Tim' }, { name: 'Jon' }]
+
+  const response =
+    query && query.name ? users.filter(user => user.name === query.name) : users
+
+  const json = JSON.stringify(response)
+  res.end(json)
+}

--- a/test/integration/api-support/pages/index.js
+++ b/test/integration/api-support/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <div>API - support</div>

--- a/test/integration/api-support/pages/user.js
+++ b/test/integration/api-support/pages/user.js
@@ -1,0 +1,1 @@
+export default () => <div>API - support</div>

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  killApp,
+  findPort,
+  launchApp,
+  fetchViaHTTP
+  // renderViaHTTP,
+} from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+let appPort
+let server
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+describe('API support', () => {
+  beforeAll(async () => {
+    appPort = await findPort()
+    server = await launchApp(appDir, appPort)
+  })
+  afterAll(() => killApp(server))
+
+  it('API request to undefined path', async () => {
+    const { status } = await fetchViaHTTP(appPort, '/api/unexisting', null, {
+      Accept: 'application/json'
+    })
+    expect(status).toEqual(501)
+  })
+
+  it('API request to list of users', async () => {
+    const data = await fetchViaHTTP(appPort, '/api/users', null, {
+      Accept: 'application/json'
+    }).then(res => res.ok && res.json())
+
+    expect(data).toEqual([{ name: 'Tim' }, { name: 'Jon' }])
+  })
+
+  it('API request to list of users with query parameter', async () => {
+    const data = await fetchViaHTTP(appPort, '/api/users?name=Tim', null, {
+      Accept: 'application/json'
+    }).then(res => res.ok && res.json())
+
+    expect(data).toEqual([{ name: 'Tim' }])
+  })
+
+  it('API request to nested posts', async () => {
+    const data = await fetchViaHTTP(appPort, '/api/posts', null, {
+      Accept: 'application/json'
+    }).then(res => res.ok && res.json())
+
+    expect(data).toEqual([{ title: 'Cool Post!' }])
+  })
+})

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -25,7 +25,7 @@ describe('API support', () => {
     const { status } = await fetchViaHTTP(appPort, '/api/unexisting', null, {
       Accept: 'application/json'
     })
-    expect(status).toEqual(501)
+    expect(status).toEqual(404)
   })
 
   it('API request to list of users', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1589,6 +1589,18 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@24.0.12":
+  version "24.0.12"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.12.tgz#0553dd0a5ac744e7dc4e8700da6d3baedbde3e8f"
+  integrity sha512-60sjqMhat7i7XntZckcSGV8iREJyXXI6yFHZkSZvCPUeOnEJ/VP1rU/WpEWQ56mvoh8NhC+sfKAuJRTyGtCOow==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/loader-utils@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@types/loader-utils/-/loader-utils-1.1.3.tgz#82b9163f2ead596c68a8c03e450fbd6e089df401"


### PR DESCRIPTION
Initial PR for #7297

This PR introduces support for `pages/api`. Details in #7297 

Request handler looks like:

```js
export default (req, res) => {}
```