### PR TITLE
Rewrite SSG Transform for Recursive Cleanup

### DIFF
--- a/packages/next/build/babel/plugins/next-ssg-transform.ts
+++ b/packages/next/build/babel/plugins/next-ssg-transform.ts
@@ -1,4 +1,4 @@
-import { PluginObj } from '@babel/core'
+import { NodePath, PluginObj } from '@babel/core'
 import * as BabelTypes from '@babel/types'
 
 const pageComponentVar = '__NEXT_COMP'
@@ -7,144 +7,242 @@ const prerenderId = '__NEXT_SPR'
 export const EXPORT_NAME_GET_STATIC_PROPS = 'unstable_getStaticProps'
 export const EXPORT_NAME_GET_STATIC_PATHS = 'unstable_getStaticPaths'
 
+const ssgExports = new Set([
+  EXPORT_NAME_GET_STATIC_PROPS,
+  EXPORT_NAME_GET_STATIC_PATHS,
+])
+
+type PluginState = { refs: Set<any>; isPrerender: boolean; done: boolean }
+
+function decorateSsgExport(
+  t: typeof BabelTypes,
+  path: NodePath<BabelTypes.Program>,
+  state: PluginState
+) {
+  path.traverse({
+    ExportDefaultDeclaration(path) {
+      if (state.done) {
+        return
+      }
+      state.done = true
+
+      const prev = path.node.declaration
+      if (prev.type.endsWith('Declaration')) {
+        prev.type = prev.type.replace(/Declaration$/, 'Expression') as any
+      }
+
+      // @ts-ignore invalid return type
+      const [pageCompPath] = path.replaceWithMultiple([
+        t.variableDeclaration('const', [
+          t.variableDeclarator(t.identifier(pageComponentVar), prev as any),
+        ]),
+        t.assignmentExpression(
+          '=',
+          t.memberExpression(
+            t.identifier(pageComponentVar),
+            t.identifier(prerenderId)
+          ),
+          t.booleanLiteral(true)
+        ),
+        t.exportDefaultDeclaration(t.identifier(pageComponentVar)),
+      ])
+      path.scope.registerDeclaration(pageCompPath)
+    },
+  })
+}
+
 export default function nextTransformSsg({
   types: t,
 }: {
   types: typeof BabelTypes
-}): PluginObj<{
-  isPrerender: boolean
-  done: boolean
-}> {
+}): PluginObj<PluginState> {
+  function getIdentifier(
+    path: NodePath<
+      | BabelTypes.FunctionDeclaration
+      | BabelTypes.FunctionExpression
+      | BabelTypes.ArrowFunctionExpression
+    >
+  ): NodePath<BabelTypes.Identifier> | null {
+    const parentPath = path.parentPath
+    if (parentPath.type === 'VariableDeclarator') {
+      const pp = parentPath as NodePath<BabelTypes.VariableDeclarator>
+      const name = pp.get('id')
+      return name.node.type === 'Identifier'
+        ? (name as NodePath<BabelTypes.Identifier>)
+        : null
+    }
+
+    if (parentPath.type === 'AssignmentExpression') {
+      const pp = parentPath as NodePath<BabelTypes.AssignmentExpression>
+      const name = pp.get('left')
+      return name.node.type === 'Identifier'
+        ? (name as NodePath<BabelTypes.Identifier>)
+        : null
+    }
+
+    if (path.node.type === 'ArrowFunctionExpression') {
+      return null
+    }
+
+    return path.node.id && path.node.id.type === 'Identifier'
+      ? (path.get('id') as NodePath<BabelTypes.Identifier>)
+      : null
+  }
+
+  function isIdentifierReferenced(
+    ident: NodePath<BabelTypes.Identifier>
+  ): boolean {
+    const b = ident.scope.getBinding(ident.node.name)
+    return b != null && b.referenced
+  }
+
+  function markFunction(
+    path: NodePath<
+      | BabelTypes.FunctionDeclaration
+      | BabelTypes.FunctionExpression
+      | BabelTypes.ArrowFunctionExpression
+    >,
+    state: PluginState
+  ) {
+    const ident = getIdentifier(path)
+    if (ident && ident.node && isIdentifierReferenced(ident)) {
+      state.refs.add(ident.node.name)
+    }
+  }
+
   return {
     visitor: {
       Program: {
-        enter(path, state) {
-          path.traverse({
-            // export function unstable_getStaticPaths() {}
-            ExportNamedDeclaration(path) {
-              const declaration = path.node.declaration
-              if (!declaration) {
-                return
-              }
-
-              if (declaration.type !== 'FunctionDeclaration') {
-                return
-              }
-
-              const name = declaration.id && declaration.id.name
-              if (name == null) {
-                throw new Error(`invariant: null function declaration`)
-              }
-
-              if (
-                name === EXPORT_NAME_GET_STATIC_PROPS ||
-                name === EXPORT_NAME_GET_STATIC_PATHS
-              ) {
-                path.remove()
-                state.isPrerender = true
-              }
-            },
-            // export { unstable_getStaticPaths } from '.'
-            ExportSpecifier(path) {
-              const name = path.node.exported.name
-              if (
-                name === EXPORT_NAME_GET_STATIC_PROPS ||
-                name === EXPORT_NAME_GET_STATIC_PATHS
-              ) {
-                state.isPrerender = true
-
-                const parent = path.parent
-
-                if (parent.type !== 'ExportNamedDeclaration') {
-                  throw new Error(
-                    `invariant: ${path.type} has unknown parent: ${parent.type}`
-                  )
-                }
-
-                if (!parent.source) {
-                  const localName = path.node.local.name
-
-                  const binding = path.scope.getBinding(localName)
-                  if (binding) {
-                    binding.path.remove()
-                  }
-                }
-
-                path.remove()
-                if (parent.specifiers.length === 0) {
-                  path.parentPath.remove()
-                }
-              }
-            },
-            // export const unstable_getStaticPaths = () => {}
-            VariableDeclaration(path) {
-              if (path.parent.type !== 'ExportNamedDeclaration') {
-                return
-              }
-
-              path.node.declarations = path.node.declarations.filter(d => {
-                const name = d.id.type === 'Identifier' && d.id.name
-
-                const isPrerender =
-                  name === EXPORT_NAME_GET_STATIC_PROPS ||
-                  name === EXPORT_NAME_GET_STATIC_PATHS
-
-                if (isPrerender) {
-                  state.isPrerender = true
-                }
-
-                return !isPrerender
-              })
-
-              if (path.node.declarations.length === 0) {
-                path.parentPath.remove()
-              }
-            },
-          })
+        enter(_, state) {
+          state.refs = new Set<string>()
+          state.isPrerender = false
+          state.done = false
         },
         exit(path, state) {
-          if (state.isPrerender) {
-            ;(path.scope as any).crawl()
+          const refs = state.refs
+          let count: number
+
+          function sweepFunction(
+            path: NodePath<
+              | BabelTypes.FunctionDeclaration
+              | BabelTypes.FunctionExpression
+              | BabelTypes.ArrowFunctionExpression
+            >
+          ) {
+            const ident = getIdentifier(path)
+            if (
+              ident &&
+              ident.node &&
+              refs.has(ident.node.name) &&
+              !isIdentifierReferenced(ident)
+            ) {
+              ++count
+
+              if (
+                t.isAssignmentExpression(path.parentPath) ||
+                t.isVariableDeclarator(path.parentPath)
+              ) {
+                path.parentPath.remove()
+              } else {
+                path.remove()
+              }
+            }
           }
 
-          path.traverse({
-            ExportDefaultDeclaration(path) {
-              if (!state.isPrerender || state.done) {
+          do {
+            ;(path.scope as any).crawl()
+            count = 0
+
+            path.traverse({
+              // eslint-disable-next-line no-loop-func
+              VariableDeclarator(path) {
+                if (path.node.id.type !== 'Identifier') {
+                  return
+                }
+
+                const local = path.get('id') as NodePath<BabelTypes.Identifier>
+                if (
+                  refs.has(local.node.name) &&
+                  !isIdentifierReferenced(local)
+                ) {
+                  ++count
+                  path.remove()
+                }
+              },
+              FunctionDeclaration: sweepFunction,
+              FunctionExpression: sweepFunction,
+              ArrowFunctionExpression: sweepFunction,
+            })
+          } while (count)
+
+          if (state.isPrerender) {
+            decorateSsgExport(t, path, state)
+          }
+        },
+      },
+      VariableDeclarator(path, state) {
+        if (path.node.id.type !== 'Identifier') {
+          return
+        }
+
+        const local = path.get('id') as NodePath<BabelTypes.Identifier>
+        if (isIdentifierReferenced(local)) {
+          state.refs.add(path.node.id.name)
+        }
+      },
+      FunctionDeclaration: markFunction,
+      FunctionExpression: markFunction,
+      ArrowFunctionExpression: markFunction,
+      ExportNamedDeclaration(path, state) {
+        const specifiers = path.get('specifiers')
+        if (specifiers.length) {
+          specifiers.forEach(s => {
+            if (ssgExports.has(s.node.exported.name)) {
+              state.isPrerender = true
+              s.remove()
+            }
+          })
+
+          if (path.node.specifiers.length < 1) {
+            path.remove()
+          }
+          return
+        }
+
+        const decl = path.get('declaration')
+        if (decl == null || decl.node == null) {
+          return
+        }
+
+        switch (decl.node.type) {
+          case 'FunctionDeclaration': {
+            const name = decl.node.id!.name
+            if (ssgExports.has(name)) {
+              state.isPrerender = true
+              path.remove()
+            }
+            break
+          }
+          case 'VariableDeclaration': {
+            const inner = decl.get('declarations') as NodePath<
+              BabelTypes.VariableDeclarator
+            >[]
+            inner.forEach(d => {
+              if (d.node.id.type !== 'Identifier') {
                 return
               }
-
-              state.done = true
-
-              const prev = path.node.declaration
-              if (prev.type.endsWith('Declaration')) {
-                prev.type = prev.type.replace(
-                  /Declaration$/,
-                  'Expression'
-                ) as any
+              const name = d.node.id.name
+              if (ssgExports.has(name)) {
+                state.isPrerender = true
+                d.remove()
               }
-
-              // @ts-ignore invalid return type
-              const [pageCompPath] = path.replaceWithMultiple([
-                t.variableDeclaration('const', [
-                  t.variableDeclarator(
-                    t.identifier(pageComponentVar),
-                    prev as any
-                  ),
-                ]),
-                t.assignmentExpression(
-                  '=',
-                  t.memberExpression(
-                    t.identifier(pageComponentVar),
-                    t.identifier(prerenderId)
-                  ),
-                  t.booleanLiteral(true)
-                ),
-                t.exportDefaultDeclaration(t.identifier(pageComponentVar)),
-              ])
-              path.scope.registerDeclaration(pageCompPath)
-            },
-          })
-        },
+            })
+            break
+          }
+          default: {
+            break
+          }
+        }
       },
     },
   }

--- a/test/unit/babel-plugin-next-ssg-transform.test.js
+++ b/test/unit/babel-plugin-next-ssg-transform.test.js
@@ -261,5 +261,39 @@ describe('babel plugin (next-ssg-transform)', () => {
         `"export class MyClass{}const __NEXT_COMP=function Test(){return __jsx(\\"div\\",null);};__NEXT_COMP.__NEXT_SPR=true export default __NEXT_COMP;"`
       )
     })
+
+    it(`should remove re-exported function declarations' dependents (variables, functions)`, () => {
+      const output = babel(trim`
+        const inceptionVar = 'hahaa';
+        var var1 = 1;
+        let var2 = 2;
+        const var3 = inceptionVar;
+
+        function inception1() {var2;}
+
+        function abc() {}
+        const b = function() {var3;};
+        const b2 = function apples() {};
+        const bla = () => {inception1};
+
+        function unstable_getStaticProps() {
+          abc();
+          b;
+          b2;
+          bla();
+          return { props: {var1} }
+        }
+
+        export { unstable_getStaticProps }
+
+        export default function Test() {
+          return <div />
+        }
+      `)
+
+      expect(output).toMatchInlineSnapshot(
+        `"const __NEXT_COMP=function Test(){return __jsx(\\"div\\",null);};__NEXT_COMP.__NEXT_SPR=true export default __NEXT_COMP;"`
+      )
+    })
   })
 })


### PR DESCRIPTION
**Preface**

This PR is heavily inspired by @developit's 🤯ing work. As expected, our implementation is about 3x the size 😄. However, it passes full type-checking.  

**Details**

This pull request improves our SSG Transform to recursively cleanup scope references that become unreferenced as _side-effect_ of dropping `getStaticProps` / `getStaticPaths`.

**Example Input**
```js
var leave_me_alone = 1;
function dont_bug_me_either() {}

const inceptionVar = "hahaa";
var var1 = 1;
let var2 = 2;
const var3 = inceptionVar;

function inception1() {
  var2;
}

function abc() {}
const b = function() {
  var3;
};
const b2 = function apples() {};
const bla = () => {
  inception1;
};

function unstable_getStaticProps() {
  abc();
  b;
  b2;
  bla();
  return { props: { var1 } };
}

export { unstable_getStaticProps };

export default function Test() {
  return <div />;
}
```

**Actual Output**
```js
var leave_me_alone = 1;
function dont_bug_me_either() {}

export default function Test() {
  return <div />;
}
```