### PR TITLE
fix: Make tsconfig.json path depend on cwd

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -93,7 +93,7 @@ async function checkDependencies({
 }
 
 export async function verifyTypeScriptSetup(dir: string): Promise<void> {
-  const tsConfigPath = path.join(dir, 'tsconfig.json')
+  const tsConfigPath = path.join(process.cwd(), 'tsconfig.json')
   const yarnLockFile = path.join(dir, 'yarn.lock')
 
   const hasTsConfig = await exists(tsConfigPath)
@@ -282,7 +282,7 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
   }
 
   // Reference `next` types
-  const appTypeDeclarations = path.join(dir, 'next-env.d.ts')
+  const appTypeDeclarations = path.join(process.cwd(), 'next-env.d.ts')
   if (!fs.existsSync(appTypeDeclarations)) {
     fs.writeFileSync(
       appTypeDeclarations,


### PR DESCRIPTION
This PR has been created to support nested directory hierarchy, where there are multiple parent directories containing the `pages` directory. 

This is so that `tsconfig.json` auto-generates in the project root - [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#overview).

Reference: [process.cwd()]( https://nodejs.org/api/process.html#process_process_cwd)

fixes: #7782