### PR TITLE
Fix yarn workspaces example

### DIFF
--- a/examples/with-yarn-workspaces/now.json
+++ b/examples/with-yarn-workspaces/now.json
@@ -4,6 +4,6 @@
     { "src": "packages/web-app/package.json", "use": "@now/next" }
   ],
   "routes": [
-    { "src": "(.*)", "dest": "packages/web-app/$1" }
+    { "src": "/(.*)", "dest": "packages/web-app/$1" }
   ]
 }

--- a/examples/with-yarn-workspaces/now.json
+++ b/examples/with-yarn-workspaces/now.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "packages/web-app/package.json", "use": "@now/next" }
+  ],
+  "routes": [
+    { "src": "(.*)", "dest": "packages/web-app/$1" }
+  ]
+}

--- a/examples/with-yarn-workspaces/now.json
+++ b/examples/with-yarn-workspaces/now.json
@@ -4,6 +4,6 @@
     { "src": "packages/web-app/package.json", "use": "@now/next" }
   ],
   "routes": [
-    { "src": "/(.*)", "dest": "packages/web-app/$1" }
+    { "src": "(.*)", "dest": "packages/web-app$1", "continue": true }
   ]
 }

--- a/examples/with-yarn-workspaces/packages/web-app/next.config.js
+++ b/examples/with-yarn-workspaces/packages/web-app/next.config.js
@@ -3,6 +3,5 @@ const withTM = require('next-transpile-modules')
 // Tell webpack to compile the "bar" package
 // https://www.npmjs.com/package/next-transpile-modules
 module.exports = withTM({
-  target: 'serverless',
   transpileModules: ['bar']
 })

--- a/examples/with-yarn-workspaces/packages/web-app/next.config.js
+++ b/examples/with-yarn-workspaces/packages/web-app/next.config.js
@@ -3,5 +3,6 @@ const withTM = require('next-transpile-modules')
 // Tell webpack to compile the "bar" package
 // https://www.npmjs.com/package/next-transpile-modules
 module.exports = withTM({
+  target: 'serverless',
   transpileModules: ['bar']
 })


### PR DESCRIPTION
This PR adds `now.json` to `with-yarn-workspaces` example to fix deployment to ZEIT Now.
Fixes: #8615 