### PR TITLE
Correctly hydrate the `query` object for client-side getInitialProps

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -273,7 +273,8 @@ export default class Router implements BaseRouter {
         return resolve(true)
       }
 
-      const { pathname, query } = parse(url, true)
+      const { pathname } = parse(url)
+      const { query } = parse(as, true)
 
       // If asked to change the current URL we should reload the current page
       // (not location.reload() but reload getInitialProps and other Next.js stuffs)


### PR DESCRIPTION
See reproduction here: https://codesandbox.io/s/hydrate-query-client-side-in-nextjs-9-6j1uz

Given the following:

`pages/index.js`

```javascript
import Link from "next/link";
export default () => (
  <div>
    Hello World.
    <br />
    <Link href="/about" as="/about?who=me">
      <a>About via Client Side</a>
    </Link>
    <br />
    <a href="/about?who=me">About via Server Side</a>
  </div>
);
```

`pages/about.js`

```javascript
const About = ({ who }) => (
  <div>
    About {who ? who : "undefined"} <br />
    <a href="/">Home</a>
  </div>
);

About.getInitialProps = ({ query }) => {
  return { who: query.who };
};

export default About;
```

When performing a server-side load of `/about?who=me`, `About.getInitialProps()` correctly hydrates the `query` object with `{ who: 'me' }`.

But, when performing a client-side load of `/about?who=me` where the query is only present in the `as` of the `<Link>` component, the query is not correctly hydrated (ie; `About.getInitialProps()` gets a `query` object with `{}`).

This fix ensures the query parameters are pulled from the `as` url on both client and server.

## Workaround

For anyone else running into this today, you can patch the `query` object to behave correctly in your `_app.js`:

`_app.js`

```javascript
import React from 'react';
import App, { Container } from 'next/app';
import queryString from 'query-string';

class MyApp extends App {
  static async getInitialProps({ Component, ctx }) {
    let pageProps = {};

    if (process.browser){
      const newUrl = new URL(`${window.location.origin}${ctx.asPath}`);
      const parsedQuery = queryString.parse(newUrl.search);
      ctx.query = { ...parsedQuery, ...ctx.query };
    }

    if (Component.getInitialProps) {
      pageProps = await Component.getInitialProps(ctx);
    }

    return { pageProps };
  }

  // ...
}

export default MyApp;
```