### PR TITLE
Increase CI Parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
       - yarn_react_integration
       - *persist_to_workspace
   test:
-    parallelism: 4
+    parallelism: 8
     executor: node
     steps:
       - *attach_workspace


### PR DESCRIPTION
CircleCI parallelism is now autoscaling, as their plans have moved to a credit-based (hours) system instead maximum parallelism.

This means we should be able to use an arbitrarily high parallel count, assuming we're not wasting resources by over provisioning. I'm hoping this gets us into the ~3 minute mark. 

![image](https://user-images.githubusercontent.com/616428/69728618-c0bd8f80-10f2-11ea-9ac7-88d2a5ad6038.png)
