### PR TITLE
Fix recursive copy failing if more folders than concurrency

### DIFF
--- a/packages/next/lib/recursive-copy.ts
+++ b/packages/next/lib/recursive-copy.ts
@@ -14,9 +14,14 @@ export async function recursiveCopy(
   source: string,
   dest: string,
   {
-    concurrency = 255,
+    concurrency = 25,
+    overwrite = false,
     filter = () => true,
-  }: { concurrency?: number; filter?(path: string): boolean } = {}
+  }: {
+    concurrency?: number
+    overwrite?: boolean
+    filter?(path: string): boolean
+  } = {}
 ) {
   const cwdPath = process.cwd()
   const from = path.resolve(cwdPath, source)
@@ -39,6 +44,7 @@ export async function recursiveCopy(
           throw err
         }
       }
+      sema.release()
       const files = await readdir(item)
       await Promise.all(files.map(file => _copy(path.join(item, file))))
     } else if (
@@ -47,11 +53,9 @@ export async function recursiveCopy(
       // we remove the base path (from) and replace \ by / (windows)
       filter(item.replace(from, '').replace(/\\/g, '/'))
     ) {
-      await copyFile(item, target, COPYFILE_EXCL)
+      await copyFile(item, target, overwrite ? undefined : COPYFILE_EXCL)
+      sema.release()
     }
-
-    sema.release()
-    return
   }
 
   await _copy(from)

--- a/packages/next/lib/recursive-copy.ts
+++ b/packages/next/lib/recursive-copy.ts
@@ -14,7 +14,7 @@ export async function recursiveCopy(
   source: string,
   dest: string,
   {
-    concurrency = 25,
+    concurrency = 32,
     overwrite = false,
     filter = () => true,
   }: {


### PR DESCRIPTION
While investigating #9403 I noticed that if you lower the concurrency below the number of folders you try to copy the function fails to finish since each folder locks the concurrency until there is non-left. 

This fixes the above and also reduces the default concurrency to `32` after running the bench on a MacBook Pro 2019 with Mojave and an old laptop with Windows 10 and comparing. 

<details>
<summary>Benchmark details</summary>

# MacBook Pro i7 2019 Mojave - node v10.17.0

## Concurrency 255
```
test recursive-copy npm module
{ sum: 413.04657399999996, nb: 10, avg: 41.304657399999996 }
test recursive-copy custom implementation
{ sum: 137.865412, nb: 10, avg: 13.786541199999998 }
```

## Concurrency 128
```
test recursive-copy npm module
{ sum: 388.76080400000006, nb: 10, avg: 38.876080400000006 }
test recursive-copy custom implementation
{ sum: 105.858304, nb: 10, avg: 10.5858304 }
```

## Concurrency 64
```
test recursive-copy npm module
{ sum: 425.52061699999996, nb: 10, avg: 42.552061699999996 }
test recursive-copy custom implementation
{ sum: 115.67729300000002, nb: 10, avg: 11.567729300000002 }
```

## Concurrency 32
```
test recursive-copy npm module
{ sum: 409.78901600000006, nb: 10, avg: 40.97890160000001 }
test recursive-copy custom implementation
{ sum: 105.63270899999998, nb: 10, avg: 10.563270899999997 }
```

# Samsung Series 9 Windows 10 - node v10.15.3

## Concurrency 255
```
test recursive-copy npm module
{ sum: 2609.5212030000002, nb: 10, avg: 260.95212030000005 }
test recursive-copy custom implementation
{ sum: 1618.309502, nb: 10, avg: 161.83095020000002 }
```

## Concurrency 128
```
test recursive-copy npm module
{ sum: 2584.7055, nb: 10, avg: 258.47055 }
test recursive-copy custom implementation
{ sum: 1515.581403, nb: 10, avg: 151.5581403 }
```

## Concurrency 64
```
test recursive-copy npm module
{ sum: 2614.3232989999997, nb: 10, avg: 261.43232989999996 }
test recursive-copy custom implementation
{ sum: 1867.159701, nb: 10, avg: 186.7159701 }
```

## Concurrency 32
```
test recursive-copy npm module
{ sum: 2535.580401, nb: 10, avg: 253.55804010000003 }
test recursive-copy custom implementation
{ sum: 1658.1967980000002, nb: 10, avg: 165.81967980000002 }
```
</details>

Fixes: #9403 
x-ref: #9420 