### PR TITLE
Anchor TypeScript check to fix invalid detection

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -28,7 +28,7 @@ function writeJson(fileName: string, object: object): Promise<void> {
 async function verifyNoTypeScript(dir: string) {
   const typescriptFiles = await recursiveReadDir(
     dir,
-    /.*\.(ts|tsx)/,
+    /.*\.(ts|tsx)$/,
     /(node_modules|.*\.d\.ts)/,
   )
 


### PR DESCRIPTION
Since this wasn't anchored it was picking up non-TypeScript files and creating a `tsconfig.json`.

Fixes: #7348 