### PR TITLE
Add next-server/types to package.json files

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -23,7 +23,8 @@
     "next-config.js",
     "next-config.d.ts",
     "amp.js",
-    "amp.d.ts"
+    "amp.d.ts",
+    "types/index.d.ts"
   ],
   "scripts": {
     "build": "taskr",


### PR DESCRIPTION
Makes sure the types in `next-server` are published.

Fixes: #7738 