### PR TITLE
Update to have default pageProps of {} instead of null

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -228,7 +228,7 @@ export async function loadGetInitialProps<
   const res = ctx.res || (ctx.ctx && ctx.ctx.res)
 
   if (!Component.getInitialProps) {
-    return null
+    return {} as any
   }
 
   const props = await Component.getInitialProps(ctx)

--- a/test/unit/loadGetInitialProps.test.js
+++ b/test/unit/loadGetInitialProps.test.js
@@ -15,7 +15,7 @@ describe('loadGetInitialProps', () => {
 
   it('should resolve to null if getInitialProps is missing', async () => {
     const result = await loadGetInitialProps(() => {}, {})
-    expect(result).toEqual(null)
+    expect(result).toEqual({})
   })
 
   it('should resolve getInitialProps', async () => {

--- a/test/unit/loadGetInitialProps.test.js
+++ b/test/unit/loadGetInitialProps.test.js
@@ -13,7 +13,7 @@ describe('loadGetInitialProps', () => {
     return expect(rejectPromise).rejects.toEqual(error)
   })
 
-  it('should resolve to null if getInitialProps is missing', async () => {
+  it('should resolve to an empty object if getInitialProps is missing', async () => {
     const result = await loadGetInitialProps(() => {}, {})
     expect(result).toEqual({})
   })


### PR DESCRIPTION
This fixes styles defined in `_app` with `styled-jsx` with a page that doesn't have `pageProps` since `styled-jsx` attempts to access `pageProps.className` which throws an error if `null`