### PR TITLE
Adjust test names for `send`

### DIFF
--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -126,19 +126,30 @@ describe('Production Usage', () => {
       expect(res.status).toBe(405)
     })
 
-    it('should return 412 method on static file if If-Unmodified-Since is invalid', async () => {
+    it('should return 412 on static file if If-Unmodified-Since is true', async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
 
       const res = await fetch(
         `http://localhost:${appPort}/_next/static/${buildId}/pages/index.js`,
         {
           method: 'GET',
-          headers: {
-            'if-unmodified-since': 'Fri, 12 Jul 2019 20:00:13 GMT'
-          }
+          headers: { 'if-unmodified-since': 'Fri, 12 Jul 2019 20:00:13 GMT' }
         }
       )
       expect(res.status).toBe(412)
+    })
+
+    it('should return 200 on static file if If-Unmodified-Since is invalid', async () => {
+      const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
+
+      const res = await fetch(
+        `http://localhost:${appPort}/_next/static/${buildId}/pages/index.js`,
+        {
+          method: 'GET',
+          headers: { 'if-unmodified-since': 'nextjs' }
+        }
+      )
+      expect(res.status).toBe(200)
     })
 
     it('should set Content-Length header', async () => {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -126,7 +126,7 @@ describe('Production Usage', () => {
       expect(res.status).toBe(405)
     })
 
-    it('should return 412 on static file if If-Unmodified-Since is true', async () => {
+    it('should return 412 on static file when If-Unmodified-Since is provided and file is modified', async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
 
       const res = await fetch(
@@ -139,7 +139,7 @@ describe('Production Usage', () => {
       expect(res.status).toBe(412)
     })
 
-    it('should return 200 on static file if If-Unmodified-Since is invalid', async () => {
+    it('should return 200 on static file if If-Unmodified-Since is invalid date', async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
 
       const res = await fetch(


### PR DESCRIPTION
The `send` package acts in a lax mode since the spec defines you're allowed to ignore a `If-Unmodified-Since`.

That means an invalid header sent to `If-Unmodified-Since` will result in a `200`, not a `400` or `412`.