### PR TITLE
Create a unique instance of transform-define

### DIFF
--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -164,7 +164,8 @@ module.exports = babelLoader.custom(babel => {
 
       options.plugins.push([
         'transform-define',
-        { 'typeof window': isServer ? 'undefined' : 'object' }
+        { 'typeof window': isServer ? 'undefined' : 'object' },
+        'next-js-transform-define-instance'
       ])
 
       // As next-server/lib has stateful modules we have to transpile commonjs

--- a/test/integration/babel/.babelrc
+++ b/test/integration/babel/.babelrc
@@ -1,6 +1,4 @@
 {
-  "presets": [
-    "next/babel",
-    "@babel/preset-flow"
-  ]
+  "presets": ["next/babel", "@babel/preset-flow"],
+  "plugins": [["transform-define", { "TEST_VAR": "hello" }]]
 }


### PR DESCRIPTION
Babel will complain about duplicate plugins when the user has their own copy of `transform-define`.

This PR fixes that!