### PR TITLE
Add missing dependency "compression" to next-server

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@ampproject/toolbox-optimizer": "1.0.1",
+    "compression": "1.7.4",
     "content-type": "1.0.4",
     "cookie": "0.4.0",
     "etag": "1.8.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -76,7 +76,6 @@
     "babel-plugin-transform-async-to-promises": "0.8.10",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "chalk": "2.4.2",
-    "compression": "1.7.4",
     "find-up": "4.0.0",
     "fork-ts-checker-webpack-plugin": "1.3.4",
     "fresh": "0.5.2",


### PR DESCRIPTION
On version 9.0.3, this error occurs after installing Next.js using [pnpm](https://pnpm.js.org) and starting a server:

```
Error: Cannot find module 'compression'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/path/to/project/node_modules/.registry.npmjs.org/next-server/9.0.3_react-dom@16.9.0+react@16.9.0/node_modules/next-server/dist/server/next-server.js:17:39)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
```

This happens because the _compression_ package isn't visible to _next-server_ in pnpm's strict `node_modules` structure.

The fix is for _next-server_ to declare _compression_ as a dependency.