### PR TITLE
Noop usage of `esm` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "cross-spawn": "6.0.5",
     "eslint": "5.16.0",
     "eslint-plugin-typescript": "0.14.0",
+    "esm": "3.2.25",
     "execa": "2.0.3",
     "express": "4.17.0",
     "faunadb": "2.6.1",

--- a/packages/next/build/babel/plugins/noop-esm.ts
+++ b/packages/next/build/babel/plugins/noop-esm.ts
@@ -1,0 +1,32 @@
+import { PluginObj } from '@babel/core'
+
+// The purpose of this plugin is to remove the `esm` package from being bundled
+// by webpack. `esm` is not compatible or relevant with a webpack world.
+//
+// Reasoning:
+// https://github.com/webpack/webpack/issues/4742
+//
+// tl;dr:
+//
+// `const bla require('esm-module')` is not the same as:
+// `import bla from 'esm-module'` -- it's equivalent to:
+// `import * as bla from 'esm-module`.
+// This means CJS packages cannot consume ESM-enabled variants of CJS modules,
+// "magically". i.e. we cannot resolve the `module` key first. This is not a
+// problem for webpack though, because it understands ESM natively unlike Node.
+
+export default function NoopEsmPatcher(): PluginObj {
+  return {
+    visitor: {
+      CallExpression(path) {
+        const { callee } = path.node
+        if (callee.type === 'Identifier' && callee.name === 'require') {
+          const arg = path.node.arguments[0]
+          if (arg && arg.type === 'StringLiteral' && arg.value === 'esm') {
+            path.getStatementParent().remove()
+          }
+        }
+      },
+    },
+  }
+}

--- a/packages/next/build/babel/plugins/noop-esm.ts
+++ b/packages/next/build/babel/plugins/noop-esm.ts
@@ -5,15 +5,7 @@ import { PluginObj } from '@babel/core'
 //
 // Reasoning:
 // https://github.com/webpack/webpack/issues/4742
-//
-// tl;dr:
-//
-// `const bla require('esm-module')` is not the same as:
-// `import bla from 'esm-module'` -- it's equivalent to:
-// `import * as bla from 'esm-module`.
-// This means CJS packages cannot consume ESM-enabled variants of CJS modules,
-// "magically". i.e. we cannot resolve the `module` key first. This is not a
-// problem for webpack though, because it understands ESM natively unlike Node.
+// https://github.com/zeit/next.js/pull/8081
 
 export default function NoopEsmPatcher(): PluginObj {
   return {

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -126,6 +126,7 @@ module.exports = (
         styledJsxOptions(options['styled-jsx']),
       ],
       require('./plugins/amp-attributes'),
+      require('./plugins/noop-esm'),
       isProduction && [
         require('babel-plugin-transform-react-remove-prop-types'),
         {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -144,7 +144,7 @@ export default async function getBaseWebpackConfig(
       ? target === 'serverless'
         ? ['module', 'main']
         : ['main', 'module']
-      : ['module', 'browser', 'main'],
+      : ['browser', 'module', 'main'],
   }
 
   const webpackMode = dev ? 'development' : 'production'

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -140,7 +140,7 @@ export default async function getBaseWebpackConfig(
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
     },
-    mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
+    mainFields: isServer ? ['module', 'main'] : ['module', 'browser', 'main'],
   }
 
   const webpackMode = dev ? 'development' : 'production'

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -140,11 +140,7 @@ export default async function getBaseWebpackConfig(
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
     },
-    mainFields: isServer
-      ? target === 'serverless'
-        ? ['module', 'main']
-        : ['main', 'module']
-      : ['browser', 'module', 'main'],
+    mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
   }
 
   const webpackMode = dev ? 'development' : 'production'

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -140,7 +140,11 @@ export default async function getBaseWebpackConfig(
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
     },
-    mainFields: isServer ? ['module', 'main'] : ['module', 'browser', 'main'],
+    mainFields: isServer
+      ? target === 'serverless'
+        ? ['module', 'main']
+        : ['main', 'module']
+      : ['module', 'browser', 'main'],
   }
 
   const webpackMode = dev ? 'development' : 'production'

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -2,8 +2,8 @@ import hash from 'string-hash'
 import { join, basename } from 'path'
 import babelLoader from 'babel-loader'
 
-// increment 'c' to invalidate cache
-const cacheKey = 'babel-cache-' + 'c' + '-'
+// increment 'd' to invalidate cache
+const cacheKey = 'babel-cache-' + 'd' + '-'
 
 module.exports = babelLoader.custom(babel => {
   const presetItem = babel.createConfigItem(require('../../babel/preset'), {

--- a/test/integration/esm/next.config.js
+++ b/test/integration/esm/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  target: 'serverless',
+  webpack: config => {
+    config.node = { fs: 'empty' }
+    return config
+  }
+}

--- a/test/integration/esm/pages/cjs.js
+++ b/test/integration/esm/pages/cjs.js
@@ -1,0 +1,12 @@
+const React = require('react')
+const { default: b, a } = require('../seeya')
+
+function A ({ text }) {
+  return <p>{text}</p>
+}
+
+A.getInitialProps = function () {
+  return { text: b + a }
+}
+
+module.exports = A

--- a/test/integration/esm/pages/mjs.js
+++ b/test/integration/esm/pages/mjs.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import b, { a } from '../seeya'
+
+function A ({ text }) {
+  return <p>{text}</p>
+}
+
+A.getInitialProps = function () {
+  return { text: b + a }
+}
+
+export default A

--- a/test/integration/esm/seeya/index.js
+++ b/test/integration/esm/seeya/index.js
@@ -1,0 +1,4 @@
+// Set options as a parameter, environment variable, or rc file.
+// eslint-disable-next-line no-global-assign
+require = require('esm')(module /* , options */)
+module.exports = require('./main.mjs')

--- a/test/integration/esm/seeya/main.mjs
+++ b/test/integration/esm/seeya/main.mjs
@@ -1,0 +1,2 @@
+export const a = 'foo'
+export default 'hello'

--- a/test/integration/esm/test/index.test.js
+++ b/test/integration/esm/test/index.test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import {
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  renderViaHTTP
+} from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+let appPort
+let app
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+describe('Serverless', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+
+  it('should noop esm for cjs', async () => {
+    const html = await renderViaHTTP(appPort, '/cjs')
+    expect(html).toMatch(/hellofoo/)
+  })
+
+  it('should noop esm for mjs', async () => {
+    const html = await renderViaHTTP(appPort, '/mjs')
+    expect(html).toMatch(/hellofoo/)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,6 +5243,11 @@ eslint@~5.4.0:
     table "^4.0.3"
     text-table "^0.2.0"
 
+esm@3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"


### PR DESCRIPTION
tl;dr: The [`esm`](https://github.com/standard-things/esm) package works great for the Node world, however, is totally unnecessary in a webpack world.
It has the same behavior of webpack but breaks static analysis.

---

Webpack code that's bundled for consumption in Node can never favor the `module` key over the `main` key, as the import semantics of CommonJS and ES Modules are not interoperable / magically compatible.

More background here: https://github.com/webpack/webpack/issues/4742

Meaning, the following code:
```js
const M = require('my-module');
```

is not equivalent to:
```js
import M from 'my-module'
```

but instead, is equivalent to:
```js
import * as M from 'my-module'
```

This means code that's instructed to unwittingly bundle against an ESM version of package suddenly becomes incompatible, as their export has moved to the `default` key.

You could argue that it's a package's responsibility to ensure that their CommonJS version exports using the `default` key:
```js
module.exports = function() { } // "WRONG"

module.exports = {
  default: function() { }
} // "CORRECT"
```

> Note: ☝️ this is the behavior of [`esm`](https://github.com/standard-things/esm), properly so.

However, this is not often seen in practice and is not possible to enforce at scale. It only takes one [incorrectly published package](https://github.com/bitinn/node-fetch) to break everyone. 😄 

As a result, we must continue (for Node packages) to import the `main` key before the `module` key, or fix them on a case-by-case basis.

That brings us to the next point, in a [`esm`](https://github.com/standard-things/esm) project, webpack _does not like_ the following code:
```js
require = require('esm')(module)
module.exports = require('./main.js')
```

Re-assigning `require` confuses webpack and causes it to bail out of its bundling job.

The solution? Delete [`esm`](https://github.com/standard-things/esm) because it already works OOTB in webpack:
```js
module.exports = require('./main.js')
```

☝️ This is what this plugin outputs for the above input.


----

~[**There is an alternative to this PR**](https://github.com/zeit/next.js/pull/8082), which is to favor `module` always and white-list every single broken package in the ecosystem to a fixed variant. This may be favorable?~

Closes https://github.com/zeit/next.js/pull/8082
Closes https://github.com/zeit/now-cli/issues/2569