### PR TITLE
Add deprecation warning for App Container

### DIFF
--- a/errors/app-container-deprecated.md
+++ b/errors/app-container-deprecated.md
@@ -2,13 +2,12 @@
 
 #### Why This Error Occurred
 
-In versions prior to v9.0.4-canary.3 the `Container` component was used in `_app` to handle scrolling to hashes. Now this handling has been moved up the tree so `Container` is no longer needed in `_app`.
-
-You should remove the `Container` component from your `_app` since it a no-op now and will be removed in future versions.
+In versions prior to v9.0.4 the `<Container>` component was used in `./pages/_app.js` to handle scrolling to hashes.
+This handling has been moved up the tree so the `<Container>` component is no longer needed in your custom `<App>`!
 
 #### Possible Ways to Fix It
 
-Remove the `Container` component from `_app`
+Remove the `<Container>` component from your Custom `<App>` (`./pages/_app.js`).
 
 **Before**
 ```jsx

--- a/errors/app-container-deprecated.md
+++ b/errors/app-container-deprecated.md
@@ -1,0 +1,45 @@
+# App Container Deprecated
+
+#### Why This Error Occurred
+
+In versions prior to v9.0.4-canary.3 the `Container` component was used in `_app` to handle scrolling to hashes. Now this handling has been moved up the tree so `Container` is no longer needed in `_app`.
+
+You should remove the `Container` component from your `_app` since it a no-op now and will be removed in future versions.
+
+#### Possible Ways to Fix It
+
+Remove the `Container` component from `_app`
+
+**Before**
+```jsx
+import React from 'react'
+import App, { Container } from 'next/app'
+
+class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}
+
+export default MyApp
+```
+
+**After**
+```jsx
+import React from 'react'
+import App from 'next/app'
+
+class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props
+    return <Component {...pageProps} />
+  }
+}
+
+export default MyApp
+```

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -57,8 +57,17 @@ export default class App<P = {}, CP = {}, S = {}> extends React.Component<
   }
 }
 
+const warnContainer = execOnce(() => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      `Warning: the \`Container\` in \`_app\` has been deprecated and should be removed. https://err.sh/zeit/next.js/app-container-deprecated`
+    )
+  }
+})
+
 // @deprecated noop for now until removal
 export function Container(p: any) {
+  if (process.env.NODE_ENV !== 'production') warnContainer()
   return p.children
 }
 
@@ -75,38 +84,38 @@ export function createUrl(router: Router) {
   const { pathname, asPath, query } = router
   return {
     get query() {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       return query
     },
     get pathname() {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       return pathname
     },
     get asPath() {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       return asPath
     },
     back: () => {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       router.back()
     },
     push: (url: string, as?: string) => {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       return router.push(url, as)
     },
     pushTo: (href: string, as?: string) => {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       const pushRoute = as ? href : ''
       const pushUrl = as || href
 
       return router.push(pushRoute, pushUrl)
     },
     replace: (url: string, as?: string) => {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       return router.replace(url, as)
     },
     replaceTo: (href: string, as?: string) => {
-      warnUrl()
+      if (process.env.NODE_ENV !== 'production') warnUrl()
       const replaceRoute = as ? href : ''
       const replaceUrl = as || href
 

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -60,7 +60,7 @@ export default class App<P = {}, CP = {}, S = {}> extends React.Component<
 const warnContainer = execOnce(() => {
   if (process.env.NODE_ENV !== 'production') {
     console.warn(
-      `Warning: the \`Container\` in \`_app\` has been deprecated and should be removed. https://err.sh/zeit/next.js/app-container-deprecated`
+      `Warning: the \`<Container>\` component in \`_app\` has been deprecated and should be removed. https://err.sh/zeit/next.js/app-container-deprecated`
     )
   }
 })

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -57,27 +57,28 @@ export default class App<P = {}, CP = {}, S = {}> extends React.Component<
   }
 }
 
-const warnContainer = execOnce(() => {
-  if (process.env.NODE_ENV !== 'production') {
+let warnContainer: () => void
+let warnUrl: () => void
+
+if (process.env.NODE_ENV !== 'production') {
+  warnContainer = execOnce(() => {
     console.warn(
-      `Warning: the \`<Container>\` component in \`_app\` has been deprecated and should be removed. https://err.sh/zeit/next.js/app-container-deprecated`
+      `Warning: the \`Container\` in \`_app\` has been deprecated and should be removed. https://err.sh/zeit/next.js/app-container-deprecated`
     )
-  }
-})
+  })
+
+  warnUrl = execOnce(() => {
+    console.error(
+      `Warning: the 'url' property is deprecated. https://err.sh/zeit/next.js/url-deprecated`
+    )
+  })
+}
 
 // @deprecated noop for now until removal
 export function Container(p: any) {
   if (process.env.NODE_ENV !== 'production') warnContainer()
   return p.children
 }
-
-const warnUrl = execOnce(() => {
-  if (process.env.NODE_ENV !== 'production') {
-    console.error(
-      `Warning: the 'url' property is deprecated. https://err.sh/zeit/next.js/url-deprecated`
-    )
-  }
-})
 
 export function createUrl(router: Router) {
   // This is to make sure we don't references the router object at call time

--- a/test/integration/app-aspath/pages/_app.js
+++ b/test/integration/app-aspath/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 export default class MyApp extends App {
   // find this
@@ -11,10 +11,6 @@ export default class MyApp extends App {
 
   render () {
     const { Component, url } = this.props
-    return (
-      <Container>
-        <Component url={url} />
-      </Container>
-    )
+    return <Component url={url} />
   }
 }

--- a/test/integration/app-document/pages/_app.js
+++ b/test/integration/app-document/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import { setState } from '../shared-module'
 
@@ -42,11 +42,9 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
-      </Container>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     )
   }
 }

--- a/test/integration/app-tree/pages/_app.tsx
+++ b/test/integration/app-tree/pages/_app.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import { render } from 'react-dom'
-import App, { Container, AppContext } from 'next/app'
+import App, { AppContext } from 'next/app'
 import { renderToString } from 'react-dom/server'
 
 class MyApp<P = {}> extends App<P & { html: string }> {
@@ -54,9 +54,7 @@ class MyApp<P = {}> extends App<P & { html: string }> {
         </Link>
       </>
     ) : (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
+      <Component {...pageProps} />
     )
   }
 }

--- a/test/integration/no-override-next-props/pages/_app.js
+++ b/test/integration/no-override-next-props/pages/_app.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import App, { Container } from 'next/app'
+import App from 'next/app'
 
 class MyApp extends App {
   static async getInitialProps ({ Component, ctx }) {
@@ -14,12 +14,7 @@ class MyApp extends App {
 
   render () {
     const { Component, pageProps } = this.props
-
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }
 

--- a/test/integration/production-config/pages/_app.js
+++ b/test/integration/production-config/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 
 import '../styles.css'
@@ -6,10 +6,6 @@ import '../styles.css'
 export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
-    return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
-    )
+    return <Component {...pageProps} />
   }
 }

--- a/test/integration/with-router/pages/_app.js
+++ b/test/integration/with-router/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import React from 'react'
 import HeaderNav from '../components/header-nav'
 
@@ -16,10 +16,10 @@ export default class MyApp extends App {
   render () {
     const { Component, pageProps } = this.props
     return (
-      <Container>
+      <>
         <HeaderNav />
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }


### PR DESCRIPTION
Adds warning when `Container` is used in `_app` since it's been deprecated. Also, removes it's usage from our test suite

Closes: #8328