### PR TITLE
Add missing Link import to routing doc

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -555,6 +555,8 @@ export default Home
 
 ```jsx
 // pages/about.js
+import Link from 'next/link'
+
 function About() {
   return (
     <>


### PR DESCRIPTION
There was a missing import for Link component for the basic routing example.