### PR TITLE
[with-apollo] Enable Server-Side Rendering of queries

### DIFF
--- a/examples/with-apollo/components/App.js
+++ b/examples/with-apollo/components/App.js
@@ -29,13 +29,10 @@ export default ({ children }) => (
         color: white;
         display: flex;
         padding: 5px 7px;
-        transition: background-color 0.3s;
       }
       button:active {
         background-color: #1b9db7;
-      }
-      button:disabled {
-        background-color: #b5bebf;
+        transition: background-color 0.3s;
       }
       button:focus {
         outline: none;

--- a/examples/with-apollo/components/PostUpvoter.js
+++ b/examples/with-apollo/components/PostUpvoter.js
@@ -1,60 +1,32 @@
-import React from 'react'
-import { useMutation } from '@apollo/react-hooks'
-import gql from 'graphql-tag'
+import React from "react";
+import { gql } from "apollo-boost";
+import { useMutation } from "@apollo/react-hooks";
 
-const UPDATE_POST_MUTATION = gql`
+const UPVOTE_POST_MUTATION = gql`
   mutation updatePost($id: ID!, $votes: Int) {
     updatePost(id: $id, votes: $votes) {
-      __typename
       id
+      __typename
       votes
     }
   }
-`
+`;
 
-export default function PostUpvoter ({ votes, id }) {
-  const [updatePost] = useMutation(UPDATE_POST_MUTATION)
-
-  const upvotePost = () => {
-    updatePost({
-      variables: {
-        id,
-        votes: votes + 1
-      },
-      optimisticResponse: {
-        __typename: 'Mutation',
-        updatePost: {
-          __typename: 'Post',
-          id,
-          votes: votes + 1
-        }
-      }
-    })
-  }
+export default function PostUpvoter({ votes, id }) {
+  const [upvotePost] = useMutation(UPVOTE_POST_MUTATION);
 
   return (
-    <button onClick={() => upvotePost()}>
+    <button
+      onClick={() => {
+        upvotePost({
+          variables: {
+            id,
+            votes: votes + 1
+          }
+        });
+      }}
+    >
       {votes}
-      <style jsx>{`
-        button {
-          background-color: transparent;
-          border: 1px solid #e4e4e4;
-          color: #000;
-        }
-        button:active {
-          background-color: transparent;
-        }
-        button:before {
-          align-self: center;
-          border-color: transparent transparent #000000 transparent;
-          border-style: solid;
-          border-width: 0 4px 6px 4px;
-          content: '';
-          height: 0;
-          margin-right: 5px;
-          width: 0;
-        }
-      `}</style>
     </button>
-  )
+  );
 }

--- a/examples/with-apollo/components/Submit.js
+++ b/examples/with-apollo/components/Submit.js
@@ -1,8 +1,9 @@
-import { useMutation } from '@apollo/react-hooks'
-import gql from 'graphql-tag'
-import { ALL_POSTS_QUERY, allPostsQueryVars } from './PostList'
+import { useState } from "react";
+import { gql } from "apollo-boost";
+import { useMutation } from "@apollo/react-hooks";
+import { allPostsQuery, allPostsQueryVars } from "./PostList";
 
-const CREATE_POST_MUTATION = gql`
+const SUBMIT_FORM_MUTATION = gql`
   mutation createPost($title: String!, $url: String!) {
     createPost(title: $title, url: $url) {
       id
@@ -12,47 +13,45 @@ const CREATE_POST_MUTATION = gql`
       createdAt
     }
   }
-`
+`;
 
-export default function Submit () {
-  const [createPost, { loading }] = useMutation(CREATE_POST_MUTATION)
-
-  const handleSubmit = event => {
-    event.preventDefault()
-    const form = event.target
-    const formData = new window.FormData(form)
-    const title = formData.get('title')
-    const url = formData.get('url')
-    form.reset()
-
-    createPost({
-      variables: { title, url },
-      update: (proxy, { data: { createPost } }) => {
-        const data = proxy.readQuery({
-          query: ALL_POSTS_QUERY,
-          variables: allPostsQueryVars
-        })
-        // Update the cache with the new post at the top of the
-        proxy.writeQuery({
-          query: ALL_POSTS_QUERY,
-          data: {
-            ...data,
-            allPosts: [createPost, ...data.allPosts]
-          },
-          variables: allPostsQueryVars
-        })
-      }
-    })
-  }
+export default function Submit() {
+  const [title, setTitle] = useState("");
+  const [url, setURL] = useState("");
+  const [submitPost] = useMutation(SUBMIT_FORM_MUTATION);
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form
+      onSubmit={event => {
+        event.preventDefault();
+        submitPost({
+          variables: { title, url },
+          refetchQueries: [
+            { query: allPostsQuery, variables: allPostsQueryVars }
+          ]
+        });
+        setTitle("");
+        setURL("");
+      }}
+    >
       <h1>Submit</h1>
-      <input placeholder='title' name='title' type='text' required />
-      <input placeholder='url' name='url' type='url' required />
-      <button type='submit' disabled={loading}>
-        Submit
-      </button>
+      <input
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        placeholder="title"
+        name="title"
+        type="text"
+        required
+      />
+      <input
+        value={url}
+        onChange={e => setURL(e.target.value)}
+        placeholder="url"
+        name="url"
+        type="url"
+        required
+      />
+      <button type="submit">Submit</button>
       <style jsx>{`
         form {
           border-bottom: 1px solid #ececec;
@@ -68,5 +67,5 @@ export default function Submit () {
         }
       `}</style>
     </form>
-  )
+  );
 }

--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -1,35 +1,35 @@
-import { ApolloClient, InMemoryCache, HttpLink } from 'apollo-boost'
-import fetch from 'isomorphic-unfetch'
+import { ApolloClient, InMemoryCache, HttpLink } from "apollo-boost";
+import fetch from "isomorphic-unfetch";
 
-let apolloClient = null
+let apolloClient = null;
 
-function create (initialState) {
+function create(initialState) {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
-  const isBrowser = typeof window !== 'undefined'
+  const isBrowser = typeof window !== "undefined";
   return new ApolloClient({
     connectToDevTools: isBrowser,
     ssrMode: !isBrowser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
-      uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
-      credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
+      uri: "https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn", // Server URL (must be absolute)
+      credentials: "same-origin", // Additional fetch() options like `credentials` or `headers`
       // Use fetch() polyfill on the server
       fetch: !isBrowser && fetch
     }),
     cache: new InMemoryCache().restore(initialState || {})
-  })
+  });
 }
 
-export default function initApollo (initialState) {
+export default function initApollo(initialState) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
-  if (typeof window === 'undefined') {
-    return create(initialState)
+  if (typeof window === "undefined") {
+    return create(initialState);
   }
 
   // Reuse client on the client-side
   if (!apolloClient) {
-    apolloClient = create(initialState)
+    apolloClient = create(initialState);
   }
 
-  return apolloClient
+  return apolloClient;
 }

--- a/examples/with-apollo/lib/with-apollo-client.js
+++ b/examples/with-apollo/lib/with-apollo-client.js
@@ -1,54 +1,56 @@
-import React from 'react'
-import initApollo from './init-apollo'
-import Head from 'next/head'
-import { getDataFromTree } from '@apollo/react-ssr'
+import React from "react";
+import initApollo from "./init-apollo";
+import Head from "next/head";
+import { getDataFromTree } from "@apollo/react-ssr";
 
 export default App => {
   return class Apollo extends React.Component {
-    static displayName = 'withApollo(App)'
-    static async getInitialProps (ctx) {
-      const { AppTree } = ctx
+    static displayName = "withApollo(App)";
+    static async getInitialProps(ctx) {
+      const { AppTree } = ctx;
 
-      let appProps = {}
+      let appProps = {};
       if (App.getInitialProps) {
-        appProps = await App.getInitialProps(ctx)
+        appProps = await App.getInitialProps(ctx);
       }
 
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
-      const apollo = initApollo()
-      if (typeof window === 'undefined') {
+      const apollo = initApollo();
+      if (typeof window === "undefined") {
         try {
           // Run all GraphQL queries
-          await getDataFromTree(<AppTree {...appProps} apolloClient={apollo} />)
+          await getDataFromTree(
+            <AppTree {...appProps} apolloClient={apollo} />
+          );
         } catch (error) {
           // Prevent Apollo Client GraphQL errors from crashing SSR.
           // Handle them in components via the data.error prop:
           // https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-query-data-error
-          console.error('Error while running `getDataFromTree`', error)
+          console.error("Error while running `getDataFromTree`", error);
         }
 
         // getDataFromTree does not call componentWillUnmount
         // head side effect therefore need to be cleared manually
-        Head.rewind()
+        Head.rewind();
       }
 
       // Extract query data from the Apollo store
-      const apolloState = apollo.cache.extract()
+      const apolloState = apollo.cache.extract();
 
       return {
         ...appProps,
         apolloState
-      }
+      };
     }
 
-    constructor (props) {
-      super(props)
-      this.apolloClient = initApollo(props.apolloState)
+    constructor(props) {
+      super(props);
+      this.apolloClient = initApollo(props.apolloState);
     }
 
-    render () {
-      return <App apolloClient={this.apolloClient} {...this.props} />
+    render() {
+      return <App apolloClient={this.apolloClient} {...this.props} />;
     }
-  }
-}
+  };
+};

--- a/examples/with-apollo/pages/_app.js
+++ b/examples/with-apollo/pages/_app.js
@@ -1,17 +1,19 @@
-import App from 'next/app'
-import React from 'react'
-import { ApolloProvider } from '@apollo/react-hooks'
-import withApolloClient from '../lib/with-apollo-client'
+import App, { Container } from "next/app";
+import React from "react";
+import withApolloClient from "../lib/with-apollo-client";
+import { ApolloProvider } from "@apollo/react-hooks";
 
 class MyApp extends App {
-  render () {
-    const { Component, pageProps, apolloClient } = this.props
+  render() {
+    const { Component, pageProps, apolloClient } = this.props;
     return (
-      <ApolloProvider client={apolloClient}>
-        <Component {...pageProps} />
-      </ApolloProvider>
-    )
+      <Container>
+        <ApolloProvider client={apolloClient}>
+          <Component {...pageProps} />
+        </ApolloProvider>
+      </Container>
+    );
   }
 }
 
-export default withApolloClient(MyApp)
+export default withApolloClient(MyApp);

--- a/examples/with-apollo/pages/about.js
+++ b/examples/with-apollo/pages/about.js
@@ -1,43 +1,18 @@
-import App from '../components/App'
-import Header from '../components/Header'
+import App from "../components/App";
+import Header from "../components/Header";
 
 export default () => (
   <App>
     <Header />
     <article>
-      <h1>The Idea Behind This Example</h1>
+      <h1>Next + Apollo : The one with Hooks</h1>
       <p>
-        <a href='https://www.apollographql.com/client/'>Apollo</a> is a GraphQL
-        client that allows you to easily query the exact data you need from a
-        GraphQL server. In addition to fetching and mutating data, Apollo
-        analyzes your queries and their results to construct a client-side cache
-        of your data, which is kept up to date as further queries and mutations
-        are run, fetching more results from the server.
-      </p>
-      <p>
-        In this simple example, we integrate Apollo seamlessly with{' '}
-        <a href='https://github.com/zeit/next.js'>Next</a> by wrapping our App component
-        inside a{' '}
-        <a href='https://facebook.github.io/react/docs/higher-order-components.html'>
-          higher-order component (HOC)
-        </a>
-        . Using the HOC pattern we're able to pass down a central store of query
-        result data created by Apollo into our React component hierarchy defined
-        inside each page of our Next application.
-      </p>
-      <p>
-        On initial page load, while on the server and inside getInitialProps, we
-        invoke the Apollo method,{' '}
-        <a href='https://www.apollographql.com/docs/react/api/react-ssr/#getdatafromtree'>
-          getDataFromTree
-        </a>
-        . This method returns a promise; at the point in which the promise
-        resolves, our Apollo Client store is completely initialized.
-      </p>
-      <p>
-        This example relies on <a href='http://graph.cool'>graph.cool</a> for
-        its GraphQL backend.
+        This example shows how the old{" "}
+        <a href="https://github.com/zeit/next.js/tree/canary/examples/with-apollo">
+          Next With Apollo
+        </a>{" "}
+        example can be migrated to use Hooks instead of Higher Order Components.
       </p>
     </article>
   </App>
-)
+);

--- a/examples/with-apollo/pages/index.js
+++ b/examples/with-apollo/pages/index.js
@@ -1,7 +1,7 @@
-import App from '../components/App'
-import Header from '../components/Header'
-import Submit from '../components/Submit'
-import PostList from '../components/PostList'
+import App from "../components/App";
+import Header from "../components/Header";
+import Submit from "../components/Submit";
+import PostList from "../components/PostList";
 
 export default () => (
   <App>
@@ -9,4 +9,4 @@ export default () => (
     <Submit />
     <PostList />
   </App>
-)
+);


### PR DESCRIPTION
While the current branch does support `useQuery` and `useMutation` hooks, everything is being rendered on the client side. Hence, we see a flash of "loading" before the content of `<PostList>` is shown.

This pull request enables server-side rendering of queries, which provides SEO benefits (this is one of the best features of Next.js after all)

Link to example on CodeSandBox, which has been viewed 2.5k + times : https://codesandbox.io/s/with-apollo-o221g