### PR TITLE
Remove invalid meta type

### DIFF
--- a/packages/next-server/lib/head.tsx
+++ b/packages/next-server/lib/head.tsx
@@ -54,7 +54,7 @@ function onlyReactElement(
   return list.concat(child)
 }
 
-const METATYPES = ['name', 'httpEquiv', 'charSet', 'viewport', 'itemProp']
+const METATYPES = ['name', 'httpEquiv', 'charSet', 'itemProp']
 
 /*
  returns a function for filtering head child elements
@@ -84,7 +84,7 @@ function unique() {
           const metatype = METATYPES[i]
           if (!h.props.hasOwnProperty(metatype)) continue
 
-          if (metatype === 'charSet' || metatype === 'viewport') {
+          if (metatype === 'charSet') {
             if (metaTypes.has(metatype)) return false
             metaTypes.add(metatype)
           } else {


### PR DESCRIPTION
This seems to have been erroneously added when attempting to follow convention of `charSet`.

`<meta viewport="" />` isn't a valid tag 😄 -- this is already handled by the below "category" code (on the `name` prop): `<meta name="viewport" />`.