### PR TITLE
Remove cache clearing from static-checker

### DIFF
--- a/packages/next/build/static-checker.ts
+++ b/packages/next/build/static-checker.ts
@@ -7,18 +7,6 @@ export default function worker(
   try {
     const { serverBundle, runtimeEnvConfig } = options || ({} as any)
     const result = isPageStatic(serverBundle, runtimeEnvConfig)
-
-    // clear require.cache to prevent running out of memory
-    // since the cache is persisted by default
-    Object.keys(require.cache).map(modId => {
-      const mod = require.cache[modId]
-      delete require.cache[modId]
-      if (mod.parent) {
-        const idx = mod.parent.children.indexOf(mod)
-        mod.parent.children.splice(idx, 1)
-      }
-    })
-
     callback(null, result)
   } catch (error) {
     callback(error)


### PR DESCRIPTION
Clearing the cache can cause unintended side effects with specific modules, it can also slow down the process of requiring pages. 

This was originally intended to prevent an out-of-memory OOM error inside of a static check worker although worker-farm should spin up a new worker in the event of an OOM.  

Fixes: #7894