### PR TITLE
[using-preact] Update example to Preact X

### DIFF
--- a/examples/using-preact/README.md
+++ b/examples/using-preact/README.md
@@ -1,4 +1,4 @@
-# Hello World example
+# Preact example
 
 ## How to use
 
@@ -43,4 +43,5 @@ This example uses [Preact](https://github.com/developit/preact) instead of React
 
 Here's how we did it:
 
-- Use `next.config.js` to customize our webpack config to support [preact-compat](https://github.com/developit/preact-compat)
+- Use `next.config.js` to customize our webpack config by aliasing React to `preact/compat`
+- Use `server.js` to make our server use Preact by aliasing React to `preact/compat`

--- a/examples/using-preact/next.config.js
+++ b/examples/using-preact/next.config.js
@@ -1,3 +1,13 @@
-const withPreact = require('@zeit/next-preact')
+module.exports = {
+  webpack: function (config) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      react: 'preact/compat',
+      react$: 'preact/compat',
+      'react-dom': 'preact/compat',
+      'react-dom$': 'preact/compat'
+    }
 
-module.exports = withPreact()
+    return config
+  }
+}

--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -7,10 +7,14 @@
     "start": "NODE_ENV=production node server.js"
   },
   "dependencies": {
-    "@zeit/next-preact": "0.1.0",
+    "module-alias": "2.2.2",
     "next": "latest",
-    "preact": "8.2.7",
-    "preact-compat": "3.18.0"
+    "preact": "10.0.0",
+    "preact-render-to-string": "5.0.7"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "react": "16.10.2",
+    "react-dom": "16.10.2"
+  }
 }

--- a/examples/using-preact/server.js
+++ b/examples/using-preact/server.js
@@ -1,7 +1,11 @@
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'
+const moduleAlias = require('module-alias')
 
-require('@zeit/next-preact/alias')()
+moduleAlias.addAliases({
+  react: 'preact/compat',
+  'react-dom': 'preact/compat'
+})
 
 const { createServer } = require('http')
 const { parse } = require('url')


### PR DESCRIPTION
I updated the example to use the newest major of Preact: Preact X, which included the compat library into the core.

I took the liberty to remove the `@zeit/next-preact` lib from the example because:

- The user has more control about what is going on with the aliases
- The user doesn't have to depend on the library to update Preact (the lib has Preact as a `peerDependency` but it is still an issue if you want to update out of the version range)
- Having everything in the example makes it clear and is easier to update

What do you think?

Fixes #9057 