### PR TITLE
fix(examples): correct the path in with-electron

### DIFF
--- a/examples/with-electron/main/index.js
+++ b/examples/with-electron/main/index.js
@@ -23,7 +23,7 @@ app.on('ready', async () => {
   const url = isDev
     ? 'http://localhost:8000/start'
     : format({
-      pathname: join(__dirname, '../renderer/start/index.html'),
+      pathname: join(__dirname, '../renderer/out/start.html'),
       protocol: 'file:',
       slashes: true
     })

--- a/examples/with-electron/main/index.js
+++ b/examples/with-electron/main/index.js
@@ -23,7 +23,7 @@ app.on('ready', async () => {
   const url = isDev
     ? 'http://localhost:8000/start'
     : format({
-      pathname: join(__dirname, '../renderer/out/start.html'),
+      pathname: join(__dirname, '../renderer/start.html'),
       protocol: 'file:',
       slashes: true
     })


### PR DESCRIPTION
Fix the production build of the `with-electron` example by pointing to the correct file.

Folder structure:
![image](https://user-images.githubusercontent.com/3842800/63040911-db168900-bec6-11e9-9be4-8c8607e75c81.png)
