### PR TITLE
Split TypeScript Flag Docs

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2317,16 +2317,35 @@ To learn more about TypeScript checkout its [documentation](https://www.typescri
 > When you feel comfortable with TypeScript, you may turn this option on in your `tsconfig.json`.
 
 > **Note**: By default, Next.js reports TypeScript errors during development for pages you are actively working on.
-> TypeScript errors for inactive pages do not block the development process.
-> Trying to run `next build` for an app that has TypeScript errors on any page will fail.
-> 
-> If you don't want to leverage this behavior and prefer to do type checks manually, set the following options in your `next.config.js`:
+> TypeScript errors for inactive pages **do not** block the development process.
+>
+> If you don't want to leverage this behavior and instead, e.g. prefer your editor's integration, you can set the following option in `next.config.js`:
 >
 > ```js
 > // next.config.js
 > module.exports = {
 >   typescript: {
 >     ignoreDevErrors: true,
+>   },
+> }
+> ```
+>
+> Next.js will still fail your **production build** (`next build`) when TypeScript errors are present in your project.
+>
+> If you'd like Next.js to dangerously produce production code even when your application is broken, you can set the following option in your `next.config.js`.
+> Be sure you are running type checks as part of your build or deploy process!
+>
+> ```js
+> // next.config.js
+> module.exports = {
+>   typescript: {
+>     // !! WARN !!
+>     // Dangerously allow Next.js to successfully build even if your project has
+>     // type errors.
+>     //
+>     // This option is rarely needed, and should be reserved for advanced
+>     // setups. You may be looking for `ignoreDevErrors` instead.
+>     // !! WARN !!
 >     ignoreBuildErrors: true,
 >   },
 > }

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -2340,8 +2340,8 @@ To learn more about TypeScript checkout its [documentation](https://www.typescri
 > module.exports = {
 >   typescript: {
 >     // !! WARN !!
->     // Dangerously allow Next.js to successfully build even if your project has
->     // type errors.
+>     // Dangerously allow production builds to successfully complete even if
+>     // your project has type errors.
 >     //
 >     // This option is rarely needed, and should be reserved for advanced
 >     // setups. You may be looking for `ignoreDevErrors` instead.


### PR DESCRIPTION
This pull request separates and clarifies the TypeScript flags and their respective functions.

We've added strong discouragement to `ignoreBuildErrors` because it should almost never be used by a typical Next.js user.

cc @kachkaev 