### PR TITLE
Fix backslashes in stats causing tests to fail on windows

### DIFF
--- a/test/integration/chunking/test/index.test.js
+++ b/test/integration/chunking/test/index.test.js
@@ -30,7 +30,11 @@ describe('Chunking', () => {
       // Error here means old chunks don't exist, so we don't need to do anything
     }
     await nextBuild(appDir)
-    stats = await readFile(join(appDir, '.next', 'stats.json'), 'utf8')
+    stats = (await readFile(join(appDir, '.next', 'stats.json'), 'utf8'))
+      // fixes backslashes in keyNames not being escaped on windows
+      .replace(/"static\\(.*?":)/g, '"static\\\\$1')
+      .replace(/("static\\.*?)\\pages\\(.*?":)/g, '$1\\\\pages\\\\$2')
+
     stats = JSON.parse(stats)
     buildId = await readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
     chunks = await readdir(join(appDir, '.next', 'static', 'chunks'))


### PR DESCRIPTION
The chunking test suite hasn't been able to run on windows since https://github.com/zeit/next.js/pull/8482 due to unescaped backslashes in the stats file causing an error to be thrown during parsing on windows 