### PR TITLE
Updates the with-styled-components example to use GlobalStyles

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -1,5 +1,15 @@
 import Document from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
+import { ServerStyleSheet, createGlobalStyle } from 'styled-components'
+
+const GlobalStyles = createGlobalStyle`
+  html {
+    box-sizing: border-box;
+  }
+
+  *, *:before, *:after {
+    box-sizing: inherit;
+  }
+`
 
 export default class MyDocument extends Document {
   static async getInitialProps (ctx) {
@@ -9,7 +19,15 @@ export default class MyDocument extends Document {
     try {
       ctx.renderPage = () =>
         originalRenderPage({
-          enhanceApp: App => props => sheet.collectStyles(<App {...props} />)
+          enhanceApp: App => props =>
+            sheet.collectStyles(
+              // Adding global styles here will stop the flash of styles when navigating
+              // your app. If you don't require global styles then you can remove `<GlobalStyles />`
+              <>
+                <GlobalStyles />
+                <App {...props} />
+              </>
+            )
         })
 
       const initialProps = await Document.getInitialProps(ctx)


### PR DESCRIPTION
I've updated the styled-components example to include GlobalStyles. I was experiencing an issue where global styles were flashing when navigating the app, this resolves the issue. Thought it might stop others going down a rabbit hole too.

Added the comment as GlobalStyles is not required to get styled-components working with Next.