### PR TITLE
Add SPR Dynamic Routes to Manifest

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -63,6 +63,7 @@ export type SprRoute = {
 export type PrerenderManifest = {
   version: number
   routes: { [route: string]: SprRoute }
+  dynamicRoutes: string[]
 }
 
 export default async function build(dir: string, conf = null): Promise<void> {
@@ -412,6 +413,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   await writeBuildId(distDir, buildId)
   const finalPrerenderRoutes: { [route: string]: SprRoute } = {}
+  const tbdPrerenderRoutes: string[] = []
 
   if (staticPages.size > 0 || sprPages.size > 0) {
     const combinedPages = [...staticPages, ...sprPages]
@@ -438,6 +440,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
         // Note: prerendering disables automatic static optimization.
         sprPages.forEach(page => {
           if (isDynamicRoute(page)) {
+            tbdPrerenderRoutes.push(page)
             delete defaultMap[page]
           }
         })
@@ -550,6 +553,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     const prerenderManifest: PrerenderManifest = {
       version: 1,
       routes: finalPrerenderRoutes,
+      dynamicRoutes: tbdPrerenderRoutes.sort(),
     }
 
     await fsWriteFile(

--- a/packages/next/next-server/server/spr-cache.ts
+++ b/packages/next/next-server/server/spr-cache.ts
@@ -72,12 +72,12 @@ export function initializeSprCache({
 
   try {
     prerenderManifest = dev
-      ? { routes: {} }
+      ? { routes: {}, dynamicRoutes: [] }
       : JSON.parse(
           fs.readFileSync(path.join(distDir, PRERENDER_MANIFEST), 'utf8')
         )
   } catch (_) {
-    prerenderManifest = { version: 1, routes: {} }
+    prerenderManifest = { version: 1, routes: {}, dynamicRoutes: [] }
   }
 
   cache = new LRUCache({

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -179,6 +179,10 @@ const runTests = (dev = false) => {
           initialRevalidateSeconds: false
         }
       })
+      expect(manifest.dynamicRoutes).toEqual([
+        '/blog/[post]',
+        '/blog/[post]/[comment]'
+      ])
     })
 
     it('outputs prerendered files correctly', async () => {


### PR DESCRIPTION
This adds dynamic routes for SPR pages to the prerender manifest so we can configure the Now Builder (`@now/next`) to handle these routes as SPR routes. Otherwise, they're treated like normal `getInitialProps` pages.

Not a breaking change so I didn't increment the `version`, plus, this is still experimental.