### PR TITLE
handleRequest() accepts custom error handler

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -185,7 +185,6 @@ export default class Server {
         res.statusCode = 500
         res.end('Internal Server Error')
       }
-      throw err
     }
   }
 


### PR DESCRIPTION
Allows the next-server `requestHandler` to take an optional `onError` callback function.

This will allow people who are using a custom server alongside Next to handle errors that occur in `/pages/_app` in a different way than just sending the "Internal Server Error" text.

By default, everything should still work as it was before