### PR TITLE
Override getKey from cacheble-response for SSR example

### DIFF
--- a/examples/ssr-caching/package.json
+++ b/examples/ssr-caching/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "cacheable-response": "^1.1.0",
     "express": "^4.14.0",
+    "mobile-detect": "^1.4.4",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/examples/ssr-caching/server.js
+++ b/examples/ssr-caching/server.js
@@ -1,6 +1,8 @@
 const cacheableResponse = require('cacheable-response')
+const MobileDetect = require('mobile-detect');
 const express = require('express')
 const next = require('next')
+
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -14,6 +16,10 @@ const ssrCache = cacheableResponse({
     data: await app.renderToHTML(req, res, pagePath, queryParams),
   }),
   send: ({ data, res }) => res.send(data),
+  getKey: (req, res) => {
+    let md = new MobileDetect(req.headers['user-agent']);
+    return `${cacheableResponse.getKey(req)}_${md.mobile() != null}}`;
+  }
 })
 
 app.prepare().then(() => {


### PR DESCRIPTION
Currently too many website are made for different screens, it is necessary to take user agent into account avoiding to send desktop server rendered html to devices and vice versa.