### PR TITLE
Default `target` in `loadConfig` instead of `next build`

### DIFF
--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -15,7 +15,7 @@ const defaultConfig: { [key: string]: any } = {
   generateBuildId: () => null,
   generateEtags: true,
   pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
-  target: 'server',
+  target: process.env.__NEXT_BUILDER_EXPERIMENTAL_TARGET || 'server',
   poweredByHeader: true,
   onDemandEntries: {
     maxInactiveAge: 60 * 1000,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -67,7 +67,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   console.log()
 
   const config = loadConfig(PHASE_PRODUCTION_BUILD, dir, conf)
-  const target = config.target
+  const { target } = config
   const buildId = debug
     ? 'unoptimized-build'
     : await generateBuildId(config.generateBuildId, nanoid)

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -67,7 +67,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   console.log()
 
   const config = loadConfig(PHASE_PRODUCTION_BUILD, dir, conf)
-  const target = process.env.__NEXT_BUILDER_EXPERIMENTAL_TARGET || config.target
+  const target = config.target
   const buildId = debug
     ? 'unoptimized-build'
     : await generateBuildId(config.generateBuildId, nanoid)

--- a/test/integration/serverless-now/next.config.js
+++ b/test/integration/serverless-now/next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60
+  },
+  experimental: {
+    autoExport: true
+  }
+}

--- a/test/integration/serverless-now/pages/index.js
+++ b/test/integration/serverless-now/pages/index.js
@@ -1,0 +1,7 @@
+const Comp = () => {
+  return <div>Hello Serverless</div>
+}
+
+Comp.getInitialProps = () => ({})
+
+export default Comp

--- a/test/integration/serverless-now/test/index.test.js
+++ b/test/integration/serverless-now/test/index.test.js
@@ -21,7 +21,9 @@ describe('Serverless', () => {
       env: { __NEXT_BUILDER_EXPERIMENTAL_TARGET: 'serverless' }
     })
     appPort = await findPort()
-    app = await nextStart(appDir, appPort)
+    app = await nextStart(appDir, appPort, {
+      env: { __NEXT_BUILDER_EXPERIMENTAL_TARGET: 'serverless' }
+    })
   })
   afterAll(() => killApp(app))
 

--- a/test/integration/serverless-now/test/index.test.js
+++ b/test/integration/serverless-now/test/index.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { existsSync } from 'fs'
+import {
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  renderViaHTTP
+} from 'next-test-utils'
+const appDir = join(__dirname, '../')
+const serverlessDir = join(appDir, '.next/serverless/pages')
+let appPort
+let app
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+describe('Serverless', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir, [], {
+      env: { __NEXT_BUILDER_EXPERIMENTAL_TARGET: 'serverless' }
+    })
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+
+  it('should render the page', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    expect(html).toMatch(/Hello Serverless/)
+  })
+
+  it('should have rendered the index page to serverless build', () => {
+    expect(existsSync(join(serverlessDir, 'index.js'))).toBeTruthy()
+  })
+
+  it('should not output _app.js and _document.js to serverless build', () => {
+    expect(existsSync(join(serverlessDir, '_app.js'))).toBeFalsy()
+    expect(existsSync(join(serverlessDir, '_document.js'))).toBeFalsy()
+  })
+})

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -126,9 +126,9 @@ export function runNextCommand (argv, options = {}) {
   })
 }
 
-export function runNextCommandDev (argv, stdOut) {
+export function runNextCommandDev (argv, stdOut, opts = {}) {
   const cwd = path.dirname(require.resolve('next/package'))
-  const env = { ...process.env, NODE_ENV: undefined }
+  const env = { ...process.env, NODE_ENV: undefined, ...opts.env }
 
   return new Promise((resolve, reject) => {
     const instance = spawn('node', ['dist/bin/next', ...argv], { cwd, env })
@@ -172,8 +172,8 @@ export function nextExport (dir, { outdir }) {
   return runNextCommand(['export', dir, '--outdir', outdir])
 }
 
-export function nextStart (dir, port) {
-  return runNextCommandDev(['start', '-p', port, dir])
+export function nextStart (dir, port, opts = {}) {
+  return runNextCommandDev(['start', '-p', port, dir], undefined, opts)
 }
 
 // Kill a launched app

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -164,8 +164,8 @@ export function launchApp (dir, port) {
   return runNextCommandDev([dir, '-p', port])
 }
 
-export function nextBuild (dir, args = []) {
-  return runNextCommand(['build', dir, ...args])
+export function nextBuild (dir, args = [], opts = {}) {
+  return runNextCommand(['build', dir, ...args], opts)
 }
 
 export function nextExport (dir, { outdir }) {


### PR DESCRIPTION
We should set the target from the environment variable during `loadConfig` instead of in `next build`. This ensures all other locations in Next.js that rely on `config` can read the correct value to toggle behaviors.