### PR TITLE
Update custom app example in README

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1526,14 +1526,11 @@ class MyApp extends App {
   // perform automatic static optimization, causing every page in your app to
   // be server-side rendered.
   //
-  // static async getInitialProps({ Component, ctx }) {
-  //   let pageProps = {}
+  // static async getInitialProps(appContext) {
+  //   // calls page's `getInitialProps` and fills `appProps.pageProps`
+  //   const appProps = await App.getInitialProps(appContext);
   //
-  //   if (Component.getInitialProps) {
-  //     pageProps = await Component.getInitialProps(ctx)
-  //   }
-  //
-  //   return { pageProps }
+  //   return { ...appProps }
   // }
 
   render() {


### PR DESCRIPTION
The code example now uses simpler and "safer" approach to call page's `getInitialProps`.

Pros:

- Shorter code.
- Probably more resilient / reliable as it goes through `loadGetInitialProps` that [handles quite a few details](https://github.com/zeit/next.js/blob/ca13752e/packages/next-server/lib/utils.ts#L216-L250).
- I've seen the approach with `const appProps = await App.getInitialProps(appContext)` in several examples and blog posts (didn't take notes though..).

Cons:

- It was less intuitive to me, initially, that this indeed calls page's `getInitialProps`.