### PR TITLE
Add test for trailing slash on API route

### DIFF
--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -55,7 +55,7 @@ function runTests (serverless = false) {
     expect(data).toEqual([{ title: 'Nextjs' }])
   })
 
-  it('shuld return error with invalid JSON', async () => {
+  it('should return error with invalid JSON', async () => {
     const data = await fetchViaHTTP(appPort, '/api/parse', null, {
       method: 'POST',
       headers: {

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -8,6 +8,7 @@ import {
   findPort,
   nextBuild,
   nextStart,
+  fetchViaHTTP,
   renderViaHTTP
 } from 'next-test-utils'
 import fetch from 'node-fetch'
@@ -142,6 +143,11 @@ describe('Serverless', () => {
     const result = await renderViaHTTP(appPort, '/api/posts/post-1')
     const { post } = JSON.parse(result)
     expect(post).toBe('post-1')
+  })
+
+  it('should 404 on API request with trailing slash', async () => {
+    const res = await fetchViaHTTP(appPort, '/api/hello/')
+    expect(res.status).toBe(404)
   })
 
   describe('With basic usage', () => {


### PR DESCRIPTION
Makes sure we test for expected behavior

Closes https://github.com/zeit/next.js/issues/7845