### PR TITLE
Fix react-native-web example by adding babel plugin

### DIFF
--- a/examples/with-react-native-web/babel.config.js
+++ b/examples/with-react-native-web/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['next/babel'],
+  plugins: [['react-native-web', { commonjs: true }]]
+}

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -5,9 +5,7 @@ module.exports = {
       // Transform all direct `react-native` imports to `react-native-web`
       'react-native$': 'react-native-web'
     }
-    defaultLoaders.babel.options.plugins = [
-      ['react-native-web', { commonjs: true }]
-    ]
+    config.resolve.extensions.push('.web.js', '.web.ts', '.web.tsx')
     return config
   }
 }

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,10 +1,13 @@
 module.exports = {
-  webpack: config => {
+  webpack: (config, { defaultLoaders }) => {
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
       // Transform all direct `react-native` imports to `react-native-web`
       'react-native$': 'react-native-web'
     }
+    defaultLoaders.babel.options.plugins = [
+      ['react-native-web', { commonjs: true }]
+    ]
     return config
   }
 }

--- a/examples/with-react-native-web/package.json
+++ b/examples/with-react-native-web/package.json
@@ -10,5 +10,8 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-native-web": "^0.11.6"
+  },
+  "devDependencies": {
+    "babel-plugin-react-native-web": "^0.11.7"
   }
 }


### PR DESCRIPTION
# Problem

This example will not compile if `react-native` is also installed in the same directory (you can test by adding `react-native` to this package.json.

It won't compile because babel also needs an alias config for react-native to react-native-web

Compile error without the babel plugin:
```
/Users/b/c/forks/next.js/examples/with-react-native-web/node_modules/react-native/Libraries/Utilities/warnOnce.js:15
const warnedKeys: {[string]: boolean} = {};
      ^^^^^^^^^^

SyntaxError: Missing initializer in const declaration
    at Module._compile (internal/modules/cjs/loader.js:760:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:827:10)
    at Module.load (internal/modules/cjs/loader.js:685:32)
    at Function.Module._load (internal/modules/cjs/loader.js:620:12)
    at Module.require (internal/modules/cjs/loader.js:723:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at Object.<anonymous> (/Users/b/c/forks/next.js/examples/with-react-native-web/node_modules/react-native/Libraries/react-native/react-native-implementation.js:14:18)
    at Module._compile (internal/modules/cjs/loader.js:816:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:827:10)
    at Module.load (internal/modules/cjs/loader.js:685:32)
    at Function.Module._load (internal/modules/cjs/loader.js:620:12)
    at Module.require (internal/modules/cjs/loader.js:723:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at Object.react-native (/Users/b/c/forks/next.js/examples/with-react-native-web/.next/server/static/development/pages/_document.js:8315:18)
    at __webpack_require__ (/Users/b/c/forks/next.js/examples/with-react-native-web/.next/server/static/development/pages/_document.js:23:31)
    at Module../pages/_document.js (/Users/b/c/forks/next.js/examples/with-react-native-web/.next/server/static/development/pages/_document.js:8145:70)
```

# Solution

Add `babel-plugin-react-native-web` which properly configures babel to use react-native-web instead of react-native

**Edit:** This does fix #7276 