### PR TITLE
Make `exportTrailingSlash` stable

### DIFF
--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -24,6 +24,7 @@ const defaultConfig: { [key: string]: any } = {
   amp: {
     canonicalBase: '',
   },
+  exportTrailingSlash: false,
   experimental: {
     cpus: Math.max(
       1,
@@ -31,7 +32,6 @@ const defaultConfig: { [key: string]: any } = {
         (os.cpus() || { length: 1 }).length) - 1
     ),
     ampBindInitData: false,
-    exportTrailingSlash: false,
     terserLoader: false,
     profiling: false,
     flyingShuttle: false,

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -817,6 +817,7 @@ Router.events.on('routeChangeError', (err, url) => {
 
 > **Note**: Using router events in `getInitialProps` is discouraged as it may result in unexpected behavior.<br/>
 > Router events should be registered when a component mounts (`useEffect` or `componentDidMount`/`componentWillUnmount`) or imperatively when an event happens.
+>
 > ```js
 > useEffect(() => {
 >   const handleRouteChange = url => {
@@ -2211,7 +2212,7 @@ Any AMP errors will cause `next export` to exit with status code `1` because the
 
 ### TypeScript Support
 
-AMP currently doesn't have built-in types for Typescript, but it's in their roadmap ([#13791](https://github.com/ampproject/amphtml/issues/13791)). As a workaround you can manually add the types to `amp.d.ts` like [here](https://stackoverflow.com/a/50601125).
+AMP currently doesn't have built-in types for TypeScript, but it's in their roadmap ([#13791](https://github.com/ampproject/amphtml/issues/13791)). As a workaround you can manually add the types to `amp.d.ts` like [here](https://stackoverflow.com/a/50601125).
 
 ## Static HTML export
 
@@ -2265,7 +2266,20 @@ module.exports = {
 }
 ```
 
-> Note that if the path ends with a directory, it will be exported as `/dir-name/index.html`, but if it ends with an extension, it will be exported as the specified filename, e.g. `/readme.md` above. If you use a file extension other than `.html`, you may need to set the `Content-Type` header to `text/html` when serving this content.
+The pages will be exported as html files, i.e. `/about` will become `/about.html`.
+
+It is possible to configure Next.js to export pages as `index.html` files and require trailing slashes, i.e. `/about` becomes `/about/index.html` and is routable via `/about/`.
+This was the default behavior prior to Next.js 9.
+You can use the following `next.config.js` to switch back to this behavior:
+
+```js
+// next.config.js
+module.exports = {
+  exportTrailingSlash: true,
+}
+```
+
+> **Note**: If the export path is a filename (e.g. `/readme.md`) and is different than `.html`, you may need to set the `Content-Type` header to `text/html` when serving this content.
 
 The second argument is an `object` with:
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -406,10 +406,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     const exportConfig = {
       ...config,
       exportPathMap: (defaultMap: any) => defaultMap,
-      experimental: {
-        ...config.experimental,
-        exportTrailingSlash: false,
-      },
+      exportTrailingSlash: false,
     }
     await exportApp(dir, exportOptions, exportConfig)
     const toMove = await recursiveReadDir(exportOptions.outdir, /.*\.html$/)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -441,7 +441,7 @@ export default async function getBaseWebpackConfig(
             }
           : {}),
         'process.env.__NEXT_EXPORT_TRAILING_SLASH': JSON.stringify(
-          config.experimental.exportTrailingSlash
+          config.exportTrailingSlash
         ),
         ...(isServer
           ? { 'typeof window': JSON.stringify('undefined') }

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -32,7 +32,7 @@ export default async function (dir, options, configuration) {
   const concurrency = options.concurrency || 10
   const threads = options.threads || Math.max(cpus().length - 1, 1)
   const distDir = join(dir, nextConfig.distDir)
-  const subFolders = nextConfig.experimental.exportTrailingSlash
+  const subFolders = nextConfig.exportTrailingSlash
 
   if (!options.buildExport && nextConfig.target !== 'server') {
     throw new Error(

--- a/test/integration/export-subfolders/next.config.js
+++ b/test/integration/export-subfolders/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  experimental: {
-    exportTrailingSlash: false
-  }
-}

--- a/test/integration/export-subfolders/test/index.test.js
+++ b/test/integration/export-subfolders/test/index.test.js
@@ -12,7 +12,7 @@ const access = promisify(fs.access)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
-describe('Export experimental.exportTrailingSlash set to false', () => {
+describe('Export config#exportTrailingSlash set to false', () => {
   beforeAll(async () => {
     await nextBuild(appDir)
     await nextExport(appDir, { outdir })

--- a/test/integration/export/next.config.js
+++ b/test/integration/export/next.config.js
@@ -9,9 +9,7 @@ module.exports = phase => {
     serverRuntimeConfig: {
       bar: 'bar'
     },
-    experimental: {
-      exportTrailingSlash: true
-    },
+    exportTrailingSlash: true,
     exportPathMap: function () {
       return {
         '/': { page: '/' },


### PR DESCRIPTION
This stabilizes `exportTrailingSlash` since the default behavior was switched in Next.js 9 and users may want the old behavior.