### PR TITLE
Remove next.config.js from create-next-app

### DIFF
--- a/packages/create-next-app/templates/default/README.md
+++ b/packages/create-next-app/templates/default/README.md
@@ -32,7 +32,6 @@ After creating an app, it should look something like:
 ├── components
 │   ├── head.js
 │   └── nav.js
-├── next.config.js
 ├── node_modules
 │   ├── [...]
 ├── package.json

--- a/packages/create-next-app/templates/default/next.config.js
+++ b/packages/create-next-app/templates/default/next.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  webpack: config => {
-    // Fixes npm packages that depend on `fs` module
-    config.node = {
-      fs: 'empty'
-    }
-    return config
-  }
-}


### PR DESCRIPTION
Removes `next.config.js` from `create-next-app` closes #8133 