### PR TITLE
Fix placeholder values being added when exporting from serverless

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -50,7 +50,7 @@ const nextServerlessLoader: loader.Loader = function() {
         : ``
     }
       import { apiResolver } from 'next-server/dist/server/api-utils'
-    
+
       export default (req, res) => {
         const params = ${
           isDynamicRoute(page)
@@ -108,7 +108,7 @@ const nextServerlessLoader: loader.Loader = function() {
         ${page === '/_error' ? `res.statusCode = 404` : ''}
         ${
           isDynamicRoute(page)
-            ? `const params = getRouteMatcher(getRouteRegex("${page}"))(parsedUrl.pathname) || {};`
+            ? `const params = fromExport ? {} : getRouteMatcher(getRouteRegex("${page}"))(parsedUrl.pathname) || {};`
             : `const params = {};`
         }
         const result = await renderToHTML(req, res, "${page}", Object.assign({}, parsedUrl.query, params), renderOpts)

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -2,6 +2,7 @@
 /* global jasmine */
 import webdriver from 'next-webdriver'
 import { join } from 'path'
+import fs from 'fs-extra'
 import {
   renderViaHTTP,
   findPort,
@@ -150,9 +151,20 @@ function runTests () {
     const text = await browser.eval(`document.body.innerHTML`)
     expect(text).toMatch(/onmpost:.*post-1/)
   })
+
+  it('should not have placeholder query values for SSS', async () => {
+    const html = await renderViaHTTP(appPort, '/on-mount/post-1')
+    expect(html).not.toMatch(/post:.*?\[post\].*?<\/p>/)
+  })
 }
 
+const nextConfig = join(appDir, 'next.config.js')
+
 describe('Dynamic Routing', () => {
+  beforeAll(async () => {
+    await fs.remove(nextConfig)
+  })
+
   describe('dev mode', () => {
     beforeAll(async () => {
       appPort = await findPort()
@@ -165,6 +177,33 @@ describe('Dynamic Routing', () => {
 
   describe('production mode', () => {
     beforeAll(async () => {
+      await runNextCommand(['build', appDir])
+
+      app = nextServer({
+        dir: appDir,
+        dev: false,
+        quiet: true
+      })
+
+      server = await startApp(app)
+      appPort = server.address().port
+    })
+    afterAll(() => stopApp(server))
+
+    runTests()
+  })
+
+  describe('SSR production mode', () => {
+    beforeAll(async () => {
+      await fs.writeFile(
+        nextConfig,
+        `
+        module.exports = {
+          target: 'serverless'
+        }
+      `
+      )
+
       await runNextCommand(['build', appDir])
 
       app = nextServer({


### PR DESCRIPTION
Makes sure `[post]` isn't shown added to query initially when auto exporting from serverless and runs the dynamic tests against serverless

Fixes: #7880