### PR TITLE
correct code in README.md to behavior described

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -777,7 +777,7 @@ import Router from 'next/router'
 
 Router.beforePopState(({ url, as, options }) => {
   // I only want to allow these two routes!
-  if (as !== '/' || as !== '/other') {
+  if (as !== '/' && as !== '/other') {
     // Have SSR render bad routes as a 404.
     window.location.href = as
     return false


### PR DESCRIPTION
change `||` to `&&` in Router.beforePopState example to match doc description