### PR TITLE
Fix getInitialProps issue in with-apollo example

### DIFF
--- a/examples/with-apollo/components/Header.js
+++ b/examples/with-apollo/components/Header.js
@@ -6,6 +6,11 @@ const Header = ({ router: { pathname } }) => (
     <Link href='/'>
       <a className={pathname === '/' ? 'is-active' : ''}>Home</a>
     </Link>
+    <Link href='/client-only'>
+      <a className={pathname === '/client-only' ? 'is-active' : ''}>
+        Client-Only
+      </a>
+    </Link>
     <Link href='/about'>
       <a className={pathname === '/about' ? 'is-active' : ''}>About</a>
     </Link>

--- a/examples/with-apollo/components/InfoBox.js
+++ b/examples/with-apollo/components/InfoBox.js
@@ -1,0 +1,17 @@
+const InfoBox = ({ children }) => (
+  <div className='info'>
+    <style jsx>{`
+      .info {
+        margin-top: 20px;
+        margin-bottom: 20px;
+        padding-top: 20px;
+        padding-bottom: 20px;
+        border-top: 1px solid #ececec;
+        border-bottom: 1px solid #ececec;
+      }
+    `}</style>
+    {children}
+  </div>
+)
+
+export default InfoBox

--- a/examples/with-apollo/components/PostList.js
+++ b/examples/with-apollo/components/PostList.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/react-hooks'
-import { NetworkStatus } from 'apollo-boost'
+import { NetworkStatus } from 'apollo-client'
 import gql from 'graphql-tag'
 import ErrorMessage from './ErrorMessage'
 import PostUpvoter from './PostUpvoter'

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -1,7 +1,9 @@
 import React, { useMemo } from 'react'
 import Head from 'next/head'
 import { ApolloProvider } from '@apollo/react-hooks'
-import { ApolloClient, InMemoryCache, HttpLink } from 'apollo-boost'
+import { ApolloClient } from 'apollo-client'
+import { InMemoryCache } from 'apollo-cache-inmemory'
+import { HttpLink } from 'apollo-link-http'
 import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -128,14 +128,12 @@ function initApolloClient (initialState) {
  */
 function createApolloClient (initialState = {}) {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
-  const isBrowser = typeof window !== 'undefined'
   return new ApolloClient({
-    ssrMode: !isBrowser, // Disables forceFetch on the server (so queries are only run once)
+    ssrMode: typeof window === 'undefined', // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
       credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
-      // Use fetch() polyfill on the server
-      fetch: !isBrowser && fetch
+      fetch
     }),
     cache: new InMemoryCache().restore(initialState)
   })

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -52,6 +52,12 @@ export function withApollo (PageComponent, { ssr = true } = {}) {
         pageProps = await PageComponent.getInitialProps(ctx)
       }
 
+      // When redirecting, the response is finished.
+      // No point in continuing to render
+      if (ctx.res && ctx.res.finished) {
+        return pageProps
+      }
+
       // Run all GraphQL queries in the component tree
       // and extract the resulting data:
       if (typeof window === 'undefined') {

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -130,7 +130,6 @@ function createApolloClient (initialState = {}) {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
   const isBrowser = typeof window !== 'undefined'
   return new ApolloClient({
-    connectToDevTools: isBrowser,
     ssrMode: !isBrowser, // Disables forceFetch on the server (so queries are only run once)
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -55,18 +55,16 @@ export function withApollo (PageComponent, { ssr = true } = {}) {
         pageProps = await PageComponent.getInitialProps(ctx)
       }
 
-      // When redirecting, the response is finished.
-      // No point in continuing to render
-      if (ctx.res && ctx.res.finished) {
-        return pageProps
-      }
-
-      // Run all GraphQL queries in the component tree
-      // and extract the resulting data:
+      // Only on the server:
       if (typeof window === 'undefined') {
-        // Only on the server
+        // When redirecting, the response is finished.
+        // No point in continuing to render
+        if (ctx.res && ctx.res.finished) {
+          return pageProps
+        }
+
+        // Only if ssr is enabled
         if (ssr) {
-          // Only if ssr is enabled
           try {
             // Run all GraphQL queries
             const { getDataFromTree } = await import('@apollo/react-ssr')

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -47,6 +47,7 @@ export function withApollo (PageComponent, { ssr = true } = {}) {
       // we can use it in `PageComponent.getInitialProp`.
       const apolloClient = (ctx.apolloClient = initApolloClient())
 
+      // Run wrapped getInitialProps methods
       let pageProps = {}
       if (PageComponent.getInitialProps) {
         pageProps = await PageComponent.getInitialProps(ctx)

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -9,14 +9,16 @@
   "dependencies": {
     "@apollo/react-hooks": "3.0.0",
     "@apollo/react-ssr": "3.0.0",
-    "apollo-boost": "0.4.4",
+    "apollo-cache-inmemory": "1.6.3",
+    "apollo-client": "2.6.4",
+    "apollo-link-http": "1.5.15",
     "graphql": "^14.0.2",
+    "graphql-tag": "2.10.1",
     "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   },
-  "author": "",
   "license": "ISC"
 }

--- a/examples/with-apollo/pages/client-only.js
+++ b/examples/with-apollo/pages/client-only.js
@@ -5,24 +5,27 @@ import Submit from '../components/Submit'
 import PostList from '../components/PostList'
 import { withApollo } from '../lib/apollo'
 
-const IndexPage = props => (
+const ClientOnlyPage = props => (
   <App>
     <Header />
     <InfoBox>
-      ℹ️ This example shows how to fetch all initial apollo queries on the
-      server. If you <a href='/'>reload</a> this page you won't see a loader
-      since Apollo fetched all needed data on the server. This prevents{' '}
+      ℹ️ This example shows how to disable apollos query fetching on the server.
+      If you <a href='/client-only'>reload</a> this page, you will see a loader
+      since Apollo didn't fetch any data on the server. This allows{' '}
       <a
         href='https://nextjs.org/blog/next-9#automatic-static-optimization'
         target='_blank'
       >
         automatic static optimization
-      </a>{' '}
-      in favour of full Server-Side-Rendering.
+      </a>
+      .
     </InfoBox>
     <Submit />
     <PostList />
   </App>
 )
 
-export default withApollo(IndexPage)
+export default withApollo(ClientOnlyPage, {
+  // Disable apollo ssr fetching in favour of automatic static optimization
+  ssr: false
+})


### PR DESCRIPTION
## Motivation

The code before had three design flaws:

* When we skip `WithApollo.getInitialProps` we [must hoist](https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over) `PageComponent.getInitialProps` **if** it is present. (Special thanks to @justinnipper for pointing me into the right direction 🙏.)
* We should expose the `apolloClient` to the underlying `PageComponent.getInitialProps` contexts. This way users are able to use apollo inside `PageComponent.getInitialProps` to perform prerender redirects or similar. (e.g. `await ctx.apolloClient.query(...)`)
* We used the apollo-boost package wich was optimized for client-usage.

## Changelog

- Fix getInitialProps hoisting
- Expose apolloClient in `pageContext`
- Disable connectToDevTools in production
- Remove apollo-boost package
- Remove author entry from package.json
- Simplify fetch polyfill
- Add redirect abort check
- Added no-ssr example
- Added some docs

**Status:** ready
**Related:** #8508, #8504
