### PR TITLE
Fix memory leak from requiring pages

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -274,6 +274,15 @@ export function isPageStatic(
   try {
     nextEnvConfig.setConfig(runtimeEnvConfig)
     const Comp = require(serverBundle).default
+
+    // clear cache to prevent memory leak
+    const mod = require.cache[serverBundle]
+    delete require.cache[serverBundle]
+    if (mod.parent) {
+      const idx = mod.parent.children.indexOf(mod)
+      mod.parent.children.splice(idx, 1)
+    }
+
     if (!Comp || !isValidElementType(Comp) || typeof Comp === 'string') {
       const invalidPage = new Error('invalid-page')
       ;(invalidPage as any).code = 'INVALID_DEFAULT_EXPORT'


### PR DESCRIPTION
When requiring a lot of big pages during build the `require.cache` can become extremely big causing an out of memory error. This manually clears the cache to prevent that 