### PR TITLE
Adds basic support for PnP

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -142,6 +142,7 @@ module.exports = (
           helpers: true,
           regenerator: true,
           useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
+          absoluteRuntime: process.versions.pnp ? __dirname : undefined,
           ...options['transform-runtime'],
         },
       ],

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -142,7 +142,7 @@ module.exports = (
           helpers: true,
           regenerator: true,
           useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
-          absoluteRuntime: process.versions.pnp ? __dirname : undefined,
+          absoluteRuntime: (process.versions as any).pnp ? __dirname : undefined,
           ...options['transform-runtime'],
         },
       ],

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -20,8 +20,8 @@ const getModernOptions = (babelOptions = {}) => {
   presetEnvOptions.exclude = [
     ...(presetEnvOptions.exclude || []),
     // Blacklist accidental inclusions
-    require.resolve('@babel/plugin-transform-regenerator'),
-    require.resolve('@babel/plugin-transform-async-to-generator')
+    'transform-regenerator',
+    'transform-async-to-generator'
   ]
 
   return {

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -20,8 +20,8 @@ const getModernOptions = (babelOptions = {}) => {
   presetEnvOptions.exclude = [
     ...(presetEnvOptions.exclude || []),
     // Blacklist accidental inclusions
-    'transform-regenerator',
-    'transform-async-to-generator'
+    require.resolve('@babel/plugin-transform-regenerator'),
+    require.resolve('@babel/plugin-transform-async-to-generator')
   ]
 
   return {
@@ -163,7 +163,7 @@ module.exports = babelLoader.custom(babel => {
       }
 
       options.plugins.push([
-        'transform-define',
+        require.resolve('babel-plugin-transform-define'),
         { 'typeof window': isServer ? 'undefined' : 'object' },
         'next-js-transform-define-instance'
       ])

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -72,6 +72,7 @@
     "autodll-webpack-plugin": "0.4.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.0.6",
+    "babel-plugin-syntax-jsx": "6.18.0",
     "babel-plugin-transform-define": "1.3.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "chalk": "2.4.2",


### PR DESCRIPTION
This diff ensures that the Babel plugins (at least the ones that get used by the smallest Next.js instance possible) are properly resolved.

After applying this, Yarn 2 can run `yarn dev` (I'm using `yarn link` to run my local Next.js build):

![image](https://user-images.githubusercontent.com/1037931/63288126-4512a200-c2bc-11e9-9f22-4981aeffcb68.png)

Fixes #8418

Ref https://github.com/babel/babel/issues/10355 for `absoluteRuntime` which is currently needed in PnP mode (otherwise the transpiled packages cannot require `@babel/runtime-corejs2` by themselves)

