### PR TITLE
__NEXT_DATA__.props doesn't have locale/messages

### DIFF
--- a/examples/with-react-intl/pages/_app.js
+++ b/examples/with-react-intl/pages/_app.js
@@ -17,7 +17,7 @@ export default class MyApp extends App {
     // Get the `locale` and `messages` from the request object on the server.
     // In the browser, use the same values that the server serialized.
     const { req } = ctx
-    const { locale, messages } = req || window.__NEXT_DATA__.props
+    const { locale, messages } = req || window.__NEXT_DATA__.props.initialProps
 
     return { pageProps, locale, messages }
   }


### PR DESCRIPTION
I had to look in the `__NEXT_DATA__.props.initialProps` to get the initial values that were generated in the server.