### PR TITLE
Fix next start in serverless mode with public directory

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -13,6 +13,7 @@ import {
   PAGES_MANIFEST,
   PHASE_PRODUCTION_SERVER,
   SERVER_DIRECTORY,
+  SERVERLESS_DIRECTORY,
 } from '../lib/constants'
 import {
   getRouteMatcher,
@@ -322,7 +323,12 @@ export default class Server {
   private generatePublicRoutes(): Route[] {
     const routes: Route[] = []
     const publicFiles = recursiveReadDirSync(this.publicDir)
-    const serverBuildPath = join(this.distDir, SERVER_DIRECTORY)
+    const serverBuildPath = join(
+      this.distDir,
+      this.nextConfig.target === 'serverless'
+        ? SERVERLESS_DIRECTORY
+        : SERVER_DIRECTORY
+    )
     const pagesManifest = require(join(serverBuildPath, PAGES_MANIFEST))
 
     publicFiles.forEach(path => {

--- a/test/integration/serverless/public/hello.txt
+++ b/test/integration/serverless/public/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -31,6 +31,11 @@ describe('Serverless', () => {
     expect(html).toMatch(/Hello World/)
   })
 
+  it('should serve file from public folder', async () => {
+    const content = await renderViaHTTP(appPort, '/hello.txt')
+    expect(content.trim()).toBe('hello world')
+  })
+
   it('should render the page with dynamic import', async () => {
     const html = await renderViaHTTP(appPort, '/dynamic')
     expect(html).toMatch(/Hello!/)


### PR DESCRIPTION
Fixes loading of pages-manifest with `next start` in `serverless` mode