### PR TITLE
Optimize script tags

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -234,7 +234,7 @@ export default async function getBaseWebpackConfig(
           // TODO(atcastle): Analyze if other cache groups should be set to 'all' as well
           chunks: 'all',
           name: 'framework',
-          // This regex ignores nested copies of framework libraries so they're 
+          // This regex ignores nested copies of framework libraries so they're
           // bundled with their issuer.
           // https://github.com/zeit/next.js/pull/9012
           test: /(?<!node_modules.*)[\\/]node_modules[\\/](react|react-dom|scheduler|prop-types)[\\/]/,
@@ -282,7 +282,7 @@ export default async function getBaseWebpackConfig(
           reuseExistingChunk: true,
         },
       },
-      maxInitialRequests: 15,
+      maxInitialRequests: 20,
     },
   }
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -279,7 +279,7 @@ export default async function getBaseWebpackConfig(
           reuseExistingChunk: true,
         },
       },
-      maxInitialRequests: 20,
+      maxInitialRequests: 15,
     },
   }
 

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -141,6 +141,7 @@ export class Head extends Component<
     const { assetPrefix, files } = this.context._documentProps
     const cssFiles =
       files && files.length ? files.filter(f => /\.css$/.test(f)) : []
+
     const cssLinkElements: JSX.Element[] = []
     cssFiles.forEach(file => {
       cssLinkElements.push(
@@ -150,9 +151,7 @@ export class Head extends Component<
           href={`${assetPrefix}/_next/${encodeURI(file)}`}
           as="style"
           crossOrigin={this.props.crossOrigin || process.crossOrigin}
-        />
-      )
-      cssLinkElements.push(
+        />,
         <link
           key={file}
           nonce={this.props.nonce}
@@ -161,9 +160,9 @@ export class Head extends Component<
           crossOrigin={this.props.crossOrigin || process.crossOrigin}
         />
       )
-    }, [])
+    })
 
-    return cssFiles.length === 0 ? null : cssLinkElements
+    return cssLinkElements.length === 0 ? null : cssLinkElements
   }
 
   getPreloadDynamicChunks() {
@@ -200,37 +199,40 @@ export class Head extends Component<
 
   getPreloadMainLinks(): JSX.Element[] | null {
     const { assetPrefix, files } = this.context._documentProps
-    if (!files || files.length === 0) {
-      return null
-    }
     const { _devOnlyInvalidateCacheQueryString } = this.context
 
-    return files
-      .filter((file: string) => {
-        // `dynamicImports` will contain both `.js` and `.module.js` when the
-        // feature is enabled. This clause will filter down to the modern
-        // variants only.
-        // Also filter  out buildManifest because it should not be preloaded for performance reasons
-        return (
-          file.endsWith(getOptionalModernScriptVariant('.js')) &&
-          !file.includes('buildManifest')
-        )
-      })
-      .map((file: string) => {
-        return (
-          <link
-            key={file}
-            nonce={this.props.nonce}
-            rel="preload"
-            href={`${assetPrefix}/_next/${encodeURI(
-              file
-            )}${_devOnlyInvalidateCacheQueryString}`}
-            as="script"
-            crossOrigin={this.props.crossOrigin || process.crossOrigin}
-          />
-        )
-      })
-      .filter(Boolean)
+    const preloadFiles =
+      files && files.length
+        ? files.filter((file: string) => {
+            // `dynamicImports` will contain both `.js` and `.module.js` when
+            // the feature is enabled. This clause will filter down to the
+            // modern variants only.
+            //
+            // Also filter out buildManifest because it should not be preloaded
+            // for performance reasons.
+            return (
+              file.endsWith(getOptionalModernScriptVariant('.js')) &&
+              !file.includes('buildManifest')
+            )
+          })
+        : []
+
+    return preloadFiles.length === 0
+      ? null
+      : preloadFiles.map((file: string) => {
+          return (
+            <link
+              key={file}
+              nonce={this.props.nonce}
+              rel="preload"
+              href={`${assetPrefix}/_next/${encodeURI(
+                file
+              )}${_devOnlyInvalidateCacheQueryString}`}
+              as="script"
+              crossOrigin={this.props.crossOrigin || process.crossOrigin}
+            />
+          )
+        })
   }
 
   render() {

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -208,8 +208,8 @@ export class Head extends Component<
             // the feature is enabled. This clause will filter down to the
             // modern variants only.
             //
-            // Also filter out _buildManifest because it should not be preloaded
-            // for performance reasons.
+            // Also filter out _buildManifest because it should not be
+            // preloaded for performance reasons.
             return (
               file.endsWith(getOptionalModernScriptVariant('.js')) &&
               !file.includes('_buildManifest')

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -208,11 +208,11 @@ export class Head extends Component<
             // the feature is enabled. This clause will filter down to the
             // modern variants only.
             //
-            // Also filter out buildManifest because it should not be preloaded
+            // Also filter out _buildManifest because it should not be preloaded
             // for performance reasons.
             return (
               file.endsWith(getOptionalModernScriptVariant('.js')) &&
-              !file.includes('buildManifest')
+              !file.includes('_buildManifest')
             )
           })
         : []

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -11,9 +11,11 @@ import {
   startApp,
   stopApp,
   File,
-  waitFor
+  waitFor,
+  renderViaHTTP
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
+import cheerio from 'cheerio'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 
@@ -462,6 +464,19 @@ describe('CSS Support', () => {
           await browser.close()
         }
       }
+    })
+
+    it(`should've preloaded the CSS file and injected it in <head>`, async () => {
+      const content = await renderViaHTTP(appPort, '/page2')
+      const $ = cheerio.load(content)
+
+      const cssPreload = $('link[rel="preload"][as="style"]')
+      expect(cssPreload.length).toBe(1)
+      expect(cssPreload.attr('href')).toMatch(/^\/_next\/static\/css\/.*\.css$/)
+
+      const cssSheet = $('link[rel="stylesheet"]')
+      expect(cssSheet.length).toBe(1)
+      expect(cssSheet.attr('href')).toMatch(/^\/_next\/static\/css\/.*\.css$/)
     })
   })
 


### PR DESCRIPTION
This PR updates two things about script loading in _document.tst:

1) This adds an additional <link rel="preload"> tag for each CSS file, directly above the <link rel="stylesheet"> tag that imports it. This is a bit of a hack that will speed up page load in Chrome--currently, the JS assets are downloaded before the CSS file, but adding the extra link tag causes the CSS to get downloaded with priority. That will in some cases speed up first contentful paint without slowing down time to hydration.

2) This removes the preload link for the buildManifest file from granular chunks (https://github.com/zeit/next.js/pull/7696). That file is not needed for hydration, so should be downloaded with a lower priority than the JS files that are.

There's also an update to the maxInitialChunks setting.