### PR TITLE
Restore package.json and yarn.lock to allow deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
           command: yarn install --frozen-lockfile --check-files
       - run:
           name: Install correct Chrome Driver version
-          command: yarn add chromedriver@76 -W
+          command: yarn add chromedriver@76 -W && git checkout yarn.lock package.json
       - run: google-chrome --version
       - run: chromedriver --version
   yarn_lint:


### PR DESCRIPTION
`lerna` aborts publishing if there are uncommitted changes so this restores the original `package.json` and `yarn.lock` after bumping the `chromedriver` version for testing. 

Fixes: 
```sh
$ lerna publish from-git --yes
lerna notice cli v3.14.1
lerna info ci enabled
lerna ERR! EUNCOMMIT Working tree has uncommitted changes, please commit or remove the following changes before continuing:
lerna ERR! EUNCOMMIT  M package.json
lerna ERR! EUNCOMMIT  M yarn.lock
```