### PR TITLE
Fix prioritization of routes with dynamic routing

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -308,13 +308,12 @@ export default class Server {
       p.includes('/$'),
     )
     return dynamicRoutedPages
+      .sort()
+      .reverse()
       .map((page) => ({
         page,
         match: getRouteMatch(page),
       }))
-      .sort((a, b) =>
-        Math.sign(a.page.match(/\/\$/g)!.length - b.page.match(/\/\$/g)!.length),
-      )
   }
 
   private async run(

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -109,8 +109,7 @@ export default class DevServer extends Server {
             continue
           }
 
-          let pageName =
-            '/' + relative(pagesDir, fileName).replace(/\\+/g, '/')
+          let pageName = '/' + relative(pagesDir, fileName).replace(/\\+/g, '/')
           if (!pageName.includes('/$')) {
             continue
           }
@@ -125,9 +124,7 @@ export default class DevServer extends Server {
           })
         }
 
-        this.dynamicRoutes = newDynamicRoutes.sort((a, b) =>
-          Math.sign(a.page.match(/\/\$/g).length - b.page.match(/\/\$/g).length)
-        )
+        this.dynamicRoutes = newDynamicRoutes.sort().reverse()
         resolve()
       })
     })

--- a/test/integration/dynamic-routing/pages/quotes/$author$.js
+++ b/test/integration/dynamic-routing/pages/quotes/$author$.js
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+
+export default () => {
+  const router = useRouter()
+  const { author } = router.query
+
+  if (!author) {
+    return <p>All quotes here</p>
+  }
+
+  return (
+    <>
+      <p>Quote by author {author} here</p>
+    </>
+  )
+}

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -41,6 +41,11 @@ function runTests () {
     expect(html).toMatch(/show comments for.*post-1.*here/i)
   })
 
+  it('should prioritize a non-dynamic folder', async () => {
+    const html = await renderViaHTTP(appPort, '/quotes')
+    expect(html).toMatch(/all quotes here/i)
+  })
+
   it('should render nested dynamic page', async () => {
     const html = await renderViaHTTP(appPort, '/post-1/comment-1')
     expect(html).toMatch(/i am.*comment-1.*on.*post-1/i)


### PR DESCRIPTION
If I have :
```
/$post/index.js
/quotes/$author$.js
```

If I request the page `/quotes`, it will get absorbed by the first route `/$post/index.js`. I expect it to be run by the second route `/quotes/$author$.js`.

This PR aims at fixing it.

- [x] add test case
- [x] fix error described above

---

#### Solution implemented

Fortunately the default descending order gives us this :
```js
> ['a','1','A','0','$'].sort()
["$", "0", "1", "A", "a"]
```

So we can use the descending order to put the pages/folders starting with `$` at the end of the list (deprioritize them).

```js
> ["/$post", "/$post/$comment", "/$post/comments", "/blog/$post/comment/$id$", "/quotes/$author$"].sort().reverse()
[
  "/quotes/$author$",
  "/blog/$post/comment/$id$",
  "/$post/comments",
  "/$post/$comment",
  "/$post"
]
```