### PR TITLE
Add CSS fixture for src dir

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -664,7 +664,7 @@ export default async function getBaseWebpackConfig(
                             'Custom <App>'
                           )}. Please move all global CSS imports to ${chalk.cyan(
                             customAppFile
-                              ? path.relative(pagesDir, customAppFile)
+                              ? path.relative(dir, customAppFile)
                               : 'pages/_app.js'
                           )}.\n` +
                           `Read more: https://err.sh/next.js/global-css`,

--- a/test/integration/css/fixtures/single-global-src/src/pages/_app.js
+++ b/test/integration/css/fixtures/single-global-src/src/pages/_app.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import App from 'next/app'
+import '../../styles/global.css'
+
+class MyApp extends App {
+  render () {
+    const { Component, pageProps } = this.props
+    return <Component {...pageProps} />
+  }
+}
+
+export default MyApp

--- a/test/integration/css/fixtures/single-global-src/src/pages/index.js
+++ b/test/integration/css/fixtures/single-global-src/src/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home () {
+  return <div className='red-text'>This text should be red.</div>
+}

--- a/test/integration/css/fixtures/single-global-src/styles/global.css
+++ b/test/integration/css/fixtures/single-global-src/styles/global.css
@@ -1,0 +1,3 @@
+.red-text {
+  color: red;
+}

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -44,6 +44,30 @@ describe('CSS Support', () => {
     })
   })
 
+  describe('Basic Global Support with src/ dir', () => {
+    const appDir = join(fixturesDir, 'single-global-src')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    it('should build successfully', async () => {
+      await nextBuild(appDir)
+    })
+
+    it(`should've emitted a single CSS file`, async () => {
+      const cssFolder = join(appDir, '.next/static/css')
+
+      const files = await readdir(cssFolder)
+      const cssFiles = files.filter(f => /\.css$/.test(f))
+
+      expect(cssFiles.length).toBe(1)
+      expect(await readFile(join(cssFolder, cssFiles[0]), 'utf8')).toContain(
+        'color:red'
+      )
+    })
+  })
+
   describe('Multi Global Support', () => {
     const appDir = join(fixturesDir, 'multi-global')
 

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -218,7 +218,9 @@ describe('CSS Support', () => {
       })
       expect(stderr).toContain('Failed to compile')
       expect(stderr).toContain('styles/global.css')
-      expect(stderr).toContain('Please move all global CSS imports')
+      expect(stderr).toMatch(
+        /Please move all global CSS imports.*?pages(\/|\\)_app/
+      )
     })
   })
 
@@ -235,7 +237,9 @@ describe('CSS Support', () => {
       })
       expect(stderr).toContain('Failed to compile')
       expect(stderr).toContain('styles/global.css')
-      expect(stderr).toContain('Please move all global CSS imports')
+      expect(stderr).toMatch(
+        /Please move all global CSS imports.*?pages(\/|\\)_app/
+      )
     })
   })
 


### PR DESCRIPTION
This adds an additional test fixture to the CSS suite for `src` directory support

x-ref: #8999