### PR TITLE
Make withApollo work with _app.js components

### DIFF
--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -34,10 +34,18 @@ export const withApollo = ({ ssr = true } = {}) => PageComponent => {
   if (ssr || PageComponent.getInitialProps) {
     WithApollo.getInitialProps = async ctx => {
       const { AppTree } = ctx
+      const inAppContext = Boolean(ctx.ctx)
 
-      // Initialize ApolloClient, add it to the ctx object so
-      // we can use it in `PageComponent.getInitialProp`.
-      const apolloClient = (ctx.apolloClient = initApolloClient())
+      // Initialize ApolloClient
+      const apolloClient = initApolloClient()
+
+      // Add apolloClient to NextPageContext & NextAppContext
+      // This allows us to consume the apolloClient inside our
+      // custom `getInitialProps({ apolloClient })`.
+      ctx.apolloClient = apolloClient
+      if (inAppContext) {
+        ctx.ctx.apolloClient = apolloClient
+      }
 
       // Run wrapped getInitialProps methods
       let pageProps = {}
@@ -61,7 +69,6 @@ export const withApollo = ({ ssr = true } = {}) => PageComponent => {
 
             // Since AppComponents and PageComponents have different context types
             // we need to modify their props a little.
-            const inAppContext = Boolean(ctx.ctx)
             let props
             if (inAppContext) {
               props = { ...pageProps, apolloClient }

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import App from 'next/app'
 import Head from 'next/head'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { ApolloClient } from 'apollo-client'
@@ -36,6 +37,10 @@ export const withApollo = ({ ssr = true } = {}) => PageComponent => {
       const { AppTree } = ctx
       const inAppContext = Boolean(ctx.ctx)
 
+      if (ctx.apolloClient) {
+        throw new Error('Multiple instances of withApollo found.')
+      }
+
       // Initialize ApolloClient
       const apolloClient = initApolloClient()
 
@@ -51,6 +56,8 @@ export const withApollo = ({ ssr = true } = {}) => PageComponent => {
       let pageProps = {}
       if (PageComponent.getInitialProps) {
         pageProps = await PageComponent.getInitialProps(ctx)
+      } else if (inAppContext) {
+        pageProps = await App.getInitialProps(ctx)
       }
 
       // Only on the server:

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -37,6 +37,15 @@ export const withApollo = ({ ssr = true } = {}) => PageComponent => {
       const { AppTree } = ctx
       const inAppContext = Boolean(ctx.ctx)
 
+      if (process.env.NODE_ENV === 'development') {
+        if (inAppContext) {
+          console.warn(
+            'Warning: You have opted-out of Automatic Static Optimization due to `withApollo` in `pages/_app`.\n' +
+              'Read more: https://err.sh/next.js/opt-out-auto-static-optimization\n'
+          )
+        }
+      }
+
       if (ctx.apolloClient) {
         throw new Error('Multiple instances of withApollo found.')
       }


### PR DESCRIPTION
## Motivation

Since we changed the `withApollo` HOC, there have been a lot of requests, regarding using the old pattern (wrapping `_app.js`). Even though it disables project wide [automatic static optimization](https://nextjs.org/blog/next-9#automatic-static-optimization).

Since it is quite easy to detect if someone wraps an `AppComponent` or an `PageComponent` we should allow both methods. In addition to that it is much easier to migrate between both approaches if the HOC supports both.

This PR allows using the `withApollo` hoc in both ways:

### A. `withApollo(PageComponent)`

**pages/index.js**

```js
import { withApollo } from '../lib/apollo'

export default withApollo(() => (
  <div>I've got apollo context! </div>
))
```

### B. `withApollo(App)` or `withApollo(CustomApp)`

Disables project wide automatic static optimization. Therefore a devonly warning is logged to the console:

> You are using the "withApollo" HOC on "_app.js" level. Please note that this disables project wide automatic static optimization. Better wrap your PageComponents directly.

**pages/_app.js**

```js
import App from 'next/app'
import { withApollo } from '../lib/apollo'
export default withApollo(App)
```

## Related

#8770, #8691

## Added value

- Easier migration path.
- More flexible.
- `ssr: false` on `_app.js` would allows project wide static optimization
- Still enforces best practice (by using an console warning)

------

**Status:** Waiting for feedback


