### PR TITLE
Update no-document-title.md

### DIFF
--- a/errors/no-document-title.md
+++ b/errors/no-document-title.md
@@ -10,7 +10,7 @@ Set `<title>` in `pages/_app.js` instead:
 
 ```js
 // pages/_app.js
-import App, { Container } from 'next/app'
+import App from 'next/app'
 import Head from 'next/head'
 import React from 'react'
 
@@ -29,12 +29,12 @@ export default class MyApp extends App {
     const { Component, pageProps } = this.props
 
     return (
-      <Container>
+      <>
         <Head>
           <title>My new cool app</title>
         </Head>
         <Component {...pageProps} />
-      </Container>
+      </>
     )
   }
 }


### PR DESCRIPTION
Remove `Container` component because the `Container` in `_app` has been deprecated.