### PR TITLE
Remove `compilerOptions` from ForkTsCheckerWebpackPlugin

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -846,7 +846,6 @@ export default async function getBaseWebpackConfig(
             checkSyntacticErrors: true,
             tsconfig: tsConfigPath,
             reportFiles: ['**', '!**/__tests__/**', '!**/?(*.)(spec|test).*'],
-            compilerOptions: { isolatedModules: true, noEmit: true },
             silent: true,
             formatter: 'codeframe',
           })


### PR DESCRIPTION
## What

[`compilerOptions`](https://www.npmjs.com/package/fork-ts-checker-webpack-plugin#options) are inferred from the project's `tsconfig.json`, which is already being rewritten to ensure that the removed options (`isolatedModules` and `noEmit`) are set.

## Why

There is nothing gained from this redundancy, and it impedes power users from overriding TypeScript build settings via `tsconfig.json`. (Ability to override is scheduled and being tracked by #8128 https://github.com/zeit/next.js/issues/8128#issuecomment-532391600.)

## Testing Plan

This change is covered by the 5 TypeScript integration tests, which specify `isolatedModules` in their `tsconfig.json` and test both type-checking success and error cases.