### PR TITLE
Add handling for rewriting to /_next with catchall

### DIFF
--- a/test/integration/custom-routes-catchall/next.config.js
+++ b/test/integration/custom-routes-catchall/next.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  experimental: {
+    rewrites() {
+      return [
+        {
+          source: '/docs/:path*',
+          destination: '/:path*',
+        },
+      ]
+    },
+  },
+}

--- a/test/integration/custom-routes-catchall/pages/hello.js
+++ b/test/integration/custom-routes-catchall/pages/hello.js
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router'
+
+console.log('hello from hello.js')
+
+const Page = () => {
+  const { query } = useRouter()
+  return (
+    <>
+      <h3>hello world</h3>
+      <span>{JSON.stringify(query)}</span>
+    </>
+  )
+}
+
+export default Page

--- a/test/integration/custom-routes-catchall/public/another.txt
+++ b/test/integration/custom-routes-catchall/public/another.txt
@@ -1,0 +1,1 @@
+some text

--- a/test/integration/custom-routes-catchall/public/static/data.json
+++ b/test/integration/custom-routes-catchall/public/static/data.json
@@ -1,0 +1,1 @@
+{ "field": "some data..." }

--- a/test/integration/custom-routes-catchall/test/index.test.js
+++ b/test/integration/custom-routes-catchall/test/index.test.js
@@ -1,0 +1,72 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  launchApp,
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  renderViaHTTP,
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+let appDir = join(__dirname, '..')
+let buildId
+let appPort
+let app
+
+const runTests = () => {
+  it('should rewrite to /_next/static correctly', async () => {
+    // ensure the bundle is built
+    await renderViaHTTP(appPort, '/hello')
+
+    const bundlePath = await join(
+      '/docs/_next/static/',
+      buildId,
+      'pages/hello.js'
+    )
+    const data = await renderViaHTTP(appPort, bundlePath)
+    expect(data).toContain('hello from hello.js')
+  })
+
+  it('should rewrite and render page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/docs/hello')
+    expect(html).toMatch(/hello world/)
+  })
+
+  it('should rewrite to public/static correctly', async () => {
+    const data = await renderViaHTTP(appPort, '/docs/static/data.json')
+    expect(data).toContain('some data...')
+  })
+
+  it('should rewrite to public file correctly', async () => {
+    const data = await renderViaHTTP(appPort, '/docs/another.txt')
+    expect(data).toContain('some text')
+  })
+}
+
+describe('Custom routes', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+      buildId = 'development'
+    })
+    afterAll(() => killApp(app))
+    runTests(true)
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+      buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
+    })
+    afterAll(() => killApp(app))
+    runTests()
+  })
+})


### PR DESCRIPTION
This makes sure we re-apply the top `/_next/...` routes underneath the `rewrites` so that users can rewrite to those paths

x-ref: https://github.com/zeit/now/pull/3327
x-ref: https://github.com/zeit/next.js/issues/9081#issuecomment-555161265