### PR TITLE
Convert Export to TypeScript

### DIFF
--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -41,7 +41,7 @@ type AmpStatus = {
   code: string
 }
 
-type AmpPageStatus = {
+export type AmpPageStatus = {
   [page: string]: { errors: AmpStatus[]; warnings: AmpStatus[] }
 }
 

--- a/packages/next/export/index.d.ts
+++ b/packages/next/export/index.d.ts
@@ -1,5 +1,0 @@
-export default function(
-  dir: string,
-  options: any,
-  configuration?: any
-): Promise<void>

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -105,7 +105,7 @@ function normalizeConfig(phase: string, config: any) {
 export default function loadConfig(
   phase: string,
   dir: string,
-  customConfig: any
+  customConfig?: object | null
 ) {
   if (customConfig) {
     return assignDefaults({ configOrigin: 'server', ...customConfig })


### PR DESCRIPTION
This pull request converts Next.js' export CLI command to use TypeScript. This is useful for upcoming changes.