### PR TITLE
feat: Support typing of the Query though NextPage

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -38,7 +38,7 @@ declare module 'react' {
  * `Page` type, use it as a guide to create `pages`.
  */
 export type NextPage<P = {}, IP = P> = {
-  (props: P): JSX.Element
+  (props: P & IP): JSX.Element
   /**
    * Used for initial page load data population. Data returned from `getInitialProps` is serialized when server rendered.
    * Make sure to return plain `Object` without using `Date`, `Map`, `Set`.


### PR DESCRIPTION
When you're constructing a page, and what to be a good type safe citizen. You'll want to-do something like this:

```ts
import { NextPage } from 'next';

interface Props {
   // redacted
}

interface InitialProps {
   pageData: {
       content: string; // Normally this would come some data controlled thing
   }
}

interface Query {
    id: number;
}

const HomePage: NextPage<Props, InitialProps, Query> = ({ pageData }) => {
    return (
        <h1>Hello World</h1>
        <p>{pageData.content}</p>
    )
};
HomePage.getInitialProps = async ({ id }) =>
    Promise.resolve({ pageData: { content: 'Im content' } });
```

As you can see there, the query properties are also typed - in the future I dare say this can be exposed in a `.d.ts` file so Next can generate that Query path (becuase it knows about it) to something like:

```ts
// paths.d.ts

// for ./pages/comment/[id].tsx
interface Page__Comment__Id {
    id: unknown
}

// ./pages/comment/[id].tsx
// Could simply just use that type, because our tsconfig.json file would include next files in its types property in the compilerOptions.
const HomePage: NextPage<Props, InitialProps, Page__Comment__Id> = ({ pageData }) => {
    return (
        <h1>Hello World</h1>
        <p>{pageData.content}</p>
    )
};
```

This would give amazing refactor opportunities, ie, you move the file (changing its path), you know know where you're referencing the query params.