### PR TITLE
Update _document.ts

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -15,12 +15,12 @@ export default class MyDocument extends Document {
       const initialProps = await Document.getInitialProps(ctx)
       return {
         ...initialProps,
-        styles: (
+        styles: [
           <>
             {initialProps.styles}
             {sheet.getStyleElement()}
           </>
-        )
+        ]
       }
     } finally {
       sheet.seal()


### PR DESCRIPTION
In `next.js 9.0.0`, `styles` is now an array:

```
export declare type DocumentInitialProps = RenderPageResult & {
    styles?: React.ReactElement[];
};
```