### PR TITLE
Normalize errors to use nextjs.org

### DIFF
--- a/errors/api-routes-static-export.md
+++ b/errors/api-routes-static-export.md
@@ -10,4 +10,4 @@ Remove any paths using API routes from your `exportPathMap` in `next.config.js`.
 
 ### Useful Links
 
-- [Static HTML export](https://github.com/zeit/next.js#static-html-export)
+- [Static HTML export](https://nextjs.org/docs#static-html-export)

--- a/errors/build-dir-not-writeable.md
+++ b/errors/build-dir-not-writeable.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-The filesystem does not allow writing to the specified directory. A common cause for this error is starting a [custom server](https://github.com/zeit/next.js#custom-server-and-routing) in development mode on a production server, for example, [now.sh](https://zeit.co) which [doesn't allow you to write to the filesystem after your app is built](https://zeit.co/docs/deployment-types/node#file-system-specifications).
+The filesystem does not allow writing to the specified directory. A common cause for this error is starting a [custom server](https://nextjs.org/docs#custom-server-and-routing) in development mode on a production server, for example, [now.sh](https://zeit.co) which [doesn't allow you to write to the filesystem after your app is built](https://zeit.co/docs/deployment-types/node#file-system-specifications).
 
 #### Possible Ways to Fix It
 
@@ -27,4 +27,4 @@ const app = next({ dev })
 
 ### Useful Links
 
-- [Custom Server documentation + examples](https://github.com/zeit/next.js#custom-server-and-routing)
+- [Custom Server documentation + examples](https://nextjs.org/docs#custom-server-and-routing)

--- a/errors/export-path-mismatch.md
+++ b/errors/export-path-mismatch.md
@@ -23,4 +23,4 @@ module.exports = {
 
 ### Useful Links
 
-- [exportPathMap](https://github.com/zeit/next.js#usage) documentation
+- [exportPathMap](https://nextjs.org/docs#usage) documentation

--- a/errors/get-initial-props-as-an-instance-method.md
+++ b/errors/get-initial-props-as-an-instance-method.md
@@ -36,4 +36,4 @@ export default YourEntryComponent
 
 ### Useful Links
 
-- [Fetching data and component lifecycle](https://github.com/zeit/next.js#fetching-data-and-component-lifecycle)
+- [Fetching data and component lifecycle](https://nextjs.org/docs#fetching-data-and-component-lifecycle)

--- a/errors/invalid-page-config.md
+++ b/errors/invalid-page-config.md
@@ -22,5 +22,5 @@ export const config = { amp: true }
 
 ### Useful Links
 
-- [Enabling AMP Support](https://github.com/zeit/next.js/#enabling-amp-support)
-- [API Middlewares](https://github.com/zeit/next.js/#api-middlewares)
+- [Enabling AMP Support](https://nextjs.org/docs#enabling-amp-support)
+- [API Middlewares](https://nextjs.org/docs#api-middlewares)

--- a/errors/opt-out-automatic-prerendering.md
+++ b/errors/opt-out-automatic-prerendering.md
@@ -2,16 +2,16 @@
 
 #### Why This Warning Occurred
 
-You are using `getInitialProps` in your [Custom `<App>`](https://github.com/zeit/next.js#custom-app).
+You are using `getInitialProps` in your [Custom `<App>`](https://nextjs.org/docs#custom-app).
 
-This causes **all pages** to be executed on the server -- disabling [Automatic Prerendering](https://github.com/zeit/next.js#automatic-prerendering).
+This causes **all pages** to be executed on the server -- disabling [Automatic Prerendering](https://nextjs.org/docs#automatic-prerendering).
 
 #### Possible Ways to Fix It
 
 Be sure you meant to use `getInitialProps` in `pages/_app`!
 There are some valid use cases for this, but it is often better to handle `getInitialProps` on a _per-page_ basis.
 
-If you copied the [Custom `<App>`](https://github.com/zeit/next.js#custom-app) example, you may be able to remove your `getInitialProps`.
+If you copied the [Custom `<App>`](https://nextjs.org/docs#custom-app) example, you may be able to remove your `getInitialProps`.
 
 The following `getInitialProps` does nothing and may be removed:
 


### PR DESCRIPTION
Move all links to point to [nextjs.org](https://nextjs.org/) instead of Github repo.