### PR TITLE
fix: resolve preset-modules

### DIFF
--- a/packages/next/build/webpack/plugins/next-esm-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-esm-plugin.ts
@@ -169,7 +169,7 @@ export default class NextEsmPlugin implements Plugin {
           }
 
           if (IS_PRESET_ENV.test(name)) {
-            presets.push(['@babel/preset-modules', { loose: true }])
+            presets.push([require('@babel/preset-modules'), { loose: true }])
           } else {
             presets.push([name, opts])
           }

--- a/packages/next/build/webpack/plugins/next-esm-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-esm-plugin.ts
@@ -169,7 +169,10 @@ export default class NextEsmPlugin implements Plugin {
           }
 
           if (IS_PRESET_ENV.test(name)) {
-            presets.push([require.resolve('@babel/preset-modules'), { loose: true }])
+            presets.push([
+              require.resolve('@babel/preset-modules'),
+              { loose: true },
+            ])
           } else {
             presets.push([name, opts])
           }

--- a/packages/next/build/webpack/plugins/next-esm-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-esm-plugin.ts
@@ -169,7 +169,7 @@ export default class NextEsmPlugin implements Plugin {
           }
 
           if (IS_PRESET_ENV.test(name)) {
-            presets.push([require('@babel/preset-modules'), { loose: true }])
+            presets.push([require.resolve('@babel/preset-modules'), { loose: true }])
           } else {
             presets.push([name, opts])
           }


### PR DESCRIPTION
https://github.com/zeit/next.js/pull/9489 started using `@babel/preset-modules` without using `require`, this is unsafe and doesn't work with PnP

`@babel/preset-modules` doesn't support pnp as it also doesn't use require, but there is a PR for this upstream, see https://github.com/babel/preset-modules/pull/6