### PR TITLE
Correct info about export limitations

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2179,7 +2179,7 @@ now
 
 With `next export`, we build a HTML version of your app. At export time we will run `getInitialProps` of your pages.
 
-The `req` and `res` fields of the `context` object passed to `getInitialProps` are not available as there is no server running.
+The `req` and `res` fields of the `context` object passed to `getInitialProps` are empty objects then as there is no server running.
 
 > **Note**: If your pages don't have `getInitialProps` you may not need `next export` at all, `next build` is already enough thanks to [automatic pre-rendering](#automatic-pre-rendering).
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2179,7 +2179,7 @@ now
 
 With `next export`, we build a HTML version of your app. At export time we will run `getInitialProps` of your pages.
 
-The `req` and `res` fields of the `context` object passed to `getInitialProps` are empty objects then as there is no server running.
+The `req` and `res` fields of the `context` object passed to `getInitialProps` are empty objects during export as there is no server running.
 
 > **Note**: If your pages don't have `getInitialProps` you may not need `next export` at all, `next build` is already enough thanks to [automatic pre-rendering](#automatic-pre-rendering).
 


### PR DESCRIPTION
In `next export` `req` and `res` objects are present, but they are empty ( https://github.com/zeit/next.js/blob/master/packages/next/export/worker.js#L42-L43 ).

Note:

- [ ] we also should update our wiki on [Redirects](https://github.com/zeit/next.js/wiki/Redirecting-in-%60getInitialProps%60), because the code below will blow up with `TypeError: res.writeHead is not a function` error on `next export`:

```jsx
export default class extends React.Component {
  static async getInitialProps({ res }) {
    if (res) {
      res.writeHead(302, {
        Location: '/about'
      })
      res.end()
    } else {
      Router.push('/about')
    }
    return {}
  }
}
```

Instead, it should be sth like this ( https://github.com/zeit/next.js/issues/3702 ):

```jsx
export default class extends React.Component {
  static async getInitialProps({ res }) {
    if (res) {
      if (res.writeHead) {
        res.writeHead(302, {
          Location: '/about'
        })
        res.end()
      }
    } else {
      Router.push('/about')
    }
    return {}
  }
}
```