### PR TITLE
Fix example active-class-anme: Add support for children of ActiveLink without a className.

### DIFF
--- a/examples/active-class-name/components/ActiveLink.js
+++ b/examples/active-class-name/components/ActiveLink.js
@@ -6,13 +6,20 @@ import React, { Children } from 'react'
 const ActiveLink = ({ children, activeClassName, ...props }) => {
   const { pathname } = useRouter()
   const child = Children.only(children)
+  const childClassName = child.props.className || ''
 
   const className =
     pathname === props.href
-      ? `${child.props.className} ${activeClassName}`
-      : child.props.className
+      ? `${childClassName} ${activeClassName}`.trim()
+      : childClassName
 
-  return <Link {...props}>{React.cloneElement(child, { className })}</Link>
+  return (
+    <Link {...props}>
+      {React.cloneElement(child, {
+        className: className !== '' ? className : null
+      })}
+    </Link>
+  )
 }
 
 ActiveLink.propTypes = {

--- a/examples/active-class-name/components/ActiveLink.js
+++ b/examples/active-class-name/components/ActiveLink.js
@@ -16,7 +16,7 @@ const ActiveLink = ({ children, activeClassName, ...props }) => {
   return (
     <Link {...props}>
       {React.cloneElement(child, {
-        className: className !== '' ? className : null
+        className: className || null
       })}
     </Link>
   )


### PR DESCRIPTION
The ActiveLink component in active-class-name example would output `class="undefined active"` for the current route if the child of ActiveLink did not have a className.

This PR fixes this issue.

---

Example:
```
<ActiveLink href="/about" activeClassName="active">
  <a>About</a>
</ActiveLink>
```
produced: `class="undefined active"`
with this PR: `class="active"`

happy 🎃