### PR TITLE
Redesigned page output

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -85,7 +85,7 @@ export function printTreeView(
 
   console.log(
     textTable(messages, {
-      align: ['l', 'l', 'l', 'r'],
+      align: ['l', 'l', 'r', 'r'],
       stringLength: str => stripAnsi(str).length,
     })
   )

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1,10 +1,15 @@
+import chalk from 'chalk'
 import crypto from 'crypto'
 import findUp from 'find-up'
 import fs from 'fs'
+import textTable from 'next/dist/compiled/text-table'
 import path from 'path'
+import stripAnsi from 'strip-ansi'
 import { promisify } from 'util'
+
 import prettyBytes from '../lib/pretty-bytes'
 import { recursiveReadDir } from '../lib/recursive-readdir'
+import { getPageChunks } from './webpack/plugins/chunk-graph-plugin'
 
 const fsStat = promisify(fs.stat)
 const fsExists = promisify(fs.exists)
@@ -20,78 +25,109 @@ export function collectPages(
   )
 }
 
-interface ChunksItem {
-  external: Set<string>,
-  internal: Set<string>
+export interface PageInfo {
+  isAmp?: boolean
+  size: number
+  chunks?: ReturnType<typeof getPageChunks>
 }
 
-interface PageInfo {
-  ampOnly: boolean,
-  serverSize: number,
-  clientSize: number,
-  chunks: ChunksItem
-}
-
-export function printTreeView(list: string[], pageInfos: Map<string, PageInfo>) {
-  /*
-    red for >250kb
-    yellow for >100kb
-    green for <100kb
-  */
-  const getSizeColor = (size: number): string => {
-    if (size < 100 * 1000) return '\x1b[32m'
-    if (size < 250 * 1000) return '\x1b[33m'
-    return '\x1b[31m'
+export function printTreeView(
+  list: string[],
+  pageInfos: Map<string, PageInfo>
+) {
+  const getPrettySize = (_size: number): string => {
+    const size = prettyBytes(_size)
+    // green for 0-100kb
+    if (_size < 100 * 1000) return chalk.green(size)
+    // yellow for 100-250kb
+    if (_size < 250 * 1000) return chalk.yellow(size)
+    // red for >= 250kb
+    return chalk.red.bold(size)
   }
 
+  const messages: string[][] = [
+    ['Page', 'Size', 'Files', 'Packages'].map(entry => chalk.underline(entry)),
+  ]
+
   list
-    .sort((a, b) => (a > b ? 1 : -1))
+    .sort((a, b) => a.localeCompare(b))
     .forEach((item, i) => {
-      const info = pageInfos.get(item)
-      let numExternal
-      let numInternal
-      let serverSize
-      let clientSize
-      let isAmp
-
-      if (info) {
-        isAmp = info.ampOnly
-        serverSize = info.serverSize
-        clientSize = info.clientSize
-
-        if (info.chunks) {
-          const { chunks } = info
-          numExternal = chunks.external.size
-          numInternal = chunks.internal.size
-        }
-      }
-
-      const corner =
+      const symbol =
         i === 0
           ? list.length === 1
             ? '─'
             : '┌'
+          : i === list.length - 1
+          ? '└'
           : '├'
 
-      console.log(` \x1b[90m${corner}\x1b[39m ${item}${isAmp ? ' (AMP)' : ''}`)
+      const pageInfo = pageInfos.get(item)
 
-      if (typeof numExternal === 'number') {
-        console.log(` \x1b[90m| \x1b[39mPackages: ${numExternal} Local modules: ${numInternal}`);
-      }
-      let sizes = ' \x1b[90m|'
-
-      if (typeof serverSize === 'number') {
-        sizes += getSizeColor(serverSize) +
-          ` Server size: ${prettyBytes(serverSize)}`
-      }
-      if (typeof clientSize === 'number') {
-        sizes += getSizeColor(clientSize) +
-          ` Client size: ${prettyBytes(clientSize)}`
-      }
-
-      if (sizes) console.log(sizes)
-      console.log(` \x1b[90m${i === list.length - 1 ? '└' : '|'}`);
+      messages.push([
+        `${symbol} ${item}`,
+        ...(pageInfo
+          ? [
+              pageInfo.isAmp
+                ? chalk.cyan('AMP')
+                : pageInfo.size >= 0
+                ? getPrettySize(pageInfo.size)
+                : 'N/A',
+              pageInfo.chunks
+                ? pageInfo.chunks.internal.size.toString()
+                : 'N/A',
+              pageInfo.chunks
+                ? pageInfo.chunks.external.size.toString()
+                : 'N/A',
+            ]
+          : ['', '', '']),
+      ])
     })
+
+  console.log(
+    textTable(messages, {
+      align: ['l', 'l', 'l', 'r'],
+      stringLength: str => stripAnsi(str).length,
+    })
+  )
+
+  // list
+  //   .sort((a, b) => (a > b ? 1 : -1))
+  //   .forEach((item, i) => {
+  //     const info = pageInfos.get(item)
+  //     let numExternal: number | undefined
+  //     let numInternal: number | undefined
+  //     let size = -1
+  //     let isAmp: boolean | undefined
+
+  //     if (info) {
+  //       isAmp = info.isAmp
+  //       size = info.size
+
+  //       if (info.chunks) {
+  //         const { chunks } = info
+  //         numExternal = chunks.external.size
+  //         numInternal = chunks.internal.size
+  //       }
+  //     }
+
+  //     const corner = i === 0 ? (list.length === 1 ? '─' : '┌') : '├'
+
+  //     console.log(` \x1b[90m${corner}\x1b[39m ${item}${isAmp ? ' (AMP)' : ''}`)
+
+  //     if (typeof numExternal === 'number') {
+  //       console.log(
+  //         ` \x1b[90m| \x1b[39mPackages: ${numExternal} Local modules: ${numInternal}`
+  //       )
+  //     }
+  //     let sizes = ' \x1b[90m|'
+
+  //     if (typeof size === 'number' && size >= 0) {
+  //       sizes += getSizeColor(size) + ` Client size: ${prettyBytes(size)}`
+  //     }
+
+  //     if (sizes) console.log(sizes)
+  //     console.log(` \x1b[90m${i === list.length - 1 ? '└' : '|'}`)
+  //   })
 
   console.log()
 }
@@ -209,35 +245,18 @@ export async function getCacheIdentifier({
     .digest('hex')
 }
 
-export async function getPageInfo(
+export async function getPageSizeInKb(
   page: string,
   distPath: string,
-  buildId: string,
-  dev: boolean,
-  serverless?: boolean,
-) {
-  const info: any = {}
-  const staticPath = dev ? 'development' : buildId
+  buildId: string
+): Promise<number> {
   const clientBundle = path.join(
-    distPath, `static/${staticPath}/pages/`, `${page}.js`
+    distPath,
+    `static/${buildId}/pages/`,
+    `${page}.js`
   )
-  const serverPath = serverless
-    ? path.join(distPath, 'serverless/pages')
-    : path.join(distPath, 'server/static', staticPath, 'pages')
-
-  const serverBundle = path.join(serverPath, `${page}.js`)
-  info.clientBundle = clientBundle
-
-  if (!dev) {
-    try {
-      info.serverSize = (await fsStat(serverBundle)).size
-    } catch (_) {}
-    try {
-      info.clientSize = (await fsStat(clientBundle)).size
-    } catch (_) {}
-  }
-
-  if (page.match(/(_app|_error|_document)/)) return info
-
-  return info
+  try {
+    return (await fsStat(clientBundle)).size
+  } catch (_) {}
+  return -1
 }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -90,45 +90,6 @@ export function printTreeView(
     })
   )
 
-  // list
-  //   .sort((a, b) => (a > b ? 1 : -1))
-  //   .forEach((item, i) => {
-  //     const info = pageInfos.get(item)
-  //     let numExternal: number | undefined
-  //     let numInternal: number | undefined
-  //     let size = -1
-  //     let isAmp: boolean | undefined
-
-  //     if (info) {
-  //       isAmp = info.isAmp
-  //       size = info.size
-
-  //       if (info.chunks) {
-  //         const { chunks } = info
-  //         numExternal = chunks.external.size
-  //         numInternal = chunks.internal.size
-  //       }
-  //     }
-
-  //     const corner = i === 0 ? (list.length === 1 ? '─' : '┌') : '├'
-
-  //     console.log(` \x1b[90m${corner}\x1b[39m ${item}${isAmp ? ' (AMP)' : ''}`)
-
-  //     if (typeof numExternal === 'number') {
-  //       console.log(
-  //         ` \x1b[90m| \x1b[39mPackages: ${numExternal} Local modules: ${numInternal}`
-  //       )
-  //     }
-  //     let sizes = ' \x1b[90m|'
-
-  //     if (typeof size === 'number' && size >= 0) {
-  //       sizes += getSizeColor(size) + ` Client size: ${prettyBytes(size)}`
-  //     }
-
-  //     if (sizes) console.log(sizes)
-  //     console.log(` \x1b[90m${i === list.length - 1 ? '└' : '|'}`)
-  //   })
-
   console.log()
 }
 


### PR DESCRIPTION
The previous page output ate up a ton of vertical space. This PR compresses the output.

The server side bundle sizes were also dropped because they're not very meaningful to the user (considering they're not minified and do not transfer over the wire).

![image](https://user-images.githubusercontent.com/616428/57662086-af2ff280-75bb-11e9-82d2-761c05f5d880.png)
