### PR TITLE
Make favicon work

### DIFF
--- a/packages/create-next-app/templates/default/pages/index.js
+++ b/packages/create-next-app/templates/default/pages/index.js
@@ -6,6 +6,7 @@ const Home = () => (
   <div>
     <Head>
       <title>Home</title>
+      <link rel='icon' href='/static/favicon.ico' />
     </Head>
 
     <Nav />


### PR DESCRIPTION
Because favicon.ico is in the /static dir and not / it doesn't show up in the browser without being explicitly called.