### PR TITLE
Bind `fetch` to `self` instead of `window`

### DIFF
--- a/packages/next/build/polyfills/fetch.js
+++ b/packages/next/build/polyfills/fetch.js
@@ -1,3 +1,4 @@
-var fetch = window.fetch.bind(window)
+/* globals self */
+var fetch = self.fetch.bind(self)
 module.exports = fetch
 module.exports.default = module.exports


### PR DESCRIPTION
This should have better compat with web workers, and be a few bytes smaller!