### PR TITLE
Don't run standard for tsx files in husky to match lint-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
       "standard --fix",
       "git add"
     ],
-    "*.{ts,tsx}": [
+    "*.tsx": [
       "prettier --write",
       "git add"
     ],
     "*.ts": [
+      "prettier --write",
       "standard --fix --parser typescript-eslint-parser --plugin typescript",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     ],
     "*.{ts,tsx}": [
       "prettier --write",
+      "git add"
+    ],
+    "*.ts": [
       "standard --fix --parser typescript-eslint-parser --plugin typescript",
       "git add"
     ]


### PR DESCRIPTION
Since `standard` isn't set up to handle `tsx` files this makes sure not to run it during the `lint-staged` hook