### PR TITLE
Test no-path relative CSS imports

### DIFF
--- a/test/integration/css/fixtures/url-global/styles/dark2.svg
+++ b/test/integration/css/fixtures/url-global/styles/dark2.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="114px" height="100px" viewBox="0 0 114 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
+    <title>Logotype - Black</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="100.929941%" y1="181.283245%" x2="41.7687834%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#FFFFFF" offset="0%"></stop>
+            <stop stop-color="#000000" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Black-Triangle" transform="translate(-293.000000, -150.000000)" fill="url(#linearGradient-1)">
+            <polygon id="Logotype---Black" points="350 150 407 250 293 250"></polygon>
+        </g>
+    </g>
+</svg>

--- a/test/integration/css/fixtures/url-global/styles/global1.css
+++ b/test/integration/css/fixtures/url-global/styles/global1.css
@@ -1,4 +1,4 @@
 .red-text {
   color: red;
-  background-image: url('./dark.svg');
+  background-image: url('./dark.svg') url(dark2.svg);
 }

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -486,11 +486,11 @@ describe('CSS Support', () => {
       expect(cssFiles.length).toBe(1)
       const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
       expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatch(
-        /^\.red-text\{color:red;background-image:url\(static\/media\/dark\.[a-z0-9]{32}\.svg\)\}\.blue-text\{color:orange;font-weight:bolder;background-image:url\(static\/media\/light\.[a-z0-9]{32}\.svg\);color:#00f\}$/
+        /^\.red-text\{color:red;background-image:url\(static\/media\/dark\.[a-z0-9]{32}\.svg\) url\(static\/media\/dark2\.[a-z0-9]{32}\.svg\)\}\.blue-text\{color:orange;font-weight:bolder;background-image:url\(static\/media\/light\.[a-z0-9]{32}\.svg\);color:#00f\}$/
       )
 
       const mediaFiles = await readdir(mediaFolder)
-      expect(mediaFiles.length).toBe(2)
+      expect(mediaFiles.length).toBe(3)
       expect(
         mediaFiles
           .map(fileName =>
@@ -503,6 +503,7 @@ describe('CSS Support', () => {
       ).toMatchInlineSnapshot(`
         Array [
           "dark.svg",
+          "dark2.svg",
           "light.svg",
         ]
       `)


### PR DESCRIPTION
This tests the ability to import a relative file without `./`, e.g. `url(dark2.svg)` should imply `url(./dark2.svg)`.

This matches the CSS spec for resolving.