### PR TITLE
Remove extra default export from readme

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1072,8 +1072,6 @@ export default function MyLink() {
     </a>
   )
 }
-
-export default MyLink
 ```
 
 You can also add it to the `componentDidMount()` lifecycle method when using `React.Component`:


### PR DESCRIPTION
Didn't have a chance to add this as a review on #8577 but this export isn't needed since the default export is defined above it in this snippet