### PR TITLE
Fix instructions for with-netlify-cms example

### DIFF
--- a/examples/with-netlify-cms/readme.md
+++ b/examples/with-netlify-cms/readme.md
@@ -18,7 +18,7 @@ Download the example:
 
 ```bash
 curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-netlify-cms
-cd nested-components
+cd with-netlify-cms
 ```
 
 Install it and run:


### PR DESCRIPTION
Looks like the directory name was missed after a copy/paste from another example.