### PR TITLE
Fix invalid href in with-tailwindcss example

### DIFF
--- a/examples/with-tailwindcss/components/nav.js
+++ b/examples/with-tailwindcss/components/nav.js
@@ -17,9 +17,9 @@ export default function Nav () {
         <ul className='flex justify-between items-center'>
           {links.map(({ href, label }) => (
             <li key={`${href}${label}`} className='ml-4'>
-              <Link href={href}>
-                <a className='btn-blue no-underline'>{label}</a>
-              </Link>
+              <a href={href} className='btn-blue no-underline'>
+                {label}
+              </a>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
`next/link` should only be used for internal links.

### Error

```log
Uncaught (in promise) Error: Invalid href passed to router: https://github.com/zeit/next.js https://err.sh/zeit/next.js/invalid-href-passed
```