### PR TITLE
Clarify type of NextApiRequest["query"]

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -163,7 +163,7 @@ export type NextApiRequest = IncomingMessage & {
    * Object of `query` values from url
    */
   query: {
-    [key: string]: string | string[]
+    [key: string]: string
   }
   /**
    * Object of `cookies` from header


### PR DESCRIPTION
This corrects the typings for `NextApiRequest["query"]` from `string | string[]` to just `string`. It looks like this type might have been intended to match the [Node.js querystring.parse() API](https://nodejs.org/api/querystring.html#querystring_querystring_parse_str_sep_eq_options), but as far as I can tell, if multiple query parameters are submitted, they are overridden rather than assembled into an array. E.g. for `page?q=1&q=2`, the Node.js API might return `{q: ['1', '2']}`, but Next.js is currently returning `{q: ['2']}`.

Not sure if that's a bug (it's certainly more convenient to not deal with arrays in this interface), but this PR at least documents the current functionality.