### PR TITLE
fixed 'with-loading' example, no longer shows NProgress loading bar for non-existent page

### DIFF
--- a/examples/with-loading/pages/_app.js
+++ b/examples/with-loading/pages/_app.js
@@ -40,9 +40,7 @@ export default class MyApp extends App {
           <Link href='/forever'>
             <a style={linkStyle}>Forever</a>
           </Link>
-          <Link href='/non-existing'>
-            <a style={linkStyle}>Non Existing Page</a>
-          </Link>
+          <a href='/non-existing' style={linkStyle}>Non Existing Page</a>
         </div>
 
         <Component {...pageProps} />


### PR DESCRIPTION
Closes #7327 

Specifically addressing #7327, changed non-existent-page link to `<a>` tag because `next/link` doesn't handle full page transitions

💪👶 