### PR TITLE
fix:5049 Make Count in with-reasonml persist in runtime

### DIFF
--- a/examples/with-reasonml/components/Counter.re
+++ b/examples/with-reasonml/components/Counter.re
@@ -1,24 +1,22 @@
-type action =
-  | Add;
-
-type state = {count: int};
+let count = ref(0);
 
 [@react.component]
 let make = () => {
-  let (state, dispatch) =
-    React.useReducer(
-      (state, action) =>
-        switch (action) {
-        | Add => {count: state.count + 1}
-        },
-      {count: 0},
-    );
+  let (_state, dispatch) = React.useReducer(
+    (_, _) => Js.Obj.empty(),
+    Js.Obj.empty()
+  );
 
-  let countMsg = "Count: " ++ string_of_int(state.count);
+  let countMsg = "Count: " ++ string_of_int(count^);
+
+  let add = () => {
+    count := count^ + 1;
+    dispatch();
+  };
 
   <div>
     <p> {ReasonReact.string(countMsg)} </p>
-    <button onClick={_ => dispatch(Add)}> {React.string("Add")} </button>
+    <button onClick={_ => add()}> {React.string("Add")} </button>
   </div>;
 };
 


### PR DESCRIPTION
This PR replicates the functionality of the shared-modules example ([shared-modules/components/Counter.js](https://github.com/zeit/next.js/blob/canary/examples/shared-modules/components/Counter.js)) with ReasonML and seeks to solve issue https://github.com/zeit/next.js/issues/5049 .

| **Status** | **Screen Capture** |
| :--- | :--- |
| **Behaviour before fix:**<br> Count resets | ![reason-counter-before](https://user-images.githubusercontent.com/31798108/57557953-cf6d7080-7373-11e9-8793-0fa6538788d2.gif) |
| **Behaviour after fix:** <br> Count persists in runtime | ![reasonml-counter](https://user-images.githubusercontent.com/31798108/57557816-5cfc9080-7373-11e9-87aa-db7cd0cb6d73.gif) |