### PR TITLE
Add some notes about Now deployment

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,15 @@
 # Migrating from v8 to v9
 
+## Preamble
+
+#### Production Deployment on ZEIT Now v2
+
+If you previously configured `routes` in your `now.json` file for dynamic routes, these rules can be removed when leveraging Next.js 9's new [Dynamic Routing feature](https://github.com/zeit/next.js#dynamic-routing).
+
+Next.js 9's dynamic routes are **automatically configured on [Now](https://zeit.co/now)** and do not require any `now.json` customization.
+
+You can read more about [Dynamic Routing here](https://github.com/zeit/next.js#dynamic-routing).
+
 ## Breaking Changes
 
 #### `@zeit/next-typescript` is no longer necessary
@@ -111,7 +121,6 @@ module.exports = {
 
 Pages in `./pages/api/` are now considered [API Routes](https://nextjs.org/blog/next-9#api-routes).
 Pages in this directory will no longer contain a client-side bundle.
-
 
 ## Deprecated Features
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -340,6 +340,11 @@ For example, `/post/abc?pid=bcd` will have the `query` object: `{ pid: 'abc' }`.
 > After hydration, Next.js will trigger an update to your application to provide the route parameters in the `query` object.
 > If your application cannot tolerate this behavior, you can opt-out of static optimization by capturing the query parameter in `getInitialProps`.
 
+> **Note**: If deploying to [ZEIT Now](https://zeit.co/now) dynamic routes will work out-of-the-box.
+> You do not need to configure custom routes in a `now.json` file.
+>
+> If you are new to ZEIT Now, you can learn how to deploy a Next.js app to it in the [_Deploying a Next.js App_ Learn section](https://nextjs.org/learn/basics/deploying-a-nextjs-app).
+
 ### Populating `<head>`
 
 <details>
@@ -2104,7 +2109,7 @@ next build
 next start
 ```
 
-To deploy Next.js with [ZEIT Now](https://zeit.co/now) see the [ZEIT Guide for Deploying Next.js with Now](https://zeit.co/guides/deploying-nextjs-with-now/).
+To deploy Next.js with [ZEIT Now](https://zeit.co/now) see the [ZEIT Guide for Deploying Next.js](https://zeit.co/guides/deploying-nextjs-with-now/) or the [Next.js Learn section about deploying on ZEIT Now](https://nextjs.org/learn/basics/deploying-a-nextjs-app/deploying-to-zeit-now).
 
 Next.js can be deployed to other hosting solutions too. Please have a look at the ['Deployment'](https://github.com/zeit/next.js/wiki/Deployment) section of the wiki.
 


### PR DESCRIPTION
Closes https://github.com/zeit/next.js/issues/8002

This adds instructions for users upgrading to give Now v2 another try. It was suggested that we point this out since Dynamic Routing is a game changer for Now v2 deployments.