### PR TITLE
Add a note for multiple dynamic route segments

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -325,7 +325,7 @@ const Post = () => {
 export default Post
 ```
 
-Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js`.
+Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js` (nested routes work the same way -  `pages/post/[pid]/[comment].js` will be matched by `pages/post/[pid]/[comment].js`). 
 The matched path parameter will be sent as a query parameter to the page.
 
 For example, the route `/post/abc` will have the following `query` object: `{ pid: 'abc' }`.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -325,7 +325,7 @@ const Post = () => {
 export default Post
 ```
 
-Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js` (nested routes work the same way -  `pages/post/[pid]/[comment].js` will be matched by `pages/post/[pid]/[comment].js`). 
+Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js` (nested routes work the same way -  `pages/post/[pid]/[comment].js` mathches `/post/1/a-comment`). 
 The matched path parameter will be sent as a query parameter to the page.
 
 For example, the route `/post/abc` will have the following `query` object: `{ pid: 'abc' }`.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -325,7 +325,7 @@ const Post = () => {
 export default Post
 ```
 
-Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js` (nested routes work the same way -  `pages/post/[pid]/[comment].js` mathches `/post/1/a-comment`). 
+Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js` (nested routes work the same way -  `pages/post/[pid]/[comment].js` matches `/post/1/a-comment`). 
 The matched path parameter will be sent as a query parameter to the page.
 
 For example, the route `/post/abc` will have the following `query` object: `{ pid: 'abc' }`.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -325,11 +325,16 @@ const Post = () => {
 export default Post
 ```
 
-Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js` (nested routes work the same way -  `pages/post/[pid]/[comment].js` matches `/post/1/a-comment`). 
+Any route like `/post/1`, `/post/abc`, etc will be matched by `pages/post/[pid].js`.
 The matched path parameter will be sent as a query parameter to the page.
 
 For example, the route `/post/abc` will have the following `query` object: `{ pid: 'abc' }`.
 Similarly, the route `/post/abc?foo=bar` will have the `query` object: `{ foo: 'bar', pid: 'abc' }`.
+
+> Note: Multiple dynamic route segments work the same way.
+>
+> For example, `pages/post/[pid]/[comment].js` would match `/post/1/a-comment`. 
+> Its `query` object would be: `{ pid: '1', comment: 'a-comment' }`.
 
 A `<Link>` for `/post/abc` looks like so:
 


### PR DESCRIPTION
Hi team,

Looking at docs I was not able to find any info on nested dynamic routes. I found all the needed info on examples https://github.com/zeit/next.js/tree/canary/examples/dynamic-routing#the-idea-behind-the-example though.

I thought it would make sense to mention about nested routes on the docs to save someone's time.

Please let me know if this makes sense to you.

Thanks 🙏 