### PR TITLE
Catch all requests in custom server

### DIFF
--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -21,7 +21,7 @@ app.prepare().then(() => {
     return app.render(req, res, '/posts', { id: req.params.id })
   })
 
-  server.get('*', (req, res) => {
+  server.all('*', (req, res) => {
     return handle(req, res)
   })
 

--- a/examples/custom-server-fastify/server.js
+++ b/examples/custom-server-fastify/server.js
@@ -29,7 +29,7 @@ fastify.register((fastify, opts, next) => {
         })
       })
 
-      fastify.get('/*', (req, reply) => {
+      fastify.all('/*', (req, reply) => {
         return app.handleRequest(req.req, reply.res).then(() => {
           reply.sent = true
         })

--- a/examples/custom-server-hapi/server.js
+++ b/examples/custom-server-hapi/server.js
@@ -39,7 +39,7 @@ app.prepare().then(async () => {
   })
 
   server.route({
-    method: 'GET',
+    method: '*',
     path: '/{p*}' /* catch all route */,
     handler: defaultHandlerWrapper(app)
   })

--- a/examples/custom-server-koa/server.js
+++ b/examples/custom-server-koa/server.js
@@ -21,7 +21,7 @@ app.prepare().then(() => {
     ctx.respond = false
   })
 
-  router.get('*', async ctx => {
+  router.all('*', async ctx => {
     await handle(ctx.req, ctx.res)
     ctx.respond = false
   })

--- a/examples/custom-server-polka/server.js
+++ b/examples/custom-server-polka/server.js
@@ -13,7 +13,7 @@ app.prepare().then(() => {
 
   server.get('/b', (req, res) => app.render(req, res, '/b', req.query))
 
-  server.get('*', (req, res) => handle(req, res))
+  server.all('*', (req, res) => handle(req, res))
 
   server.listen(port, err => {
     if (err) throw err


### PR DESCRIPTION
Some users aren't aware they need to edit their custom server example to support various HTTP Methods (e.g. POST for API Routes).

Instead, we should just handle all HTTP Methods out-of-the-box.

---

Closes #8237