### PR TITLE
Remove default export from constants.d.ts

### DIFF
--- a/packages/next/constants.d.ts
+++ b/packages/next/constants.d.ts
@@ -1,2 +1,1 @@
 export * from './dist/next-server/lib/constants'
-export { default } from './dist/next-server/lib/constants'


### PR DESCRIPTION
`constants.d.ts` is re-exporting a non-existent `default` export from `next-server/lib/constants`, which is breaking VSCode auto-imports for as per https://github.com/microsoft/TypeScript/issues/29227. Making this change with `patch-package` is fixing the issue 🙏 

Is there a different/better way to fix this?

