### PR TITLE
Fix userAgent type error in README.md

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2177,7 +2177,7 @@ Next.js provides `NextPage` type that can be used for pages in the `pages` direc
 import { NextPage } from 'next'
 
 interface Props {
-  userAgent: string
+  userAgent?: string
 }
 
 const Page: NextPage<Props> = ({ userAgent }) => (
@@ -2208,7 +2208,7 @@ import React from 'react'
 import { NextPageContext } from 'next'
 
 interface Props {
-  userAgent: string
+  userAgent?: string
 }
 
 export default class Page extends React.Component<Props> {


### PR DESCRIPTION
Cheers.

There was an error in README.md.
`userAgent` type is `string` in Props, but `userAgent` is `string | undefined` in fact.
Hence, type error has occurred.