### PR TITLE
[WIP] Aggressive Elimination for Pages

### DIFF
--- a/packages/next/build/webpack/loaders/next-minify-loader.ts
+++ b/packages/next/build/webpack/loaders/next-minify-loader.ts
@@ -1,0 +1,33 @@
+import loaderUtils from 'loader-utils'
+import { loader } from 'webpack'
+
+import minify from '../plugins/terser-webpack-plugin/src/minify'
+
+const nextMiniferLoader: loader.Loader = function(source, inputSourceMap) {
+  this.cacheable()
+
+  const strSource = source instanceof Buffer ? source.toString('utf8') : source
+
+  const options = loaderUtils.getOptions(this) || {}
+  const { error, code } = minify({
+    file: options.file || 'noop.js',
+    input: strSource,
+    terserOptions: {
+      ...options.terserOptions,
+      // Detect if webpack source maps are on and enable Terser support,
+      // overriding whatever was sent.
+      sourceMap: !!inputSourceMap,
+    },
+  })
+
+  if (error) {
+    this.callback(new Error(`Error from Terser: ${error.message}`))
+    return
+  }
+
+  // TODO: source map support
+  this.callback(undefined, code)
+  return
+}
+
+export default nextMiniferLoader

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/minify.ts
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/minify.ts
@@ -6,6 +6,7 @@ import { minify as terser, MinifyOptions } from 'terser'
 const IS_MODERN_OUTPUT = /\.module\.js$/
 
 const buildTerserOptions = ({
+  sourceMap = false,
   ecma,
   warnings,
   parse = {},
@@ -21,6 +22,7 @@ const buildTerserOptions = ({
   /* eslint-enable camelcase */
   safari10,
 }: MinifyOptions = {}) => ({
+  sourceMap,
   ecma,
   warnings,
   parse: { ...parse },

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -36,6 +36,7 @@ const defaultConfig: { [key: string]: any } = {
   },
   exportTrailingSlash: false,
   experimental: {
+    aggressiveElimination: false,
     ampBindInitData: false,
     cpus: Math.max(
       1,


### PR DESCRIPTION
**Preface**: This PR is very early, and I'm only opening it to solicit feedback.
I think we need to refactor our webpack config to be more modular, as it's getting unwieldy.

Also, it doesn't yet support dev-time source maps (**mandatory**).

---

This pull request introduces aggressive code elimination for the `pages/` directory.

This will be vital for `getStaticProps`, `getStaticPaths`, and `getServerProps`.

It may also help users who leverage `getInitialProps`.

Due to the assumptions we must force the minifier to make (**assume everything is pure**) it's not a reasonable default for existing apps.

Assuming everything is pure allows us to drop top-level functions calls the user may make, such as `fs.readFileSync()` etc.
It is also **not** a reasonable default for non `pages/` (e.g. `components/`), though, it'd be amazing to get to that future. 😄 


After these calls are eliminated, we can fully shake the `fs` import so it doesn't cause a bundle error for the client-build.

This must be implemented as a loader so webpack never sees the import and tries to bundle it. Shaking post-bundling is too late.

Using one of the new three (3) lifecycle methods as defined in #9524 would be the best way to opt-into this behavior.

---

**Example Input**

```js
import { Pool } from "pg";

const pool = new Pool();

export async function getStaticProps() {
  const date = await pool.query("SELECT NOW()", (err, res) => {
    console.log(err, res);
    pool.end();
  });

  return { props: { date } };
}

export default function({ date }) {
  return date;
}
```

**Example Output**

Our `next/babel` preset drops the `getStaticProps` export. Leaving us with:
```js
import { Pool } from "pg";

const pool = new Pool();

export default function({ date }) {
  return date;
}
```

This code then drops the following line (since it assumes everything is pure):
```js
const pool = new Pool();
```

If we did not assume everything was pure, it'd actually output this:
```js
new Pool();
```

Meaning we couldn't shake the import.

However, since we assume everything is pure in this PR, we're left with:

```js
import { Pool } from "pg";
export default function({ date: date }) {
  return date;
}
```

The only step remaining is to drop the unused imports, which should be pretty trivial with one more pass of Babel or a lightweight Acorn parser / transform.

Terser does not support dropping unused imports. 😢 

**Objective ... to be continued**
```js
export default function({ date }) {
  return date;
}
```