### PR TITLE
Make DefaultLoading return null for dynamic

### DIFF
--- a/packages/next-server/lib/dynamic.tsx
+++ b/packages/next-server/lib/dynamic.tsx
@@ -67,7 +67,7 @@ export function noSSR<P = {}>(
 }
 
 function DefaultLoading() {
-  return <p>loading...</p>
+  return null
 }
 
 // function dynamic<P = {}, O extends DynamicOptions>(options: O):


### PR DESCRIPTION
Removes the default of `Loading...` to prevent unwanted behavior
