### PR TITLE
Updating hapijs package name

### DIFF
--- a/examples/custom-server-hapi/package.json
+++ b/examples/custom-server-hapi/package.json
@@ -7,7 +7,7 @@
     "start": "NODE_ENV=production node server.js"
   },
   "dependencies": {
-    "hapi": "^18.1.0",
+    "@hapi/hapi": "^18.3.1",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/examples/custom-server-hapi/server.js
+++ b/examples/custom-server-hapi/server.js
@@ -1,5 +1,5 @@
 const next = require('next')
-const Hapi = require('hapi')
+const Hapi = require('@hapi/hapi')
 const {
   pathWrapper,
   defaultHandlerWrapper,


### PR DESCRIPTION
Hapi was moved to a new module under the name [@hapijs/hapi](https://www.npmjs.com/package/@hapi/hapi).

Right now installing just as hapi is giving you this warning:

```bash
npm WARN deprecated hapi@18.1.0: This module has moved and is now available at @hapi/hapi. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
```
This change does not affect the integration with next and it continues to work great.