### PR TITLE
Add test for public router fields during SSR

### DIFF
--- a/test/integration/with-router/pages/ssr.js
+++ b/test/integration/with-router/pages/ssr.js
@@ -1,0 +1,6 @@
+import * as React from 'react'
+import { withRouter } from 'next/router'
+
+export default withRouter(function SSR ({ router }) {
+  return <span>{`Pathname: ${router.pathname}`}</span>
+})

--- a/test/integration/with-router/test/index.test.js
+++ b/test/integration/with-router/test/index.test.js
@@ -10,7 +10,8 @@ import {
   killApp,
   nextBuild,
   startApp,
-  stopApp
+  stopApp,
+  renderViaHTTP
 } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
@@ -108,5 +109,10 @@ describe('withRouter SSR', () => {
       `No router instance found. you should only use "next/router" inside the client side of your app. https://err.sh/`
     )
     await browser.close()
+  })
+
+  it('should resolve public fields', async () => {
+    const html = await renderViaHTTP(port, '/ssr')
+    expect(html).toMatch(/Pathname: \/ssr/)
   })
 })


### PR DESCRIPTION
Ensures that public router fields like `pathname` are correctly set during SSR.