### PR TITLE
Add default value for pageConfig for custom _error

### DIFF
--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -249,7 +249,7 @@ export async function renderToHTML(
     ampPath = '',
     App,
     Document,
-    pageConfig,
+    pageConfig = {},
     DocumentMiddleware,
     Component,
     buildManifest,

--- a/test/integration/custom-error/next.config.js
+++ b/test/integration/custom-error/next.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  target: 'serverless'
-}

--- a/test/integration/custom-error/next.config.js
+++ b/test/integration/custom-error/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'serverless'
+}

--- a/test/integration/custom-error/pages/_error.js
+++ b/test/integration/custom-error/pages/_error.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+class Error extends React.Component {
+  static getInitialProps ({ res, err }) {
+    const statusCode = res ? res.statusCode : err ? err.statusCode : null
+    return { statusCode }
+  }
+
+  render () {
+    return (
+      <>
+        <h3>Custom error!!</h3>
+        <p>
+          {this.props.statusCode
+            ? `An error ${this.props.statusCode} occurred on server`
+            : 'An error occurred on client'}
+        </p>
+      </>
+    )
+  }
+}
+
+export default Error

--- a/test/integration/custom-error/pages/index.js
+++ b/test/integration/custom-error/pages/index.js
@@ -1,0 +1,7 @@
+const Page = () => <p>Hello world</p>
+
+Page.getInitialProps = () => {
+  throw new Error('oof')
+}
+
+export default Page

--- a/test/integration/custom-error/test/index.test.js
+++ b/test/integration/custom-error/test/index.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 /* global jasmine */
+import fs from 'fs-extra'
 import { join } from 'path'
 import {
   renderViaHTTP,
@@ -11,19 +12,44 @@ import {
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 const appDir = join(__dirname, '..')
+const nextConfig = join(appDir, 'next.config.js')
 let appPort
 let app
 
-describe('Custom _error', () => {
-  beforeAll(async () => {
-    await nextBuild(appDir)
-    appPort = await findPort()
-    app = await nextStart(appDir, appPort)
-  })
-  afterAll(() => killApp(app))
-
+const runTests = () => {
   it('renders custom _error successfully', async () => {
     const html = await renderViaHTTP(appPort, '/')
     expect(html).toMatch(/Custom error/)
+  })
+}
+
+describe('Custom _error', () => {
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('serverless mode', () => {
+    beforeAll(async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { target: 'serverless' }`
+      )
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(async () => {
+      await killApp(app)
+      await fs.remove(nextConfig)
+    })
+
+    runTests()
   })
 })

--- a/test/integration/custom-error/test/index.test.js
+++ b/test/integration/custom-error/test/index.test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  renderViaHTTP,
+  findPort,
+  nextBuild,
+  nextStart,
+  killApp
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '..')
+let appPort
+let app
+
+describe('Custom _error', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+
+  it('renders custom _error successfully', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    expect(html).toMatch(/Custom error/)
+  })
+})


### PR DESCRIPTION
Makes sure `pageConfig` has a default value of `{}` when rendering custom `_error` page.

Fixes: #7977 