### PR TITLE
Update example analyze bundles

### DIFF
--- a/examples/analyze-bundles/README.md
+++ b/examples/analyze-bundles/README.md
@@ -39,16 +39,12 @@ yarn dev
 
 ## The idea behind the example
 
-This example shows how to analyze the output bundles using [@zeit/next-bundle-analyzer](https://github.com/zeit/next-plugins/tree/master/packages/next-bundle-analyzer)
+This example shows how to analyze the output bundles using [@next/bundle-analyzer](https://github.com/zeit/next.js/tree/master/packages/next-bundle-analyzer)
 
 To analyze your webpack output, invoke the following command:
 
 ```bash
 npm run analyze
-npm run analyze:server
-npm run analyze:browser
 # or
 yarn analyze
-yarn analyze:server
-yarn analyze:browser
 ```

--- a/examples/analyze-bundles/next.config.js
+++ b/examples/analyze-bundles/next.config.js
@@ -1,19 +1,12 @@
-const withBundleAnalyzer = require('@zeit/next-bundle-analyzer')
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+})
 
 const nextConfig = {
-  analyzeServer: ['server', 'both'].includes(process.env.BUNDLE_ANALYZE),
-  analyzeBrowser: ['browser', 'both'].includes(process.env.BUNDLE_ANALYZE),
-  bundleAnalyzerConfig: {
-    server: {
-      analyzerMode: 'static',
-      reportFilename: '../bundles/server.html',
-    },
-    browser: {
-      analyzerMode: 'static',
-      reportFilename: '../bundles/client.html',
-    },
-  },
+  // any configs you need
   webpack(config) {
+    // any customized webpack config
+    // https://nextjs.org/docs#customizing-webpack-config
     return config
   },
 }

--- a/examples/analyze-bundles/next.config.js
+++ b/examples/analyze-bundles/next.config.js
@@ -4,11 +4,6 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 
 const nextConfig = {
   // any configs you need
-  webpack(config) {
-    // any customized webpack config
-    // https://nextjs.org/docs#customizing-webpack-config
-    return config
-  },
 }
 
 module.exports = withBundleAnalyzer(nextConfig)

--- a/examples/analyze-bundles/package.json
+++ b/examples/analyze-bundles/package.json
@@ -5,12 +5,10 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "analyze": "BUNDLE_ANALYZE=both next build",
-    "analyze:server": "BUNDLE_ANALYZE=server next build",
-    "analyze:browser": "BUNDLE_ANALYZE=browser next build"
+    "analyze": "ANALYZE=true yarn build"
   },
   "dependencies": {
-    "@zeit/next-bundle-analyzer": "^0.1.2",
+    "@next/bundle-analyzer": "^9.1.4",
     "faker": "^4.1.0",
     "next": "latest",
     "react": "^16.7.0",

--- a/examples/analyze-bundles/package.json
+++ b/examples/analyze-bundles/package.json
@@ -5,10 +5,11 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "analyze": "ANALYZE=true yarn build"
+    "analyze": "cross-env ANALYZE=true yarn build"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^9.1.4",
+    "cross-env": "^6.0.3",
     "faker": "^4.1.0",
     "next": "latest",
     "react": "^16.7.0",


### PR DESCRIPTION
* Follow these updates:
  1. `server` and `browser` options
      * [next-plugins/index.js at 9ecca7b492518464897ea866b4abcdc6214bf705 · zeit/next-plugins](https://github.com/zeit/next-plugins/blob/9ecca7b492518464897ea866b4abcdc6214bf705/packages/next-bundle-analyzer/index.js)
  2. [Deprecate next-bundle-analyzer (#468) · zeit/next-plugins@e453804](https://github.com/zeit/next-plugins/commit/e453804d07f309d8b22e11930aa08a260f86108d#diff-5cea9b17189292d8fedc98eeda86bb0b)
  3. [Move next-bundle-analyzer to Next.js repo (#6445) · zeit/next.js@42cff0a](https://github.com/zeit/next.js/commit/42cff0a09c4ae42016500b1797ae4f0bd8438e88#diff-4e57124572a8e05f52d373c300523f6a)
      * "Remove options from bundle-analyzer"
* Support Windows
  * [kentcdodds/cross-env](https://github.com/kentcdodds/cross-env)
