### PR TITLE
fix apollo server initialization in api-routes-apollo-server-and-client example

### DIFF
--- a/examples/api-routes-apollo-server-and-client/pages/api/graphql.js
+++ b/examples/api-routes-apollo-server-and-client/pages/api/graphql.js
@@ -1,8 +1,7 @@
 import { ApolloServer } from 'apollo-server-micro'
-import { typeDefs } from '../../apollo/type-defs'
-import { resolvers } from '../../apollo/resolvers'
+import { schema } from '../../apollo/schema'
 
-const apolloServer = new ApolloServer({ typeDefs, resolvers })
+const apolloServer = new ApolloServer({ schema })
 
 export const config = {
   api: {


### PR DESCRIPTION
I faced an issue similar to [this one](https://github.com/apollographql/apollo-server/issues/1534) when using the code from the api-routes-apollo-server-and-client example. As suggested by [this comment](https://github.com/apollographql/apollo-server/issues/1534#issuecomment-413172932), passing `typeDefs` and `resolvers` both to `makeExecutableSchema(...)` and to `new ApolloServer(...)` results in two different schemas.  