### PR TITLE
Add default message for 410

### DIFF
--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -6,6 +6,7 @@ const statusCodes: { [code: number]: string } = {
   400: 'Bad Request',
   404: 'This page could not be found',
   405: 'Method Not Allowed',
+  410: 'Page Deleted',
   500: 'Internal Server Error',
 }
 


### PR DESCRIPTION
Added default message "Page Deleted" for when Error component receives prop `statusCode` but nothing for prop `title`

https://github.com/zeit/next.js/issues/8087