### PR TITLE
Create simple Sentry example for exception reporting.

### DIFF
--- a/examples/with-sentry-simple/README.md
+++ b/examples/with-sentry-simple/README.md
@@ -1,0 +1,70 @@
+[![Deploy To Now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-sentry-simple)
+
+# Sentry (Simple Example)
+
+## How To Use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-sentry-simple with-sentry-simple
+# or
+yarn create next-app --example with-sentry-simple with-sentry-simple
+```
+
+### Download Manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-sentry-simple
+cd with-sentry-simple
+```
+
+Install it and run:
+
+**NPM**
+
+```bash
+npm install
+npm run dev
+```
+
+**Yarn**
+
+```bash
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [Now](https://zeit.co/now) ([Download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## About Example
+
+This is a simple example showing how to use [Sentry](https://sentry.io) to catch & report errors on both client + server side.
+
+- `_document.js` is _server-side only_ and is used to change the initial server-side rendered document markup. We listen at the node process level to capture exceptions.
+- `_app.js` is client-side only and is used to initialize pages. We use the `componentDidCatch` lifecycle method to catch uncaught exceptions.
+
+**Note**: Source maps will not be sent to Sentry when running locally. It's also possible you will see duplicate errors sent when testing
+locally due to hot reloading. For a more accurate simulation, please deploy to Now.
+
+### Configuration
+
+You will need a _Sentry DSN_ for your project. You can get it from the settings of your project in **Client Keys (DSN)**. Then, copy the string labeled **DSN (Public)**.
+
+The Sentry DSN should then be updated in `_app.js`.
+
+```js
+Sentry.init({
+  dsn: 'PUT_YOUR_SENTRY_DSN_HERE'
+});
+```
+
+_Note: Committing environment variables is not secure and is done here only for demonstration purposes. See the [`with-dotenv`](../with-dotenv) or [`with-now-env`](../with-now-env) for examples of how to set environment variables safely._

--- a/examples/with-sentry-simple/next.config.js
+++ b/examples/with-sentry-simple/next.config.js
@@ -1,0 +1,7 @@
+const withSourceMaps = require('@zeit/next-source-maps')()
+
+module.exports = withSourceMaps({
+  webpack (config, _options) {
+    return config
+  }
+})

--- a/examples/with-sentry-simple/package.json
+++ b/examples/with-sentry-simple/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "with-sentry-simple",
+  "version": "1.0.0",
+  "license": "ISC",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@sentry/browser": "^5.1.0",
+    "next": "latest",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  },
+  "devDependencies": {
+    "@zeit/next-source-maps": "0.0.4-canary.1"
+  }
+}

--- a/examples/with-sentry-simple/pages/_app.js
+++ b/examples/with-sentry-simple/pages/_app.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import App, { Container } from 'next/app'
+import * as Sentry from '@sentry/browser'
+
+Sentry.init({
+  dsn: 'ENTER_YOUR_SENTRY_DSN_HERE'
+})
+
+class MyApp extends App {
+  static async getInitialProps ({ Component, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps }
+  }
+
+  componentDidCatch (error, errorInfo) {
+    Sentry.withScope((scope) => {
+      Object.keys(errorInfo).forEach((key) => {
+        scope.setExtra(key, errorInfo[key])
+      })
+
+      Sentry.captureException(error)
+    })
+
+    super.componentDidCatch(error, errorInfo)
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}
+
+export default MyApp

--- a/examples/with-sentry-simple/pages/_document.js
+++ b/examples/with-sentry-simple/pages/_document.js
@@ -1,0 +1,31 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import * as Sentry from '@sentry/browser'
+
+process.on('unhandledRejection', (err) => {
+  Sentry.captureException(err)
+})
+
+process.on('uncaughtException', (err) => {
+  Sentry.captureException(err)
+})
+
+class MyDocument extends Document {
+  static async getInitialProps (ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render () {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/examples/with-sentry-simple/pages/index.js
+++ b/examples/with-sentry-simple/pages/index.js
@@ -1,0 +1,49 @@
+import React from 'react'
+
+class Index extends React.Component {
+  static getInitialProps ({ query }) {
+    if (query.raiseError) {
+      throw new Error('Error in getInitialProps')
+    }
+  }
+
+  state = {
+    raiseErrorInRender: false,
+    raiseErrorInUpdate: false
+  };
+
+  componentDidUpdate () {
+    if (this.state.raiseErrorInUpdate) {
+      throw new Error('Error in componentDidUpdate')
+    }
+  }
+
+  raiseErrorInUpdate = () => this.setState({ raiseErrorInUpdate: '1' });
+  raiseErrorInRender = () => this.setState({ raiseErrorInRender: '1' });
+
+  render () {
+    if (this.state.raiseErrorInRender) {
+      throw new Error('Error in render')
+    }
+
+    return (
+      <div>
+        <h2>Sentry Example 🚨</h2>
+        <ul>
+          <li>
+            <a href='#' onClick={this.raiseErrorInRender}>
+              Raise the error in render
+            </a>
+          </li>
+          <li>
+            <a href='#' onClick={this.raiseErrorInUpdate}>
+              Raise the error in componentDidUpdate
+            </a>
+          </li>
+        </ul>
+      </div>
+    )
+  }
+}
+
+export default Index


### PR DESCRIPTION
## Overview

For many teams using Next.js, setting up exception monitoring is a critical requirement before going to production. The current [with-sentry](https://github.com/zeit/next.js/pull/5727) example, while [thorough](https://github.com/zeit/next.js/pull/5727#issuecomment-446007181), is very complicated for beginners. 

This PR adds a simple example showing how to use [Sentry](https://sentry.io) to catch & report errors on both client and server-side.

- `_document.js` is _server-side only_ and is used to change the initial server-side rendered document markup. We listen at the node process level to capture exceptions.
- `_app.js` is client-side only and is used to initialize pages. We use the `componentDidCatch` lifecycle method to catch uncaught exceptions.

**Note**: Source maps will not be sent to Sentry when running locally. It's also possible you will see duplicate errors sent when testing locally due to hot reloading. For a more accurate simulation, please deploy to Now.

## Testing
With the example deployed the Now, I can click the links to simulate errors.
![image](https://user-images.githubusercontent.com/9113740/56599399-190c3c00-65bc-11e9-8bc6-3d89d5e4fb32.png)
Then, I'm able to see the errors flow into Sentry.
![image](https://user-images.githubusercontent.com/9113740/56599502-4c4ecb00-65bc-11e9-88ef-fe1e78dd2aee.png)
The errors are properly source mapped.
![image](https://user-images.githubusercontent.com/9113740/56599512-540e6f80-65bc-11e9-8902-486b0809129b.png)

@lfades 