### PR TITLE
Fix Experimental CSS Ordering

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -559,7 +559,17 @@ export default async function getBaseWebpackConfig(
               : [
                   // During development we load CSS via JavaScript so we can
                   // hot reload it without refreshing the page.
-                  dev && require.resolve('style-loader'),
+                  dev && {
+                    loader: require.resolve('style-loader'),
+                    options: {
+                      // By default, style-loader injects CSS into the bottom
+                      // of <head>. This causes ordering problems between dev
+                      // and prod. To fix this, we render a <noscript> tag for
+                      // the styles to be placed within. These styles will be
+                      // applied _before_ <style jsx global>.
+                      insert: `#__next_css__DO_NOT_USE__`,
+                    },
+                  },
                   // When building for production we extract CSS into
                   // separate files.
                   !dev && {

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -457,6 +457,13 @@ export class Head extends Component<
             />
             {this.getPreloadDynamicChunks()}
             {this.getPreloadMainLinks()}
+            {this.context._documentProps.isDevelopment &&
+              this.context._documentProps.hasCssMode && (
+                // this element is used to mount development styles so the
+                // ordering matches production
+                // (by default, style-loader injects at the bottom of <head />)
+                <noscript id="__next_css__DO_NOT_USE__" />
+              )}
             {this.getCssLinks()}
             {styles || null}
           </>

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -353,9 +353,8 @@ export class Head extends Component<
                   __html: `body{display:none}`,
                 }}
               />
-              <noscript>
+              <noscript data-next-hydrating>
                 <style
-                  data-next-hydrating
                   dangerouslySetInnerHTML={{
                     __html: `body{display:unset}`,
                   }}

--- a/test/integration/css/fixtures/with-styled-jsx/pages/_app.js
+++ b/test/integration/css/fixtures/with-styled-jsx/pages/_app.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import App from 'next/app'
+import '../styles/global.css'
+
+class MyApp extends App {
+  render () {
+    const { Component, pageProps } = this.props
+    return <Component {...pageProps} />
+  }
+}
+
+export default MyApp

--- a/test/integration/css/fixtures/with-styled-jsx/pages/index.js
+++ b/test/integration/css/fixtures/with-styled-jsx/pages/index.js
@@ -1,0 +1,12 @@
+export default function Home () {
+  return (
+    <>
+      <div className='my-text'>This text should be red.</div>
+      <style jsx global>{`
+        .my-text {
+          color: green;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/test/integration/css/fixtures/with-styled-jsx/pages/index.js
+++ b/test/integration/css/fixtures/with-styled-jsx/pages/index.js
@@ -1,7 +1,7 @@
 export default function Home () {
   return (
     <>
-      <div className='my-text'>This text should be red.</div>
+      <div className='my-text'>This text should be green.</div>
       <style jsx global>{`
         .my-text {
           color: green;

--- a/test/integration/css/fixtures/with-styled-jsx/styles/global.css
+++ b/test/integration/css/fixtures/with-styled-jsx/styles/global.css
@@ -1,0 +1,3 @@
+.my-text {
+  color: red;
+}

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -139,19 +139,19 @@ describe('CSS Support', () => {
 
       const { version, mappings, sourcesContent } = JSON.parse(cssMapContent)
       expect({ version, mappings, sourcesContent }).toMatchInlineSnapshot(`
-                Object {
-                  "mappings": "AAAA,+CACE,4BACE,WACF,CAFA,mBACE,WACF,CAFA,uBACE,WACF,CAFA,wBACE,WACF,CAFA,cACE,WACF,CACF",
-                  "sourcesContent": Array [
-                    "@media (480px <= width < 768px) {
-                  ::placeholder {
-                    color: green;
-                  }
-                }
-                ",
-                  ],
-                  "version": 3,
-                }
-            `)
+        Object {
+          "mappings": "AAAA,+CACE,4BACE,WACF,CAFA,mBACE,WACF,CAFA,uBACE,WACF,CAFA,wBACE,WACF,CAFA,cACE,WACF,CACF",
+          "sourcesContent": Array [
+            "@media (480px <= width < 768px) {
+          ::placeholder {
+            color: green;
+          }
+        }
+        ",
+          ],
+          "version": 3,
+        }
+      `)
     })
   })
 
@@ -402,11 +402,11 @@ describe('CSS Support', () => {
           )
           .sort()
       ).toMatchInlineSnapshot(`
-                        Array [
-                          "dark.svg",
-                          "light.svg",
-                        ]
-                  `)
+        Array [
+          "dark.svg",
+          "light.svg",
+        ]
+      `)
     })
   })
 

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -139,19 +139,19 @@ describe('CSS Support', () => {
 
       const { version, mappings, sourcesContent } = JSON.parse(cssMapContent)
       expect({ version, mappings, sourcesContent }).toMatchInlineSnapshot(`
-        Object {
-          "mappings": "AAAA,+CACE,4BACE,WACF,CAFA,mBACE,WACF,CAFA,uBACE,WACF,CAFA,wBACE,WACF,CAFA,cACE,WACF,CACF",
-          "sourcesContent": Array [
-            "@media (480px <= width < 768px) {
-          ::placeholder {
-            color: green;
-          }
-        }
-        ",
-          ],
-          "version": 3,
-        }
-      `)
+                Object {
+                  "mappings": "AAAA,+CACE,4BACE,WACF,CAFA,mBACE,WACF,CAFA,uBACE,WACF,CAFA,wBACE,WACF,CAFA,cACE,WACF,CACF",
+                  "sourcesContent": Array [
+                    "@media (480px <= width < 768px) {
+                  ::placeholder {
+                    color: green;
+                  }
+                }
+                ",
+                  ],
+                  "version": 3,
+                }
+            `)
     })
   })
 
@@ -402,11 +402,92 @@ describe('CSS Support', () => {
           )
           .sort()
       ).toMatchInlineSnapshot(`
-                Array [
-                  "dark.svg",
-                  "light.svg",
-                ]
-            `)
+                        Array [
+                          "dark.svg",
+                          "light.svg",
+                        ]
+                  `)
+    })
+  })
+
+  describe('Ordering with styled-jsx (dev)', () => {
+    const appDir = join(fixturesDir, 'with-styled-jsx')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    let appPort
+    let app
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(async () => {
+      await killApp(app)
+    })
+
+    it('should have the correct color (css ordering)', async () => {
+      let browser
+      try {
+        browser = await webdriver(appPort, '/')
+        await waitFor(2000) // ensure application hydrates
+
+        const currentColor = await browser.eval(
+          `window.getComputedStyle(document.querySelector('.my-text')).color`
+        )
+        expect(currentColor).toMatchInlineSnapshot(`"rgb(0, 128, 0)"`)
+      } finally {
+        if (browser) {
+          await browser.close()
+        }
+      }
+    })
+  })
+
+  describe('Ordering with styled-jsx (prod)', () => {
+    const appDir = join(fixturesDir, 'with-styled-jsx')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    let appPort
+    let app
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      const server = nextServer({
+        dir: appDir,
+        dev: false,
+        quiet: true
+      })
+
+      app = await startApp(server)
+      appPort = app.address().port
+    })
+    afterAll(async () => {
+      await stopApp(app)
+    })
+
+    it('should have the correct color (css ordering)', async () => {
+      let browser
+      try {
+        browser = await webdriver(appPort, '/')
+        await waitFor(2000) // ensure application hydrates
+
+        const currentColor = await browser.eval(
+          `window.getComputedStyle(document.querySelector('.my-text')).color`
+        )
+        expect(currentColor).toMatchInlineSnapshot(`"rgb(0, 128, 0)"`)
+      } finally {
+        if (browser) {
+          await browser.close()
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
This fixes CSS ordering between development and production.

Before this change, globally imported CSS would come _after_ `<style jsx global>` in development, but _before_ in production.

After this change, it'll always be applied before.