### PR TITLE
Update 8.Question_about_next.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/8.Question_about_next.md
+++ b/.github/ISSUE_TEMPLATE/8.Question_about_next.md
@@ -5,4 +5,4 @@ about: If you have a question related to Next.js or the examples. Reach out to t
 
 # Question about Next.js
 
-Questions should be posted on https://spectrum.chat/next-js
+GitHub Issues are reserved for Bug reports and Feature requests. The best place to get your question answered is to post it on https://spectrum.chat/next-js.


### PR DESCRIPTION
I've noticed that you're still getting questions asked here despite the previous template being clear - today a user even expressed they thought the prompt meant: post a question on Spectrum then post a link to that question here. 

This change makes the suggestion more explicit. 

You could additionally add something like "Questions posted on Github will likely be closed" which I think would cut down on the number of people ignoring the prompt. But you might feel that is too aggressive.