### PR TITLE
Add warning when empty object is returned from getInitialProps

### DIFF
--- a/errors/empty-object-getInitialProps.md
+++ b/errors/empty-object-getInitialProps.md
@@ -1,0 +1,13 @@
+# Empty Object Returned From `getInitialProps`
+
+#### Why This Error Occurred
+
+In one of your page components you added a `getInitialProps` that returned an empty object. This is de-optimizes automatic prerendering. If you **meant** to do this and understand the **consequences** you can ignore this message as it is only shown in development.
+
+#### Possible Ways to Fix It
+
+Look for any page's using `getInitialProps` that return an empty object `{}`. You might also need to update higher order components (HOCs) to not only add `getInitialProps` if they are present on the passed component.
+
+### Useful Links
+
+- [Automatic Prerendering Documentation](https://nextjs.org/docs/#automatic-prerendering)

--- a/errors/empty-object-getInitialProps.md
+++ b/errors/empty-object-getInitialProps.md
@@ -6,7 +6,7 @@ In one of your page components you added a `getInitialProps` that returned an em
 
 #### Possible Ways to Fix It
 
-Look for any page's using `getInitialProps` that return an empty object `{}`. You might also need to update higher order components (HOCs) to not only add `getInitialProps` if they are present on the passed component.
+Look for any page's using `getInitialProps` that return an empty object `{}`. You might also need to update higher order components (HOCs) to only add `getInitialProps` if they are present on the passed component.
 
 ### Useful Links
 

--- a/errors/empty-object-getInitialProps.md
+++ b/errors/empty-object-getInitialProps.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-In one of your page components you added a `getInitialProps` that returned an empty object. This is de-optimizes automatic prerendering. If you **meant** to do this and understand the **consequences** you can ignore this message as it is only shown in development.
+In one of your page components you added a `getInitialProps` that returned an empty object. This de-optimizes automatic prerendering. If you **meant** to do this and understand the **consequences** you can ignore this message as it is only shown in development.
 
 #### Possible Ways to Fix It
 

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -249,6 +249,16 @@ export async function loadGetInitialProps<
     throw new Error(message)
   }
 
+  if (process.env.NODE_ENV !== 'production') {
+    if (Object.keys(props).length === 0 && !ctx.ctx) {
+      console.warn(
+        `${getDisplayName(
+          Component
+        )} returned an empty object from \`getInitialProps\`. This de-optimizes and prevents automatic prerendering. https://err.sh/zeit/next.js/empty-object-getInitialProps`
+      )
+    }
+  }
+
   return props
 }
 

--- a/packages/next-server/server/render.tsx
+++ b/packages/next-server/server/render.tsx
@@ -357,15 +357,8 @@ export async function renderToHTML(
       isSkeleton && !isDataPrerender
         ? { pageProps: {} }
         : await loadGetInitialProps(App, {
+            AppTree: ctx.AppTree,
             Component,
-            AppTree: (props: any) => {
-              const appProps = { ...props, Component, router }
-              return (
-                <AppContainer>
-                  <App {...appProps} />
-                </AppContainer>
-              )
-            },
             router,
             ctx,
           })

--- a/test/integration/empty-object-getInitialProps/pages/another.js
+++ b/test/integration/empty-object-getInitialProps/pages/another.js
@@ -1,0 +1,5 @@
+const Another = () => 'hi'
+
+Another.getInitialProps = () => ({})
+
+export default Another

--- a/test/integration/empty-object-getInitialProps/pages/index.js
+++ b/test/integration/empty-object-getInitialProps/pages/index.js
@@ -1,0 +1,5 @@
+const Index = () => 'hi'
+
+Index.getInitialProps = () => ({})
+
+export default Index

--- a/test/integration/empty-object-getInitialProps/pages/static.js
+++ b/test/integration/empty-object-getInitialProps/pages/static.js
@@ -1,0 +1,1 @@
+export default () => 'hi'

--- a/test/integration/empty-object-getInitialProps/test/index.test.js
+++ b/test/integration/empty-object-getInitialProps/test/index.test.js
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import webdriver from 'next-webdriver'
+import {
+  renderViaHTTP,
+  findPort,
+  launchApp,
+  killApp,
+  waitFor
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = join(__dirname, '..')
+let output = ''
+let appPort
+let app
+
+const handleOutput = msg => {
+  output += msg
+}
+
+describe('Empty Project', () => {
+  beforeAll(async () => {
+    appPort = await findPort()
+    app = await launchApp(appDir, appPort, {
+      onStdout: handleOutput,
+      onStderr: handleOutput
+    })
+  })
+  afterAll(() => killApp(app))
+
+  it('It should show empty object warning on SSR', async () => {
+    output = ''
+    await renderViaHTTP(appPort, '/')
+    await waitFor(100)
+    expect(output).toMatch(/returned an empty object from `getInitialProps`/)
+  })
+
+  it('It should not show empty object warning for page without `getInitialProps`', async () => {
+    output = ''
+    await renderViaHTTP(appPort, '/static')
+    await waitFor(100)
+    expect(output).not.toMatch(
+      /returned an empty object from `getInitialProps`/
+    )
+  })
+
+  it('should show empty object warning during client transition', async () => {
+    const browser = await webdriver(appPort, '/static')
+    await browser.eval(`(function() {
+      window.gotWarn = false
+      const origWarn = console.warn
+      window.console.warn = function () {
+        if (arguments[0].match(/returned an empty object from \`getInitialProps\`/)) {
+          window.gotWarn = true
+        }
+        origWarn.apply(this, arguments)
+      }
+      window.next.router.replace('/another')
+    })()`)
+    await waitFor(300)
+    const gotWarn = await browser.eval(`window.gotWarn`)
+    expect(gotWarn).toBe(true)
+    await browser.close()
+  })
+})


### PR DESCRIPTION
This helps users notice when they are de-opting automatic prerendering by returning an empty object from `getInitialProps`

Closes: #8354