### PR TITLE
Add Express with HTTP/2 example

### DIFF
--- a/examples/custom-server-express-http2/README.md
+++ b/examples/custom-server-express-http2/README.md
@@ -1,0 +1,55 @@
+# Custom Express HTTP/2 Server example
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/segmentio/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
+
+```bash
+npx create-next-app --example custom-server-express-http2 custom-server-express-http2-app
+# or
+yarn create next-app --example custom-server-express-http2 custom-server-express-http2-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/custom-server-express-http2
+cd custom-server-express-http2
+```
+
+Create the public and private keys:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
+  -keyout privateKey.key -out certificate.cert
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## The idea behind the example
+
+Most of the times the default Next server will be enough but sometimes you want to run your own server to customize routes or other kind of the app behavior. Next provides a [Custom server and routing](https://github.com/zeit/next.js#custom-server-and-routing) so you can customize as much as you want.
+
+Because the Next.js server is just a node.js module you can combine it with any other part of the node.js ecosystem. In this case we are using a HTTP/2 server with the spdy package. Beside its name, the package spdy provides support for both http/2 (h2) and spdy (2,3,3.1), and allow to be combined with express to build a custom router on top of Next and serve content through HTTP/2.
+
+The example shows a server that render and serves two single pages when their corresponding route are requested. You can obviously use more advanced express routing strategy depending on your needs.
+
+Since no major browser support HTTP/2 without encryption, don't forget to generate self-signed local certificate for development purpose.

--- a/examples/custom-server-express-http2/package.json
+++ b/examples/custom-server-express-http2/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "custom-server-express-http2",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "release": "cross-env NODE_ENV=production next build",
+    "start": "cross-env NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "compression": "^1.7.4",
+    "express": "^4.17.1",
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0",
+    "spdy": "^4.0.1"
+  },
+  "devDependencies": {
+    "cross-env": "^5.2.0"
+  }
+}

--- a/examples/custom-server-express-http2/pages/about.js
+++ b/examples/custom-server-express-http2/pages/about.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+export default () => (
+  <div>
+    <h3>This is the /about page. </h3>
+    <Link href='/'>
+      <a> &larr; Back home</a>
+    </Link>
+  </div>
+)

--- a/examples/custom-server-express-http2/pages/index.js
+++ b/examples/custom-server-express-http2/pages/index.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+export default () => (
+  <div>
+    <h3>Hello World.</h3>
+    <Link href='/about'>
+      <a>About</a>
+    </Link>
+  </div>
+)

--- a/examples/custom-server-express-http2/server.js
+++ b/examples/custom-server-express-http2/server.js
@@ -1,0 +1,59 @@
+const next = require('next')
+const express = require('express')
+const compression = require('compression')
+const spdy = require('spdy')
+const path = require('path')
+const fs = require('fs')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+// create your own certificate with openssl for development
+const options = {
+  key: fs.readFileSync(path.join(__dirname, '/privateKey.key')),
+  cert: fs.readFileSync(path.join(__dirname, '/certificate.crt'))
+}
+
+const shouldCompress = (req, res) => {
+  // don't compress responses asking explicitly not
+  if (req.headers['x-no-compression']) {
+    return false
+  }
+
+  // use compression filter function
+  return compression.filter(req, res)
+}
+
+app.prepare().then(() => {
+  // create the express app
+  const expressApp = express()
+
+  // set up compression in express
+  expressApp.use(compression({ filter: shouldCompress }))
+
+  // declaring routes for our pages
+  expressApp.get('/', (req, res) => {
+    return app.render(req, res, '/', req.query)
+  })
+  expressApp.get('/about', (req, res) => {
+    return app.render(req, res, '/about', req.query)
+  })
+
+  // fallback all request to next request handler
+  expressApp.all('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  // start the HTTP/2 server with express
+  spdy.createServer(options, expressApp).listen(port, error => {
+    if (error) {
+      console.error(error)
+      return process.exit(1)
+    } else {
+      console.log(`HTTP/2 server listening on port: ${port}`)
+    }
+  })
+})


### PR DESCRIPTION
Since we won't have support for HTTP/2 before (hopefully) Express v5, this is an example of how to build a custom server using Express (v4) in combination with an HTTP/2 server (spdy) to leverage both of their advantages.