### PR TITLE
Add empty publicRuntimeConfig to serverless tests

### DIFF
--- a/test/integration/serverless/next.config.js
+++ b/test/integration/serverless/next.config.js
@@ -6,5 +6,7 @@ module.exports = {
   },
   experimental: {
     publicDirectory: true
-  }
+  },
+  // make sure error isn't thrown from empty publicRuntimeConfig
+  publicRuntimeConfig: {}
 }


### PR DESCRIPTION
This makes sure error isn't thrown when not actually used