### PR TITLE
Allow TypeScript Namespaces

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -116,7 +116,7 @@ module.exports = (
           ...options['preset-react'],
         },
       ],
-      require('@babel/preset-typescript'),
+      [require('@babel/preset-typescript'), { allowNamespaces: true }],
     ],
     plugins: [
       [


### PR DESCRIPTION
This enables Babel's [partial `namespace` support](https://babeljs.io/docs/en/babel-plugin-transform-typescript#impartial-namespace-support).

Without this flag, the usage will simply emit an error. This error also urges users to turn on this option when it's a case Babel can handle.

For this reason, we should just turn it on. Babel plans on making this option on-by-default very soon, so we should just do it now!

----

Closes #9255
Fixes #8900 