### PR TITLE
`typeof window` is `object` on the client

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -453,7 +453,7 @@ export default async function getBaseWebpackConfig(
         ),
         ...(isServer
           ? { 'typeof window': JSON.stringify('undefined') }
-          : undefined),
+          : { 'typeof window': JSON.stringify('object') }),
       }),
       !isServer &&
         new ReactLoadablePlugin({


### PR DESCRIPTION
Follow up to https://github.com/zeit/next.js/pull/7605

This will allow the client-side bundles to be optimized as well.