### PR TITLE
Avoid lambda nomenclature when `target != 'serverless'`

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -443,5 +443,9 @@ export default async function build(dir: string, conf = null): Promise<void> {
     await flyingShuttle.save(allStaticPages, pageInfos)
   }
 
-  printTreeView(Object.keys(allMappedPages), allPageInfos)
+  printTreeView(
+    Object.keys(allMappedPages),
+    allPageInfos,
+    target === 'serverless'
+  )
 }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -37,7 +37,8 @@ export interface PageInfo {
 
 export function printTreeView(
   list: string[],
-  pageInfos: Map<string, PageInfo>
+  pageInfos: Map<string, PageInfo>,
+  serverless: boolean
 ) {
   const getPrettySize = (_size: number): string => {
     const size = prettyBytes(_size)
@@ -73,7 +74,9 @@ export function printTreeView(
             ? ' '
             : pageInfo && pageInfo.static
             ? chalk.bold('⚡')
-            : 'λ'
+            : serverless
+            ? 'λ'
+            : 'σ'
         } ${item}`,
         ...(pageInfo
           ? [
@@ -104,13 +107,21 @@ export function printTreeView(
   console.log(
     textTable(
       [
-        [
-          'λ',
-          '(Lambda)',
-          `page was emitted as a lambda (i.e. ${chalk.cyan(
-            'getInitialProps'
-          )})`,
-        ],
+        serverless
+          ? [
+              'λ',
+              '(Lambda)',
+              `page was emitted as a lambda (i.e. ${chalk.cyan(
+                'getInitialProps'
+              )})`,
+            ]
+          : [
+              'σ',
+              '(Server)',
+              `page will be server rendered (i.e. ${chalk.cyan(
+                'getInitialProps'
+              )})`,
+            ],
         [
           chalk.bold('⚡'),
           '(Static File)',


### PR DESCRIPTION
This will prevent user confusion about their builds being custom servers / next-powered server / or serverless.