### PR TITLE
Remove `__NEXT_REPLACE__BUILD_ID__` workaround

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -59,6 +59,7 @@ export function createEntrypoints(
     absoluteDocumentPath: pages['/_document'],
     absoluteErrorPath: pages['/_error'],
     distDir: DOT_NEXT_ALIAS,
+    buildId,
     assetPrefix: config.assetPrefix,
     generateEtags: config.generateEtags,
     ampBindInitData: config.experimental.ampBindInitData,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -571,11 +571,7 @@ export default async function getBaseWebpackConfig(
             )
           },
         }),
-      isLikeServerless &&
-        new ServerlessPlugin(buildId, {
-          isServer,
-          isTrace: isServerlessTrace,
-        }),
+      isServerless && new ServerlessPlugin(),
       isServer && new PagesManifestPlugin(isLikeServerless),
       target === 'server' &&
         isServer &&

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -12,6 +12,7 @@ export type ServerlessLoaderQuery = {
   absoluteAppPath: string
   absoluteDocumentPath: string
   absoluteErrorPath: string
+  buildId: string
   assetPrefix: string
   ampBindInitData: boolean | string
   generateEtags: string
@@ -23,6 +24,7 @@ const nextServerlessLoader: loader.Loader = function() {
     distDir,
     absolutePagePath,
     page,
+    buildId,
     canonicalBase,
     assetPrefix,
     ampBindInitData,
@@ -88,7 +90,7 @@ const nextServerlessLoader: loader.Loader = function() {
         buildManifest,
         reactLoadableManifest,
         canonicalBase: "${canonicalBase}",
-        buildId: "__NEXT_REPLACE__BUILD_ID__",
+        buildId: "${buildId}",
         assetPrefix: "${assetPrefix}",
         ampBindInitData: ${ampBindInitData === true ||
           ampBindInitData === 'true'}

--- a/packages/next/build/webpack/plugins/serverless-plugin.ts
+++ b/packages/next/build/webpack/plugins/serverless-plugin.ts
@@ -7,94 +7,24 @@ import { connectChunkAndModule } from 'webpack/lib/GraphHelpers'
  * This is to make sure there is a single render bundle instead of that bundle importing dynamic chunks
  */
 
-const NEXT_REPLACE_BUILD_ID = '__NEXT_REPLACE__BUILD_ID__'
-
-function replaceInBuffer(buffer: Buffer, from: string, to: string) {
-  const target = Buffer.from(from, 'utf8')
-  const replacement = Buffer.from(to, 'utf8')
-
-  function bufferTee(source: Buffer): Buffer {
-    const index = source.indexOf(target)
-    if (index === -1) {
-      // Escape recursion loop
-      return source
-    }
-
-    const b1 = source.slice(0, index)
-    const b2 = source.slice(index + target.length)
-
-    const nextBuffer = bufferTee(b2)
-    return Buffer.concat(
-      [b1, replacement, nextBuffer],
-      index + replacement.length + nextBuffer.length
-    )
-  }
-
-  return bufferTee(buffer)
-}
-
-function interceptFileWrites(
-  compiler: Compiler,
-  contentFn: (input: Buffer) => Buffer
-) {
-  compiler.outputFileSystem = new Proxy(compiler.outputFileSystem, {
-    get(target, propKey) {
-      const orig = (target as any)[propKey]
-      if (propKey !== 'writeFile') {
-        return orig
-      }
-
-      return function(targetPath: string, content: Buffer, ...args: any[]) {
-        return orig.call(target, targetPath, contentFn(content), ...args)
-      }
-    },
-  })
-}
-
 export class ServerlessPlugin {
-  private buildId: string
-  private isServer: boolean
-  private isTrace: boolean
-
-  constructor(
-    buildId: string,
-    { isServer, isTrace }: { isServer: boolean; isTrace: boolean }
-  ) {
-    this.buildId = buildId
-    this.isServer = isServer
-    this.isTrace = isTrace
-  }
-
   apply(compiler: Compiler) {
-    if (!this.isServer) {
-      return
-    }
-
-    interceptFileWrites(compiler, content =>
-      replaceInBuffer(content, NEXT_REPLACE_BUILD_ID, this.buildId)
-    )
-
-    if (!this.isTrace) {
-      compiler.hooks.compilation.tap('ServerlessPlugin', compilation => {
-        compilation.hooks.optimizeChunksBasic.tap(
-          'ServerlessPlugin',
-          chunks => {
-            chunks.forEach(chunk => {
-              // If chunk is not an entry point skip them
-              if (chunk.hasEntryModule()) {
-                const dynamicChunks = chunk.getAllAsyncChunks()
-                if (dynamicChunks.size !== 0) {
-                  for (const dynamicChunk of dynamicChunks) {
-                    for (const module of dynamicChunk.modulesIterable) {
-                      connectChunkAndModule(chunk, module)
-                    }
-                  }
+    compiler.hooks.compilation.tap('ServerlessPlugin', compilation => {
+      compilation.hooks.optimizeChunksBasic.tap('ServerlessPlugin', chunks => {
+        chunks.forEach(chunk => {
+          // If chunk is not an entry point skip them
+          if (chunk.hasEntryModule()) {
+            const dynamicChunks = chunk.getAllAsyncChunks()
+            if (dynamicChunks.size !== 0) {
+              for (const dynamicChunk of dynamicChunks) {
+                for (const module of dynamicChunk.modulesIterable) {
+                  connectChunkAndModule(chunk, module)
                 }
               }
-            })
+            }
           }
-        )
+        })
       })
-    }
+    })
   }
 }


### PR DESCRIPTION
We no longer need this because we don't run terser on serverless bundles.

On a mission to 🚮 code. 

---

Closes https://github.com/zeit/next.js/issues/8436