### PR TITLE
Allow to describe initial props in the NextPage type

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -27,14 +27,14 @@ declare module 'react' {
 /**
  * `Page` type, use it as a guide to create `pages`.
  */
-export type NextPage<P = {}> = {
+export type NextPage<P = {}, IP = P> = {
   (props: P): JSX.Element
   /**
    * Used for initial page load data population. Data returned from `getInitialProps` is serialized when server rendered.
    * Make sure to return plain `Object` without using `Date`, `Map`, `Set`.
    * @param ctx Context of `page`
    */
-  getInitialProps?(ctx: NextPageContext): Promise<P>
+  getInitialProps?(ctx: NextPageContext): Promise<IP>
 }
 
 export { NextPageContext, NextComponentType }


### PR DESCRIPTION
_@types/next_ provided the `NextFunctionComponent` type to describe pages. It allowed us to specify the type of initial props separately from the type of all the props a page component might get. This is useful, because we can wrap a page component into some HOC that provides the page with additional props which don't belong to initial props.
So, I'd like to add initial props as the second generic type parameter to the `NextPage` type.