### PR TITLE
Add info about removing @zeit/next-typescript on .babelrc

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -652,7 +652,7 @@ export default async function getBaseWebpackConfig(
 
     if (foundTsRule) {
       console.warn(
-        '\n@zeit/next-typescript is no longer needed since Next.js has built-in support for TypeScript now. Please remove it from your next.config.js\n'
+        '\n@zeit/next-typescript is no longer needed since Next.js has built-in support for TypeScript now. Please remove it from your next.config.js and your .babelrc\n'
       )
     }
   }


### PR DESCRIPTION
Adding extra info to prevent #7803 from being confusing, this PR adds extra info on the deprecation message to also remove `@zeit/next-typescript-babel` on `.babelrc`.