### PR TITLE
Allow selective static export

### DIFF
--- a/packages/next/cli/next-export.ts
+++ b/packages/next/cli/next-export.ts
@@ -15,6 +15,8 @@ const nextExport: cliCommand = argv => {
       '--outdir': String,
       '--threads': Number,
       '--concurrency': Number,
+      '--overwrite': Boolean,
+      '--filter': String,
 
       // Aliases
       '-h': '--help',
@@ -68,6 +70,8 @@ const nextExport: cliCommand = argv => {
     threads: args['--threads'],
     concurrency: args['--concurrency'],
     outdir: args['--outdir'] ? resolve(args['--outdir']) : join(dir, 'out'),
+    overwrite: args['--overwrite'] || args['--filter'] !== undefined || false,
+    filter: args['--filter'] || '',
   }
 
   exportApp(dir, options)


### PR DESCRIPTION
We've got static sites based on next.js where the content evolves a lot.
Every time a page content is updated, we have to re-export the whole site and it takes a long time.

This patch would allow selective exports by introducing two new options to the export command :
- `--filter`
- `--overwrite`

By using the proposed `--filter ` argument, you can specify a path like `/en/ski-lessons/children` that would restrict the scope of the export to all paths that starts with the specified value : it can be a partial path or a total path.

`next export --filter "/en/ski-lessons/children"`

When you specify the `--filter` argument, it implies that only the data for the matching pages has evolved, not the code. This why we propose a second argument `--overwrite` that let us reuse existing exported site in the `outDir`.

`next export --overwrite`

*Note : When using the `--filter` argument, we default to overwrite mode, but you can specify it explicitly when regenerating the whole site (without `--filter`) if its code didn't evolve.*

