### PR TITLE
#8517 Fix: Performance Marks regression

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -281,7 +281,7 @@ function markRenderComplete () {
 }
 
 function clearMarks () {
-  performance.clearMarks()
+  ['beforeRender', 'afterHydrate', 'afterRender'].forEach(function(mark){performance.clearMarks(mark)})
   /*
    * TODO: uncomment the following line when we have a way to
    * expose this to user code.

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -281,7 +281,9 @@ function markRenderComplete () {
 }
 
 function clearMarks () {
-  ['beforeRender', 'afterHydrate', 'afterRender'].forEach(function(mark){performance.clearMarks(mark)})
+  ;['beforeRender', 'afterHydrate', 'afterRender'].forEach(function (mark) {
+    performance.clearMarks(mark)
+  })
   /*
    * TODO: uncomment the following line when we have a way to
    * expose this to user code.


### PR DESCRIPTION
Fixes #8517 

- clear just next-specific performance marks instead of ALL marks

I'm not sure if these are all the marks to be cleared. Feel free to edit, improve or reject.