### PR TITLE
Ensure that all <link> elements have a key prop

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -146,6 +146,7 @@ export class Head extends Component<
     cssFiles.forEach(file => {
       cssLinkElements.push(
         <link
+          key="${file}-preload"
           nonce={this.props.nonce}
           rel="preload"
           href={`${assetPrefix}/_next/${encodeURI(file)}`}


### PR DESCRIPTION
Before this patch users would see the following warning during initial compilation:

```
Warning: Each child in a list should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.
    in link
    in Head
    in html
    in Html
    in Document
    in Context.Provider
    in Context.Provider
```