### PR TITLE
Disable telemetry for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ commands:
               circleci tests glob "test/**/*.test.*" | \
               circleci tests split
             )
+          environment:
+            NEXT_TELEMETRY_DISABLED: '1'
   test_browser:
     parameters:
       browser:
@@ -66,6 +68,7 @@ commands:
           environment:
             BROWSERSTACK: 'true'
             BROWSER_NAME: << parameters.browser >>
+            NEXT_TELEMETRY_DISABLED: '1'
   save_npm_token:
     steps:
       - run:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,9 @@
 pool:
   vmImage: 'vs2017-win2016'
 
+variables:
+  NEXT_TELEMETRY_DISABLED: '1'
+
 strategy:
   maxParallel: 10
   matrix:


### PR DESCRIPTION
This disables telemetry collection for our CI tests (to not clutter it).