### PR TITLE
Update link ref handling to clean up previous listeners

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -54,7 +54,6 @@ export type LinkProps = {
   passHref?: boolean
   onError?: (error: Error) => void
   prefetch?: boolean
-  childRef?: React.RefObject<any>
 }
 
 let observer: IntersectionObserver

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -54,6 +54,7 @@ export type LinkProps = {
   passHref?: boolean
   onError?: (error: Error) => void
   prefetch?: boolean
+  childRef?: React.RefObject<any>
 }
 
 let observer: IntersectionObserver
@@ -113,16 +114,13 @@ class Link extends Component<LinkProps> {
 
   cleanUpListeners = () => {}
 
-  componentDidMount() {
-    this.cleanUpListeners = () => {}
-  }
-
   componentWillUnmount() {
     this.cleanUpListeners()
   }
 
   handleRef(ref: Element) {
     if (this.props.prefetch && IntersectionObserver && ref && ref.tagName) {
+      this.cleanUpListeners()
       this.cleanUpListeners = listenToIntersections(ref, () => {
         this.prefetch()
       })


### PR DESCRIPTION
This makes sure the previous listeners are cleaned up before overwriting the cleanup function. 