### PR TITLE
Disable <title/> warning when React Helmet is used

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -207,7 +207,8 @@ export class Head extends Component<OriginProps> {
     // show a warning if Head contains <title> (only in development)
     if (process.env.NODE_ENV !== 'production') {
       children = React.Children.map(children, (child: any) => {
-        if (child && child.type === 'title') {
+        const isReactHelmet = child && child.props && child.props['data-react-helmet']
+        if (child && child.type === 'title' && !isReactHelmet) {
           console.warn(
             "Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title"
           )


### PR DESCRIPTION
Disabling this warning:
https://github.com/zeit/next.js/issues/4596

We use React Helmet in the project (according to `examples/with-react-helmet`).
Helmet `<title />` is injected into `_document` using `Helmet.renderStatic().` And then controlled by every page.
Everything is rendered correctly. And this warning is really annoying...