### PR TITLE
Better test case for serverless export

### DIFF
--- a/test/integration/auto-export-serverless-error/test/index.test.js
+++ b/test/integration/auto-export-serverless-error/test/index.test.js
@@ -9,10 +9,14 @@ const appDir = path.join(__dirname, '..')
 
 describe('Auto Export Error Serverless', () => {
   it('fails to emit the page', async () => {
-    await nextBuild(appDir)
+    const { stderr } = await nextBuild(appDir, [], {
+      stderr: true
+    })
 
     expect(
       fs.existsSync(path.join(appDir, '.next/serverless/pages/index.html'))
     ).toBe(false)
+    expect(stderr).toContain('ReferenceError')
+    expect(stderr).toContain('Build error occurred')
   })
 })


### PR DESCRIPTION
This checks that the program output actually claims there was a build error.

x-ref: https://github.com/zeit/next.js/pull/8738