### PR TITLE
Add temp secret for PR Stats Action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -10,5 +10,5 @@ workflow "Generate release stats" {
 
 action "PR Stats" {
   uses = "zeit/next-stats-action@master"
-  secrets = ["GITHUB_TOKEN"]
+  secrets = ["GITHUB_TOKEN", "PR_STATS_TEMP_TOKEN"]
 }


### PR DESCRIPTION
This adds another token to use until we sort out why the provided token is 403ing on posting comments