### PR TITLE
Remove _app files from modern build manifest

### DIFF
--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -25,8 +25,9 @@ const generateClientManifest = (
 ): string => {
   const clientManifest: { [s: string]: string[] } = {}
   const appDependencies = new Set(assetMap.pages['/_app'])
-  delete assetMap.pages['/_app']
+
   Object.entries(assetMap.pages).forEach(([page, dependencies]) => {
+    if (page === '/_app') return
     // Filter out dependencies in the _app entry, because those will have already
     // been loaded by the client prior to a navigation event
     const filteredDeps = dependencies.filter(

--- a/test/integration/chunking-minimal/next.config.js
+++ b/test/integration/chunking-minimal/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  experimental: {
+    modern: true,
+    granularChunks: true
+  }
+}

--- a/test/integration/chunking-minimal/pages/index.js
+++ b/test/integration/chunking-minimal/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <p>hi</p>

--- a/test/integration/chunking-minimal/test/index.test.js
+++ b/test/integration/chunking-minimal/test/index.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { readFile } from 'fs-extra'
+import { nextBuild } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+
+const appDir = join(__dirname, '../')
+let buildId
+
+describe('Chunking (minimal)', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    buildId = await readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
+  })
+
+  it('should have an empty client-manifest', async () => {
+    const manifest = await readFile(
+      join(appDir, '.next/static', buildId, '_buildManifest.js'),
+      'utf8'
+    )
+    expect(manifest).not.toMatch(/\.js/)
+  })
+
+  it('should have an empty modern client-manifest', async () => {
+    const manifest = await readFile(
+      join(appDir, '.next/static', buildId, '_buildManifest.module.js'),
+      'utf8'
+    )
+    expect(manifest).not.toMatch(/\.js/)
+  })
+})


### PR DESCRIPTION
Deleting `_app` from the assetMap causes the modern build-manifest to not be able to de-dupe the dependencies. This fixes that and adds tests to prevent regression.

Fixes: #8434