### PR TITLE
Enhancement: Upgrade css-loader version to 1.0.0

### DIFF
--- a/examples/with-algolia-react-instantsearch/package.json
+++ b/examples/with-algolia-react-instantsearch/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "css-loader": "^0.28.1",
+    "css-loader": "1.0.0",
     "prop-types": "^15.5.10",
     "qs": "^6.4.0",
     "next": "latest",


### PR DESCRIPTION
This PR seeks to upgrade `css-loader` to version 1.0.0 in `with-algolia-react-instantsearch` following a Snyk recommendation. 

See this CVE: https://app.snyk.io/test/npm/css-loader/0.28.11