### PR TITLE
Updated "firebase-admin" module and added "firebase-functions-test" & "grpc" modules in with-firebase-hosting example

### DIFF
--- a/examples/with-firebase-hosting/package.json
+++ b/examples/with-firebase-hosting/package.json
@@ -19,8 +19,9 @@
     "install-deps": "cd \"dist/functions\" && npm i"
   },
   "dependencies": {
-    "firebase-admin": "^6.3.0",
+    "firebase-admin": "^8.2.0",
     "firebase-functions": "^2.1.0",
+    "grpc": "^1.22.2",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
@@ -29,6 +30,7 @@
     "@babel/cli": "^7.2.0",
     "cpx": "^1.5.0",
     "cross-env": "^5.2.0",
+    "firebase-functions-test": "^0.1.6",
     "firebase-tools": "^6.1.0",
     "rimraf": "^2.6.0"
   }


### PR DESCRIPTION
### Fix of following three errors on "npm run serve" in with-firebase-hosting example

1. Error due to **"firebase-admin@6.3.0" module too old**:
```
=== Serving from '/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting'...

⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: Emulator started at http://localhost:5001
i  functions: Watching "/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/dist/functions" for Cloud Functions...
i  hosting: Serving hosting files from: dist/public
✔  hosting: Local server: http://localhost:5000
⚠  The Cloud Functions emulator requires the module "firebase-admin" to be version >7.0.0 so your version is too old. You can probably fix this by running "npm install firebase-admin@latest" in your functions directory.
i  functions: Your functions could not be parsed due to an issue with your node_modules (see above)
```
Fixed using:
`npm install firebase-admin@latest`

2. Error due to **missing "firebase-functions-test"** development dependency:
```
=== Serving from '/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting'...

⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: Emulator started at http://localhost:5001
i  functions: Watching "/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/dist/functions" for Cloud Functions...
i  hosting: Serving hosting files from: dist/public
✔  hosting: Local server: http://localhost:5000
⚠  The Cloud Functions emulator requires the module "firebase-functions-test" to be installed as a development dependency. To fix this, run "npm install --save-dev firebase-functions-test" in your functions directory.
i  functions: Your functions could not be parsed due to an issue with your node_modules (see above)
```
Fixed using:
`npm install --save-dev firebase-functions-test`

3. Error due to **missing "grpc" module**:
```
=== Serving from '/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting'...

⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: Emulator started at http://localhost:5001
i  functions: Watching "/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/dist/functions" for Cloud Functions...
i  hosting: Serving hosting files from: dist/public
✔  hosting: Local server: http://localhost:5000
⚠  TypeError [ERR_INVALID_ARG_VALUE]: The argument 'id' must be a non-empty string. Received ''
    at Module.require (internal/modules/cjs/loader.js:633:11)
    at require (internal/modules/cjs/helpers.js:20:18)
    at InitializeFirebaseAdminStubs (/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:231:18)
    at /Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:461:9
    at Generator.next (<anonymous>)
    at /Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:3:12)
    at main (/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:431:12)
    at Object.<anonymous> (/Users/chaitanyareddy/crkxed/next.js/examples/with-firebase-hosting/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:521:5)
⚠  Your function was killed because it raised an unhandled error.
```
Fixed using:
`npm install grpc`