### PR TITLE
Fix `import next from "next"`

### DIFF
--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -19,6 +19,7 @@ function createServer(options: NextServerConstructor): Server {
 
 // Support commonjs `require('next')`
 module.exports = createServer
+exports = module.exports
 
 // Support `import next from 'next'`
 export default createServer


### PR DESCRIPTION
Fixes #9208.

I wanted to add a test to demonstrate the problem, but I couldn't find a suitable place for one. Happy to do it with a pointer, if desired. Otherwise ,`yarn demonstrate` in [this repo](https://github.com/Peeja/test-next.js-9208) will demonstrate the issue; you can use `yarn link` to run against this branch and see the problem fixed.