### PR TITLE
Make Node code prefer `.module` in package.json

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -139,8 +139,11 @@ export default async function getBaseWebpackConfig(
       next: NEXT_PROJECT_ROOT,
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
-      // Collection of improperly published ecosystem packages:
-      'node-fetch': 'node-fetch/lib/index.js',
+
+      // Collection of improperly published ecosystem packages
+      // Reasons:
+      //   1. CJS-variant does not export using `default` key
+      'node-fetch': 'node-fetch/lib/index.js', // (1)
     },
     mainFields: isServer ? ['module', 'main'] : ['browser', 'module', 'main'],
   }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -143,7 +143,7 @@ export default async function getBaseWebpackConfig(
       // Collection of incorrectly published packages in the ecosystem
       // Reasons:
       //   1. CJS-variant does not export using `default` key
-      'node-fetch': 'node-fetch/lib/index.js', // (1)
+      'node-fetch': 'node-fetch/lib/index.js', // reason 1: v2.6.0
     },
     mainFields: isServer ? ['module', 'main'] : ['browser', 'module', 'main'],
   }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -139,6 +139,8 @@ export default async function getBaseWebpackConfig(
       next: NEXT_PROJECT_ROOT,
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
+      // Collection of improperly published ecosystem packages:
+      'node-fetch': 'node-fetch/lib/index.js',
     },
     mainFields: isServer ? ['module', 'main'] : ['browser', 'module', 'main'],
   }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -140,7 +140,7 @@ export default async function getBaseWebpackConfig(
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
 
-      // Collection of improperly published ecosystem packages
+      // Collection of incorrectly published packages in the ecosystem
       // Reasons:
       //   1. CJS-variant does not export using `default` key
       'node-fetch': 'node-fetch/lib/index.js', // (1)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -140,7 +140,7 @@ export default async function getBaseWebpackConfig(
       [PAGES_DIR_ALIAS]: path.join(dir, 'pages'),
       [DOT_NEXT_ALIAS]: distDir,
     },
-    mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
+    mainFields: isServer ? ['module', 'main'] : ['browser', 'module', 'main'],
   }
 
   const webpackMode = dev ? 'development' : 'production'


### PR DESCRIPTION
This makes bundled Node code prefer the `module`s key and uses aliases to fix incorrectly published packages.
You can find more details on why this is necessary in https://github.com/zeit/next.js/pull/8081.

This may get tricky as packages fix these problems between versions, though we can probably figure something out.

An alternative so we don't need to maintain a whitelist is to noop the behavior of `esm`, [found in this pull request](https://github.com/zeit/next.js/pull/8081).

> Note: This pull request is already tested.
> https://github.com/zeit/next.js/blob/canary/test/integration/serverless/test/index.test.js#L72-L78

---

Closes https://github.com/zeit/next.js/pull/8081
Closes https://github.com/zeit/now-cli/issues/2569