### PR TITLE
Don't load from serverless in dev mode

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -49,6 +49,7 @@ export default class Server {
     runtimeConfig?: { [key: string]: any }
     assetPrefix?: string,
     autoExport: boolean,
+    dev?: boolean,
   }
   router: Router
 
@@ -349,7 +350,7 @@ export default class Server {
     query: ParsedUrlQuery = {},
     opts: any,
   ) {
-    const serverless = this.nextConfig.target === 'serverless'
+    const serverless = !this.renderOpts.dev && this.nextConfig.target === 'serverless'
     // try serving a static AMP version first
     if (query.amp) {
       try {


### PR DESCRIPTION
Since we use the `server` dir in dev mode this makes sure we don't try to load from the `serverless` one