### PR TITLE
Support `repeat`ing Dynamic Route Params

### DIFF
--- a/packages/next/next-server/lib/router/utils/route-matcher.ts
+++ b/packages/next/next-server/lib/router/utils/route-matcher.ts
@@ -8,15 +8,18 @@ export function getRouteMatcher(routeRegex: ReturnType<typeof getRouteRegex>) {
       return false
     }
 
+    const decode = decodeURIComponent
     const params: { [paramName: string]: string | string[] } = {}
 
     Object.keys(groups).forEach((slugName: string) => {
-      const m = routeMatch[groups[slugName]]
+      const g = groups[slugName]
+      const m = routeMatch[g.pos]
       if (m !== undefined) {
-        params[slugName] =
-          m.indexOf('/') !== -1
-            ? m.split('/').map(entry => decodeURIComponent(entry))
-            : decodeURIComponent(m)
+        params[slugName] = ~m.indexOf('/')
+          ? m.split('/').map(entry => decode(entry))
+          : g.repeat
+          ? [decode(m)]
+          : decode(m)
       }
     })
     return params

--- a/packages/next/next-server/lib/router/utils/route-regex.ts
+++ b/packages/next/next-server/lib/router/utils/route-regex.ts
@@ -1,27 +1,31 @@
 export function getRouteRegex(
   normalizedRoute: string
-): { re: RegExp; groups: { [groupName: string]: number } } {
+): {
+  re: RegExp
+  groups: { [groupName: string]: { pos: number; repeat: boolean } }
+} {
   // Escape all characters that could be considered RegEx
   const escapedRoute = (normalizedRoute.replace(/\/$/, '') || '/').replace(
     /[|\\{}()[\]^$+*?.-]/g,
     '\\$&'
   )
 
-  const groups: { [groupName: string]: number } = {}
+  const groups: { [groupName: string]: { pos: number; repeat: boolean } } = {}
   let groupIndex = 1
 
   const parameterizedRoute = escapedRoute.replace(
     /\/\\\[([^/]+?)\\\](?=\/|$)/g,
-    (_, $1) => (
-      (groups[
+    (_, $1) => {
+      const isCatchAll = /^(\\\.){3}/.test($1)
+      groups[
         $1
           // Un-escape key
           .replace(/\\([|\\{}()[\]^$+*?.-])/g, '$1')
           .replace(/^\.{3}/, '')
         // eslint-disable-next-line no-sequences
-      ] = groupIndex++),
-      $1.indexOf('\\.\\.\\.') === 0 ? '/(.+?)' : '/([^/]+?)'
-    )
+      ] = { pos: groupIndex++, repeat: isCatchAll }
+      return isCatchAll ? '/(.+?)' : '/([^/]+?)'
+    }
   )
 
   return {

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -151,7 +151,7 @@ function runTests(dev) {
   it('[catch all] should pass param in getInitialProps during SSR', async () => {
     const html = await renderViaHTTP(appPort, '/p1/p2/all-ssr/test1')
     const $ = cheerio.load(html)
-    expect($('#all-ssr-content').text()).toBe('{"rest":"test1"}')
+    expect($('#all-ssr-content').text()).toBe('{"rest":["test1"]}')
   })
 
   it('[catch all] should pass params in getInitialProps during SSR', async () => {
@@ -192,7 +192,7 @@ function runTests(dev) {
       await browser.waitForElementByCss('#all-ssr-content')
 
       const text = await browser.elementByCss('#all-ssr-content').text()
-      expect(text).toBe('{"rest":"hello"}')
+      expect(text).toBe('{"rest":["hello"]}')
     } finally {
       if (browser) await browser.close()
     }
@@ -229,7 +229,7 @@ function runTests(dev) {
   it('[ssg: catch all] should pass param in getInitialProps during SSR', async () => {
     const html = await renderViaHTTP(appPort, '/p1/p2/all-ssg/test1')
     const $ = cheerio.load(html)
-    expect($('#all-ssg-content').text()).toBe('{"rest":"test1"}')
+    expect($('#all-ssg-content').text()).toBe('{"rest":["test1"]}')
   })
 
   it('[ssg: catch all] should pass params in getInitialProps during SSR', async () => {
@@ -241,7 +241,7 @@ function runTests(dev) {
   it('[predefined ssg: catch all] should pass param in getInitialProps during SSR', async () => {
     const html = await renderViaHTTP(appPort, '/p1/p2/predefined-ssg/test1')
     const $ = cheerio.load(html)
-    expect($('#all-ssg-content').text()).toBe('{"rest":"test1"}')
+    expect($('#all-ssg-content').text()).toBe('{"rest":["test1"]}')
   })
 
   it('[predefined ssg: catch all] should pass params in getInitialProps during SSR', async () => {
@@ -256,7 +256,7 @@ function runTests(dev) {
   it('[predefined ssg: prerendered catch all] should pass param in getInitialProps during SSR', async () => {
     const html = await renderViaHTTP(appPort, '/p1/p2/predefined-ssg/one-level')
     const $ = cheerio.load(html)
-    expect($('#all-ssg-content').text()).toBe('{"rest":"one-level"}')
+    expect($('#all-ssg-content').text()).toBe('{"rest":["one-level"]}')
   })
 
   it('[predefined ssg: prerendered catch all] should pass params in getInitialProps during SSR', async () => {
@@ -278,7 +278,7 @@ function runTests(dev) {
       await browser.waitForElementByCss('#all-ssg-content')
 
       const text = await browser.elementByCss('#all-ssg-content').text()
-      expect(text).toBe('{"rest":"hello"}')
+      expect(text).toBe('{"rest":["hello"]}')
     } finally {
       if (browser) await browser.close()
     }


### PR DESCRIPTION
Catch-all routes should always appear as arrays. Not alternate between a string and array.

This matches `path-to-regexp` behavior, which is used for our custom routes.

```js
> require('path-to-regexp').match('/:test*')('/foo')
{
  path: '/foo',
  index: 0,
  params: [Object: null prototype] { test: [ 'foo' ] }
}
```

Also, this matches Node behavior too:
```js
> function foo(...abc){console.log(abc)}

> foo('a')
[ 'a' ]
```