### PR TITLE
Add warning for experimental config usage

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -180,7 +180,7 @@ export type NextApiResponse<T = any> = ServerResponse & {
 /**
  * Utils
  */
-export function execOnce(this: any, fn: () => any) {
+export function execOnce(this: any, fn: (...args: any) => any) {
   let used = false
   return (...args: any) => {
     if (!used) {

--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -46,7 +46,7 @@ const defaultConfig: { [key: string]: any } = {
 
 const experimentalWarning = execOnce(() => {
   console.warn(
-    `\nFound experimental config:\nExperimental configs can change at anytime and aren't officially supported (use at your own risk).\n`
+    `\nFound experimental config:\nExperimental features can change at anytime and aren't officially supported (use at your own risk).\n`
   )
 })
 

--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -1,6 +1,7 @@
 import os from 'os'
 import findUp from 'find-up'
 import { CONFIG_FILE } from '../lib/constants'
+import { execOnce } from '../lib/utils'
 
 const targets = ['server', 'serverless']
 
@@ -43,8 +44,18 @@ const defaultConfig: { [key: string]: any } = {
   publicRuntimeConfig: {},
 }
 
+const experimentalWarning = execOnce(() => {
+  console.warn(
+    `\nFound experimental config:\nExperimental configs can change at anytime and aren't officially supported (use at your own risk).\n`
+  )
+})
+
 function assignDefaults(userConfig: { [key: string]: any }) {
   Object.keys(userConfig).forEach((key: string) => {
+    if (key === 'experimental' && userConfig[key]) {
+      experimentalWarning()
+    }
+
     const maybeObject = userConfig[key]
     if (!!maybeObject && maybeObject.constructor === Object) {
       userConfig[key] = {


### PR DESCRIPTION
Adds a warning when a user adds an `experimental` config to their `next.config.js`