### PR TITLE
Disable Anonymous Telemetry

### DIFF
--- a/packages/next/telemetry/storage.ts
+++ b/packages/next/telemetry/storage.ts
@@ -32,7 +32,7 @@ const TELEMETRY_KEY_SALT = `telemetry.salt`
 
 const { NEXT_TELEMETRY_DISABLED, NEXT_TELEMETRY_DEBUG } = process.env
 
-let isDisabled: boolean = !!NEXT_TELEMETRY_DISABLED
+let isDisabled: boolean = true || !!NEXT_TELEMETRY_DISABLED
 
 function notify() {
   // No notification needed if telemetry is not enabled


### PR DESCRIPTION
We need to disable anonymous telemetry until we figure out how we want to store the data.