### PR TITLE
Adjust Create Next App install env

### DIFF
--- a/packages/create-next-app/helpers/install.ts
+++ b/packages/create-next-app/helpers/install.ts
@@ -36,7 +36,10 @@ export function install(
       ].filter(Boolean) as string[]).concat(dependencies || [])
     }
 
-    const child = spawn(command, args, { stdio: 'inherit' })
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      env: { ...process.env, ADBLOCK: '1', DISABLE_OPENCOLLECTIVE: '1' },
+    })
     child.on('close', code => {
       if (code !== 0) {
         reject({ command: `${command} ${args.join(' ')}` })


### PR DESCRIPTION
This sets well-known environment variables during a managed install for the user to suppress unnecessary CLI output.