### PR TITLE
Remove _document context

### DIFF
--- a/packages/next/next-server/lib/document-context.ts
+++ b/packages/next/next-server/lib/document-context.ts
@@ -1,0 +1,9 @@
+import * as React from 'react'
+import { DocumentProps } from './utils'
+
+type DocumentContext = {
+  readonly _documentProps: DocumentProps
+  readonly _devOnlyInvalidateCacheQueryString: string
+}
+
+export const DocumentContext = React.createContext<DocumentContext>(null as any)

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -4,6 +4,7 @@ import { ComponentType } from 'react'
 import { ParsedUrlQuery } from 'querystring'
 import { ManifestItem } from '../server/render'
 import { NextRouter } from './router/router'
+import { DocumentContext as DocumentComponentContext } from './document-context'
 
 /**
  * Types used by both next and next-server
@@ -20,7 +21,12 @@ export type DocumentType = NextComponentType<
   DocumentContext,
   DocumentInitialProps,
   DocumentProps
->
+> & {
+  renderDocument(
+    Document: DocumentType,
+    props: DocumentProps
+  ): React.ReactElement
+}
 
 export type AppType = NextComponentType<
   AppContextType,

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -209,8 +209,8 @@ function renderDocument(
     '<!DOCTYPE html>' +
     renderToStaticMarkup(
       <AmpStateContext.Provider value={ampState}>
-        <Document
-          __NEXT_DATA__={{
+        {Document.renderDocument(Document, {
+          __NEXT_DATA__: {
             dataManager: dataManagerData,
             props, // The result of getInitialProps
             page: pathname, // The rendered page
@@ -224,21 +224,21 @@ function renderDocument(
             dynamicIds:
               dynamicImportsIds.length === 0 ? undefined : dynamicImportsIds,
             err: err ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
-          }}
-          dangerousAsPath={dangerousAsPath}
-          canonicalBase={canonicalBase}
-          ampPath={ampPath}
-          inAmpMode={inAmpMode}
-          isDevelopment={!!dev}
-          hasCssMode={hasCssMode}
-          hybridAmp={hybridAmp}
-          staticMarkup={staticMarkup}
-          devFiles={devFiles}
-          files={files}
-          dynamicImports={dynamicImports}
-          assetPrefix={assetPrefix}
-          {...docProps}
-        />
+          },
+          dangerousAsPath,
+          canonicalBase,
+          ampPath,
+          inAmpMode,
+          isDevelopment: !!dev,
+          hasCssMode,
+          hybridAmp,
+          staticMarkup,
+          devFiles,
+          files,
+          dynamicImports,
+          assetPrefix,
+          ...docProps,
+        })}
       </AmpStateContext.Provider>
     )
   )


### PR DESCRIPTION
Refactors `_document.js` to use the new style `React.createContext` API. 