### PR TITLE
Fix PageConfig plugin running for non-pages

### DIFF
--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -61,8 +61,11 @@ module.exports = babelLoader.custom(babel => {
         customOptions: { isServer, asyncToPromises }
       }
     ) {
+      const { cwd } = cfg.options
       const filename = this.resourcePath
       const options = Object.assign({}, cfg.options)
+      const isPageFile = filename.startsWith(join(cwd, 'pages'))
+
       if (cfg.hasFilesystemConfig()) {
         for (const file of [cfg.babelrc, cfg.config]) {
           // We only log for client compilation otherwise there will be double output
@@ -77,7 +80,7 @@ module.exports = babelLoader.custom(babel => {
         options.presets = [...options.presets, presetItem]
       }
 
-      if (!isServer) {
+      if (!isServer && isPageFile) {
         const pageConfigPlugin = babel.createConfigItem(
           [require('../../babel/plugins/next-page-config')],
           { type: 'plugin' }

--- a/test/integration/page-config/config/index.js
+++ b/test/integration/page-config/config/index.js
@@ -1,0 +1,1 @@
+export const config = 'world'

--- a/test/integration/page-config/pages/index.js
+++ b/test/integration/page-config/pages/index.js
@@ -1,0 +1,8 @@
+import { config as hello } from '../something'
+import { config as world } from '../config'
+
+export default () => (
+  <p>
+    {hello} {world}
+  </p>
+)

--- a/test/integration/page-config/something.js
+++ b/test/integration/page-config/something.js
@@ -1,0 +1,1 @@
+export const config = 'hello'

--- a/test/integration/page-config/test/index.test.js
+++ b/test/integration/page-config/test/index.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '..')
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+describe('Page Config', () => {
+  it('builds without error when export const config is used outside page', async () => {
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).not.toMatch(/Failed to compile\./)
+  })
+})


### PR DESCRIPTION
Makes sure to only run the PageConfig babel plugin for page files. 

Fixes: #7834 