### PR TITLE
Add Working with Ghost and Next.js to Recipes

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2673,6 +2673,8 @@ For the production deployment, you can use the same configuration and run `now` 
 - [Dealing with SSR and server only modules](https://arunoda.me/blog/ssr-and-server-only-modules)
 - [Building with React-Material-UI-Next-Express-Mongoose-Mongodb](https://github.com/builderbook/builderbook)
 - [Build a SaaS Product with React-Material-UI-Next-MobX-Express-Mongoose-MongoDB-TypeScript](https://github.com/async-labs/saas)
+- [Working with Ghost and Next.js](https://ghost.org/docs/api/v2/nextjs/)
+
 
 ## FAQ
 


### PR DESCRIPTION
Thought people might want to know how to use the Ghost API with Next.js 🎸

Hoping this is in the right file path. Can I ask if this will get merged into the right branch for the site as well?

Link added: https://ghost.org/docs/api/v2/nextjs/