### PR TITLE
Remove with-styled-components Auto Prerendering warning

### DIFF
--- a/examples/with-styled-components/pages/_app.js
+++ b/examples/with-styled-components/pages/_app.js
@@ -9,16 +9,6 @@ const theme = {
 }
 
 export default class MyApp extends App {
-  static async getInitialProps ({ Component, ctx }) {
-    let pageProps = {}
-
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx)
-    }
-
-    return { pageProps }
-  }
-
   render () {
     const { Component, pageProps } = this.props
     return (


### PR DESCRIPTION
The with-styled-components example has copied the documentation `_app.js` example including the unneeded `getInitialProps` method.  

This means anything in pages isn't Prerendered even though it could be, changing this is a tradeoff as previously the example was closer to the documentation however removing it reduces warnings the user experiences, is best practise from a performance point of view and is less code. 

Merge or discard as you see fit, this caught me out for a little while yesterday regardless of the warning. 