### PR TITLE
Revert "Don't require test job for deploying"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ workflows:
                 - canary
       - deploy:
           requires:
-            - build
+            - test
           filters:
             branches:
               only:


### PR DESCRIPTION
Reverts zeit/next.js#8194

This change was done before we got tests to pass via clearing CircleCI cache.