### PR TITLE
Update to always require next/config when setting config

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -15,7 +15,6 @@ import { getPageChunks } from './webpack/plugins/chunk-graph-plugin'
 const fsStat = promisify(fs.stat)
 const fsExists = promisify(fs.exists)
 const fsReadFile = promisify(fs.readFile)
-const nextEnvConfig = require('next-server/config')
 
 export function collectPages(
   directory: string,
@@ -268,7 +267,7 @@ export function isPageStatic(
   runtimeEnvConfig: any
 ): { static?: boolean; prerender?: boolean } {
   try {
-    nextEnvConfig.setConfig(runtimeEnvConfig)
+    require('next-server/config').setConfig(runtimeEnvConfig)
     const mod = require(serverBundle)
     const Comp = mod.default
 
@@ -290,7 +289,7 @@ export function hasCustomAppGetInitialProps(
   _appBundle: string,
   runtimeEnvConfig: any
 ): boolean {
-  nextEnvConfig.setConfig(runtimeEnvConfig)
+  require('next-server/config').setConfig(runtimeEnvConfig)
   let mod = require(_appBundle)
 
   if (_appBundle.endsWith('_app.js')) {


### PR DESCRIPTION
Since we clear the `require.cache` we need to re-require `next/config` before calling `setConfig`

Fixes: #7713 