### PR TITLE
Adds user timing marks and measures for hydration/render

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
       "examples/with-kea/**",
       "examples/with-mobx/**",
       "test/integration/client-navigation/pages/throw-undefined.js"
-    ]
+    ],
+    "globals": [ "performance" ]
   },
   "devDependencies": {
     "@babel/plugin-proposal-object-rest-spread": "7.4.4",

--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -246,7 +246,7 @@ export default class Router implements BaseRouter {
 
   change(method: string, _url: Url, _as: Url, options: any): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      performance.mark('linkClick') // marking route changes as a navigation start entry
+      performance.mark('routeChange') // marking route changes as a navigation start entry
       // If url and as provided as an object representation,
       // we'll format them into the string version here.
       const url = typeof _url === 'object' ? formatWithValidation(_url) : _url

--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -11,6 +11,7 @@ import {
   getURL,
   loadGetInitialProps,
   NextPageContext,
+  SUPPORTS_PERFORMANCE_USER_TIMING,
 } from '../utils'
 import { rewriteUrlForNextExport } from './rewrite-url-for-export'
 import { getRouteMatcher } from './utils/route-matcher'
@@ -247,7 +248,7 @@ export default class Router implements BaseRouter {
   change(method: string, _url: Url, _as: Url, options: any): Promise<boolean> {
     return new Promise((resolve, reject) => {
       // marking route changes as a navigation start entry
-      if (typeof performance !== 'undefined') {
+      if (SUPPORTS_PERFORMANCE_USER_TIMING) {
         performance.mark('routeChange')
       }
 

--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -246,7 +246,11 @@ export default class Router implements BaseRouter {
 
   change(method: string, _url: Url, _as: Url, options: any): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      performance.mark('routeChange') // marking route changes as a navigation start entry
+      // marking route changes as a navigation start entry
+      if (typeof performance !== 'undefined') {
+        performance.mark('routeChange')
+      }
+
       // If url and as provided as an object representation,
       // we'll format them into the string version here.
       const url = typeof _url === 'object' ? formatWithValidation(_url) : _url

--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -246,6 +246,7 @@ export default class Router implements BaseRouter {
 
   change(method: string, _url: Url, _as: Url, options: any): Promise<boolean> {
     return new Promise((resolve, reject) => {
+      performance.mark('linkClick') // marking route changes as a navigation start entry
       // If url and as provided as an object representation,
       // we'll format them into the string version here.
       const url = typeof _url === 'object' ? formatWithValidation(_url) : _url

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -282,3 +282,9 @@ export function formatWithValidation(
 
   return format(url as any, options)
 }
+
+export const SUPPORTS_PERFORMANCE = typeof performance !== 'undefined'
+export const SUPPORTS_PERFORMANCE_USER_TIMING =
+  SUPPORTS_PERFORMANCE &&
+  typeof performance.mark === 'function' &&
+  typeof performance.measure === 'function'

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -240,34 +240,42 @@ export async function renderError (props) {
 // If hydrate does not exist, eg in preact.
 let isInitialRender = typeof ReactDOM.hydrate === 'function'
 function renderReactElement (reactEl, domEl) {
-  performance.mark('beforeHydrate') // mark start of hydration
+  performance.mark('beforeRender') // mark start of hydrate/render
 
   // The check for `.hydrate` is there to support React alternatives like preact
   if (isInitialRender) {
     ReactDOM.hydrate(reactEl, domEl, markHydrateComplete)
     isInitialRender = false
   } else {
-    ReactDOM.render(reactEl, domEl, markHydrateComplete)
+    ReactDOM.render(reactEl, domEl, markRenderComplete)
   }
 }
 
 function markHydrateComplete () {
   performance.mark('afterHydrate') // mark end of hydration
-  logTimings()
+
+  performance.measure('Next.js-before-hydration', null, 'beforeRender')
+  performance.measure('Next.js-hydration', 'beforeRender', 'afterHydrate')
+
+  clearMarks()
 }
 
-function logTimings () {
+function markRenderComplete () {
+  performance.mark('afterRender') // mark end of render
+
   const navStartEntries = performance.getEntriesByName('linkClick', 'mark')
-  const navStartEntry =
-    navStartEntries.length >= 1 ? navStartEntries[0].name : null
 
   performance.measure(
-    'Next.js-time-to-hydrate)',
-    navStartEntry,
-    'beforeHydrate'
+    'Next.js-nav-to-render',
+    navStartEntries[0].name,
+    'beforeRender'
   )
-  performance.measure('Next.js-hydration', 'beforeHydrate', 'afterHydrate')
+  performance.measure('Next.js-render', 'beforeRender', 'afterRender')
 
+  clearMarks()
+}
+
+function clearMarks () {
   performance.clearMarks()
   performance.clearMeasures()
 }

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -240,13 +240,43 @@ export async function renderError (props) {
 // If hydrate does not exist, eg in preact.
 let isInitialRender = typeof ReactDOM.hydrate === 'function'
 function renderReactElement (reactEl, domEl) {
+  window.performance.mark('beforeHydrate') // mark start of hydration
+
   // The check for `.hydrate` is there to support React alternatives like preact
   if (isInitialRender) {
-    ReactDOM.hydrate(reactEl, domEl)
+    ReactDOM.hydrate(reactEl, domEl, markHydrateComplete)
     isInitialRender = false
   } else {
-    ReactDOM.render(reactEl, domEl)
+    ReactDOM.render(reactEl, domEl, markHydrateComplete)
   }
+}
+
+function markHydrateComplete () {
+  window.performance.mark('afterHydrate') // mark end of hydration
+  logTimings()
+}
+
+function logTimings () {
+  const navStartEntries = window.performance.getEntriesByName(
+    'linkClick',
+    'mark'
+  )
+  const navStartEntry =
+    navStartEntries.length >= 1 ? navStartEntries[0].name : null
+
+  window.performance.measure(
+    '⌛ (Next.js) Readiness (time-to-hydrate)',
+    navStartEntry,
+    'beforeHydrate'
+  )
+  window.performance.measure(
+    '💧 (Next.js) Hydration',
+    'beforeHydrate',
+    'afterHydrate'
+  )
+
+  window.performance.clearMarks()
+  window.performance.clearMeasures()
 }
 
 function AppContainer ({ children }) {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -4,7 +4,11 @@ import ReactDOM from 'react-dom'
 import HeadManager from './head-manager'
 import { createRouter, makePublicRouterInstance } from 'next/router'
 import mitt from 'next-server/dist/lib/mitt'
-import { loadGetInitialProps, getURL } from 'next-server/dist/lib/utils'
+import {
+  loadGetInitialProps,
+  getURL,
+  SUPPORTS_PERFORMANCE_USER_TIMING
+} from 'next-server/dist/lib/utils'
 import PageLoader from './page-loader'
 import * as envConfig from 'next-server/config'
 import { HeadManagerContext } from 'next-server/dist/lib/head-manager-context'
@@ -241,7 +245,7 @@ export async function renderError (props) {
 let isInitialRender = typeof ReactDOM.hydrate === 'function'
 function renderReactElement (reactEl, domEl) {
   // mark start of hydrate/render
-  if (typeof performance !== 'undefined') {
+  if (SUPPORTS_PERFORMANCE_USER_TIMING) {
     performance.mark('beforeRender')
   }
 
@@ -255,7 +259,7 @@ function renderReactElement (reactEl, domEl) {
 }
 
 function markHydrateComplete () {
-  if (typeof performance === 'undefined') return
+  if (!SUPPORTS_PERFORMANCE_USER_TIMING) return
 
   performance.mark('afterHydrate') // mark end of hydration
 
@@ -266,7 +270,7 @@ function markHydrateComplete () {
 }
 
 function markRenderComplete () {
-  if (typeof performance === 'undefined') return
+  if (!SUPPORTS_PERFORMANCE_USER_TIMING) return
 
   performance.mark('afterRender') // mark end of render
   const navStartEntries = performance.getEntriesByName('routeChange', 'mark')

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -240,7 +240,7 @@ export async function renderError (props) {
 // If hydrate does not exist, eg in preact.
 let isInitialRender = typeof ReactDOM.hydrate === 'function'
 function renderReactElement (reactEl, domEl) {
-  window.performance.mark('beforeHydrate') // mark start of hydration
+  performance.mark('beforeHydrate') // mark start of hydration
 
   // The check for `.hydrate` is there to support React alternatives like preact
   if (isInitialRender) {
@@ -252,31 +252,24 @@ function renderReactElement (reactEl, domEl) {
 }
 
 function markHydrateComplete () {
-  window.performance.mark('afterHydrate') // mark end of hydration
+  performance.mark('afterHydrate') // mark end of hydration
   logTimings()
 }
 
 function logTimings () {
-  const navStartEntries = window.performance.getEntriesByName(
-    'linkClick',
-    'mark'
-  )
+  const navStartEntries = performance.getEntriesByName('linkClick', 'mark')
   const navStartEntry =
     navStartEntries.length >= 1 ? navStartEntries[0].name : null
 
-  window.performance.measure(
-    '⌛ (Next.js) Readiness (time-to-hydrate)',
+  performance.measure(
+    'Next.js-time-to-hydrate)',
     navStartEntry,
     'beforeHydrate'
   )
-  window.performance.measure(
-    '💧 (Next.js) Hydration',
-    'beforeHydrate',
-    'afterHydrate'
-  )
+  performance.measure('Next.js-hydration', 'beforeHydrate', 'afterHydrate')
 
-  window.performance.clearMarks()
-  window.performance.clearMeasures()
+  performance.clearMarks()
+  performance.clearMeasures()
 }
 
 function AppContainer ({ children }) {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -240,7 +240,10 @@ export async function renderError (props) {
 // If hydrate does not exist, eg in preact.
 let isInitialRender = typeof ReactDOM.hydrate === 'function'
 function renderReactElement (reactEl, domEl) {
-  performance.mark('beforeRender') // mark start of hydrate/render
+  // mark start of hydrate/render
+  if (typeof performance !== 'undefined') {
+    performance.mark('beforeRender')
+  }
 
   // The check for `.hydrate` is there to support React alternatives like preact
   if (isInitialRender) {
@@ -252,6 +255,8 @@ function renderReactElement (reactEl, domEl) {
 }
 
 function markHydrateComplete () {
+  if (typeof performance === 'undefined') return
+
   performance.mark('afterHydrate') // mark end of hydration
 
   performance.measure('Next.js-before-hydration', null, 'beforeRender')
@@ -261,6 +266,8 @@ function markHydrateComplete () {
 }
 
 function markRenderComplete () {
+  if (typeof performance === 'undefined') return
+
   performance.mark('afterRender') // mark end of render
   const navStartEntries = performance.getEntriesByName('routeChange', 'mark')
 

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -262,11 +262,14 @@ function markHydrateComplete () {
 
 function markRenderComplete () {
   performance.mark('afterRender') // mark end of render
+  const navStartEntries = performance.getEntriesByName('routeChange', 'mark')
 
-  const navStartEntries = performance.getEntriesByName('linkClick', 'mark')
+  if (!navStartEntries.length) {
+    return
+  }
 
   performance.measure(
-    'Next.js-nav-to-render',
+    'Next.js-route-change-to-render',
     navStartEntries[0].name,
     'beforeRender'
   )

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -168,8 +168,6 @@ class Link extends Component<LinkProps> {
       scroll = as.indexOf('#') < 0
     }
 
-    performance.mark('linkClick') // marking link clicks as a navigation start entry
-
     // replace state instead of push if prop is present
     Router[this.props.replace ? 'replace' : 'push'](href, as, {
       shallow: this.props.shallow,

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -168,6 +168,8 @@ class Link extends Component<LinkProps> {
       scroll = as.indexOf('#') < 0
     }
 
+    window.performance.mark('linkClick') // marking link clicks as a navigation start entry
+
     // replace state instead of push if prop is present
     Router[this.props.replace ? 'replace' : 'push'](href, as, {
       shallow: this.props.shallow,

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -168,7 +168,7 @@ class Link extends Component<LinkProps> {
       scroll = as.indexOf('#') < 0
     }
 
-    window.performance.mark('linkClick') // marking link clicks as a navigation start entry
+    performance.mark('linkClick') // marking link clicks as a navigation start entry
 
     // replace state instead of push if prop is present
     Router[this.props.replace ? 'replace' : 'push'](href, as, {


### PR DESCRIPTION
For context, see Issue #8070.

---

This PR adds user timings for:

* Link clicks
* Before hydration and render
* After hydration and render

With these marks, the following measures are added:

#### For page loads

* `Next.js-before-hydration`: measures page load to "right before hydration"
* `Next.js-hydration`: measures hydration step

<img width="1736" alt="Screen Shot 2019-07-22 at 4 50 01 PM" src="https://user-images.githubusercontent.com/12476932/61683343-1c51b980-acca-11e9-8ffa-3fd436c04b29.png">

#### For navigation

* `Next.js-nav-to-render`: measures navigation start to "right before render"
* `Next.js-render`: measures hydration step

<img width="1736" alt="Screen Shot 2019-07-22 at 4 52 12 PM" src="https://user-images.githubusercontent.com/12476932/61683391-2f648980-acca-11e9-8ce6-f1961feb6ec0.png">

Testing on a [simple example app](https://github.com/zeit/next.js/tree/master/examples/parameterized-routing), hydration aligns with the `hydrate` method in the callstack (and the same for `render`)

<img width="1736" alt="Screen Shot 2019-07-17 at 2 10 43 PM" src="https://user-images.githubusercontent.com/12476932/61415715-5a07aa00-a8a6-11e9-9da7-95e5cf9cedeb.png">

_Note: These marks are added for both development and production modes_