### PR TITLE
Add progress for analyzing and auto-prerendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@babel/preset-react": "7.0.0",
     "@mdx-js/loader": "0.18.0",
     "@types/jest": "24.0.13",
+    "@types/progress": "2.0.3",
     "@types/string-hash": "1.1.1",
     "@zeit/next-css": "1.0.2-canary.2",
     "@zeit/next-sass": "1.0.2-canary.2",

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -42,7 +42,6 @@ import {
   getPageChunks,
 } from './webpack/plugins/chunk-graph-plugin'
 import { writeBuildId } from './write-build-id'
-// @ts-ignore
 import createProgress from 'tty-aware-progress'
 
 const fsUnlink = promisify(fs.unlink)
@@ -328,7 +327,9 @@ export default async function build(dir: string, conf = null): Promise<void> {
     staticCheckWorker,
     ['default']
   )
-  const staticCheckProgress = createProgress(pageKeys.length)
+  const staticCheckProgress = createProgress(pageKeys.length, {
+    stream: process.stdout,
+  })
 
   await Promise.all(
     pageKeys.map(async page => {

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -27,7 +27,7 @@ const mkdirp = promisify(mkdirpModule)
 
 export default async function (dir, options, configuration) {
   function log (message) {
-    if (options.silent) return
+    if (options.silent || options.buildExport) return
     console.log(message)
   }
 

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -157,7 +157,9 @@ export default async function (dir, options, configuration) {
     )
   }
 
-  const progress = !options.silent && createProgress(filteredPaths.length)
+  const progress =
+    !options.silent &&
+    createProgress(filteredPaths.length, { stream: process.stdout })
 
   const chunks = filteredPaths.reduce((result, route, i) => {
     const worker = i % threads

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -5,6 +5,11 @@ declare module 'webpack/lib/GraphHelpers'
 declare module 'unfetch'
 declare module 'styled-jsx/server'
 
+declare module 'tty-aware-progress' {
+  import createProgress from 'tty-aware-progress/src'
+  export = createProgress
+}
+
 declare module 'next/dist/compiled/nanoid/index.js' {
   function nanoid(size?: number): string
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2243,6 +2243,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
 
+"@types/progress@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/progress/-/progress-2.0.3.tgz#7ccbd9c6d4d601319126c469e73b5bb90dfc8ccc"
+  integrity sha512-bPOsfCZ4tsTlKiBjBhKnM8jpY5nmIll166IPD58D92hR7G7kZDfx5iB9wGF4NfZrdKolebjeAr3GouYkSGoJ/A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prompts@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/prompts/-/prompts-2.0.1.tgz#afae5a8b0616a33cd31557bec74e2fd4a32f4afe"


### PR DESCRIPTION
Shows the progress used with `next export` while analyzing pages/auto-prerendering eligible pages

<img width="947" alt="Screen Shot 2019-08-14 at 2 50 14 PM" src="https://user-images.githubusercontent.com/22380829/63051579-1606c580-bea3-11e9-8026-4a86edceb1e2.png">
