### PR TITLE
Add handling for invalid pages during autoExport

### DIFF
--- a/errors/page-without-valid-component.md
+++ b/errors/page-without-valid-component.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-While auto exporting a page a valid React Component wasn't found. This could mean you you have a file in `pages` that does `export default { some: 'object' }` instead of a React Component.
+While auto exporting a page a valid React Component wasn't found. This could mean you have a file in `pages` that does `export default { some: 'object' }` instead of a React Component.
 
 #### Possible Ways to Fix It
 

--- a/errors/page-without-valid-component.md
+++ b/errors/page-without-valid-component.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-While auto exporting a page a valid React Component wasn't found. This could mean you have a file in `pages` that does `export default { some: 'object' }` instead of a React Component.
+While auto exporting a page a valid React Component wasn't found. This could mean you have a file in `pages` that exports something that is not a React Component.
 
 #### Possible Ways to Fix It
 

--- a/errors/page-without-valid-component.md
+++ b/errors/page-without-valid-component.md
@@ -1,0 +1,9 @@
+# Page Without Valid React Component
+
+#### Why This Error Occurred
+
+While auto exporting a page a valid React Component wasn't found. This could mean you you have a file in `pages` that does `export default { some: 'object' }` instead of a React Component.
+
+#### Possible Ways to Fix It
+
+Move any non-page files that don't export a React Component as the default export to a different folder like `components` or `lib`.

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -280,6 +280,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   const { autoExport } = config.experimental
   const staticPages = new Set<string>()
+  const invalidPages = new Set<string>()
   const pageInfos = new Map<string, PageInfo>()
   let pagesManifest: any = {}
   let customAppGetInitialProps: boolean | undefined
@@ -336,14 +337,29 @@ export default async function build(dir: string, conf = null): Promise<void> {
       }
 
       if (customAppGetInitialProps === false && nonReservedPage) {
-        if (isPageStatic(serverBundle, runtimeEnvConfig)) {
-          staticPages.add(page)
-          isStatic = true
+        try {
+          if (isPageStatic(serverBundle, runtimeEnvConfig)) {
+            staticPages.add(page)
+            isStatic = true
+          }
+        } catch (err) {
+          if (err.code !== 'INVALID_DEFAULT_EXPORT') throw err
+          invalidPages.add(page)
         }
       }
     }
 
     pageInfos.set(page, { size, chunks, serverBundle, static: isStatic })
+  }
+
+  if (invalidPages.size > 0) {
+    throw new Error(
+      `autoExport failed: found page${
+        invalidPages.size === 1 ? '' : 's'
+      } without React Component as default export\n${[...invalidPages]
+        .map(pg => `pages${pg}`)
+        .join('\n')}\n`
+    )
   }
 
   if (Array.isArray(configs[0].plugins)) {

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -358,7 +358,9 @@ export default async function build(dir: string, conf = null): Promise<void> {
         invalidPages.size === 1 ? '' : 's'
       } without React Component as default export\n${[...invalidPages]
         .map(pg => `pages${pg}`)
-        .join('\n')}\n`
+        .join(
+          '\n'
+        )}\n\nSee https://err.sh/zeit/next.js/page-without-valid-component for more info.\n`
     )
   }
 

--- a/test/integration/invalid-page-autoExport/next.config.js
+++ b/test/integration/invalid-page-autoExport/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    autoExport: true
+  }
+}

--- a/test/integration/invalid-page-autoExport/pages/also-invalid.js
+++ b/test/integration/invalid-page-autoExport/pages/also-invalid.js
@@ -1,0 +1,1 @@
+export default 'just a string'

--- a/test/integration/invalid-page-autoExport/pages/also-valid.js
+++ b/test/integration/invalid-page-autoExport/pages/also-valid.js
@@ -1,0 +1,7 @@
+import React, { Component } from 'react'
+
+export default class AlsoValid extends Component {
+  render () {
+    return <div>Hi there</div>
+  }
+}

--- a/test/integration/invalid-page-autoExport/pages/invalid.js
+++ b/test/integration/invalid-page-autoExport/pages/invalid.js
@@ -1,0 +1,5 @@
+const obj = {
+  something: 'idk'
+}
+
+export default obj

--- a/test/integration/invalid-page-autoExport/pages/valid.js
+++ b/test/integration/invalid-page-autoExport/pages/valid.js
@@ -1,0 +1,1 @@
+export default () => <p>Hello world</p>

--- a/test/integration/invalid-page-autoExport/test/index.test.js
+++ b/test/integration/invalid-page-autoExport/test/index.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+/* global jasmine, test */
+import path from 'path'
+import { nextBuild } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = path.join(__dirname, '..')
+
+describe('Invalid Page autoExport', () => {
+  it('Fails softly with descriptive error', async () => {
+    const { stderr } = await nextBuild(appDir, [], { stderr: true })
+
+    expect(stderr).toMatch(
+      /autoExport failed: found pages without React Component as default export/
+    )
+    expect(stderr).toMatch(/pages\/invalid/)
+    expect(stderr).toMatch(/pages\/also-invalid/)
+  })
+})


### PR DESCRIPTION
This catches and gives a descriptive error when a user doesn't export a valid component from a page with `autoExport` enabled