### PR TITLE
Update with-apollo example

### DIFF
--- a/examples/with-apollo/.babelrc
+++ b/examples/with-apollo/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    [
+      "graphql-tag"
+    ]
+  ]
+}

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -20,5 +20,8 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "babel-plugin-graphql-tag": "^2.5.0"
+  }
 }


### PR DESCRIPTION
Add `babel-plugin-graphql-tag` to the with-apollo example to compile graphql tags during build.

Additionally, it removes the `graphql` package in the final bundle; which is 33kb (8.45kb gzipped).

A build of the example shows a bundle size reduction of 17% for the two pages that require Apollo.

