### PR TITLE
example for sass global import

### DIFF
--- a/examples/with-sass-global-import/README.md
+++ b/examples/with-sass-global-import/README.md
@@ -1,0 +1,52 @@
+# Example app with sass global imports
+
+#Purpose:
+
+Nextjs doesnt let you use sass global variables directly
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-next-sass-global-import with-next-sass-global-import
+# or
+yarn create next-app --example with-next-sass-global-import with-next-sass-global-import
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-next-sass-global-import
+cd with-next-sass-global-import
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Run production build with:
+
+```bash
+npm run build
+npm run start
+# or
+yarn build
+yarn start
+```
+
+## The idea behind the example
+
+- An app with next-sass and sass-resources-loader to gloabally access the variables in sass
+
+This example uses next-sass with sass-resources-loader . The config can be found in `next.config.js`

--- a/examples/with-sass-global-import/components/Button.js
+++ b/examples/with-sass-global-import/components/Button.js
@@ -1,0 +1,6 @@
+import './index.scss'
+const Button = () => {
+  return <button className="btn">Hey There</button>
+}
+
+export default Button

--- a/examples/with-sass-global-import/components/index.scss
+++ b/examples/with-sass-global-import/components/index.scss
@@ -1,0 +1,4 @@
+.btn {
+  background: $primary-ui-color;
+  color: $primary-text-color;
+}

--- a/examples/with-sass-global-import/next.config.js
+++ b/examples/with-sass-global-import/next.config.js
@@ -1,0 +1,20 @@
+const withSass = require('@zeit/next-sass')
+const resourcesLoader = {
+  loader: 'sass-resources-loader',
+  options: {
+    resources: ['./styles/colors.scss'], // place your global imports here
+  },
+}
+module.exports = withSass({
+  webpack: (config, options) => {
+    config.module.rules.map(rule => {
+      if (
+        rule.test.source.includes('scss') ||
+        rule.test.source.includes('sass')
+      ) {
+        rule.use.push(resourcesLoader)
+      }
+    })
+    return config
+  },
+})

--- a/examples/with-sass-global-import/package.json
+++ b/examples/with-sass-global-import/package.json
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@zeit/next-sass": "^1.0.1",
+    "next": "^9.0.5",
+    "node-sass": "^4.12.0",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
+    "sass-resources-loader": "^2.0.1"
+  }
+}

--- a/examples/with-sass-global-import/pages/_app.js
+++ b/examples/with-sass-global-import/pages/_app.js
@@ -1,0 +1,12 @@
+import App from 'next/app'
+import React from 'react'
+import '../styles/index.scss'
+
+class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props
+    return <Component {...pageProps} />
+  }
+}
+
+export default MyApp

--- a/examples/with-sass-global-import/pages/index.js
+++ b/examples/with-sass-global-import/pages/index.js
@@ -1,0 +1,7 @@
+import React from 'react'
+import Button from '../components/Button'
+export default () => (
+  <div>
+    <Button></Button>
+  </div>
+)

--- a/examples/with-sass-global-import/styles/colors.scss
+++ b/examples/with-sass-global-import/styles/colors.scss
@@ -1,0 +1,2 @@
+$primary-text-color: white;
+$primary-ui-color: #03a87c;

--- a/examples/with-sass-global-import/styles/index.scss
+++ b/examples/with-sass-global-import/styles/index.scss
@@ -1,0 +1,2 @@
+@import "colors";
+


### PR DESCRIPTION
Currently there is no option for accessing global variables in sass.
It always throws an error while accessing variables so there is a workaround for that using sass-resources-loader.

I made this example illustrating that.