### PR TITLE
Add missing dependency to next-server

### DIFF
--- a/packages/next-server/package.json
+++ b/packages/next-server/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@ampproject/toolbox-optimizer": "1.0.1",
+    "chalk": "2.4.2",
     "compression": "1.7.4",
     "content-type": "1.0.4",
     "cookie": "0.4.0",


### PR DESCRIPTION
`next-server` is requiring `chalk` but it's not defined in its dependencies.