### PR TITLE
Revert fs-extra upgrade due to issue in latest version with jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint": "5.16.0",
     "eslint-plugin-typescript": "0.14.0",
     "express": "4.17.0",
-    "fs-extra": "8.0.1",
+    "fs-extra": "7.0.1",
     "get-port": "5.0.0",
     "isomorphic-unfetch": "3.0.0",
     "jest-cli": "24.8.0",

--- a/test/integration/with-router/test/index.test.js
+++ b/test/integration/with-router/test/index.test.js
@@ -84,7 +84,7 @@ describe('withRouter', () => {
   })
 })
 
-describe('withRouter SSR', async () => {
+describe('withRouter SSR', () => {
   let server
   let port
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5768,16 +5768,7 @@ fs-extra@5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.0.1.tgz#90294081f978b1f182f347a440a209154344285b"
-  integrity sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^7.0.0:
+fs-extra@7.0.1, fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==


### PR DESCRIPTION
We can't upgrade to the latest version of `fs-extra` due to: https://github.com/jprichardson/node-fs-extra/issues/687