### PR TITLE
Re-add retrying tests in CircleCi to prevent false failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: Run All Tests
           command: >
-            yarn testall $(circleci tests glob "test/**/*.test.*" | circleci tests split --split-by=timings --timings-type=classname)
+            yarn testall $(circleci tests glob "test/**/*.test.*" | circleci tests split --split-by=timings --timings-type=classname) || (yarn git-clean; yarn git-reset; yarn testall $(circleci tests glob "test/**/*.test.*" | circleci tests split --split-by=timings --timings-type=classname))
           environment:
             JEST_JUNIT_OUTPUT: 'reports/junit/js-test-results.xml'
             JEST_JUNIT_CLASSNAME: '{filepath}'


### PR DESCRIPTION
This got reverted since it was grouped in with the ncc fixes so this re-adds it by itself. 