### PR TITLE
Do not mix `null` in `getCssLinks` return value

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -146,26 +146,22 @@ export class Head extends Component<
 
   getCssLinks() {
     const { assetPrefix, files } = this.context._documentProps
-    if (!files || files.length === 0) {
-      return null
-    }
+    const cssFiles =
+      files && files.length ? files.filter(f => /\.css$/.test(f)) : []
 
-    return files.map((file: string) => {
-      // Only render .css files here
-      if (!/\.css$/.test(file)) {
-        return null
-      }
-
-      return (
-        <link
-          key={file}
-          nonce={this.props.nonce}
-          rel="stylesheet"
-          href={`${assetPrefix}/_next/${encodeURI(file)}`}
-          crossOrigin={this.props.crossOrigin || process.crossOrigin}
-        />
-      )
-    })
+    return cssFiles.length === 0
+      ? null
+      : cssFiles.map((file: string) => {
+          return (
+            <link
+              key={file}
+              nonce={this.props.nonce}
+              rel="stylesheet"
+              href={`${assetPrefix}/_next/${encodeURI(file)}`}
+              crossOrigin={this.props.crossOrigin || process.crossOrigin}
+            />
+          )
+        })
   }
 
   getPreloadDynamicChunks() {


### PR DESCRIPTION
Minor nit, but previously the return type was:
```ts
(JSX.Element | null)[] | null
```

Now, it's simply:
```ts
JSX.Element[] | null
```