### PR TITLE
Extract `isDynamicRoute` helper

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -15,6 +15,7 @@ import {
 import { rewriteUrlForNextExport } from './rewrite-url-for-export'
 import { getRouteMatcher } from './utils/route-matcher'
 import { getRouteRegex } from './utils/route-regex'
+import { isDynamicRoute } from './utils/is-dynamic'
 
 function toRoute(path: string): string {
   return path.replace(/\/$/, '') || '/'
@@ -273,8 +274,7 @@ export default class Router implements BaseRouter {
       const route = toRoute(pathname)
       const { shallow = false } = options
 
-      // detect dynamic routing
-      if (route.indexOf('/$') !== -1) {
+      if (isDynamicRoute(route)) {
         const { pathname: asPathname } = parse(as)
         const rr = getRouteRegex(route)
         const routeMatch = getRouteMatcher(rr)(asPathname)

--- a/packages/next-server/lib/router/utils/index.ts
+++ b/packages/next-server/lib/router/utils/index.ts
@@ -1,3 +1,4 @@
 export { getRouteMatcher } from './route-matcher'
 export { getRouteRegex } from './route-regex'
 export { getSortedRoutes } from './sorted-routes'
+export { isDynamicRoute } from './is-dynamic'

--- a/packages/next-server/lib/router/utils/is-dynamic.ts
+++ b/packages/next-server/lib/router/utils/is-dynamic.ts
@@ -1,0 +1,3 @@
+export function isDynamicRoute(route: string): boolean {
+  return route.indexOf('/$') !== -1
+}

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -19,6 +19,7 @@ import {
   getRouteMatcher,
   getRouteRegex,
   getSortedRoutes,
+  isDynamicRoute,
 } from '../lib/router/utils'
 import * as envConfig from '../lib/runtime-config'
 import { NextApiRequest, NextApiResponse } from '../lib/utils'
@@ -359,8 +360,8 @@ export default class Server {
 
   private getDynamicRoutes() {
     const manifest = require(this.buildManifest)
-    const dynamicRoutedPages = Object.keys(manifest.pages).filter(p =>
-      p.includes('/$')
+    const dynamicRoutedPages = Object.keys(manifest.pages).filter(
+      isDynamicRoute
     )
     return getSortedRoutes(dynamicRoutedPages).map(page => ({
       page,

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -2,6 +2,7 @@ import { loader } from 'webpack'
 import { join } from 'path'
 import { parse } from 'querystring'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next-server/constants'
+import { isDynamicRoute } from 'next-server/dist/lib/router/utils'
 
 export type ServerlessLoaderQuery = {
   page: string
@@ -42,7 +43,7 @@ const nextServerlessLoader: loader.Loader = function() {
     import {renderToHTML} from 'next-server/dist/server/render';
     import {sendHTML} from 'next-server/dist/server/send-html';
     ${
-      page.includes('/$')
+      isDynamicRoute(page)
         ? `import {getRouteMatcher, getRouteRegex} from 'next-server/dist/lib/router/utils';`
         : ''
     }
@@ -82,7 +83,7 @@ const nextServerlessLoader: loader.Loader = function() {
       try {
         ${page === '/_error' ? `res.statusCode = 404` : ''}
         ${
-          page.includes('/$')
+          isDynamicRoute(page)
             ? `const params = getRouteMatcher(getRouteRegex("${page}"))(parsedUrl.pathname) || {};`
             : `const params = {};`
         }

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -12,6 +12,7 @@ import { DataManagerContext } from 'next-server/dist/lib/data-manager-context'
 import { RouterContext } from 'next-server/dist/lib/router-context'
 import { DataManager } from 'next-server/dist/lib/data-manager'
 import { parse as parseQs, stringify as stringifyQs } from 'querystring'
+import { isDynamicRoute } from 'next-server/dist/lib/router/utils'
 
 // Polyfill Promise globally
 // This is needed because Webpack's dynamic loading(common chunks) code
@@ -83,7 +84,7 @@ class Container extends React.Component {
     // If it's a dynamic route (/$ inside) or has a querystring
     if (
       data.nextExport &&
-      (router.pathname.indexOf('/$') !== -1 || window.location.search)
+      (isDynamicRoute(router.pathname) || window.location.search)
     ) {
       // update query on mount for exported pages
       router.replace(

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -12,7 +12,8 @@ import Watchpack from 'watchpack'
 import {
   getRouteMatcher,
   getRouteRegex,
-  getSortedRoutes
+  getSortedRoutes,
+  isDynamicRoute
 } from 'next-server/dist/lib/router/utils'
 import React from 'react'
 
@@ -113,7 +114,7 @@ export default class DevServer extends Server {
           }
 
           let pageName = '/' + relative(pagesDir, fileName).replace(/\\+/g, '/')
-          if (!pageName.includes('/$')) {
+          if (!isDynamicRoute(pageName)) {
             continue
           }
 


### PR DESCRIPTION
This consolidates the logic that matches a dynamic route into a single file.

This is important as we iterate on our dynamic routing implementation from ongoing conversations in the RFC (https://github.com/zeit/next.js/issues/7607).