### PR TITLE
Improve type definitions

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -215,7 +215,7 @@ export async function loadGetInitialProps<
   C extends BaseContext,
   IP = {},
   P = {}
->(Component: NextComponentType<C, IP, P>, ctx: C): Promise<IP | null> {
+>(Component: NextComponentType<C, IP, P>, ctx: C): Promise<IP> {
   if (process.env.NODE_ENV !== 'production') {
     if (Component.prototype && Component.prototype.getInitialProps) {
       const message = `"${getDisplayName(

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -112,7 +112,7 @@ function getRouter() {
 export default singletonRouter as SingletonRouter
 
 // Reexport the withRoute HOC
-export { default as withRouter } from './with-router'
+export { default as withRouter, WithRouterProps } from './with-router'
 
 export function useRouter() {
   return React.useContext(RouterContext)

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -38,7 +38,9 @@ declare module 'react' {
  * `Page` type, use it as a guide to create `pages`.
  */
 export type NextPage<P = {}, IP = P> = {
-  (props: P): JSX.Element
+  (props: P): JSX.Element | null
+  defaultProps?: Partial<P>
+  displayName?: string
   /**
    * Used for initial page load data population. Data returned from `getInitialProps` is serialized when server rendered.
    * Make sure to return plain `Object` without using `Date`, `Map`, `Set`.


### PR DESCRIPTION
* `loadGetInitialProps` will never resolve `null` https://github.com/adam187/next.js/blob/5c79d09bb9fa5bb3dcd5d796d2c0bbfc6254aaef/packages/next-server/lib/utils.ts#L240
* export `WithRouterProps`
* make `NextPage` more like `React.FC`