### PR TITLE
Fix windows backslashes not being replaced when identifying AMP pages

### DIFF
--- a/packages/next/build/webpack/plugins/next-drop-client-page-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-drop-client-page-plugin.ts
@@ -11,7 +11,8 @@ export class DropClientPage implements Plugin {
         const asset = compilation.assets[assetKey]
 
         if (asset && asset._value && asset._value.includes('__NEXT_DROP_CLIENT_FILE__')) {
-          const page = '/' + assetKey.split('pages/')[1]
+          const cleanAssetKey = assetKey.replace(/\\/g, '/')
+          const page = '/' + cleanAssetKey.split('pages/')[1]
           const pageNoExt = page.split(extname(page))[0]
 
           this.ampPages.add(pageNoExt.replace(/\/index$/, '') || '/')


### PR DESCRIPTION
This would now cause builds to fail on windows since when printing the tree it would try to access a value that isn't there. 