### PR TITLE
`next export` should skip iSSG fallback page

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -155,6 +155,14 @@ export default async function(
       continue
     }
 
+    // iSSG pages that are dynamic should not export templated version by
+    // default. In most cases, this would never work. There is no server that
+    // could run `getStaticProps`. If users make their page work lazily, they
+    // can manually add it to the `exportPathMap`.
+    if (prerenderManifest && prerenderManifest.dynamicRoutes[page]) {
+      continue
+    }
+
     defaultPathMap[page] = { page }
   }
 

--- a/test/integration/prerender/next.config.js
+++ b/test/integration/prerender/next.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  exportPathMap: function(defaultPathMap) {
-    if (defaultPathMap['/blog/[post]']) {
-      throw new Error('Found SPR page in the default export path map')
-    }
-    return defaultPathMap
-  },
-}

--- a/test/integration/prerender/next.config.js
+++ b/test/integration/prerender/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  exportPathMap: function(defaultPathMap) {
+    if (defaultPathMap['/blog/[post]']) {
+      throw new Error('Found SPR page in the default export path map')
+    }
+    return defaultPathMap
+  },
+}

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -477,7 +477,15 @@ describe('SPR Prerender', () => {
       exportDir = join(appDir, 'out')
       await fs.writeFile(
         nextConfig,
-        `module.exports = { exportTrailingSlash: true }`
+        `module.exports = {
+          exportTrailingSlash: true,
+          exportPathMap: function(defaultPathMap) {
+            if (defaultPathMap['/blog/[post]']) {
+              throw new Error('Found SPR page in the default export path map')
+            }
+            return defaultPathMap
+          },
+        }`
       )
       await nextBuild(appDir)
       await nextExport(appDir, { outdir: exportDir })


### PR DESCRIPTION
Like we do in `next build`, `next export` should skip exporting a dynamically routed page which was not defined in `getStaticPaths`.

https://github.com/zeit/next.js/blob/dc0c940978a3be14d0211f88e6ec26352564f6ad/packages/next/build/index.ts#L515-L525

In the common scenario, the fallback page would require a server so it could run `getStaticProps`.
In practice, users of `next export` will need to define all of their routes **up front** using `getStaticPaths`.

For users who do happen to implement client-side fallback behavior (which I suspect to be the minority), they can manually re-add the template version to their `exportPathMap`.
However, this should **not be the default**.