### PR TITLE
with-apollo-auth: add cookie path property

### DIFF
--- a/examples/with-apollo-auth/components/RegisterBox.js
+++ b/examples/with-apollo-auth/components/RegisterBox.js
@@ -24,7 +24,8 @@ const RegisterBox = () => {
   const onCompleted = data => {
     // Store the token in cookie
     document.cookie = cookie.serialize('token', data.signinUser.token, {
-      maxAge: 30 * 24 * 60 * 60 // 30 days
+      maxAge: 30 * 24 * 60 * 60, // 30 days
+      path: '/' // make cookie available for all routes underneath "/"
     })
     // Force a reload of all the current queries now that the user is
     // logged in


### PR DESCRIPTION
played around with that example and was wondering why it didn't work any more when having an `auth/login` page.

I hope this addition will spare someone else some confusion :)