### PR TITLE
Fix typo within blog-starter example

### DIFF
--- a/examples/blog-starter/pages/posts/syntax-highlighting.mdx
+++ b/examples/blog-starter/pages/posts/syntax-highlighting.mdx
@@ -4,7 +4,7 @@ import BlogPost from '../../components/layouts/blog-post'
 export const meta = {
   published: true,
   publishedAt: '2018-05-19',
-  title: 'Sintax highlighting',
+  title: 'Syntax highlighting',
   summary:
     'Here are some code snippets to show you how syntax highlighting works',
   image: '/static/site-feature.png',


### PR DESCRIPTION
Noticed a minor typo when installing and having a look around the blog example.