### PR TITLE
Fix POST and PUT on api routes

### DIFF
--- a/packages/next-server/server/router.ts
+++ b/packages/next-server/server/router.ts
@@ -31,17 +31,6 @@ export default class Router {
     res: ServerResponse,
     parsedUrl: UrlWithParsedQuery,
   ) {
-    const isApi = req.url!.match(/^\/api\//)
-
-    if (
-      req.method !== 'GET' &&
-      req.method !== 'HEAD' &&
-      (isApi && req.method !== 'POST') &&
-      (isApi && req.method !== 'PUT')
-    ) {
-      return
-    }
-
     const { pathname } = parsedUrl
     for (const route of this.routes) {
       const params = route.match(pathname)

--- a/packages/next-server/server/router.ts
+++ b/packages/next-server/server/router.ts
@@ -1,14 +1,19 @@
-import {IncomingMessage, ServerResponse} from 'http'
-import {UrlWithParsedQuery} from 'url'
+import { IncomingMessage, ServerResponse } from 'http'
+import { UrlWithParsedQuery } from 'url'
 import pathMatch from './lib/path-match'
 
 export const route = pathMatch()
 
-type Params = {[param: string]: any}
+type Params = { [param: string]: any }
 
 export type Route = {
-  match: (pathname: string|undefined) => false|Params,
-  fn: (req: IncomingMessage, res: ServerResponse, params: Params, parsedUrl: UrlWithParsedQuery) => void,
+  match: (pathname: string | undefined) => false | Params
+  fn: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    params: Params,
+    parsedUrl: UrlWithParsedQuery,
+  ) => void,
 }
 
 export default class Router {
@@ -21,8 +26,19 @@ export default class Router {
     this.routes.unshift(route)
   }
 
-  match(req: IncomingMessage, res: ServerResponse, parsedUrl: UrlWithParsedQuery) {
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
+  match(
+    req: IncomingMessage,
+    res: ServerResponse,
+    parsedUrl: UrlWithParsedQuery,
+  ) {
+    const isApi = req.url!.match(/^\/api\//)
+
+    if (
+      req.method !== 'GET' &&
+      req.method !== 'HEAD' &&
+      (isApi && req.method !== 'POST') &&
+      (isApi && req.method !== 'PUT')
+    ) {
       return
     }
 

--- a/test/integration/api-support/pages/api/posts/index.js
+++ b/test/integration/api-support/pages/api/posts/index.js
@@ -1,6 +1,14 @@
+import url from 'url'
+
 export default (req, res) => {
   res.writeHead(200, { 'Content-Type': 'application/json' })
 
-  const json = JSON.stringify([{ title: 'Cool Post!' }])
-  res.end(json)
+  if (req.method === 'POST') {
+    const { query } = url.parse(req.url, true)
+    const json = JSON.stringify([{ title: query.title }])
+    res.end(json)
+  } else {
+    const json = JSON.stringify([{ title: 'Cool Post!' }])
+    res.end(json)
+  }
 }

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -22,33 +22,50 @@ describe('API support', () => {
   afterAll(() => killApp(server))
 
   it('API request to undefined path', async () => {
-    const { status } = await fetchViaHTTP(appPort, '/api/unexisting', null, {
-      Accept: 'application/json'
-    })
+    const { status } = await fetchViaHTTP(appPort, '/api/unexisting', null, {})
     expect(status).toEqual(404)
   })
 
   it('API request to list of users', async () => {
-    const data = await fetchViaHTTP(appPort, '/api/users', null, {
-      Accept: 'application/json'
-    }).then(res => res.ok && res.json())
+    const data = await fetchViaHTTP(appPort, '/api/users', null, {}).then(
+      res => res.ok && res.json()
+    )
 
     expect(data).toEqual([{ name: 'Tim' }, { name: 'Jon' }])
   })
 
   it('API request to list of users with query parameter', async () => {
-    const data = await fetchViaHTTP(appPort, '/api/users?name=Tim', null, {
-      Accept: 'application/json'
-    }).then(res => res.ok && res.json())
+    const data = await fetchViaHTTP(
+      appPort,
+      '/api/users?name=Tim',
+      null,
+      {}
+    ).then(res => res.ok && res.json())
 
     expect(data).toEqual([{ name: 'Tim' }])
   })
 
   it('API request to nested posts', async () => {
-    const data = await fetchViaHTTP(appPort, '/api/posts', null, {
-      Accept: 'application/json'
-    }).then(res => res.ok && res.json())
+    const data = await fetchViaHTTP(appPort, '/api/posts', null, {}).then(
+      res => res.ok && res.json()
+    )
 
     expect(data).toEqual([{ title: 'Cool Post!' }])
+  })
+
+  it('Post on pages', async () => {
+    const data = await fetchViaHTTP(appPort, '/users', null, {
+      method: 'POST'
+    }).then(res => res.status)
+
+    expect(data).toEqual(404)
+  })
+
+  it('API post on route', async () => {
+    const data = await fetchViaHTTP(appPort, '/api/posts?title=Nextjs', null, {
+      method: 'POST'
+    }).then(res => res.ok && res.json())
+
+    expect(data).toEqual([{ title: 'Nextjs' }])
   })
 })

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -91,15 +91,6 @@ describe('Production Usage', () => {
       expect(res.status).toBe(404)
     })
 
-    it('should render 501 if the HTTP method is not GET or HEAD', async () => {
-      const url = `http://localhost:${appPort}/_next/abcdef`
-      const methods = ['POST', 'PUT', 'DELETE']
-      for (const method of methods) {
-        const res = await fetch(url, { method })
-        expect(res.status).toBe(501)
-      }
-    })
-
     it('should set Content-Length header', async () => {
       const url = `http://localhost:${appPort}`
       const res = await fetch(url)


### PR DESCRIPTION
This enables `POST` and `PUT` for `/api/` routes.