### PR TITLE
Only copy `public/` directory if enabled

### DIFF
--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -149,7 +149,11 @@ export default async function (dir, options, configuration) {
 
   const publicDir = join(dir, CLIENT_PUBLIC_FILES_PATH)
   // Copy public directory
-  if (existsSync(publicDir)) {
+  if (
+    nextConfig.experimental &&
+    nextConfig.experimental.publicDirectory &&
+    existsSync(publicDir)
+  ) {
     log('  copying "public" directory')
     await recursiveCopy(publicDir, outDir, {
       filter (path) {


### PR DESCRIPTION
This fixes cases where uses may export to a directory called `public/`.

Fixes https://github.com/zeit/next.js/issues/7964