### PR TITLE
Add export statement for appGetInitialProps

### DIFF
--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -19,7 +19,7 @@ export type AppProps<P = {}> = AppPropsType<Router, P>
  * `App` component is used for initialize of pages. It allows for overwriting and full control of the `page` initialization.
  * This allows for keeping state between navigation, custom error handling, injecting additional data.
  */
-async function appGetInitialProps({
+export async function appGetInitialProps({
   Component,
   ctx,
 }: AppContext): Promise<AppInitialProps> {


### PR DESCRIPTION
Hello Zeit team,

I was looking to use App as a type definition (like [#6707](https://github.com/zeit/next.js/issues/6707)) but I could not find something working to get my `getInitialProps` typed aswell.
I think it could be cool to add and export statement on `appGetInitialProps` as it could be useful in this case.

It will be super cool to have your opinion on it!
Thank you!