### PR TITLE
Don't confuse the user with an eagerly created `tsconfig.json`

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -25,41 +25,24 @@ function writeJson(fileName: string, object: object): Promise<void> {
   )
 }
 
-async function verifyNoTypeScript(dir: string) {
+async function hasTypeScript(dir: string): Promise<boolean> {
   const typescriptFiles = await recursiveReadDir(
     dir,
     /.*\.(ts|tsx)$/,
     /(node_modules|.*\.d\.ts)/
   )
 
-  if (typescriptFiles.length > 0) {
-    console.warn(
-      chalk.yellow(
-        `We detected TypeScript in your project (${chalk.bold(
-          `.${typescriptFiles[0]}`
-        )}) and created a ${chalk.bold('tsconfig.json')} file for you.`
-      )
-    )
-    console.warn()
-    return false
-  }
-  return true
+  return typescriptFiles.length > 0
 }
 
 export async function verifyTypeScriptSetup(dir: string): Promise<void> {
-  let firstTimeSetup = false
-  const yarnLockFile = path.join(dir, 'yarn.lock')
   const tsConfigPath = path.join(dir, 'tsconfig.json')
-  const toInstall: string[] = []
+  const yarnLockFile = path.join(dir, 'yarn.lock')
 
-  if (!(await exists(tsConfigPath))) {
-    if (await verifyNoTypeScript(dir)) {
-      return
-    }
-    await writeJson(tsConfigPath, {})
-    firstTimeSetup = true
-  }
+  const hasTsConfig = await exists(tsConfigPath)
   const isYarn = await exists(yarnLockFile)
+
+  const firstTimeSetup = !hasTsConfig && (await hasTypeScript(dir))
 
   // Ensure TypeScript is installed
   let typescriptPath = ''
@@ -151,6 +134,18 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
     getCanonicalFileName: (fileName: string) => fileName,
     getCurrentDirectory: ts.sys.getCurrentDirectory,
     getNewLine: () => os.EOL,
+  }
+
+  if (firstTimeSetup) {
+    console.log(
+      chalk.yellow(
+        `We detected TypeScript in your project and created a ${chalk.bold(
+          'tsconfig.json'
+        )} file for you.`
+      )
+    )
+
+    await writeJson(tsConfigPath, {})
   }
 
   const messages = []

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -145,6 +145,7 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
         )} file for you.`
       )
     )
+    console.log()
 
     await writeJson(tsConfigPath, {})
   }

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -41,8 +41,13 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
 
   const hasTsConfig = await exists(tsConfigPath)
   const isYarn = await exists(yarnLockFile)
+  const hasTypeScriptFiles = await hasTypeScript(dir)
 
-  let firstTimeSetup = !hasTsConfig && (await hasTypeScript(dir))
+  if (!(hasTsConfig || hasTypeScriptFiles)) {
+    return
+  }
+
+  let firstTimeSetup = !hasTsConfig && hasTypeScriptFiles
 
   // Ensure TypeScript is installed
   let typescriptPath = ''

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -42,12 +42,13 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
   const hasTsConfig = await exists(tsConfigPath)
   const isYarn = await exists(yarnLockFile)
 
-  const firstTimeSetup = !hasTsConfig && (await hasTypeScript(dir))
+  let firstTimeSetup = !hasTsConfig && (await hasTypeScript(dir))
 
   // Ensure TypeScript is installed
   let typescriptPath = ''
   let ts: typeof import('typescript')
 
+  const toInstall: string[] = []
   try {
     await resolveP('@types/react/index.d.ts', { basedir: dir })
   } catch (_) {


### PR DESCRIPTION
This prevents an eagerly created `tsconfig.json` with empty contents which can be confusing to the user if they haven't installed `typescript` yet.