### PR TITLE
Update routes-manifest and add tests

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -619,9 +619,20 @@ export default async function build(dir: string, conf = null): Promise<void> {
     await fsWriteFile(manifestPath, JSON.stringify(pagesManifest), 'utf8')
   }
 
-  const buildCustomRoute = (r: { source: string }) => {
+  const buildCustomRoute = (
+    r: {
+      source: string
+      statusCode?: number
+    },
+    isRedirect = false
+  ) => {
     return {
       ...r,
+      ...(isRedirect
+        ? {
+            statusCode: r.statusCode || 307,
+          }
+        : {}),
       regex: pathToRegexp(r.source, [], {
         strict: true,
         sensitive: false,
@@ -633,7 +644,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     path.join(distDir, ROUTES_MANIFEST),
     JSON.stringify({
       version: 1,
-      redirects: redirects.map(r => buildCustomRoute(r)),
+      redirects: redirects.map(r => buildCustomRoute(r, true)),
       rewrites: rewrites.map(r => buildCustomRoute(r)),
       dynamicRoutes: getSortedRoutes(dynamicRoutes).map(page => ({
         page,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -21,6 +21,7 @@ import {
   SERVER_DIRECTORY,
   SERVERLESS_DIRECTORY,
   ROUTES_MANIFEST,
+  DEFAULT_REDIRECT_STATUS,
 } from '../next-server/lib/constants'
 import {
   getRouteRegex,
@@ -636,7 +637,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       ...r,
       ...(isRedirect
         ? {
-            statusCode: r.statusCode || 307,
+            statusCode: r.statusCode || DEFAULT_REDIRECT_STATUS,
           }
         : {}),
       regex: routeRegex.source,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -626,6 +626,12 @@ export default async function build(dir: string, conf = null): Promise<void> {
     },
     isRedirect = false
   ) => {
+    const keys: any[] = []
+    const routeRegex = pathToRegexp(r.source, keys, {
+      strict: true,
+      sensitive: false,
+    })
+
     return {
       ...r,
       ...(isRedirect
@@ -633,10 +639,8 @@ export default async function build(dir: string, conf = null): Promise<void> {
             statusCode: r.statusCode || 307,
           }
         : {}),
-      regex: pathToRegexp(r.source, [], {
-        strict: true,
-        sensitive: false,
-      }).source,
+      regex: routeRegex.source,
+      regexKeys: keys.map(k => k.name),
     }
   }
 

--- a/packages/next/next-server/lib/constants.ts
+++ b/packages/next/next-server/lib/constants.ts
@@ -29,3 +29,4 @@ export const IS_BUNDLED_PAGE_REGEX = /^static[/\\][^/\\]+[/\\]pages.*\.js$/
 // matches static/<buildid>/pages/:page*.js
 export const ROUTE_NAME_REGEX = /^static[/\\][^/\\]+[/\\]pages[/\\](.*)\.js$/
 export const SERVERLESS_ROUTE_NAME_REGEX = /^pages[/\\](.*)\.js$/
+export const DEFAULT_REDIRECT_STATUS = 307

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -16,6 +16,7 @@ import {
   SERVER_DIRECTORY,
   SERVERLESS_DIRECTORY,
   ROUTES_MANIFEST,
+  DEFAULT_REDIRECT_STATUS,
 } from '../lib/constants'
 import {
   getRouteMatcher,
@@ -415,7 +416,7 @@ export default class Server {
 
               if (r.type === 'redirect') {
                 res.setHeader('Location', newUrl)
-                res.statusCode = statusCode || 307
+                res.statusCode = statusCode || DEFAULT_REDIRECT_STATUS
                 res.end()
                 return
               }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import { IncomingMessage, ServerResponse } from 'http'
 import { join, resolve, sep } from 'path'
 import { parse as parseQs, ParsedUrlQuery } from 'querystring'
-import { parse as parseUrl, UrlWithParsedQuery } from 'url'
+import { parse as parseUrl, format as formatUrl, UrlWithParsedQuery } from 'url'
 
 import { withCoalescedInvoke } from '../../lib/coalesced-function'
 import {
@@ -692,6 +692,14 @@ export default class Server {
     if (!isSpr) {
       // handle serverless
       if (isLikeServerless) {
+        const curUrl = parseUrl(req.url!, true)
+        req.url = formatUrl({
+          ...curUrl,
+          query: {
+            ...curUrl.query,
+            ...query,
+          },
+        })
         return result.Component.renderReqToHTML(req, res)
       }
 

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  // target: 'serverless',
   experimental: {
     async rewrites () {
       return [


### PR DESCRIPTION
This adds tests for serverless mode and custom routes and updates the `routes-manifest` with default `statusCode` for `redirects` and `regexKeys` from the `path-to-regexp`