### PR TITLE
[custom-server-typescript] fixed custom server build issues

### DIFF
--- a/examples/custom-server-typescript/.gitignore
+++ b/examples/custom-server-typescript/.gitignore
@@ -4,5 +4,5 @@ node_modules/
 # next.js build output
 .next
 
-# typescript build output
+# production server output
 dist

--- a/examples/custom-server-typescript/README.md
+++ b/examples/custom-server-typescript/README.md
@@ -40,5 +40,6 @@ now
 ## The idea behind the example
 
 The example shows how you can use [TypeScript](https://typescriptlang.com) on both the server and the client while using [Nodemon](https://nodemon.io/) to live reload the server code without affecting the Next.js universal code.
-Server entry point is `server/index.ts` in development and `production-server/index.js` in production.
+
+Server entry point is `server/index.ts` in development and `dist/index.js` in production.
 The second directory should be added to `.gitignore`.

--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "watch": ["server"],
-  "ext": "ts",
+  "watch": ["server/**/*.ts", "static/**/*.json"],
   "exec": "ts-node --project tsconfig.server.json server/index.ts"
 }
+

--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "watch": ["server/**/*.ts", "static/**/*.json"],
+  "watch": ["server", "static"],
   "exec": "ts-node --project tsconfig.server.json server/index.ts"
 }
 

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -1,21 +1,24 @@
 {
+  "name": "custom-server-typescript",
+  "version": "1.0.0",
   "scripts": {
     "dev": "nodemon",
-    "build": "next build && tsc && tsc --project tsconfig.server.json",
-    "start": "cross-env NODE_ENV=production node .next/server"
+    "build": "next build && tsc --project tsconfig.server.json",
+    "start": "cross-env NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
-    "next": "latest",
+    "next": "^8.1.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },
   "devDependencies": {
-    "@types/next": "^8.0.1",
-    "@types/react": "^16.8.8",
+    "@types/next": "^8.0.5",
+    "@types/react": "^16.8.17",
+    "@types/react-dom": "16.8.4",
     "@zeit/next-typescript": "^1.1.1",
     "cross-env": "^5.2.0",
-    "nodemon": "^1.18.10",
-    "ts-node": "^8.0.3",
-    "typescript": "^3.3.3333"
+    "nodemon": "^1.19.0",
+    "ts-node": "^8.1.0",
+    "typescript": "^3.4.5"
   }
 }

--- a/examples/custom-server-typescript/server/index.ts
+++ b/examples/custom-server-typescript/server/index.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'http'
 import { parse } from 'url'
-import * as next from 'next'
+import next from 'next'
 
 const port = parseInt(process.env.PORT || '3000', 10)
 const dev = process.env.NODE_ENV !== 'production'
@@ -22,4 +22,7 @@ app.prepare()
     }
   })
   .listen(port)
+
+  // tslint:disable-next-line:no-console
+  console.log(`> Server listening at http://localhost:${port} as ${dev ? 'development' : process.env.NODE_ENV}`);
 })

--- a/examples/custom-server-typescript/tsconfig.json
+++ b/examples/custom-server-typescript/tsconfig.json
@@ -1,30 +1,23 @@
 {
-  "compileOnSave": false,
   "compilerOptions": {
-    "noEmit": true,
-    "strict": true,
     "target": "esnext",
     "module": "esnext",
     "jsx": "preserve",
-    "allowJs": true,
+    "lib": ["dom", "es2017"],
+    "baseUrl": ".",
     "moduleResolution": "node",
+    "strict": true,
+    "allowJs": true,
+    "noEmit": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "isolatedModules": true,
     "removeComments": false,
     "preserveConstEnums": true,
-    "sourceMap": true,
-    "skipLibCheck": true,
-    "baseUrl": ".",
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "lib": [
-      "dom",
-      "es2015",
-      "es2016"
-    ],
-    "outDir": ".next"
+    "sourceMap": true
   },
-  "exclude": [".next", "server/**/*.*"]
+  "exclude": ["dist", ".next", "out", "next.config.js"]
 }

--- a/examples/custom-server-typescript/tsconfig.server.json
+++ b/examples/custom-server-typescript/tsconfig.server.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
     "module": "commonjs",
+    "outDir": "dist",
     "target": "es2017",
-    "lib": ["es2017"]
+    "isolatedModules": false,
+    "noEmit": false
   },
-  "include": ["server/**/*.ts"],
-  "exclude": [".next"]
+  "include": ["server/**/*.ts"]
 }


### PR DESCRIPTION
Fixes #7376.

I've attempted to clean up the `custom-server-typescript` example and
cleaned up the issues that were encountered by some people, mainly the
incorrect build paths.

Note that I'm still using the stable Next.js, since typings for the
server doesn't seem to be exported yet in `canary`.