### PR TITLE
Support <Link> with absolute urls and non-local ones

### DIFF
--- a/packages/next-server/lib/router/router.ts
+++ b/packages/next-server/lib/router/router.ts
@@ -12,6 +12,8 @@ import {
   loadGetInitialProps,
   NextPageContext,
   SUPPORTS_PERFORMANCE_USER_TIMING,
+  getLocationOrigin,
+  isLocal,
 } from '../utils'
 import { rewriteUrlForNextExport } from './rewrite-url-for-export'
 import { getRouteMatcher } from './utils/route-matcher'
@@ -559,9 +561,8 @@ export default class Router implements BaseRouter {
    */
   prefetch(url: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      const { pathname, protocol } = parse(url)
-
-      if (!pathname || protocol) {
+      const { pathname } = parse(url)
+      if (!pathname || !isLocal(url)) {
         if (process.env.NODE_ENV !== 'production') {
           throw new Error(
             `Invalid href passed to router: ${url} https://err.sh/zeit/next.js/invalid-href-passed`

--- a/packages/next-server/lib/utils.ts
+++ b/packages/next-server/lib/utils.ts
@@ -1,4 +1,4 @@
-import { format, UrlObject, URLFormatOptions } from 'url'
+import { format, UrlObject, URLFormatOptions, parse } from 'url'
 import { ServerResponse, IncomingMessage } from 'http'
 import { ComponentType } from 'react'
 import { ParsedUrlQuery } from 'querystring'
@@ -198,6 +198,15 @@ export function execOnce(this: any, fn: (...args: any) => any) {
 export function getLocationOrigin() {
   const { protocol, hostname, port } = window.location
   return `${protocol}//${hostname}${port ? ':' + port : ''}`
+}
+
+export function isLocal(href: string) {
+  const url = parse(href, false, true)
+  const origin = parse(getLocationOrigin(), false, true)
+
+  return (
+    !url.host || (url.protocol === origin.protocol && url.host === origin.host)
+  )
 }
 
 export function getURL() {

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -1,7 +1,7 @@
 /* global __NEXT_DATA__ */
 declare const __NEXT_DATA__: any
 
-import { resolve, parse, UrlObject } from 'url'
+import { resolve, UrlObject } from 'url'
 import React, { Component, Children } from 'react'
 import PropTypes from 'prop-types'
 import Router from './router'
@@ -9,17 +9,8 @@ import { rewriteUrlForNextExport } from 'next-server/dist/lib/router/rewrite-url
 import {
   execOnce,
   formatWithValidation,
-  getLocationOrigin,
+  isLocal,
 } from 'next-server/dist/lib/utils'
-
-function isLocal(href: string) {
-  const url = parse(href, false, true)
-  const origin = parse(getLocationOrigin(), false, true)
-
-  return (
-    !url.host || (url.protocol === origin.protocol && url.host === origin.host)
-  )
-}
 
 type Url = string | UrlObject
 type FormatResult = { href: string; as?: string }

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -187,6 +187,9 @@ class Link extends Component<LinkProps> {
     const { pathname } = window.location
     const { href: parsedHref } = this.formatUrls(this.props.href, this.props.as)
     const href = resolve(pathname, parsedHref)
+
+    if (!isLocal(href)) return
+
     Router.prefetch(href)
   }
 

--- a/test/integration/invalid-href/test/index.test.js
+++ b/test/integration/invalid-href/test/index.test.js
@@ -71,8 +71,8 @@ describe('Invalid hrefs', () => {
       await showsError('/first?method=replace', firstErrorRegex, true)
     })
 
-    it('shows error when https://google.com is used as href on Link', async () => {
-      await showsError('/second', secondErrorRegex)
+    it('does not show error when https://google.com is used as href on Link', async () => {
+      await noError('/second')
     })
 
     it('shows error when http://google.com is used as href on router.push', async () => {
@@ -104,7 +104,7 @@ describe('Invalid hrefs', () => {
       await noError('/first?method=replace', true)
     })
 
-    it('shows error when https://google.com is used as href on Link', async () => {
+    it('does not show error when https://google.com is used as href on Link', async () => {
       await noError('/second')
     })
 

--- a/test/integration/invalid-href/test/index.test.js
+++ b/test/integration/invalid-href/test/index.test.js
@@ -59,8 +59,8 @@ describe('Invalid hrefs', () => {
     })
     afterAll(() => killApp(app))
 
-    it('shows error when mailto: is used as href on Link', async () => {
-      await showsError('/first', firstErrorRegex)
+    it('does not show error when mailto: is used as href on Link', async () => {
+      await noError('/first')
     })
 
     it('shows error when mailto: is used as href on router.push', async () => {
@@ -92,7 +92,7 @@ describe('Invalid hrefs', () => {
     })
     afterAll(() => killApp())
 
-    it('shows error when mailto: is used as href on Link', async () => {
+    it('does not show error when mailto: is used as href on Link', async () => {
       await noError('/first')
     })
 


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/8555

Two changes:
First, update `Router` so that it can prefetch even when an absolute url is passed, as long as it is local.
Second, update `Link` so that it does not attempt to prefetch when a non-local link is passed.

Extracted `isLocal` from `Link` into a helper function.