### PR TITLE
Fix SPR always revalidating in production

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -594,6 +594,7 @@ export default class Server {
 
     // Complete the response with cached data if its present
     const cachedData = await getSprCache(sprCacheKey)
+
     if (cachedData) {
       const data = isSprData
         ? JSON.stringify(cachedData.pageData)

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -594,7 +594,6 @@ export default class Server {
 
     // Complete the response with cached data if its present
     const cachedData = await getSprCache(sprCacheKey)
-
     if (cachedData) {
       const data = isSprData
         ? JSON.stringify(cachedData.pageData)

--- a/packages/next/next-server/server/spr-cache.ts
+++ b/packages/next/next-server/server/spr-cache.ts
@@ -35,7 +35,7 @@ export const calculateRevalidate = (pathname: string): number | false => {
   // in development we don't have a prerender-manifest
   // and default to always revalidating to allow easier debugging
   const curTime = new Date().getTime()
-  if (!sprOptions.dev) return curTime
+  if (sprOptions.dev) return curTime
 
   const { initialRevalidateSeconds } = prerenderManifest.routes[pathname] || {
     initialRevalidateSeconds: 1,
@@ -157,9 +157,11 @@ export async function setSprCache(
   }
 
   pathname = normalizePagePath(pathname)
+  const revalidateAfter = calculateRevalidate(pathname)
+
   cache.set(pathname, {
     ...data,
-    revalidateAfter: calculateRevalidate(pathname),
+    revalidateAfter,
   })
 
   // TODO: This option needs to cease to exist unless it stops mutating the

--- a/packages/next/next-server/server/spr-cache.ts
+++ b/packages/next/next-server/server/spr-cache.ts
@@ -157,11 +157,9 @@ export async function setSprCache(
   }
 
   pathname = normalizePagePath(pathname)
-  const revalidateAfter = calculateRevalidate(pathname)
-
   cache.set(pathname, {
     ...data,
-    revalidateAfter,
+    revalidateAfter: calculateRevalidate(pathname),
   })
 
   // TODO: This option needs to cease to exist unless it stops mutating the

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -259,17 +259,33 @@ const runTests = (dev = false) => {
       expect(new Set(vals).size).toBe(1)
     })
 
+    it('should not revalidate when set to false', async () => {
+      const route = '/something'
+      const initialHtml = await renderViaHTTP(appPort, route)
+      let newHtml = await renderViaHTTP(appPort, route)
+      expect(initialHtml).toBe(newHtml)
+
+      newHtml = await renderViaHTTP(appPort, route)
+      expect(initialHtml).toBe(newHtml)
+
+      newHtml = await renderViaHTTP(appPort, route)
+      expect(initialHtml).toBe(newHtml)
+    })
+
     it('should handle revalidating HTML correctly', async () => {
       const route = '/blog/post-1/comment-1'
       const initialHtml = await renderViaHTTP(appPort, route)
       expect(initialHtml).toMatch(/Post:.*?post-1/)
       expect(initialHtml).toMatch(/Comment:.*?comment-1/)
 
+      let newHtml = await renderViaHTTP(appPort, route)
+      expect(newHtml).toBe(initialHtml)
+
       await waitFor(2 * 1000)
       await renderViaHTTP(appPort, route)
 
       await waitFor(2 * 1000)
-      const newHtml = await renderViaHTTP(appPort, route)
+      newHtml = await renderViaHTTP(appPort, route)
       expect(newHtml === initialHtml).toBe(false)
       expect(newHtml).toMatch(/Post:.*?post-1/)
       expect(newHtml).toMatch(/Comment:.*?comment-1/)
@@ -281,11 +297,14 @@ const runTests = (dev = false) => {
       expect(initialJson).toMatch(/post-2/)
       expect(initialJson).toMatch(/comment-3/)
 
+      let newJson = await renderViaHTTP(appPort, route)
+      expect(newJson).toBe(initialJson)
+
       await waitFor(2 * 1000)
       await renderViaHTTP(appPort, route)
 
       await waitFor(2 * 1000)
-      const newJson = await renderViaHTTP(appPort, route)
+      newJson = await renderViaHTTP(appPort, route)
       expect(newJson === initialJson).toBe(false)
       expect(newJson).toMatch(/post-2/)
       expect(newJson).toMatch(/comment-3/)


### PR DESCRIPTION
This fixes SPR pages not honoring the revalidate period and adds tests to make sure the content isn't always being updated in production