### PR TITLE
Change default body display setting

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -356,7 +356,7 @@ export class Head extends Component<
               <noscript data-next-hydrating>
                 <style
                   dangerouslySetInnerHTML={{
-                    __html: `body{display:unset}`,
+                    __html: `body{display:block}`,
                   }}
                 />
               </noscript>


### PR DESCRIPTION
This fixes development viewing of no-JavaScript end-users' experience. 

This only affected people using **experimental CSS** -- also, production Next.js builds were not plagued by this.