### PR TITLE
publicRuntimeConfig boolean check when serverless

### DIFF
--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -135,9 +135,7 @@ export default function loadConfig(
     if (
       userConfig.target &&
       userConfig.target !== 'server' &&
-      userConfig.publicRuntimeConfig === undefined &&
-      userConfig.publicRuntimeConfig === null &&
-      Object.keys(userConfig.publicRuntimeConfig).length !== 0
+      userConfig.publicRuntimeConfig !== false
     ) {
       // TODO: change error message tone to "Only compatible with [fat] server mode"
       throw new Error(

--- a/packages/next-server/server/config.ts
+++ b/packages/next-server/server/config.ts
@@ -135,12 +135,15 @@ export default function loadConfig(
     if (
       userConfig.target &&
       userConfig.target !== 'server' &&
-      userConfig.publicRuntimeConfig &&
+      userConfig.publicRuntimeConfig === undefined &&
+      userConfig.publicRuntimeConfig === null &&
       Object.keys(userConfig.publicRuntimeConfig).length !== 0
     ) {
       // TODO: change error message tone to "Only compatible with [fat] server mode"
       throw new Error(
-        'Cannot use publicRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'
+        'Cannot use publicRuntimeConfig with target=serverless. ' +
+        'If you are trying to do a serverless deployment, set publicRuntimeConfig as false. ' +
+        'https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'
       )
     }
 


### PR DESCRIPTION
Hello,

First off, thanks for this amazing framework! In serverless deployments `publicRuntimeConfig` cannot be used. However, `publicRuntimeConfig` is an empty object by default, which means that by default line 138 will always return `true` (by default, of course). I think the error message is a bit vague when it comes to debugging as well.

My proposal is to remove line 138 (`userConfig.publicRuntimeConfig &&`) and line 139 because (`Object.keys(userConfig.publicRuntimeConfig).length !== 0`) checks if it's an empty object, (meaning `{}` or rather `Boolean(Object.keys({}).length)` which would always return `false`). I simply changed it to check if the setting has not been set to `false` (because I assume this is for serverless type configs only).

I also opened a PR in #8590 regarding the markdown file of potential issues when using `publicRuntimeConfig` in serverless.

Apologize if I'm missing something.