### PR TITLE
Remove `stale-if-error` header from SPR

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -533,7 +533,7 @@ export default class Server {
     if (revalidate) {
       res.setHeader(
         'Cache-Control',
-        `s-maxage=${revalidate}, stale-while-revalidate, stale-if-error`
+        `s-maxage=${revalidate}, stale-while-revalidate`
       )
     }
     res.end(payload)


### PR DESCRIPTION
The Now CDN does not support the `stale-if-error` header and already behaves like that for `stale-while-revalidate`.

Removing this header allows Now CDN to use its default headers instead of sending _only_ `stale-if-error` after stripping `s-maxage` and `stale-while-revalidate`.