### PR TITLE
Add default values for runtime config

### DIFF
--- a/packages/next-server/lib/runtime-config.ts
+++ b/packages/next-server/lib/runtime-config.ts
@@ -4,6 +4,11 @@ export default () => {
   return runtimeConfig
 }
 
-export function setConfig(configValue: any) {
-  runtimeConfig = configValue
+export function setConfig(
+  { publicRuntimeConfig, serverRuntimeConfig } = {} as any
+) {
+  runtimeConfig = {
+    publicRuntimeConfig: publicRuntimeConfig || {},
+    serverRuntimeConfig: serverRuntimeConfig || {},
+  }
 }

--- a/packages/next-server/lib/runtime-config.ts
+++ b/packages/next-server/lib/runtime-config.ts
@@ -4,11 +4,6 @@ export default () => {
   return runtimeConfig
 }
 
-export function setConfig(
-  { publicRuntimeConfig, serverRuntimeConfig } = {} as any
-) {
-  runtimeConfig = {
-    publicRuntimeConfig: publicRuntimeConfig || {},
-    serverRuntimeConfig: serverRuntimeConfig || {},
-  }
+export function setConfig(configValue: any) {
+  runtimeConfig = configValue
 }

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -167,11 +167,11 @@ type Send<T> = (body: T) => void
  */
 export type NextApiResponse<T = any> = ServerResponse & {
   /**
-   * Send data `any` data in reponse
+   * Send data `any` data in response
    */
   send: Send<T>
   /**
-   * Send data `json` data in reponse
+   * Send data `json` data in response
    */
   json: Send<T>
   status: (statusCode: number) => NextApiResponse<T>

--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -39,6 +39,8 @@ const defaultConfig: { [key: string]: any } = {
     documentMiddleware: false,
     publicDirectory: false,
   },
+  serverRuntimeConfig: {},
+  publicRuntimeConfig: {},
 }
 
 function assignDefaults(userConfig: { [key: string]: any }) {
@@ -102,6 +104,12 @@ export default function loadConfig(
         (canonicalBase.endsWith('/')
           ? canonicalBase.slice(0, -1)
           : canonicalBase) || ''
+    }
+
+    if (userConfig.target === 'serverless' && userConfig.publicRuntimeConfig) {
+      throw new Error(
+        'Cannot use publicRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'
+      )
     }
 
     return assignDefaults({ configOrigin: CONFIG_FILE, ...userConfig })

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -118,7 +118,7 @@ export default class Server {
 
     // Only the `publicRuntimeConfig` key is exposed to the client side
     // It'll be rendered as part of __NEXT_DATA__ on the client side
-    if (Object.keys(publicRuntimeConfig).length) {
+    if (Object.keys(publicRuntimeConfig).length > 0) {
       this.renderOpts.runtimeConfig = publicRuntimeConfig
     }
 

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -118,7 +118,7 @@ export default class Server {
 
     // Only the `publicRuntimeConfig` key is exposed to the client side
     // It'll be rendered as part of __NEXT_DATA__ on the client side
-    if (publicRuntimeConfig) {
+    if (Object.keys(publicRuntimeConfig).length) {
       this.renderOpts.runtimeConfig = publicRuntimeConfig
     }
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -201,11 +201,6 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   let result: CompilerResult = { warnings: [], errors: [] }
   if (target === 'serverless') {
-    if (config.publicRuntimeConfig)
-      throw new Error(
-        'Cannot use publicRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'
-      )
-
     const clientResult = await runCompiler(configs[0])
     // Fail build if clientResult contains errors
     if (clientResult.errors.length > 0) {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -17,7 +17,7 @@ import { isDynamicRoute } from 'next-server/dist/lib/router/utils/is-dynamic'
 // Polyfill Promise globally
 // This is needed because Webpack's dynamic loading(common chunks) code
 // depends on Promise.
-// So we need to polyfill it
+// So, we need to polyfill it.
 // See: https://webpack.js.org/guides/code-splitting/#dynamic-imports
 if (!window.Promise) {
   window.Promise = Promise
@@ -185,7 +185,7 @@ export async function render (props) {
 
 // This method handles all runtime and debug errors.
 // 404 and 500 errors are special kind of errors
-// and they are still handle via the main render method
+// and they are still handle via the main render method.
 export async function renderError (props) {
   const { App, err } = props
 
@@ -193,14 +193,14 @@ export async function renderError (props) {
     return webpackHMR.reportRuntimeError(webpackHMR.prepareError(err))
   }
 
-  // Make sure we log the error to the console, otherwise users can't track down issues
+  // Make sure we log the error to the console, otherwise users can't track down issues.
   console.error(err)
 
   ErrorComponent = await pageLoader.loadPage('/_error')
 
   // In production we do a normal render with the `ErrorComponent` as component.
   // If we've gotten here upon initial render, we can use the props from the server.
-  // Otherwise, we need to call `getInitialProps` on `App` before mounting
+  // Otherwise, we need to call `getInitialProps` on `App` before mounting.
   const initProps = props.props
     ? props.props
     : await loadGetInitialProps(App, {
@@ -212,7 +212,7 @@ export async function renderError (props) {
   await doRender({ ...props, err, Component: ErrorComponent, props: initProps })
 }
 
-// If hydrate does not exist, eg in preact
+// If hydrate does not exist, eg in preact.
 let isInitialRender = typeof ReactDOM.hydrate === 'function'
 function renderReactElement (reactEl, domEl) {
   // The check for `.hydrate` is there to support React alternatives like preact
@@ -267,7 +267,7 @@ async function doRender ({ App, Component, props, err }) {
   props = props || lastAppProps.props
 
   const appProps = { Component, err, router, ...props }
-  // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error
+  // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error.
   lastAppProps = appProps
 
   emitter.emit('before-reactdom-render', {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -17,7 +17,7 @@ import { isDynamicRoute } from 'next-server/dist/lib/router/utils/is-dynamic'
 // Polyfill Promise globally
 // This is needed because Webpack's dynamic loading(common chunks) code
 // depends on Promise.
-// So, we need to polyfill it.
+// So we need to polyfill it
 // See: https://webpack.js.org/guides/code-splitting/#dynamic-imports
 if (!window.Promise) {
   window.Promise = Promise
@@ -185,7 +185,7 @@ export async function render (props) {
 
 // This method handles all runtime and debug errors.
 // 404 and 500 errors are special kind of errors
-// and they are still handle via the main render method.
+// and they are still handle via the main render method
 export async function renderError (props) {
   const { App, err } = props
 
@@ -193,14 +193,14 @@ export async function renderError (props) {
     return webpackHMR.reportRuntimeError(webpackHMR.prepareError(err))
   }
 
-  // Make sure we log the error to the console, otherwise users can't track down issues.
+  // Make sure we log the error to the console, otherwise users can't track down issues
   console.error(err)
 
   ErrorComponent = await pageLoader.loadPage('/_error')
 
   // In production we do a normal render with the `ErrorComponent` as component.
   // If we've gotten here upon initial render, we can use the props from the server.
-  // Otherwise, we need to call `getInitialProps` on `App` before mounting.
+  // Otherwise, we need to call `getInitialProps` on `App` before mounting
   const initProps = props.props
     ? props.props
     : await loadGetInitialProps(App, {
@@ -212,7 +212,7 @@ export async function renderError (props) {
   await doRender({ ...props, err, Component: ErrorComponent, props: initProps })
 }
 
-// If hydrate does not exist, eg in preact.
+// If hydrate does not exist, eg in preact
 let isInitialRender = typeof ReactDOM.hydrate === 'function'
 function renderReactElement (reactEl, domEl) {
   // The check for `.hydrate` is there to support React alternatives like preact
@@ -267,7 +267,7 @@ async function doRender ({ App, Component, props, err }) {
   props = props || lastAppProps.props
 
   const appProps = { Component, err, router, ...props }
-  // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error.
+  // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error
   lastAppProps = appProps
 
   emitter.emit('before-reactdom-render', {
@@ -276,7 +276,7 @@ async function doRender ({ App, Component, props, err }) {
     appProps
   })
 
-  // In development runtime errors are caught by react-error-overlay.
+  // In development runtime errors are caught by react-error-overlay
   if (process.env.NODE_ENV === 'development') {
     renderReactElement(
       <AppContainer>
@@ -285,7 +285,7 @@ async function doRender ({ App, Component, props, err }) {
       appElement
     )
   } else {
-    // In production we catch runtime errors using componentDidCatch which will trigger renderError.
+    // In production we catch runtime errors using componentDidCatch which will trigger renderError
     renderReactElement(
       <AppContainer>
         <App {...appProps} />

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -1,3 +1,4 @@
+/* global location */
 import React, { Suspense } from 'react'
 import ReactDOM from 'react-dom'
 import HeadManager from './head-manager'
@@ -84,7 +85,7 @@ class Container extends React.Component {
     // If it's a dynamic route or has a querystring
     if (
       data.nextExport &&
-      (isDynamicRoute(router.pathname) || window.location.search)
+      (isDynamicRoute(router.pathname) || location.search)
     ) {
       // update query on mount for exported pages
       router.replace(
@@ -92,7 +93,7 @@ class Container extends React.Component {
           '?' +
           stringifyQs({
             ...router.query,
-            ...parseQs(window.location.search.substr(1))
+            ...parseQs(location.search.substr(1))
           }),
         asPath
       )
@@ -104,7 +105,7 @@ class Container extends React.Component {
   }
 
   scrollToHash () {
-    let { hash } = window.location
+    let { hash } = location
     hash = hash && hash.substring(1)
     if (!hash) return
 

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -49,7 +49,7 @@ __webpack_public_path__ = `${prefix}/_next/` //eslint-disable-line
 // Initialize next/config with the environment configuration
 envConfig.setConfig({
   serverRuntimeConfig: {},
-  publicRuntimeConfig: runtimeConfig
+  publicRuntimeConfig: runtimeConfig || {}
 })
 
 const asPath = getURL()

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -110,7 +110,7 @@ export default async function (dir, options, configuration) {
 
   const { serverRuntimeConfig, publicRuntimeConfig } = nextConfig
 
-  if (publicRuntimeConfig) {
+  if (Object.keys(publicRuntimeConfig).length > 0) {
     renderOpts.runtimeConfig = publicRuntimeConfig
   }
 

--- a/test/integration/production/pages/runtime-config.js
+++ b/test/integration/production/pages/runtime-config.js
@@ -1,0 +1,16 @@
+import getConfig from 'next/config'
+
+const page = () => {
+  const { publicRuntimeConfig, serverRuntimeConfig } = getConfig()
+
+  return (
+    <>
+      {publicRuntimeConfig && <p>found public config</p>}
+      {serverRuntimeConfig && <p>found server config</p>}
+    </>
+  )
+}
+
+page.getInitialProps = () => ({})
+
+export default page

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -375,6 +375,12 @@ describe('Production Usage', () => {
       await browser.close()
     })
 
+    it('should have default runtime values when not defined', async () => {
+      const html = await renderViaHTTP(appPort, '/runtime-config')
+      expect(html).toMatch(/found public config/)
+      expect(html).toMatch(/found server config/)
+    })
+
     if (browserName === 'chrome') {
       it('should add preload tags when Link prefetch prop is used', async () => {
         const browser = await webdriver(appPort, '/prefetch')

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -381,6 +381,13 @@ describe('Production Usage', () => {
       expect(html).toMatch(/found server config/)
     })
 
+    it('should not have runtimeConfig in __NEXT_DATA__', async () => {
+      const html = await renderViaHTTP(appPort, '/runtime-config')
+      const $ = cheerio.load(html)
+      const script = $('#__NEXT_DATA__').html()
+      expect(script).not.toMatch(/runtimeConfig/)
+    })
+
     if (browserName === 'chrome') {
       it('should add preload tags when Link prefetch prop is used', async () => {
         const browser = await webdriver(appPort, '/prefetch')


### PR DESCRIPTION
Makes sure default values for `publicRuntimeConfig` and `serverRuntimeConfig` are set. Also moves the error when `publicRuntimeConfig` is used with `target: 'serverless'` into the config loading. 

Fixes another aspect of #7713