### PR TITLE
Fix bug in hook destructuring optimization when ignoring array elements

### DIFF
--- a/packages/next/build/babel/plugins/optimize-hook-destructuring.ts
+++ b/packages/next/build/babel/plugins/optimize-hook-destructuring.ts
@@ -48,8 +48,17 @@ export default function({
       if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return
 
       path.parent.id = t.objectPattern(
-        path.parent.id.elements.map((element, i) =>
-          t.objectProperty(t.numericLiteral(i), element)
+        path.parent.id.elements.reduce<Array<BabelTypes.ObjectProperty>>(
+          (patterns, element, i) => {
+            if (element === null) {
+              return patterns
+            }
+
+            return patterns.concat(
+              t.objectProperty(t.numericLiteral(i), element)
+            )
+          },
+          []
         )
       )
     },

--- a/test/unit/next-babel.test.js
+++ b/test/unit/next-babel.test.js
@@ -116,5 +116,23 @@ describe('next/babel', () => {
         `"import{useState}from'react';var _useState=useState(0),count=_useState[0],setCount=_useState[1];"`
       )
     })
+
+    it('should be able to ignore some Array-destructured hook return values', () => {
+      const output = babel(
+        trim`
+        import { useState } from 'react';
+        const [, setCount] = useState(0);
+      `,
+        true
+      )
+
+      expect(output).toMatch(trim`
+        var _useState=useState(0),setCount=_useState[1];
+      `)
+
+      expect(output).toMatchInlineSnapshot(
+        `"import{useState}from'react';var _useState=useState(0),setCount=_useState[1];"`
+      )
+    })
   })
 })


### PR DESCRIPTION
Recent versions of next.js contain optimization in hook destructuring. (see #8381)

This transform inputs such as

```ts
function Foo() {
  const [count, setCount] = useState(0);
}
```

to outputs like:

```ts
function Foo() {
  const { 0: count, 1: setCount } = useState(0);
}
```

However when some of the values are ignored in the destructuring process, an error is emitted.

```ts
function Foo() {
  const [, foo] = useSomeHook(arg);
}

// --> TypeError: Property value of ObjectProperty expected node to be of a type ["Expression","PatternLike"] but instead got null
//        at Array.map (<anonymous>)
```

This is because when some elements are ignored, those elements are marked as `null` in babel, and it violates the babel's validation logic where it is passed to the second argument of `t.objectProperty`.

This PR fixes this bug by adding a filtering logic for ignored elements.