### PR TITLE
Fix global Bluebird causing HMR connection to fail

### DIFF
--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -366,8 +366,6 @@ export default function onDemandEntryHandler(
           req.on('close', () => {
             clearInterval(pingInterval)
           })
-          // Do initial ping right after EventSource is finished being set up
-          setImmediate(() => runPing())
           next()
         }
       }


### PR DESCRIPTION
When `Bluebird` is used to replace the built-in `Promise` in a custom server it can cause conflicts with the order the middleware is handled for the HMR connection since the `on-demand-entries` was sending the initial ping using `setImmediate`.

It appears there isn't a need for sending the initial ping right away and we can defer it to the normal interval

Fixes: #8835