### PR TITLE
Fix children key in with-typescript-styled-components example

### DIFF
--- a/examples/with-typescript-styled-components/pages/_document.tsx
+++ b/examples/with-typescript-styled-components/pages/_document.tsx
@@ -15,12 +15,12 @@ export default class MyDocument extends Document {
       const initialProps = await Document.getInitialProps(ctx)
       return {
         ...initialProps,
-        styles: [
+        styles: (
           <>
             {initialProps.styles}
             {sheet.getStyleElement()}
-          </>,
-        ],
+          </>
+        ),
       }
     } finally {
       sheet.seal()


### PR DESCRIPTION
It had this warning:
```
Warning: Each child in a list should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.
    in Fragment
    in Head
    in html
    in Html
    in MyDocument
    in Context.Provider
[ info ]  bundled successfully, waiting for typecheck results ...
[ ready ] compiled successfully - ready on http://localhost:3000
[ wait ]  compiling ...
[ ready ] compiled successfully - ready on http://localhost:3000

```

As we can see from types:
```typescript
export declare type DocumentInitialProps = RenderPageResult & {
    styles?: React.ReactElement[] | React.ReactFragment;
};
```
we can pass React.Fragment instead of array which fixes this warning.