### PR TITLE
Don't externalize ssr-prepass if added by user

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -242,7 +242,19 @@ export default async function getBaseWebpackConfig(
           // When the serverless target is used all node_modules will be compiled into the output bundles
           // So that the serverless bundles have 0 runtime dependencies
           'amp-toolbox-optimizer', // except this one
-          ...(config.experimental.ampBindInitData ? [] : ['react-ssr-prepass']),
+          (context, request, callback) => {
+            if (
+              request === 'react-ssr-prepass' &&
+              !config.experimental.ampBindInitData
+            ) {
+              // if it's the Next.js' require mark it as external
+              // since it's not used
+              if (context.includes('next-server/dist/server')) {
+                return callback(undefined, `commonjs ${request}`)
+              }
+            }
+            return callback()
+          },
         ],
     optimization: Object.assign(
       {

--- a/test/integration/ssr-prepass/next.config.js
+++ b/test/integration/ssr-prepass/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'serverless'
+}

--- a/test/integration/ssr-prepass/pages/index.js
+++ b/test/integration/ssr-prepass/pages/index.js
@@ -1,0 +1,3 @@
+import ssrPrepass from 'react-ssr-prepass'
+
+export default () => <p>hello {ssrPrepass && 'world'}</p>

--- a/test/integration/ssr-prepass/test/index.test.js
+++ b/test/integration/ssr-prepass/test/index.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  killApp,
+  findPort,
+  nextStart,
+  nextBuild,
+  renderViaHTTP
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 30
+
+const appDir = join(__dirname, '../')
+let appPort
+let app
+
+describe('SSR Prepass', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+
+  it('should not externalize when used outside Next.js', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    expect(html).toMatch(/hello.*?world/)
+  })
+})


### PR DESCRIPTION
Makes sure to only externalize `react-ssr-prepass` when it's actually not used.

Fixes: #7889