### PR TITLE
Exit process after build

### DIFF
--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -55,11 +55,13 @@ const nextBuild: cliCommand = argv => {
     )
   }
 
-  build(dir).catch(err => {
-    // tslint:disable-next-line
-    console.error('> Build error occurred')
-    printAndExit(err)
-  })
+  build(dir)
+    .then(() => process.exit(0))
+    .catch(err => {
+      // tslint:disable-next-line
+      console.error('> Build error occurred')
+      printAndExit(err)
+    })
 }
 
 export { nextBuild }


### PR DESCRIPTION
The new `autoExport` feature requires we kill the process after building (in case of a SQL connection pool for SSR, etc).