### PR TITLE
Add support for ZEIT Now CI detection

### DIFF
--- a/packages/next/telemetry/anonymous-meta.ts
+++ b/packages/next/telemetry/anonymous-meta.ts
@@ -12,6 +12,7 @@ type AnonymousMeta = {
   cpuSpeed: number | null
   memoryInMb: number
   isDocker: boolean
+  isNowDev: boolean
   isCI: boolean
   ciName: string | null
 }
@@ -24,6 +25,7 @@ export function getAnonymousMeta(): AnonymousMeta {
   }
 
   const cpus = os.cpus() || []
+  const { NOW_REGION } = process.env
   traits = {
     // Software information
     systemPlatform: os.platform(),
@@ -36,6 +38,7 @@ export function getAnonymousMeta(): AnonymousMeta {
     memoryInMb: Math.trunc(os.totalmem() / Math.pow(1024, 2)),
     // Environment information
     isDocker: isDockerFunction(),
+    isNowDev: NOW_REGION === 'dev1',
     isCI: ciEnvironment.isCI,
     ciName: (ciEnvironment.isCI && ciEnvironment.name) || null,
   }

--- a/packages/next/telemetry/anonymous-meta.ts
+++ b/packages/next/telemetry/anonymous-meta.ts
@@ -1,6 +1,7 @@
-import ciEnvironment from 'ci-info'
 import isDockerFunction from 'is-docker'
 import os from 'os'
+
+import * as ciEnvironment from './ci-info'
 
 type AnonymousMeta = {
   systemPlatform: NodeJS.Platform

--- a/packages/next/telemetry/ci-info.ts
+++ b/packages/next/telemetry/ci-info.ts
@@ -1,0 +1,8 @@
+import ciEnvironment from 'ci-info'
+
+const { isCI: _isCI, name: _name } = ciEnvironment
+
+const isZeitNow = !!process.env.NOW_BUILDER
+
+export const isCI = isZeitNow || _isCI
+export const name = isZeitNow ? 'ZEIT Now' : _name

--- a/packages/next/telemetry/storage.ts
+++ b/packages/next/telemetry/storage.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk'
-import ciEnvironment from 'ci-info'
 import Conf from 'conf'
 import { BinaryLike, createHash, randomBytes } from 'crypto'
 import findUp from 'find-up'
@@ -7,6 +6,7 @@ import isDockerFunction from 'is-docker'
 import path from 'path'
 
 import { getAnonymousMeta } from './anonymous-meta'
+import * as ciEnvironment from './ci-info'
 import { _postPayload } from './post-payload'
 import { getProjectId } from './project-id'
 


### PR DESCRIPTION
This adds explicit detection support for ZEIT Now since `ci-info` hasn't merged ZEIT Now support in multiple months: https://github.com/watson/ci-info/pull/37.