### PR TITLE
Insert <style> tags after anchor element

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -564,10 +564,32 @@ export default async function getBaseWebpackConfig(
                     options: {
                       // By default, style-loader injects CSS into the bottom
                       // of <head>. This causes ordering problems between dev
-                      // and prod. To fix this, we render a <noscript> tag for
-                      // the styles to be placed within. These styles will be
-                      // applied _before_ <style jsx global>.
-                      insert: `#__next_css__DO_NOT_USE__`,
+                      // and prod. To fix this, we render a <noscript> tag as
+                      // an "anchor" for the styles to be placed after. These
+                      // styles will be applied _before_ <style jsx global>.
+                      insert: function(element: Node) {
+                        const parent = document.querySelector('head') as Element
+                        const anchor = document.querySelector(
+                          '#__next_css__DO_NOT_USE__'
+                        )
+
+                        // @ts-ignore
+                        const lastInsert = window.__lastInsertedByStyleLoader
+
+                        if (lastInsert && lastInsert.nextSibling) {
+                          // if a style element was already inserted, insert after
+                          parent.insertBefore(element, lastInsert.nextSibling)
+                        } else if (anchor && anchor.nextSibling) {
+                          // else, insert after the anchor
+                          parent.insertBefore(element, anchor.nextSibling)
+                        } else {
+                          // fallback to inserting in last position into head
+                          parent.appendChild(element)
+                        }
+
+                        // @ts-ignore
+                        window.__lastInsertedByStyleLoader = element
+                      },
                     },
                   },
                   // When building for production we extract CSS into

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -567,7 +567,7 @@ export default async function getBaseWebpackConfig(
                       // and prod. To fix this, we render a <noscript> tag as
                       // an "anchor" for the styles to be placed after. These
                       // styles will be applied _before_ <style jsx global>.
-                      insert: function(element: Node) {
+                      insert: (element: Node) => {
                         const parent = document.querySelector('head') as Element
                         const anchor = document.querySelector(
                           '#__next_css__DO_NOT_USE__'


### PR DESCRIPTION
Related to https://github.com/zeit/next.js/pull/8790

This PR injects the style tags **after** the noscript tag. Before this PR, the style tags were injected **inside** the noscript tag.

This solves a bug where snapshotted + rerendered html of the page is not rendered with the styles applied.