### PR TITLE
Check Files during Install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
     steps:
       - run:
           name: Installing Dependencies
-          command: yarn install --frozen-lockfile
+          command: yarn install --frozen-lockfile --check-files
   yarn_lint:
     steps:
       - run:
@@ -56,7 +56,7 @@ commands:
       - run:
           name: Run All Tests
           command: |
-            yarn check && node run-tests.js $(
+            node run-tests.js $(
               circleci tests glob "test/**/*.test.*" | \
               circleci tests split
             )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ steps:
     displayName: Cache Yarn packages
 
   - script: |
-      yarn --frozen-lockfile --check-files
+      yarn install --frozen-lockfile --check-files
     displayName: 'Install dependencies'
 
   - script: |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "lerna run build --stream --parallel",
     "dev2": "while true; do yarn --check-files && yarn dev; done",
     "testonly": "jest",
-    "testall": "yarn check && yarn run testonly -- --ci --reporters=default --reporters=jest-junit --forceExit --runInBand",
+    "testall": "yarn run testonly -- --ci --reporters=default --reporters=jest-junit --forceExit --runInBand",
     "pretest": "yarn run lint",
     "git-reset": "git reset --hard HEAD",
     "git-clean": "git clean -d -x -e node_modules -e packages -f",


### PR DESCRIPTION
Let's try to use `--check-files` instead of `yarn check` so we fix the installation instead of simply failing (and require manual cache clear).