### PR TITLE
Respect custom webpack config 'stats' options

### DIFF
--- a/packages/next/build/compiler.ts
+++ b/packages/next/build/compiler.ts
@@ -1,8 +1,8 @@
 import webpack, { Stats } from 'webpack'
 
 export type CompilerResult = {
-  errors: Error[]
-  warnings: Error[]
+  errors: string[]
+  warnings: string[]
 }
 
 function generateStats(result: CompilerResult, stat: Stats): CompilerResult {

--- a/packages/next/build/compiler.ts
+++ b/packages/next/build/compiler.ts
@@ -6,11 +6,16 @@ export type CompilerResult = {
 }
 
 function generateStats(result: CompilerResult, stat: Stats): CompilerResult {
-  const { errors, warnings } = stat.toJson({
-    all: false,
-    warnings: true,
-    errors: true,
-  })
+  const statsConfig = stat.compilation.compiler.options.stats
+  const statsConfigOrDefault = statsConfig
+    ? statsConfig
+    : {
+        all: false,
+        warnings: true,
+        errors: true,
+      }
+
+  const { errors, warnings } = stat.toJson(statsConfigOrDefault)
   if (errors.length > 0) {
     result.errors.push(...errors)
   }

--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import textTable from 'next/dist/compiled/text-table'
 import createStore from 'next/dist/compiled/unistore'
 import stripAnsi from 'strip-ansi'
+import webpack from 'webpack'
 
 import formatWebpackMessages from '../../client/dev/error-overlay/format-webpack-messages'
 import { OutputState, store as consoleStore } from './store'
@@ -13,8 +14,8 @@ export function startedDevelopmentServer(appUrl: string) {
   consoleStore.setState({ appUrl })
 }
 
-let previousClient: any = null
-let previousServer: any = null
+let previousClient: webpack.Compiler | null = null
+let previousServer: webpack.Compiler | null = null
 
 type CompilerDiagnostics = {
   errors: string[] | null
@@ -196,8 +197,8 @@ export function ampValidation(
 }
 
 export function watchCompilers(
-  client: any,
-  server: any,
+  client: webpack.Compiler,
+  server: webpack.Compiler,
   enableTypeCheckingOnClient: boolean,
   onTypeChecked: (diagnostics: CompilerDiagnostics) => void
 ) {
@@ -212,7 +213,7 @@ export function watchCompilers(
 
   function tapCompiler(
     key: string,
-    compiler: any,
+    compiler: webpack.Compiler,
     hasTypeChecking: boolean,
     onEvent: (status: WebpackStatus) => void
   ) {
@@ -257,7 +258,7 @@ export function watchCompilers(
         )
     }
 
-    compiler.hooks.done.tap(`NextJsDone-${key}`, (stats: any) => {
+    compiler.hooks.done.tap(`NextJsDone-${key}`, stats => {
       buildStore.setState({ amp: {} })
 
       const statsConfig = stats.compilation.compiler.options.stats

--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -260,8 +260,17 @@ export function watchCompilers(
     compiler.hooks.done.tap(`NextJsDone-${key}`, (stats: any) => {
       buildStore.setState({ amp: {} })
 
+      const statsConfig = stats.compilation.compiler.options.stats
+      const statsConfigOrDefault = statsConfig
+        ? statsConfig
+        : {
+            all: false,
+            warnings: true,
+            errors: true,
+          }
+
       const { errors, warnings } = formatWebpackMessages(
-        stats.toJson({ all: false, warnings: true, errors: true })
+        stats.toJson(statsConfigOrDefault)
       )
 
       const hasErrors = errors && errors.length


### PR DESCRIPTION
Fixes #6349 

We're not respecting custom [`stats` options from the webpack config](https://webpack.js.org/configuration/stats/#stats), which keeps things like `warningsFilter` from working.

This PR fixes that so that we properly use the provided options if they are provided.