### PR TITLE
Enable strict export presence in webpack

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -352,6 +352,7 @@ export default async function getBaseWebpackConfig(
     },
     // @ts-ignore this is filtered
     module: {
+      strictExportPresence: true,
       rules: [
         (selectivePageBuilding || config.experimental.terserLoader) &&
           !isServer &&


### PR DESCRIPTION
This causes the webpack build to error if the user imports something that isn't present.