### PR TITLE
Informative Error for Invalid Global CSS

### DIFF
--- a/errors/global-css.md
+++ b/errors/global-css.md
@@ -1,0 +1,11 @@
+# Global CSS Must Be in Your Custom <App>
+
+#### Why This Error Occurred
+
+An attempt to import Global CSS from a file other than `pages/_app.js` was made.
+
+Global CSS cannot be used in files other than your Custom `<App>` due to its side-effects and ordering problems.
+
+#### Possible Ways to Fix It
+
+Relocate all Global CSS imports to your `pages/_app.js` file.

--- a/packages/next/build/webpack/loaders/error-loader.ts
+++ b/packages/next/build/webpack/loaders/error-loader.ts
@@ -1,0 +1,13 @@
+import loaderUtils from 'loader-utils'
+import { loader } from 'webpack'
+
+const ErrorLoader: loader.Loader = function() {
+  const options = loaderUtils.getOptions(this) || {}
+
+  const { reason = 'An unknown error has occurred' } = options
+
+  const err = new Error(reason)
+  this.emitError(err)
+}
+
+export default ErrorLoader

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -194,7 +194,7 @@ describe('CSS Support', () => {
       })
       expect(stderr).toContain('Failed to compile')
       expect(stderr).toContain('styles/global.css')
-      expect(stderr).toContain('no loaders are configured to process this file')
+      expect(stderr).toContain('Please move all global CSS imports')
     })
   })
 
@@ -211,7 +211,7 @@ describe('CSS Support', () => {
       })
       expect(stderr).toContain('Failed to compile')
       expect(stderr).toContain('styles/global.css')
-      expect(stderr).toContain('no loaders are configured to process this file')
+      expect(stderr).toContain('Please move all global CSS imports')
     })
   })
 
@@ -228,7 +228,7 @@ describe('CSS Support', () => {
       })
       expect(stderr).toContain('Failed to compile')
       expect(stderr).toContain('styles/global.css')
-      expect(stderr).toContain('no loaders are configured to process this file')
+      expect(stderr).toContain('Please move all global CSS imports')
     })
   })
 


### PR DESCRIPTION
This adds a helpful error message with a (basic) err.sh link for invalid Global CSS usage.

We'll want to expand on this topic more and offer alternatives when CSS Modules support lands.

---

There are already tests for invalid CSS handling. I've updated the expected message to be the new variant.

[**It's better to view this DIFF with white space changes turned off.**](https://github.com/zeit/next.js/pull/8958/files?w=1)