### PR TITLE
Lower default concurrency for run-tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,5 +32,5 @@ steps:
     displayName: 'Yarn check'
 
   - script: |
-      node run-tests.js -c 2 -g $(group)
+      node run-tests.js -g $(group)
     displayName: 'Run tests'

--- a/run-tests.js
+++ b/run-tests.js
@@ -8,7 +8,7 @@ const glob = promisify(_glob)
 const exec = promisify(execOrig)
 
 const NUM_RETRIES = 2
-const DEFAULT_CONCURRENCY = 3
+const DEFAULT_CONCURRENCY = 2
 
 ;(async () => {
   let concurrencyIdx = process.argv.indexOf('-c')


### PR DESCRIPTION
The higher concurrency was working in CircleCi for a bit but seems to not be working now so this lowers the default to 2