### PR TITLE
Don't throw with new serverless-trace and selective page build

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -85,7 +85,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   const isLikeServerless = isTargetLikeServerless(target)
 
-  if (selectivePageBuilding && target !== 'serverless') {
+  if (selectivePageBuilding && !isLikeServerless) {
     throw new Error(
       `Cannot use ${
         isFlyingShuttle ? 'flying shuttle' : '`now dev`'


### PR DESCRIPTION
Updates the check from only `serverless` to `isLikeServerless` since we have the `serverless-trace` mode now and using the selective page can be useful when debugging