### PR TITLE
Avoid sending user errors to client

### DIFF
--- a/packages/next-server/server/api-utils.ts
+++ b/packages/next-server/server/api-utils.ts
@@ -49,7 +49,8 @@ export async function apiResolver(
     if (e instanceof ApiError) {
       sendError(res, e.statusCode, e.message)
     } else {
-      throw e
+      console.error(e)
+      sendError(res, 500, 'Internal Server Error')
     }
   }
 }
@@ -226,7 +227,7 @@ export function sendError(
 ) {
   res.statusCode = statusCode
   res.statusMessage = message
-  res.end()
+  res.end(message)
 }
 
 interface LazyProps {

--- a/packages/next-server/server/api-utils.ts
+++ b/packages/next-server/server/api-utils.ts
@@ -49,7 +49,7 @@ export async function apiResolver(
     if (e instanceof ApiError) {
       sendError(res, e.statusCode, e.message)
     } else {
-      sendError(res, 500, e.message)
+      throw e
     }
   }
 }

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -312,13 +312,16 @@ export default class Server {
         return mod.default(req, res)
       }
     }
-
-    apiResolver(
-      req,
-      res,
-      params,
-      resolverFunction ? require(resolverFunction) : undefined
-    )
+    try {
+      await apiResolver(
+        req,
+        res,
+        params,
+        resolverFunction ? require(resolverFunction) : undefined
+      )
+    } catch (e) {
+      throw e
+    }
   }
 
   /**

--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -312,16 +312,13 @@ export default class Server {
         return mod.default(req, res)
       }
     }
-    try {
-      await apiResolver(
-        req,
-        res,
-        params,
-        resolverFunction ? require(resolverFunction) : undefined
-      )
-    } catch (e) {
-      throw e
-    }
+
+    await apiResolver(
+      req,
+      res,
+      params,
+      resolverFunction ? require(resolverFunction) : undefined
+    )
   }
 
   /**

--- a/test/integration/api-support/pages/api/user-error.js
+++ b/test/integration/api-support/pages/api/user-error.js
@@ -1,0 +1,3 @@
+export default (req, res) => {
+  throw new Error('User error')
+}

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -53,6 +53,13 @@ function runTests (serverless = false) {
     expect(json).toEqual({ error: 'Server error!' })
   })
 
+  it('should throw Internal Server Error', async () => {
+    const res = await fetchViaHTTP(appPort, '/api/user-error', null, {})
+
+    expect(res.status).toBe(500)
+    expect(res.statusText).toBe('Internal Server Error')
+  })
+
   it('should parse JSON body', async () => {
     const data = await fetchViaHTTP(appPort, '/api/parse', null, {
       method: 'POST',

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -55,9 +55,9 @@ function runTests (serverless = false) {
 
   it('should throw Internal Server Error', async () => {
     const res = await fetchViaHTTP(appPort, '/api/user-error', null, {})
-
+    const text = await res.text()
     expect(res.status).toBe(500)
-    expect(res.statusText).toBe('Internal Server Error')
+    expect(text).toBe('Internal Server Error')
   })
 
   it('should parse JSON body', async () => {


### PR DESCRIPTION
The errors should be caught in userland and not send back to the client. 

Closes https://github.com/zeit/next.js/pull/7526