### PR TITLE
Fix `window.fetch` Polyfill

### DIFF
--- a/packages/next/build/polyfills/fetch.js
+++ b/packages/next/build/polyfills/fetch.js
@@ -1,1 +1,3 @@
-export default window.fetch
+var fetch = window.fetch.bind(window)
+module.exports = fetch
+module.exports.default = module.exports


### PR DESCRIPTION
This adds CJS and ESM support for our `window.fetch` polyfill stub file.

x-ref #9363 
fixes #9362