### PR TITLE
Configure the Default Revalidate

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -405,6 +405,8 @@ export async function renderToHTML(
           )
         }
       } else if (data.revalidate === false) {
+        // `false` is an allowed behavior. We'll catch `revalidate: true` and
+        // fall into our default behavior.
       } else {
         // By default, we revalidate after 1 second. This value is optimal for
         // the most up-to-date page possible, but without a 1-to-1

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -404,6 +404,12 @@ export async function renderToHTML(
             `Warning: A page's revalidate option was set to more than a year. This may have been done in error.\nTo only run getStaticProps at build-time and not revalidate at runtime, you can set \`revalidate\` to \`false\`!`
           )
         }
+      } else if (data.revalidate === false) {
+      } else {
+        // By default, we revalidate after 1 second. This value is optimal for
+        // the most up-to-date page possible, but without a 1-to-1
+        // request-refresh ratio.
+        data.revalidate = 1
       }
 
       props.pageProps = data.props

--- a/test/integration/prerender/pages/default-revalidate.js
+++ b/test/integration/prerender/pages/default-revalidate.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps () {
+  return {
+    props: {
+      world: 'world',
+      time: new Date().getTime()
+    }
+  }
+}
+
+export default ({ world, time }) => (
+  <>
+    <p>hello {world}</p>
+    <span>time: {time}</span>
+    <Link href='/'>
+      <a id='home'>to home</a>
+    </Link>
+    <br />
+    <Link href='/something'>
+      <a id='something'>to something</a>
+    </Link>
+  </>
+)

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -172,6 +172,9 @@ const runTests = (dev = false) => {
         '/another': {
           initialRevalidateSeconds: 0
         },
+        '/default-revalidate': {
+          initialRevalidateSeconds: 1
+        },
         '/something': {
           initialRevalidateSeconds: false
         }


### PR DESCRIPTION
The default revalidate behavior should be configured by Next.js. Otherwise, the behavior might drift or change in non-semver compliant ways between Next.js and the builder (or other 3rd party setups).