### PR TITLE
Test custom Document fragment `styles`

### DIFF
--- a/test/integration/app-document-style-fragment/pages/_document.js
+++ b/test/integration/app-document-style-fragment/pages/_document.js
@@ -1,0 +1,36 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps (ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+
+    return {
+      ...initialProps,
+      styles: (
+        <>
+          {initialProps.styles}
+          <style
+            id='sbg'
+            dangerouslySetInnerHTML={{
+              __html: `html { background: hotpink; }`
+            }}
+          />
+        </>
+      )
+    }
+  }
+
+  render () {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/test/integration/app-document-style-fragment/pages/index.js
+++ b/test/integration/app-document-style-fragment/pages/index.js
@@ -1,0 +1,16 @@
+function Hi () {
+  return (
+    <div>
+      <p>Hello world!</p>
+      <style jsx>{`
+        p {
+          font-size: 16.4px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+Hi.getInitialProps = () => ({})
+
+export default Hi

--- a/test/integration/app-document-style-fragment/test/index.test.js
+++ b/test/integration/app-document-style-fragment/test/index.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import {
+  stopApp,
+  startApp,
+  nextBuild,
+  nextServer,
+  renderViaHTTP
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60
+const appDir = join(__dirname, '../')
+let appPort
+let server
+let app
+
+describe('Custom Document Fragment Styles', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    app = nextServer({
+      dir: join(__dirname, '../'),
+      dev: false,
+      quiet: true
+    })
+
+    server = await startApp(app)
+    appPort = server.address().port
+  })
+  afterAll(() => stopApp(server))
+
+  it('correctly adds styles from fragment styles key', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    const $ = cheerio.load(html)
+
+    const styles = $('style').text()
+    expect(styles).toMatch(/background:(.*|)hotpink/)
+    expect(styles).toMatch(/font-size:(.*|)16\.4px/)
+  })
+})


### PR DESCRIPTION
This ensures we don't regress on supporting `styles: <>...</>` in a custom document.