### PR TITLE
Prevent false positive experimental warning

### DIFF
--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -55,7 +55,11 @@ const experimentalWarning = execOnce(() => {
 
 function assignDefaults(userConfig: { [key: string]: any }) {
   Object.keys(userConfig).forEach((key: string) => {
-    if (key === 'experimental' && userConfig[key]) {
+    if (
+      key === 'experimental' &&
+      userConfig[key] &&
+      userConfig[key] !== defaultConfig.experimental
+    ) {
       experimentalWarning()
     }
 

--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -59,7 +59,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     if (
       key === 'experimental' &&
       userConfig[key] &&
-      userConfig[key] !== defaultConfig.experimental
+      userConfig[key] !== defaultConfig[key]
     ) {
       experimentalWarning()
     }

--- a/test/integration/config-experimental-warning/pages/index.js
+++ b/test/integration/config-experimental-warning/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi'

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { nextBuild, File } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 30
+const appDir = join(__dirname, '..')
+const configFile = new File(join(appDir, '/next.config.js'))
+
+describe('Promise in next config', () => {
+  afterAll(() => configFile.delete())
+
+  it('should not show warning with default config from function', async () => {
+    configFile.write(`
+      module.exports = (phase, { defaultConfig }) => {
+        return {
+          target: 'server',
+          ...defaultConfig,
+        }
+      }
+    `)
+
+    const { stderr } = await nextBuild(appDir, [], { stderr: true })
+    expect(stderr).not.toMatch(/Found experimental config:/)
+  })
+
+  it('should not show warning with config from object', async () => {
+    configFile.write(`
+      module.exports = {
+        target: 'server'
+      }
+    `)
+    const { stderr } = await nextBuild(appDir, [], { stderr: true })
+    expect(stderr).not.toMatch(/Found experimental config:/)
+  })
+
+  it('should show warning with config from object with experimental', async () => {
+    configFile.write(`
+      module.exports = {
+        target: 'server',
+        experimental: {
+          publicDirectory: true
+        }
+      }
+    `)
+    const { stderr } = await nextBuild(appDir, [], { stderr: true })
+    expect(stderr).toMatch(/Found experimental config:/)
+  })
+
+  it('should show warning with config from function with experimental', async () => {
+    configFile.write(`
+      module.exports = (phase) => ({
+        target: 'server',
+        experimental: {
+          publicDirectory: true
+        }
+      })
+    `)
+    const { stderr } = await nextBuild(appDir, [], { stderr: true })
+    expect(stderr).toMatch(/Found experimental config:/)
+  })
+})


### PR DESCRIPTION
When you have a config function:

https://github.com/zeit/next.js/blob/canary/packages/next-server/server/config.ts#L76

`defaultConfig.experimental` ends up as user config here and it creates a false positive warning even if a user doesn't have any experimental config.  