### PR TITLE
Add test for internal URL handling in render

### DIFF
--- a/test/integration/custom-server/server.js
+++ b/test/integration/custom-server/server.js
@@ -32,6 +32,10 @@ app.prepare().then(() => {
       return app.render(req, res, '/dashboard/index')
     }
 
+    if (/static\/hello\.text/.test(req.url)) {
+      return app.render(req, res, '/static/hello.text')
+    }
+
     handleNextRequests(req, res)
   })
 

--- a/test/integration/custom-server/static/hello.txt
+++ b/test/integration/custom-server/static/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -45,6 +45,11 @@ describe('Custom Server', () => {
     beforeAll(() => startServer())
     afterAll(() => killApp(server))
 
+    it('should serve internal file from render', async () => {
+      const data = await renderViaHTTP(appPort, '/static/hello.txt')
+      expect(data).toMatch(/hello world/)
+    })
+
     it('should handle render with undefined query', async () => {
       expect(await renderViaHTTP(appPort, '/no-query')).toMatch(/"query":/)
     })


### PR DESCRIPTION
This ensures the behavior when you call `render` for an internal URL from a custom server