### PR TITLE
Components passed to getInitialProps() are wrapped in Context Providers

### DIFF
--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -344,7 +344,13 @@ export async function renderToHTML(
   )
 
   try {
-    props = await loadGetInitialProps(App, { Component, router, ctx })
+    const InitialPropsApp = props => (
+      <AppContainer>
+        <App {...props} />
+      </AppContainer>
+    );
+    InitialPropsApp.getInitialProps = App.getInitialProps;
+    props = await loadGetInitialProps(InitialPropsApp, { Component, router, ctx })
   } catch (err) {
     if (!dev || !err) throw err
     ctx.err = err


### PR DESCRIPTION
Fixes #7731 #6042 

Possibly a simpler alternative to #7732?