### PR TITLE
Add `StrictMode` toggle

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -736,6 +736,7 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_PRERENDER_INDICATOR': JSON.stringify(
           config.devIndicators.autoPrerender
         ),
+        'process.env.__NEXT_STRICT_MODE': JSON.stringify(config.strictMode),
         ...(isServer
           ? {
               // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -736,7 +736,9 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_PRERENDER_INDICATOR': JSON.stringify(
           config.devIndicators.autoPrerender
         ),
-        'process.env.__NEXT_STRICT_MODE': JSON.stringify(config.strictMode),
+        'process.env.__NEXT_STRICT_MODE': JSON.stringify(
+          config.reactStrictMode
+        ),
         ...(isServer
           ? {
               // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -372,11 +372,19 @@ async function doRender ({ App, Component, props, err }) {
     appProps
   })
 
-  // We catch runtime errors using componentDidCatch which will trigger renderError
-  renderReactElement(
+  const elem = (
     <AppContainer>
       <App {...appProps} />
-    </AppContainer>,
+    </AppContainer>
+  )
+
+  // We catch runtime errors using componentDidCatch which will trigger renderError
+  renderReactElement(
+    process.env.__NEXT_STRICT_MODE ? (
+      <React.StrictMode>{elem}</React.StrictMode>
+    ) : (
+      elem
+    ),
     appElement
   )
 

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -53,6 +53,7 @@ const defaultConfig: { [key: string]: any } = {
   },
   serverRuntimeConfig: {},
   publicRuntimeConfig: {},
+  strictMode: true,
 }
 
 const experimentalWarning = execOnce(() => {

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -53,7 +53,7 @@ const defaultConfig: { [key: string]: any } = {
   },
   serverRuntimeConfig: {},
   publicRuntimeConfig: {},
-  reactStrictMode: true,
+  reactStrictMode: false,
 }
 
 const experimentalWarning = execOnce(() => {

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -53,7 +53,7 @@ const defaultConfig: { [key: string]: any } = {
   },
   serverRuntimeConfig: {},
   publicRuntimeConfig: {},
-  strictMode: true,
+  reactStrictMode: true,
 }
 
 const experimentalWarning = execOnce(() => {


### PR DESCRIPTION
Ref https://github.com/zeit/next-roadmap/issues/142

Renders apps in `<React.StrictMode />` for development warnings. Defaults to `true` since `StrictMode` is the preferred path forward, but it can be disabled by adding `strictMode: false` to `next.config.json`.