### PR TITLE
Pass down App initialProps to Document context

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -143,7 +143,7 @@ export type DocumentProps = DocumentInitialProps & {
   __NEXT_DATA__: NEXT_DATA
   dangerousAsPath: string
   ampPath: string
-  appProps: AppInitialProps
+  appProps?: AppInitialProps
   inAmpMode: boolean
   hybridAmp: boolean
   staticMarkup: boolean

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -143,6 +143,7 @@ export type DocumentProps = DocumentInitialProps & {
   __NEXT_DATA__: NEXT_DATA
   dangerousAsPath: string
   ampPath: string
+  appProps: AppInitialProps
   inAmpMode: boolean
   hybridAmp: boolean
   staticMarkup: boolean

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -540,7 +540,7 @@ export async function renderToHTML(
     }
   }
 
-  const docProps = await loadGetInitialProps(Document, { ...ctx, renderPage })
+  const docProps = await loadGetInitialProps(Document, { ...ctx, appProps: props, renderPage })
   // the response might be finished on the getInitialProps call
   if (isResSent(res) && !isSpr) return null
 


### PR DESCRIPTION
# Problem
Currently the `AppTree` HOC that is passed to `Document's Context` is a wrapper around the naked `App` Component.  
If `AppTree` is used inside `Document.getInitialProps`, the wrapped `App` Component is missing its initial props, thus having weird behavior when used in conjunction with 3rd-party library functions that require them (i.e: Apollo's `getDataFromTree`).

# Solution
This pull request modifies the render function, passing down `App` initial props to `Document` context in `loadGetInitialProps` so we can use `AppTree` with initial props and have it behaving correctly.

# Showcase
I made a demo showing how it can be used to simplify Next.js integration with Apollo, avoiding the need of wrapping `Page` and `App` components with any Apollo hocs.

https://gist.github.com/Tylerian/16d48e5850b407ba9e3654e17d334c1e

magic line:
https://gist.github.com/Tylerian/16d48e5850b407ba9e3654e17d334c1e#file-_document-tsx-L69