### PR TITLE
fix: fix terminal links (cmd-click) on VSCode

### DIFF
--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -84,6 +84,6 @@ store.subscribe(state => {
 
   Log.ready(
     'compiled successfully' +
-      (state.appUrl ? ` (ready on ${state.appUrl})` : '')
+      (state.appUrl ? ` - ready on ${state.appUrl}` : '')
   )
 })


### PR DESCRIPTION
- caused by immediately trailing paren which vscode sees as a url part

This is admittedly super small, but in next 9 (great btw!), the vscode shows convenient links to http://localhost:3000.  But in the new log (ready on http://localhost:3000), vscode highlights "http://localhost:3000)" *with the trailing )* which causes the click not to work.  

Removing the paren fixes it