### PR TITLE
Update to not rely on client build for serverless-trace

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -49,16 +49,18 @@ export function createEntrypoints(
   pages: PagesMapping,
   target: 'server' | 'serverless' | 'experimental-serverless-trace',
   buildId: string,
-  config: any
+  config: any,
+  distDir: string
 ): Entrypoints {
   const client: WebpackEntrypoints = {}
   const server: WebpackEntrypoints = {}
+  const isServerlessTrace = target === 'experimental-serverless-trace'
 
   const defaultServerlessOptions = {
     absoluteAppPath: pages['/_app'],
     absoluteDocumentPath: pages['/_document'],
     absoluteErrorPath: pages['/_error'],
-    distDir: DOT_NEXT_ALIAS,
+    distDir: isServerlessTrace ? distDir : DOT_NEXT_ALIAS,
     buildId,
     assetPrefix: config.assetPrefix,
     generateEtags: config.generateEtags,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -89,7 +89,13 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   const allMappedPages = createPagesMapping(allPagePaths, config.pageExtensions)
   const mappedPages = createPagesMapping(pagePaths, config.pageExtensions)
-  const entrypoints = createEntrypoints(mappedPages, target, buildId, config)
+  const entrypoints = createEntrypoints(
+    mappedPages,
+    target,
+    buildId,
+    config,
+    distDir
+  )
   const configs = await Promise.all([
     getBaseWebpackConfig(dir, {
       tracer,
@@ -126,8 +132,10 @@ export default async function build(dir: string, conf = null): Promise<void> {
   }
 
   let result: CompilerResult = { warnings: [], errors: [] }
-  // TODO: why do we need this?? https://github.com/zeit/next.js/issues/8253
-  if (isLikeServerless) {
+
+  // the serverless build needs to run after since it relies on
+  // manifests produced in the client build
+  if (target === 'serverless') {
     const clientResult = await runCompiler(clientConfig)
     // Fail build if clientResult contains errors
     if (clientResult.errors.length > 0) {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -5,6 +5,7 @@ import {
   REACT_LOADABLE_MANIFEST,
   SERVER_DIRECTORY,
   SERVERLESS_DIRECTORY,
+  BUILD_MANIFEST,
 } from 'next-server/constants'
 import resolve from 'next/dist/compiled/resolve/index.js'
 import path from 'path'
@@ -35,6 +36,10 @@ import { TerserPlugin } from './webpack/plugins/terser-webpack-plugin/src/index'
 import { ProfilingPlugin } from './webpack/plugins/profiling-plugin'
 
 type ExcludesFalse = <T>(x: T | false) => x is T
+
+const manifestsRegex = new RegExp(
+  `(${BUILD_MANIFEST}|${REACT_LOADABLE_MANIFEST})`
+)
 
 const escapePathVariables = (value: any) => {
   return typeof value === 'string'
@@ -316,6 +321,10 @@ export default async function getBaseWebpackConfig(
 
             if (notExternalModules.indexOf(request) !== -1) {
               return callback()
+            }
+
+            if (isServerlessTrace && request.match(manifestsRegex)) {
+              return callback(undefined, `commonjs ${request}`)
             }
 
             resolve(

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -46,8 +46,11 @@ const nextServerlessLoader: loader.Loader = function() {
     curDistDir = curDistDir.join('/')
   }
 
-  const buildManifest = join(curDistDir, BUILD_MANIFEST)
-  const reactLoadableManifest = join(curDistDir, REACT_LOADABLE_MANIFEST)
+  const addDistDir = (file: string) =>
+    join(curDistDir as string, file).replace(/\\/g, '/')
+
+  const buildManifest = addDistDir(BUILD_MANIFEST)
+  const reactLoadableManifest = addDistDir(REACT_LOADABLE_MANIFEST)
 
   if (page.match(API_ROUTE)) {
     return `

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -38,7 +38,9 @@ const nextServerlessLoader: loader.Loader = function() {
   let curDistDir =
     distDir === DOT_NEXT_ALIAS
       ? distDir
-      : relative(join(distDir, 'serverless/pages', page), distDir).split('/')
+      : relative(join(distDir, 'serverless/pages', page), distDir)
+          .replace(/\\/g, '/')
+          .split('/')
 
   if (Array.isArray(curDistDir)) {
     // remove extra level up


### PR DESCRIPTION
Since the bundling step takes place in the builder for serverless-trace we don't need to rely on the client build to produce the manifest.

Closes: #8253