### PR TITLE
Don't remove path in page-config plugin

### DIFF
--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -109,8 +109,6 @@ export default function nextPageConfig({
                   state.bundleDropped = true
                   return
                 }
-                // remove export const config from bundle
-                path.remove()
               },
             },
             state


### PR DESCRIPTION
This can remove non-page config paths unintentionally like `export const meta = {}` so it's better to leave for now