### PR TITLE
Fix TypeScript typing

### DIFF
--- a/examples/with-typescript/next-env.d.ts
+++ b/examples/with-typescript/next-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="next" />

--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -84,7 +84,7 @@ if (args['--help']) {
 }
 
 const defaultEnv = command === 'dev' ? 'development' : 'production'
-process.env.NODE_ENV = process.env.NODE_ENV || defaultEnv
+;(process.env as any).NODE_ENV = process.env.NODE_ENV || defaultEnv
 
 // this needs to come after we set the correct NODE_ENV or
 // else it might cause SSR to break

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -286,7 +286,10 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
   if (!fs.existsSync(appTypeDeclarations)) {
     fs.writeFileSync(
       appTypeDeclarations,
-      `/// <reference types="next" />${os.EOL}`
+      '/// <reference types="next" />' +
+        os.EOL +
+        '/// <reference types="next/types/global" />' +
+        os.EOL
     )
   }
 }

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -252,7 +252,7 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
   }
 
   if (parsedTsConfig.include == null) {
-    appTsConfig.include = ['**/*.ts', '**/*.tsx']
+    appTsConfig.include = ['next-env.d.ts', '**/*.ts', '**/*.tsx']
   }
 
   if (messages.length > 0) {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -36,7 +36,8 @@
     "router.d.ts",
     "amp.js",
     "amp.d.ts",
-    "types/index.d.ts"
+    "types/index.d.ts",
+    "types/global.d.ts"
   ],
   "bin": {
     "next": "./dist/bin/next"

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="node" />
+
+// Extend the NodeJS namespace with Next.js-defined properties
+declare namespace NodeJS {
+  interface Process {
+    readonly browser: boolean
+  }
+
+  interface ProcessEnv {
+    readonly NODE_ENV: 'development' | 'production'
+  }
+}

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -7,6 +7,6 @@ declare namespace NodeJS {
   }
 
   interface ProcessEnv {
-    readonly NODE_ENV: 'development' | 'production'
+    readonly NODE_ENV: 'development' | 'production' | 'test'
   }
 }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -1,3 +1,7 @@
+/// <reference types="node" />
+/// <reference types="react" />
+/// <reference types="react-dom" />
+
 import React from 'react'
 
 import {
@@ -6,20 +10,6 @@ import {
   NextApiResponse,
   NextApiRequest,
 } from 'next-server/dist/lib/utils'
-
-/// <reference types="node" />
-/// <reference types="react" />
-/// <reference types="react-dom" />
-
-declare namespace NodeJS {
-  interface Process {
-    readonly browser: boolean
-  }
-
-  interface ProcessEnv {
-    readonly NODE_ENV: 'development' | 'production'
-  }
-}
 
 // Extend the React types with missing properties
 declare module 'react' {

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -12,10 +12,12 @@ import {
 /// <reference types="react-dom" />
 
 declare namespace NodeJS {
+  interface Process {
+    readonly browser: boolean
+  }
+
   interface ProcessEnv {
     readonly NODE_ENV: 'development' | 'production'
-    readonly browser: boolean
-    readonly crossOrigin?: string
   }
 }
 

--- a/test/integration/typescript/pages/hello.tsx
+++ b/test/integration/typescript/pages/hello.tsx
@@ -3,6 +3,7 @@ import { hello } from '../components/hello'
 import { World } from '../components/world'
 
 export default function HelloPage(): JSX.Element {
+  console.log(process.browser)
   return (
     <div>
       {hello()} <World />

--- a/test/integration/typescript/tsconfig.json
+++ b/test/integration/typescript/tsconfig.json
@@ -4,5 +4,5 @@
     "module": "esnext",
     "jsx": "preserve"
   },
-  "include": ["components", "pages"]
+  "include": ["next-env.d.ts", "components", "pages"]
 }


### PR DESCRIPTION
This correctly defines `process.browser` instead of `process.env.browser`.

It also removes `process.crossOrigin` because it's not found in our documentation anywhere and is mostly used for internal purposes.

This also **adds a test** for `process.browser`. 🎉 