### PR TITLE
Add types for `<Html>` and `<Head>` element

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1269,10 +1269,8 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head>
-          <style>{`body { margin: 0 } /* custom! */`}</style>
-        </Head>
-        <body className="custom_class">
+        <Head />
+        <body>
           <Main />
           <NextScript />
         </body>
@@ -1284,7 +1282,7 @@ class MyDocument extends Document {
 export default MyDocument
 ```
 
-All of `<Head />`, `<Main />` and `<NextScript />` are required for page to be properly rendered.
+All of `<Html>`, `<Head />`, `<Main />` and `<NextScript />` are required for page to be properly rendered.
 
 **Note: React-components outside of `<Main />` will not be initialised by the browser. Do _not_ add application logic here. If you need shared components in all your pages (like a menu or a toolbar), take a look at the `App` component instead.**
 

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -88,7 +88,12 @@ export default class Document<P = {}> extends Component<DocumentProps & P> {
   }
 }
 
-export class Html extends Component {
+export class Html extends Component<
+  React.DetailedHTMLProps<
+    React.HtmlHTMLAttributes<HTMLHtmlElement>,
+    HTMLHtmlElement
+  >
+> {
   static contextTypes = {
     _documentProps: PropTypes.any,
   }
@@ -105,7 +110,13 @@ export class Html extends Component {
   }
 }
 
-export class Head extends Component<OriginProps> {
+export class Head extends Component<
+  OriginProps &
+    React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLHeadElement>,
+      HTMLHeadElement
+    >
+> {
   static contextTypes = {
     _documentProps: PropTypes.any,
     _devOnlyInvalidateCacheQueryString: PropTypes.string,


### PR DESCRIPTION
Ran into this converting _document to Typescript, I couldn't add the `lang` attribute.