### PR TITLE
s/getStaticParams/getStaticPaths/

### DIFF
--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -8,7 +8,7 @@ const pageComponentVar = '__NEXT_COMP'
 // this value can't be optimized by terser so the shorter the better
 const prerenderId = '__NEXT_SPR'
 const EXPORT_NAME_GET_STATIC_PROPS = 'unstable_getStaticProps'
-const EXPORT_NAME_GET_STATIC_PARAMS = 'unstable_getStaticParams'
+const EXPORT_NAME_GET_STATIC_PARAMS = 'unstable_getStaticPaths'
 const STRING_LITERAL_DROP_BUNDLE = '__NEXT_DROP_CLIENT_FILE__'
 
 // replace program path with just a variable with the drop identifier

--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -8,7 +8,7 @@ const pageComponentVar = '__NEXT_COMP'
 // this value can't be optimized by terser so the shorter the better
 const prerenderId = '__NEXT_SPR'
 const EXPORT_NAME_GET_STATIC_PROPS = 'unstable_getStaticProps'
-const EXPORT_NAME_GET_STATIC_PARAMS = 'unstable_getStaticPaths'
+const EXPORT_NAME_GET_STATIC_PATHS = 'unstable_getStaticPaths'
 const STRING_LITERAL_DROP_BUNDLE = '__NEXT_DROP_CLIENT_FILE__'
 
 // replace program path with just a variable with the drop identifier
@@ -71,7 +71,7 @@ export default function nextPageConfig({
                     if (
                       specifier.exported.name ===
                         EXPORT_NAME_GET_STATIC_PROPS ||
-                      specifier.exported.name === EXPORT_NAME_GET_STATIC_PARAMS
+                      specifier.exported.name === EXPORT_NAME_GET_STATIC_PATHS
                     ) {
                       if (
                         specifier.exported.name === EXPORT_NAME_GET_STATIC_PROPS
@@ -97,7 +97,7 @@ export default function nextPageConfig({
                 if (
                   id &&
                   (id.name === EXPORT_NAME_GET_STATIC_PROPS ||
-                    id.name === EXPORT_NAME_GET_STATIC_PARAMS)
+                    id.name === EXPORT_NAME_GET_STATIC_PATHS)
                 ) {
                   if (id.name === EXPORT_NAME_GET_STATIC_PROPS) {
                     state.isPrerender = true

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -603,7 +603,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
         } else {
           // For a dynamic SPR page, we did not copy its html nor data exports.
           // Instead, we must copy specific versions of this page as defined by
-          // `unstable_getStaticParams` (additionalSprPaths).
+          // `unstable_getStaticPaths` (additionalSprPaths).
           const extraRoutes = additionalSprPaths.get(page) || []
           for (const route of extraRoutes) {
             await moveExportedPage(route, route, true, 'html')

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -242,6 +242,13 @@ export async function isPageStatic(
     const hasGetInitialProps = !!(Comp as any).getInitialProps
     const hasStaticProps = !!mod.unstable_getStaticProps
     const hasStaticPaths = !!mod.unstable_getStaticPaths
+    const hasLegacyStaticParams = !!mod.unstable_getStaticParams
+
+    if (hasLegacyStaticParams) {
+      throw new Error(
+        `unstable_getStaticParams was replaced with unstable_getStaticPaths. Please update your code.`
+      )
+    }
 
     // A page cannot be prerendered _and_ define a data requirement. That's
     // contradictory!

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -299,9 +299,8 @@ export async function isPageStatic(
                 `URL Parameters intended for this dynamic route must be nested under the \`params\` key, i.e.:` +
                 `\n\n\treturn { params: { ${_validParamKeys
                   .map((k, i) => `${k}: "${i}"`)
-                  .join(', ')} }` +
-                `\n\nKeys that need moved: ${invalidKeys.join(', ')}.
-            `
+                  .join(', ')} } }` +
+                `\n\nKeys that need moved: ${invalidKeys.join(', ')}.`
             )
           }
 

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -267,7 +267,7 @@ export async function isPageStatic(
       const _validParamKeys = Object.keys(_routeMatcher(page))
 
       const toPrerender: Array<
-        { params: { [key: string]: string } } | string
+        { params?: { [key: string]: string } } | string
       > = await mod.unstable_getStaticPaths()
       toPrerender.forEach(entry => {
         // For a string-provided path, we must make sure it matches the dynamic
@@ -285,9 +285,11 @@ export async function isPageStatic(
         // For the object-provided path, we must make sure it specifies all
         // required keys.
         else {
+          // TODO: friendlier error message when they do not nest under `props`
+          const { params = {} } = entry
           let builtPage = page
           _validParamKeys.forEach(validParamKey => {
-            if (typeof entry[validParamKey] !== 'string') {
+            if (typeof params[validParamKey] !== 'string') {
               throw new Error(
                 `A required parameter (${validParamKey}) was not provided as a string.`
               )
@@ -295,7 +297,7 @@ export async function isPageStatic(
 
             builtPage = builtPage.replace(
               `[${validParamKey}]`,
-              encodeURIComponent(entry[validParamKey])
+              encodeURIComponent(params[validParamKey])
             )
           })
 

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -241,7 +241,7 @@ export async function isPageStatic(
 
     const hasGetInitialProps = !!(Comp as any).getInitialProps
     const hasStaticProps = !!mod.unstable_getStaticProps
-    const hasStaticParams = !!mod.unstable_getStaticParams
+    const hasStaticPaths = !!mod.unstable_getStaticPaths
 
     // A page cannot be prerendered _and_ define a data requirement. That's
     // contradictory!
@@ -250,14 +250,14 @@ export async function isPageStatic(
     }
 
     // A page cannot have static parameters if it is not a dynamic page.
-    if (hasStaticProps && hasStaticParams && !isDynamicRoute(page)) {
+    if (hasStaticProps && hasStaticPaths && !isDynamicRoute(page)) {
       throw new Error(
-        `unstable_getStaticParams can only be used with dynamic pages. https://nextjs.org/docs#dynamic-routing`
+        `unstable_getStaticPaths can only be used with dynamic pages. https://nextjs.org/docs#dynamic-routing`
       )
     }
 
     let prerenderPaths: string[] | undefined
-    if (hasStaticProps && hasStaticParams) {
+    if (hasStaticProps && hasStaticPaths) {
       prerenderPaths = [] as string[]
 
       const _routeRegex = getRouteRegex(page)
@@ -267,8 +267,8 @@ export async function isPageStatic(
       const _validParamKeys = Object.keys(_routeMatcher(page))
 
       const toPrerender: Array<
-        { [key: string]: string } | string
-      > = await mod.unstable_getStaticParams()
+        { params: { [key: string]: string } } | string
+      > = await mod.unstable_getStaticPaths()
       toPrerender.forEach(entry => {
         // For a string-provided path, we must make sure it matches the dynamic
         // route.

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -292,7 +292,19 @@ export async function isPageStatic(
         // For the object-provided path, we must make sure it specifies all
         // required keys.
         else {
-          // TODO: friendlier error message when they do not nest under `props`
+          const invalidKeys = Object.keys(entry).filter(key => key !== 'params')
+          if (invalidKeys.length) {
+            throw new Error(
+              `Additional keys were returned from \`unstable_getStaticPaths\` in page "${page}". ` +
+                `URL Parameters intended for this dynamic route must be nested under the \`params\` key, i.e.:` +
+                `\n\n\treturn { params: { ${_validParamKeys
+                  .map((k, i) => `${k}: "${i}"`)
+                  .join(', ')} }` +
+                `\n\nKeys that need moved: ${invalidKeys.join(', ')}.
+            `
+            )
+          }
+
           const { params = {} } = entry
           let builtPage = page
           _validParamKeys.forEach(validParamKey => {

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -298,9 +298,9 @@ export async function isPageStatic(
               `Additional keys were returned from \`unstable_getStaticPaths\` in page "${page}". ` +
                 `URL Parameters intended for this dynamic route must be nested under the \`params\` key, i.e.:` +
                 `\n\n\treturn { params: { ${_validParamKeys
-                  .map((k, i) => `${k}: "${i}"`)
+                  .map(k => `${k}: ...`)
                   .join(', ')} } }` +
-                `\n\nKeys that need moved: ${invalidKeys.join(', ')}.`
+                `\n\nKeys that need moved: ${invalidKeys.join(', ')}.\n`
             )
           }
 

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -101,7 +101,7 @@ const nextServerlessLoader: loader.Loader = function() {
     export const unstable_getStaticProps = ComponentInfo['unstable_getStaticProp' + 's']
     ${
       isDynamicRoute(page)
-        ? "export const unstable_getStaticParams = ComponentInfo['unstable_getStaticParam' + 's']"
+        ? "export const unstable_getStaticPaths = ComponentInfo['unstable_getStaticPath' + 's']"
         : ''
     }
     export const config = ComponentInfo['confi' + 'g'] || {}

--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -21,7 +21,7 @@ export type LoadComponentsReturnType = {
     props: any
     revalidate: number | false
   }
-  unstable_getStaticParams?: () => void
+  unstable_getStaticPaths?: () => void
   buildManifest?: any
   reactLoadableManifest?: any
   Document?: any
@@ -41,7 +41,7 @@ export async function loadComponents(
       Component,
       pageConfig: Component.config || {},
       unstable_getStaticProps: Component.unstable_getStaticProps,
-      unstable_getStaticParams: Component.unstable_getStaticParams,
+      unstable_getStaticPaths: Component.unstable_getStaticPaths,
     }
   }
   const documentPath = join(
@@ -89,6 +89,6 @@ export async function loadComponents(
     reactLoadableManifest,
     pageConfig: ComponentMod.config || {},
     unstable_getStaticProps: ComponentMod.unstable_getStaticProps,
-    unstable_getStaticParams: ComponentMod.unstable_getStaticParams,
+    unstable_getStaticPaths: ComponentMod.unstable_getStaticPaths,
   }
 }

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -432,9 +432,8 @@ export async function renderToHTML(
       if (invalidKeys.length) {
         throw new Error(
           `Additional keys were returned from \`getStaticProps\`. Properties intended for your component must be nested under the \`props\` key, e.g.:` +
-            `\n\n\treturn { props: { title: 'My Title', content: '...' }` +
-            `\n\nKeys that need moved: ${invalidKeys.join(', ')}.
-        `
+            `\n\n\treturn { props: { title: 'My Title', content: '...' } }` +
+            `\n\nKeys that need moved: ${invalidKeys.join(', ')}.`
         )
       }
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -158,7 +158,7 @@ type RenderOpts = {
     props: any
     revalidate: number | false
   }
-  unstable_getStaticParams?: () => void
+  unstable_getStaticPaths?: () => void
 }
 
 function renderDocument(
@@ -279,7 +279,7 @@ export async function renderToHTML(
     reactLoadableManifest,
     ErrorDebug,
     unstable_getStaticProps,
-    unstable_getStaticParams,
+    unstable_getStaticPaths,
   } = renderOpts
 
   const callMiddleware = async (method: string, args: any[], props = false) => {
@@ -321,9 +321,9 @@ export async function renderToHTML(
     throw new Error(SPR_GET_INITIAL_PROPS_CONFLICT + ` ${pathname}`)
   }
 
-  if (!!unstable_getStaticParams && !isSpr) {
+  if (!!unstable_getStaticPaths && !isSpr) {
     throw new Error(
-      `unstable_getStaticParams was added without a unstable_getStaticProps in ${pathname}. Without unstable_getStaticProps, unstable_getStaticParams does nothing`
+      `unstable_getStaticPaths was added without a unstable_getStaticProps in ${pathname}. Without unstable_getStaticProps, unstable_getStaticPaths does nothing`
     )
   }
 

--- a/test/integration/prerender-invalid-paths/pages/[foo]/[post].js
+++ b/test/integration/prerender-invalid-paths/pages/[foo]/[post].js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticPaths() {
+  return [{ foo: 'bad', baz: 'herro' }]
+}
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps({ params }) {
+  return {
+    props: {
+      post: params.post,
+      time: (await import('perf_hooks')).performance.now(),
+    },
+  }
+}
+
+export default () => {
+  return <div />
+}

--- a/test/integration/prerender-invalid-paths/test/index.test.js
+++ b/test/integration/prerender-invalid-paths/test/index.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '..')
+
+describe('Legacy Prerender', () => {
+  describe('handles old getStaticParams', () => {
+    it('should fail the build', async () => {
+      const out = await nextBuild(appDir, [], { stderr: true })
+      expect(out.stderr).toMatch(`Build error occurred`)
+      expect(out.stderr).toMatch('Additional keys were returned from')
+      expect(out.stderr).toMatch('return { params: { foo: "0", post: "1" } }')
+      expect(out.stderr).toMatch('Keys that need moved: foo, baz.')
+    })
+  })
+})

--- a/test/integration/prerender-invalid-paths/test/index.test.js
+++ b/test/integration/prerender-invalid-paths/test/index.test.js
@@ -12,7 +12,7 @@ describe('Legacy Prerender', () => {
       const out = await nextBuild(appDir, [], { stderr: true })
       expect(out.stderr).toMatch(`Build error occurred`)
       expect(out.stderr).toMatch('Additional keys were returned from')
-      expect(out.stderr).toMatch('return { params: { foo: "0", post: "1" } }')
+      expect(out.stderr).toMatch('return { params: { foo: ..., post: ... } }')
       expect(out.stderr).toMatch('Keys that need moved: foo, baz.')
     })
   })

--- a/test/integration/prerender-legacy/pages/blog/[post].js
+++ b/test/integration/prerender-legacy/pages/blog/[post].js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticParams() {
+  return ['/blog/post-1']
+}
+
+// eslint-disable-next-line camelcase
+export async function unstable_getStaticProps({ params }) {
+  return {
+    props: {
+      post: params.post,
+      time: (await import('perf_hooks')).performance.now(),
+    },
+  }
+}
+
+export default () => {
+  return <div />
+}

--- a/test/integration/prerender-legacy/test/index.test.js
+++ b/test/integration/prerender-legacy/test/index.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '..')
+
+describe('Legacy Prerender', () => {
+  describe('handles old getStaticParams', () => {
+    it('should fail the build', async () => {
+      const out = await nextBuild(appDir, [], { stderr: true })
+      expect(out.stderr).toMatch(`Build error occurred`)
+      expect(out.stderr).toMatch(
+        'unstable_getStaticParams was replaced with unstable_getStaticPaths. Please update your code.'
+      )
+    })
+  })
+})

--- a/test/integration/prerender/pages/blog/[post]/[comment].js
+++ b/test/integration/prerender/pages/blog/[post]/[comment].js
@@ -2,8 +2,11 @@ import React from 'react'
 import Link from 'next/link'
 
 // eslint-disable-next-line camelcase
-export async function unstable_getStaticParams() {
-  return ['/blog/post-1/comment-1', { post: 'post-2', comment: 'comment-2' }]
+export async function unstable_getStaticPaths() {
+  return [
+    '/blog/post-1/comment-1',
+    { params: { post: 'post-2', comment: 'comment-2' } },
+  ]
 }
 
 // eslint-disable-next-line camelcase

--- a/test/integration/prerender/pages/blog/[post]/index.js
+++ b/test/integration/prerender/pages/blog/[post]/index.js
@@ -2,8 +2,13 @@ import React from 'react'
 import Link from 'next/link'
 
 // eslint-disable-next-line camelcase
-export async function unstable_getStaticParams() {
-  return ['/blog/post-1', { post: 'post-2' }, '/blog/[post3]', '/blog/post.1']
+export async function unstable_getStaticPaths() {
+  return [
+    '/blog/post-1',
+    { params: { post: 'post-2' } },
+    '/blog/[post3]',
+    '/blog/post.1',
+  ]
 }
 
 // eslint-disable-next-line camelcase

--- a/test/integration/prerender/pages/user/[user]/profile.js
+++ b/test/integration/prerender/pages/user/[user]/profile.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Link from 'next/link'
 
 // eslint-disable-next-line camelcase
-export async function unstable_getStaticParams() {
+export async function unstable_getStaticPaths() {
   return []
 }
 

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -249,12 +249,12 @@ const runTests = (dev = false) => {
       }
     })
 
-    it('should show error when getStaticParams is used without getStaticProps', async () => {
+    it('should show error when getStaticPaths is used without getStaticProps', async () => {
       const pagePath = join(appDir, 'pages/no-getStaticProps.js')
       await fs.writeFile(
         pagePath,
         `
-        export async function unstable_getStaticParams() {
+        export async function unstable_getStaticPaths() {
           return []
         }
 
@@ -268,7 +268,7 @@ const runTests = (dev = false) => {
       await waitFor(500)
 
       expect(html).toMatch(
-        /unstable_getStaticParams was added without a unstable_getStaticProps in/
+        /unstable_getStaticPaths was added without a unstable_getStaticProps in/
       )
     })
   } else {

--- a/test/unit/babel-plugin-next-page-config.test.js
+++ b/test/unit/babel-plugin-next-page-config.test.js
@@ -32,7 +32,7 @@ describe('babel plugin (next-page-config)', () => {
   describe('getStaticProps support', () => {
     it('should remove separate named export specifiers', () => {
       const output = babel(trim`
-        export { unstable_getStaticParams } from '.'
+        export { unstable_getStaticPaths } from '.'
         export { a as unstable_getStaticProps } from '.'
 
         export default function Test() {
@@ -46,7 +46,7 @@ describe('babel plugin (next-page-config)', () => {
 
     it('should remove combined named export specifiers', () => {
       const output = babel(trim`
-        export { unstable_getStaticParams, a as unstable_getStaticProps } from '.'
+        export { unstable_getStaticPaths, a as unstable_getStaticProps } from '.'
 
         export default function Test() {
           return <div />
@@ -59,7 +59,7 @@ describe('babel plugin (next-page-config)', () => {
 
     it('should retain extra named export specifiers', () => {
       const output = babel(trim`
-        export { unstable_getStaticParams, a as unstable_getStaticProps, foo, bar as baz } from '.'
+        export { unstable_getStaticPaths, a as unstable_getStaticProps, foo, bar as baz } from '.'
 
         export default function Test() {
           return <div />
@@ -72,7 +72,7 @@ describe('babel plugin (next-page-config)', () => {
 
     it('should remove named export declarations', () => {
       const output = babel(trim`
-        export function unstable_getStaticParams() {
+        export function unstable_getStaticPaths() {
           return []
         }
 


### PR DESCRIPTION
This replaces `unstable_getStaticParams` with `unstable_getStaticPaths` and requires nesting under the `params` key as defined in the RFC.

For the time being, we'll fail the build if users still define `unstable_getStaticParams` to force them to upgrade.

![image](https://user-images.githubusercontent.com/616428/69774070-d36fad00-1162-11ea-8e4e-cbcf1f7df111.png)
