### PR TITLE
Fix Inferno Example – Apply Next.js Aliases to Webpack Config

### DIFF
--- a/examples/using-inferno/next.config.js
+++ b/examples/using-inferno/next.config.js
@@ -7,6 +7,7 @@ module.exports = {
     }
 
     config.resolve.alias = {
+      ...config.resolve.alias,
       react: 'inferno-compat',
       'react-dom': 'inferno-compat'
     }


### PR DESCRIPTION
next build fails on the using-inferno example. 

to replicate:
```
cd examples/using-inferno
npm install
npm run build
```

Error produced:
```
> using-inferno@1.0.0 build /Users/<NAME>/repo/next.js/examples/using-inferno
> next build

Creating an optimized production build  

Failed to compile.

./node_modules/next/dist/build/webpack/loaders/next-client-pages-loader.js?page=%2Fabout&absolutePagePath=private-next-pages%2Fabout.js
Module not found: Can't resolve 'private-next-pages/about.js' in '/Users/<NAME>/repo/next.js/examples/using-inferno'

> Build error occurred
Error: > webpack config.resolve.alias was incorrectly overriden. https://err.sh/zeit/next.js/invalid-resolve-alias
    at build (/Users/<NAME>/repo/next.js/examples/using-inferno/node_modules/next/dist/build/index.js:7:719)
Creating an optimized production build .npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! using-inferno@1.0.0 build: `next build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the using-inferno@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/<NAME>/.npm/_logs/2019-10-07T23_28_24_950Z-debug.log
````

As indicated by https://err.sh/zeit/next.js/invalid-resolve-alias, I added `...config.resolve.alias` and it works as expected.

Side note: Inferno 1.4.0 is from roughly 3 years ago, I can open a separate PR, but I'm not positive on the implications of this yet.
