### PR TITLE
Remove `now.json` from examples

### DIFF
--- a/examples/dynamic-routing/now.json
+++ b/examples/dynamic-routing/now.json
@@ -1,4 +1,0 @@
-{
-  "version": 2,
-  "builds": [{ "src": "package.json", "use": "@now/next@canary" }]
-}

--- a/examples/with-graphql-hooks/.nowignore
+++ b/examples/with-graphql-hooks/.nowignore
@@ -1,1 +1,0 @@
-node_modules

--- a/examples/with-graphql-hooks/now.json
+++ b/examples/with-graphql-hooks/now.json
@@ -1,5 +1,0 @@
-{
-  "version": 2,
-  "name": "next-with-graphql-hooks",
-  "builds": [{ "src": "next.config.js", "use": "@now/next" }]
-}

--- a/examples/with-react-multi-carousel/now.json
+++ b/examples/with-react-multi-carousel/now.json
@@ -1,5 +1,0 @@
-{
-  "version": 2,
-  "name": "nextjs",
-  "builds": [{ "src": "package.json", "use": "@now/next" }]
-}

--- a/examples/with-semantic-ui/now.json
+++ b/examples/with-semantic-ui/now.json
@@ -1,5 +1,0 @@
-{
-  "version": 2,
-  "name": "with-semantic-ui",
-  "builds": [{ "src": "package.json", "use": "@now/next" }]
-}


### PR DESCRIPTION
`now.json` files are no longer required to deploy Next.js applications. 😄 