### PR TITLE
Add file attribute to timings data

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -124,9 +124,9 @@ const timings = []
     for (const timing of timings) {
       const timeInSeconds = timing.time / 1000
       junitData += `
-        <testsuite name="${
-          timing.file
-        }" tests="1" errors="0" failures="0" skipped="0" timestamp="${new Date().toJSON()}" time="${timeInSeconds}">
+        <testsuite name="${timing.file}" file="${
+        timing.file
+      }" tests="1" errors="0" failures="0" skipped="0" timestamp="${new Date().toJSON()}" time="${timeInSeconds}">
           <testcase classname="tests suite should pass" name="${
             timing.file
           }" time="${timeInSeconds}"></testcase>


### PR DESCRIPTION
After inspecting the results from the CircleCi test API it looks like the `file` attribute might be needed for correctly distributing tests also