### PR TITLE
Fixes nav start argument in user timing check

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -255,7 +255,11 @@ function markHydrateComplete () {
 
   performance.mark('afterHydrate') // mark end of hydration
 
-  performance.measure('Next.js-before-hydration', null, 'beforeRender')
+  performance.measure(
+    'Next.js-before-hydration',
+    'navigationStart',
+    'beforeRender'
+  )
   performance.measure('Next.js-hydration', 'beforeRender', 'afterHydrate')
 
   clearMarks()


### PR DESCRIPTION
Fixes #8347

`null` isn't supported for `startMark` in `performance.measure` for IE11 and Safari. This PR switches it to the `navigationStart` PerformanceTiming property