### PR TITLE
Add example with `forwardRef` for `next/link` to readme

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -585,6 +585,29 @@ export default About
 
 Note: if passing a functional component as a child of `<Link>` you will need to wrap it in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref)
 
+**Example with `React.forwardRef`**
+
+```jsx
+import React from 'react'
+import Link from 'next/link'
+
+// `onClick`, `href`, and `ref` need to be passed to the DOM element
+// for proper handling
+const MyButton = React.forwardRef(({ onClick, href }, ref) => (
+  <a href={href} onClick={onClick} ref={ref}>
+    Click Me
+  </a>
+))
+
+export default () => (
+  <>
+    <Link href='/another'>
+      <MyButton />
+    </Link>
+  </>
+)
+```
+
 **Custom routes (using props from URL)**
 
 If you find that your use case is not covered by [Dynamic Routing](#dynamic-routing) then you can create a custom server and manually add dynamic routes.


### PR DESCRIPTION
Since we support function components as children of `next/link` for now this shows an example of how `React.forwardRef` needs to be used with it for proper handling. 

x-ref: #8425