### PR TITLE
docs: Document breaking change concerning api-routes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -107,6 +107,11 @@ module.exports = {
 }
 ```
 
+#### `pages/api` is treated differently
+
+Pages in `pages/api` are now considered [API routes](https://nextjs.org/blog/next-9#api-routes). Pages in that directory will no longer contain a client-side bundle. 
+
+
 ## Deprecated Features
 
 #### `next/dynamic` has deprecated loading multiple modules at once

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -107,9 +107,10 @@ module.exports = {
 }
 ```
 
-#### `pages/api` is treated differently
+#### `./pages/api/` is treated differently
 
-Pages in `pages/api` are now considered [API routes](https://nextjs.org/blog/next-9#api-routes). Pages in that directory will no longer contain a client-side bundle. 
+Pages in `./pages/api/` are now considered [API Routes](https://nextjs.org/blog/next-9#api-routes).
+Pages in this directory will no longer contain a client-side bundle.
 
 
 ## Deprecated Features


### PR DESCRIPTION
Implications are probably incomplete. It would help adding a migration step if this is possible.

Would like to work on making the name configurable and adding a warning. `api` is so generic that `next` shouldn't impose what kind of content lives in those pages.