### PR TITLE
Fix examples #9064: with-immutable-redux-wrapper

### DIFF
--- a/examples/with-immutable-redux-wrapper/README.md
+++ b/examples/with-immutable-redux-wrapper/README.md
@@ -1,6 +1,6 @@
 # Immutable Redux Example
 
-> This example and documentation is based on the [with-redux](https://github.com/zeit/next.js/tree/master/examples/with-redux) example.
+> This example and documentation is based on the [with-redux-wrapper](https://github.com/zeit/next.js/tree/master/examples/with-redux-wrapper) example.
 
 ## How to use
 

--- a/examples/with-immutable-redux-wrapper/package.json
+++ b/examples/with-immutable-redux-wrapper/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "immutable": "4.0.0-rc.9",
     "next": "latest",
-    "next-redux-wrapper": "2.0.0-beta.6",
+    "next-redux-wrapper": "4.0.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-redux": "^5.0.1",


### PR DESCRIPTION
bumps next-redux-wrapper package version that contains babel runtime fix https://github.com/zeit/next.js/issues/9064