### PR TITLE
Fix typo and wording in README.md

### DIFF
--- a/examples/with-dotenv/README.md
+++ b/examples/with-dotenv/README.md
@@ -44,6 +44,6 @@ This example shows how to inline env vars.
 **Please note**:
 
 - It is a bad practice to commit env vars to a repository. Thats why you should normally [gitignore](https://git-scm.com/docs/gitignore) your `.env` file.
-- In this example, as soon as you reference an env var in your code it will be automatically be publicly available and exposed to the client.
+- In this example, as soon as you reference an env var in your code, it will automatically be made publicly available and exposed to the client.
 - If you want to have more centralized control of what is exposed to the client check out the example [with-universal-configuration-build-time](../with-universal-configuration-build-time).
-- Env vars are set (inlined) at build time. If you need to configure your app on rutime check out [examples/with-universal-configuration-runtime](../with-universal-configuration-runtime).
+- Env vars are set (inlined) at build time. If you need to configure your app at runtime, check out [examples/with-universal-configuration-runtime](../with-universal-configuration-runtime).


### PR DESCRIPTION
The first corrected sentence did not feel very natural.
The second one contained a typo.