### PR TITLE
Fix typo in the example's code

### DIFF
--- a/examples/with-redux-reselect-recompose/reducers/index.js
+++ b/examples/with-redux-reselect-recompose/reducers/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux'
 import count, { initialState as countState } from './count'
 
-export const intitialState = {
+export const initialState = {
   count: countState
 }
 


### PR DESCRIPTION
Before the fix:
<img width="978" alt="1  khoangtrieu: tmux a (tmux) 2019-06-23 15-29-23" src="https://user-images.githubusercontent.com/3213579/59982749-c9ea8380-95cb-11e9-8d98-bfd444142bc9.png">
