### PR TITLE
Fix using withRouter in _app opting out of auto prerender

### DIFF
--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -38,6 +38,8 @@ export default function withRouter<
   }
 
   WithRouteWrapper.getInitialProps = ComposedComponent.getInitialProps
+  // This is needed to allow checking for custom getInitialProps in _app
+  ;(WithRouteWrapper as any).origGetInitialProps = (ComposedComponent as any).origGetInitialProps
   if (process.env.NODE_ENV !== 'production') {
     const name =
       ComposedComponent.displayName || ComposedComponent.name || 'Unknown'


### PR DESCRIPTION
Since we don't also add the `origGetInitialProps` we aren't able to compare it when `withRouter` is used in `_app` causing auto prerendering to be disabled

Related thread: https://spectrum.chat/next-js/general/withrouter-on-app-js-causing-all-pages-to-have-getinititialprops~e3b2f445-9f94-4472-823d-f9d5cd4d21d3