### PR TITLE
Enhancement: Remove caret range for node-sass

### DIFF
--- a/examples/with-next-sass/package.json
+++ b/examples/with-next-sass/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@zeit/next-sass": "^1.0.0",
     "next": "latest",
-    "node-sass": "^4.7.2",
+    "node-sass": "4.7.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   }


### PR DESCRIPTION
This PR seeks to amend `node-sass` version in `with-next-sass` by removing the caret range in `package.json` following a Snyk recommendation. 

CVEs: 
https://app.snyk.io/vuln/SNYK-JS-NODESASS-535500
https://app.snyk.io/vuln/SNYK-JS-NODESASS-535497
https://app.snyk.io/vuln/SNYK-JS-NODESASS-535502
https://app.snyk.io/vuln/SNYK-JS-NODESASS-535498
