### PR TITLE
Fix index.js for API routes

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { stringify } from 'querystring'
-import { PAGES_DIR_ALIAS, DOT_NEXT_ALIAS } from '../lib/constants'
+import { PAGES_DIR_ALIAS, DOT_NEXT_ALIAS, API_ROUTE } from '../lib/constants'
 import { ServerlessLoaderQuery } from './webpack/loaders/next-serverless-loader'
 
 type PagesMapping = {
@@ -68,7 +68,7 @@ export function createEntrypoints(
   Object.keys(pages).forEach(page => {
     const absolutePagePath = pages[page]
     const bundleFile = page === '/' ? '/index.js' : `${page}.js`
-    const isApiRoute = bundleFile.startsWith('/api/')
+    const isApiRoute = bundleFile.match(API_ROUTE)
 
     const bundlePath = join('static', buildId, 'pages', bundleFile)
 

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { parse } from 'querystring'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next-server/constants'
 import { isDynamicRoute } from 'next-server/dist/lib/router/utils'
+import { API_ROUTE } from '../../../lib/constants'
 
 export type ServerlessLoaderQuery = {
   page: string
@@ -39,7 +40,7 @@ const nextServerlessLoader: loader.Loader = function() {
     '/'
   )
 
-  if (page.startsWith('/api/')) {
+  if (page.match(API_ROUTE)) {
     return `
     ${
       isDynamicRoute(page)

--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -16,7 +16,7 @@ export const NEXT_PROJECT_ROOT_DIST_SERVER = join(
 )
 
 // Regex for API routes
-export const API_ROUTE = /^\/api(?:\/.*)?$/
+export const API_ROUTE = /^\/api(?:\/|$)/
 
 // Because on Windows absolute paths in the generated code can break because of numbers, eg 1 in the path,
 // we have to use a private alias

--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -15,6 +15,9 @@ export const NEXT_PROJECT_ROOT_DIST_SERVER = join(
   'server'
 )
 
+// Regex for API routes
+export const API_ROUTE = /^\/api(?:\/.*)?$/
+
 // Because on Windows absolute paths in the generated code can break because of numbers, eg 1 in the path,
 // we have to use a private alias
 export const PAGES_DIR_ALIAS = 'private-next-pages'

--- a/test/integration/api-support/pages/api/index.js
+++ b/test/integration/api-support/pages/api/index.js
@@ -1,0 +1,3 @@
+export default (req, res) => {
+  res.send('Index should work')
+}

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -45,6 +45,27 @@ function runTests (serverless = false) {
     killApp(app)
   })
 
+  it('should work with index api', async () => {
+    if (serverless) {
+      const port = await findPort()
+      const resolver = require(join(appDir, '.next/serverless/pages/api.js'))
+        .default
+
+      const server = createServer(resolver).listen(port)
+      const res = await fetchViaHTTP(port, '/api')
+      const text = await res.text()
+      server.close()
+
+      expect(text).toEqual('Index should work')
+    } else {
+      const text = await fetchViaHTTP(appPort, '/api', null, {}).then(
+        res => res.ok && res.text()
+      )
+
+      expect(text).toEqual('Index should work')
+    }
+  })
+
   it('should return custom error', async () => {
     const data = await fetchViaHTTP(appPort, '/api/error', null, {})
     const json = await data.json()


### PR DESCRIPTION
This fixes the problem with `/pages/api/index.js` not creating serverless function. Fixes #8111 