### PR TITLE
Remove experimental async-to-promises code

### DIFF
--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -38,7 +38,6 @@ const defaultConfig: { [key: string]: any } = {
     terserLoader: false,
     profiling: false,
     flyingShuttle: false,
-    asyncToPromises: false,
     documentMiddleware: false,
     granularChunks: false,
     publicDirectory: false,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -73,7 +73,6 @@ export default async function getBaseWebpackConfig(
         distDir,
         cwd: dir,
         cache: !selectivePageBuilding,
-        asyncToPromises: config.experimental.asyncToPromises,
       },
     },
     // Backwards compat

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -53,7 +53,6 @@ module.exports = babelLoader.custom(babel => {
     customOptions (opts) {
       const custom = {
         isServer: opts.isServer,
-        asyncToPromises: opts.asyncToPromises,
         isModern: opts.isModern,
         hasModern: opts.hasModern
       }
@@ -83,7 +82,6 @@ module.exports = babelLoader.custom(babel => {
       )
 
       delete loader.isServer
-      delete loader.asyncToPromises
       delete loader.cache
       delete loader.distDir
       delete loader.isModern
@@ -94,7 +92,7 @@ module.exports = babelLoader.custom(babel => {
       cfg,
       {
         source,
-        customOptions: { isServer, asyncToPromises, isModern, hasModern }
+        customOptions: { isServer, isModern, hasModern }
       }
     ) {
       const { cwd } = cfg.options
@@ -156,40 +154,6 @@ module.exports = babelLoader.custom(babel => {
         )
 
         options.presets = [...additionalPresets, presetItemModern]
-      }
-
-      if (!isModern && asyncToPromises) {
-        const asyncToPromisesPlugin = babel.createConfigItem(
-          [
-            'babel-plugin-transform-async-to-promises',
-            {
-              inlineHelpers: true
-            }
-          ],
-          { type: 'plugin' }
-        )
-        options.plugins = options.plugins || []
-        options.plugins.push(asyncToPromisesPlugin)
-
-        const regeneratorPlugin = options.plugins.find(plugin => {
-          return plugin[0] === require('@babel/plugin-transform-runtime')
-        })
-        if (regeneratorPlugin) {
-          regeneratorPlugin[1].regenerator = false
-        }
-
-        const babelPresetEnv = (options.presets || []).find((preset = []) => {
-          return preset[0] === require('@babel/preset-env').default
-        })
-        if (babelPresetEnv) {
-          babelPresetEnv[1].exclude = (
-            options.presets[0][1].exclude || []
-          ).concat([
-            'transform-typeof-symbol',
-            'transform-regenerator',
-            'transform-async-to-generator'
-          ])
-        }
       }
 
       // If the file has `module.exports` we have to transpile commonjs because Babel adds `import` statements

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -73,7 +73,6 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.6",
     "babel-plugin-react-require": "3.0.0",
-    "babel-plugin-transform-async-to-promises": "0.8.10",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "chalk": "2.4.2",
     "find-up": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,11 +3214,6 @@ babel-plugin-syntax-jsx@6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
-babel-plugin-transform-async-to-promises@0.8.10:
-  version "0.8.10"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.10.tgz#d6b75ebcd08a27b780cc4306525e6bfc5e070303"
-  integrity sha512-+697AuoK7Skokmeu5MOhMP7IoOyKhhYjt73vaYUbf9PW9A0wl/NjVm2fJGVmjbjhhyYcnEqjfgRNCYuErHv1Sg==
-
 babel-plugin-transform-react-remove-prop-types@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"


### PR DESCRIPTION
Removes the opt-in code for the babel plugin `babel-plugin-transform-async-to-promises`