### PR TITLE
Error on Size Reduction

### DIFF
--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -81,7 +81,9 @@ describe('Production response size', () => {
     )
 
     // These numbers are without gzip compression!
-    expect(responseSizeKilobytes).toBeLessThanOrEqual(230) // Kilobytes
+    const delta = responseSizeKilobytes - 230
+    expect(delta).toBeLessThanOrEqual(0) // don't increase size
+    expect(delta).toBeGreaterThanOrEqual(-2) // don't decrease size without updating target
   })
 
   it('should not increase the overall response size of modern build', async () => {
@@ -99,6 +101,8 @@ describe('Production response size', () => {
     )
 
     // These numbers are without gzip compression!
-    expect(responseSizeKilobytes).toBeLessThanOrEqual(204) // Kilobytes
+    const delta = responseSizeKilobytes - 204
+    expect(delta).toBeLessThanOrEqual(0) // don't increase size
+    expect(delta).toBeGreaterThanOrEqual(-2) // don't decrease size without updating target
   })
 })


### PR DESCRIPTION
Instead of ensuring we're under a certain size, this updates the test to expect we're identical or within a `-2 kB` boundary.

If we ever get smaller than our test, we should be updating it to not regress down the line (in size increase).