### PR TITLE
Remove 405 from render method 

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -524,12 +524,6 @@ export default class Server {
     return this.findPageComponents(pathname, query)
       .then(
         result => {
-          if (!(req.method === 'GET' || req.method === 'HEAD')) {
-            res.statusCode = 405
-            res.setHeader('Allow', ['GET', 'HEAD'])
-            return this.renderError(null, req, res, pathname, query)
-          }
-
           return this.renderToHTMLWithComponents(
             req,
             res,
@@ -552,12 +546,6 @@ export default class Server {
 
             return this.findPageComponents(dynamicRoute.page, query).then(
               result => {
-                if (!(req.method === 'GET' || req.method === 'HEAD')) {
-                  res.statusCode = 405
-                  res.setHeader('Allow', ['GET', 'HEAD'])
-                  return this.renderError(null, req, res, pathname, query)
-                }
-
                 return this.renderToHTMLWithComponents(
                   req,
                   res,

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -197,14 +197,6 @@ function runTests (serverless = false) {
     expect(data).toEqual({ nextjs: 'cool' })
   })
 
-  it('should return 405 on POST on pages', async () => {
-    const res = await fetchViaHTTP(appPort, '/user', null, {
-      method: 'POST'
-    })
-
-    expect(res.status).toEqual(405)
-  })
-
   it('should return JSON on post on API', async () => {
     const data = await fetchViaHTTP(appPort, '/api/blog?title=Nextjs', null, {
       method: 'POST'

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -197,6 +197,14 @@ function runTests (serverless = false) {
     expect(data).toEqual({ nextjs: 'cool' })
   })
 
+  it('should return 200 on POST on pages', async () => {
+    const res = await fetchViaHTTP(appPort, '/user', null, {
+      method: 'POST'
+    })
+
+    expect(res.status).toEqual(200)
+  })
+
   it('should return JSON on post on API', async () => {
     const data = await fetchViaHTTP(appPort, '/api/blog?title=Nextjs', null, {
       method: 'POST'

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -80,6 +80,13 @@ describe('Production Usage', () => {
       expect(res.status).toBe(404)
     })
 
+    it('should render 200 for POST on page', async () => {
+      const res = await fetch(`http://localhost:${appPort}/about`, {
+        method: 'POST'
+      })
+      expect(res.status).toBe(200)
+    })
+
     it('should render 404 for POST on missing page', async () => {
       const res = await fetch(`http://localhost:${appPort}/fake-page`, {
         method: 'POST'

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -80,13 +80,6 @@ describe('Production Usage', () => {
       expect(res.status).toBe(404)
     })
 
-    it('should render 405 for POST on page', async () => {
-      const res = await fetch(`http://localhost:${appPort}/about`, {
-        method: 'POST'
-      })
-      expect(res.status).toBe(405)
-    })
-
     it('should render 404 for POST on missing page', async () => {
       const res = await fetch(`http://localhost:${appPort}/fake-page`, {
         method: 'POST'


### PR DESCRIPTION
This PR reverts changes of `405` on different `http` methods then `GET` and `HEAD`

Fixes #8045