### PR TITLE
Favicon should have low importance

### DIFF
--- a/packages/create-next-app/templates/default/pages/index.js
+++ b/packages/create-next-app/templates/default/pages/index.js
@@ -6,7 +6,7 @@ const Home = () => (
   <div>
     <Head>
       <title>Home</title>
-      <link rel='icon' href='/static/favicon.ico' />
+      <link rel='shortcut icon' href='/static/favicon.ico' importance='low' />
     </Head>
 
     <Nav />

--- a/packages/create-next-app/templates/default/pages/index.js
+++ b/packages/create-next-app/templates/default/pages/index.js
@@ -6,7 +6,7 @@ const Home = () => (
   <div>
     <Head>
       <title>Home</title>
-      <link rel='shortcut icon' href='/static/favicon.ico' importance='low' />
+      <link rel='icon' href='/static/favicon.ico' importance='low' />
     </Head>
 
     <Nav />


### PR DESCRIPTION
I thought we didn't have a favicon in our template, but apparently we do (this was on my list I reorganized last night and marked as a quick-to-fix).

While I was here, I added `importance=low` and ~fixed the `rel` for IE9 compatibility~.