### PR TITLE
fix(build): fix build with relay

### DIFF
--- a/examples/with-react-relay-network-modern/next.config.js
+++ b/examples/with-react-relay-network-modern/next.config.js
@@ -5,6 +5,20 @@ const Dotenv = require('dotenv-webpack')
 
 module.exports = {
   webpack: (config, { isServer }) => {
+    
+    const originalEntry = config.entry;
+    config.entry = async () => {
+      const entries = await originalEntry();
+      const keys = Object.keys(entries);
+      keys.forEach(key => {
+        if (key.includes('__generated__')) {
+          delete entries[key];
+        }
+      });
+
+      return entries;
+    };
+    
     config.plugins.push(
       new Dotenv({
         path: path.join(__dirname, '.env'),


### PR DESCRIPTION
Build was breaking because of relay `/__generated__` on pages directory. 
I made the fix based on [this issue](https://github.com/zeit/next.js/issues/8617#issuecomment-527980479).
Removing `/__generated__` entries from build with webpack
