### PR TITLE
Simplify mobx example

### DIFF
--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -8,15 +8,18 @@ class MyMobxApp extends App {
     store: new Store(),
   }
 
+  // Fetching serialized(JSON) store state
   static async getInitialProps(appContext) {
-    let appProps = await App.getInitialProps(appContext)
+    const appProps = await App.getInitialProps(appContext)
+    const initialStoreState = await fetchInitialStoreState()
 
     return {
       ...appProps,
-      initialStoreState: fetchInitialStoreState(),
+      initialStoreState,
     }
   }
 
+  // Hydrate serialized state to store
   static getDerivedStateFromProps(props, state) {
     state.store.hydrate(props.initialStoreState)
     return state

--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -1,37 +1,32 @@
 import App, { Container } from 'next/app'
 import React from 'react'
-import { initializeStore } from '../store'
+import { fetchInitialStoreState, Store } from '../store'
 import { Provider } from 'mobx-react'
 
 class MyMobxApp extends App {
-  static async getInitialProps(appContext) {
-    // Get or Create the store with `undefined` as initialState
-    // This allows you to set a custom default initialState
-    const mobxStore = initializeStore()
-    // Provide the store to getInitialProps of pages
-    appContext.ctx.mobxStore = mobxStore
+  state = {
+    store: new Store(),
+  }
 
+  static async getInitialProps(appContext) {
     let appProps = await App.getInitialProps(appContext)
 
     return {
       ...appProps,
-      initialMobxState: mobxStore,
+      initialStoreState: fetchInitialStoreState(),
     }
   }
 
-  constructor(props) {
-    super(props)
-    const isServer = typeof window === 'undefined'
-    this.mobxStore = isServer
-      ? props.initialMobxState
-      : initializeStore(props.initialMobxState)
+  static getDerivedStateFromProps(props, state) {
+    state.store.hydrate(props.initialStoreState)
+    return state
   }
 
   render() {
     const { Component, pageProps } = this.props
     return (
       <Container>
-        <Provider store={this.mobxStore}>
+        <Provider store={this.state.store}>
           <Component {...pageProps} />
         </Provider>
       </Container>

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -4,14 +4,16 @@ import { useStaticRendering } from 'mobx-react'
 const isServer = typeof window === 'undefined'
 useStaticRendering(isServer)
 
-class Store {
+export class Store {
   @observable lastUpdate = 0
   @observable light = false
 
-  constructor(isServer, initialData = {}) {
+  hydrate(serializedStore) {
     this.lastUpdate =
-      initialData.lastUpdate != null ? initialData.lastUpdate : Date.now()
-    this.light = !!initialData.light
+      serializedStore.lastUpdate != null
+        ? serializedStore.lastUpdate
+        : Date.now()
+    this.light = !!serializedStore.light
   }
 
   @action start = () => {
@@ -24,15 +26,6 @@ class Store {
   stop = () => clearInterval(this.timer)
 }
 
-let store = null
-
-export function initializeStore(initialData) {
-  // Always make a new store if server, otherwise state is shared between requests
-  if (isServer) {
-    return new Store(isServer, initialData)
-  }
-  if (store === null) {
-    store = new Store(isServer, initialData)
-  }
-  return store
+export function fetchInitialStoreState() {
+  return {}
 }

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -26,6 +26,7 @@ export class Store {
   stop = () => clearInterval(this.timer)
 }
 
-export function fetchInitialStoreState() {
+export async function fetchInitialStoreState() {
+  // You can do anything to fetch initial store state
   return {}
 }


### PR DESCRIPTION
There are no needs to check that data is fetching from server or not.

I exploit state of App component to pass serialized store state from SSR to CSR.

## First rendering:

1. (SSR) `getInitialProps` : Prepare initial serialized store state(ex: Fetching data from server)
2. (SSR) `getDerivedStateFromProps` : Hydrate serialized store state to store instance
3. (SSR) Rendering... : Next serialize store in `state` of `MyMobxApp` component and pass serialized state to CSR.
4. (CSR) `getDerivedStateFromProps` : Hydrate serialized store state from SSR again
5. (CSR) Rendering again.... and... PROFIT!!

## Next rendering:

1. (CSR) `getInitialProps` : Prepare initial serialized store state
2. (CSR) `getDerivedStateFromProps` : Hydrate serialized store state to store instance
3. (CSR) Rendering... PROFIT!!