### PR TITLE
🐛 Support multiple Next.js versions in one file

### DIFF
--- a/packages/next-server/taskfile-typescript.js
+++ b/packages/next-server/taskfile-typescript.js
@@ -41,7 +41,7 @@ try {
       // update file's data
       file.data = Buffer.from(
         result.outputText.replace(
-          /process\.env\.__NEXT_VERSION/,
+          /process\.env\.__NEXT_VERSION/g,
           `"${require('./package.json').version}"`
         ),
         'utf8'

--- a/packages/next/taskfile-babel.js
+++ b/packages/next/taskfile-babel.js
@@ -41,7 +41,7 @@ module.exports = function (task) {
 
 function setNextVersion (code) {
   return code.replace(
-    /process\.env\.__NEXT_VERSION/,
+    /process\.env\.__NEXT_VERSION/g,
     `"${require('./package.json').version}"`
   )
 }


### PR DESCRIPTION
We need to match this regex with a global directive to make sure more than the first instance is always replaced.