### PR TITLE
Fix TypeScript setup with empty file

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -192,6 +192,14 @@ export async function verifyTypeScriptSetup(dir: string): Promise<void> {
       path.dirname(tsConfigPath)
     )
 
+    if (result.errors) {
+      result.errors = result.errors.filter(
+        ({ code }) =>
+          // No inputs were found in config file
+          code !== 18003
+      )
+    }
+
     if (result.errors && result.errors.length) {
       throw new Error(
         ts.formatDiagnostic(result.errors[0], formatDiagnosticHost)

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -1,7 +1,14 @@
 /* eslint-env jest */
 /* global jasmine */
 import path from 'path'
-import { exists, remove, readFile, readJSON, writeJSON } from 'fs-extra'
+import {
+  exists,
+  remove,
+  readFile,
+  readJSON,
+  writeJSON,
+  createFile
+} from 'fs-extra'
 
 import { launchApp, findPort, killApp, renderViaHTTP } from 'next-test-utils'
 
@@ -25,6 +32,28 @@ describe('Fork ts checker plugin', () => {
 
   it('Creates a default tsconfig.json when one is missing', async () => {
     expect(await exists(tsConfig)).toBe(true)
+
+    const tsConfigContent = await readFile(tsConfig)
+    let parsedTsConfig
+    expect(() => {
+      parsedTsConfig = JSON.parse(tsConfigContent)
+    }).not.toThrow()
+
+    expect(parsedTsConfig.exclude[0]).toBe('node_modules')
+  })
+
+  it('Works with an empty tsconfig.json (docs)', async () => {
+    await killApp(app)
+
+    await remove(tsConfig)
+    await new Promise(resolve => setTimeout(resolve, 500))
+    expect(await exists(tsConfig)).toBe(false)
+    await createFile(tsConfig)
+    await new Promise(resolve => setTimeout(resolve, 500))
+    expect(await readFile(tsConfig, 'utf8')).toBe('')
+
+    appPort = await findPort()
+    app = await launchApp(appDir, appPort)
 
     const tsConfigContent = await readFile(tsConfig)
     let parsedTsConfig


### PR DESCRIPTION
New versions of TypeScript now throw an error when no matching TypeScript files are found. We still want to setup in this case.

-----

Closes #8324