### PR TITLE
Export `WithRouterProps` type

### DIFF
--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -110,7 +110,7 @@ function getRouter() {
 export default singletonRouter as SingletonRouter
 
 // Reexport the withRoute HOC
-export { default as withRouter } from './with-router'
+export { default as withRouter, WithRouterProps } from './with-router'
 
 export function useRouter() {
   return React.useContext(RouterContext)


### PR DESCRIPTION
This PR adds the `WithRouterProps` type to `next/router`.

Historically (using Next 8.1.0 + `@types/next`), you could `import { withRouter, WithRouterProps } from 'next/router'`. Now, it seems like the best / only way to get `WithRouterProps` is to import from `next/dist/client/with-router` or `next-server/router`.