### PR TITLE
Track framework bundle separately

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -56,6 +56,10 @@ const renames = [
     srcGlob: '.next/static/chunks/commons!(*.module.js)',
     dest: '.next/static/chunks/commons.HASH.js'
   },
+  {
+    srcGlob: '.next/static/chunks/framework!(*.module.js)',
+    dest: '.next/static/chunks/framework.HASH.js'
+  },
   // modern
   {
     srcGlob: '.next/static/runtime/main-*.module.js',
@@ -68,6 +72,10 @@ const renames = [
   {
     srcGlob: '.next/static/chunks/commons*.module.js',
     dest: '.next/static/chunks/commons.HASH.module.js'
+  },
+  {
+    srcGlob: '.next/static/chunks/framework*.module.js',
+    dest: '.next/static/chunks/framework.HASH.module.js'
   },
   // misc
   {


### PR DESCRIPTION
This updates the test stats configuration to track the framework chunk size separately.