### PR TITLE
Add package.json to with-zones example, make create-next-app work

### DIFF
--- a/examples/with-zones/README.md
+++ b/examples/with-zones/README.md
@@ -21,14 +21,6 @@ curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 
 cd with-zones
 ```
 
-Install it and run:
-
-```bash
-npm install
-# or
-yarn
-```
-
 ## The idea behind this example
 
 With Next.js you can use multiple apps as a single app using it's multi-zones feature.

--- a/examples/with-zones/package.json
+++ b/examples/with-zones/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "with-zones-example",
+  "private": true
+}


### PR DESCRIPTION
For `npx create-next-app --example with-zones` to work, `examples/with-zones/package.json` must exist:

https://github.com/zeit/next.js/blob/f0b6d0a1e2f56a3523c67e554b996d549d65b262/packages/create-next-app/helpers/examples.ts#L7-L9

This PR adds it.