### PR TITLE
Make sure to only change query if autoExport is enabled

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -48,6 +48,7 @@ export default class Server {
     generateEtags: boolean
     runtimeConfig?: { [key: string]: any }
     assetPrefix?: string,
+    autoExport: boolean,
   }
   router: Router
 
@@ -78,6 +79,7 @@ export default class Server {
     this.renderOpts = {
       ampBindInitData: this.nextConfig.experimental.ampBindInitData,
       poweredByHeader: this.nextConfig.poweredByHeader,
+      autoExport: this.nextConfig.experimental.autoExport,
       staticMarkup,
       buildId: this.buildId,
       generateEtags,

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -109,6 +109,7 @@ function render(
 }
 
 type RenderOpts = {
+  autoExport: boolean
   ampBindInitData: boolean
   staticMarkup: boolean
   buildId: string
@@ -220,6 +221,7 @@ export async function renderToHTML(
   const {
     err,
     dev = false,
+    autoExport = false,
     ampBindInitData = false,
     staticMarkup = false,
     ampPath = '',
@@ -253,13 +255,15 @@ export async function renderToHTML(
       )
     }
 
-    const isStaticPage = typeof (Component as any).getInitialProps !== 'function'
-    const defaultAppGetInitialProps = App.getInitialProps === (App as any).origGetInitialProps
+    if (autoExport) {
+      const isStaticPage = typeof (Component as any).getInitialProps !== 'function'
+      const defaultAppGetInitialProps = App.getInitialProps === (App as any).origGetInitialProps
 
-    if (isStaticPage && defaultAppGetInitialProps) {
-      // remove query values except ones that will be set during export
-      query = {
-        amp: query.amp,
+      if (isStaticPage && defaultAppGetInitialProps) {
+        // remove query values except ones that will be set during export
+        query = {
+          amp: query.amp,
+        }
       }
     }
   }


### PR DESCRIPTION
This makes sure we don't change the query when detecting a static page if `autoExport` isn't enabled