### PR TITLE
Fix package count being zero when project contains blocked name 

### DIFF
--- a/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
+++ b/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
@@ -43,7 +43,7 @@ export function getPageChunks(
     if (mod.includes('node_modules/')) {
       if (
         mod.match(
-          /(@babel|core-js|styled-jsx|string-hash|object-assign|process|react|react-dom|regenerator-runtime|webpack|node-libs-browser)/
+          /node_modules\/(@babel|core-js|styled-jsx|string-hash|object-assign|process|react|react-dom|regenerator-runtime|webpack|node-libs-browser)\//
         )
       ) {
         return null

--- a/test/integration/build-stats-output/react-site/pages/something.js
+++ b/test/integration/build-stats-output/react-site/pages/something.js
@@ -1,0 +1,3 @@
+import fetch from 'isomorphic-unfetch'
+console.log(fetch)
+export default () => <p>Hello world</p>

--- a/test/integration/build-stats-output/test/index.test.js
+++ b/test/integration/build-stats-output/test/index.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+const appDir = join(__dirname, '../react-site')
+
+describe('Build Stats Output', () => {
+  it('Shows correct package count in output', async () => {
+    const { stdout } = await nextBuild(appDir, undefined, { stdout: true })
+    expect(stdout).toMatch(/\/something .*?5/)
+  })
+})


### PR DESCRIPTION
If a project's folder is named `react-site` or something it would cause all packages to be ignored. 

Fixes: #7783 