### PR TITLE
Update to error on usage of serverRuntimeConfig with serverless

### DIFF
--- a/errors/serverless-publicRuntimeConfig.md
+++ b/errors/serverless-publicRuntimeConfig.md
@@ -1,8 +1,8 @@
-# Using `publicRuntimeConfig` with `target` set to `serverless`
+# Using `publicRuntimeConfig` or `serverRuntimeConfig` with `target` set to `serverless`
 
 #### Why This Error Occurred
 
-In the `serverless` target environment `next.config.js` is not loaded, so we don't support `publicRuntimeConfig`.
+In the `serverless` target environment `next.config.js` is not loaded, so we don't support `publicRuntimeConfig` or `serverRuntimeConfig`.
 
 #### Possible Ways to Fix It
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2045,7 +2045,7 @@ AuthMethod({ key: process.env.CUSTOM_KEY, secret: process.env.CUSTOM_SECRET })
 
 #### Runtime configuration
 
-> **Warning:** Note that this option is not available when using `target: 'serverless'`
+> **Warning:** Note that these options are not available when using `target: 'serverless'`
 
 > **Warning:** Generally you want to use build-time configuration to provide your configuration.
 > The reason for this is that runtime configuration adds rendering / initialization overhead and is **incompatible with [automatic static optimization](#automatic-static-optimization)**.

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -147,12 +147,14 @@ export default function loadConfig(
     if (
       userConfig.target &&
       userConfig.target !== 'server' &&
-      userConfig.publicRuntimeConfig &&
-      Object.keys(userConfig.publicRuntimeConfig).length !== 0
+      ((userConfig.publicRuntimeConfig &&
+        Object.keys(userConfig.publicRuntimeConfig).length !== 0) ||
+        (userConfig.serverRuntimeConfig &&
+          Object.keys(userConfig.serverRuntimeConfig).length !== 0))
     ) {
       // TODO: change error message tone to "Only compatible with [fat] server mode"
       throw new Error(
-        'Cannot use publicRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'
+        'Cannot use publicRuntimeConfig or serverRuntimeConfig with target=serverless https://err.sh/zeit/next.js/serverless-publicRuntimeConfig'
       )
     }
 

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -143,10 +143,12 @@ export default class Server {
     }
 
     // Initialize next/config with the environment configuration
-    envConfig.setConfig({
-      serverRuntimeConfig,
-      publicRuntimeConfig,
-    })
+    if (this.nextConfig.target === 'server') {
+      envConfig.setConfig({
+        serverRuntimeConfig,
+        publicRuntimeConfig,
+      })
+    }
 
     const routes = this.generateRoutes()
     this.router = new Router(routes)

--- a/test/integration/serverless-runtime-configs/pages/index.js
+++ b/test/integration/serverless-runtime-configs/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi'

--- a/test/integration/serverless-runtime-configs/test/index.test.js
+++ b/test/integration/serverless-runtime-configs/test/index.test.js
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+const nextConfigPath = join(appDir, 'next.config.js')
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const cleanUp = () => fs.remove(nextConfigPath)
+
+describe('Serverless runtime configs', () => {
+  beforeAll(() => cleanUp())
+  afterAll(() => cleanUp())
+
+  it('should error on usage of publicRuntimeConfig', async () => {
+    await fs.writeFile(
+      nextConfigPath,
+      `module.exports = {
+      target: 'serverless',
+      publicRuntimeConfig: {
+        hello: 'world'
+      }
+    }`
+    )
+
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).toMatch(
+      /Cannot use publicRuntimeConfig or serverRuntimeConfig/
+    )
+  })
+
+  it('should error on usage of serverRuntimeConfig', async () => {
+    await fs.writeFile(
+      nextConfigPath,
+      `module.exports = {
+      target: 'serverless',
+      serverRuntimeConfig: {
+        hello: 'world'
+      }
+    }`
+    )
+
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).toMatch(
+      /Cannot use publicRuntimeConfig or serverRuntimeConfig/
+    )
+  })
+})


### PR DESCRIPTION
Since we don't load `next.config.js` for serverless mode we don't support `serverRuntimeConfig` along with `publicRuntimeConfig`