### PR TITLE
Update workers for `next export`

### DIFF
--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -3,7 +3,6 @@ import { promisify } from 'util'
 import { extname, join, dirname, sep } from 'path'
 import { renderToHTML } from '../next-server/server/render'
 import { writeFile, access } from 'fs'
-import { Sema } from 'async-sema'
 import AmpHtmlValidator from 'amphtml-validator'
 import { loadComponents } from '../next-server/server/load-components'
 import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
@@ -11,192 +10,180 @@ import { getRouteMatcher } from '../next-server/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../next-server/lib/router/utils/route-regex'
 
 const envConfig = require('../next-server/lib/runtime-config')
-const mkdirp = promisify(mkdirpModule)
 const writeFileP = promisify(writeFile)
+const mkdirp = promisify(mkdirpModule)
 const accessP = promisify(access)
 
 global.__NEXT_DATA__ = {
   nextExport: true
 }
 
-process.on(
-  'message',
-  async ({
-    distDir,
-    buildId,
-    exportPaths,
-    exportPathMap,
-    outDir,
-    renderOpts,
-    serverRuntimeConfig,
-    concurrency,
-    subFolders,
-    serverless
-  }) => {
-    const sema = new Sema(concurrency, { capacity: exportPaths.length })
-    try {
-      const work = async path => {
-        await sema.acquire()
-        let { query = {} } = exportPathMap[path]
-        const { page, sprPage } = exportPathMap[path]
-        const filePath = path === '/' ? '/index' : path
-        const ampPath = `${filePath}.amp`
-
-        // Check if the page is a specified dynamic route
-        if (isDynamicRoute(page) && page !== path) {
-          const params = getRouteMatcher(getRouteRegex(page))(path)
-          if (params) {
-            query = {
-              ...query,
-              ...params
-            }
-          } else {
-            throw new Error(
-              `The provided export path '${path}' doesn't match the '${page}' page.\nRead more: https://err.sh/zeit/next.js/export-path-mismatch`
-            )
-          }
-        }
-
-        const headerMocks = {
-          headers: {},
-          getHeader: () => ({}),
-          setHeader: () => {},
-          hasHeader: () => false,
-          removeHeader: () => {},
-          getHeaderNames: () => []
-        }
-
-        const req = {
-          url: path,
-          ...headerMocks
-        }
-        const res = {
-          ...headerMocks
-        }
-
-        if (sprPage && isDynamicRoute(page)) {
-          query._nextPreviewSkeleton = 1
-          // pass via `req` to avoid adding code to serverless bundle
-          req.url +=
-            (req.url.includes('?') ? '&' : '?') + '_nextPreviewSkeleton=1'
-        }
-
-        envConfig.setConfig({
-          serverRuntimeConfig,
-          publicRuntimeConfig: renderOpts.runtimeConfig
-        })
-
-        let htmlFilename = `${filePath}${sep}index.html`
-        if (!subFolders) htmlFilename = `${filePath}.html`
-
-        const pageExt = extname(page)
-        const pathExt = extname(path)
-        // Make sure page isn't a folder with a dot in the name e.g. `v1.2`
-        if (pageExt !== pathExt && pathExt !== '') {
-          // If the path has an extension, use that as the filename instead
-          htmlFilename = path
-        } else if (path === '/') {
-          // If the path is the root, just use index.html
-          htmlFilename = 'index.html'
-        }
-
-        const baseDir = join(outDir, dirname(htmlFilename))
-        const htmlFilepath = join(outDir, htmlFilename)
-
-        await mkdirp(baseDir)
-        let html
-        let curRenderOpts = {}
-        let renderMethod = renderToHTML
-
-        if (serverless) {
-          renderMethod = require(join(
-            distDir,
-            'serverless/pages',
-            (page === '/' ? 'index' : page) + '.js'
-          )).renderReqToHTML
-          const result = await renderMethod(req, res, true)
-          curRenderOpts = result.renderOpts
-          html = result.html
-        } else {
-          const components = await loadComponents(
-            distDir,
-            buildId,
-            page,
-            serverless
-          )
-
-          if (typeof components.Component === 'string') {
-            html = components.Component
-          } else {
-            curRenderOpts = { ...components, ...renderOpts, ampPath }
-            html = await renderMethod(req, res, page, query, curRenderOpts)
-          }
-        }
-
-        const validateAmp = async (html, page) => {
-          const validator = await AmpHtmlValidator.getInstance()
-          const result = validator.validateString(html)
-          const errors = result.errors.filter(e => e.severity === 'ERROR')
-          const warnings = result.errors.filter(e => e.severity !== 'ERROR')
-
-          if (warnings.length || errors.length) {
-            process.send({
-              type: 'amp-validation',
-              payload: {
-                page,
-                result: {
-                  errors,
-                  warnings
-                }
-              }
-            })
-          }
-        }
-
-        if (curRenderOpts.inAmpMode) {
-          await validateAmp(html, path)
-        } else if (curRenderOpts.hybridAmp) {
-          // we need to render the AMP version
-          let ampHtmlFilename = `${ampPath}${sep}index.html`
-          if (!subFolders) {
-            ampHtmlFilename = `${ampPath}.html`
-          }
-          const ampBaseDir = join(outDir, dirname(ampHtmlFilename))
-          const ampHtmlFilepath = join(outDir, ampHtmlFilename)
-
-          try {
-            await accessP(ampHtmlFilepath)
-          } catch (_) {
-            // make sure it doesn't exist from manual mapping
-            let ampHtml
-            if (serverless) {
-              req.url += (req.url.includes('?') ? '&' : '?') + 'amp=1'
-              ampHtml = (await renderMethod(req, res, true)).html
-            } else {
-              ampHtml = await renderMethod(
-                req,
-                res,
-                page,
-                { ...query, amp: 1 },
-                curRenderOpts
-              )
-            }
-
-            await validateAmp(ampHtml, page + '?amp=1')
-            await mkdirp(ampBaseDir)
-            await writeFileP(ampHtmlFilepath, ampHtml, 'utf8')
-          }
-        }
-
-        await writeFileP(htmlFilepath, html, 'utf8')
-        process.send({ type: 'progress' })
-        sema.release()
-      }
-      await Promise.all(exportPaths.map(work))
-      process.send({ type: 'done' })
-    } catch (err) {
-      console.error(err)
-      process.send({ type: 'error', payload: err })
-    }
+export default async function ({
+  path,
+  pathMap,
+  distDir,
+  buildId,
+  outDir,
+  renderOpts,
+  serverRuntimeConfig,
+  subFolders,
+  serverless
+}) {
+  let results = {
+    ampValidations: []
   }
-)
+
+  try {
+    let { query = {} } = pathMap
+    const { page, sprPage } = pathMap
+    const filePath = path === '/' ? '/index' : path
+    const ampPath = `${filePath}.amp`
+
+    // Check if the page is a specified dynamic route
+    if (isDynamicRoute(page) && page !== path) {
+      const params = getRouteMatcher(getRouteRegex(page))(path)
+      if (params) {
+        query = {
+          ...query,
+          ...params
+        }
+      } else {
+        throw new Error(
+          `The provided export path '${path}' doesn't match the '${page}' page.\nRead more: https://err.sh/zeit/next.js/export-path-mismatch`
+        )
+      }
+    }
+
+    const headerMocks = {
+      headers: {},
+      getHeader: () => ({}),
+      setHeader: () => {},
+      hasHeader: () => false,
+      removeHeader: () => {},
+      getHeaderNames: () => []
+    }
+
+    const req = {
+      url: path,
+      ...headerMocks
+    }
+    const res = {
+      ...headerMocks
+    }
+
+    if (sprPage && isDynamicRoute(page)) {
+      query._nextPreviewSkeleton = 1
+      // pass via `req` to avoid adding code to serverless bundle
+      req.url += (req.url.includes('?') ? '&' : '?') + '_nextPreviewSkeleton=1'
+    }
+
+    envConfig.setConfig({
+      serverRuntimeConfig,
+      publicRuntimeConfig: renderOpts.runtimeConfig
+    })
+
+    let htmlFilename = `${filePath}${sep}index.html`
+    if (!subFolders) htmlFilename = `${filePath}.html`
+
+    const pageExt = extname(page)
+    const pathExt = extname(path)
+    // Make sure page isn't a folder with a dot in the name e.g. `v1.2`
+    if (pageExt !== pathExt && pathExt !== '') {
+      // If the path has an extension, use that as the filename instead
+      htmlFilename = path
+    } else if (path === '/') {
+      // If the path is the root, just use index.html
+      htmlFilename = 'index.html'
+    }
+
+    const baseDir = join(outDir, dirname(htmlFilename))
+    const htmlFilepath = join(outDir, htmlFilename)
+
+    await mkdirp(baseDir)
+    let html
+    let curRenderOpts = {}
+    let renderMethod = renderToHTML
+
+    if (serverless) {
+      renderMethod = require(join(
+        distDir,
+        'serverless/pages',
+        (page === '/' ? 'index' : page) + '.js'
+      )).renderReqToHTML
+      const result = await renderMethod(req, res, true)
+      curRenderOpts = result.renderOpts
+      html = result.html
+    } else {
+      const components = await loadComponents(
+        distDir,
+        buildId,
+        page,
+        serverless
+      )
+
+      if (typeof components.Component === 'string') {
+        html = components.Component
+      } else {
+        curRenderOpts = { ...components, ...renderOpts, ampPath }
+        html = await renderMethod(req, res, page, query, curRenderOpts)
+      }
+    }
+
+    const validateAmp = async (html, page) => {
+      const validator = await AmpHtmlValidator.getInstance()
+      const result = validator.validateString(html)
+      const errors = result.errors.filter(e => e.severity === 'ERROR')
+      const warnings = result.errors.filter(e => e.severity !== 'ERROR')
+
+      if (warnings.length || errors.length) {
+        results.ampValidations.push({
+          page,
+          result: {
+            errors,
+            warnings
+          }
+        })
+      }
+    }
+
+    if (curRenderOpts.inAmpMode) {
+      await validateAmp(html, path)
+    } else if (curRenderOpts.hybridAmp) {
+      // we need to render the AMP version
+      let ampHtmlFilename = `${ampPath}${sep}index.html`
+      if (!subFolders) {
+        ampHtmlFilename = `${ampPath}.html`
+      }
+      const ampBaseDir = join(outDir, dirname(ampHtmlFilename))
+      const ampHtmlFilepath = join(outDir, ampHtmlFilename)
+
+      try {
+        await accessP(ampHtmlFilepath)
+      } catch (_) {
+        // make sure it doesn't exist from manual mapping
+        let ampHtml
+        if (serverless) {
+          req.url += (req.url.includes('?') ? '&' : '?') + 'amp=1'
+          ampHtml = (await renderMethod(req, res, true)).html
+        } else {
+          ampHtml = await renderMethod(
+            req,
+            res,
+            page,
+            { ...query, amp: 1 },
+            curRenderOpts
+          )
+        }
+
+        await validateAmp(ampHtml, page + '?amp=1')
+        await mkdirp(ampBaseDir)
+        await writeFileP(ampHtmlFilepath, ampHtml, 'utf8')
+      }
+    }
+    await writeFileP(htmlFilepath, html, 'utf8')
+    return results
+  } catch (error) {
+    console.error(`\nError occurred prerendering ${path}:`, error)
+    return { ...results, error: true }
+  }
+}

--- a/test/integration/handles-export-errors/pages/index copy 10.js
+++ b/test/integration/handles-export-errors/pages/index copy 10.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 11.js
+++ b/test/integration/handles-export-errors/pages/index copy 11.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 12.js
+++ b/test/integration/handles-export-errors/pages/index copy 12.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 13.js
+++ b/test/integration/handles-export-errors/pages/index copy 13.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 2.js
+++ b/test/integration/handles-export-errors/pages/index copy 2.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 3.js
+++ b/test/integration/handles-export-errors/pages/index copy 3.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 4.js
+++ b/test/integration/handles-export-errors/pages/index copy 4.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 5.js
+++ b/test/integration/handles-export-errors/pages/index copy 5.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 6.js
+++ b/test/integration/handles-export-errors/pages/index copy 6.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 7.js
+++ b/test/integration/handles-export-errors/pages/index copy 7.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 8.js
+++ b/test/integration/handles-export-errors/pages/index copy 8.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy 9.js
+++ b/test/integration/handles-export-errors/pages/index copy 9.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index copy.js
+++ b/test/integration/handles-export-errors/pages/index copy.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/pages/index.js
+++ b/test/integration/handles-export-errors/pages/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => hello.world

--- a/test/integration/handles-export-errors/test/index.test.js
+++ b/test/integration/handles-export-errors/test/index.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+/* global jasmine */
+import path from 'path'
+import { nextBuild } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const appDir = path.join(__dirname, '..')
+
+describe('Handles Errors During Export', () => {
+  it('Does not crash workers', async () => {
+    const { stdout, stderr } = await nextBuild(appDir, [], {
+      stdout: true,
+      stderr: true
+    })
+
+    expect(stdout + stderr).not.toMatch(/ERR_IPC_CHANNEL_CLOSED/)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -9699,26 +9699,6 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-server@9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/next-server/-/next-server-9.0.5.tgz#4b7fe976d0900dd865b3c5777287ccd4df200794"
-  integrity sha512-99+2QXbB0WDw0Oec1LQRVMAsnqcPR7UdJgcMMGrxql/o9w/E4i0lQu7ucEU7ageVnyVqzfjfoNJNhyODyRyOJA==
-  dependencies:
-    "@ampproject/toolbox-optimizer" "1.0.1"
-    compression "1.7.4"
-    content-type "1.0.4"
-    cookie "0.4.0"
-    etag "1.8.1"
-    find-up "4.0.0"
-    fresh "0.5.2"
-    path-to-regexp "2.1.0"
-    prop-types "15.7.2"
-    raw-body "2.4.0"
-    react-is "16.8.6"
-    send "0.17.1"
-    styled-jsx "3.2.1"
-    url "0.11.0"
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -13054,20 +13034,6 @@ strong-log-transformer@^2.0.0:
     duplexer "^0.1.1"
     minimist "^1.2.0"
     through "^2.3.4"
-
-styled-jsx@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.1.tgz#452051fe50df5e9c7c7f3dd20fa46c3060ac65b0"
-  integrity sha512-gM/WOrWYRpWReivzQqetEGohUc/TJSvUoZ5T/UJxJZIsVIPlRQLnp7R8Oue4q49sI08EBRQjQl2oBL3sfdrw2g==
-  dependencies:
-    babel-plugin-syntax-jsx "6.18.0"
-    babel-types "6.26.0"
-    convert-source-map "1.6.0"
-    loader-utils "1.2.3"
-    source-map "0.7.3"
-    string-hash "1.1.3"
-    stylis "3.5.4"
-    stylis-rule-sheet "0.0.10"
 
 styled-jsx@3.2.2:
   version "3.2.2"


### PR DESCRIPTION
This replaces the custom workers set up with `jest-workers` to match our other workers usage. It also cleans up the error logging a bit when an export fails.

Relevant links:
https://spectrum.chat/next-js/general/nextjs-9-build-error~d75762f9-2d71-491f-884f-e1d11305b516