### PR TITLE
Fix syntax error in ie11 from next-server/amp

### DIFF
--- a/packages/next-server/amp.js
+++ b/packages/next-server/amp.js
@@ -1,2 +1,2 @@
-const { useAmp } = require('./dist/lib/amp')
-module.exports = { useAmp }
+const amp = require('./dist/lib/amp')
+module.exports = { useAmp: amp.useAmp }

--- a/test/integration/production/pages/some-amp.js
+++ b/test/integration/production/pages/some-amp.js
@@ -1,0 +1,11 @@
+import { useAmp } from 'next/amp'
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('error', () => {
+    document.querySelector('p').innerText('error')
+  })
+}
+
+export const config = { amp: 'hybrid' }
+
+export default () => <p>{useAmp() ? 'AMP' : 'Not AMP'}</p>

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -566,6 +566,13 @@ describe('Production Usage', () => {
     expect(text).toMatch(/some interesting title/)
   })
 
+  it('should handle AMP correctly in IE', async () => {
+    const browser = await webdriver(appPort, '/some-amp')
+    await waitFor(1000)
+    const text = await browser.elementByCss('p').text()
+    expect(text).toBe('Not AMP')
+  })
+
   dynamicImportTests(context, (p, q) => renderViaHTTP(context.appPort, p, q))
 
   processEnv(context)


### PR DESCRIPTION
Removes newer syntax from untranspiled file `next-server/amp` which isn't supported in ie11

Fixes: #8024 