### PR TITLE
Fix rerenders in with-context-api example

### DIFF
--- a/examples/with-context-api/components/CounterProvider.js
+++ b/examples/with-context-api/components/CounterProvider.js
@@ -6,37 +6,27 @@ const CounterContext = React.createContext()
 /* Then create a provider Component */
 class CounterProvider extends Component {
   state = {
-    count: 0
-  }
-
-  increase = () => {
-    this.setState({
-      count: this.state.count + 1
-    })
-  }
-
-  increaseBy = val => {
-    this.setState({
-      count: this.state.count + val
-    })
-  }
-
-  decrease = () => {
-    this.setState({
-      count: this.state.count - 1
-    })
+    count: 0,
+    increase: () => {
+      this.setState((state, props) => ({
+        count: state.count + 1
+      }))
+    },
+    increaseBy: val => {
+      this.setState((state, props) => ({
+        count: state.count + val
+      }))
+    },
+    decrease: () => {
+      this.setState((state, props) => ({
+        count: state.count - 1
+      }))
+    }
   }
 
   render () {
     return (
-      <CounterContext.Provider
-        value={{
-          count: this.state.count,
-          increase: this.increase,
-          decrease: this.decrease,
-          increaseBy: this.increaseBy
-        }}
-      >
+      <CounterContext.Provider value={this.state}>
         {this.props.children}
       </CounterContext.Provider>
     )


### PR DESCRIPTION
The code before this PR had several issues:

1. Context uses reference identity to determine when to re-render, there are some gotchas that could trigger unintentional renders in consumers when a provider’s parent re-renders. https://reactjs.org/docs/context.html#caveats

2. `setState` should use the reducer pattern in this example to make sure clicks are not swallowed by react batch.