### PR TITLE
Minify ncc'd packages for download speed

### DIFF
--- a/packages/next/taskfile-ncc.js
+++ b/packages/next/taskfile-ncc.js
@@ -9,6 +9,7 @@ module.exports = function (task) {
     return ncc(join(__dirname, file.dir, file.base), {
       // cannot bundle
       externals: ['chokidar'],
+      minify: true,
       ...options
     }).then(({ code, assets }) => {
       Object.keys(assets).forEach(key =>


### PR DESCRIPTION
The packages we bundle within Next.js can be minified to reduce the number of bytes over the wire during install time.