### PR TITLE
Don’t add loadable if it’s not used

### DIFF
--- a/packages/next-server/lib/loadable.js
+++ b/packages/next-server/lib/loadable.js
@@ -296,7 +296,7 @@ Loadable.preloadAll = () => {
   })
 }
 
-Loadable.preloadReady = ids => {
+Loadable.preloadReady = (ids = []) => {
   return new Promise(resolve => {
     const res = () => {
       initialized = true
@@ -305,6 +305,10 @@ Loadable.preloadReady = ids => {
     // We always will resolve, errors should be handled within loading UIs.
     flushInitializers(READY_INITIALIZERS, ids).then(res, res)
   })
+}
+
+if (typeof window !== 'undefined') {
+  window.__NEXT_PRELOADREADY = Loadable.preloadReady
 }
 
 export default Loadable

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -7,7 +7,6 @@ import mitt from 'next-server/dist/lib/mitt'
 import { loadGetInitialProps, getURL } from 'next-server/dist/lib/utils'
 import PageLoader from './page-loader'
 import * as envConfig from 'next-server/config'
-import Loadable from 'next-server/dist/lib/loadable'
 import { HeadManagerContext } from 'next-server/dist/lib/head-manager-context'
 import { DataManagerContext } from 'next-server/dist/lib/data-manager-context'
 import { RouterContext } from 'next-server/dist/lib/router-context'
@@ -155,7 +154,9 @@ export default async ({ webpackHMR: passedWebpackHMR } = {}) => {
     initialErr = error
   }
 
-  await Loadable.preloadReady(dynamicIds || [])
+  if (window.__NEXT_PRELOADREADY) {
+    await window.__NEXT_PRELOADREADY(dynamicIds)
+  }
 
   if (dynamicBuildId === true) {
     pageLoader.onDynamicBuildId()


### PR DESCRIPTION
Part of https://github.com/zeit/next.js/pull/7536 separated out so it can be merged.

This makes sure `next/dynamic` is not added when it's not used, decreasing default bundle sizes.