### PR TITLE
Monkey patch `next-sass` and `next-less`

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -892,7 +892,7 @@ export default async function getBaseWebpackConfig(
     }
   }
 
-  // Patch `@zeit/next-sass` and `@zeit/next-css` compatibility
+  // Patch `@zeit/next-sass` and `@zeit/next-less` compatibility
   if (
     !isServer &&
     webpackConfig.module &&

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -968,7 +968,7 @@ export default async function getBaseWebpackConfig(
             }
           }
         } catch (_) {
-          // ooh noo :-(
+          // The error is not required to be handled.
         }
       })
     })


### PR DESCRIPTION
These two legacy Next.js plugins use poor webpack practices: they define plugins without resolving it themselves.

As a result, the resolution root is unknown by webpack and you get into package hoisting bugs.

To fix this, we emulate the logic these packages should've performed themselves on a best-effort basis.

---

Fixes https://github.com/zeit/next-plugins/issues/543
Fixes https://github.com/zeit/next-plugins/issues/541