### PR TITLE
Make sure renderOpts is available before checking

### DIFF
--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -111,7 +111,7 @@ export default async function ({
         (page === '/' ? 'index' : page) + '.js'
       )).renderReqToHTML
       const result = await renderMethod(req, res, true)
-      curRenderOpts = result.renderOpts
+      curRenderOpts = result.renderOpts || {}
       html = result.html
     } else {
       const components = await loadComponents(

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -146,7 +146,7 @@ export default async function ({
       }
     }
 
-    if (curRenderOpts && curRenderOpts.inAmpMode) {
+    if (curRenderOpts.inAmpMode) {
       await validateAmp(html, path)
     } else if (curRenderOpts.hybridAmp) {
       // we need to render the AMP version

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -146,7 +146,7 @@ export default async function ({
       }
     }
 
-    if (curRenderOpts.inAmpMode) {
+    if (curRenderOpts && curRenderOpts.inAmpMode) {
       await validateAmp(html, path)
     } else if (curRenderOpts.hybridAmp) {
       // we need to render the AMP version


### PR DESCRIPTION
If an error occurs this might be unavailable, so this prevents an extra error from being shown