### PR TITLE
Inline `relayPaintMetrics` function

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -249,10 +249,7 @@ function renderReactElement (reactEl, domEl) {
   } else {
     ReactDOM.render(reactEl, domEl, markRenderComplete)
   }
-  relayPaintMetrics()
-}
 
-function relayPaintMetrics () {
   if (onPerfEntry) {
     performance.getEntriesByType('paint').forEach(onPerfEntry)
   }


### PR DESCRIPTION
This function was only used once. I missed it in review, but this should save us a few bytes.