### PR TITLE
[Monorepo] Add example on how to resolve absolute import paths in transpiled packages

### DIFF
--- a/examples/with-yarn-workspaces/packages/web-app/next.config.js
+++ b/examples/with-yarn-workspaces/packages/web-app/next.config.js
@@ -9,7 +9,7 @@ module.exports = withTM({
   // Add this if you want webpack to resolve the absolute import
   // paths that are internal to the transpiled module
   // (e.g. if you had the "paths" option set in bar/tsconfig.json)
-  webpack: function(config) {
+  webpack: function (config) {
     const rootDirOfEntireProject = path.resolve('../../')
     const bar = path.join(rootDirOfEntireProject, 'node_modules/bar')
     config.resolve.modules.push(bar)

--- a/examples/with-yarn-workspaces/packages/web-app/next.config.js
+++ b/examples/with-yarn-workspaces/packages/web-app/next.config.js
@@ -1,7 +1,18 @@
 const withTM = require('next-transpile-modules')
+const path = require('path')
 
 // Tell webpack to compile the "bar" package
 // https://www.npmjs.com/package/next-transpile-modules
 module.exports = withTM({
-  transpileModules: ['bar']
+  transpileModules: ['bar'],
+
+  // Add this if you want webpack to resolve the absolute import
+  // paths that are internal to the transpiled module
+  // (e.g. if you had the "paths" option set in bar/tsconfig.json)
+  webpack: function(config) {
+    const rootDirOfEntireProject = path.resolve('../../')
+    const bar = path.join(rootDirOfEntireProject, 'node_modules/bar')
+    config.resolve.modules.push(bar)
+    return config
+  }
 })

--- a/examples/with-yarn-workspaces/packages/web-app/package.json
+++ b/examples/with-yarn-workspaces/packages/web-app/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "next": "latest",
-    "next-transpile-modules": "^2.0.0",
+    "next-transpile-modules": "^2.3.1",
     "react": "^16.8.3",
     "react-dom": "^16.8.3"
   },


### PR DESCRIPTION
Given the folder structure:
```
root (yarn workspace root)
└── packages
    └── businesslogic
    │   ├── domain
    │   │   └── entity.ts (export default Entity)
    │   ├── usecases
    │   │   └── usecase.ts (import Entity from 'domain/entity') -> absolute import path!
    │   └── package.json ("name": "businesslogic")
    │   └── tsconfig.json
    └── nextjs
        ├── pages
        │   └── index.ts  (import UseCase from "businesslogic/usecases/usecase")
        └── next.config.json
```
And in `root/packages/businesslogic/tsconfig.json`:
(see [Typescript Module Resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html))
```
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "*": ["*"]  // Capture all absolute paths
    }
  }
}
```

Then on running `next build` without this solution you would get the error 
```
Failed to compile.

root/packages/businesslogic/usecases/usecase.ts
Module not found: Can't resolve 'domain/entity' in 'root/node_modules/businesslogic/usecases'
```