### PR TITLE
Update prefetch check to prevent re-prefetching

### DIFF
--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -165,8 +165,12 @@ export default class PageLoader {
 
   async prefetch (route) {
     route = this.normalizeRoute(route)
-    const scriptRoute = route === '/' ? '/index.js' : `${route}.js`
-    if (this.prefetchCache.has(scriptRoute)) {
+    const scriptRoute = `${route === '/' ? '/index' : route}.js`
+
+    if (
+      this.prefetchCache.has(scriptRoute) ||
+      document.getElementById(`__NEXT_PAGE__${route}`)
+    ) {
       return
     }
     this.prefetchCache.add(scriptRoute)

--- a/test/integration/flying-shuttle/test/index.test.js
+++ b/test/integration/flying-shuttle/test/index.test.js
@@ -148,6 +148,22 @@ describe('Flying Shuttle', () => {
     }
   })
 
+  it('should not re-prefetch for the page its already on', async () => {
+    const browser = await webdriver(appPort, '/')
+    const links = await browser.elementsByCss('link[rel=preload]')
+    let found = false
+
+    for (const link of links) {
+      const href = await link.getAttribute('href')
+      if (href.endsWith('index.js')) {
+        found = true
+        break
+      }
+    }
+    expect(found).toBe(false)
+    if (browser) await browser.close()
+  })
+
   it('should render /index', async () => {
     const html = await renderViaHTTP(secondAppPort, '/')
     expect(html).toMatch(/omega lol/)


### PR DESCRIPTION
This prevents re-prefetching. For example, if you are on page `/dashboard` and you have a link to `/dashboard` it will prefetch it as `/_next/static/client/pages/dashboard.cHZNhycGW7BNNabRlJdK5.js` and then also prefetch it as  `/_next/static/Bi4Mtg2_ooAIAQGumY5XD/pages/dashboard.js`