### PR TITLE
Update legacy _app context

### DIFF
--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -13,7 +13,7 @@ type SingletonRouterBase = {
   ready(cb: () => any): void
 }
 
-export { Router, NextRouter }
+export { Router, RouterContext, NextRouter }
 
 export type SingletonRouter = SingletonRouterBase & NextRouter
 

--- a/packages/next/client/with-router.tsx
+++ b/packages/next/client/with-router.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { NextComponentType, NextPageContext } from '../next-server/lib/utils'
-import { NextRouter } from './router'
+import { NextRouter, RouterContext } from './router'
 
 export type WithRouterProps = {
   router: NextRouter
@@ -21,19 +20,12 @@ export default function withRouter<
   class WithRouteWrapper extends React.Component<ExcludeRouterProps<P>> {
     static displayName?: string
     static getInitialProps?: any
-    static contextTypes = {
-      router: PropTypes.object,
-    }
+    static contextType = RouterContext
 
-    context!: WithRouterProps
+    context!: React.ContextType<typeof RouterContext>
 
     render() {
-      return (
-        <ComposedComponent
-          router={this.context.router}
-          {...this.props as any}
-        />
-      )
+      return <ComposedComponent router={this.context} {...this.props as any} />
     }
   }
 

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -1,5 +1,4 @@
 import React, { ErrorInfo } from 'react'
-import PropTypes from 'prop-types'
 import {
   execOnce,
   loadGetInitialProps,
@@ -7,7 +6,7 @@ import {
   AppInitialProps,
   AppPropsType,
 } from '../next-server/lib/utils'
-import { Router, makePublicRouterInstance } from '../client/router'
+import { Router } from '../client/router'
 
 export { AppInitialProps }
 
@@ -31,17 +30,8 @@ export default class App<P = {}, CP = {}, S = {}> extends React.Component<
   P & AppProps<CP>,
   S
 > {
-  static childContextTypes = {
-    router: PropTypes.object,
-  }
   static origGetInitialProps = appGetInitialProps
   static getInitialProps = appGetInitialProps
-
-  getChildContext() {
-    return {
-      router: makePublicRouterInstance(this.props.router),
-    }
-  }
 
   // Kept here for backwards compatibility.
   // When someone ended App they could call `super.componentDidCatch`.

--- a/test/integration/build-stats-output/test/index.test.js
+++ b/test/integration/build-stats-output/test/index.test.js
@@ -9,6 +9,6 @@ const appDir = join(__dirname, '../react-site')
 describe('Build Stats Output', () => {
   it('Shows correct package count in output', async () => {
     const { stdout } = await nextBuild(appDir, undefined, { stdout: true })
-    expect(stdout).toMatch(/\/something .*?5/)
+    expect(stdout).toMatch(/\/something .*?4/)
   })
 })


### PR DESCRIPTION
In order to introduce `<StrictMode>`, we need to clean up the existing warnings. One of those warnings is about the legacy context introduced by `_app.js`.

We don't actually need this because:
1. It's an undocumented API
2. The router is already available via the new-style `RouterContext` in order to support e.g. the `useRouter` hook

So this PR removes it from `_app`, and updates the `withRouter` function to use the new context object instead.