### PR TITLE
Avoid sending internal error messages to client

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -302,7 +302,7 @@ export default class Server {
       if (e instanceof ApiError) {
         sendError(res, e.statusCode, e.message)
       } else {
-        sendError(res, 500, e.message)
+        throw e
       }
     }
   }


### PR DESCRIPTION
With the current implementation of the api "express-like api", we are sending errors that are not caught in user land back to the client.

This PR aims at fixing this.