### PR TITLE
Update granular chunks to produce up to 25 chunks per entrypoint

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -282,7 +282,8 @@ export default async function getBaseWebpackConfig(
           reuseExistingChunk: true,
         },
       },
-      maxInitialRequests: 20,
+      maxInitialRequests: 25,
+      minSize: 20000,
     },
   }
 


### PR DESCRIPTION
Small change, based on results from lab analysis. 25 chunks performs better on high-complexity apps, even on slower devices. MinSize is lowered (from the default SplitChunksPlugin value of 30000) to further increase granularity.