### PR TITLE
Test React integration using `next` dist-tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,11 @@ commands:
       - run:
           name: Linting
           command: yarn lint
-  yarn_react_canary:
+  yarn_react_integration:
     steps:
       - run:
-          name: Upgrade to React Canary
-          command: yarn upgrade react@canary react-dom@canary -W --dev # upgrade (vs add) will skip re-building Next.js, which doesn't bundle React internals (so this is OK!)
+          name: Upgrade to most recent release in React's Next channel
+          command: yarn upgrade react@next react-dom@next -W --dev # upgrade (vs add) will skip re-building Next.js, which doesn't bundle React internals (so this is OK!)
   yarn_info:
     steps:
       - run:
@@ -128,7 +128,7 @@ jobs:
     executor: node
     steps:
       - *attach_workspace
-      - yarn_react_canary
+      - yarn_react_integration
       - *persist_to_workspace
   test:
     parallelism: 3


### PR DESCRIPTION
Instead of `canary`. React uses `next` to represent the next minor release.

I'm about to post on the React blog with more details. I would like to link to y'all's CircleCI config as an example, if you don't mind.