### PR TITLE
Make react-ssr-prepass external if not enabled

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -228,6 +228,7 @@ export default async function getBaseWebpackConfig(
           // When the serverless target is used all node_modules will be compiled into the output bundles
           // So that the serverless bundles have 0 runtime dependencies
           'amp-toolbox-optimizer', // except this one
+          ...(config.experimental.ampBindInitData ? [] : ['react-ssr-prepass']),
         ],
     optimization: Object.assign(
       {


### PR DESCRIPTION
Since this was made a `devDependency` we need to make it external or else serverless builds will fail. 