### PR TITLE
Use Better Telemetry Directory

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -83,12 +83,6 @@ export default async function build(dir: string, conf = null): Promise<void> {
     )
   }
 
-  let backgroundWork: (Promise<any> | undefined)[] = []
-  backgroundWork.push(
-    recordVersion({ cliCommand: 'build' }),
-    recordNextPlugins(path.resolve(dir))
-  )
-
   const buildSpinner = createSpinner({
     prefixText: 'Creating an optimized production build',
   })
@@ -101,6 +95,12 @@ export default async function build(dir: string, conf = null): Promise<void> {
   const publicDir = path.join(dir, 'public')
   const pagesDir = findPagesDir(dir)
   let publicFiles: string[] = []
+
+  let backgroundWork: (Promise<any> | undefined)[] = []
+  backgroundWork.push(
+    recordVersion({ cliCommand: 'build' }),
+    recordNextPlugins(path.resolve(dir))
+  )
 
   await verifyTypeScriptSetup(dir, pagesDir)
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -30,6 +30,7 @@ import {
   recordNextPlugins,
   recordVersion,
 } from '../telemetry/events'
+import { setDistDir as setTelemetryDir } from '../telemetry/storage'
 import { CompilerResult, runCompiler } from './compiler'
 import { createEntrypoints, createPagesMapping } from './entries'
 import { generateBuildId } from './generate-build-id'
@@ -96,6 +97,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   const { target } = config
   const buildId = await generateBuildId(config.generateBuildId, nanoid)
   const distDir = path.join(dir, config.distDir)
+  setTelemetryDir(distDir)
   const publicDir = path.join(dir, 'public')
   const pagesDir = findPagesDir(dir)
   let publicFiles: string[] = []

--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
-import { resolve, join } from 'path'
 import { existsSync } from 'fs'
 import arg from 'next/dist/compiled/arg/index.js'
+import { resolve } from 'path'
+
+import { cliCommand } from '../bin/next'
 import build from '../build'
 import { printAndExit } from '../server/lib/utils'
-import { cliCommand } from '../bin/next'
 
 const nextBuild: cliCommand = argv => {
   const args = arg(

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -10,6 +10,7 @@ import { recursiveCopy } from '../lib/recursive-copy'
 import { recursiveDelete } from '../lib/recursive-delete'
 import { formatAmpMessages } from '../build/output/index'
 import { setDistDir as setTelemetryDir } from '../telemetry/storage'
+import { recordVersion } from '../telemetry/events'
 import loadConfig, {
   isTargetLikeServerless
 } from '../next-server/server/config'
@@ -82,6 +83,10 @@ export default async function (dir, options, configuration) {
   const threads = options.threads || Math.max(cpus().length - 1, 1)
   const distDir = join(dir, nextConfig.distDir)
   setTelemetryDir(distDir)
+  if (!options.buildExport) {
+    recordVersion({ cliCommand: 'export' })
+  }
+
   const subFolders = nextConfig.exportTrailingSlash
   const isLikeServerless = nextConfig.target !== 'server'
 

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -9,6 +9,7 @@ import { existsSync, readFileSync, copyFile as copyFileOrig } from 'fs'
 import { recursiveCopy } from '../lib/recursive-copy'
 import { recursiveDelete } from '../lib/recursive-delete'
 import { formatAmpMessages } from '../build/output/index'
+import { setDistDir as setTelemetryDir } from '../telemetry/storage'
 import loadConfig, {
   isTargetLikeServerless
 } from '../next-server/server/config'
@@ -80,6 +81,7 @@ export default async function (dir, options, configuration) {
   const nextConfig = configuration || loadConfig(PHASE_EXPORT, dir)
   const threads = options.threads || Math.max(cpus().length - 1, 1)
   const distDir = join(dir, nextConfig.distDir)
+  setTelemetryDir(distDir)
   const subFolders = nextConfig.exportTrailingSlash
   const isLikeServerless = nextConfig.target !== 'server'
 

--- a/packages/next/export/index.js
+++ b/packages/next/export/index.js
@@ -82,8 +82,8 @@ export default async function (dir, options, configuration) {
   const nextConfig = configuration || loadConfig(PHASE_EXPORT, dir)
   const threads = options.threads || Math.max(cpus().length - 1, 1)
   const distDir = join(dir, nextConfig.distDir)
-  setTelemetryDir(distDir)
   if (!options.buildExport) {
+    setTelemetryDir(distDir)
     recordVersion({ cliCommand: 'export' })
   }
 

--- a/packages/next/server/next-dev-server.js
+++ b/packages/next/server/next-dev-server.js
@@ -10,6 +10,7 @@ import { ampValidation } from '../build/output/index'
 import * as Log from '../build/output/log'
 import { verifyTypeScriptSetup } from '../lib/verifyTypeScriptSetup'
 import Watchpack from 'watchpack'
+import { setDistDir as setTelemetryDir } from '../telemetry/storage'
 import { recordVersion } from '../telemetry/events'
 import fs from 'fs'
 import {
@@ -188,6 +189,7 @@ export default class DevServer extends Server {
     await this.startWatcher()
     this.setDevReady()
 
+    setTelemetryDir(this.distDir)
     recordVersion({ cliCommand: 'dev' })
   }
 

--- a/packages/next/telemetry/storage.ts
+++ b/packages/next/telemetry/storage.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import Conf from 'conf'
 import { BinaryLike, createHash, randomBytes } from 'crypto'
-import findUp from 'find-up'
 import isDockerFunction from 'is-docker'
 import path from 'path'
 
@@ -9,6 +8,8 @@ import { getAnonymousMeta } from './anonymous-meta'
 import * as ciEnvironment from './ci-info'
 import { _postPayload } from './post-payload'
 import { getProjectId } from './project-id'
+
+let distDir: string | undefined
 
 let config: Conf<any> | undefined
 let projectId: string | undefined
@@ -71,12 +72,10 @@ function setup() {
     return
   }
 
-  let cwd =
-    ciEnvironment.isCI || isDockerFunction()
-      ? // CI environments will normally cache `node_modules/`
-        findUp.sync('node_modules')
+  const cwd =
+    (ciEnvironment.isCI || isDockerFunction()) && distDir
+      ? path.join(distDir, '.cache')
       : undefined
-  if (cwd) cwd = path.join(cwd, '.next')
 
   config = new Conf({ projectName: 'nextjs', cwd })
 
@@ -100,6 +99,10 @@ function setup() {
   }
 
   notify()
+}
+
+export function setDistDir(_distDir: string) {
+  distDir = _distDir
 }
 
 export function computeHash(payload: BinaryLike): string | null {

--- a/packages/next/telemetry/storage.ts
+++ b/packages/next/telemetry/storage.ts
@@ -74,7 +74,7 @@ function setup() {
 
   const cwd =
     (ciEnvironment.isCI || isDockerFunction()) && distDir
-      ? path.join(distDir, '.cache')
+      ? path.join(distDir, 'cache')
       : undefined
 
   config = new Conf({ projectName: 'nextjs', cwd })


### PR DESCRIPTION
So, as it turns out, storing in `node_modules` is a bad idea.

Both npm and Yarn will remove additional files when you run `npm install` or `yarn install`.

Instead, we'll store this inside of Next.js' `distDir`. This should also be cached by users, if it's not, it probably won't be any worse as compared to `node_modules`.