### PR TITLE
Fix webpack externals resolving

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -316,7 +316,7 @@ export default async function getBaseWebpackConfig(
 
             let res
             try {
-              res = resolveRequest(request, context)
+              res = resolveRequest(request, dir)
             } catch (err) {
               if (
                 request === 'react-ssr-prepass' &&

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -113,6 +113,10 @@ export default async function ({
       const result = await renderMethod(req, res, true)
       curRenderOpts = result.renderOpts || {}
       html = result.html
+
+      if (!html) {
+        throw new Error(`Failed to render serverless page`)
+      }
     } else {
       const components = await loadComponents(
         distDir,

--- a/test/integration/serverless-trace/pages/abc.js
+++ b/test/integration/serverless-trace/pages/abc.js
@@ -1,1 +1,2 @@
-export default () => <div>test</div>
+import { useRouter } from 'next/router'
+export default () => <div>test {useRouter().pathname}</div>


### PR DESCRIPTION
This fixes externals not resolving correctly for `experimental-serverless-trace`. This is due to webpack's provided `context` being used instead of the project's `dir`. Also adds failing test to `serverless-trace` suite and makes sure to throw error when auto-prerendering from a serverless bundle fails

x-ref: #8669 