### PR TITLE
Add React import in first code example of manual setup

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -161,6 +161,8 @@ After that, the file-system is the main API. Every `.js` file becomes a route th
 Populate `./pages/index.js` inside your project:
 
 ```jsx
+import React from 'react';
+
 function Home() {
   return <div>Welcome to Next.js!</div>
 }


### PR DESCRIPTION
Small alright, but if one follows the current instructions by the word one gets `ReferenceError: React is not defined`.