### PR TITLE
Fix Error-overlay not being cleared when type error is corrected

### DIFF
--- a/packages/next/client/dev-error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev-error-overlay/hot-dev-client.js
@@ -266,6 +266,7 @@ async function tryApplyUpdates (onHotUpdateSuccess) {
   }
 
   if (!isUpdateAvailable() || !canApplyUpdates()) {
+    ErrorOverlay.dismissBuildError()
     return
   }
 

--- a/test/integration/typescript/pages/type-error-recover.tsx
+++ b/test/integration/typescript/pages/type-error-recover.tsx
@@ -1,0 +1,1 @@
+export default () => <p>Hello world</p>

--- a/test/integration/typescript/test/hmr.js
+++ b/test/integration/typescript/test/hmr.js
@@ -47,13 +47,10 @@ export default (context, renderViaHTTP) => {
         await check(() => getReactErrorOverlayContent(browser), /Type 'Element' is not assignable to type 'boolean'/)
 
         writeFileSync(pagePath, origContent)
-        await check(() => browser.elementByCss('p').text(), /Hello world/)
-
-        writeFileSync(pagePath, errContent)
-        await check(() => getReactErrorOverlayContent(browser), /Type 'Element' is not assignable to type 'boolean'/)
-
-        writeFileSync(pagePath, origContent)
-        await check(() => browser.elementByCss('p').text(), /Hello world/)
+        await check(async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.match(/iframe/) ? 'fail' : 'success'
+        }, /success/)
       } finally {
         if (browser) browser.close()
         writeFileSync(pagePath, origContent)

--- a/test/integration/typescript/test/hmr.js
+++ b/test/integration/typescript/test/hmr.js
@@ -2,7 +2,7 @@
 import webdriver from 'next-webdriver'
 import { readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
-import { check, getBrowserBodyText } from 'next-test-utils'
+import { check, getBrowserBodyText, getReactErrorOverlayContent } from 'next-test-utils'
 
 export default (context, renderViaHTTP) => {
   describe('Hot Module Reloading', () => {
@@ -13,7 +13,7 @@ export default (context, renderViaHTTP) => {
           browser = await webdriver(context.appPort, '/hello')
           await check(() => getBrowserBodyText(browser), /Hello World/)
 
-          const pagePath = join(__dirname, '../', 'components', 'hello.ts')
+          const pagePath = join(context.appDir, 'components', 'hello.ts')
 
           const originalContent = readFileSync(pagePath, 'utf8')
           const editedContent = originalContent.replace('Hello', 'COOL page')
@@ -33,6 +33,31 @@ export default (context, renderViaHTTP) => {
           }
         }
       })
+    })
+
+    it('should recover from a type error', async () => {
+      let browser
+      const pagePath = join(context.appDir, 'pages/type-error-recover.tsx')
+      const origContent = readFileSync(pagePath, 'utf8')
+      try {
+        browser = await webdriver(context.appPort, '/type-error-recover')
+        const errContent = origContent.replace('() =>', '(): boolean =>')
+
+        writeFileSync(pagePath, errContent)
+        await check(() => getReactErrorOverlayContent(browser), /Type 'Element' is not assignable to type 'boolean'/)
+
+        writeFileSync(pagePath, origContent)
+        await check(() => browser.elementByCss('p').text(), /Hello world/)
+
+        writeFileSync(pagePath, errContent)
+        await check(() => getReactErrorOverlayContent(browser), /Type 'Element' is not assignable to type 'boolean'/)
+
+        writeFileSync(pagePath, origContent)
+        await check(() => browser.elementByCss('p').text(), /Hello world/)
+      } finally {
+        if (browser) browser.close()
+        writeFileSync(pagePath, origContent)
+      }
     })
   })
 }

--- a/test/integration/typescript/test/index.test.js
+++ b/test/integration/typescript/test/index.test.js
@@ -12,7 +12,8 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 describe('TypeScript Features', () => {
   beforeAll(async () => {
     context.appPort = await findPort()
-    context.server = await launchApp(join(__dirname, '../'), context.appPort)
+    context.appDir = join(__dirname, '../')
+    context.server = await launchApp(context.appDir, context.appPort)
 
     // pre-build all pages at the start
     await Promise.all([renderViaHTTP(context.appPort, '/hello')])


### PR DESCRIPTION
If a type error was corrected without any other changes the Error-overlay isn't always cleared