### PR TITLE
Fixed Utility Method Documentation Spelling

### DIFF
--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -135,7 +135,7 @@ export function getQueryParser({ url }: IncomingMessage) {
 }
 
 /**
- * Parse cookeies from `req` header
+ * Parse cookies from `req` header
  * @param req request object
  */
 export function getCookieParser(req: IncomingMessage) {


### PR DESCRIPTION
fixed the spelling of "cookies" in the getCookieParser utility method documentation 🍪