### PR TITLE
Remove extra build logs

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -92,9 +92,6 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   await verifyTypeScriptSetup(dir, pagesDir)
 
-  console.log('Creating an optimized production build ...')
-  console.log()
-
   if (config.experimental.publicDirectory) {
     publicFiles = await recursiveReadDir(publicDir, /.*/)
   }


### PR DESCRIPTION
These didn't get removed when merging the new build indicators and are no longer needed