### PR TITLE
Do not default TypeScript to `strict: true`

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -119,7 +119,7 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
     lib: { suggested: ['dom', 'dom.iterable', 'esnext'] },
     allowJs: { suggested: true },
     skipLibCheck: { suggested: true },
-    strict: { suggested: true },
+    strict: { suggested: false },
     forceConsistentCasingInFileNames: { suggested: true },
     noEmit: { suggested: true },
 


### PR DESCRIPTION
Users who are testing out Next.js' TypeScript support shouldn't be stuck behind a failure to compile screen. This will allow advanced users to opt into `strict: true` when they're ready.