### PR TITLE
Add 'deploy' script to surface error

### DIFF
--- a/examples/with-ant-design-less/package.json
+++ b/examples/with-ant-design-less/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "deploy": "next build && next export"
   },
   "dependencies": {
     "@zeit/next-less": "^1.0.1",


### PR DESCRIPTION
This example fails with the latest version of next. The failure is upon export, so adding a script which includes 'next export' to better surface this error. Thanks.