### PR TITLE
Fix build package stats not being measured due to backslashes

### DIFF
--- a/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
+++ b/packages/next/build/webpack/plugins/chunk-graph-plugin.ts
@@ -36,6 +36,8 @@ export function getPageChunks(
   const external = new Set<string>() // from node_modules
   const internal = new Set<string>() // from project
   ;[...(manifest.pages[page] || []), ...(pageModules[page] || [])].map(mod => {
+    mod = mod.replace(/\\/g, '/')
+
     if (mod.match(/(next-server|next)\//)) {
       return null
     }


### PR DESCRIPTION
Adds handling for backslashes in module name causing package stats to not work on windows. 