### PR TITLE
Fix missing .test on exclude Regex in webpack-config

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -412,7 +412,7 @@ export default async function getBaseWebpackConfig(
               /next-server[\\/]dist[\\/]lib/.test(path) ||
               /next[\\/]dist[\\/]client/.test(path) ||
               /next[\\/]dist[\\/]pages/.test(path) ||
-              /[\\/](strip-ansi|ansi-regex)[\\/]/
+              /[\\/](strip-ansi|ansi-regex)[\\/]/.test(path)
             ) {
               return false
             }


### PR DESCRIPTION
Just fixes `.test(path)` that was missing on a Regex in webpack-config