### PR TITLE
Make sure API routes are built in production

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -63,7 +63,10 @@ export function createEntrypoints(pages: PagesMapping, target: 'server'|'serverl
     if (page === '/_document') {
       return
     }
-    client[bundlePath] = `next-client-pages-loader?${stringify({page, absolutePagePath})}!`
+
+    if(!isApiRoute) {
+      client[bundlePath] = `next-client-pages-loader?${stringify({page, absolutePagePath})}!`
+    }
   })
 
   return {

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -50,13 +50,16 @@ export function createEntrypoints(pages: PagesMapping, target: 'server'|'serverl
   Object.keys(pages).forEach((page) => {
     const absolutePagePath = pages[page]
     const bundleFile = page === '/' ? '/index.js' : `${page}.js`
+    const isApiRoute = bundleFile.startsWith('/api')
+
     const bundlePath = join('static', buildId, 'pages', bundleFile)
-    if(target === 'serverless' && page !== '/_app' && page !== '/_document') {
+    if(isApiRoute || target === 'server') {
+      server[bundlePath] = [absolutePagePath]
+    } else if(target === 'serverless' && page !== '/_app' && page !== '/_document') {
       const serverlessLoaderOptions: ServerlessLoaderQuery = {page, absolutePagePath, ...defaultServerlessOptions}
       server[join('pages', bundleFile)] = `next-serverless-loader?${stringify(serverlessLoaderOptions)}!`
-    } else if(target === 'server') {
-      server[bundlePath] = [absolutePagePath]
     }
+
     if (page === '/_document') {
       return
     }

--- a/test/integration/production/pages/api/hello.js
+++ b/test/integration/production/pages/api/hello.js
@@ -1,0 +1,3 @@
+export default (req, res) => {
+  res.end('API hello works')
+}

--- a/test/integration/production/pages/api/index.js
+++ b/test/integration/production/pages/api/index.js
@@ -1,0 +1,3 @@
+export default (req, res) => {
+  res.end('API index works')
+}

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -154,6 +154,22 @@ describe('Production Usage', () => {
     })
   })
 
+  describe('API routes', () => {
+    it('should work with pages/api/index.js', async () => {
+      const url = `http://localhost:${appPort}/api`
+      const res = await fetch(url)
+      const body = await res.text()
+      expect(body).toEqual('API index works')
+    })
+
+    it('should work with pages/api/hello.js', async () => {
+      const url = `http://localhost:${appPort}/api/hello`
+      const res = await fetch(url)
+      const body = await res.text()
+      expect(body).toEqual('API hello works')
+    })
+  })
+
   describe('With navigation', () => {
     it('should navigate via client side', async () => {
       const browser = await webdriver(appPort, '/')


### PR DESCRIPTION
This makes sure `next build` output will contain API routes with just `(req, res) =>` as handler.
Previous the page would get wrapped by the serverless loader, which adds React rendering for serverless.

This also makes sure there is no client-side bundle for the api route in production. Development still has to be covered, @huv1k is going to implement that.