### PR TITLE
Deprecate Container usage

### DIFF
--- a/examples/form-handler/pages/_app.js
+++ b/examples/form-handler/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { Provider } from 'react-redux'
 import withRedux from 'next-redux-wrapper'
@@ -18,11 +18,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, store } = this.props
     return (
-      <Container>
-        <Provider store={store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-antd-mobile/pages/_app.js
+++ b/examples/with-antd-mobile/pages/_app.js
@@ -1,12 +1,12 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import Head from 'next/head'
 
 export default class CustomApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
+      <>
         <Head>
           <meta
             name='viewport'
@@ -22,7 +22,7 @@ export default class CustomApp extends App {
           `}</style>
         </Head>
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-apollo-and-redux-saga/pages/_app.js
+++ b/examples/with-apollo-and-redux-saga/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { Provider } from 'react-redux'
 import withRedux from 'next-redux-wrapper'
@@ -20,11 +20,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, store } = this.props
     return (
-      <Container>
-        <Provider store={store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-apollo-and-redux/pages/_app.js
+++ b/examples/with-apollo-and-redux/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { Provider } from 'react-redux'
 import withRedux from 'next-redux-wrapper'
@@ -18,11 +18,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, store } = this.props
     return (
-      <Container>
-        <Provider store={store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-apollo-auth/pages/_app.js
+++ b/examples/with-apollo-auth/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { ApolloProvider } from 'react-apollo'
 import withApollo from '../lib/withApollo'
@@ -7,11 +7,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, apolloClient } = this.props
     return (
-      <Container>
-        <ApolloProvider client={apolloClient}>
-          <Component {...pageProps} />
-        </ApolloProvider>
-      </Container>
+      <ApolloProvider client={apolloClient}>
+        <Component {...pageProps} />
+      </ApolloProvider>
     )
   }
 }

--- a/examples/with-apollo/pages/_app.js
+++ b/examples/with-apollo/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import withApolloClient from '../lib/with-apollo-client'
 import { ApolloProvider } from 'react-apollo'
@@ -7,11 +7,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, apolloClient } = this.props
     return (
-      <Container>
-        <ApolloProvider client={apolloClient}>
-          <Component {...pageProps} />
-        </ApolloProvider>
-      </Container>
+      <ApolloProvider client={apolloClient}>
+        <Component {...pageProps} />
+      </ApolloProvider>
     )
   }
 }

--- a/examples/with-app-layout/pages/_app.js
+++ b/examples/with-app-layout/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 class Layout extends React.Component {
   render () {
@@ -12,11 +12,9 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
-      </Container>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     )
   }
 }

--- a/examples/with-context-api/pages/_app.js
+++ b/examples/with-context-api/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 /* First we import our provider */
 import CounterProvider from '../components/CounterProvider'
 
@@ -6,12 +6,10 @@ class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        {/* Then we wrap our components with the provider */}
-        <CounterProvider>
-          <Component {...pageProps} />
-        </CounterProvider>
-      </Container>
+      /* Then we wrap our components with the provider */
+      <CounterProvider>
+        <Component {...pageProps} />
+      </CounterProvider>
     )
   }
 }

--- a/examples/with-dynamic-app-layout/pages/_app.js
+++ b/examples/with-dynamic-app-layout/pages/_app.js
@@ -1,15 +1,13 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Component.Layout>
-          <Component {...pageProps} />
-        </Component.Layout>
-      </Container>
+      <Component.Layout>
+        <Component {...pageProps} />
+      </Component.Layout>
     )
   }
 }

--- a/examples/with-fela/pages/_app.js
+++ b/examples/with-fela/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import FelaProvider from '../FelaProvider'
 
@@ -16,11 +16,9 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps, renderer } = this.props
     return (
-      <Container>
-        <FelaProvider renderer={renderer}>
-          <Component {...pageProps} />
-        </FelaProvider>
-      </Container>
+      <FelaProvider renderer={renderer}>
+        <Component {...pageProps} />
+      </FelaProvider>
     )
   }
 }

--- a/examples/with-flow/pages/_app.js
+++ b/examples/with-flow/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import Link from 'next/link'
 import React from 'react'
 
@@ -16,7 +16,7 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
+      <>
         <header>
           <nav>
             <Link href='/'>
@@ -36,7 +36,7 @@ export default class MyApp extends App {
         <Component {...pageProps} />
 
         <footer>I`m here to stay</footer>
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-graphql-hooks/pages/_app.js
+++ b/examples/with-graphql-hooks/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import withGraphQLClient from '../lib/with-graphql-client'
 import { ClientContext } from 'graphql-hooks'
@@ -7,11 +7,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, graphQLClient } = this.props
     return (
-      <Container>
-        <ClientContext.Provider value={graphQLClient}>
-          <Component {...pageProps} />
-        </ClientContext.Provider>
-      </Container>
+      <ClientContext.Provider value={graphQLClient}>
+        <Component {...pageProps} />
+      </ClientContext.Provider>
     )
   }
 }

--- a/examples/with-graphql-react/pages/_app.js
+++ b/examples/with-graphql-react/pages/_app.js
@@ -1,17 +1,15 @@
 import 'cross-fetch/polyfill'
 import { GraphQLProvider } from 'graphql-react'
 import { withGraphQLApp } from 'next-graphql-react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 class CustomApp extends App {
   render () {
     const { Component, pageProps, graphql } = this.props
     return (
-      <Container>
-        <GraphQLProvider graphql={graphql}>
-          <Component {...pageProps} />
-        </GraphQLProvider>
-      </Container>
+      <GraphQLProvider graphql={graphql}>
+        <Component {...pageProps} />
+      </GraphQLProvider>
     )
   }
 }

--- a/examples/with-grommet/pages/_app.js
+++ b/examples/with-grommet/pages/_app.js
@@ -1,16 +1,14 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { Grommet, grommet as grommetTheme } from 'grommet'
 
 export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Grommet theme={grommetTheme}>
-          <Component {...pageProps} />
-        </Grommet>
-      </Container>
+      <Grommet theme={grommetTheme}>
+        <Component {...pageProps} />
+      </Grommet>
     )
   }
 }

--- a/examples/with-immutable-redux-wrapper/pages/_app.js
+++ b/examples/with-immutable-redux-wrapper/pages/_app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Provider } from 'react-redux'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import withRedux from 'next-redux-wrapper'
 import { makeStore } from '../store'
 import { fromJS } from 'immutable'
@@ -17,11 +17,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, store } = this.props
     return (
-      <Container>
-        <Provider store={store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-kea/pages/_app.js
+++ b/examples/with-kea/pages/_app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Provider } from 'react-redux'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import withRedux from 'next-redux-wrapper'
 import { initStore } from '../store'
 
@@ -16,11 +16,9 @@ export default class MyApp extends App {
   render() {
     const { Component, pageProps, store } = this.props
     return (
-      <Container>
-        <Provider store={store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-loading/pages/_app.js
+++ b/examples/with-loading/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import Link from 'next/link'
 import NProgress from 'nprogress'
 import Router from 'next/router'
@@ -29,7 +29,7 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
+      <>
         <div style={{ marginBottom: 20 }}>
           <Link href='/'>
             <a style={linkStyle}>Home</a>
@@ -46,7 +46,7 @@ export default class MyApp extends App {
         </div>
 
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-mobx-react-lite/pages/_app.js
+++ b/examples/with-mobx-react-lite/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { InjectStoreContext, initializeData } from '../store'
 
@@ -21,11 +21,9 @@ class MyMobxApp extends App {
   render () {
     const { Component, pageProps, initialStoreData } = this.props
     return (
-      <Container>
-        <InjectStoreContext initialData={initialStoreData}>
-          <Component {...pageProps} />
-        </InjectStoreContext>
-      </Container>
+      <InjectStoreContext initialData={initialStoreData}>
+        <Component {...pageProps} />
+      </InjectStoreContext>
     )
   }
 }

--- a/examples/with-mobx-state-tree-typescript/pages/_app.tsx
+++ b/examples/with-mobx-state-tree-typescript/pages/_app.tsx
@@ -1,6 +1,6 @@
 import { Provider } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { initializeStore, IStore } from '../stores/store'
 
@@ -42,11 +42,9 @@ class MyApp extends App {
   public render() {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Provider store={this.store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={this.store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-mobx-state-tree/pages/_app.js
+++ b/examples/with-mobx-state-tree/pages/_app.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Provider } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { initializeStore } from '../stores/store'
 
 export default class MyApp extends App {
@@ -35,11 +35,9 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Provider store={this.store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={this.store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { fetchInitialStoreState, Store } from '../store'
 import { Provider } from 'mobx-react'
@@ -28,11 +28,9 @@ class MyMobxApp extends App {
   render() {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Provider store={this.state.store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={this.state.store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-next-page-transitions/pages/_app.js
+++ b/examples/with-next-page-transitions/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { PageTransition } from 'next-page-transitions'
 
 import Loader from '../components/Loader'
@@ -20,7 +20,7 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
+      <>
         <PageTransition
           timeout={TIMEOUT}
           classNames='page-transition'
@@ -61,7 +61,7 @@ export default class MyApp extends App {
             transition: opacity ${TIMEOUT}ms;
           }
         `}</style>
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-next-seo/pages/_app.js
+++ b/examples/with-next-seo/pages/_app.js
@@ -3,7 +3,7 @@
  * that will apply to every page. Full info on how the default works
  * can be found here: https://github.com/garmeeh/next-seo#default-seo-configuration
  */
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import NextSeo from 'next-seo'
 
@@ -22,11 +22,11 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        {/* Here we call NextSeo and pass our default configuration to it  */}
+      /* Here we call NextSeo and pass our default configuration to it  */
+      <>
         <NextSeo config={SEO} />
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-orbit-components/pages/_app.js
+++ b/examples/with-orbit-components/pages/_app.js
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { getTokens } from '@kiwicom/orbit-components'
 import { ThemeProvider, createGlobalStyle } from 'styled-components'
 
@@ -18,14 +18,12 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <ThemeProvider theme={{ orbit: tokens }}>
-          <>
-            <GlobalStyle />
-            <Component {...pageProps} />
-          </>
-        </ThemeProvider>
-      </Container>
+      <ThemeProvider theme={{ orbit: tokens }}>
+        <>
+          <GlobalStyle />
+          <Component {...pageProps} />
+        </>
+      </ThemeProvider>
     )
   }
 }

--- a/examples/with-overmind/pages/_app.js
+++ b/examples/with-overmind/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { createOvermind, createOvermindSSR, rehydrate } from 'overmind'
 import { Provider } from 'overmind-react'
 import { config } from '../overmind'
@@ -48,11 +48,9 @@ class MyApp extends App {
     const { Component } = this.props
 
     return (
-      <Container>
-        <Provider value={this.overmind}>
-          <Component />
-        </Provider>
-      </Container>
+      <Provider value={this.overmind}>
+        <Component />
+      </Provider>
     )
   }
 }

--- a/examples/with-portals-ssr/pages/_app.js
+++ b/examples/with-portals-ssr/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { prepareClientPortals } from '@jesstelford/react-portal-universal'
 
 if (typeof window !== 'undefined') {
@@ -13,11 +13,11 @@ class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        {/* This is where we'll render one of our universal portals */}
+      /* This is where we'll render one of our universal portals */
+      <>
         <div id='modal' />
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-prefetching/pages/_app.js
+++ b/examples/with-prefetching/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import Header from '../components/Header'
 
@@ -16,10 +16,10 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
+      <>
         <Header />
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-react-ga/pages/_app.js
+++ b/examples/with-react-ga/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import Router from 'next/router'
 import { initGA, logPageView } from '../utils/analytics'
 
@@ -22,10 +22,6 @@ export default class MyApp extends App {
 
   render () {
     const { Component, pageProps } = this.props
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }

--- a/examples/with-react-helmet/pages/_app.js
+++ b/examples/with-react-helmet/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import Helmet from 'react-helmet'
 
 export default class MyApp extends App {
@@ -17,7 +17,7 @@ export default class MyApp extends App {
     const { Component, pageProps } = this.props
 
     return (
-      <Container>
+      <>
         <Helmet
           htmlAttributes={{ lang: 'en' }}
           title='Hello next.js!'
@@ -30,7 +30,7 @@ export default class MyApp extends App {
           ]}
         />
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-react-intl/pages/_app.js
+++ b/examples/with-react-intl/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { IntlProvider, addLocaleData } from 'react-intl'
 
@@ -32,15 +32,9 @@ export default class MyApp extends App {
     const { Component, pageProps, locale, messages, initialNow } = this.props
 
     return (
-      <Container>
-        <IntlProvider
-          locale={locale}
-          messages={messages}
-          initialNow={initialNow}
-        >
-          <Component {...pageProps} />
-        </IntlProvider>
-      </Container>
+      <IntlProvider locale={locale} messages={messages} initialNow={initialNow}>
+        <Component {...pageProps} />
+      </IntlProvider>
     )
   }
 }

--- a/examples/with-react-multi-carousel/pages/_app.js
+++ b/examples/with-react-multi-carousel/pages/_app.js
@@ -3,7 +3,7 @@ This is copy paste from the with-material-ui example.
 */
 
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import Head from 'next/head'
 import { MuiThemeProvider } from '@material-ui/core/styles'
 import CssBaseline from '@material-ui/core/CssBaseline'
@@ -20,7 +20,7 @@ class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
+      <>
         <Head>
           <title>react-multi-carousel</title>
         </Head>
@@ -36,7 +36,7 @@ class MyApp extends App {
             <Component pageContext={this.pageContext} {...pageProps} />
           </MuiThemeProvider>
         </JssProvider>
-      </Container>
+      </>
     )
   }
 }

--- a/examples/with-react-relay-network-modern/pages/_app.js
+++ b/examples/with-react-relay-network-modern/pages/_app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { QueryRenderer, fetchQuery } from 'react-relay'
-import NextApp, { Container } from 'next/app'
+import NextApp from 'next/app'
 
 import { initEnvironment, createEnvironment } from '../lib/createEnvironment'
 
@@ -41,18 +41,16 @@ export default class App extends NextApp {
     )
 
     return (
-      <Container>
-        <QueryRenderer
-          environment={environment}
-          query={Component.query}
-          variables={variables}
-          render={({ error, props }) => {
-            if (error) return <div>{error.message}</div>
-            else if (props) return <Component {...props} />
-            return <div>Loading</div>
-          }}
-        />
-      </Container>
+      <QueryRenderer
+        environment={environment}
+        query={Component.query}
+        variables={variables}
+        render={({ error, props }) => {
+          if (error) return <div>{error.message}</div>
+          else if (props) return <Component {...props} />
+          return <div>Loading</div>
+        }}
+      />
     )
   }
 }

--- a/examples/with-react-useragent/pages/_app.js
+++ b/examples/with-react-useragent/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { UserAgentProvider } from '@quentin-sommer/react-useragent'
 
 const PageWrapper = Comp =>
@@ -30,11 +30,7 @@ const PageWrapper = Comp =>
 class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }
 

--- a/examples/with-redux-observable/pages/_app.js
+++ b/examples/with-redux-observable/pages/_app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Provider } from 'react-redux'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import withRedux from 'next-redux-wrapper'
 import makeStore from '../redux'
 
@@ -16,11 +16,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, store } = this.props
     return (
-      <Container>
-        <Provider store={store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-redux-persist/pages/_app.js
+++ b/examples/with-redux-persist/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import withReduxStore from '../lib/with-redux-store'
 import { Provider } from 'react-redux'
@@ -14,16 +14,14 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, reduxStore } = this.props
     return (
-      <Container>
-        <Provider store={reduxStore}>
-          <PersistGate
-            loading={<Component {...pageProps} />}
-            persistor={this.persistor}
-          >
-            <Component {...pageProps} />
-          </PersistGate>
-        </Provider>
-      </Container>
+      <Provider store={reduxStore}>
+        <PersistGate
+          loading={<Component {...pageProps} />}
+          persistor={this.persistor}
+        >
+          <Component {...pageProps} />
+        </PersistGate>
+      </Provider>
     )
   }
 }

--- a/examples/with-redux-saga/pages/_app.js
+++ b/examples/with-redux-saga/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { Provider } from 'react-redux'
 import withRedux from 'next-redux-wrapper'
@@ -20,11 +20,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, store } = this.props
     return (
-      <Container>
-        <Provider store={store}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={store}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-redux-thunk/pages/_app.js
+++ b/examples/with-redux-thunk/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import withReduxStore from '../lib/with-redux-store'
 import { Provider } from 'react-redux'
@@ -7,11 +7,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, reduxStore } = this.props
     return (
-      <Container>
-        <Provider store={reduxStore}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={reduxStore}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-redux-wrapper/pages/_app.js
+++ b/examples/with-redux-wrapper/pages/_app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Provider } from 'react-redux'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import withRedux from 'next-redux-wrapper'
 import { initStore } from '../store'
 
@@ -17,11 +17,9 @@ export default withRedux(initStore)(
     render () {
       const { Component, pageProps, store } = this.props
       return (
-        <Container>
-          <Provider store={store}>
-            <Component {...pageProps} />
-          </Provider>
-        </Container>
+        <Provider store={store}>
+          <Component {...pageProps} />
+        </Provider>
       )
     }
   }

--- a/examples/with-redux/pages/_app.js
+++ b/examples/with-redux/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import withReduxStore from '../lib/with-redux-store'
 import { Provider } from 'react-redux'
@@ -7,11 +7,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, reduxStore } = this.props
     return (
-      <Container>
-        <Provider store={reduxStore}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={reduxStore}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-rematch/pages/_app.js
+++ b/examples/with-rematch/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 
 import withRematch from '../shared/withRematch'
@@ -8,11 +8,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps, reduxStore } = this.props
     return (
-      <Container>
-        <Provider store={reduxStore}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider store={reduxStore}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/examples/with-segment-analytics/pages/_app.js
+++ b/examples/with-segment-analytics/pages/_app.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Page from '../components/Page'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 export default class MyApp extends App {
   static async getInitialProps ({ Component, router, ctx }) {
@@ -17,11 +17,9 @@ export default class MyApp extends App {
     const { Component, pageProps } = this.props
 
     return (
-      <Container>
-        <Page>
-          <Component {...pageProps} />
-        </Page>
-      </Container>
+      <Page>
+        <Component {...pageProps} />
+      </Page>
     )
   }
 }

--- a/examples/with-sentry-simple/pages/_app.js
+++ b/examples/with-sentry-simple/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import * as Sentry from '@sentry/browser'
 
 Sentry.init({
@@ -22,11 +22,7 @@ class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
 
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }
 

--- a/examples/with-socket.io/pages/_app.js
+++ b/examples/with-socket.io/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import io from 'socket.io-client'
 
@@ -28,11 +28,7 @@ class MyApp extends App {
 
   render () {
     const { Component, pageProps } = this.props
-    return (
-      <Container>
-        <Component {...pageProps} socket={this.state.socket} />
-      </Container>
-    )
+    return <Component {...pageProps} socket={this.state.socket} />
   }
 }
 

--- a/examples/with-styled-components/pages/_app.js
+++ b/examples/with-styled-components/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { ThemeProvider } from 'styled-components'
 
@@ -12,11 +12,9 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <ThemeProvider theme={theme}>
-          <Component {...pageProps} />
-        </ThemeProvider>
-      </Container>
+      <ThemeProvider theme={theme}>
+        <Component {...pageProps} />
+      </ThemeProvider>
     )
   }
 }

--- a/examples/with-styletron/pages/_app.js
+++ b/examples/with-styletron/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import { Provider as StyletronProvider } from 'styletron-react'
 import { styletron, debug } from '../styletron'
 
@@ -7,11 +7,9 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <StyletronProvider value={styletron} debug={debug} debugAfterHydration>
-          <Component {...pageProps} />
-        </StyletronProvider>
-      </Container>
+      <StyletronProvider value={styletron} debug={debug} debugAfterHydration>
+        <Component {...pageProps} />
+      </StyletronProvider>
     )
   }
 }

--- a/examples/with-tailwindcss/pages/_app.js
+++ b/examples/with-tailwindcss/pages/_app.js
@@ -1,16 +1,12 @@
 import '../styles/index.css'
 
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
 
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }

--- a/examples/with-unstated/pages/_app.js
+++ b/examples/with-unstated/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { Provider } from 'unstated'
 import { counterStore } from '../containers/CounterContainer'
@@ -27,11 +27,9 @@ class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Provider inject={[counterStore]}>
-          <Component {...pageProps} />
-        </Provider>
-      </Container>
+      <Provider inject={[counterStore]}>
+        <Component {...pageProps} />
+      </Provider>
     )
   }
 }

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1518,7 +1518,7 @@ To override, create the `./pages/_app.js` file and override the App class as sho
 
 ```js
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 class MyApp extends App {
   // Only uncomment this method if you have blocking data requirements for
@@ -1538,12 +1538,7 @@ class MyApp extends App {
 
   render() {
     const { Component, pageProps } = this.props
-
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }
 

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -53,11 +53,7 @@ export default class App<P = {}, CP = {}, S = {}> extends React.Component<
   render() {
     const { router, Component, pageProps } = this.props as AppProps<CP>
     const url = createUrl(router)
-    return (
-      <Container>
-        <Component {...pageProps} url={url} />
-      </Container>
-    )
+    return <Component {...pageProps} url={url} />
   }
 }
 


### PR DESCRIPTION
This updates all examples to no longer use `Container` as it's not needed anymore since Next.js 9.

It updates:
- All examples
- Readme
- _app to be slightly smaller

We'll soon add a deprecation message for `Container` and it can be removed in Next.js 10.
