### PR TITLE
Fix Dynamic `next export` Page Hydration Mismatch

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -123,7 +123,7 @@ export default class Router implements BaseRouter {
     // until after mount to prevent hydration mismatch
     this.asPath =
       // @ts-ignore this is temporarily global (attached to window)
-      isDynamicRoute(pathname) && __NEXT_DATA__.nextExport ? pathname : as
+      isDynamicRoute(pathname) && __NEXT_DATA__.autoExport ? pathname : as
     this.sub = subscription
     this.clc = null
     this._wrapApp = wrapApp

--- a/test/integration/export-dynamic-pages/next.config.js
+++ b/test/integration/export-dynamic-pages/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  exportPathMap() {
+    return {
+      '/regression/jeff-is-cool': { page: '/regression/[slug]' },
+    }
+  },
+}

--- a/test/integration/export-dynamic-pages/pages/regression/[slug].js
+++ b/test/integration/export-dynamic-pages/pages/regression/[slug].js
@@ -1,0 +1,13 @@
+import { useRouter } from 'next/router'
+
+function Regression() {
+  const { asPath } = useRouter()
+  if (typeof window !== 'undefined') {
+    window.__AS_PATHS = [...new Set([...(window.__AS_PATHS || []), asPath])]
+  }
+  return <div id="asPath">{asPath}</div>
+}
+
+Regression.getInitialProps = () => ({})
+
+export default Regression

--- a/test/integration/export-dynamic-pages/test/index.test.js
+++ b/test/integration/export-dynamic-pages/test/index.test.js
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import webdriver from 'next-webdriver'
+import {
+  nextBuild,
+  nextExport,
+  startCleanStaticServer,
+  stopApp,
+  renderViaHTTP,
+  waitFor,
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const appDir = join(__dirname, '../')
+const outdir = join(appDir, 'out')
+
+describe('Export Dyanmic Pages', () => {
+  let server
+  let port
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    await nextExport(appDir, { outdir })
+
+    server = await startCleanStaticServer(outdir)
+    port = server.address().port
+  })
+
+  afterAll(async () => {
+    await stopApp(server)
+  })
+
+  it('should of exported with correct asPath', async () => {
+    const html = await renderViaHTTP(port, '/regression/jeff-is-cool')
+    const $ = cheerio.load(html)
+    expect($('#asPath').text()).toBe('/regression/jeff-is-cool')
+  })
+
+  it('should hydrate with correct asPath', async () => {
+    expect.assertions(1)
+    const browser = await webdriver(port, '/regression/jeff-is-cool')
+    try {
+      await waitFor(3000)
+      expect(await browser.eval(`window.__AS_PATHS`)).toEqual([
+        '/regression/jeff-is-cool',
+      ])
+    } finally {
+      await browser.close()
+    }
+  })
+})

--- a/test/integration/export-dynamic-pages/test/index.test.js
+++ b/test/integration/export-dynamic-pages/test/index.test.js
@@ -12,7 +12,7 @@ import {
   waitFor,
 } from 'next-test-utils'
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -286,6 +286,15 @@ export async function startStaticServer(dir) {
   return server
 }
 
+export async function startCleanStaticServer(dir) {
+  const app = express()
+  const server = http.createServer(app)
+  app.use(express.static(dir, { extensions: ['html'] }))
+
+  await promiseCall(server, 'listen')
+  return server
+}
+
 export async function check(contentFn, regex) {
   let found = false
   const timeout = setTimeout(async () => {


### PR DESCRIPTION
We were incorrectly treating `next export` pages as automatically exported pages during `next build`.

As a result, only **dynamic route `next export`** pages were suffering from a hydration mismatch. This PR fixes the mismatch.