### PR TITLE
Correctly pass props down in with-lingui example HOC

### DIFF
--- a/examples/with-lingui/components/withLang.js
+++ b/examples/with-lingui/components/withLang.js
@@ -20,12 +20,14 @@ export default (Component, defaultLang = 'en') =>
     }
 
     render () {
+      const { language, catalogs, ...restProps } = this.props;
+
       return (
         <I18nProvider
-          language={this.props.language}
-          catalogs={this.props.catalogs}
+          language={language}
+          catalogs={catalogs}
         >
-          <Component />
+          <Component {...restProps} />
         </I18nProvider>
       )
     }

--- a/examples/with-lingui/components/withLang.js
+++ b/examples/with-lingui/components/withLang.js
@@ -20,7 +20,7 @@ export default (Component, defaultLang = 'en') =>
     }
 
     render () {
-      const { language, catalogs, ...restProps } = this.props;
+      const { language, catalogs, ...restProps } = this.props
 
       return (
         <I18nProvider


### PR DESCRIPTION
The WithLang HOC provided as part of the with-lingui example does not pass props down to the wrapped component.

This means that the result of getInitialProps is not passed to the page component.

This commit passes all props which aren't specific to the HOC implementation down to the wrapped component.