### PR TITLE
HTTP methods docs and REST example

### DIFF
--- a/examples/api-routes-rest/README.md
+++ b/examples/api-routes-rest/README.md
@@ -12,24 +12,7 @@ npx create-next-app --example api-routes-rest api-routes-rest-app
 yarn create next-app --example api-routes-rest api-routes-rest-app
 ```
 
-### Download manually
-
-Download the example:
-
-```bash
-curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/api-routes-rest
-cd api-routes-rest
-```
-
-Install it and run:
-
-```bash
-npm install
-npm run dev
-# or
-yarn
-yarn dev
-```
+### Deploy to Now
 
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
 

--- a/examples/api-routes-rest/README.md
+++ b/examples/api-routes-rest/README.md
@@ -4,7 +4,7 @@
 
 ### Using `create-next-app`
 
-Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+Execute [`create-next-app`](https://www.npmjs.com/package/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
 
 ```bash
 npx create-next-app --example api-routes-rest api-routes-rest-app

--- a/examples/api-routes-rest/README.md
+++ b/examples/api-routes-rest/README.md
@@ -1,0 +1,42 @@
+# API routes with REST
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example api-routes-rest api-routes-rest-app
+# or
+yarn create next-app --example api-routes-rest api-routes-rest-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/api-routes-rest
+cd api-routes-rest
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+Next.js ships with [API routes](https://github.com/zeit/next.js#api-routes), which provide an easy solution to build your own `API`. This example shows how it can be used to create your [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) api.

--- a/examples/api-routes-rest/package.json
+++ b/examples/api-routes-rest/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "api-routes-rest",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "isomorphic-unfetch": "3.0.0",
+    "next": "latest",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  },
+  "license": "ISC"
+}

--- a/examples/api-routes-rest/pages/api/user/[id].js
+++ b/examples/api-routes-rest/pages/api/user/[id].js
@@ -1,7 +1,7 @@
 export default (req, res) => {
   const {
     query: { id, name },
-    method,
+    method
   } = req
 
   switch (method) {
@@ -11,7 +11,8 @@ export default (req, res) => {
       break
     case 'PUT':
       // Update or create data in your database
-      res.status(200).json({ id, name: name ? name : `User ${id}` })
+      res.status(200).json({ id, name: name || `User ${id}` })
+      break
     default:
       res.setHeader('Allow', ['GET', 'PUT'])
       res.status(405).end(`Method ${method} Not Allowed`)

--- a/examples/api-routes-rest/pages/api/user/[id].js
+++ b/examples/api-routes-rest/pages/api/user/[id].js
@@ -1,0 +1,19 @@
+export default (req, res) => {
+  const {
+    query: { id, name },
+    method,
+  } = req
+
+  switch (method) {
+    case 'GET':
+      // Get data from your database
+      res.status(200).json({ id, name: `User ${id}` })
+      break
+    case 'PUT':
+      // Update or create data in your database
+      res.status(200).json({ id, name: name ? name : `User ${id}` })
+    default:
+      res.setHeader('Allow', ['GET', 'PUT'])
+      res.status(405).end(`Method ${method} Not Allowed`)
+  }
+}

--- a/examples/api-routes-rest/pages/api/users.js
+++ b/examples/api-routes-rest/pages/api/users.js
@@ -1,0 +1,13 @@
+// Fake users data
+const users = [
+  {
+    id: 1
+  },
+  { id: 2 },
+  { id: 3 }
+]
+
+export default (req, res) => {
+  // Get data from your database
+  res.status(200).json(users)
+}

--- a/examples/api-routes-rest/pages/index.js
+++ b/examples/api-routes-rest/pages/index.js
@@ -1,0 +1,23 @@
+import fetch from 'isomorphic-unfetch'
+import Link from 'next/link'
+
+const Index = ({ users }) => (
+  <ul>
+    {users.map(user => (
+      <li key={user.id}>
+        <Link href='/user/[id]' as={`/user/${user.id}`}>
+          <a>{`User ${user.id}`}</a>
+        </Link>
+      </li>
+    ))}
+  </ul>
+)
+
+Index.getInitialProps = async () => {
+  const response = await fetch('http://localhost:3000/api/users')
+  const users = await response.json()
+
+  return { users }
+}
+
+export default Index

--- a/examples/api-routes-rest/pages/user/[id].js
+++ b/examples/api-routes-rest/pages/user/[id].js
@@ -1,0 +1,12 @@
+import fetch from 'isomorphic-unfetch'
+
+const User = ({ user }) => <div>{user.name}</div>
+
+User.getInitialProps = async ({ query: { id } }, res) => {
+  const response = await fetch(`http://localhost:3000/api/user/${id}`)
+  const user = await response.json()
+
+  return { user }
+}
+
+export default User

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1065,7 +1065,7 @@ export default (req, res) => {
 
 - `res` refers to [NextApiResponse](https://github.com/zeit/next.js/blob/v9.0.0/packages/next-server/lib/utils.ts#L168-L178) which extends [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse)
 
-To handle different HTTP methods with your api calls you can handle it by `req.method` in your resolver function:
+To handle different HTTP methods for API calls you can access `req.method` in your resolver function:
 
 ```js
 export default (req, res) => {

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1041,6 +1041,7 @@ export default withRouter(MyLink)
     <li><a href="/examples/api-routes-micro">API routes with micro</a></li>
     <li><a href="/examples/api-routes-middleware">API routes with middleware</a></li>
     <li><a href="/examples/api-routes-graphql">API routes with GraphQL server</a></li>
+    <li><a href="/examples/api-routes-rest">API routes with REST</a></li>    
   </ul>
 </details>
 
@@ -1063,6 +1064,18 @@ export default (req, res) => {
 - `req` refers to [NextApiRequest](https://github.com/zeit/next.js/blob/v9.0.0/packages/next-server/lib/utils.ts#L143-L158) which extends [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
 
 - `res` refers to [NextApiResponse](https://github.com/zeit/next.js/blob/v9.0.0/packages/next-server/lib/utils.ts#L168-L178) which extends [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse)
+
+To handle different HTTP methods with your api calls you can handle it by `req.method` in your resolver function:
+
+```js
+export default (req, res) => {
+  if (req.method === 'POST') {
+    // Process your POST request
+  } else {
+    // Handle the rest of your HTTP methods
+  }
+}
+```
 
 > **Note**: API Routes [do not specify CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), so they'll be **same-origin only** by default.
 > You can customize this behavior by wrapping your export with CORS middleware.


### PR DESCRIPTION
This PR improves documentation for `HTTP` methods and provides simple `REST` api example. Fixes #8084 