### PR TITLE
Remove experimental debug flag

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -512,11 +512,7 @@ export default class Router implements BaseRouter {
   prefetch(url: string): Promise<void> {
     return new Promise((resolve, reject) => {
       // Prefetch is not supported in development mode because it would trigger on-demand-entries
-      if (
-        process.env.NODE_ENV !== 'production' ||
-        process.env.__NEXT_EXPERIMENTAL_DEBUG
-      )
-        return
+      if (process.env.NODE_ENV !== 'production') return
 
       const { pathname } = parse(url)
       // @ts-ignore pathname is always defined

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -59,22 +59,12 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   await verifyTypeScriptSetup(dir)
 
-  const debug =
-    process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG === 'true' ||
-    process.env.__NEXT_BUILDER_EXPERIMENTAL_DEBUG === '1'
-
-  console.log(
-    debug
-      ? 'Creating a development build ...'
-      : 'Creating an optimized production build ...'
-  )
+  console.log('Creating an optimized production build ...')
   console.log()
 
   const config = loadConfig(PHASE_PRODUCTION_BUILD, dir, conf)
   const { target } = config
-  const buildId = debug
-    ? 'unoptimized-build'
-    : await generateBuildId(config.generateBuildId, nanoid)
+  const buildId = await generateBuildId(config.generateBuildId, nanoid)
   const distDir = path.join(dir, config.distDir)
   const pagesDir = path.join(dir, 'pages')
 
@@ -192,7 +182,6 @@ export default async function build(dir: string, conf = null): Promise<void> {
   )
   const configs = await Promise.all([
     getBaseWebpackConfig(dir, {
-      debug,
       buildId,
       isServer: false,
       config,
@@ -201,7 +190,6 @@ export default async function build(dir: string, conf = null): Promise<void> {
       selectivePageBuilding,
     }),
     getBaseWebpackConfig(dir, {
-      debug,
       buildId,
       isServer: true,
       config,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -41,7 +41,6 @@ export default async function getBaseWebpackConfig(
   dir: string,
   {
     dev = false,
-    debug = false,
     isServer = false,
     buildId,
     config,
@@ -50,7 +49,6 @@ export default async function getBaseWebpackConfig(
     selectivePageBuilding = false,
   }: {
     dev?: boolean
-    debug?: boolean
     isServer?: boolean
     buildId: string
     config: any
@@ -177,7 +175,7 @@ export default async function getBaseWebpackConfig(
     },
   }
 
-  const devtool = dev || debug ? 'cheap-module-source-map' : false
+  const devtool = dev ? 'cheap-module-source-map' : false
 
   let webpackConfig: webpack.Configuration = {
     devtool,
@@ -298,8 +296,8 @@ export default async function getBaseWebpackConfig(
                     },
                   },
                 },
-            minimize: !(dev || debug),
-            minimizer: !(dev || debug)
+            minimize: !dev,
+            minimizer: !dev
               ? [
                   new TerserPlugin({
                     ...terserPluginConfig,
@@ -373,8 +371,7 @@ export default async function getBaseWebpackConfig(
       strictExportPresence: true,
       rules: [
         (selectivePageBuilding || config.experimental.terserLoader) &&
-          !isServer &&
-          !debug && {
+          !isServer && {
             test: /\.(js|mjs|jsx)$/,
             exclude: /\.min\.(js|mjs|jsx)$/,
             use: {
@@ -443,7 +440,6 @@ export default async function getBaseWebpackConfig(
               'process.env.__NEXT_DIST_DIR': JSON.stringify(distDir),
             }
           : {}),
-        'process.env.__NEXT_EXPERIMENTAL_DEBUG': JSON.stringify(debug),
         'process.env.__NEXT_EXPORT_TRAILING_SLASH': JSON.stringify(
           config.experimental.exportTrailingSlash
         ),


### PR DESCRIPTION
This removes a debug mode that was added for our `@now/next` builder. The builder now leverages our dev server directly.