### PR TITLE
Parallelize requiring pages for static check

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -373,6 +373,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
           } catch (err) {
             if (err.message !== 'INVALID_DEFAULT_EXPORT') throw err
             invalidPages.add(page)
+            staticCheckSema.release()
           }
         }
       }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -371,7 +371,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
               isStatic = true
             }
           } catch (err) {
-            if (err.code !== 'INVALID_DEFAULT_EXPORT') throw err
+            if (err.message !== 'INVALID_DEFAULT_EXPORT') throw err
             invalidPages.add(page)
           }
         }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -295,7 +295,9 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   process.env.NEXT_PHASE = PHASE_PRODUCTION_BUILD
 
-  const staticCheckSema = new Sema(5, { capacity: pageKeys.length })
+  const staticCheckSema = new Sema(config.experimental.cpus, {
+    capacity: pageKeys.length,
+  })
   const staticCheckWorkers = workerFarm(
     {
       maxConcurrentCalls: config.experimental.cpus,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -38,6 +38,8 @@ import {
 import { writeBuildId } from './write-build-id'
 import { recursiveReadDir } from '../lib/recursive-readdir'
 import mkdirpOrig from 'mkdirp'
+import workerFarm from 'worker-farm'
+import { Sema } from 'async-sema'
 
 const fsUnlink = promisify(fs.unlink)
 const fsRmdir = promisify(fs.rmdir)
@@ -45,6 +47,8 @@ const fsMove = promisify(fs.rename)
 const fsReadFile = promisify(fs.readFile)
 const fsWriteFile = promisify(fs.writeFile)
 const mkdirp = promisify(mkdirpOrig)
+
+const staticCheckWorker = require.resolve('./static-checker')
 
 export default async function build(dir: string, conf = null): Promise<void> {
   if (!(await isWriteable(dir))) {
@@ -291,66 +295,91 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   process.env.NEXT_PHASE = PHASE_PRODUCTION_BUILD
 
-  for (const page of pageKeys) {
-    const chunks = getPageChunks(page)
+  const staticCheckSema = new Sema(5, { capacity: pageKeys.length })
+  const staticCheckWorkers = workerFarm(
+    {
+      maxConcurrentCalls: config.experimental.cpus,
+    },
+    staticCheckWorker,
+    ['default']
+  )
 
-    const actualPage = page === '/' ? '/index' : page
-    const size = await getPageSizeInKb(actualPage, distPath, buildId)
-    const bundleRelative = path.join(
-      target === 'serverless' ? 'pages' : `static/${buildId}/pages`,
-      actualPage + '.js'
-    )
-    const serverBundle = path.join(
-      distPath,
-      target === 'serverless' ? SERVERLESS_DIRECTORY : SERVER_DIRECTORY,
-      bundleRelative
-    )
+  await Promise.all(
+    pageKeys.map(async page => {
+      const chunks = getPageChunks(page)
 
-    let isStatic = false
+      const actualPage = page === '/' ? '/index' : page
+      const size = await getPageSizeInKb(actualPage, distPath, buildId)
+      const bundleRelative = path.join(
+        target === 'serverless' ? 'pages' : `static/${buildId}/pages`,
+        actualPage + '.js'
+      )
+      const serverBundle = path.join(
+        distPath,
+        target === 'serverless' ? SERVERLESS_DIRECTORY : SERVER_DIRECTORY,
+        bundleRelative
+      )
 
-    if (autoExport) {
-      pagesManifest[page] = bundleRelative.replace(/\\/g, '/')
+      let isStatic = false
 
-      const runtimeEnvConfig = {
-        publicRuntimeConfig: config.publicRuntimeConfig,
-        serverRuntimeConfig: config.serverRuntimeConfig,
-      }
-      const nonReservedPage = !page.match(/^\/(_app|_error|_document|api)/)
+      if (autoExport) {
+        pagesManifest[page] = bundleRelative.replace(/\\/g, '/')
 
-      if (nonReservedPage && customAppGetInitialProps === undefined) {
-        customAppGetInitialProps = hasCustomAppGetInitialProps(
-          target === 'serverless'
-            ? serverBundle
-            : path.join(
-                distPath,
-                SERVER_DIRECTORY,
-                `/static/${buildId}/pages/_app.js`
-              ),
-          runtimeEnvConfig
-        )
+        const runtimeEnvConfig = {
+          publicRuntimeConfig: config.publicRuntimeConfig,
+          serverRuntimeConfig: config.serverRuntimeConfig,
+        }
+        const nonReservedPage = !page.match(/^\/(_app|_error|_document|api)/)
 
-        if (customAppGetInitialProps) {
-          console.warn(
-            'Opting out of automatic exporting due to custom `getInitialProps` in `pages/_app`\n'
+        if (nonReservedPage && customAppGetInitialProps === undefined) {
+          customAppGetInitialProps = hasCustomAppGetInitialProps(
+            target === 'serverless'
+              ? serverBundle
+              : path.join(
+                  distPath,
+                  SERVER_DIRECTORY,
+                  `/static/${buildId}/pages/_app.js`
+                ),
+            runtimeEnvConfig
           )
-        }
-      }
 
-      if (customAppGetInitialProps === false && nonReservedPage) {
-        try {
-          if (isPageStatic(serverBundle, runtimeEnvConfig)) {
-            staticPages.add(page)
-            isStatic = true
+          if (customAppGetInitialProps) {
+            console.warn(
+              'Opting out of automatic exporting due to custom `getInitialProps` in `pages/_app`\n'
+            )
           }
-        } catch (err) {
-          if (err.code !== 'INVALID_DEFAULT_EXPORT') throw err
-          invalidPages.add(page)
+        }
+
+        if (customAppGetInitialProps === false && nonReservedPage) {
+          try {
+            await staticCheckSema.acquire()
+            const result: any = await new Promise((resolve, reject) => {
+              staticCheckWorkers.default(
+                { serverBundle, runtimeEnvConfig },
+                (error: Error | null, result: any) => {
+                  if (error) return reject(error)
+                  resolve(result || {})
+                }
+              )
+            })
+            staticCheckSema.release()
+
+            if (result.isStatic) {
+              staticPages.add(page)
+              isStatic = true
+            }
+          } catch (err) {
+            if (err.code !== 'INVALID_DEFAULT_EXPORT') throw err
+            invalidPages.add(page)
+          }
         }
       }
-    }
 
-    pageInfos.set(page, { size, chunks, serverBundle, static: isStatic })
-  }
+      pageInfos.set(page, { size, chunks, serverBundle, static: isStatic })
+    })
+  )
+
+  workerFarm.end(staticCheckWorkers)
 
   if (invalidPages.size > 0) {
     throw new Error(

--- a/packages/next/build/static-checker.ts
+++ b/packages/next/build/static-checker.ts
@@ -1,0 +1,14 @@
+import { isPageStatic } from './utils'
+
+export default function worker(
+  options: any,
+  callback: (err: Error | null, data?: any) => void
+) {
+  try {
+    const { serverBundle, runtimeEnvConfig } = options || ({} as any)
+    const isStatic = isPageStatic(serverBundle, runtimeEnvConfig)
+    callback(null, { isStatic })
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -276,9 +276,7 @@ export function isPageStatic(
     const Comp = require(serverBundle).default
 
     if (!Comp || !isValidElementType(Comp) || typeof Comp === 'string') {
-      const invalidPage = new Error('invalid-page')
-      ;(invalidPage as any).code = 'INVALID_DEFAULT_EXPORT'
-      throw invalidPage
+      throw new Error('INVALID_DEFAULT_EXPORT')
     }
     return typeof (Comp as any).getInitialProps !== 'function'
   } catch (err) {

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -275,14 +275,6 @@ export function isPageStatic(
     nextEnvConfig.setConfig(runtimeEnvConfig)
     const Comp = require(serverBundle).default
 
-    // clear cache to prevent memory leak
-    const mod = require.cache[serverBundle]
-    delete require.cache[serverBundle]
-    if (mod.parent) {
-      const idx = mod.parent.children.indexOf(mod)
-      mod.parent.children.splice(idx, 1)
-    }
-
     if (!Comp || !isValidElementType(Comp) || typeof Comp === 'string') {
       const invalidPage = new Error('invalid-page')
       ;(invalidPage as any).code = 'INVALID_DEFAULT_EXPORT'


### PR DESCRIPTION
This prevents an OOM in build and speeds up checking