### PR TITLE
Add Experimental CSS Before Anchor

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -565,30 +565,20 @@ export default async function getBaseWebpackConfig(
                       // By default, style-loader injects CSS into the bottom
                       // of <head>. This causes ordering problems between dev
                       // and prod. To fix this, we render a <noscript> tag as
-                      // an "anchor" for the styles to be placed after. These
+                      // an anchor for the styles to be placed before. These
                       // styles will be applied _before_ <style jsx global>.
                       insert: (element: Node) => {
-                        const parent = document.querySelector('head') as Element
-                        const anchor = document.querySelector(
+                        // These elements should always exist. If they do not,
+                        // this code should fail.
+                        const anchorElement = document.querySelector(
                           '#__next_css__DO_NOT_USE__'
-                        )
+                        )!
+                        const parentNode = anchorElement.parentNode! // Normally <head>
 
-                        // @ts-ignore
-                        const lastInsert = window.__lastInsertedByStyleLoader
-
-                        if (lastInsert && lastInsert.nextSibling) {
-                          // if a style element was already inserted, insert after
-                          parent.insertBefore(element, lastInsert.nextSibling)
-                        } else if (anchor && anchor.nextSibling) {
-                          // else, insert after the anchor
-                          parent.insertBefore(element, anchor.nextSibling)
-                        } else {
-                          // fallback to inserting in last position into head
-                          parent.appendChild(element)
-                        }
-
-                        // @ts-ignore
-                        window.__lastInsertedByStyleLoader = element
+                        // Each style tag should be placed right before our
+                        // anchor. By inserting before and not after, we do not
+                        // need to track the last inserted element.
+                        parentNode.insertBefore(element, anchorElement)
                       },
                     },
                   },


### PR DESCRIPTION
This simplifies the CSS insert function and fixes its edge cases around nextSibling by inserting before the anchor instead of after it.