### PR TITLE
(examples/with-immutable-redux-wrapper) Fix README.md

### DIFF
--- a/examples/with-immutable-redux-wrapper/README.md
+++ b/examples/with-immutable-redux-wrapper/README.md
@@ -20,7 +20,7 @@ Download the example:
 
 ```bash
 curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-immutable-redux-wrapper
-cd with-redux-wrapper
+cd with-immutable-redux-wrapper
 ```
 
 Install it and run:


### PR DESCRIPTION
There is a typo in folder name.
I've fixed it.
