### PR TITLE
[Docs] Update static file serving section

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -286,8 +286,6 @@ function MyImage() {
 export default MyImage
 ```
 
-To serve static files from the root directory you can add a folder called `public` and reference those files from the root, e.g: `/robots.txt`.
-
 _Note: Don't name the `public` directory anything else. The name can't be changed and is the only directory that Next.js uses for serving static assets._
 
 ### Dynamic Routing


### PR DESCRIPTION
This block seemed redundant 

```
To serve static files from the root directory you can add a folder called `public` and reference those files from the root, e.g: `/robots.txt`.
```

The block above this already mentions the same thing:
```
Create a folder called `public` in your project root directory. From your code you can then reference those files starting from the baseURL `/`
```

We could add the `robots.txt` example to the first block itself if necessary