### PR TITLE
Fix example with-firebase-hosting-and-typescript

### DIFF
--- a/examples/with-firebase-hosting-and-typescript/package.json
+++ b/examples/with-firebase-hosting-and-typescript/package.json
@@ -21,8 +21,8 @@
     "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {
-    "firebase-admin": "^6.3.0",
-    "firebase-functions": "^2.1.0",
+    "firebase-admin": "^8.0.0",
+    "firebase-functions": "^3.1.0",
     "next": "latest",
     "react": "16.8.6",
     "react-dom": "16.8.6"
@@ -33,7 +33,7 @@
     "@types/react-dom": "16.8.4",
     "cpx": "1.5.0",
     "cross-env": "5.2.0",
-    "firebase-tools": "^6.1.0",
+    "firebase-tools": "^7.1.0",
     "rimraf": "2.6.2",
     "tslint": "^5.11.0",
     "tslint-react": "^3.6.0",

--- a/examples/with-firebase-hosting-and-typescript/src/app/next.config.js
+++ b/examples/with-firebase-hosting-and-typescript/src/app/next.config.js
@@ -1,0 +1,3 @@
+module.exports = { 
+  distDir: '../../dist/functions/next'
+}

--- a/examples/with-firebase-hosting-and-typescript/src/app/next.config.js
+++ b/examples/with-firebase-hosting-and-typescript/src/app/next.config.js
@@ -1,3 +1,3 @@
-module.exports = { 
+module.exports = {
   distDir: '../../dist/functions/next'
 }


### PR DESCRIPTION
An error occured because `next.config.js` was removed. (#7815)
Then I have restored the file and upgraded firebase version

