### PR TITLE
Allow manually setting amphtml and canonical links

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -257,6 +257,9 @@ export class Head extends Component<
         )
     }
 
+    let hasAmphtmlRel = false
+    let hasCanonicalRel = false
+
     // show warning and remove conflicting amp head tags
     head = !inAmpMode
       ? head
@@ -268,7 +271,9 @@ export class Head extends Component<
           if (type === 'meta' && props.name === 'viewport') {
             badProp = 'name="viewport"'
           } else if (type === 'link' && props.rel === 'canonical') {
-            badProp = 'rel="canonical"'
+            hasCanonicalRel = true
+          } else if (type === 'link' && props.rel === 'amphtml') {
+            hasAmphtmlRel = true
           } else if (type === 'script') {
             // only block if
             // 1. it has a src and isn't pointing to ampproject's CDN
@@ -341,10 +346,12 @@ export class Head extends Component<
               name="viewport"
               content="width=device-width,minimum-scale=1,initial-scale=1"
             />
-            <link
-              rel="canonical"
-              href={canonicalBase + cleanAmpPath(dangerousAsPath)}
-            />
+            {!hasCanonicalRel && (
+              <link
+                rel="canonical"
+                href={canonicalBase + cleanAmpPath(dangerousAsPath)}
+              />
+            )}
             {/* https://www.ampproject.org/docs/fundamentals/optimize_amp#optimize-the-amp-runtime-loading */}
             <link
               rel="preload"
@@ -383,7 +390,7 @@ export class Head extends Component<
         )}
         {!inAmpMode && (
           <>
-            {hybridAmp && (
+            {!hasAmphtmlRel && hybridAmp && (
               <link
                 rel="amphtml"
                 href={canonicalBase + getAmpPath(ampPath, dangerousAsPath)}

--- a/test/integration/amphtml/pages/manual-rels.js
+++ b/test/integration/amphtml/pages/manual-rels.js
@@ -1,0 +1,15 @@
+import Head from 'next/head'
+import { useAmp } from 'next/amp'
+
+export const config = { amp: 'hybrid' }
+
+export default () => (
+  <>
+    <Head>
+      {!useAmp() && <link rel='amphtml' href='/my-custom-amphtml' />}
+      <link rel='canonical' href='/my-custom-canonical' />
+    </Head>
+
+    <p>Hello world</p>
+  </>
+)

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -188,6 +188,19 @@ describe('AMP Usage', () => {
       await validateAMP(html)
       expect($('meta[name=viewport]').attr('content')).not.toBe('something :p')
     })
+
+    it('should allow manually setting canonical', async () => {
+      const html = await renderViaHTTP(appPort, '/manual-rels?amp=1')
+      const $ = cheerio.load(html)
+      await validateAMP(html)
+      expect($('link[rel=canonical]').attr('href')).toBe('/my-custom-canonical')
+    })
+
+    it('should allow manually setting amphtml rel', async () => {
+      const html = await renderViaHTTP(appPort, '/manual-rels')
+      const $ = cheerio.load(html)
+      expect($('link[rel=amphtml]').attr('href')).toBe('/my-custom-amphtml')
+    })
   })
 
   describe('combined styles', () => {


### PR DESCRIPTION
To allow users to incrementally implement Next.js' AMP support and also handle extra cases, this allows manually adding `amphtml` and `canonical` links in AMP mode. 

Closes: #7706 
Closes: #8074 