### PR TITLE
Remove useMemo from apollo examples

### DIFF
--- a/examples/api-routes-apollo-server-and-client/apollo/client.js
+++ b/examples/api-routes-apollo-server-and-client/apollo/client.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import Head from 'next/head'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { ApolloClient } from 'apollo-client'
@@ -16,10 +16,7 @@ let apolloClient = null
  */
 export function withApollo (PageComponent, { ssr = true } = {}) {
   const WithApollo = ({ apolloClient, apolloState, ...pageProps }) => {
-    const client = useMemo(
-      () => apolloClient || initApolloClient(apolloState),
-      []
-    )
+    const client = apolloClient || initApolloClient(apolloState)
     return (
       <ApolloProvider client={client}>
         <PageComponent {...pageProps} />

--- a/examples/with-apollo-auth/lib/apollo.js
+++ b/examples/with-apollo-auth/lib/apollo.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import cookie from 'cookie'
 import Head from 'next/head'
@@ -19,15 +19,7 @@ import fetch from 'isomorphic-unfetch'
  */
 export function withApollo (PageComponent, { ssr = true } = {}) {
   const WithApollo = ({ apolloClient, apolloState, ...pageProps }) => {
-    const client = useMemo(() => {
-      // We pass in the apolloClient directly when using getDataFromTree
-      if (apolloClient) {
-        return apolloClient
-      }
-
-      // Otherwise initClient using apolloState
-      return initApolloClient(apolloState, { getToken })
-    }, [])
+    const client = apolloClient || initApolloClient(apolloState, { getToken })
     return (
       <ApolloProvider client={client}>
         <PageComponent {...pageProps} />

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import Head from 'next/head'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { ApolloClient } from 'apollo-client'
@@ -18,10 +18,7 @@ let apolloClient = null
  */
 export function withApollo (PageComponent, { ssr = true } = {}) {
   const WithApollo = ({ apolloClient, apolloState, ...pageProps }) => {
-    const client = useMemo(
-      () => apolloClient || initApolloClient(apolloState),
-      []
-    )
+    const client = apolloClient || initApolloClient(apolloState)
     return (
       <ApolloProvider client={client}>
         <PageComponent {...pageProps} />


### PR DESCRIPTION
## Changes

Removes `useMemo` from apollo examples.

## Motivation

We don’t need useMemo here since its functionality is already covered by initApolloClient.

https://github.com/zeit/next.js/blob/d0b982b020394108c178d15943f2728b4aa9de9e/examples/with-apollo/lib/apollo.js#L110-L123

Thanks to @mpoisot

## Affected examples:

- with-apollo
- with-apollo-auth
- api-routes-apollo-server-and-client

closes #8810