### PR TITLE
Fix deduplicating dynamic (array) meta tags

### DIFF
--- a/test/integration/client-navigation/pages/head.js
+++ b/test/integration/client-navigation/pages/head.js
@@ -97,8 +97,27 @@ export default () => (
       <link rel="stylesheet" href="/dup-style.css" />
 
       {/* only one tag will be rendered as they have the same key */}
+
       <link rel="stylesheet" href="dedupe-style.css" key="my-style" />
       <link rel="stylesheet" href="dedupe-style.css" key="my-style" />
+
+      {/* such style can be used for alternate links on _app vs individual pages */}
+      {['pl', 'en'].map(language => (
+        <link
+          rel="alternate"
+          key={language}
+          hrefLang={language}
+          href={'/first/' + language}
+        />
+      ))}
+      {['pl', 'en'].map(language => (
+        <link
+          rel="alternate"
+          key={language}
+          hrefLang={language}
+          href={'/last/' + language}
+        />
+      ))}
     </Head>
     <h1>I can have meta tags</h1>
   </div>

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -80,6 +80,12 @@ export default function(render, fetch) {
       expect(html).not.toContain(
         '<link rel="stylesheet" href="dedupe-style.css"/><link rel="stylesheet" href="dedupe-style.css"/>'
       )
+      expect(html).toContain(
+        '<link rel="alternate" hrefLang="en" href="/last/en"/>'
+      )
+      expect(html).not.toContain(
+        '<link rel="alternate" hrefLang="en" href="/first/en"/>'
+      )
     })
 
     test('header helper dedupes tags with the same key as the default', async () => {


### PR DESCRIPTION
If react element has custom key, its object representation doesn't necessairly start with `.$`. For example elements generated with `.map` will have custom keys like `.v:$foobar`. Indeed any string after `$` should be considered custom key. And that's what this PR fixes.

As a result meta tags that are generated with `.map` are deduplicated. One use case for this is generation of alternate links on _app.js versus individual pages:

```jsx
{alternativeLanguages.map(language => (
  <link
    rel='alternate'
    key={language}
    hrefLang={language}
    href={generateAltLink(language)}
   />
))}
```

Without this fix alternate links are duplicated because links on _app.js have keys like `.v:$pl` and links on pages have keys like `.u:$pl`.

It also makes previous hacky fix in #8960 unnecessary, so I remove its code.