### PR TITLE
Handle windows backslashes when checking ssr-prepass

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -247,7 +247,9 @@ export default async function getBaseWebpackConfig(
             ) {
               // if it's the Next.js' require mark it as external
               // since it's not used
-              if (context.includes('next-server/dist/server')) {
+              if (
+                context.replace(/\\/g, '/').includes('next-server/dist/server')
+              ) {
                 return callback(undefined, `commonjs ${request}`)
               }
             }


### PR DESCRIPTION
This makes sure we replace windows backslashes before checking the context. This wasn't caught by our tests since the package is installed as a dev dependency. Things like this should be caught when we update our test setup. 