### PR TITLE
Remove usage of `process.browser`

### DIFF
--- a/examples/with-apollo-and-redux-saga/lib/initApollo.js
+++ b/examples/with-apollo-and-redux-saga/lib/initApollo.js
@@ -6,15 +6,16 @@ import fetch from 'isomorphic-unfetch'
 let apolloClient = null
 
 // Polyfill fetch() on the server (used by apollo-client)
-if (!process.browser) {
+if (typeof window === 'undefined') {
   global.fetch = fetch
 }
 
 function create (initialState) {
+  const isBrowser = typeof window !== 'undefined'
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
   return new ApolloClient({
-    connectToDevTools: process.browser,
-    ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
+    connectToDevTools: isBrowser,
+    ssrMode: !isBrowser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
       credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
@@ -26,7 +27,7 @@ function create (initialState) {
 export default function initApollo (initialState) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return create(initialState)
   }
 

--- a/examples/with-apollo-and-redux-saga/lib/withApollo.js
+++ b/examples/with-apollo-and-redux-saga/lib/withApollo.js
@@ -34,7 +34,7 @@ export default ComposedComponent => {
 
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
-      if (!process.browser) {
+      if (typeof window === 'undefined') {
         const apollo = initApollo()
 
         try {

--- a/examples/with-apollo-and-redux/lib/initApollo.js
+++ b/examples/with-apollo-and-redux/lib/initApollo.js
@@ -6,15 +6,16 @@ import fetch from 'isomorphic-unfetch'
 let apolloClient = null
 
 // Polyfill fetch() on the server (used by apollo-client)
-if (!process.browser) {
+if (typeof window === 'undefined') {
   global.fetch = fetch
 }
 
 function create (initialState) {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
+  const isBrowser = typeof window !== 'undefined'
   return new ApolloClient({
-    connectToDevTools: process.browser,
-    ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
+    connectToDevTools: isBrowser,
+    ssrMode: !isBrowser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
       credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
@@ -26,7 +27,7 @@ function create (initialState) {
 export default function initApollo (initialState) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return create(initialState)
   }
 

--- a/examples/with-apollo-and-redux/lib/withApollo.js
+++ b/examples/with-apollo-and-redux/lib/withApollo.js
@@ -34,7 +34,7 @@ export default ComposedComponent => {
 
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
-      if (!process.browser) {
+      if (typeof window === 'undefined') {
         const apollo = initApollo()
 
         try {

--- a/examples/with-apollo-auth/lib/initApollo.js
+++ b/examples/with-apollo-auth/lib/initApollo.js
@@ -6,7 +6,7 @@ import fetch from 'isomorphic-unfetch'
 let apolloClient = null
 
 // Polyfill fetch() on the server (used by apollo-client)
-if (!process.browser) {
+if (typeof window === 'undefined') {
   global.fetch = fetch
 }
 
@@ -28,9 +28,10 @@ function create (initialState, { getToken, fetchOptions }) {
   })
 
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
+  const isBrowser = typeof window !== 'undefined'
   return new ApolloClient({
-    connectToDevTools: process.browser,
-    ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
+    connectToDevTools: isBrowser,
+    ssrMode: !isBrowser, // Disables forceFetch on the server (so queries are only run once)
     link: authLink.concat(httpLink),
     cache: new InMemoryCache().restore(initialState || {})
   })
@@ -39,7 +40,7 @@ function create (initialState, { getToken, fetchOptions }) {
 export default function initApollo (initialState, options) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     let fetchOptions = {}
     // If you are using a https_proxy, add fetchOptions with 'https-proxy-agent' agent instance
     // 'https-proxy-agent' is required here because it's a sever-side only module

--- a/examples/with-apollo-auth/lib/withApollo.js
+++ b/examples/with-apollo-auth/lib/withApollo.js
@@ -43,7 +43,7 @@ export default App => {
         return {}
       }
 
-      if (!process.browser) {
+      if (typeof window === 'undefined') {
         // Run all graphql queries in the component tree
         // and extract the resulting data
         try {

--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -5,14 +5,15 @@ let apolloClient = null
 
 function create (initialState) {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
+  const isBrowser = typeof window !== 'undefined'
   return new ApolloClient({
-    connectToDevTools: process.browser,
-    ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
+    connectToDevTools: isBrowser,
+    ssrMode: !isBrowser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
       credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
       // Use fetch() polyfill on the server
-      fetch: !process.browser && fetch
+      fetch: !isBrowser && fetch
     }),
     cache: new InMemoryCache().restore(initialState || {})
   })
@@ -21,7 +22,7 @@ function create (initialState) {
 export default function initApollo (initialState) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return create(initialState)
   }
 

--- a/examples/with-apollo/lib/with-apollo-client.js
+++ b/examples/with-apollo/lib/with-apollo-client.js
@@ -17,7 +17,7 @@ export default App => {
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
       const apollo = initApollo()
-      if (!process.browser) {
+      if (typeof window === 'undefined') {
         try {
           // Run all GraphQL queries
           await getDataFromTree(

--- a/examples/with-cookie-auth/www/pages/profile.js
+++ b/examples/with-cookie-auth/www/pages/profile.js
@@ -44,7 +44,7 @@ Profile.getInitialProps = async ctx => {
   const url = `${process.env.API_URL}/api/profile.js`
 
   const redirectOnError = () =>
-    process.browser
+    typeof window !== 'undefined'
       ? Router.push('/login')
       : ctx.res.writeHead(302, { Location: '/login' }).end()
 

--- a/examples/with-graphql-hooks/lib/init-graphql.js
+++ b/examples/with-graphql-hooks/lib/init-graphql.js
@@ -6,17 +6,17 @@ let graphQLClient = null
 
 function create (initialState = {}) {
   return new GraphQLClient({
-    ssrMode: !process.browser,
+    ssrMode: typeof window === 'undefined',
     url: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn',
     cache: memCache({ initialState }),
-    fetch: process.browser ? fetch.bind() : unfetch, // eslint-disable-line
+    fetch: typeof window !== 'undefined' ? fetch.bind() : unfetch, // eslint-disable-line
   })
 }
 
 export default function initGraphQL (initialState) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return create(initialState)
   }
 

--- a/examples/with-graphql-hooks/lib/with-graphql-client.js
+++ b/examples/with-graphql-hooks/lib/with-graphql-client.js
@@ -18,7 +18,7 @@ export default App => {
       // and extract the resulting data
       const graphQLClient = initGraphQL()
       let graphQLState = {}
-      if (!process.browser) {
+      if (typeof window === 'undefined') {
         try {
           // Run all GraphQL queries
           graphQLState = await getInitialState({

--- a/examples/with-mobx-react-lite/store.js
+++ b/examples/with-mobx-react-lite/store.js
@@ -2,7 +2,7 @@ import { action } from 'mobx'
 import { useObservable, useStaticRendering } from 'mobx-react-lite'
 import { createContext, useCallback } from 'react'
 
-const isServer = !process.browser
+const isServer = typeof window === 'undefined'
 useStaticRendering(isServer)
 
 let StoreContext = createContext()

--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -21,7 +21,7 @@ class MyMobxApp extends App {
 
   constructor(props) {
     super(props)
-    const isServer = !process.browser
+    const isServer = typeof window === 'undefined'
     this.mobxStore = isServer
       ? props.initialMobxState
       : initializeStore(props.initialMobxState)

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -1,7 +1,7 @@
 import { action, observable } from 'mobx'
 import { useStaticRendering } from 'mobx-react'
 
-const isServer = !process.browser
+const isServer = typeof window === 'undefined'
 useStaticRendering(isServer)
 
 class Store {

--- a/examples/with-overmind/pages/_app.js
+++ b/examples/with-overmind/pages/_app.js
@@ -24,7 +24,7 @@ class MyApp extends App {
 
     const mutations = props.pageProps.mutations || []
 
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       // On the client we just instantiate the Overmind instance and run
       // the "changePage" action
       this.overmind = createOvermind(config)

--- a/examples/with-portals-ssr/pages/_app.js
+++ b/examples/with-portals-ssr/pages/_app.js
@@ -2,7 +2,7 @@ import React from 'react'
 import App, { Container } from 'next/app'
 import { prepareClientPortals } from '@jesstelford/react-portal-universal'
 
-if (process.browser) {
+if (typeof window !== 'undefined') {
   // On the client, we have to run this once before React attempts a render.
   // Here in _app is a great place to do it as this file is only required once,
   // and right now (outside the constructor) is before React is invoked.

--- a/examples/with-react-esi/src/components/BreakingNews.js
+++ b/examples/with-react-esi/src/components/BreakingNews.js
@@ -11,8 +11,9 @@ const BreakingNews = props => (
           <p>{breaking.body}</p>
         </article>
       ))}
-    We are <b>{process.browser ? 'client-side' : 'server-side'}</b> (now, check
-    the source of this page)
+    We are{' '}
+    <b>{typeof window !== 'undefined' ? 'client-side' : 'server-side'}</b> (now,
+    check the source of this page)
     <div>
       <small>generated at {new Date().toISOString()}</small>
     </div>

--- a/examples/with-react-esi/src/components/Weather.js
+++ b/examples/with-react-esi/src/components/Weather.js
@@ -7,7 +7,7 @@ export default class TopArticles extends React.Component {
   static async getInitialProps ({ props, req, res }) {
     // Fetch the weather from a remote API, it may take some time...
     return new Promise(resolve => {
-      console.log(process.browser ? 'client-side' : 'server-side')
+      console.log(typeof window !== 'undefined' ? 'client-side' : 'server-side')
       // Simulate a delay (slow network, huge computation...)
       setTimeout(
         () =>
@@ -21,7 +21,7 @@ export default class TopArticles extends React.Component {
   }
 
   render () {
-    console.log(process.browser ? 'client-side' : 'server-side')
+    console.log(typeof window !== 'undefined' ? 'client-side' : 'server-side')
 
     return (
       <section>

--- a/examples/with-react-multi-carousel/src/getPageContext.js
+++ b/examples/with-react-multi-carousel/src/getPageContext.js
@@ -43,7 +43,7 @@ let pageContext
 export default function getPageContext () {
   // Make sure to create a new context for every server-side request so that data
   // isn't shared between connections (which would be bad).
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return createPageContext()
   }
 

--- a/examples/with-react-relay-network-modern/lib/createEnvironment/index.js
+++ b/examples/with-react-relay-network-modern/lib/createEnvironment/index.js
@@ -1,6 +1,7 @@
 import 'isomorphic-fetch'
 
-export const { initEnvironment, createEnvironment } = (!process.browser
+export const { initEnvironment, createEnvironment } = (typeof window ===
+'undefined'
   ? require('./server')
   : require('./client')
 ).default

--- a/examples/with-react-uwp/pages/index.js
+++ b/examples/with-react-uwp/pages/index.js
@@ -9,7 +9,7 @@ import { Button, ColorPicker, DatePicker, ProgressRing } from 'react-uwp'
 class Index extends Component {
   static async getInitialProps ({ req }) {
     let userAgent
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       userAgent = navigator.userAgent
     } else {
       userAgent = req.headers['user-agent']

--- a/examples/with-relay-modern-server-express/lib/createRelayEnvironment.js
+++ b/examples/with-relay-modern-server-express/lib/createRelayEnvironment.js
@@ -7,7 +7,8 @@ let relayEnvironment = null
 // and returns its results as a Promise:
 function fetchQuery (operation, variables, cacheConfig, uploadables) {
   // Because we implement the graphql server, the client must to point to the same host
-  const relayServer = process.browser ? '' : process.env.RELAY_SERVER
+  const relayServer =
+    typeof window !== 'undefined' ? '' : process.env.RELAY_SERVER
   return fetch(`${relayServer}/graphql`, {
     method: 'POST',
     headers: {
@@ -28,7 +29,7 @@ export default function initEnvironment ({ records = {} } = {}) {
 
   // Make sure to create a new Relay environment for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return new Environment({
       network,
       store

--- a/examples/with-relay-modern/lib/createRelayEnvironment.js
+++ b/examples/with-relay-modern/lib/createRelayEnvironment.js
@@ -26,7 +26,7 @@ export default function initEnvironment ({ records = {} } = {}) {
 
   // Make sure to create a new Relay environment for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return new Environment({
       network,
       store

--- a/examples/with-sentry/utils/sentry.js
+++ b/examples/with-sentry/utils/sentry.js
@@ -1,5 +1,4 @@
 // NOTE: This require will be replaced with `@sentry/browser` when
-// process.browser === true thanks to the webpack config in next.config.js
 const Sentry = require('@sentry/node')
 const SentryIntegrations = require('@sentry/integrations')
 const Cookie = require('js-cookie')
@@ -53,7 +52,7 @@ module.exports = (release = process.env.SENTRY_RELEASE) => {
             scope.setExtra('statusCode', res.statusCode)
           }
 
-          if (process.browser) {
+          if (typeof window !== 'undefined') {
             scope.setTag('ssr', false)
             scope.setExtra('query', query)
             scope.setExtra('pathname', pathname)

--- a/examples/with-unstated/pages/_app.js
+++ b/examples/with-unstated/pages/_app.js
@@ -6,7 +6,7 @@ import { counterStore } from '../containers/CounterContainer'
 class MyApp extends App {
   static async getInitialProps () {
     // do your server state here
-    if (!process.browser) {
+    if (typeof window === 'undefined') {
       // reset state for each request
       counterStore.resetState()
       // process state, in this case counter start with 999
@@ -20,7 +20,7 @@ class MyApp extends App {
     super(props)
     // pass the state to client store
     // serverState will be reset when client navigate with Link
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       counterStore.initState(props.serverState.count)
     }
   }

--- a/packages/next/lib/data.ts
+++ b/packages/next/lib/data.ts
@@ -47,7 +47,7 @@ export function createHook(
     }
 
     // @ts-ignore webpack optimization
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       const res = fetch(router.route + '?' + stringify(router.query), {
         headers: {
           accept: 'application/amp.bind+json',


### PR DESCRIPTION
This removes the use of a legacy `process.browser` field in favor of `typeof window`.