### PR TITLE
Prioritize public files over dynamic routes in development mode

### DIFF
--- a/test/integration/dynamic-routing/public/hello.txt
+++ b/test/integration/dynamic-routing/public/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -150,6 +150,11 @@ function runTests () {
     const text = await browser.eval(`document.body.innerHTML`)
     expect(text).toMatch(/onmpost:.*post-1/)
   })
+
+  it('should prioritize public files over dynamic routes', async () => {
+    const content = await renderViaHTTP(appPort, '/hello.txt')
+    expect(content).toMatch(/hello world/)
+  })
 }
 
 describe('Dynamic Routing', () => {


### PR DESCRIPTION
This makes sure a dynamic route at the root doesn't cause files in the `public` folder to not be able to be matched in development mode. 