### PR TITLE
Make sure to bust cache if define plugin values changed

### DIFF
--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -68,6 +68,7 @@ module.exports = babelLoader.custom(babel => {
                 (opts.isServer ? '-server' : '') +
                 (opts.isModern ? '-modern' : '') +
                 (opts.hasModern ? '-has-modern' : '') +
+                opts.definePluginEnv +
                 JSON.stringify(
                   babel.loadPartialConfig({
                     filename,
@@ -88,6 +89,7 @@ module.exports = babelLoader.custom(babel => {
       delete loader.isModern
       delete loader.hasModern
       delete loader.pagesDir
+      delete loader.definePluginEnv
       return { loader, custom }
     },
     config (


### PR DESCRIPTION
Noticed that if you run a build with `exportTrailingSlash` disabled and then run another with it enabled it can cause stale files to be use creating an invalid build. 

This makes sure to consider the current `DefinePlugin` values for the babel cache identifier preventing stale files from being used

x-ref: #9258