### PR TITLE
Removes clearing of performance measures

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -302,12 +302,6 @@ function clearMarks () {
   ;['beforeRender', 'afterHydrate', 'afterRender', 'routeChange'].forEach(
     mark => performance.clearMarks(mark)
   )
-  ;[
-    'Next.js-before-hydration',
-    'Next.js-hydration',
-    'Next.js-route-change-to-render',
-    'Next.js-render'
-  ].forEach(measure => performance.clearMeasures(measure))
 }
 
 function AppContainer ({ children }) {


### PR DESCRIPTION
1. Clearing measures will mean we'll have to ensure every site uses perfRelayer to get this information. There's no harm in leaving them present in addition to the relayer in case it's not used
2. The FID PR #8884 will rely on these measures to determine input delay pre + post hydration