### PR TITLE
Make sure to include client query params

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -104,6 +104,10 @@ export default async ({
     pageLoader.onDynamicBuildId()
   }
 
+  for (const [key, value] of new URLSearchParams(window.location.search)) {
+    query[key] = value
+  }
+
   router = createRouter(page, query, asPath, {
     initialProps: props,
     pageLoader,


### PR DESCRIPTION
Fixes #4804

When creating the router in the client, the query object is [generated](https://github.com/zeit/next.js/blob/19c635175ba7556a222bd46f9a68bfb3beeeb7cd/packages/next/client/index.js#L25) from the `__NEXT_DATA__` object coming from the server.

This works when serving using `next`, but when you export to static assets, that query will always be empty (unless you pass query params in your path map as shown [here](https://github.com/zeit/next.js/issues/4804#issuecomment-406222124))

This PR extends the query object coming from the server with the query params from the `window.location` object. When running as a server, those should match, and when running from exported static files the query params will be added to any statically provided in the path map.