### PR TITLE
Ghost URL Typo

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2673,7 +2673,7 @@ For the production deployment, you can use the same configuration and run `now` 
 - [Dealing with SSR and server only modules](https://arunoda.me/blog/ssr-and-server-only-modules)
 - [Building with React-Material-UI-Next-Express-Mongoose-Mongodb](https://github.com/builderbook/builderbook)
 - [Build a SaaS Product with React-Material-UI-Next-MobX-Express-Mongoose-MongoDB-TypeScript](https://github.com/async-labs/saas)
-- [Working with Ghost and Next.js](https://ghost.org/docs/api/v2/nextjs/)
+- [Working with Ghost and Next.js](https://ghost.org/docs/api/nextjs/)
 
 
 ## FAQ


### PR DESCRIPTION
Our documentation uses a specific URL pattern to ensure people are directed to the latest version of our docs, hence the removal of `v2/` in this case. Thanks!