### PR TITLE
Prevent CSS script tags in granular chunks

### DIFF
--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -98,7 +98,7 @@ export default class PageLoader {
         if (process.env.__NEXT_GRANULAR_CHUNKS) {
           this.getDependencies(route).then(deps => {
             deps.forEach(d => {
-              if (!/\.css$/.test(d) && !document.querySelector(`script[src^="${d}"]`)) {
+              if (/\.js$/.test(d) && !document.querySelector(`script[src^="${d}"]`)) {
                 this.loadScript(d, route, false)
               }
             })

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -98,7 +98,7 @@ export default class PageLoader {
         if (process.env.__NEXT_GRANULAR_CHUNKS) {
           this.getDependencies(route).then(deps => {
             deps.forEach(d => {
-              if (!document.querySelector(`script[src^="${d}"]`)) {
+              if (!/\.css$/.test(d) && !document.querySelector(`script[src^="${d}"]`)) {
                 this.loadScript(d, route, false)
               }
             })


### PR DESCRIPTION
This prevents page-loader.js from inserting script tags for CSS dependencies with granualr chunks enabled. This fixes https://github.com/zeit/next.js/issues/9302