### PR TITLE
Add warning for getStaticParams without getStaticProps

### DIFF
--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -21,6 +21,7 @@ export type LoadComponentsReturnType = {
     props: any
     revalidate: number | false
   }
+  unstable_getStaticParams?: () => void
   buildManifest?: any
   reactLoadableManifest?: any
   Document?: any
@@ -40,6 +41,7 @@ export async function loadComponents(
       Component,
       pageConfig: Component.config || {},
       unstable_getStaticProps: Component.unstable_getStaticProps,
+      unstable_getStaticParams: Component.unstable_getStaticParams,
     }
   }
   const documentPath = join(
@@ -87,5 +89,6 @@ export async function loadComponents(
     reactLoadableManifest,
     pageConfig: ComponentMod.config || {},
     unstable_getStaticProps: ComponentMod.unstable_getStaticProps,
+    unstable_getStaticParams: ComponentMod.unstable_getStaticParams,
   }
 }

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -158,6 +158,7 @@ type RenderOpts = {
     props: any
     revalidate: number | false
   }
+  unstable_getStaticParams?: () => void
 }
 
 function renderDocument(
@@ -268,6 +269,7 @@ export async function renderToHTML(
     reactLoadableManifest,
     ErrorDebug,
     unstable_getStaticProps,
+    unstable_getStaticParams,
   } = renderOpts
 
   const isSpr = !!unstable_getStaticProps
@@ -281,6 +283,12 @@ export async function renderToHTML(
 
   if (hasPageGetInitialProps && isSpr) {
     throw new Error(SPR_GET_INITIAL_PROPS_CONFLICT + ` ${pathname}`)
+  }
+
+  if (!!unstable_getStaticParams && !isSpr) {
+    console.error(
+      `unstable_getStaticParams was added without a unstable_getStaticProps in ${pathname}. Without unstable_getStaticProps, unstable_getStaticParams does nothing`
+    )
   }
 
   if (dev) {

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -286,7 +286,7 @@ export async function renderToHTML(
   }
 
   if (!!unstable_getStaticParams && !isSpr) {
-    console.error(
+    throw new Error(
       `unstable_getStaticParams was added without a unstable_getStaticProps in ${pathname}. Without unstable_getStaticProps, unstable_getStaticParams does nothing`
     )
   }

--- a/run-tests.js
+++ b/run-tests.js
@@ -8,7 +8,7 @@ const glob = promisify(_glob)
 const exec = promisify(execOrig)
 
 const NUM_RETRIES = 2
-const DEFAULT_CONCURRENCY = 3
+const DEFAULT_CONCURRENCY = 2
 
 ;(async () => {
   let concurrencyIdx = process.argv.indexOf('-c')

--- a/test/integration/prerender/pages/no-getStaticProps.js
+++ b/test/integration/prerender/pages/no-getStaticProps.js
@@ -1,6 +1,0 @@
-// eslint-disable-next-line
-export async function unstable_getStaticParams() {
-  return []
-}
-
-export default () => 'hi'

--- a/test/integration/prerender/pages/no-getStaticProps.js
+++ b/test/integration/prerender/pages/no-getStaticProps.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line
+export async function unstable_getStaticParams() {
+  return []
+}
+
+export default () => 'hi'

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -237,6 +237,14 @@ const runTests = (dev = false) => {
         await fs.writeFile(indexPage, origContent)
       }
     })
+
+    it('should show error when getStaticParams is used without getStaticProps', async () => {
+      await renderViaHTTP(appPort, '/no-getStaticProps')
+      await waitFor(500)
+      expect(stderr).toMatch(
+        /unstable_getStaticParams was added without a unstable_getStaticProps in/
+      )
+    })
   } else {
     it('should should use correct caching headers for a no-revalidate page', async () => {
       const initialRes = await fetchViaHTTP(appPort, '/something')
@@ -370,7 +378,11 @@ describe('SPR Prerender', () => {
   describe('dev mode', () => {
     beforeAll(async () => {
       appPort = await findPort()
-      app = await launchApp(appDir, appPort)
+      app = await launchApp(appDir, appPort, {
+        onStderr: msg => {
+          stderr += msg
+        }
+      })
       buildId = 'development'
     })
     afterAll(() => killApp(app))

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -239,9 +239,24 @@ const runTests = (dev = false) => {
     })
 
     it('should show error when getStaticParams is used without getStaticProps', async () => {
-      await renderViaHTTP(appPort, '/no-getStaticProps')
+      const pagePath = join(appDir, 'pages/no-getStaticProps.js')
+      await fs.writeFile(
+        pagePath,
+        `
+        export async function unstable_getStaticParams() {
+          return []
+        }
+
+        export default () => 'hi'
+      `,
+        'utf8'
+      )
+
+      const html = await renderViaHTTP(appPort, '/no-getStaticProps')
+      await fs.remove(pagePath)
       await waitFor(500)
-      expect(stderr).toMatch(
+
+      expect(html).toMatch(
         /unstable_getStaticParams was added without a unstable_getStaticProps in/
       )
     })


### PR DESCRIPTION
Since `getStaticParams` does nothing without `getStaticProps` this adds a warning letting the user know since it's dead code without `getStaticProps`