### PR TITLE
Fix typo in serverless loader

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -69,9 +69,9 @@ const nextServerlessLoader: loader.Loader = function() {
           }
           const resolver = require('${absolutePagePath}')
           apiResolver(req, res, params, resolver)
-        } catch (error) {
-          await onError(err)
+        } catch (err) {
           console.error(err)
+          await onError(err)
           res.statusCode = 500
           res.end('Internal Server Error')
         }

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -68,7 +68,7 @@ const nextServerlessLoader: loader.Loader = function() {
               : `{}`
           }
           const resolver = require('${absolutePagePath}')
-          apiResolver(req, res, params, resolver)
+          apiResolver(req, res, params, resolver, onError)
         } catch (err) {
           console.error(err)
           await onError(err)

--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -15,7 +15,7 @@ export async function apiResolver(
   res: NextApiResponse,
   params: any,
   resolverModule: any,
-  onError: ({ err }: { err: any }) => Promise<void>
+  onError?: ({ err }: { err: any }) => Promise<void>
 ) {
   try {
     let config: PageConfig = {}
@@ -57,7 +57,7 @@ export async function apiResolver(
       sendError(res, err.statusCode, err.message)
     } else {
       console.error(err)
-      await onError({ err })
+      if (onError) await onError({ err })
       sendError(res, 500, 'Internal Server Error')
     }
   }

--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -14,7 +14,8 @@ export async function apiResolver(
   req: NextApiRequest,
   res: NextApiResponse,
   params: any,
-  resolverModule: any
+  resolverModule: any,
+  onError: ({ err }: { err: any }) => Promise<void>
 ) {
   try {
     let config: PageConfig = {}
@@ -51,11 +52,12 @@ export async function apiResolver(
 
     const resolver = interopDefault(resolverModule)
     resolver(req, res)
-  } catch (e) {
-    if (e instanceof ApiError) {
-      sendError(res, e.statusCode, e.message)
+  } catch (err) {
+    if (err instanceof ApiError) {
+      sendError(res, err.statusCode, err.message)
     } else {
-      console.error(e)
+      console.error(err)
+      await onError({ err })
       sendError(res, 500, 'Internal Server Error')
     }
   }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -100,7 +100,7 @@ export default class Server {
     dev?: boolean
   }
   private compression?: Middleware
-  private onErrorMiddleware?: ({ err }: { err: Error }) => void
+  private onErrorMiddleware?: ({ err }: { err: Error }) => Promise<void>
   router: Router
   protected dynamicRoutes?: Array<{ page: string; match: RouteMatch }>
   protected customRoutes?: {
@@ -498,7 +498,8 @@ export default class Server {
       req,
       res,
       params,
-      resolverFunction ? require(resolverFunction) : undefined
+      resolverFunction ? require(resolverFunction) : undefined,
+      this.onErrorMiddleware
     )
   }
 

--- a/test/integration/serverless/pages/api/top-level-error.js
+++ b/test/integration/serverless/pages/api/top-level-error.js
@@ -1,0 +1,6 @@
+throw new Error('top-level-oops')
+
+// eslint-disable-next-line
+export default (req, res) => {
+  res.end('hi')
+}


### PR DESCRIPTION
This fixes a typo for the `catch` param for a serverless API route. Also, fixes `onError` not being called inside `apiResolver`

Fixes: #9430