### PR TITLE
Temporary: SPR: Use Group Index Mapping

### DIFF
--- a/test/integration/serverless/pages/dr/[slug].js
+++ b/test/integration/serverless/pages/dr/[slug].js
@@ -1,0 +1,5 @@
+const SlugPage = ({ query }) => <div>{JSON.stringify(query)}</div>
+
+SlugPage.getInitialProps = ({ query }) => ({ query })
+
+export default SlugPage


### PR DESCRIPTION
This pull request is a temporary addition that uses the `x-now-route-params` header in serverless.

This header returns the regex groups with indexes, not their named variants.
As a result, we must use the `getRouteMatcher` utility to reverse this into Next.js' expected names.

Since this got complex, I've added a test for it. We should probably remove this behavior sooner than later.