### PR TITLE
Remove outdated "extras" section in `with-tailwindcss` example README

### DIFF
--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -43,19 +43,6 @@ Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.
 now
 ```
 
-### Extras
-
-In the `package.json` you'll see some extra commands.
-
-* `yarn dev:css`
-  * used by `yarn dev` generate css bundle and watch css files for changes
-  * includes css imported into `index.css`
-  * will **not** autoreload browser when css changes
-* `yarn build:css`
-  * used by `yarn build` to generate css bundle
-
-These can be used manually but using the usual commands will run them anyways.
-
 ## The idea behind the example
 
 This setup is a basic starting point for using tailwind css and next. Along with tailwind, this example


### PR DESCRIPTION
Hello there !

Thanks for the amazing work !

The `Extras` section in the README from `with-tailwindcss` example is outdated as all the commands mentioned are no longer in the `package.json` like stated.

This commit just removed those.

Cheers !