### PR TITLE
Add err.sh for prerender error

### DIFF
--- a/errors/prerender-error.md
+++ b/errors/prerender-error.md
@@ -1,0 +1,11 @@
+# Prerender Error
+
+#### Why This Error Occurred
+
+While prerendering a page an error occurred. This can occur for many reasons from adding non-pages e.g. `components` to your `pages` folder or expecting props to be populated which are not.
+
+#### Possible Ways to Fix It
+
+- Make sure to move any non-pages out of the `pages` folder
+- Check for any code that assumes a prop is available even when it might not be
+- Check for any out of date modules that you might be relying on

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -229,7 +229,10 @@ export default async function({
     await writeFileP(htmlFilepath, html, 'utf8')
     return results
   } catch (error) {
-    console.error(`\nError occurred prerendering page "${path}":`, error)
+    console.error(
+      `\nError occurred prerendering page "${path}" https://err.sh/zeit/next.js/prerender-error:`,
+      error
+    )
     return { ...results, error: true }
   }
 }


### PR DESCRIPTION
This adds the start of an err.sh with some explanations of cases where a prerender error could occur and how to address those specific errors