### PR TITLE
export LinkProps

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -45,7 +45,7 @@ function formatUrl(url: Url) {
   return url && typeof url === 'object' ? formatWithValidation(url) : url
 }
 
-type LinkProps = {
+export type LinkProps = {
   href: Url
   as?: Url | undefined
   replace?: boolean


### PR DESCRIPTION
Would like to be able to wrap next.js `Link` in a type-safe way. 

Aside, isn't `| undefined` here redundant?
```ts
  as?: Url | undefined
```