### PR TITLE
Compile dependencies for IE11

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -405,12 +405,14 @@ export default async function getBaseWebpackConfig(
             /next-server[\\/]dist[\\/]lib/,
             /next[\\/]dist[\\/]client/,
             /next[\\/]dist[\\/]pages/,
+            /[\\/](strip-ansi|ansi-regex)[\\/]/,
           ],
           exclude: (path: string) => {
             if (
               /next-server[\\/]dist[\\/]lib/.test(path) ||
               /next[\\/]dist[\\/]client/.test(path) ||
-              /next[\\/]dist[\\/]pages/.test(path)
+              /next[\\/]dist[\\/]pages/.test(path) ||
+              /[\\/](strip-ansi|ansi-regex)[\\/]/
             ) {
               return false
             }


### PR DESCRIPTION
This PR compiles development-time dependencies that cause invalid syntax errors in IE 11 (ES 5).

Closes #7610
Closes #7612