### PR TITLE
Ensure Node types are installed (for `process.env` types)

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -36,6 +36,7 @@ async function checkDependencies({
   const requiredPackages = [
     { file: 'typescript', pkg: 'typescript' },
     { file: '@types/react/index.d.ts', pkg: '@types/react' },
+    { file: '@types/node/index.d.ts', pkg: '@types/node' },
   ]
 
   const missingPackages = requiredPackages.filter(p => {


### PR DESCRIPTION
This ensures the user has `@types/node` installed. This is for `process.env` autocompletion (and because Next supports SSR which runs in Node).