### PR TITLE
Delay asPath populating for non-dynamic pages also

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -85,11 +85,15 @@ class Container extends React.Component {
   componentDidMount () {
     this.scrollToHash()
 
-    // If page was exported and has a querystring
-    // If it's a dynamic route or has a querystring
+    // If page was exported we need to refresh the router information
+    // since it could be a dynamic page that needs to parse params,
+    // new query values could be present, or the asPath could have changed
     if (
       data.nextExport &&
-      (isDynamicRoute(router.pathname) || location.search || data.skeleton)
+      (isDynamicRoute(router.pathname) ||
+        location.search ||
+        data.skeleton ||
+        router.pathname !== asPath)
     ) {
       // update query on mount for exported pages
       router.replace(

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -118,11 +118,10 @@ export default class Router implements BaseRouter {
     this.pageLoader = pageLoader
     this.pathname = pathname
     this.query = query
-    // if auto prerendered and dynamic route wait to update asPath
+    // if auto prerendered wait to update asPath
     // until after mount to prevent hydration mismatch
-    this.asPath =
-      // @ts-ignore this is temporarily global (attached to window)
-      isDynamicRoute(pathname) && __NEXT_DATA__.nextExport ? pathname : as
+    // @ts-ignore this is temporarily global (attached to window)
+    this.asPath = __NEXT_DATA__.nextExport ? pathname : as
     this.sub = subscription
     this.clc = null
     this._wrapApp = wrapApp

--- a/test/integration/custom-server-aspath/pages/a.js
+++ b/test/integration/custom-server-aspath/pages/a.js
@@ -1,0 +1,9 @@
+import { useRouter } from 'next/router'
+
+const Page = () => {
+  const router = useRouter()
+  const { asPath } = router
+  return <p>Hello {asPath}</p>
+}
+
+export default Page

--- a/test/integration/custom-server-aspath/pages/b.js
+++ b/test/integration/custom-server-aspath/pages/b.js
@@ -1,0 +1,9 @@
+import { useRouter } from 'next/router'
+
+const Page = () => {
+  const router = useRouter()
+  const { asPath } = router
+  return <p>Hello {asPath}</p>
+}
+
+export default Page

--- a/test/integration/custom-server-aspath/pages/c.js
+++ b/test/integration/custom-server-aspath/pages/c.js
@@ -1,0 +1,9 @@
+import { useRouter } from 'next/router'
+
+const Page = () => {
+  return <p>Hello {useRouter().asPath}</p>
+}
+
+Page.getInitialProps = () => ({})
+
+export default Page

--- a/test/integration/custom-server-aspath/server.js
+++ b/test/integration/custom-server-aspath/server.js
@@ -1,0 +1,30 @@
+const http = require('http')
+const next = require('next')
+
+const dev = process.env.NODE_ENV !== 'production'
+const port = process.env.PORT || 3000
+const dir = __dirname
+
+const app = next({ dev, dir })
+const handleNextRequests = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = new http.Server((req, res) => {
+    switch (req.url) {
+      case '/a':
+        return app.render(req, res, '/b')
+      case '/b':
+        return app.render(req, res, '/a')
+      case '/d':
+        return app.render(req, res, '/c')
+    }
+    handleNextRequests(req, res)
+  })
+
+  server.listen(port, err => {
+    if (err) {
+      throw err
+    }
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})

--- a/test/integration/custom-server-aspath/test/index.test.js
+++ b/test/integration/custom-server-aspath/test/index.test.js
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+/* global jasmine */
+import webdriver from 'next-webdriver'
+import path from 'path'
+import {
+  initNextServerScript,
+  renderViaHTTP,
+  findPort,
+  killApp,
+  waitFor
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = path.join(__dirname, '../')
+let appPort
+let server
+
+const context = {}
+
+const startServer = async (optEnv = {}) => {
+  const scriptPath = path.join(appDir, 'server.js')
+  context.appPort = appPort = await findPort()
+  const env = Object.assign({}, process.env, { PORT: `${appPort}` }, optEnv)
+
+  server = await initNextServerScript(
+    scriptPath,
+    /ready on/i,
+    env,
+    /ReferenceError: options is not defined/
+  )
+}
+
+describe('Custom Server asPath handling', () => {
+  beforeAll(() => startServer())
+  afterAll(() => killApp(server))
+
+  it('should ignore custom asPath for prerendered pages SSR', async () => {
+    let html = await renderViaHTTP(appPort, '/a')
+    expect(html).toMatch(/Hello.*?\/b/)
+
+    html = await renderViaHTTP(appPort, '/b')
+    expect(html).toMatch(/Hello.*?\/a/)
+  })
+
+  it('should update asPath for prerendered pages after mount CSR', async () => {
+    const browser = await webdriver(appPort, '/a')
+    await waitFor(500)
+    const asPath = await browser.eval(`window.next.router.asPath`)
+    expect(asPath).toBe('/a')
+  })
+
+  it('should allow custom asPath for non-prerendered pages', async () => {
+    const html = await renderViaHTTP(appPort, '/d')
+    expect(html).toMatch(/Hello.*?\/d/)
+  })
+})


### PR DESCRIPTION
Since auto prerendered pages can be served with a different `asPath` than their `pathname` we need to delay updating this value also to prevent breaking hydration

Fixes: #8757