### PR TITLE
Adds the PnP plugin by default

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -445,6 +445,7 @@ export default async function getBaseWebpackConfig(
         'node_modules',
         ...nodePathList, // Support for NODE_PATH environment variable
       ],
+      plugins: [PnpWebpackPlugin],
     },
     // @ts-ignore this is filtered
     module: {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -10,6 +10,7 @@ import resolve from 'next/dist/compiled/resolve/index.js'
 import path from 'path'
 import crypto from 'crypto'
 import webpack from 'webpack'
+import pnpWebpackPlugin from 'pnp-webpack-plugin'
 
 import {
   DOT_NEXT_ALIAS,
@@ -153,6 +154,7 @@ export default async function getBaseWebpackConfig(
       [DOT_NEXT_ALIAS]: distDir,
     },
     mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
+    plugins: [PnpWebpackPlugin],
   }
 
   const webpackMode = dev ? 'development' : 'production'

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -10,7 +10,8 @@ import resolve from 'next/dist/compiled/resolve/index.js'
 import path from 'path'
 import crypto from 'crypto'
 import webpack from 'webpack'
-import pnpWebpackPlugin from 'pnp-webpack-plugin'
+// @ts-ignore: Currently missing types
+import PnpWebpackPlugin from 'pnp-webpack-plugin'
 
 import {
   DOT_NEXT_ALIAS,

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -96,6 +96,7 @@
     "mkdirp": "0.5.1",
     "node-fetch": "2.6.0",
     "path-to-regexp": "2.1.0",
+    "pnp-webpack-plugin": "1.5.0",
     "prop-types": "15.7.2",
     "prop-types-exact": "1.2.0",
     "raw-body": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10835,6 +10835,13 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+pnp-webpack-plugin@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.5.0.tgz#62a1cd3068f46d564bb33c56eb250e4d586676eb"
+  integrity sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==
+  dependencies:
+    ts-pnp "^1.1.2"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -13583,6 +13590,11 @@ tryer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-pnp@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.4.tgz#ae27126960ebaefb874c6d7fa4729729ab200d90"
+  integrity sha512-1J/vefLC+BWSo+qe8OnJQfWTYRS6ingxjwqmHMqaMxXMj7kFtKLgAaYW3JeX3mktjgUL+etlU8/B4VUAUI9QGw==
 
 tslib@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Using PnP with Webpack 4 currently requires an external plugin (this [will be fixed with Webpack 5](https://github.com/webpack/enhanced-resolve/blob/master/lib/PnpPlugin.js)). This diff adds it by default to avoid users having to configure it manually (which is a significant devx improvement since it must be added to both `resolve.plugins` and `resolveLoader.plugins` instead of the usual `plugins`).

[This](https://github.com/arcanis/pnp-webpack-plugin) is the plugin I'm talking about. Most importantly, it has [zero effect](https://github.com/arcanis/pnp-webpack-plugin/blob/master/index.js#L113-L117) on users that do not operate under PnP settings, so it shouldn't be breaking or anything. It will just unlock some possibilities for new users 🥳