### PR TITLE
[typings] Allow NextComponentType → getInitialProps to be sync

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -13,7 +13,7 @@ export type NextComponentType<
   IP = {},
   P = {}
 > = ComponentType<P> & {
-  getInitialProps?(context: C): Promise<IP>
+  getInitialProps?(context: C): IP | Promise<IP>
 }
 
 export type DocumentType = NextComponentType<


### PR DESCRIPTION
Next.js typings require the return type of `getInitialProps` to be `Promise<IP>`. Thus, not putting `async` before the implementation of this function produces a typing error.

Having a synchronous `getInitialProps` function may make sense in a number of scenarios. Here is an example for [`next-i18next`](https://github.com/isaachinman/next-i18next):

```tsx
import { NextComponentType, NextPageContext } from "next";
import { useTranslation } from "react-i18next";

// ideally, the below typing should be put in a separate file to be reused across pages
type I18nPage<P = {}> = NextComponentType<
  NextPageContext,
  { namespacesRequired: string[] },
  P & { namespacesRequired: string[] }
>;

const IndexPage: I18nPage = () => {
  const { t } = useTranslation();
  return <div>{t("my-namespace:my-message")}</div>;
};

IndexPage.getInitialProps = () => ({
  namespacesRequired: ["my-namespace", "commons"],
});

export default IndexPage;
```

In `@types/next` both `IP` and `Promise<IP>` [are supported as function return type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/132720a17e15cdfcffade54dd4a23a21c1e16831/types/next/index.d.ts#L140-L146).