### PR TITLE
Run all Azure tests with node v10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,10 @@ strategy:
     node-10-2:
       group: 2/4
       node_version: ^10.10.0
-    node-8-1:
+    node-10-3:
       group: 3/4
       node_version: ^10.10.0
-    node-8-2:
+    node-10-4:
       group: 4/4
       node_version: ^10.10.0
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,17 +8,17 @@ strategy:
   maxParallel: 10
   matrix:
     node-10-1:
-      group: 1/2
+      group: 1/4
       node_version: ^10.10.0
     node-10-2:
-      group: 2/2
+      group: 2/4
       node_version: ^10.10.0
     node-8-1:
-      group: 1/2
-      node_version: ^8.12.0
+      group: 3/4
+      node_version: ^10.10.0
     node-8-2:
-      group: 2/2
-      node_version: ^8.12.0
+      group: 4/4
+      node_version: ^10.10.0
 
 steps:
   - task: NodeTool@0

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -354,10 +354,8 @@ describe('CSS Support', () => {
 
       expect(cssFiles.length).toBe(1)
       const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
-      expect(
-        cssContent.replace(/\/\*.*?\*\//g, '').trim()
-      ).toMatchInlineSnapshot(
-        `".red-text{color:red;background-image:url(static/media/dark.aec5f3c9cc94e82b1ec7e67df51fee37.svg)}.blue-text{color:orange;font-weight:bolder;background-image:url(static/media/light.a3db2506d3b40692ea343b66d8277fb9.svg);color:#00f}"`
+      expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatch(
+        /^\.red-text\{color:red;background-image:url\(static\/media\/dark\.[a-z0-9]{32}\.svg\)\}\.blue-text\{color:orange;font-weight:bolder;background-image:url\(static\/media\/light\.[a-z0-9]{32}\.svg\);color:#00f\}$/
       )
 
       const mediaFiles = await readdir(mediaFolder)


### PR DESCRIPTION
Since we cover node v8 in CircleCi we might be able to speed up Azure by testing only node v10 could potentially test node v8 of windows in GitHub Actions also