### PR TITLE
Make recursiveReadDir return sorted array

### DIFF
--- a/packages/next/lib/recursive-readdir.ts
+++ b/packages/next/lib/recursive-readdir.ts
@@ -42,5 +42,5 @@ export async function recursiveReadDir(
     })
   )
 
-  return arr
+  return arr.sort()
 }


### PR DESCRIPTION
This function is used to return the /pages folder content.
The way it is today is that every run might result in a different order of files, which makes the whole webpack chunks be different.
An ordered list of files will result in a deterministic build, which will improve caching.