### PR TITLE
Add back in second line of comment

### DIFF
--- a/examples/with-sentry/utils/sentry.js
+++ b/examples/with-sentry/utils/sentry.js
@@ -1,4 +1,5 @@
-// NOTE: This require will be replaced with `@sentry/browser` when
+// NOTE: This require will be replaced with `@sentry/browser`
+// client side thanks to the webpack config in next.config.js
 const Sentry = require('@sentry/node')
 const SentryIntegrations = require('@sentry/integrations')
 const Cookie = require('js-cookie')


### PR DESCRIPTION
The second line of this comment was removed in the previous commit due to the usage of process.browser.

https://github.com/zeit/next.js/commit/c03e94bebddff570e2181bf3b8c34adf0c704470#diff-a15b49cbb3a523d81a74e0fab7f08eb5

This meant the comment was incomplete and confusing.