### PR TITLE
Allow passing options to @babel/preset-typescript

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -39,6 +39,7 @@ function styledJsxOptions(options: StyledJsxBabelOptions) {
 type NextBabelPresetOptions = {
   'preset-env'?: any
   'preset-react'?: any
+  'preset-typescript'?: any
   'class-properties'?: any
   'transform-runtime'?: any
   'experimental-modern-preset'?: PluginItem
@@ -116,7 +117,10 @@ module.exports = (
           ...options['preset-react'],
         },
       ],
-      require('@babel/preset-typescript'),
+      [
+        require('@babel/preset-typescript'),
+        { ...options['preset-typescript'] },
+      ],
     ],
     plugins: [
       [


### PR DESCRIPTION
I'm porting an existing React/TypeScript application which is making use of TS namespaces to Next.js. I found out that `@babel/preset-typescript` could not be configured and thus I was unabled to enable the [`allowNamespaces` option](https://babeljs.io/docs/en/babel-plugin-transform-typescript#impartial-namespace-support). This PR adds the ability to pass options to `@babel/preset-typescript`.

Fixes: https://github.com/zeit/next.js/issues/8900