### PR TITLE
Only run global css sourcemaps in dev

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -731,7 +731,7 @@ export default async function getBaseWebpackConfig(
                               stage: 3,
                             }),
                           ],
-                          sourceMap: true,
+                          sourceMap: dev,
                         },
                       },
                     ].filter(Boolean),


### PR DESCRIPTION
At the moment it's emitting sourcemaps into the `<style>` tags regardless of the environment