### PR TITLE
Match `public/static/` folder before `static/`

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -219,6 +219,10 @@ export default class Server {
   }
 
   protected generateRoutes(): Route[] {
+    const publicRoutes = fs.existsSync(this.publicDir)
+      ? this.generatePublicRoutes()
+      : []
+
     const routes: Route[] = [
       {
         match: route('/_next/static/:path*'),
@@ -270,6 +274,7 @@ export default class Server {
           await this.render404(req, res, parsedUrl)
         },
       },
+      ...publicRoutes,
       {
         // It's very important to keep this route's param optional.
         // (but it should support as many params as needed, separated by '/')
@@ -293,10 +298,6 @@ export default class Server {
         },
       },
     ]
-
-    if (fs.existsSync(this.publicDir)) {
-      routes.push(...this.generatePublicRoutes())
-    }
 
     if (this.nextConfig.useFileSystemPublicRoutes) {
       this.dynamicRoutes = this.getDynamicRoutes()

--- a/test/integration/basic/public/static/legacy.txt
+++ b/test/integration/basic/public/static/legacy.txt
@@ -1,0 +1,1 @@
+new static folder

--- a/test/integration/basic/test/public-folder.js
+++ b/test/integration/basic/test/public-folder.js
@@ -6,6 +6,9 @@ export default context => {
     it('should allow access to public files', async () => {
       const data = await renderViaHTTP(context.appPort, '/data/data.txt')
       expect(data).toBe('data')
+
+      const legacy = await renderViaHTTP(context.appPort, '/static/legacy.txt')
+      expect(legacy).toMatch(`new static folder`)
     })
   })
 }

--- a/test/integration/production/public/static/legacy.txt
+++ b/test/integration/production/public/static/legacy.txt
@@ -1,0 +1,1 @@
+new static folder

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -377,8 +377,10 @@ describe('Production Usage', () => {
     it('Should allow access to public files', async () => {
       const data = await renderViaHTTP(appPort, '/data/data.txt')
       const file = await renderViaHTTP(appPort, '/file')
+      const legacy = await renderViaHTTP(appPort, '/static/legacy.txt')
       expect(data).toBe('data')
       expect(file).toBe('test')
+      expect(legacy).toMatch(`new static folder`)
     })
 
     it('should reload the page on page script error', async () => {

--- a/test/integration/serverless/public/static/legacy.txt
+++ b/test/integration/serverless/public/static/legacy.txt
@@ -1,0 +1,1 @@
+new static folder

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -56,6 +56,9 @@ describe('Serverless', () => {
   it('should serve file from public folder', async () => {
     const content = await renderViaHTTP(appPort, '/hello.txt')
     expect(content.trim()).toBe('hello world')
+
+    const legacy = await renderViaHTTP(appPort, '/static/legacy.txt')
+    expect(legacy).toMatch(`new static folder`)
   })
 
   it('should render the page with dynamic import', async () => {


### PR DESCRIPTION
The `public/` directory must be matched before the catch-all `static/` folder.

I've added test cases for Development, Production, and Serverless.

The behavior is already correct in Development & `@now/next` -- only Production was wrong (`static/` catch-all favored before `public/`).

Fixes https://github.com/zeit/next.js/issues/8985