### PR TITLE
[typescript] `allowSyntheticDefaultImports` is not required when `esModuleInterop` is enabled

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -107,7 +107,6 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
     lib: { suggested: ['dom', 'dom.iterable', 'esnext'] },
     allowJs: { suggested: true },
     skipLibCheck: { suggested: true },
-    allowSyntheticDefaultImports: { suggested: true },
     strict: { suggested: true },
     forceConsistentCasingInFileNames: { suggested: true },
 


### PR DESCRIPTION
As mentioned on previous PRs related to TypeScript, setting `esModuleInterop`
to `true` automatically sets `allowSyntheticDefaultImports` to `true` as
well, so this config validation is not required.

Reference: https://github.com/zeit/next.js/pull/7169#discussion_r280831148