### PR TITLE
Seperate client uri from server in with-apollo examples

### DIFF
--- a/examples/with-apollo-and-redux-saga/lib/initApollo.js
+++ b/examples/with-apollo-and-redux-saga/lib/initApollo.js
@@ -4,6 +4,9 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null
+const uri = process.browser
+  ? 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'  // Client URL
+  : 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'  // Server URL (must be absolute)
 
 // Polyfill fetch() on the server (used by apollo-client)
 if (!process.browser) {
@@ -16,7 +19,7 @@ function create (initialState) {
     connectToDevTools: process.browser,
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
-      uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
+      uri,
       credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
     }),
     cache: new InMemoryCache().restore(initialState || {})

--- a/examples/with-apollo-and-redux/lib/initApollo.js
+++ b/examples/with-apollo-and-redux/lib/initApollo.js
@@ -4,6 +4,9 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null
+const uri = process.browser
+  ? 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'  // Client URL
+  : 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'  // Server URL (must be absolute)
 
 // Polyfill fetch() on the server (used by apollo-client)
 if (!process.browser) {
@@ -16,7 +19,7 @@ function create (initialState) {
     connectToDevTools: process.browser,
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
-      uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
+      uri,
       credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
     }),
     cache: new InMemoryCache().restore(initialState || {})

--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -2,6 +2,9 @@ import { ApolloClient, InMemoryCache, HttpLink } from 'apollo-boost'
 import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null
+const uri = process.browser
+  ? 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'  // Client URL
+  : 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn'  // Server URL (must be absolute)
 
 function create (initialState) {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
@@ -9,7 +12,7 @@ function create (initialState) {
     connectToDevTools: process.browser,
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
-      uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
+      uri,
       credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
       // Use fetch() polyfill on the server
       fetch: !process.browser && fetch


### PR DESCRIPTION
Separating uri parameter passed to Apollo HttpLink in three with-apollo-* examples. The `with-apollo-auth` is untouched as it is integrated with graphcool more deeply.

### Why

For those who put up their own graphql server, it is common to expose `/graphql` as the graphql endpoint for their website.

Given a typical setting that we have a graphql server running at `localhost:3001` and next server running at `localhost:3000/`, with requests to `https://www.foo.bar/graphql` forwarded to `localhost:3001` and others to `localhost:3000`.
In the original code in this case, an unnecessary ssl negotiation will happen in SSR (from next server to the reverse proxy and to graphql server) and will consume more time comparing to posting directly to `localhost:3001` as they are in the same protected network.