### PR TITLE
Fix Legacy CSS Modules on the Server

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -922,11 +922,7 @@ export default async function getBaseWebpackConfig(
   }
 
   // Patch `@zeit/next-sass` and `@zeit/next-less` compatibility
-  if (
-    !isServer &&
-    webpackConfig.module &&
-    Array.isArray(webpackConfig.module.rules)
-  ) {
+  if (webpackConfig.module && Array.isArray(webpackConfig.module.rules)) {
     ;[].forEach.call(webpackConfig.module.rules, function(
       rule: webpack.RuleSetRule
     ) {


### PR DESCRIPTION
CSS Modules run their loader on the server, so we need to patch both variants of the webpack configuration.