### PR TITLE
check dll cache before getting the exports

### DIFF
--- a/packages/next/build/webpack/plugins/dll-import.ts
+++ b/packages/next/build/webpack/plugins/dll-import.ts
@@ -11,11 +11,15 @@ export function importAutoDllPlugin({ distDir }: { distDir: string }) {
     path.join(distDir, 'cache', 'autodll-webpack-plugin')
   )
   require.cache[autodllPaths] = Object.assign({}, require.cache[autodllPaths], {
-    exports: Object.assign({}, require.cache[autodllPaths].exports, {
-      cacheDir: autodllCachePath,
-      getManifestPath: (hash: string) => (bundleName: string) =>
-        path.resolve(autodllCachePath, hash, `${bundleName}.manifest.json`),
-    }),
+    exports: Object.assign(
+      {},
+      require.cache[autodllPaths] ? require.cache[autodllPaths].exports : {},
+      {
+        cacheDir: autodllCachePath,
+        getManifestPath: (hash: string) => (bundleName: string) =>
+          path.resolve(autodllCachePath, hash, `${bundleName}.manifest.json`),
+      }
+    ),
   })
 
   const AutoDllPlugin = require('autodll-webpack-plugin')


### PR DESCRIPTION
this fixes running tests where `next({ dev: true }).prepare()` results in 

```
  at Object.importAutoDllPlugin (node_modules/next/dist/build/webpack/plugins/dll-import.js:12:64)
  at webpackConfig.plugins.dev (node_modules/next/dist/build/webpack-config.js:264:56)
  at Object.getBaseWebpackConfig [as default] (node_modules/next/dist/build/webpack-config.js:283:15)
  at HotReloader.getWebpackConfig (node_modules/next/dist/server/hot-reloader.js:162:37)
```