### PR TITLE
feat(web): Passing actual status code instead 200

### DIFF
--- a/examples/custom-server-hapi/next-wrapper.js
+++ b/examples/custom-server-hapi/next-wrapper.js
@@ -5,19 +5,21 @@ const nextHandlerWrapper = app => {
     return h.close
   }
 }
-const defaultHandlerWrapper = app => async ({ raw: { req, res }, url }) => {
+const defaultHandlerWrapper = app => async ({ raw: { req, res }, url }, h) => {
   const { pathname, query } = url
-  return app.renderToHTML(req, res, pathname, query)
+  const html = await app.renderToHTML(req, res, pathname, query)
+  return h.response(html).code(res.statusCode)
 }
 
-const pathWrapper = (app, pathName, opts) => async ({ raw, query, params }) => {
-  return app.renderToHTML(
+const pathWrapper = (app, pathName, opts) => async ({ raw, query, params }, h) => {
+  const html = await app.renderToHTML(
     raw.req,
     raw.res,
     pathName,
     { ...query, ...params },
     opts
   )
+  return h.response(html).code(raw.res.statusCode)
 }
 
 module.exports = { pathWrapper, defaultHandlerWrapper, nextHandlerWrapper }


### PR DESCRIPTION
Hi 👋 

Right now If you create a custom hapijs server both the **defaultHandlerWrapper** and **pathWrapper** methods are returning the promise that generate the html. 

But with this behavior if I start my server and then go to a nonexistent  url I will get the default error component but with a status code of 200.

![nextjs-404-default-example](https://user-images.githubusercontent.com/461124/60551650-94434a00-9cf1-11e9-84af-37b384b33af3.png)

In order to tell hapi what is the right status code that we want to return to the client we can make a tiny change to the **defaultHandlerWrapper** and **pathWrapper** methods.

```js
const defaultHandlerWrapper = app => async ({ raw: { req, res }, url }, h) => {
  const { pathname, query } = url;
  // generate the html
  const html = await app.renderToHTML(req, res, pathname, query);
  // return the html and passing the current status code
  return h.response(html).code(res.statusCode);
};
```

```js
const pathWrapper = (app, pathName, opts) => async (
  { raw, query, params },
  h
) => {
  const html = await app.renderToHTML(
    raw.req,
    raw.res,
    pathName,
    { ...query, ...params },
    opts
  );
  return h.response(html).code(raw.res.statusCode);
};
```
![nextjs-404-actual-status-codepng](https://user-images.githubusercontent.com/461124/60551876-61e61c80-9cf2-11e9-92a1-e355bb203f68.PNG)

Not sure if this is out of the scope of the example, but maybe worth to mention this in the readme file? 🤔 
