### PR TITLE
Fix can-not-output-to-public error title

### DIFF
--- a/errors/can-not-output-to-public.md
+++ b/errors/can-not-output-to-public.md
@@ -1,4 +1,4 @@
-# Can't Override Next Props
+# Cannot output to /public
 
 #### Why This Error Occurred
 


### PR DESCRIPTION
Seems like a copy/paste issue.

Not sure about the case and the use of cannot/can’t/can not – haven’t seen a consistent behavior in other error files.