### PR TITLE
Don't mark page as nextExport if it's SPR

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -313,6 +313,7 @@ export async function renderToHTML(
     }
   }
   if (isAutoExport) renderOpts.autoExport = true
+  if (isSpr) renderOpts.nextExport = false
 
   await Loadable.preloadAll() // Make sure all dynamic imports are loaded
 

--- a/test/integration/prerender/pages/blog/[post]/index.js
+++ b/test/integration/prerender/pages/blog/[post]/index.js
@@ -18,6 +18,10 @@ export async function unstable_getStaticProps ({ params }) {
     })
   }
 
+  if (params.post === 'post-100') {
+    throw new Error('such broken..')
+  }
+
   return {
     props: {
       post: params.post,

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -327,6 +327,14 @@ const runTests = (dev = false) => {
       expect(newJson).toMatch(/post-2/)
       expect(newJson).toMatch(/comment-3/)
     })
+
+    it('should not fetch prerender data on mount', async () => {
+      const browser = await webdriver(appPort, '/blog/post-100')
+      await browser.eval('window.thisShouldStay = true')
+      await waitFor(2 * 1000)
+      const val = await browser.eval('window.thisShouldStay')
+      expect(val).toBe(true)
+    })
   }
 }
 


### PR DESCRIPTION
This fixes dynamic pages fetching the SPR data on mount since they are marked as `nextExport`, not sure if this is reliably testable will investigate