### PR TITLE
Add Support for Event Flushing

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -137,18 +137,16 @@ export default async function build(dir: string, conf = null): Promise<void> {
   let publicFiles: string[] = []
   let hasPublicDir = false
 
-  let backgroundWork: (Promise<any> | undefined)[] = []
-  backgroundWork.push(
-    telemetry.record(
-      eventVersion({
-        cliCommand: 'build',
-        isSrcDir: path.relative(dir, pagesDir!).startsWith('src'),
-        hasNowJson: !!(await findUp('now.json', { cwd: dir })),
-        isCustomServer: null,
-      })
-    ),
-    eventNextPlugins(path.resolve(dir)).then(events => telemetry.record(events))
+  telemetry.record(
+    eventVersion({
+      cliCommand: 'build',
+      isSrcDir: path.relative(dir, pagesDir!).startsWith('src'),
+      hasNowJson: !!(await findUp('now.json', { cwd: dir })),
+      isCustomServer: null,
+    })
   )
+
+  eventNextPlugins(path.resolve(dir)).then(events => telemetry.record(events))
 
   await verifyTypeScriptSetup(dir, pagesDir)
 
@@ -322,13 +320,11 @@ export default async function build(dir: string, conf = null): Promise<void> {
     console.warn()
   } else {
     console.log(chalk.green('Compiled successfully.\n'))
-    backgroundWork.push(
-      telemetry.record(
-        eventBuildDuration({
-          totalPageCount: pagePaths.length,
-          durationInSeconds: webpackBuildEnd[0],
-        })
-      )
+    telemetry.record(
+      eventBuildDuration({
+        totalPageCount: pagePaths.length,
+        durationInSeconds: webpackBuildEnd[0],
+      })
     )
   }
   const postBuildSpinner = createSpinner({
@@ -673,15 +669,13 @@ export default async function build(dir: string, conf = null): Promise<void> {
   console.log()
 
   const analysisEnd = process.hrtime(analysisBegin)
-  backgroundWork.push(
-    telemetry.record(
-      eventBuildOptimize({
-        durationInSeconds: analysisEnd[0],
-        totalPageCount: pagePaths.length,
-        staticPageCount: staticPages.size,
-        ssrPageCount: pagePaths.length - staticPages.size,
-      })
-    )
+  telemetry.record(
+    eventBuildOptimize({
+      durationInSeconds: analysisEnd[0],
+      totalPageCount: pagePaths.length,
+      staticPageCount: staticPages.size,
+      ssrPageCount: pagePaths.length - staticPages.size,
+    })
   )
 
   if (sprPages.size > 0) {
@@ -780,5 +774,5 @@ export default async function build(dir: string, conf = null): Promise<void> {
     })
   }
 
-  await Promise.all(backgroundWork).catch(() => {})
+  await telemetry.flush()
 }

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -93,8 +93,10 @@ export default async function(
   const nextConfig = configuration || loadConfig(PHASE_EXPORT, dir)
   const threads = options.threads || Math.max(cpus().length - 1, 1)
   const distDir = join(dir, nextConfig.distDir)
-  if (!options.buildExport) {
-    const telemetry = new Telemetry({ distDir })
+
+  let telemetry = options.buildExport ? null : new Telemetry({ distDir })
+
+  if (telemetry) {
     telemetry.record(
       eventVersion({
         cliCommand: 'export',
@@ -369,4 +371,8 @@ export default async function(
   }
   // Add an empty line to the console for the better readability.
   log('')
+
+  if (telemetry) {
+    await telemetry.flush()
+  }
 }

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -94,7 +94,7 @@ export default async function(
   const threads = options.threads || Math.max(cpus().length - 1, 1)
   const distDir = join(dir, nextConfig.distDir)
 
-  let telemetry = options.buildExport ? null : new Telemetry({ distDir })
+  const telemetry = options.buildExport ? null : new Telemetry({ distDir })
 
   if (telemetry) {
     telemetry.record(


### PR DESCRIPTION
This adds support for flushing events to the `Telemetry` class instead of hand-rolling when used.

The benefit here is we can add a flush for `next export`!