### PR TITLE
Update to check browserName instead of browser.log

### DIFF
--- a/test/integration/app-document/test/csp.js
+++ b/test/integration/app-document/test/csp.js
@@ -5,7 +5,7 @@ export default (context, render) => {
   describe('With CSP enabled', () => {
     it('should load inline script by hash', async () => {
       const browser = await webdriver(context.appPort, '/?withCSP=hash')
-      if (browser.log) {
+      if (global.browserName !== 'chrome') {
         const errLog = await browser.log('browser')
         expect(errLog.filter(e => e.source === 'security')).toEqual([])
       }
@@ -14,7 +14,7 @@ export default (context, render) => {
 
     it('should load inline script by nonce', async () => {
       const browser = await webdriver(context.appPort, '/?withCSP=nonce')
-      if (browser.log) {
+      if (global.browserName !== 'chrome') {
         const errLog = await browser.log('browser')
         expect(errLog.filter(e => e.source === 'security')).toEqual([])
       }

--- a/test/integration/app-document/test/csp.js
+++ b/test/integration/app-document/test/csp.js
@@ -5,7 +5,7 @@ export default (context, render) => {
   describe('With CSP enabled', () => {
     it('should load inline script by hash', async () => {
       const browser = await webdriver(context.appPort, '/?withCSP=hash')
-      if (global.browserName !== 'chrome') {
+      if (global.browserName === 'chrome') {
         const errLog = await browser.log('browser')
         expect(errLog.filter(e => e.source === 'security')).toEqual([])
       }
@@ -14,7 +14,7 @@ export default (context, render) => {
 
     it('should load inline script by nonce', async () => {
       const browser = await webdriver(context.appPort, '/?withCSP=nonce')
-      if (global.browserName !== 'chrome') {
+      if (global.browserName === 'chrome') {
         const errLog = await browser.log('browser')
         expect(errLog.filter(e => e.source === 'security')).toEqual([])
       }

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -58,7 +58,7 @@ export default (context, render) => {
             /Browser hydrated/
           )
 
-          if (browser.log) {
+          if (global.browserName !== 'chrome') {
             const logs = await browser.log('browser')
 
             logs.forEach(logItem => {

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -58,7 +58,7 @@ export default (context, render) => {
             /Browser hydrated/
           )
 
-          if (global.browserName !== 'chrome') {
+          if (global.browserName === 'chrome') {
             const logs = await browser.log('browser')
 
             logs.forEach(logItem => {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -453,7 +453,7 @@ describe('Production Usage', () => {
 
       it('should reload the page on page script error with prefetch', async () => {
         const browser = await webdriver(appPort, '/counter')
-        if (!browser.log) return
+        if (global.browserName !== 'chrome') return
         const counter = await browser
           .elementByCss('#increase')
           .click()

--- a/test/jest-environment.js
+++ b/test/jest-environment.js
@@ -124,7 +124,7 @@ class CustomEnvironment extends NodeEnvironment {
         }
       }
     }
-    this.global.browserName = BROWSER_NAME
+    this.global.browserName = browserOptions.browserName
     this.global.isBrowserStack = isBrowserStack
     // Mock current browser set up
     this.global.bsWd = async (appPort, pathname) => {


### PR DESCRIPTION
This will help us catch if this feature stops working in chrome also instead of just silently returning in the tests