### PR TITLE
Improve NextApiResponse typing

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -174,7 +174,7 @@ export type NextApiResponse = ServerResponse & {
    * Send data `json` data in reponse
    */
   json: Send
-  status: (statusCode: number) => void
+  status: (statusCode: number) => NextApiResponse
 }
 
 /**

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -160,21 +160,21 @@ export type NextApiRequest = IncomingMessage & {
 /**
  * Send body of response
  */
-type Send = (body: any) => void
+type Send<T> = (body: T) => void
 
 /**
  * Next `API` route response
  */
-export type NextApiResponse = ServerResponse & {
+export type NextApiResponse<T = any> = ServerResponse & {
   /**
    * Send data `any` data in reponse
    */
-  send: Send
+  send: Send<T>
   /**
    * Send data `json` data in reponse
    */
-  json: Send
-  status: (statusCode: number) => NextApiResponse
+  json: Send<T>
+  status: (statusCode: number) => NextApiResponse<T>
 }
 
 /**


### PR DESCRIPTION
Introducing two changes here

#### Fix NextApiResponse.status type signature 989e549
According to the [doc](https://github.com/zeit/next.js#helper-functions) we can chain the function call (thanks to [here](https://github.com/zeit/next.js/blob/f204935251aba0914c59d94c09588cf85a8352a0/packages/next-server/server/api-utils.ts#L146))


#### Improve NextApiResponse typing fb11fd2
Makes the _NextApiResponse_ accept a type argument
Currently `res.json(...)` is not type checked but it could be helpful to see at a glance the handler signature, like so:

```js
export type MyResponse =
  | {ok: true; blabla: message}
  | {ok: false; message: string}

export default function handle(
  req: NextApiRequest,
  res: NextApiResponse<MyResponse>,
) {
  //...
  res.json({ok: true, blabla: ...}) // typecheck!!
}
```

I didn't make the _NextApiRequest_ generic because—we can't trust the request input—we would have to validate it anyway.

What do you think ?
