### PR TITLE
[examples] Add with-auth0 and with-passport

### DIFF
--- a/examples/with-auth0/README.md
+++ b/examples/with-auth0/README.md
@@ -46,7 +46,6 @@ AUTH0_CLIENT_ID = client_id
 AUTH0_CLIENT_SECRET = client_secret
 # Available in dashboard -> APIs -> copy the API Audience
 AUTH0_AUDIENCE = https://user.auth0.com/api/v2/
-# Don't need to change this one
 AUTH0_REDIRECT_URI = http://localhost:3000/api/login/callback
 ```
 

--- a/examples/with-auth0/README.md
+++ b/examples/with-auth0/README.md
@@ -1,0 +1,93 @@
+# Auth0 Example
+
+## How to use
+
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```bash
+npm i -g create-next-app
+create-next-app --example with-auth0 with-auth0-app
+```
+
+### Download manually
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-auth0
+cd with-auth0
+```
+
+Install the dependencies:
+
+```bash
+npm install
+# or
+yarn
+```
+
+### Run locally
+
+You need to have an account with [Auth0](https://auth0.com/signup) first. Then you need to [register a regular web application](https://auth0.com/docs/dashboard/guides/applications/register-app-regular-web), we'll use that app to run the application in localhost.
+
+In the settings of the application, go to `Allowed Callback URLs` and add:
+
+```bash
+http://localhost:3000/api/login/callback
+```
+
+Now we need to add the credentials in the settings to our app. Create a new file called `.env` in the root folder and add the following environment variables using your application credentials:
+
+```bash
+AUTH0_DOMAIN = user.auth0.com
+AUTH0_CLIENT_ID = client_id
+AUTH0_CLIENT_SECRET = client_secret
+# Available in dashboard -> APIs -> copy the API Audience
+AUTH0_AUDIENCE = https://user.auth0.com/api/v2/
+# Don't need to change this one
+AUTH0_REDIRECT_URI = http://localhost:3000/api/login/callback
+```
+
+The recommended way to run the example is using [now](https://zeit.co/now) ([download](https://zeit.co/download)):
+
+```bash
+now dev
+```
+
+With the above command we can start our application and add the environment variables
+
+### Deploy
+
+To do a deployment we'll use [now](https://zeit.co/now), you need to add the secrets in [now.json](./now.json) to your account first:
+
+```bash
+now secrets add @auth0_domain VALUE
+now secrets add @auth0_client_id VALUE
+now secrets add @auth0_client_secret VALUE
+now secrets add @auth0_audience VALUE
+now secrets add @auth0_redirect_uri VALUE
+```
+
+To get the secrets from above follow the same steps for creating an Auth0 application in [Run Locally](#run-locally). The recommended approach is to create 2 apps, one for production and another one for localhost, for production we use [now secrets](https://zeit.co/docs/v2/environment-variables-and-secrets) and for localhost a local `.env` file.
+
+> Make sure `ROOT_URL` in `now.json` is set to the domain the app will use in production, in development it always defaults to `http://localhost:3000`
+
+Then deploy it:
+
+```bash
+now
+```
+
+## The idea behind the example
+
+In this example we use [Auth0](https://auth0.com) to authenticate users using cookies, you can check the folder `pages/api` to see how it works
+
+The example uses both Client Side Rendering (CSR) and Server Side Rendering (SSR) to handle the authentication. There are 2 pages that show how every method works:
+
+- [pages/index.js](./pages/index.js): The header changes after the login token is found in cookies, this happens in the client and because of it the page can be prerendered (exported to static HTML)
+
+- [pages/profile.js](./pages/profile.js): This page fetches the user using `getInitialProps` (SSR), if there's no user it will do a redirect, and if there's an user the page will be rendered with the user's data. Compared to `index.js`, this page won't have a blink in the header because the user will be available since the first render, but it also can't be prerendered, meaning it will require more server resources and have a slower first render
+
+If you run `yarn build`/`npm run build`, you'll notice that Next.js will export a static HTML file in the case of `pages/index.js`, and a lambda for `pages/profile.js`

--- a/examples/with-auth0/README.md
+++ b/examples/with-auth0/README.md
@@ -72,8 +72,6 @@ now secrets add @auth0_redirect_uri VALUE
 
 To get the secrets from above follow the same steps for creating an Auth0 application in [Run Locally](#run-locally). The recommended approach is to create 2 apps, one for production and another one for localhost, for production we use [now secrets](https://zeit.co/docs/v2/environment-variables-and-secrets) and for localhost a local `.env` file.
 
-> Make sure `ROOT_URL` in `now.json` is set to the domain the app will use in production, in development it always defaults to `http://localhost:3000`
-
 Then deploy it:
 
 ```bash

--- a/examples/with-auth0/components/header.js
+++ b/examples/with-auth0/components/header.js
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+import { loginUrl } from '../lib/auth'
+import { useHasUser, useLogout } from '../lib/user'
+
+const Header = ({ user }) => {
+  const hasUser = useHasUser()
+  const logout = useLogout()
+
+  return (
+    <header>
+      <nav>
+        <ul>
+          <li>
+            <Link href='/'>
+              <a>Home</a>
+            </Link>
+          </li>
+          <li>
+            <Link href='/about'>
+              <a>About</a>
+            </Link>
+          </li>
+          {hasUser ? (
+            <>
+              <li>
+                <Link href='/profile'>
+                  <a>Profile</a>
+                </Link>
+              </li>
+              <li>
+                <button onClick={logout}>Logout</button>
+              </li>
+            </>
+          ) : (
+            <li>
+              <a href={loginUrl('/profile')}>Login</a>
+            </li>
+          )}
+        </ul>
+      </nav>
+      <style jsx>{`
+        header {
+          padding: 0.2rem;
+          color: #fff;
+          background-color: #333;
+        }
+        nav {
+          max-width: 42rem;
+          margin: 1.5rem auto;
+        }
+        ul {
+          display: flex;
+          list-style: none;
+          margin-left: 0;
+          padding-left: 0;
+        }
+        li {
+          margin-right: 1rem;
+        }
+        li:nth-child(2) {
+          margin-right: auto;
+        }
+        a {
+          color: #fff;
+          text-decoration: none;
+        }
+        button {
+          font-size: 1rem;
+          color: #fff;
+          cursor: pointer;
+          border: none;
+          background: none;
+        }
+      `}</style>
+    </header>
+  )
+}
+
+export default Header

--- a/examples/with-auth0/components/header.js
+++ b/examples/with-auth0/components/header.js
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import { loginUrl } from '../lib/auth'
 import { useHasUser, useLogout } from '../lib/user'
 
 const Header = ({ user }) => {
@@ -33,7 +32,7 @@ const Header = ({ user }) => {
             </>
           ) : (
             <li>
-              <a href={loginUrl('/profile')}>Login</a>
+              <a href='/api/login'>Login</a>
             </li>
           )}
         </ul>

--- a/examples/with-auth0/components/layout.js
+++ b/examples/with-auth0/components/layout.js
@@ -1,0 +1,42 @@
+import Head from 'next/head'
+import Header from './header'
+import { TokenProvider } from '../lib/user'
+
+const Layout = ({ user, children }) => (
+  <>
+    <Head>
+      <title>With Cookies</title>
+    </Head>
+
+    <TokenProvider>
+      <Header user={user} />
+
+      <main>
+        <div className='container'>{children}</div>
+      </main>
+    </TokenProvider>
+
+    <style jsx>{`
+      .container {
+        max-width: 42rem;
+        margin: 1.5rem auto;
+      }
+    `}</style>
+    <style jsx global>{`
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        color: #333;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Helvetica Neue', Arial, Noto Sans, sans-serif, 'Apple Color Emoji',
+          'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+      }
+    `}</style>
+  </>
+)
+
+export default Layout

--- a/examples/with-auth0/lib/api/auth-utils.js
+++ b/examples/with-auth0/lib/api/auth-utils.js
@@ -1,28 +1,4 @@
-import url from 'url'
-import { ROOT_URL } from '../configs'
-
 const IS_PROD = process.env.NODE_ENV === 'production'
-
-export function isValidPath (path) {
-  // Large paths are not allowed
-  if (!path || path.length > 50) return
-
-  const redirectTo = url.parse(ROOT_URL + path)
-
-  return Boolean(redirectTo && redirectTo.hostname && redirectTo.path === path)
-}
-
-export function getAuth0RedirectUrl (redirectUrl, path) {
-  // If the redirect path sent by the app is invalid then don't use it
-  if (!isValidPath(path)) {
-    return redirectUrl
-  }
-  const redirectTo = url.parse(redirectUrl, true)
-
-  redirectTo.query.redirectPath = path
-
-  return url.format(redirectTo)
-}
 
 export function getCookieOptions (options) {
   return {

--- a/examples/with-auth0/lib/api/auth-utils.js
+++ b/examples/with-auth0/lib/api/auth-utils.js
@@ -1,0 +1,36 @@
+import url from 'url'
+import { ROOT_URL } from '../configs'
+
+const IS_PROD = process.env.NODE_ENV === 'production'
+
+export function isValidPath (path) {
+  // Large paths are not allowed
+  if (!path || path.length > 50) return
+
+  const redirectTo = url.parse(ROOT_URL + path)
+
+  return Boolean(redirectTo && redirectTo.hostname && redirectTo.path === path)
+}
+
+export function getAuth0RedirectUrl (redirectUrl, path) {
+  // If the redirect path sent by the app is invalid then don't use it
+  if (!isValidPath(path)) {
+    return redirectUrl
+  }
+  const redirectTo = url.parse(redirectUrl, true)
+
+  redirectTo.query.redirectPath = path
+
+  return url.format(redirectTo)
+}
+
+export function getCookieOptions (options) {
+  return {
+    httpOnly: false,
+    path: '/',
+    secure: IS_PROD,
+    maxAge: 60 * 60 * 24,
+    sameSite: true,
+    ...options
+  }
+}

--- a/examples/with-auth0/lib/api/jwt-verify.js
+++ b/examples/with-auth0/lib/api/jwt-verify.js
@@ -1,0 +1,56 @@
+import jwt from 'jsonwebtoken'
+import jwksClient from 'jwks-rsa'
+
+const audience = process.env.AUTH0_AUDIENCE
+const jwtOptions = {
+  algorithms: ['RS256'],
+  maxAge: '1 day'
+}
+
+// Create a client to retrieve secret keys
+const client = jwksClient({
+  jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`
+})
+
+// Retrieves the secret keys
+function getSigningKey (header, cb) {
+  client.getSigningKey(header.kid, (error, key) => {
+    if (error) cb(error)
+    else cb(null, key.publicKey || key.rsaPublicKey)
+  })
+}
+
+export class AuthError extends Error {
+  constructor (status, message) {
+    super(message)
+    this.name = 'AuthError'
+    this.status = status
+  }
+}
+
+// Verifies a JWT
+export const verify = (token, options) =>
+  new Promise((resolve, reject) => {
+    const opts = { ...options, ...jwtOptions }
+
+    jwt.verify(token, getSigningKey, opts, (error, payload) => {
+      if (error) reject(error)
+      else resolve(payload)
+    })
+  })
+
+export const verifyRequest = async req => {
+  const accessToken = req.cookies.access_token
+  const idToken = req.cookies.id_token
+
+  if (!accessToken || !idToken) {
+    throw new AuthError(401, 'You are not allowed to be here')
+  }
+
+  return {
+    accessToken: await verify(accessToken, { audience }),
+    // You could also verify id_token too, is currently commented because its `exp` is way before access_token
+    // idToken: await verify(idToken),
+    idToken: jwt.decode(idToken)
+  }
+}

--- a/examples/with-auth0/lib/auth.js
+++ b/examples/with-auth0/lib/auth.js
@@ -1,0 +1,28 @@
+export function getToken (req = {}) {
+  if (typeof window === 'undefined') {
+    const { cookie } = (req && req.headers) || {}
+    if (!cookie) return
+
+    const cookies = require('cookie').parse(cookie)
+    return cookies.id_token
+  }
+
+  const Cookies = require('js-cookie')
+  return Cookies.get('id_token')
+}
+
+export function removeToken (res = {}) {
+  if (typeof window === 'undefined') {
+    res.setHeader(
+      'Set-Cookie',
+      require('cookie').serialize('id_token', null, { path: '/', maxAge: 0 })
+    )
+  } else {
+    const Cookies = require('js-cookie')
+    Cookies.remove('id_token', { path: '/' })
+  }
+}
+
+export function loginUrl (redirectPath = '/') {
+  return `/api/login?redirectPath=${encodeURIComponent(redirectPath)}`
+}

--- a/examples/with-auth0/lib/auth.js
+++ b/examples/with-auth0/lib/auth.js
@@ -22,7 +22,3 @@ export function removeToken (res = {}) {
     Cookies.remove('id_token', { path: '/' })
   }
 }
-
-export function loginUrl (redirectPath = '/') {
-  return `/api/login?redirectPath=${encodeURIComponent(redirectPath)}`
-}

--- a/examples/with-auth0/lib/configs.js
+++ b/examples/with-auth0/lib/configs.js
@@ -1,0 +1,4 @@
+export const ROOT_URL =
+  process.env.NODE_ENV === 'production'
+    ? process.env.ROOT_URL
+    : 'http://localhost:3000'

--- a/examples/with-auth0/lib/configs.js
+++ b/examples/with-auth0/lib/configs.js
@@ -1,4 +1,0 @@
-export const ROOT_URL =
-  process.env.NODE_ENV === 'production'
-    ? process.env.ROOT_URL
-    : 'http://localhost:3000'

--- a/examples/with-auth0/lib/fetch-api.js
+++ b/examples/with-auth0/lib/fetch-api.js
@@ -1,8 +1,8 @@
 import fetch from 'isomorphic-unfetch'
-import { ROOT_URL } from './configs'
+import getHost from './get-host'
 
 export default function fetchApi (req, path, fetchOptions = {}) {
-  const url = ROOT_URL + path
+  const url = getHost(req) + path
 
   // In SSR the `credentials` option does nothing, that's only useful in the browser
   // so instead we send the auth cookies manually
@@ -11,7 +11,7 @@ export default function fetchApi (req, path, fetchOptions = {}) {
       ...fetchOptions,
       headers: {
         ...fetchOptions.headers,
-        // Because this method only allows requests to the same domain (ROOT_URL), it's safe
+        // Because this method only allows requests to the same domain, it's safe
         // to send the same cookies, but you could manually send only the auth cookies too
         cookie: req.headers.cookie
       }

--- a/examples/with-auth0/lib/fetch-api.js
+++ b/examples/with-auth0/lib/fetch-api.js
@@ -1,0 +1,26 @@
+import fetch from 'isomorphic-unfetch'
+import { ROOT_URL } from './configs'
+
+export default function fetchApi (req, path, fetchOptions = {}) {
+  const url = ROOT_URL + path
+
+  // In SSR the `credentials` option does nothing, that's only useful in the browser
+  // so instead we send the auth cookies manually
+  if (typeof window === 'undefined') {
+    const options = {
+      ...fetchOptions,
+      headers: {
+        ...fetchOptions.headers,
+        // Because this method only allows requests to the same domain (ROOT_URL), it's safe
+        // to send the same cookies, but you could manually send only the auth cookies too
+        cookie: req.headers.cookie
+      }
+    }
+    return fetch(url, options)
+  }
+
+  return fetch(url, {
+    ...fetchOptions,
+    credentials: 'same-origin'
+  })
+}

--- a/examples/with-auth0/lib/get-host.js
+++ b/examples/with-auth0/lib/get-host.js
@@ -1,0 +1,13 @@
+// This is not production ready, (except with providers that ensure a secure host, like Now)
+// For production consider setting the host in an environment variable
+export default function getHost (req) {
+  if (typeof window === 'undefined') {
+    const { host } = req.headers
+
+    if (process.env.NODE_ENV === 'production') {
+      return `https://${host}`
+    }
+    return `http://${host}`
+  }
+  return ''
+}

--- a/examples/with-auth0/lib/redirect.js
+++ b/examples/with-auth0/lib/redirect.js
@@ -1,0 +1,10 @@
+import Router from 'next/router'
+
+export default function redirect (res, path) {
+  if (typeof window === 'undefined') {
+    res.writeHead(302, { Location: path })
+    res.end()
+  } else {
+    Router.push(path)
+  }
+}

--- a/examples/with-auth0/lib/user.js
+++ b/examples/with-auth0/lib/user.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import fetch from 'isomorphic-unfetch'
+import { useRouter } from 'next/router'
+import decodeJwt from 'jwt-decode'
+import { getToken, removeToken } from './auth'
+
+const initialContext = [undefined, () => {}]
+const Token = React.createContext(initialContext)
+const User = React.createContext(initialContext)
+let isPageReady = false
+
+export function getTokenPayload (token) {
+  try {
+    return decodeJwt(token)
+  } catch (error) {
+    // Ignore invalid tokens
+  }
+}
+
+export function UserProvider ({ user, children }) {
+  // Save the user and don't update it unless it's required, this is especially useful for pages
+  // that require SSR and do a fetch of the user in `getInitialProps`
+  const [state, setUser] = React.useState(user)
+
+  return <User.Provider value={[state, setUser]}>{children}</User.Provider>
+}
+
+export function TokenProvider ({ children }) {
+  const [token, setToken] = React.useState(
+    // Don't try to set the token in the first page render to avoid a content mismatch
+    isPageReady ? getToken() : undefined
+  )
+
+  React.useEffect(() => {
+    isPageReady = true
+    setToken(getToken())
+  }, [])
+
+  return <Token.Provider value={[token, setToken]}>{children}</Token.Provider>
+}
+
+export const useToken = () => React.useContext(Token)[0]
+
+export const useUser = () => React.useContext(User)[0]
+
+// Returns the payload of a client-side token
+export const usePayload = () => {
+  const token = useToken()
+  const payload = React.useMemo(() => token && getTokenPayload(token), [token])
+
+  return payload
+}
+
+// Returns true if there's a valid payload or a user set
+export const useHasUser = () => {
+  const payload = usePayload()
+  const user = useUser()
+
+  return Boolean(payload || user)
+}
+
+export const useLogout = () => {
+  const setToken = React.useContext(Token)[1]
+  const setUser = React.useContext(User)[1]
+  const router = useRouter()
+
+  return async () => {
+    const res = await fetch('/api/logout')
+
+    if (res.ok) {
+      // Clear the state of user contexts, remove the token from cookies and do a redirect
+      setToken()
+      setUser()
+      removeToken()
+      router.push('/')
+    }
+  }
+}

--- a/examples/with-auth0/next.config.js
+++ b/examples/with-auth0/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  target: 'serverless',
+  env: {
+    ROOT_URL: process.env.ROOT_URL
+  }
+}

--- a/examples/with-auth0/next.config.js
+++ b/examples/with-auth0/next.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  target: 'serverless',
-  env: {
-    ROOT_URL: process.env.ROOT_URL
-  }
-}

--- a/examples/with-auth0/now.json
+++ b/examples/with-auth0/now.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "env": {
+    "ROOT_URL": "https://mysite.com",
+    "AUTH0_DOMAIN": "@auth0_domain",
+    "AUTH0_CLIENT_ID": "@auth0_client_id",
+    "AUTH0_CLIENT_SECRET": "@auth0_client_secret",
+    "AUTH0_AUDIENCE": "@auth0_audience",
+    "AUTH0_REDIRECT_URI": "@auth0_redirect_uri"
+  }
+}

--- a/examples/with-auth0/now.json
+++ b/examples/with-auth0/now.json
@@ -1,7 +1,6 @@
 {
   "version": 2,
   "env": {
-    "ROOT_URL": "https://mysite.com",
     "AUTH0_DOMAIN": "@auth0_domain",
     "AUTH0_CLIENT_ID": "@auth0_client_id",
     "AUTH0_CLIENT_SECRET": "@auth0_client_secret",

--- a/examples/with-auth0/package.json
+++ b/examples/with-auth0/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "with-auth0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "cookie": "0.4.0",
+    "isomorphic-unfetch": "^3.0.0",
+    "js-cookie": "^2.2.1",
+    "jsonwebtoken": "8.5.1",
+    "jwks-rsa": "1.6.0",
+    "jwt-decode": "2.2.0",
+    "nanoid": "2.0.3",
+    "next": "latest",
+    "qs": "6.8.0",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
+  }
+}

--- a/examples/with-auth0/pages/about.js
+++ b/examples/with-auth0/pages/about.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import Layout from '../components/layout'
+
+const Home = () => (
+  <Layout>
+    <h1>Auth0 example</h1>
+    <p>
+      This is the about page, navigations between this page and <i>Home</i> are
+      always pretty fast, <i>Profile</i> takes more time because it uses SSR to
+      fetch the user first
+    </p>
+  </Layout>
+)
+
+export default Home

--- a/examples/with-auth0/pages/api/data.js
+++ b/examples/with-auth0/pages/api/data.js
@@ -1,0 +1,5 @@
+export default (req, res) => {
+  console.log('WOAH')
+  res.writeHead(302, { Location: '/' })
+  res.end()
+}

--- a/examples/with-auth0/pages/api/data.js
+++ b/examples/with-auth0/pages/api/data.js
@@ -1,5 +1,0 @@
-export default (req, res) => {
-  console.log('WOAH')
-  res.writeHead(302, { Location: '/' })
-  res.end()
-}

--- a/examples/with-auth0/pages/api/login/callback.js
+++ b/examples/with-auth0/pages/api/login/callback.js
@@ -2,7 +2,6 @@ import qs from 'qs'
 import cookie from 'cookie'
 import jwt from 'jsonwebtoken'
 import fetch from 'isomorphic-unfetch'
-import { ROOT_URL } from '../../../lib/configs'
 import { getCookieOptions } from '../../../lib/api/auth-utils'
 
 const url = `https://${process.env.AUTH0_DOMAIN}/oauth/token`
@@ -59,7 +58,7 @@ export default async (req, res) => {
         cookie.serialize('nonce', '', { maxAge: 0, path: '/' })
       ])
 
-      res.writeHead(302, { Location: ROOT_URL })
+      res.writeHead(302, { Location: '/' })
       res.end()
     } else {
       const error = new Error(response.statusText)

--- a/examples/with-auth0/pages/api/login/callback.js
+++ b/examples/with-auth0/pages/api/login/callback.js
@@ -1,0 +1,78 @@
+import qs from 'qs'
+import cookie from 'cookie'
+import jwt from 'jsonwebtoken'
+import fetch from 'isomorphic-unfetch'
+import { ROOT_URL } from '../../../lib/configs'
+import { isValidPath, getCookieOptions } from '../../../lib/api/auth-utils'
+
+const url = `https://${process.env.AUTH0_DOMAIN}/oauth/token`
+const fetchOptions = code => ({
+  method: 'POST',
+  headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  body: qs.stringify({
+    grant_type: 'authorization_code',
+    client_id: process.env.AUTH0_CLIENT_ID,
+    client_secret: process.env.AUTH0_CLIENT_SECRET,
+    redirect_uri: `${process.env.AUTH0_REDIRECT_URI}/api/auth/callback/`,
+    code
+  })
+})
+
+function validateTokens (data) {
+  if (data && data.id_token && data.access_token) {
+    return data
+  }
+  throw new Error('Invalid credentials')
+}
+
+export default async (req, res) => {
+  const { state, nonce } = req.cookies
+  const { state: incomingState, code, redirectPath } = req.query
+
+  try {
+    // confirm state match to mitigate CSRF
+    if (state !== incomingState) {
+      throw new Error('State mismatch, CSRF attack likely.')
+    }
+
+    const response = await fetch(url, fetchOptions(code))
+
+    if (response.ok) {
+      const data = validateTokens(await response.json())
+      const user = jwt.decode(data.id_token)
+
+      if (nonce !== user.nonce) {
+        throw new Error(
+          'Nonce mismatch, potential token replay attack underway.'
+        )
+      }
+
+      res.setHeader('Set-Cookie', [
+        cookie.serialize('id_token', data.id_token, getCookieOptions()),
+        cookie.serialize(
+          'access_token',
+          data.access_token,
+          getCookieOptions({ httpOnly: true })
+        ),
+        // Clear unrequired cookies
+        cookie.serialize('state', '', { maxAge: 0, path: '/' }),
+        cookie.serialize('nonce', '', { maxAge: 0, path: '/' })
+      ])
+
+      // Redirect the user to a selected path
+      const redirectTo = isValidPath(redirectPath)
+        ? ROOT_URL + redirectPath
+        : ROOT_URL
+
+      res.writeHead(302, { Location: redirectTo })
+      res.end()
+    } else {
+      const error = new Error(response.statusText)
+      error.status = response.status
+      throw error
+    }
+  } catch (error) {
+    console.error(error)
+    res.status(error.status || 400).end(error.message)
+  }
+}

--- a/examples/with-auth0/pages/api/login/callback.js
+++ b/examples/with-auth0/pages/api/login/callback.js
@@ -3,7 +3,7 @@ import cookie from 'cookie'
 import jwt from 'jsonwebtoken'
 import fetch from 'isomorphic-unfetch'
 import { ROOT_URL } from '../../../lib/configs'
-import { isValidPath, getCookieOptions } from '../../../lib/api/auth-utils'
+import { getCookieOptions } from '../../../lib/api/auth-utils'
 
 const url = `https://${process.env.AUTH0_DOMAIN}/oauth/token`
 const fetchOptions = code => ({
@@ -27,7 +27,7 @@ function validateTokens (data) {
 
 export default async (req, res) => {
   const { state, nonce } = req.cookies
-  const { state: incomingState, code, redirectPath } = req.query
+  const { state: incomingState, code } = req.query
 
   try {
     // confirm state match to mitigate CSRF
@@ -59,12 +59,7 @@ export default async (req, res) => {
         cookie.serialize('nonce', '', { maxAge: 0, path: '/' })
       ])
 
-      // Redirect the user to a selected path
-      const redirectTo = isValidPath(redirectPath)
-        ? ROOT_URL + redirectPath
-        : ROOT_URL
-
-      res.writeHead(302, { Location: redirectTo })
+      res.writeHead(302, { Location: ROOT_URL })
       res.end()
     } else {
       const error = new Error(response.statusText)

--- a/examples/with-auth0/pages/api/login/index.js
+++ b/examples/with-auth0/pages/api/login/index.js
@@ -1,0 +1,49 @@
+import url from 'url'
+import cookie from 'cookie'
+import nanoid from 'nanoid'
+import {
+  getAuth0RedirectUrl,
+  getCookieOptions
+} from '../../../lib/api/auth-utils'
+
+// Returns the Authorization URL:
+// https://auth0.com/docs/flows/guides/auth-code/call-api-auth-code#example-authorization-url
+const getAuthorizeUrl = (state, nonce, redirectPath) => {
+  const domain = process.env.AUTH0_DOMAIN
+  const authorizeUrl = url.parse(`https://${domain}/authorize`, true)
+
+  authorizeUrl.query.response_type = 'code'
+  authorizeUrl.query.audience = process.env.AUTH0_AUDIENCE
+  authorizeUrl.query.client_id = process.env.AUTH0_CLIENT_ID
+  authorizeUrl.query.redirect_uri = getAuth0RedirectUrl(
+    process.env.AUTH0_REDIRECT_URI,
+    redirectPath
+  )
+  authorizeUrl.query.scope = 'openid profile'
+  authorizeUrl.query.state = state
+  authorizeUrl.query.nonce = nonce
+
+  return url.format(authorizeUrl)
+}
+
+export default async (req, res) => {
+  // This is the path used to redirect the user after a successful login
+  const { redirectPath } = req.query
+  // Generate random opaque value for state
+  const state = nanoid()
+  // https://auth0.com/docs/api-auth/tutorials/nonce
+  const nonce = nanoid()
+  const options = { httpOnly: true, sameSite: false }
+
+  // Add state and nonce cookies for /login/callback to check
+  res.setHeader('Set-Cookie', [
+    cookie.serialize('state', state, getCookieOptions(options)),
+    cookie.serialize('nonce', nonce, getCookieOptions(options))
+  ])
+
+  const authorizeUrl = getAuthorizeUrl(state, nonce, redirectPath)
+
+  // Redirect to Auth0
+  res.writeHead(302, { Location: authorizeUrl })
+  res.end()
+}

--- a/examples/with-auth0/pages/api/login/index.js
+++ b/examples/with-auth0/pages/api/login/index.js
@@ -1,24 +1,18 @@
 import url from 'url'
 import cookie from 'cookie'
 import nanoid from 'nanoid'
-import {
-  getAuth0RedirectUrl,
-  getCookieOptions
-} from '../../../lib/api/auth-utils'
+import { getCookieOptions } from '../../../lib/api/auth-utils'
 
 // Returns the Authorization URL:
 // https://auth0.com/docs/flows/guides/auth-code/call-api-auth-code#example-authorization-url
-const getAuthorizeUrl = (state, nonce, redirectPath) => {
+const getAuthorizeUrl = (state, nonce) => {
   const domain = process.env.AUTH0_DOMAIN
   const authorizeUrl = url.parse(`https://${domain}/authorize`, true)
 
   authorizeUrl.query.response_type = 'code'
   authorizeUrl.query.audience = process.env.AUTH0_AUDIENCE
   authorizeUrl.query.client_id = process.env.AUTH0_CLIENT_ID
-  authorizeUrl.query.redirect_uri = getAuth0RedirectUrl(
-    process.env.AUTH0_REDIRECT_URI,
-    redirectPath
-  )
+  authorizeUrl.query.redirect_uri = process.env.AUTH0_REDIRECT_URI
   authorizeUrl.query.scope = 'openid profile'
   authorizeUrl.query.state = state
   authorizeUrl.query.nonce = nonce
@@ -27,8 +21,6 @@ const getAuthorizeUrl = (state, nonce, redirectPath) => {
 }
 
 export default async (req, res) => {
-  // This is the path used to redirect the user after a successful login
-  const { redirectPath } = req.query
   // Generate random opaque value for state
   const state = nanoid()
   // https://auth0.com/docs/api-auth/tutorials/nonce
@@ -41,7 +33,7 @@ export default async (req, res) => {
     cookie.serialize('nonce', nonce, getCookieOptions(options))
   ])
 
-  const authorizeUrl = getAuthorizeUrl(state, nonce, redirectPath)
+  const authorizeUrl = getAuthorizeUrl(state, nonce)
 
   // Redirect to Auth0
   res.writeHead(302, { Location: authorizeUrl })

--- a/examples/with-auth0/pages/api/logout.js
+++ b/examples/with-auth0/pages/api/logout.js
@@ -1,0 +1,26 @@
+import fetch from 'isomorphic-unfetch'
+import cookie from 'cookie'
+
+const url = `https://${process.env.AUTH0_DOMAIN}/v2/logout`
+
+export default async (req, res) => {
+  try {
+    const response = await fetch(url)
+
+    if (response.ok) {
+      res.setHeader(
+        'Set-Cookie',
+        cookie.serialize('access_token', '', { maxAge: 0, path: '/' })
+      )
+      res.statusCode = 200
+      res.json({ done: true })
+    } else {
+      const error = new Error(response.statusText)
+      error.status = response.status
+      throw error
+    }
+  } catch (error) {
+    console.error(error)
+    res.status(error.status || 500).end(error.message)
+  }
+}

--- a/examples/with-auth0/pages/api/profile.js
+++ b/examples/with-auth0/pages/api/profile.js
@@ -1,0 +1,11 @@
+import { verifyRequest } from '../../lib/api/jwt-verify'
+
+export default async (req, res) => {
+  try {
+    const { idToken } = await verifyRequest(req)
+    res.status(200).json(idToken)
+  } catch (error) {
+    console.error(error)
+    res.status(error.status || 400).end(error.message)
+  }
+}

--- a/examples/with-auth0/pages/index.js
+++ b/examples/with-auth0/pages/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import Layout from '../components/layout'
+
+const Home = () => (
+  <Layout>
+    <h1>Auth0 example</h1>
+    <p>
+      To test the login with click in <i>Login</i>
+    </p>
+    <p>
+      Once you have logged in you should be able to click in <i>Profile</i> and{' '}
+      <i>Logout</i>
+    </p>
+  </Layout>
+)
+
+export default Home

--- a/examples/with-auth0/pages/profile-jwt.js
+++ b/examples/with-auth0/pages/profile-jwt.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import Link from 'next/link'
+import Layout from '../components/layout'
+import { getToken } from '../lib/auth'
+import redirect from '../lib/redirect'
+import { UserProvider, getTokenPayload } from '../lib/user'
+
+const Profile = props => {
+  const { name, picture } = props.user || {}
+
+  return (
+    <UserProvider user={props.user}>
+      <Layout>
+        <img src={picture} alt='Avatar' />
+        <h1>{name}</h1>
+        <p>
+          This page uses SSR to decode the payload of <i>id_token</i>
+        </p>
+        <p>
+          because there are no API calls it should render faster than{' '}
+          <Link href='/profile'>
+            <a>/profile</a>
+          </Link>
+        </p>
+
+        <style jsx>{`
+          img {
+            max-width: 200px;
+            border-radius: 0.5rem;
+          }
+          h1 {
+            margin-bottom: 0;
+          }
+          .lead {
+            margin-top: 0;
+            font-size: 1.5rem;
+            font-weight: 300;
+            color: #666;
+          }
+          p {
+            color: #6a737d;
+          }
+        `}</style>
+      </Layout>
+    </UserProvider>
+  )
+}
+
+Profile.getInitialProps = async ({ req, res }) => {
+  const token = getToken(req)
+
+  if (token) {
+    const user = getTokenPayload(token)
+    if (user) return { user }
+  }
+
+  redirect(res, '/')
+  return {}
+}
+
+export default Profile

--- a/examples/with-auth0/pages/profile.js
+++ b/examples/with-auth0/pages/profile.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import Link from 'next/link'
+import Layout from '../components/layout'
+import fetchApi from '../lib/fetch-api'
+import redirect from '../lib/redirect'
+import { UserProvider } from '../lib/user'
+
+const Profile = props => {
+  const { name, picture } = props.user || {}
+
+  return (
+    <UserProvider user={props.user}>
+      <Layout>
+        <img src={picture} alt='Avatar' />
+        <h1>{name}</h1>
+        <p>
+          This Page does a request to <a href='/api/profile'>/api/profile</a> to
+          get info about the user
+        </p>
+        <p>
+          if you to the page{' '}
+          <Link href='/profile-jwt'>
+            <a>/profile-jwt</a>
+          </Link>{' '}
+          you should be able to see the same user info, but directly from the
+          JWT payload of <i>id_token</i>
+        </p>
+
+        <style jsx>{`
+          img {
+            max-width: 200px;
+            border-radius: 0.5rem;
+          }
+          h1 {
+            margin-bottom: 0;
+          }
+          .lead {
+            margin-top: 0;
+            font-size: 1.5rem;
+            font-weight: 300;
+            color: #666;
+          }
+          p {
+            color: #6a737d;
+          }
+        `}</style>
+      </Layout>
+    </UserProvider>
+  )
+}
+
+Profile.getInitialProps = async ({ req, res }) => {
+  try {
+    const response = await fetchApi(req, '/api/profile')
+
+    if (response.ok) {
+      return { user: await response.json() }
+    } else {
+      throw new Error(response.statusText)
+    }
+  } catch (error) {
+    console.error(error)
+    redirect(res, '/')
+    return {}
+  }
+}
+
+export default Profile

--- a/examples/with-cookie-auth/utils/get-host.js
+++ b/examples/with-cookie-auth/utils/get-host.js
@@ -1,14 +1,13 @@
 // This is not production ready, (except with providers that ensure a secure host, like Now)
-// For production consider the usage of environment variables and NODE_ENV
-function getHost (req) {
-  if (!req) return ''
+// For production consider setting the host in an environment variable
+export default function getHost (req) {
+  if (typeof window === 'undefined') {
+    const { host } = req.headers
 
-  const { host } = req.headers
-
-  if (host.startsWith('localhost')) {
+    if (process.env.NODE_ENV === 'production') {
+      return `https://${host}`
+    }
     return `http://${host}`
   }
-  return `https://${host}`
+  return ''
 }
-
-export default getHost

--- a/examples/with-passport/.env
+++ b/examples/with-passport/.env
@@ -1,0 +1,5 @@
+# You can add your OAuth application here, this is only for development
+# for production use now secrets or a similar alternative
+ACCESS_TOKEN_SECRET = secret
+GITHUB_CLIENT_ID = cff76ecad3e2d499f4b2
+GITHUB_CLIENT_SECRET = 706dab1ca5fa225bfb63f15f99ec356244cc6206

--- a/examples/with-passport/README.md
+++ b/examples/with-passport/README.md
@@ -1,0 +1,69 @@
+# Example app utilizing cookie-based authentication
+
+## How to use
+
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/segmentio/create-next-app) to bootstrap the example:
+
+```bash
+npm i -g create-next-app
+create-next-app --example with-passport with-passport-app
+```
+
+### Download manually
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-passport
+cd with-passport
+```
+
+Install the dependencies:
+
+```bash
+npm install
+# or
+yarn
+```
+
+### Run locally
+
+The recommended way to run the example is using [now](https://zeit.co/now) ([download](https://zeit.co/download)):
+
+```bash
+now dev
+```
+
+With the above command we can start our application and add the required environment variables
+
+### Deploy
+
+To do a deployment we'll use [now](https://zeit.co/now), you need to add the secrets in [now.json](./now.json) to your account first:
+
+```bash
+now secrets add @access-token-secret YOUR_SECRET
+now secrets add @github-client-id YOUR_API_KEY
+now secrets add @github-client-secret YOUR_CLIENT_SECRET
+```
+
+To get the secrets from above you'll have to create an OAuth app in GitHub, you can see how to do it [here](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/), the recommended approach is to create 2 apps, one for production and another one for localhost, for production we use [now secrets](https://zeit.co/docs/v2/environment-variables-and-secrets) and for localhost a local [.env](./.env) file
+
+Then deploy it:
+
+```bash
+now
+```
+
+## The idea behind the example
+
+In this example we use [Passport](http://www.passportjs.org) and GitHub to authenticate users and store a [JWT](https://jwt.io) token in a cookie, you can check the folder `pages/api` to see how it works
+
+The example uses both Client Side Rendering (CSR) and Server Side Rendering (SSR) to handle the authentication. There are 2 pages that show how every method works:
+
+- [pages/index.js](./pages/index.js): The header changes after the login token is found in cookies, this happens in the client and because of it the page can be prerendered (exported to static HTML)
+
+- [pages/profile.js](./pages/profile.js): This page fetches the user using `getInitialProps` (SSR), if there's no user it will do a redirect, and if there's an user the page will be rendered with the user's data. Compared to `index.js`, this page won't have a blink in the header because the user will be available since the first render, but it also can't be prerendered, meaning it will require more server resources and have a slower first render
+
+If you run `yarn build`/`npm run build`, you'll notice that Next.js will export a static HTML file in the case of `pages/index.js`, and a lambda for `pages/profile.js`

--- a/examples/with-passport/README.md
+++ b/examples/with-passport/README.md
@@ -1,4 +1,4 @@
-# Example app utilizing cookie-based authentication
+# Passport.js Example
 
 ## How to use
 
@@ -49,6 +49,8 @@ now secrets add @github-client-secret YOUR_CLIENT_SECRET
 ```
 
 To get the secrets from above you'll have to create an OAuth app in GitHub, you can see how to do it [here](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/), the recommended approach is to create 2 apps, one for production and another one for localhost, for production we use [now secrets](https://zeit.co/docs/v2/environment-variables-and-secrets) and for localhost a local [.env](./.env) file
+
+> Make sure `ROOT_URL` in `now.json` is set to the domain the app will use in production, in development it always defaults to `http://localhost:3000`
 
 Then deploy it:
 

--- a/examples/with-passport/components/header.js
+++ b/examples/with-passport/components/header.js
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+import { loginUrl } from '../lib/auth'
+import { useHasUser, useLogout } from '../lib/user'
+
+const Header = ({ user }) => {
+  const hasUser = useHasUser()
+  const logout = useLogout()
+
+  return (
+    <header>
+      <nav>
+        <ul>
+          <li>
+            <Link href='/'>
+              <a>Home</a>
+            </Link>
+          </li>
+          <li>
+            <Link href='/about'>
+              <a>About</a>
+            </Link>
+          </li>
+          {hasUser ? (
+            <>
+              <li>
+                <Link href='/profile'>
+                  <a>Profile</a>
+                </Link>
+              </li>
+              <li>
+                <button onClick={logout}>Logout</button>
+              </li>
+            </>
+          ) : (
+            <li>
+              <a href={loginUrl('/profile')}>Login</a>
+            </li>
+          )}
+        </ul>
+      </nav>
+      <style jsx>{`
+        header {
+          padding: 0.2rem;
+          color: #fff;
+          background-color: #333;
+        }
+        nav {
+          max-width: 42rem;
+          margin: 1.5rem auto;
+        }
+        ul {
+          display: flex;
+          list-style: none;
+          margin-left: 0;
+          padding-left: 0;
+        }
+        li {
+          margin-right: 1rem;
+        }
+        li:nth-child(2) {
+          margin-right: auto;
+        }
+        a {
+          color: #fff;
+          text-decoration: none;
+        }
+        button {
+          font-size: 1rem;
+          color: #fff;
+          cursor: pointer;
+          border: none;
+          background: none;
+        }
+      `}</style>
+    </header>
+  )
+}
+
+export default Header

--- a/examples/with-passport/components/layout.js
+++ b/examples/with-passport/components/layout.js
@@ -1,0 +1,42 @@
+import Head from 'next/head'
+import Header from './header'
+import { TokenProvider } from '../lib/user'
+
+const Layout = ({ user, children }) => (
+  <>
+    <Head>
+      <title>With Cookies</title>
+    </Head>
+
+    <TokenProvider>
+      <Header user={user} />
+
+      <main>
+        <div className='container'>{children}</div>
+      </main>
+    </TokenProvider>
+
+    <style jsx>{`
+      .container {
+        max-width: 42rem;
+        margin: 1.5rem auto;
+      }
+    `}</style>
+    <style jsx global>{`
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        color: #333;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Helvetica Neue', Arial, Noto Sans, sans-serif, 'Apple Color Emoji',
+          'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+      }
+    `}</style>
+  </>
+)
+
+export default Layout

--- a/examples/with-passport/lib/auth.js
+++ b/examples/with-passport/lib/auth.js
@@ -1,0 +1,28 @@
+export function getToken (req = {}) {
+  if (typeof window === 'undefined') {
+    const { cookie } = (req && req.headers) || {}
+    if (!cookie) return
+
+    const { loginToken } = require('cookie').parse(cookie)
+    return loginToken
+  }
+
+  const Cookies = require('js-cookie')
+  return Cookies.get('loginToken')
+}
+
+export function removeToken (res = {}) {
+  if (typeof window === 'undefined') {
+    res.setHeader(
+      'Set-Cookie',
+      require('cookie').serialize('loginToken', null, { path: '/', maxAge: 0 })
+    )
+  } else {
+    const Cookies = require('js-cookie')
+    Cookies.remove('loginToken', { path: '/' })
+  }
+}
+
+export function loginUrl (redirectPath = '/') {
+  return `/api/login/github?redirectPath=${encodeURIComponent(redirectPath)}`
+}

--- a/examples/with-passport/lib/configs.js
+++ b/examples/with-passport/lib/configs.js
@@ -1,0 +1,4 @@
+export const ROOT_URL =
+  process.env.NODE_ENV === 'production'
+    ? process.env.ROOT_URL
+    : 'http://localhost:3000'

--- a/examples/with-passport/lib/passport/github.js
+++ b/examples/with-passport/lib/passport/github.js
@@ -1,0 +1,18 @@
+import GitHub from 'passport-github'
+import { ROOT_URL } from '../configs'
+import { createJwt } from './jwt'
+
+export const callbackURL = `${ROOT_URL}/api/login/github/callback`
+
+export const githubStrategy = new GitHub.Strategy(
+  {
+    passReqToCallback: true,
+    clientID: process.env.GITHUB_CLIENT_ID,
+    clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    callbackURL
+  },
+  (_req, _accessToken, _refreshToken, profile, done) => {
+    const accessToken = createJwt(profile)
+    done(null, { accessToken })
+  }
+)

--- a/examples/with-passport/lib/passport/jwt.js
+++ b/examples/with-passport/lib/passport/jwt.js
@@ -1,0 +1,55 @@
+import jwt from 'jsonwebtoken'
+import { ROOT_URL } from '../configs'
+
+const SECRET = process.env.ACCESS_TOKEN_SECRET
+const algorithm = 'HS256'
+const verityOptions = {
+  audience: ROOT_URL,
+  algorithms: [algorithm]
+}
+
+export class AuthError extends Error {
+  constructor (status, message) {
+    super(message)
+    this.name = 'AuthError'
+    this.status = status
+  }
+}
+
+export const createJwt = ({ id, provider, displayName, username }) => {
+  const payload = {
+    id,
+    provider,
+    displayName,
+    username,
+    expiresIn: '30d',
+    aud: ROOT_URL,
+    iat: Math.floor(Date.now() / 1000)
+  }
+  return jwt.sign(payload, SECRET, { algorithm })
+}
+
+export const verifyJwt = token =>
+  new Promise((resolve, reject) => {
+    jwt.verify(token, SECRET, verityOptions, (error, payload) => {
+      if (error) reject(error)
+      else resolve(payload)
+    })
+  })
+
+export const authenticate = req => {
+  const { authorization } = req.headers
+
+  if (!authorization) {
+    throw new AuthError(401, 'The authorization header is missing')
+  }
+
+  const [scheme, token] = authorization.split(' ')
+  const isBearer = scheme && scheme.toLowerCase() === 'bearer'
+
+  if (!isBearer || !token) {
+    throw new AuthError(401, 'The authorization header is invalid')
+  }
+
+  return verifyJwt(token)
+}

--- a/examples/with-passport/lib/redirect.js
+++ b/examples/with-passport/lib/redirect.js
@@ -1,0 +1,10 @@
+import Router from 'next/router'
+
+export default function redirect (res, path) {
+  if (typeof window === 'undefined') {
+    res.writeHead(302, { Location: path })
+    res.end()
+  } else {
+    Router.push(path)
+  }
+}

--- a/examples/with-passport/lib/user.js
+++ b/examples/with-passport/lib/user.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import decodeJwt from 'jwt-decode'
+import { getToken, removeToken } from './auth'
+
+const initialContext = [undefined, () => {}]
+const Token = React.createContext(initialContext)
+const User = React.createContext(initialContext)
+let isPageReady = false
+
+function getTokenPayload (token) {
+  try {
+    return decodeJwt(token)
+  } catch (error) {
+    // Ignore invalid tokens
+  }
+}
+
+export function UserProvider ({ user, children }) {
+  // Save the user and don't update it unless it's required, this is especially useful for pages
+  // that require SSR and do a fetch of the user in `getInitialProps`
+  const [state, setUser] = React.useState(user)
+
+  return <User.Provider value={[state, setUser]}>{children}</User.Provider>
+}
+
+export function TokenProvider ({ children }) {
+  const [token, setToken] = React.useState(
+    // Don't try to set the token in the first page render to avoid a content mismatch
+    isPageReady ? getToken() : undefined
+  )
+
+  React.useEffect(() => {
+    isPageReady = true
+    setToken(getToken())
+  }, [])
+
+  return <Token.Provider value={[token, setToken]}>{children}</Token.Provider>
+}
+
+export const useToken = () => React.useContext(Token)[0]
+
+export const useUser = () => React.useContext(User)[0]
+
+// Returns the payload of a client-side token
+export const usePayload = () => {
+  const token = useToken()
+  const payload = React.useMemo(() => token && getTokenPayload(token), [token])
+
+  return payload
+}
+
+// Returns true if there's a valid payload or a user set
+export const useHasUser = () => {
+  const payload = usePayload()
+  const user = useUser()
+
+  return Boolean(payload || user)
+}
+
+export const useLogout = () => {
+  const setToken = React.useContext(Token)[1]
+  const setUser = React.useContext(User)[1]
+  const router = useRouter()
+
+  return () => {
+    // Clear the state of user contexts, remove the token from cookies and do a redirect
+    setToken()
+    setUser()
+    removeToken()
+    router.push('/')
+  }
+}

--- a/examples/with-passport/next.config.js
+++ b/examples/with-passport/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  target: 'serverless',
+  env: {
+    ROOT_URL: process.env.ROOT_URL
+  }
+}

--- a/examples/with-passport/now.json
+++ b/examples/with-passport/now.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "env": {
+    "ROOT_URL": "https://mysite.com",
+    "ACCESS_TOKEN_SECRET": "@access-token-secret",
+    "GITHUB_CLIENT_ID": "@github-client-id",
+    "GITHUB_CLIENT_SECRET": "@github-client-secret"
+  }
+}

--- a/examples/with-passport/package.json
+++ b/examples/with-passport/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "with-auth0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "cookie": "0.4.0",
+    "express": "4.17.1",
+    "isomorphic-unfetch": "^3.0.0",
+    "js-cookie": "2.2.1",
+    "jsonwebtoken": "8.5.1",
+    "jwt-decode": "2.2.0",
+    "next": "latest",
+    "passport": "0.4.0",
+    "passport-github": "1.1.0",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
+  }
+}

--- a/examples/with-passport/package.json
+++ b/examples/with-passport/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "with-auth0",
+  "name": "with-passport",
   "scripts": {
     "dev": "next",
     "build": "next build",

--- a/examples/with-passport/pages/about.js
+++ b/examples/with-passport/pages/about.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import Layout from '../components/layout'
+
+const Home = () => (
+  <Layout>
+    <h1>Passport authentication example</h1>
+
+    <p>
+      This is the about page, navigations between this page and <i>Home</i> are
+      always pretty fast, <i>Profile</i> takes more time because it uses SSR to
+      fetch the user first
+    </p>
+  </Layout>
+)
+
+export default Home

--- a/examples/with-passport/pages/api/login/github/callback.js
+++ b/examples/with-passport/pages/api/login/github/callback.js
@@ -1,0 +1,39 @@
+import url from 'url'
+import express from 'express'
+import passport from 'passport'
+import { ROOT_URL } from '../../../../lib/configs'
+import { githubStrategy } from '../../../../lib/passport/github'
+
+const app = express()
+const isProd = process.env.NODE_ENV === 'production'
+
+app.disable('x-powered-by')
+
+app.use(passport.initialize())
+
+passport.use(githubStrategy)
+
+app.get('/api/login/github/callback', (req, res) => {
+  passport.authenticate('github', (err, data) => {
+    if (err) {
+      console.error(err)
+      res.status(500).send('Login with Github failed')
+    } else {
+      let redirectTo = url.parse(ROOT_URL + req.query.redirectPath, true)
+
+      // Handle invalid redirectPath
+      if (!redirectTo || !redirectTo.hostname) {
+        redirectTo = url.parse(ROOT_URL)
+      }
+
+      res.cookie('loginToken', data.accessToken, {
+        path: '/',
+        secure: isProd,
+        maxAge: 1000 * 60 * 60 * 24 * 30 // 30 days
+      })
+      res.redirect(url.format(redirectTo))
+    }
+  })(req, res)
+})
+
+export default app

--- a/examples/with-passport/pages/api/login/github/index.js
+++ b/examples/with-passport/pages/api/login/github/index.js
@@ -1,0 +1,27 @@
+import url from 'url'
+import express from 'express'
+import passport from 'passport'
+import { githubStrategy, callbackURL } from '../../../../lib/passport/github'
+
+const app = express()
+
+app.disable('x-powered-by')
+
+app.use(passport.initialize())
+
+passport.use(githubStrategy)
+
+app.get('/api/login/github', (req, res) => {
+  // This is the path used to redirect the user after a successful login
+  const { redirectPath } = req.query
+  const redirectTo = url.parse(callbackURL, true)
+
+  redirectTo.query.redirectPath = url.format(redirectPath)
+
+  passport.authenticate('github', { callbackURL: url.format(redirectTo) })(
+    req,
+    res
+  )
+})
+
+export default app

--- a/examples/with-passport/pages/api/login/github/index.js
+++ b/examples/with-passport/pages/api/login/github/index.js
@@ -16,7 +16,7 @@ app.get('/api/login/github', (req, res) => {
   const { redirectPath } = req.query
   const redirectTo = url.parse(callbackURL, true)
 
-  redirectTo.query.redirectPath = url.format(redirectPath)
+  redirectTo.query.redirectPath = redirectPath
 
   passport.authenticate('github', { callbackURL: url.format(redirectTo) })(
     req,

--- a/examples/with-passport/pages/api/profile.js
+++ b/examples/with-passport/pages/api/profile.js
@@ -16,13 +16,14 @@ export default async (req, res) => {
 
     if (response.ok) {
       const data = await response.json()
-      return res.status(200).json(parseUser(data))
+      res.status(200).json(parseUser(data))
     } else {
       const error = new Error(response.statusText)
       error.status = response.status
       throw error
     }
   } catch (error) {
-    res.status(error.status || 400).json({ message: error.message })
+    console.error(error)
+    res.status(error.status || 400).end(error.message)
   }
 }

--- a/examples/with-passport/pages/api/profile.js
+++ b/examples/with-passport/pages/api/profile.js
@@ -1,0 +1,28 @@
+import fetch from 'isomorphic-unfetch'
+import { authenticate } from '../../lib/passport/jwt'
+
+const parseUser = data => ({
+  username: data.login,
+  name: data.name,
+  avatarUrl: data.avatar_url,
+  bio: data.bio
+})
+
+export default async (req, res) => {
+  try {
+    const payload = await authenticate(req)
+    const url = `https://api.github.com/users/${payload.username}`
+    const response = await fetch(url)
+
+    if (response.ok) {
+      const data = await response.json()
+      return res.status(200).json(parseUser(data))
+    } else {
+      const error = new Error(response.statusText)
+      error.status = response.status
+      throw error
+    }
+  } catch (error) {
+    res.status(error.status || 400).json({ message: error.message })
+  }
+}

--- a/examples/with-passport/pages/index.js
+++ b/examples/with-passport/pages/index.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import Layout from '../components/layout'
+
+const Home = () => (
+  <Layout>
+    <h1>Passport authentication example</h1>
+
+    <p>
+      To test the login with GitHub click in <i>Login</i>
+    </p>
+    <p>
+      Once you have logged in you should be able to click in <i>Profile</i> and{' '}
+      <i>Logout</i>
+    </p>
+  </Layout>
+)
+
+export default Home

--- a/examples/with-passport/pages/profile.js
+++ b/examples/with-passport/pages/profile.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import fetch from 'isomorphic-unfetch'
+import Layout from '../components/layout'
+import { ROOT_URL } from '../lib/configs'
+import { getToken } from '../lib/auth'
+import redirect from '../lib/redirect'
+import { UserProvider } from '../lib/user'
+
+const Profile = props => {
+  const { name, login, bio, avatarUrl } = props.user || {}
+
+  return (
+    <UserProvider user={props.user}>
+      <Layout>
+        <img src={avatarUrl} alt='Avatar' />
+        <h1>{name}</h1>
+        <p className='lead'>{login}</p>
+        <p>{bio}</p>
+
+        <style jsx>{`
+          img {
+            max-width: 200px;
+            border-radius: 0.5rem;
+          }
+          h1 {
+            margin-bottom: 0;
+          }
+          .lead {
+            margin-top: 0;
+            font-size: 1.5rem;
+            font-weight: 300;
+            color: #666;
+          }
+          p {
+            color: #6a737d;
+          }
+        `}</style>
+      </Layout>
+    </UserProvider>
+  )
+}
+
+Profile.getInitialProps = async ({ req, res }) => {
+  const loginToken = getToken(req)
+  const url = ROOT_URL + '/api/profile'
+
+  if (loginToken) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${loginToken}`
+        }
+      })
+
+      if (response.ok) {
+        return { user: await response.json() }
+      } else {
+        throw new Error(response.statusText)
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  redirect(res, '/')
+  return {}
+}
+
+export default Profile


### PR DESCRIPTION
- Both examples to cookie based authentication and have pages with CSR and SSR
- Both examples rely only in API routes for the backend
- The Passport.js example has a very simple access token setup, meanwhile the auth0 example follows more strict security measurements