### PR TITLE
Add deprecation message for `next/dynamic` modules

### DIFF
--- a/errors/next-dynamic-modules.md
+++ b/errors/next-dynamic-modules.md
@@ -1,0 +1,64 @@
+# `next/dynamic` has deprecated loading multiple modules at once
+
+#### Why This Error Occurred
+
+The ability to load multiple modules at once has been deprecated in `next/dynamic` to be closer to React's implementation (`React.lazy` and `Suspense`).
+
+Updating code that relies on this behavior is relatively straightforward! We've provided an example of a before/after to help you migrate your application:
+
+#### Possible Ways To Fix It
+
+Migrate to using separate dynamic calls for each module.
+
+Before
+```js
+import dynamic from 'next/dynamic'
+
+const HelloBundle = dynamic({
+  modules: () => {
+    const components = {
+      Hello1: () => import('../components/hello1').then(m => m.default),
+      Hello2: () => import('../components/hello2').then(m => m.default),
+    }
+
+    return components
+  },
+  render: (props, { Hello1, Hello2 }) => (
+    <div>
+      <h1>{props.title}</h1>
+      <Hello1 />
+      <Hello2 />
+    </div>
+  ),
+})
+
+function DynamicBundle() {
+  return <HelloBundle title="Dynamic Bundle" />
+}
+
+export default DynamicBundle
+```
+
+After
+```js
+import dynamic from 'next/dynamic'
+
+const Hello1 = dynamic(() => import('../components/hello1'))
+const Hello2 = dynamic(() => import('../components/hello2'))
+
+function HelloBundle({ title }) {
+  return (
+    <div>
+      <h1>{title}</h1>
+      <Hello1 />
+      <Hello2 />
+    </div>
+  )
+}
+
+function DynamicBundle() {
+  return <HelloBundle title="Dynamic Bundle" />
+}
+
+export default DynamicBundle
+```

--- a/packages/next-server/lib/dynamic.tsx
+++ b/packages/next-server/lib/dynamic.tsx
@@ -37,6 +37,9 @@ export type LoadableOptions<P = {}> = LoadableBaseOptions<P> & {
 }
 
 export type DynamicOptions<P = {}> = LoadableBaseOptions<P> & {
+  /**
+   * @deprecated the modules option has been planned for removal
+   */
   render?(props: P, loaded: any): JSX.Element
 }
 
@@ -117,6 +120,12 @@ export default function dynamic<P = {}>(
     typeof dynamicOptions === 'object' &&
     !(dynamicOptions instanceof Promise)
   ) {
+    if (process.env.NODE_ENV !== 'production') {
+      // show deprecation warning in development
+      console.warn(
+        'The modules option for next/dynamic has been deprecated. See here for more info https://err.sh/zeit/next.js/next-dynamic-modules'
+      )
+    }
     // Support for `render` when using a mapping, eg: `dynamic({ modules: () => {return {HelloWorld: import('../hello-world')}, render(props, loaded) {} } })
     if (dynamicOptions.render) {
       loadableOptions.render = (loaded, props) =>


### PR DESCRIPTION
Adds warning when usage of `next/dynamic` modules is used and adds err.sh explaining migration