### PR TITLE
fix regex to not match any string with double underscore

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -438,7 +438,7 @@ export default async function getBaseWebpackConfig(
       new ChunkNamesPlugin(),
       new webpack.DefinePlugin({
         ...Object.keys(config.env).reduce((acc, key) => {
-          if (/^(?:NODE_.+)|(?:__.+)$/i.test(key)) {
+          if (/^(?:NODE_.+)|^(?:__.+)$/i.test(key)) {
             throw new Error(
               `The key "${key}" under "env" in next.config.js is not allowed. https://err.sh/zeit/next.js/env-key-not-allowed`
             )

--- a/test/integration/production-config/next.config.js
+++ b/test/integration/production-config/next.config.js
@@ -13,6 +13,11 @@ module.exports = withCSS(
         ? {
           NODE_ENV: 'abc'
         }
+        : {}),
+      ...(process.env.ENABLE_ENV_WITH_UNDERSCORES
+        ? {
+          SOME__ENV__VAR: '123'
+        }
         : {})
     },
     onDemandEntries: {

--- a/test/integration/production-config/test/index.test.js
+++ b/test/integration/production-config/test/index.test.js
@@ -40,7 +40,7 @@ describe('Production Config Usage', () => {
   })
 
   describe('env', () => {
-    it('should fail with __ in env key', async () => {
+    it('should fail with leading __ in env key', async () => {
       const result = await runNextCommand(['build', appDir], {
         env: { ENABLE_ENV_FAIL_UNDERSCORE: true },
         stdout: true,
@@ -58,6 +58,16 @@ describe('Production Config Usage', () => {
       })
 
       expect(result.stderr).toMatch(/The key "NODE_ENV" under/)
+    })
+
+    it('should allow __ within env key', async () => {
+      const result = await runNextCommand(['build', appDir], {
+        env: { ENABLE_ENV_WITH_UNDERSCORES: true },
+        stdout: true,
+        stderr: true
+      })
+
+      expect(result.stderr).not.toMatch(/The key "SOME__ENV__VAR" under/)
     })
   })
 


### PR DESCRIPTION
According to [this](https://github.com/zeit/next.js/blob/master/errors/env-key-not-allowed.md)

> Next.js configures internal variables for replacement itself. These start with __ or NODE_, for this reason they are not allowed as values for env in next.config.js



However, the current regex captures strings with double underscores anywhere in the string such as:

`SOME__ENV__VAR`

Adding the carrot after the `|` (or) operator fixes the regex to match the intention of the original author in #6260


