### PR TITLE
Fix maxConcurrentCalls used instead of maxConcurrentWorkers

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -300,7 +300,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   })
   const staticCheckWorkers = workerFarm(
     {
-      maxConcurrentCalls: config.experimental.cpus,
+      maxConcurrentWorkers: config.experimental.cpus,
     },
     staticCheckWorker,
     ['default']


### PR DESCRIPTION
Fixes typo for `maxConcurrentWorkers` which can cause error since it's limiting the wrong thing