### PR TITLE
Update to always add SPR pages to prerender-manifest

### DIFF
--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -100,22 +100,12 @@ export default async function ({
     let curRenderOpts = {}
     let renderMethod = renderToHTML
 
-    // eslint-disable-next-line camelcase
-    const renderedDuringBuild = unstable_getStaticProps => {
-      // eslint-disable-next-line camelcase
-      return !buildExport && unstable_getStaticProps && !isDynamicRoute(path)
-    }
-
     if (serverless) {
       const mod = require(join(
         distDir,
         'serverless/pages',
         (page === '/' ? 'index' : page) + '.js'
       ))
-
-      // for non-dynamic SPR pages we should have already
-      // prerendered the file
-      if (renderedDuringBuild(mod.unstable_getStaticProps)) return results
 
       renderMethod = mod.renderReqToHTML
       const result = await renderMethod(req, res, true)
@@ -132,12 +122,6 @@ export default async function ({
         page,
         serverless
       )
-
-      // for non-dynamic SPR pages we should have already
-      // prerendered the file
-      if (renderedDuringBuild(components.unstable_getStaticProps)) {
-        return results
-      }
 
       if (typeof components.Component === 'string') {
         html = components.Component

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -122,6 +122,9 @@ const runTests = (dev = false) => {
 
       expect(manifest.version).toBe(1)
       expect(manifest.routes).toEqual({
+        '/blog/[post]': {
+          initialRevalidateSeconds: 10
+        },
         '/blog/[post3]': {
           initialRevalidateSeconds: 10
         },
@@ -130,6 +133,9 @@ const runTests = (dev = false) => {
         },
         '/blog/post-2': {
           initialRevalidateSeconds: 10
+        },
+        '/blog/[post]/[comment]': {
+          initialRevalidateSeconds: 2
         },
         '/blog/post-1/comment-1': {
           initialRevalidateSeconds: 2


### PR DESCRIPTION
This makes sure all SPR pages are added to the `prerender-manifest`. We initially didn't add this since we weren't sure it would be needed but it ended up being needed