### PR TITLE
Make babel-next jsx-pragma optional

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -43,6 +43,7 @@ type NextBabelPresetOptions = {
   'transform-runtime'?: any
   'experimental-modern-preset'?: PluginItem
   'styled-jsx'?: StyledJsxBabelOptions
+  'jsx-pragma'?: boolean
 }
 
 type BabelPreset = {
@@ -119,7 +120,7 @@ module.exports = (
       require('@babel/preset-typescript'),
     ],
     plugins: [
-      [
+      options['jsx-pragma'] !== false && [
         require('./plugins/jsx-pragma'),
         {
           // This produces the following injected import for modules containing JSX:

--- a/test/unit/next-babel.test.js
+++ b/test/unit/next-babel.test.js
@@ -29,6 +29,13 @@ const babel = (code, esm = false, presetOptions = {}) =>
 
 describe('next/babel', () => {
   describe('jsx-pragma', () => {
+    it('should be optional', () => {
+      const output = babel(`const a = () => <a href="/">home</a>;`, true, {
+        'jsx-pragma': false
+      })
+      // it should not add a React import:
+      expect(output).not.toMatch(`import React from"react"`)
+    })
     it('should transform JSX to use a local identifier in modern mode', () => {
       const output = babel(`const a = () => <a href="/">home</a>;`, true)
 


### PR DESCRIPTION
Potential workaround for #9253 

This allows people using a custom `.babelrc` to provide a flag to turn off `jsx-pragma`, which I am seeing cause double React imports in my current setup.

Caveat: I'm new to next.js, trying to port an existing CRA to use it as a POC. I don't know how important `jsx-pragma` is. 