### PR TITLE
pass webpack-bundle-analyzer options to next-bundle-analyzer

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,4 +1,4 @@
-module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
+module.exports = ({ enabled = true, analyzerOptions = {} } = {}) => (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack (config, options) {
       if (enabled) {
@@ -6,7 +6,8 @@ module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
         config.plugins.push(
           new BundleAnalyzerPlugin({
             analyzerMode: 'static',
-            reportFilename: options.isServer ? '../analyze/server.html' : './analyze/client.html'
+            reportFilename: options.isServer ? '../analyze/server.html' : './analyze/client.html',
+            ...analyzerOptions
           })
         )
       }

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -22,7 +22,9 @@ Create a next.config.js (and make sure you have next-bundle-analyzer set up)
 const withBundleAnalyzer = require("@next/bundle-analyzer")({ enabled: process.env.ANALYZE === "true" });
 module.exports = withBundleAnalyzer({});
 ```
+
 `webpack-bundle-analyzer` options can also be passed as below
+
 ```js
 const withBundleAnalyzer = require("@next/bundle-analyzer")({ 
   enabled: process.env.ANALYZE === "true",
@@ -31,6 +33,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
   } 
 });
 ```
+
 Then you can run the command below:
 
 ```bash

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -22,7 +22,15 @@ Create a next.config.js (and make sure you have next-bundle-analyzer set up)
 const withBundleAnalyzer = require("@next/bundle-analyzer")({ enabled: process.env.ANALYZE === "true" });
 module.exports = withBundleAnalyzer({});
 ```
-
+`webpack-bundle-analyzer` options can also be passed as below
+```js
+const withBundleAnalyzer = require("@next/bundle-analyzer")({ 
+  enabled: process.env.ANALYZE === "true",
+  analyzerOptions: {
+    openAnalyzer: false
+  } 
+});
+```
 Then you can run the command below:
 
 ```bash


### PR DESCRIPTION
This pull request adds the ability to pass `webpack-bundle-analyzer` options to `next-bundle-analyzer`

Use case:
Sometimes we don't want to open the analyzer by default, so used to write as below:
```js
new BundleAnalyzerPlugin({
  analyzerMode: "static",
  openAnalyzer: false,
  reportFilename: isServer
      ? "../server-bundle-analysis.html"
      : "./client-bundle-analysis.html"
})
```
this implementation will provide the ability to pass bundle-analyzer config as below:
```js
const withBundleAnalyzer = require("@next/bundle-analyzer")({ 
  enabled: process.env.ANALYZE === "true",
  analyzerOptions: {
    openAnalyzer: false
  } 
});
```