### PR TITLE
fix(relay-examples): fix relay build examples

### DIFF
--- a/examples/with-react-relay-network-modern/next.config.js
+++ b/examples/with-react-relay-network-modern/next.config.js
@@ -5,19 +5,18 @@ const Dotenv = require('dotenv-webpack')
 
 module.exports = {
   webpack: (config, { isServer }) => {
-
-    const originalEntry = config.entry;
+    const originalEntry = config.entry
     config.entry = async () => {
-      const entries = await originalEntry();
-      const keys = Object.keys(entries);
+      const entries = await originalEntry()
+      const keys = Object.keys(entries)
       keys.forEach(key => {
         if (key.includes('__generated__')) {
-          delete entries[key];
+          delete entries[key]
         }
-      });
+      })
 
-      return entries;
-    };
+      return entries
+    }
 
     config.plugins.push(
       new Dotenv({

--- a/examples/with-react-relay-network-modern/next.config.js
+++ b/examples/with-react-relay-network-modern/next.config.js
@@ -5,6 +5,20 @@ const Dotenv = require('dotenv-webpack')
 
 module.exports = {
   webpack: (config, { isServer }) => {
+
+    const originalEntry = config.entry;
+    config.entry = async () => {
+      const entries = await originalEntry();
+      const keys = Object.keys(entries);
+      keys.forEach(key => {
+        if (key.includes('__generated__')) {
+          delete entries[key];
+        }
+      });
+
+      return entries;
+    };
+
     config.plugins.push(
       new Dotenv({
         path: path.join(__dirname, '.env'),

--- a/examples/with-relay-modern-server-express/next.config.js
+++ b/examples/with-relay-modern-server-express/next.config.js
@@ -5,19 +5,18 @@ const Dotenv = require('dotenv-webpack')
 
 module.exports = {
   webpack: config => {
-    
-    const originalEntry = config.entry;
+    const originalEntry = config.entry
     config.entry = async () => {
-      const entries = await originalEntry();
-      const keys = Object.keys(entries);
+      const entries = await originalEntry()
+      const keys = Object.keys(entries)
       keys.forEach(key => {
         if (key.includes('__generated__')) {
-          delete entries[key];
+          delete entries[key]
         }
-      });
+      })
 
-      return entries;
-    };
+      return entries
+    }
 
     config.plugins = config.plugins || []
 

--- a/examples/with-relay-modern-server-express/next.config.js
+++ b/examples/with-relay-modern-server-express/next.config.js
@@ -5,6 +5,20 @@ const Dotenv = require('dotenv-webpack')
 
 module.exports = {
   webpack: config => {
+    
+    const originalEntry = config.entry;
+    config.entry = async () => {
+      const entries = await originalEntry();
+      const keys = Object.keys(entries);
+      keys.forEach(key => {
+        if (key.includes('__generated__')) {
+          delete entries[key];
+        }
+      });
+
+      return entries;
+    };
+
     config.plugins = config.plugins || []
 
     config.plugins = [

--- a/examples/with-relay-modern/next.config.js
+++ b/examples/with-relay-modern/next.config.js
@@ -5,19 +5,18 @@ const Dotenv = require('dotenv-webpack')
 
 module.exports = {
   webpack: config => {
-
-    const originalEntry = config.entry;
+    const originalEntry = config.entry
     config.entry = async () => {
-      const entries = await originalEntry();
-      const keys = Object.keys(entries);
+      const entries = await originalEntry()
+      const keys = Object.keys(entries)
       keys.forEach(key => {
         if (key.includes('__generated__')) {
-          delete entries[key];
+          delete entries[key]
         }
-      });
+      })
 
-      return entries;
-    };
+      return entries
+    }
     config.plugins = config.plugins || []
 
     config.plugins = [

--- a/examples/with-relay-modern/next.config.js
+++ b/examples/with-relay-modern/next.config.js
@@ -5,6 +5,19 @@ const Dotenv = require('dotenv-webpack')
 
 module.exports = {
   webpack: config => {
+
+    const originalEntry = config.entry;
+    config.entry = async () => {
+      const entries = await originalEntry();
+      const keys = Object.keys(entries);
+      keys.forEach(key => {
+        if (key.includes('__generated__')) {
+          delete entries[key];
+        }
+      });
+
+      return entries;
+    };
     config.plugins = config.plugins || []
 
     config.plugins = [


### PR DESCRIPTION
Build was breaking because of relay `/__generated__` on pages directory.
I made the fix based on [this issue](https://github.com/zeit/next.js/issues/8617#issuecomment-527980479).
The fix consists of removing `/__generated__` entries from build with webpack config