### PR TITLE
fix(examples/with-apollo): fix import error

### DIFF
--- a/examples/with-apollo/lib/init-apollo.js
+++ b/examples/with-apollo/lib/init-apollo.js
@@ -1,4 +1,4 @@
-import { ApolloClient, InMemoryCache, HttpLink } from 'apollo-boost'
+import ApolloClient, { InMemoryCache, HttpLink } from 'apollo-boost'
 import fetch from 'isomorphic-unfetch'
 
 let apolloClient = null


### PR DESCRIPTION
Import `ApolloClient` from default, otherwise some composed features will not work, like `onError`.