### PR TITLE
Correctly define NODE_ENV and `process.browser`

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -15,6 +15,7 @@ declare namespace NodeJS {
   interface ProcessEnv {
     readonly NODE_ENV: 'development' | 'production'
     readonly browser: boolean
+    readonly crossOrigin?: string
   }
 }
 

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -11,6 +11,13 @@ import {
 /// <reference types="react" />
 /// <reference types="react-dom" />
 
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly NODE_ENV: 'development' | 'production'
+    readonly browser: boolean
+  }
+}
+
 // Extend the React types with missing properties
 declare module 'react' {
   // <html amp=""> support


### PR DESCRIPTION
`process.env.NODE_ENV` can only be set to `development` or `production`, so this should help prevent users from tripping over themselves. Type checking isn't supported / ran in `next.config.js` so this won't affect their usage there (which is downright confusing anyway).

This also defines the non-existent `process.browser` and `process.crossOrigin` types that we define.