### PR TITLE
Revert "Improve type definitions"

### DIFF
--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -215,7 +215,7 @@ export async function loadGetInitialProps<
   C extends BaseContext,
   IP = {},
   P = {}
->(Component: NextComponentType<C, IP, P>, ctx: C): Promise<IP> {
+>(Component: NextComponentType<C, IP, P>, ctx: C): Promise<IP | null> {
   if (process.env.NODE_ENV !== 'production') {
     if (Component.prototype && Component.prototype.getInitialProps) {
       const message = `"${getDisplayName(

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -112,7 +112,7 @@ function getRouter() {
 export default singletonRouter as SingletonRouter
 
 // Reexport the withRoute HOC
-export { default as withRouter, WithRouterProps } from './with-router'
+export { default as withRouter } from './with-router'
 
 export function useRouter() {
   return React.useContext(RouterContext)

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -38,9 +38,7 @@ declare module 'react' {
  * `Page` type, use it as a guide to create `pages`.
  */
 export type NextPage<P = {}, IP = P> = {
-  (props: P): JSX.Element | null
-  defaultProps?: Partial<P>
-  displayName?: string
+  (props: P): JSX.Element
   /**
    * Used for initial page load data population. Data returned from `getInitialProps` is serialized when server rendered.
    * Make sure to return plain `Object` without using `Date`, `Map`, `Set`.


### PR DESCRIPTION
Reverts zeit/next.js#8097

This PR caused bundle sizes to increase. We need to fix this bug before we continue adding invalid TypeScript exports to our code.