### PR TITLE
Add Next.js Version as Metadata

### DIFF
--- a/packages/next/telemetry/anonymous-meta.ts
+++ b/packages/next/telemetry/anonymous-meta.ts
@@ -17,6 +17,7 @@ type AnonymousMeta = {
   isWsl: boolean
   isCI: boolean
   ciName: string | null
+  nextVersion: string
 }
 
 let traits: AnonymousMeta | undefined
@@ -44,6 +45,7 @@ export function getAnonymousMeta(): AnonymousMeta {
     isWsl: isWslBoolean,
     isCI: ciEnvironment.isCI,
     ciName: (ciEnvironment.isCI && ciEnvironment.name) || null,
+    nextVersion: process.env.__NEXT_VERSION as string,
   }
 
   return traits


### PR DESCRIPTION
This adds the Next.js version as metadata so we don't have to join to a CLI session to get this information.

Long term, this will provide more performant queries.