### PR TITLE
Add Typescript to next-mdx readme

### DIFF
--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -72,3 +72,7 @@ module.exports = withMDX({
   pageExtensions: ['js', 'jsx', 'mdx'],
 })
 ```
+
+## Typescript
+
+Follow [this guide](https://mdxjs.com/advanced/typescript) from the MDX docs.


### PR DESCRIPTION
I added a link to the MDX docs because to enable Typescript we do exactly the same.