### PR TITLE
Prevents externalizing non-hoisted packages

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -336,6 +336,17 @@ export default async function getBaseWebpackConfig(
               return callback()
             }
 
+            let baseRes
+            try {
+              baseRes = resolveRequest(request, dir)
+            } catch (err) {}
+
+            // If the package, when required from the root, would be different from
+            // what the real resolution would use, then we cannot externalize it
+            if (baseRes !== res) {
+              return callback()
+            }
+
             // Default pages have to be transpiled
             if (
               !res.match(/next[/\\]dist[/\\]next-server[/\\]/) &&


### PR DESCRIPTION
This diff ensures that the packages that wouldn't get the correct resolution if required from the root are properly bundled (and thus don't risk requiring the wrong files if they were loaded at runtime via `require`).

Tested manually, it solved the `core-js` error I previously saw.

Fixes #8736 