### PR TITLE
Update the with-graphql-react example

### DIFF
--- a/examples/with-graphql-react/package.json
+++ b/examples/with-graphql-react/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "license": "ISC",
   "dependencies": {
-    "cross-fetch": "^3.0.1",
-    "graphql-react": "^8.0.2",
-    "next": "^8.0.3",
-    "next-graphql-react": "^3.0.0",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "cross-fetch": "^3.0.2",
+    "graphql-react": "^8.2.0",
+    "next": "^8.1.0",
+    "next-graphql-react": "^3.0.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   },
   "scripts": {
     "dev": "next",

--- a/examples/with-graphql-react/pages/_app.js
+++ b/examples/with-graphql-react/pages/_app.js
@@ -1,5 +1,5 @@
 import 'cross-fetch/polyfill'
-import { GraphQLContext } from 'graphql-react'
+import { GraphQLProvider } from 'graphql-react'
 import { withGraphQLApp } from 'next-graphql-react'
 import App, { Container } from 'next/app'
 
@@ -8,9 +8,9 @@ class CustomApp extends App {
     const { Component, pageProps, graphql } = this.props
     return (
       <Container>
-        <GraphQLContext.Provider value={graphql}>
+        <GraphQLProvider graphql={graphql}>
           <Component {...pageProps} />
-        </GraphQLContext.Provider>
+        </GraphQLProvider>
       </Container>
     )
   }

--- a/examples/with-graphql-react/pages/index.js
+++ b/examples/with-graphql-react/pages/index.js
@@ -6,7 +6,7 @@ export default () => {
       options.url = 'https://graphql-pokemon.now.sh'
     },
     operation: {
-      query: `
+      query: /* GraphQL */ `
         {
           pokemon(name: "Pikachu") {
             name


### PR DESCRIPTION
- Update dependencies, especially [`graphql-react`](https://npm.im/graphql-react).
- Use the [`graphql-react` v8.2.0](https://github.com/jaydenseric/graphql-react/releases/tag/v8.2.0) API. Unnecessary loading on the client after SSR is prevented by using the new [`GraphQLProvider`](https://github.com/jaydenseric/graphql-react#function-graphqlprovider) component instead of using [`GraphQLContext.Provider`](https://github.com/jaydenseric/graphql-react#constant-graphqlcontext) directly.
- Use a `/* GraphQL */` comment template string tag so text editors can syntax highlight, lint and format the GraphQL query.