### PR TITLE
Another publicRuntimeConfig with target set to serverless potential issue

### DIFF
--- a/errors/serverless-publicRuntimeConfig.md
+++ b/errors/serverless-publicRuntimeConfig.md
@@ -6,7 +6,7 @@ In the `serverless` target environment `next.config.js` is not loaded, so we don
 
 #### Possible Ways to Fix It
 
-Use config option `env` to set **build time** variables like such:
+- Use config option `env` to set **build time** variables like such:
 
 ```js
 // next.config.js
@@ -14,6 +14,16 @@ module.exports = {
   env: {
     special: 'value',
   },
+}
+```
+
+- If you are trying to do a serverless deployment, set `publicRuntimeConfig` explicitly as `false`:
+
+```js
+// next.config.js
+module.exports = {
+  target: 'serverless',
+  publicRuntimeConfig: false, // publicRuntimeConfig is an object by default so it passes a boolean check, so needs to be set as false.
 }
 ```
 


### PR DESCRIPTION
`publicRuntimeConfig` is an empty object by default in [this file](https://github.com/zeit/next.js/blob/canary/packages/next-server/server/config.ts).
In line 138 of the referred file, `userConfig.publicRuntimeConfig` will always be truthy by default.