### PR TITLE
Enable Experimental CSS Source Maps in Dev

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -592,7 +592,7 @@ export default async function getBaseWebpackConfig(
                   // Resolve CSS `@import`s and `url()`s
                   {
                     loader: require.resolve('css-loader'),
-                    options: { importLoaders: 1, sourceMap: !dev },
+                    options: { importLoaders: 1, sourceMap: true },
                   },
 
                   // Compile CSS
@@ -614,7 +614,7 @@ export default async function getBaseWebpackConfig(
                           stage: 3,
                         }),
                       ],
-                      sourceMap: !dev,
+                      sourceMap: true,
                     },
                   },
                 ].filter(Boolean),


### PR DESCRIPTION
Source maps should be enabled in development so that original styles can be inspected.
This is in-line with other Next.js behavior (source maps in dev).

I'm not sure if we really need to "test" this? 🤔 I'll leave it up to the reviewer if they think we need a test.