### PR TITLE
Fix with-tailwindcss build issues

### DIFF
--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -14,8 +14,8 @@
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^1.3.0",
-    "autoprefixer": "^7.1.6",
-    "cssnano": "^3.10.0",
+    "autoprefixer": "^9.6.5",
+    "cssnano": "^4.1.0",
     "postcss-easy-import": "^3.0.0",
     "tailwindcss": "^1.0.1"
   }


### PR DESCRIPTION
The with-tailwindcss example was failing to build due to a deprecated function in one of cssnano's dependencies. 

Fixes #9174 