### PR TITLE
Delay updating asPath for auto exported pages

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -163,7 +163,11 @@ export default async ({ webpackHMR: passedWebpackHMR } = {}) => {
     await window.__NEXT_PRELOADREADY(dynamicIds)
   }
 
-  router = createRouter(page, query, asPath, {
+  // if auto prerendered and dynamic route wait to update asPath
+  // until after mount to prevent hydration mismatch
+  const initialAsPath = isDynamicRoute(page) && data.nextExport ? page : asPath
+
+  router = createRouter(page, query, initialAsPath, {
     initialProps: props,
     pageLoader,
     App,

--- a/test/integration/auto-export/test/index.test.js
+++ b/test/integration/auto-export/test/index.test.js
@@ -66,12 +66,12 @@ describe('Auto Export', () => {
 
     runTests()
 
-    it('should show hydration warning from mismatching asPath', async () => {
+    it('should not show hydration warning from mismatching asPath', async () => {
       const browser = await webdriver(appPort, '/zeit/cmnt-1')
       await waitFor(500)
 
       const numCaught = await browser.eval(`window.caughtWarns.length`)
-      expect(numCaught).toBe(1)
+      expect(numCaught).toBe(0)
     })
   })
 })

--- a/test/integration/auto-export/test/index.test.js
+++ b/test/integration/auto-export/test/index.test.js
@@ -73,5 +73,12 @@ describe('Auto Export', () => {
       const numCaught = await browser.eval(`window.caughtWarns.length`)
       expect(numCaught).toBe(0)
     })
+
+    it('should update asPath after mount', async () => {
+      const browser = await webdriver(appPort, '/zeit/cmnt-2')
+      await waitFor(500)
+      const html = await browser.eval(`document.documentElement.innerHTML`)
+      expect(html).toMatch(/\/zeit\/cmnt-2/)
+    })
   })
 })


### PR DESCRIPTION
Since we parse the `asPath` from the URL and this value will differ during auto-prerender we need to wait before updating this value similar to the query values to prevent a hydration mismatch

Closes: #8660 