### PR TITLE
Update stats-config to be more deterministic

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -89,6 +89,7 @@ module.exports = {
           path: 'next.config.js',
           content: `
             module.exports = {
+              generateBuildId: () => 'BUILD_ID',
               webpack(config) {
                 config.optimization.minimize = false
                 config.optimization.minimizer = undefined
@@ -109,6 +110,7 @@ module.exports = {
           path: 'next.config.js',
           content: `
             module.exports = {
+              generateBuildId: () => 'BUILD_ID',
               experimental: {
                 modern: true,
                 granularChunks: true
@@ -134,6 +136,7 @@ module.exports = {
           path: 'next.config.js',
           content: `
             module.exports = {
+              generateBuildId: () => 'BUILD_ID',
               target: 'serverless',
               experimental: {
                 modern: true,


### PR DESCRIPTION
Adds `generateBuildId` config to keep the `BUILD_ID` the same each run