### PR TITLE
Catch error from failing to unobserve

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -101,8 +101,8 @@ const listenToIntersections = (el: any, cb: any) => {
   return () => {
     try {
       observer.unobserve(el)
-    } catch (_) {
-      /* not detrimental if it fails to unobserve */
+    } catch (err) {
+      console.error(err)
     }
     listeners.delete(el)
   }

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -99,7 +99,11 @@ const listenToIntersections = (el: any, cb: any) => {
   observer.observe(el)
   listeners.set(el, cb)
   return () => {
-    observer.unobserve(el)
+    try {
+      observer.unobserve(el)
+    } catch (_) {
+      /* not detrimental if it fails to unobserve */
+    }
     listeners.delete(el)
   }
 }


### PR DESCRIPTION
It seems some versions (v.15) of MS Edge will throw an error on `IntersectionObserver#unobserve` so this adds catching of it since it's not a critical error if it fails to `unobserve`

Fixes: #8572