### PR TITLE
Make sure to fail export when prerender fails with serverless bundle

### DIFF
--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -113,6 +113,10 @@ export default async function ({
       const result = await renderMethod(req, res, true)
       curRenderOpts = result.renderOpts || {}
       html = result.html
+
+      if (!html) {
+        throw new Error(`Failed to render serverless page`)
+      }
     } else {
       const components = await loadComponents(
         distDir,

--- a/test/integration/auto-export-serverless-error/next.config.js
+++ b/test/integration/auto-export-serverless-error/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'serverless'
+}

--- a/test/integration/auto-export-serverless-error/pages/index.js
+++ b/test/integration/auto-export-serverless-error/pages/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+export default () => something.error

--- a/test/integration/auto-export-serverless-error/test/index.test.js
+++ b/test/integration/auto-export-serverless-error/test/index.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs'
+import path from 'path'
+import { nextBuild } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+const appDir = path.join(__dirname, '..')
+
+describe('Auto Export Error Serverless', () => {
+  it('Refreshes query on mount', async () => {
+    await nextBuild(appDir)
+
+    expect(
+      fs.existsSync(path.join(appDir, '.next/serverless/pages/index.html'))
+    ).toBe(false)
+  })
+})

--- a/test/integration/auto-export-serverless-error/test/index.test.js
+++ b/test/integration/auto-export-serverless-error/test/index.test.js
@@ -8,7 +8,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
 const appDir = path.join(__dirname, '..')
 
 describe('Auto Export Error Serverless', () => {
-  it('Refreshes query on mount', async () => {
+  it('fails to emit the page', async () => {
     await nextBuild(appDir)
 
     expect(


### PR DESCRIPTION
This makes sure that the build doesn't fail quietly when an error occurs when prerendering from serverless bundle