### PR TITLE
Remove old test `<Link>`

### DIFF
--- a/test/integration/dynamic-routing/pages/index.js
+++ b/test/integration/dynamic-routing/pages/index.js
@@ -14,10 +14,10 @@ export default () => (
     <Link href='/$post/$comment' as='/post-1/comment-1'>
       <a id='view-post-1-comment-1'>View comment 1 on post 1</a>
     </Link>
-    <br />
-    <Link href='/blog/$post/comment/$id' as='/blog/543/comment'>
+    {/* <br />
+    <Link href='/blog/$post/comment/$id$' as='/blog/543/comment'>
       <a id='view-blog-post-1-comments'>View all comments on blog post 543</a>
-    </Link>
+    </Link> */}
     <br />
     <Link href='/blog/$post/comment/$id' as='/blog/321/comment/123'>
       <a id='view-nested-dynamic-cmnt'>View comment 123 on blog post 321</a>


### PR DESCRIPTION
This link is no longer required -- it was left over from optional routing.