### PR TITLE
replaces HOC with `useAuthSync` hook in `with-cookie-auth` example

### DIFF
--- a/examples/with-cookie-auth/pages/profile.js
+++ b/examples/with-cookie-auth/pages/profile.js
@@ -3,10 +3,12 @@ import Router from 'next/router'
 import fetch from 'isomorphic-unfetch'
 import nextCookie from 'next-cookies'
 import Layout from '../components/layout'
-import { withAuthSync } from '../utils/auth'
+import { useAuthSync } from '../utils/auth'
 import getHost from '../utils/get-host'
 
 const Profile = props => {
+  useAuthSync();
+  
   const { name, login, bio, avatarUrl } = props.data
 
   return (
@@ -72,4 +74,4 @@ Profile.getInitialProps = async ctx => {
   }
 }
 
-export default withAuthSync(Profile)
+export default (Profile)

--- a/examples/with-cookie-auth/utils/auth.js
+++ b/examples/with-cookie-auth/utils/auth.js
@@ -35,36 +35,20 @@ export const logout = () => {
   Router.push('/login')
 }
 
-export const withAuthSync = WrappedComponent => {
-  const Wrapper = props => {
-    const syncLogout = event => {
-      if (event.key === 'logout') {
-        console.log('logged out from storage!')
-        Router.push('/login')
-      }
+export const useAuthSync = () =>{
+  const syncLogout = event => {
+    if (event.key === 'logout') {
+      console.log('logged out from storage!')
+      Router.push('/login')
     }
-
-    useEffect(() => {
-      window.addEventListener('storage', syncLogout)
-
-      return () => {
-        window.removeEventListener('storage', syncLogout)
-        window.localStorage.removeItem('logout')
-      }
-    }, [null])
-
-    return <WrappedComponent {...props} />
   }
 
-  Wrapper.getInitialProps = async ctx => {
-    const token = auth(ctx)
+  useEffect(() => {
+    window.addEventListener('storage', syncLogout)
 
-    const componentProps =
-      WrappedComponent.getInitialProps &&
-      (await WrappedComponent.getInitialProps(ctx))
-
-    return { ...componentProps, token }
-  }
-
-  return Wrapper
+    return () => {
+      window.removeEventListener('storage', syncLogout)
+      window.localStorage.removeItem('logout')
+    }
+  }, [])
 }


### PR DESCRIPTION
Hi there! 

I like the last update made to the [with-cookie-auth](https://github.com/zeit/next.js/tree/canary/examples/with-cookie-auth) example, but I think we can always go all the way in replacing the `withAuthSync` HOC with a hook. Right now it does not return any value but could return useful info.