### PR TITLE
 Make sure to 404 for /_next/static

### DIFF
--- a/packages/next-server/server/next-server.ts
+++ b/packages/next-server/server/next-server.ts
@@ -208,6 +208,10 @@ export default class Server {
           // The commons folder holds commonschunk files
           // The chunks folder holds dynamic entries
           // The buildId folder holds pages and potentially other assets. As buildId changes per build it can be long-term cached.
+
+          // make sure to 404 for /_next/static itself
+          if (!params.path) return this.render404(req, res, parsedUrl)
+
           if (
             params.path[0] === CLIENT_STATIC_FILES_RUNTIME ||
             params.path[0] === 'chunks' ||

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -80,6 +80,11 @@ describe('Production Usage', () => {
       expect(res.status).toBe(404)
     })
 
+    it('should render 404 for /_next/static route', async () => {
+      const html = await renderViaHTTP(appPort, '/_next/static')
+      expect(html).toMatch(/This page could not be found/)
+    })
+
     it('should render 200 for POST on page', async () => {
       const res = await fetch(`http://localhost:${appPort}/about`, {
         method: 'POST'

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -52,6 +52,11 @@ describe('Serverless', () => {
     expect(html).toMatch(/This page could not be found/)
   })
 
+  it('should render 404 for /_next/static', async () => {
+    const html = await renderViaHTTP(appPort, '/_next/static')
+    expect(html).toMatch(/This page could not be found/)
+  })
+
   it('should render an AMP page', async () => {
     const html = await renderViaHTTP(appPort, '/some-amp?amp=1')
     expect(html).toMatch(/Hi Im an AMP page/)


### PR DESCRIPTION
If someone visits `/_next/static` itself it causes an error since we are expecting the `path` param to be populated. This makes sure to 404 when the `path` param is empty for `/_next/static`

Fixes: #8563