### PR TITLE
Add retrying to CircleCi and fixes for ncc'ed webpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: Run All Tests
           command: >
-            yarn testall $(circleci tests glob "test/**/*.test.*" | circleci tests split --split-by=timings --timings-type=classname)
+            yarn testall $(circleci tests glob "test/**/*.test.*" | circleci tests split --split-by=timings --timings-type=classname) || (yarn git-clean; yarn git-reset; yarn testall $(circleci tests glob "test/**/*.test.*" | circleci tests split --split-by=timings --timings-type=classname))
           environment:
             JEST_JUNIT_OUTPUT: 'reports/junit/js-test-results.xml'
             JEST_JUNIT_CLASSNAME: '{filepath}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,9 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
+    yarn install --ignore-scripts && cd packages/next && yarn prepublish && cd ../..
+
+- script: |
     yarn install
   displayName: 'Install dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,9 +16,6 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
-    yarn install --ignore-scripts && cd packages/next && yarn prepublish && cd ../..
-
-- script: |
     yarn install
   displayName: 'Install dependencies'
 

--- a/packages/next/build/webpack/loaders/noop-loader.ts
+++ b/packages/next/build/webpack/loaders/noop-loader.ts
@@ -1,4 +1,4 @@
-import { loader } from 'webpack'
+import { loader } from 'next/dist/compiled/webpack'
 
 const NoopLoader: loader.Loader = (source) => source
 export default NoopLoader

--- a/packages/next/build/webpack/plugins/dll-import.ts
+++ b/packages/next/build/webpack/plugins/dll-import.ts
@@ -1,9 +1,8 @@
 import path from 'path'
 
 export function importAutoDllPlugin({ distDir }: { distDir: string }) {
-  const autodllPaths = path.join(
-    path.dirname(require.resolve('autodll-webpack-plugin')),
-    'paths.js'
+  const autodllPaths = require.resolve(
+    'next/dist/compiled/autodll-webpack-plugin/paths'
   )
   require(autodllPaths)
 
@@ -18,6 +17,6 @@ export function importAutoDllPlugin({ distDir }: { distDir: string }) {
     }),
   })
 
-  const AutoDllPlugin = require('autodll-webpack-plugin')
+  const AutoDllPlugin = require('next/dist/compiled/autodll-webpack-plugin')
   return AutoDllPlugin
 }

--- a/packages/next/build/webpack/plugins/fork-ts-checker-watcher-hook.ts
+++ b/packages/next/build/webpack/plugins/fork-ts-checker-watcher-hook.ts
@@ -1,9 +1,9 @@
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin'
 import { NormalizedMessage } from 'fork-ts-checker-webpack-plugin/lib/NormalizedMessage'
-import webpack from 'webpack'
+import webpack from 'next/dist/compiled/webpack'
 
 export function Apply(compiler: webpack.Compiler) {
-  const hooks = ForkTsCheckerWebpackPlugin.getCompilerHooks(compiler)
+  const hooks = ForkTsCheckerWebpackPlugin.getCompilerHooks(compiler as any)
 
   let additionalFiles: string[] = []
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -68,7 +68,6 @@
     "@babel/runtime-corejs2": "7.1.2",
     "amphtml-validator": "1.0.23",
     "async-sema": "2.2.0",
-    "autodll-webpack-plugin": "0.4.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.5",
     "babel-plugin-react-require": "3.0.0",

--- a/packages/next/taskfile-ncc.js
+++ b/packages/next/taskfile-ncc.js
@@ -25,6 +25,13 @@ module.exports = function (task) {
       if (options && options.packageName) {
         writePackageManifest.call(this, options.packageName)
       }
+      // make sure to use our compiled version of webpack
+      code = code
+        .replace(/require\(('|")webpack('|")\)/g, 'require("next/dist/compiled/webpack")')
+        .replace(
+          /webpack\/lib\/node\/NodeOutputFileSystem/g,
+          'next/dist/compiled/webpack/lib/node/NodeOutputFileSystem'
+        )
 
       file.data = Buffer.from(code, 'utf8')
     })

--- a/packages/next/taskfile-ncc.js
+++ b/packages/next/taskfile-ncc.js
@@ -1,4 +1,7 @@
 'use strict'
+// this fixes Azure on node 10 with ncc
+// without exits with: error Command failed with exit code 3221225477.
+process.pkg = true
 
 const ncc = require('@zeit/ncc')
 const { existsSync, readFileSync } = require('fs')

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1,5 +1,5 @@
 const notifier = require('node-notifier')
-const relative = require('path').relative
+const { relative } = require('path')
 
 const babelClientOpts = {
   presets: [
@@ -56,6 +56,18 @@ export async function ncc_webpack (task, opts) {
 }
 
 // eslint-disable-next-line camelcase
+export async function ncc_webpack_NodeOutputFileSystem (task, opts) {
+  await task
+    .source(opts.src || relative(__dirname, require.resolve('webpack/lib/node/NodeOutputFileSystem')))
+    .ncc({
+      externals: ['webpack']
+    })
+    .target('dist/compiled/webpack/lib/node/NodeOutputFileSystem')
+
+  notify('Compiled webpack NodeOutputFileSystem')
+}
+
+// eslint-disable-next-line camelcase
 export async function ncc_webpack_graph_helpers (task, opts) {
   await task
     .source(opts.src || relative(__dirname, require.resolve('webpack/lib/GraphHelpers')))
@@ -83,10 +95,22 @@ export async function ncc_autodll_webpack_plugin (task, opts) {
   await task
     .source(opts.src || relative(__dirname, require.resolve('autodll-webpack-plugin')))
     .ncc({
-      externals: ['chokidar', 'webpack'],
+      externals: ['chokidar', 'webpack', './paths'],
       packageName: 'autodll-webpack-plugin'
     })
     .target('dist/compiled/autodll-webpack-plugin')
+
+  notify('Compiled autodll-webpack-plugin')
+}
+
+// eslint-disable-next-line camelcase
+export async function ncc_autodll_webpack_plugin_paths (task, opts) {
+  await task
+    .source(opts.src || relative(__dirname, require.resolve('autodll-webpack-plugin')))
+    .ncc({
+      externals: ['chokidar', 'webpack']
+    })
+    .target('dist/compiled/autodll-webpack-plugin/paths')
 
   notify('Compiled autodll-webpack-plugin')
 }
@@ -145,7 +169,7 @@ export async function ncc_text_table (task, opts) {
 }
 
 export async function precompile (task) {
-  await task.parallel(['ncc_webpack', 'ncc_webpack_graph_helpers', 'ncc_webpack_hot_middleware', 'ncc_autodll_webpack_plugin', 'ncc_webpack_dev_middleware', 'ncc_unistore', 'ncc_resolve', 'ncc_arg', 'ncc_nanoid', 'ncc_text_table'])
+  await task.parallel(['ncc_webpack', 'ncc_webpack_NodeOutputFileSystem', 'ncc_webpack_graph_helpers', 'ncc_webpack_hot_middleware', 'ncc_autodll_webpack_plugin', 'ncc_autodll_webpack_plugin_paths', 'ncc_webpack_dev_middleware', 'ncc_unistore', 'ncc_resolve', 'ncc_arg', 'ncc_nanoid', 'ncc_text_table'])
 }
 
 export async function compile (task) {


### PR DESCRIPTION
Since CircleCi still occasionally encounters errors while testing this adds test-take2 to it similar to travis-ci and Azure. 

Also, added some fixes for ncc'ing `webpack` that were missed by the tests since the modules are installed as `devDependencies` during testing. 