### PR TITLE
Move cross-env from devDependencies to dependencies

### DIFF
--- a/examples/custom-server-express/package.json
+++ b/examples/custom-server-express/package.json
@@ -7,12 +7,10 @@
     "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "express": "^4.14.0",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
-  },
-  "devDependencies": {
-    "cross-env": "^5.2.0"
   }
 }

--- a/examples/custom-server-fastify/package.json
+++ b/examples/custom-server-fastify/package.json
@@ -7,12 +7,10 @@
     "start": "cross-env NODE_ENV=production node ./server.js"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "fastify": "2.1.0",
     "next": "latest",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
-  },
-  "devDependencies": {
-    "cross-env": "^5.2.0"
   }
 }

--- a/examples/custom-server-hapi/package.json
+++ b/examples/custom-server-hapi/package.json
@@ -4,10 +4,11 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
     "@hapi/hapi": "^18.3.1",
+    "cross-env": "^5.2.0",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/examples/custom-server-koa/package.json
+++ b/examples/custom-server-koa/package.json
@@ -4,9 +4,10 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "koa": "^2.0.1",
     "koa-router": "^7.1.0",
     "next": "latest",

--- a/examples/custom-server-micro/package.json
+++ b/examples/custom-server-micro/package.json
@@ -6,6 +6,7 @@
     "start": "cross-env NODE_ENV=production micro"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "micro": "^9.3.3",
     "micro-route": "^2.5.0",
     "next": "latest",
@@ -13,7 +14,6 @@
     "react-dom": "^16.8.4"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
     "micro-dev": "^3.0.0"
   }
 }

--- a/examples/custom-server-nodemon/package.json
+++ b/examples/custom-server-nodemon/package.json
@@ -2,9 +2,10 @@
   "scripts": {
     "dev": "nodemon server/index.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server/index.js"
+    "start": "cross-env NODE_ENV=production node server/index.js"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/examples/custom-server-polka/package.json
+++ b/examples/custom-server-polka/package.json
@@ -4,9 +4,10 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "next": "latest",
     "polka": "0.5.1",
     "react": "^16.7.0",

--- a/examples/custom-server-reasonml/package.json
+++ b/examples/custom-server-reasonml/package.json
@@ -8,7 +8,7 @@
     "next-build": "next build",
     "dev": "bsb -make-world && node server/server.bs.js",
     "next:build": "bsb -make-world && next build",
-    "start": "NODE_ENV=production node server/server.bs.js"
+    "start": "cross-env NODE_ENV=production node server/server.bs.js"
   },
   "keywords": [
     "BuckleScript"
@@ -19,6 +19,7 @@
     "bs-platform": "^4.0.18"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "next": "latest",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -7,6 +7,7 @@
     "start": "cross-env NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
+    "cross-env": "^5.2.0",
     "next": "latest",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
@@ -15,7 +16,6 @@
     "@types/node": "^12.0.12",
     "@types/react": "^16.8.17",
     "@types/react-dom": "16.8.4",
-    "cross-env": "^5.2.0",
     "nodemon": "^1.19.0",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"


### PR DESCRIPTION
- We use `cross-env` in `npm start`. In my point of view, this command is for production, so `cross-env` should be put into `dependencies`.
- Add `cross-env` to all custom server examples for Windows users.