### PR TITLE
Remove Scope Bindings for SSG

### DIFF
--- a/packages/next/build/babel/plugins/next-ssg-transform.ts
+++ b/packages/next/build/babel/plugins/next-ssg-transform.ts
@@ -55,16 +55,27 @@ export default function nextTransformSsg({
                 name === EXPORT_NAME_GET_STATIC_PROPS ||
                 name === EXPORT_NAME_GET_STATIC_PATHS
               ) {
-                path.remove()
                 state.isPrerender = true
 
-                if (path.parent.type !== 'ExportNamedDeclaration') {
+                const parent = path.parent
+
+                if (parent.type !== 'ExportNamedDeclaration') {
                   throw new Error(
-                    `invariant: ${path.type} has unknown parent: ${path.parent.type}`
+                    `invariant: ${path.type} has unknown parent: ${parent.type}`
                   )
                 }
 
-                if (path.parent.specifiers.length === 0) {
+                if (!parent.source) {
+                  const localName = path.node.local.name
+
+                  const binding = path.scope.getBinding(localName)
+                  if (binding) {
+                    binding.path.remove()
+                  }
+                }
+
+                path.remove()
+                if (parent.specifiers.length === 0) {
                   path.parentPath.remove()
                 }
               }

--- a/test/unit/babel-plugin-next-ssg-transform.test.js
+++ b/test/unit/babel-plugin-next-ssg-transform.test.js
@@ -187,5 +187,41 @@ describe('babel plugin (next-ssg-transform)', () => {
         `"export const foo=2;const __NEXT_COMP=function Test(){return __jsx(\\"div\\",null);};__NEXT_COMP.__NEXT_SPR=true export default __NEXT_COMP;"`
       )
     })
+
+    it('should remove re-exported variable declarations', () => {
+      const output = babel(trim`
+        const unstable_getStaticPaths = () => {
+          return []
+        }
+
+        export { unstable_getStaticPaths }
+
+        export default function Test() {
+          return <div />
+        }
+      `)
+
+      expect(output).toMatchInlineSnapshot(
+        `"const __NEXT_COMP=function Test(){return __jsx(\\"div\\",null);};__NEXT_COMP.__NEXT_SPR=true export default __NEXT_COMP;"`
+      )
+    })
+
+    it('should remove re-exported function declarations', () => {
+      const output = babel(trim`
+        function unstable_getStaticPaths() {
+          return []
+        }
+
+        export { unstable_getStaticPaths }
+
+        export default function Test() {
+          return <div />
+        }
+      `)
+
+      expect(output).toMatchInlineSnapshot(
+        `"const __NEXT_COMP=function Test(){return __jsx(\\"div\\",null);};__NEXT_COMP.__NEXT_SPR=true export default __NEXT_COMP;"`
+      )
+    })
   })
 })


### PR DESCRIPTION
Adds support for the following form:
```js
const unstable_getStaticPaths = () => {
  return []
}

export { unstable_getStaticPaths }

export default function Test() {
  return <div />
}
```