### PR TITLE
Upgrade with-typescript-styled-components example

### DIFF
--- a/examples/with-typescript-styled-components/.babelrc
+++ b/examples/with-typescript-styled-components/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["next/babel", "@zeit/next-typescript/babel"],
+  "presets": ["next/babel"],
   "plugins": [["styled-components", { "ssr": true }]]
 }

--- a/examples/with-typescript-styled-components/next-env.d.ts
+++ b/examples/with-typescript-styled-components/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/examples/with-typescript-styled-components/next.config.js
+++ b/examples/with-typescript-styled-components/next.config.js
@@ -1,2 +1,0 @@
-const withTypescript = require('@zeit/next-typescript')
-module.exports = withTypescript()

--- a/examples/with-typescript-styled-components/package.json
+++ b/examples/with-typescript-styled-components/package.json
@@ -7,17 +7,18 @@
     "start": "next start"
   },
   "dependencies": {
-    "@types/next": "^8.0.1",
-    "@types/react": "^16.8.6",
-    "@types/styled-components": "^4.1.11",
-    "@zeit/next-typescript": "^1.1.1",
-    "next": "^8.0.3",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3",
+    "next": "9.0.0",
+    "react": "16.8.6",
+    "react-dom": "16.8.6",
     "styled-components": "^4.1.3"
   },
   "devDependencies": {
-    "babel-plugin-styled-components": "^1.10.0"
+    "@types/node": "12.0.12",
+    "@types/react": "16.8.23",
+    "@types/react-dom": "16.8.4",
+    "@types/styled-components": "4.1.16",
+    "babel-plugin-styled-components": "^1.10.0",
+    "typescript": "3.5.2"
   },
   "license": "ISC"
 }

--- a/examples/with-typescript-styled-components/pages/_document.tsx
+++ b/examples/with-typescript-styled-components/pages/_document.tsx
@@ -1,8 +1,8 @@
-import Document, { NextDocumentContext } from 'next/document'
+import Document, { DocumentContext } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
 export default class MyDocument extends Document {
-  static async getInitialProps(ctx: NextDocumentContext) {
+  static async getInitialProps(ctx: DocumentContext) {
     const sheet = new ServerStyleSheet()
     const originalRenderPage = ctx.renderPage
 
@@ -15,12 +15,12 @@ export default class MyDocument extends Document {
       const initialProps = await Document.getInitialProps(ctx)
       return {
         ...initialProps,
-        styles: (
+        styles: [
           <>
             {initialProps.styles}
             {sheet.getStyleElement()}
-          </>
-        ),
+          </>,
+        ],
       }
     } finally {
       sheet.seal()

--- a/examples/with-typescript-styled-components/tsconfig.json
+++ b/examples/with-typescript-styled-components/tsconfig.json
@@ -3,7 +3,10 @@
     "target": "esnext",
     "module": "esnext",
     "jsx": "preserve",
-    "lib": ["dom", "es2017"],
+    "lib": [
+      "dom",
+      "es2017"
+    ],
     "moduleResolution": "node",
     "allowJs": true,
     "noEmit": true,
@@ -15,6 +18,17 @@
     "removeComments": false,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "esModuleInterop": true
-  }
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
 }


### PR DESCRIPTION
I am glad that Next.js v9 has been released.
I updated next of with-typescript-styled-components sample.