### PR TITLE
remove outdir line from tsconfig.server.json

### DIFF
--- a/examples/custom-server-typescript/tsconfig.server.json
+++ b/examples/custom-server-typescript/tsconfig.server.json
@@ -4,8 +4,7 @@
     "noEmit": false,
     "module": "commonjs",
     "target": "es2017",
-    "lib": ["es2017"],
-    "outDir": ".next/server"
+    "lib": ["es2017"]
   },
   "include": ["server/**/*.ts"],
   "exclude": [".next"]


### PR DESCRIPTION
Closes #7347

Stops from building typescript into `./next/server/server` directory.