### PR TITLE
Update Prerender Manifest

### DIFF
--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -152,37 +152,55 @@ const runTests = (dev = false) => {
       expect(manifest.version).toBe(1)
       expect(manifest.routes).toEqual({
         '/': {
+          dataRoute: '/_next/data/index.json',
           initialRevalidateSeconds: 1
         },
         '/blog/[post3]': {
+          dataRoute: '/_next/data/blog/[post3].json',
           initialRevalidateSeconds: 10
         },
         '/blog/post-1': {
+          dataRoute: '/_next/data/blog/post-1.json',
           initialRevalidateSeconds: 10
         },
         '/blog/post-2': {
+          dataRoute: '/_next/data/blog/post-2.json',
           initialRevalidateSeconds: 10
         },
         '/blog/post-1/comment-1': {
+          dataRoute: '/_next/data/blog/post-1/comment-1.json',
           initialRevalidateSeconds: 2
         },
         '/blog/post-2/comment-2': {
+          dataRoute: '/_next/data/blog/post-2/comment-2.json',
           initialRevalidateSeconds: 2
         },
         '/another': {
+          dataRoute: '/_next/data/another.json',
           initialRevalidateSeconds: 0
         },
         '/default-revalidate': {
+          dataRoute: '/_next/data/default-revalidate.json',
           initialRevalidateSeconds: 1
         },
         '/something': {
+          dataRoute: '/_next/data/something.json',
           initialRevalidateSeconds: false
         }
       })
-      expect(manifest.dynamicRoutes).toEqual([
-        '/blog/[post]',
-        '/blog/[post]/[comment]'
-      ])
+      expect(manifest.dynamicRoutes).toEqual({
+        '/blog/[post]': {
+          dataRoute: '/_next/data/blog/[post].json',
+          dataRouteRegex: '^\\/_next\\/data\\/blog\\/([^\\/]+?)\\.json$',
+          routeRegex: '^\\/blog\\/([^\\/]+?)(?:\\/)?$'
+        },
+        '/blog/[post]/[comment]': {
+          dataRoute: '/_next/data/blog/[post]/[comment].json',
+          dataRouteRegex:
+            '^\\/_next\\/data\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.json$',
+          routeRegex: '^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$'
+        }
+      })
     })
 
     it('outputs prerendered files correctly', async () => {


### PR DESCRIPTION
This updates the prerender manifest, including a few changes:

1. Prerendered routes now contain their data-route equivalent in the manifest
    * It's important we decouple this implementation detail from the builder since it's really Next.js that's dictating it. Right now, the `@now/next` builder assumes to use `/_next/data` -- but that's not going to be true much longer (i.e. build ID).
1. Dynamic (Lazy) Prerendered routes also contain their data-route equivalent ☝️ 
1. Dynamic (Lazy) Prerendered routes now export their route regex.
    * Right now, the `@now/next` builder reaches deep into Next.js' internals to create dynamic route regex. This is really fragile (and already broke once when we dropped `next-server`). Going forward, we need to vendor this information so the builder can be "dumb" and only glue our output manifests to ZEIT Now primitives.

Still haven't bumped the version past `1` since this is all experimental code.