### PR TITLE
Remove "small" wording from runtime config overhead

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1698,7 +1698,7 @@ AuthMethod({ key: process.env.CUSTOM_KEY, secret: process.env.CUSTOM_SECRET })
 > **Warning:** Note that this option is not available when using `target: 'serverless'`
 
 > **Warning:** Generally you want to use build-time configuration to provide your configuration.
-> The reason for this is that runtime configuration adds a small rendering / initialization overhead.
+> The reason for this is that runtime configuration adds rendering / initialization overhead.
 
 The `next/config` module gives your app access to the `publicRuntimeConfig` and `serverRuntimeConfig` stored in your `next.config.js`.
 


### PR DESCRIPTION
Using runtime configuration can cause you to opt-out of entire classes of optimizations. These optimizations could make your application an order of magnitude faster (i.e. prerendering).