### PR TITLE
`typeof window` will always be undefined on the server

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -451,6 +451,9 @@ export default async function getBaseWebpackConfig(
           !config.experimental.autoExport &&
             config.experimental.exportTrailingSlash
         ),
+        ...(isServer
+          ? { 'typeof window': JSON.stringify('undefined') }
+          : undefined),
       }),
       !isServer &&
         new ReactLoadablePlugin({


### PR DESCRIPTION
This should allow Terser to tree shake code branches.

This change was suggested by @timneutkens after a conversation with @developit. 🙏  