### PR TITLE
Added a HTTP POST example to the api-routes example

### DIFF
--- a/examples/api-routes/pages/api/people/index.js
+++ b/examples/api-routes/pages/api/people/index.js
@@ -1,5 +1,14 @@
 import { people } from '../../../data'
 
 export default (req, res) => {
-  res.status(200).json(people)
+  if (req.method === 'POST') {
+    if (req.headers['content-type'].startsWith('application/json')) {
+      // req.body will be automatically parsed to JSON when the request's Content-Type is `application/json`
+      res.json(req.body)
+    } else {
+      res.send(req.body)
+    }
+  } else {
+    res.status(200).json(people)
+  }
 }

--- a/examples/api-routes/pages/api/people/index.js
+++ b/examples/api-routes/pages/api/people/index.js
@@ -4,9 +4,13 @@ export default (req, res) => {
   if (req.method === 'POST') {
     if (req.headers['content-type'].startsWith('application/json')) {
       // req.body will be automatically parsed to JSON when the request's Content-Type is `application/json`
-      res.json(req.body)
+      res.send('The data you sent has been interpreted as application/json.')
     } else {
-      res.send(req.body)
+      res
+        .status(400)
+        .send(
+          'Please POST JSON and use Content-Type="application/json" in your HTTP headers.'
+        )
     }
   } else {
     res.status(200).json(people)

--- a/examples/with-typescript/.gitignore
+++ b/examples/with-typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -388,6 +388,8 @@ When you need state, lifecycle hooks or **initial data population** you can expo
 Using a stateless function:
 
 ```jsx
+import fetch from 'isomorphic-unfetch';
+
 function Page({ stars }) {
   return <div>Next stars: {stars}</div>
 }


### PR DESCRIPTION
For some reason it took me some time to figure out how to `HTTP POST` data to the newly introduced API Routes.

Maybe because I was so fixated on express-like syntax `app.get`, `app.post`, `app.put` that I thought you could only `GET` stuff with the the API routes.

To save others from falling down that rabbit hole I added a short snippet to the `api-routes` example. I also added a check and comment to reiterate that next automatically parses the body if the `content-type` is `application-json`  