### PR TITLE
Re-add RouterContext export

### DIFF
--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -13,7 +13,7 @@ type SingletonRouterBase = {
   ready(cb: () => any): void
 }
 
-export { Router, NextRouter }
+export { Router, RouterContext, NextRouter }
 
 export type SingletonRouter = SingletonRouterBase & NextRouter
 


### PR DESCRIPTION
We stub the RouterContext.Provider in our tests, making the previous change to remove the export a breaking change. Perhaps you can add it back since it's a very convenient to write router-tests.