### PR TITLE
Ensure requests are resolved as directories

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -319,7 +319,7 @@ export default async function getBaseWebpackConfig(
             // exist.
             let res
             try {
-              res = resolveRequest(request, context)
+              res = resolveRequest(request, `${context}/`)
             } catch (err) {
               // This is a special case for the Next.js data experiment. This
               // will be removed in the future.
@@ -354,7 +354,7 @@ export default async function getBaseWebpackConfig(
             // we need to bundle the code (even if it _should_ be external).
             let baseRes
             try {
-              baseRes = resolveRequest(request, dir)
+              baseRes = resolveRequest(request, `${dir}/`)
             } catch (err) {}
 
             // Same as above: if the package, when required from the root,

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -75,8 +75,8 @@ const renames = [
 module.exports = {
   commentHeading: 'Stats from current PR',
   commentReleaseHeading: 'Stats from current release',
-  appBuildCommand: 'yarn next build',
-  appStartCommand: 'yarn next start --port $PORT',
+  appBuildCommand: 'NEXT_TELEMETRY_DISABLED=1 yarn next build',
+  appStartCommand: 'NEXT_TELEMETRY_DISABLED=1 yarn next start --port $PORT',
   mainRepo: 'zeit/next.js',
   mainBranch: 'canary',
   autoMergeMain: true,


### PR DESCRIPTION
`resolveRequest` will strip down to the base directory (`path.basename`) if there's no trailing slash as it assumes you passed a file.