### PR TITLE
Update Link for create-next-app

### DIFF
--- a/packages/create-next-app/templates/default/pages/index.js
+++ b/packages/create-next-app/templates/default/pages/index.js
@@ -18,16 +18,16 @@ const Home = () => (
       </p>
 
       <div className='row'>
-        <Link href='https://github.com/zeit/next.js#getting-started'>
+        <Link href='https://github.com/zeit/next.js#setup'>
           <a className='card'>
             <h3>Getting Started &rarr;</h3>
-            <p>Learn more about Next.js on GitHub and in their examples</p>
+            <p>Learn more about Next.js on GitHub and in their examples.</p>
           </a>
         </Link>
         <Link href='https://github.com/zeit/next.js/tree/master/examples'>
           <a className='card'>
             <h3>Examples &rarr;</h3>
-            <p>Find other example boilerplates on the Next.js GitHub</p>
+            <p>Find other example boilerplates on the Next.js GitHub.</p>
           </a>
         </Link>
         <Link href='https://github.com/zeit/next.js'>


### PR DESCRIPTION
This PR updates the anchor link for the Getting Started card on the `create-next-app` default template. The current anchor link no longer exists.