### PR TITLE
Simplify getRouteRegex Callsites

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -267,8 +267,7 @@ export async function isPageStatic(
     if (hasStaticProps && hasStaticPaths) {
       prerenderPaths = [] as string[]
 
-      const _routeRegex = getRouteRegex(page)
-      const _routeMatcher = getRouteMatcher(_routeRegex)
+      const _routeMatcher = getRouteMatcher(getRouteRegex(page))
 
       // Get the default list of allowed params.
       const _validParamKeys = Object.keys(_routeMatcher(page))

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -316,8 +316,7 @@ export default class Router implements BaseRouter {
 
       if (isDynamicRoute(route)) {
         const { pathname: asPathname } = parse(as)
-        const rr = getRouteRegex(route)
-        const routeMatch = getRouteMatcher(rr)(asPathname)
+        const routeMatch = getRouteMatcher(getRouteRegex(route))(asPathname)
         if (!routeMatch) {
           const error =
             `The provided \`as\` value (${asPathname}) is incompatible with the \`href\` value (${route}). ` +


### PR DESCRIPTION
This inlines 2x calls to `getRouteRegex` since it's never reused.