### PR TITLE
Aggressively Replace Constants

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -242,6 +242,7 @@ export default async function getBaseWebpackConfig(
         cache: true,
         babelPresetPlugins,
         hasModern: !!config.experimental.modern,
+        development: dev,
       },
     },
     // Backwards compat

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -58,6 +58,7 @@ module.exports = babelLoader.custom(babel => {
         pagesDir: opts.pagesDir,
         hasModern: opts.hasModern,
         babelPresetPlugins: opts.babelPresetPlugins,
+        development: opts.development,
       }
       const filename = join(opts.cwd, 'noop.js')
       const loader = Object.assign(
@@ -70,6 +71,7 @@ module.exports = babelLoader.custom(babel => {
                 (opts.isServer ? '-server' : '') +
                 (opts.isModern ? '-modern' : '') +
                 (opts.hasModern ? '-has-modern' : '') +
+                (opts.development ? '-development' : '') +
                 JSON.stringify(
                   babel.loadPartialConfig({
                     filename,
@@ -91,6 +93,7 @@ module.exports = babelLoader.custom(babel => {
       delete loader.hasModern
       delete loader.pagesDir
       delete loader.babelPresetPlugins
+      delete loader.development
       return { loader, custom }
     },
     config(
@@ -103,6 +106,7 @@ module.exports = babelLoader.custom(babel => {
           hasModern,
           pagesDir,
           babelPresetPlugins,
+          development,
         },
       }
     ) {
@@ -175,7 +179,11 @@ module.exports = babelLoader.custom(babel => {
 
       options.plugins.push([
         require.resolve('babel-plugin-transform-define'),
-        { 'typeof window': isServer ? 'undefined' : 'object' },
+        {
+          'process.env.NODE_ENV': development ? 'development' : 'production',
+          'typeof window': isServer ? 'undefined' : 'object',
+          'process.browser': isServer ? false : true,
+        },
         'next-js-transform-define-instance',
       ])
 

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -71,7 +71,7 @@ module.exports = babelLoader.custom(babel => {
                 (opts.isServer ? '-server' : '') +
                 (opts.isModern ? '-modern' : '') +
                 (opts.hasModern ? '-has-modern' : '') +
-                (opts.development ? '-development' : '') +
+                (opts.development ? '-development' : '-production') +
                 JSON.stringify(
                   babel.loadPartialConfig({
                     filename,

--- a/test/unit/next-babel-loader.test.js
+++ b/test/unit/next-babel-loader.test.js
@@ -66,9 +66,14 @@ describe('next-babel-loader', () => {
       )
     })
 
-    it('should replace typeof window expression top level', async () => {
+    it('should replace typeof window expression top level (client)', async () => {
       const code = await babel('typeof window;')
       expect(code).toMatchInlineSnapshot(`"\\"object\\";"`)
+    })
+
+    it('should replace typeof window expression top level (server)', async () => {
+      const code = await babel('typeof window;', { isServer: true })
+      expect(code).toMatchInlineSnapshot(`"\\"undefined\\";"`)
     })
 
     it('should replace typeof window expression nested', async () => {

--- a/test/unit/next-babel-loader.test.js
+++ b/test/unit/next-babel-loader.test.js
@@ -1,0 +1,191 @@
+/* eslint-env jest */
+
+const loader = require('next/dist/build/webpack/loaders/next-babel-loader')
+const os = require('os')
+
+const babel = async (
+  code,
+  {
+    isServer = false,
+    resourcePath = 'index.js',
+    hasModern = false,
+    development = false,
+  } = {}
+) => {
+  let isAsync = false
+  return new Promise((resolve, reject) => {
+    function callback(err, content) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(content)
+      }
+    }
+
+    const res = loader.bind({
+      resourcePath,
+      async() {
+        isAsync = true
+        return callback
+      },
+      callback,
+      query: {
+        // babel opts
+        babelrc: false,
+        configFile: false,
+        sourceType: 'module',
+        compact: true,
+        caller: {
+          name: 'tests',
+          supportsStaticESM: true,
+        },
+        // loader opts
+        cwd: os.tmpdir(),
+        isServer,
+        distDir: os.tmpdir(),
+        pagesDir: os.tmpdir(),
+        cache: false,
+        babelPresetPlugins: [],
+        hasModern,
+        development,
+      },
+    })(code, null)
+
+    if (!isAsync) {
+      resolve(res)
+    }
+  })
+}
+
+describe('next-babel-loader', () => {
+  describe('replace constants', () => {
+    it('should replace typeof window expression nested', async () => {
+      const code = await babel('function a(){console.log(typeof window)}')
+      expect(code).toMatchInlineSnapshot(
+        `"function a(){console.log(\\"object\\");}"`
+      )
+    })
+
+    it('should replace typeof window expression top level', async () => {
+      const code = await babel('typeof window;')
+      expect(code).toMatchInlineSnapshot(`"\\"object\\";"`)
+    })
+
+    it('should replace typeof window expression nested', async () => {
+      const code = await babel(
+        `function a(){console.log(typeof window === 'undefined')}`
+      )
+      expect(code).toMatchInlineSnapshot(`"function a(){console.log(false);}"`)
+    })
+
+    it('should replace typeof window expression top level', async () => {
+      const code = await babel(`typeof window === 'undefined';`)
+      expect(code).toMatchInlineSnapshot(`"false;"`)
+    })
+
+    it('should replace typeof window expression top level', async () => {
+      const code = await babel(`typeof window === 'object';`)
+      expect(code).toMatchInlineSnapshot(`"true;"`)
+    })
+
+    it('should replace typeof window expression top level', async () => {
+      const code = await babel(`typeof window !== 'undefined';`)
+      expect(code).toMatchInlineSnapshot(`"true;"`)
+    })
+
+    it('should replace typeof window expression top level', async () => {
+      const code = await babel(`typeof window !== 'object';`)
+      expect(code).toMatchInlineSnapshot(`"false;"`)
+    })
+
+    it('should replace typeof window expression top level', async () => {
+      const code = await babel(`typeof window !== 'undefined';`, {
+        isServer: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"false;"`)
+    })
+
+    it('should replace typeof window expression top level', async () => {
+      const code = await babel(`typeof window !== 'object';`, {
+        isServer: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"true;"`)
+    })
+
+    it('should replace process.browser (1)', async () => {
+      const code = await babel(`process.browser`, {
+        isServer: false,
+      })
+      expect(code).toMatchInlineSnapshot(`"true;"`)
+    })
+
+    it('should replace process.browser (2)', async () => {
+      const code = await babel(`process.browser`, {
+        isServer: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"false;"`)
+    })
+
+    it('should replace process.browser (3)', async () => {
+      const code = await babel(`process.browser == false`, {
+        isServer: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"true;"`)
+    })
+
+    it('should replace process.browser (4)', async () => {
+      const code = await babel(`if (process.browser === false) {}`, {
+        isServer: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"if(true){}"`)
+    })
+
+    it('should replace process.browser (5)', async () => {
+      const code = await babel(`if (process.browser) {}`, {
+        isServer: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"if(false){}"`)
+    })
+
+    it('should replace NODE_ENV on client (dev)', async () => {
+      const code = await babel(`process.env.NODE_ENV`, {
+        isServer: false,
+        development: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"\\"development\\";"`)
+    })
+
+    it('should replace NODE_ENV on client (prod)', async () => {
+      const code = await babel(`process.env.NODE_ENV`, {
+        isServer: false,
+        development: false,
+      })
+      expect(code).toMatchInlineSnapshot(`"\\"production\\";"`)
+    })
+
+    it('should replace NODE_ENV on server', async () => {
+      const code = await babel(`process.env.NODE_ENV`, {
+        isServer: true,
+      })
+      expect(code).toMatchInlineSnapshot(`"\\"production\\";"`)
+    })
+
+    it('should replace NODE_ENV in statement (dev)', async () => {
+      const code = await babel(
+        `if (process.env.NODE_ENV === 'development') {}`,
+        { development: true }
+      )
+      expect(code).toMatchInlineSnapshot(`"if(true){}"`)
+    })
+
+    it('should replace NODE_ENV in statement (prod)', async () => {
+      const code = await babel(`if (process.env.NODE_ENV === 'production') {}`)
+      expect(code).toMatchInlineSnapshot(`"if(true){}"`)
+    })
+
+    it('should replace NODE_ENV in statement (prod)', async () => {
+      const code = await babel(`if (process.env.NODE_ENV !== 'production') {}`)
+      expect(code).toMatchInlineSnapshot(`"if(false){}"`)
+    })
+  })
+})


### PR DESCRIPTION
This teaches our Babel loader to replace more constants that are related to **dead code elimination**.

Normally, webpack+terser handles this. 
However, we want to eliminate server/client code **before** webpack parses it so we skip bundling it (and do not require it be a dynamic import).