### PR TITLE
[prerender-indicator] Prevent blocking while hidden

### DIFF
--- a/packages/next/client/dev/prerender-indicator.js
+++ b/packages/next/client/dev/prerender-indicator.js
@@ -47,7 +47,10 @@ export default function initializeBuildWatcher () {
     }
   }
 
-  shadowHost.addEventListener('click', () => (shadowHost.style.opacity = 0))
+  shadowHost.addEventListener('click', () => {
+    shadowHost.style.opacity = 0
+    shadowHost.style.pointerEvents = 'none'
+  })
   shadowHost.addEventListener('mouseenter', () => {
     container.classList.add(`${prefix}expanded`)
   })


### PR DESCRIPTION
Allow clickthrough to previously inaccessible elements after indicator has been hidden.