### PR TITLE
Use `data-next-page` instead of `id=__NEXT_PAGE__`

### DIFF
--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -120,7 +120,7 @@ export default class PageLoader {
 
       // If the page is loading via SSR, we need to wait for it
       // rather downloading it again.
-      if (document.getElementById(`__NEXT_PAGE__${route}`)) {
+      if (document.querySelector(`script[data-next-page="${route}"]`)) {
         return
       }
 
@@ -234,7 +234,7 @@ export default class PageLoader {
     // its own deduping mechanism.
     if (
       document.querySelector(`link[rel="preload"][href^="${url}"]`) ||
-      document.getElementById(`__NEXT_PAGE__${route}`)
+      document.querySelector(`script[data-next-page="${route}"]`)
     ) {
       return
     }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -614,7 +614,7 @@ export class NextScript extends Component<OriginProps> {
     const pageScript = [
       <script
         async
-        id={`__NEXT_PAGE__${page}`}
+        data-next-page={page}
         key={page}
         src={
           assetPrefix +
@@ -630,7 +630,7 @@ export class NextScript extends Component<OriginProps> {
       process.env.__NEXT_MODERN_BUILD && (
         <script
           async
-          id={`__NEXT_PAGE__${page}`}
+          data-next-page={page}
           key={`${page}-modern`}
           src={
             assetPrefix +
@@ -651,7 +651,7 @@ export class NextScript extends Component<OriginProps> {
     const appScript = [
       <script
         async
-        id={`__NEXT_PAGE__/_app`}
+        data-next-page="/_app"
         src={
           assetPrefix +
           (dynamicBuildId
@@ -667,7 +667,7 @@ export class NextScript extends Component<OriginProps> {
       process.env.__NEXT_MODERN_BUILD && (
         <script
           async
-          id={`__NEXT_PAGE__/_app`}
+          data-next-page="/_app"
           src={
             assetPrefix +
             (dynamicBuildId


### PR DESCRIPTION
This fixes duplicate element ids in the dom when using modern mode.