### PR TITLE
Adjust Babel Config for Jest Users

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -69,9 +69,10 @@ module.exports = (
     ...options['preset-env'],
   }
 
-  // When transpiling for the server, target the current Node version if not explicitly specified:
+  // When transpiling for the server or tests, target the current Node version
+  // if not explicitly specified:
   if (
-    isServer &&
+    (isServer || isTest) &&
     (!presetEnvConfig.targets || !('node' in presetEnvConfig.targets))
   ) {
     presetEnvConfig.targets = {


### PR DESCRIPTION
This adjusts our Babel configuration to default to targeting Node for Jest users (test environment).

This change is necessary as we started shipping Next.js as ES.Latest instead of compiled to ES5.

This resolves the mismatch between Babel-compiled classes and ES6 classes (which causes things like `new NextClass(...)`) to be broken.

Users who still explicitly set their targets will override this behavior, as expected.

tl;dr:

This allows a Babel config like so to work:
```json
{
  "presets": ["next/babel"],
  "plugins": ["inline-react-svg"]
}
```

Instead of requiring:
```json
{
  "presets": ["next/babel"],
  "plugins": ["inline-react-svg"],
  "env": {
    "test": {
      "presets": [
        ["next/babel", { "preset-env": { "targets": { "node": "current" } } }]
      ],
    }
  }
}
```

This is CRA's default behavior and we haven't had an opened issue for it to-date.