### PR TITLE
Use Real Identifier for SSG Transform

### DIFF
--- a/packages/next/build/babel/plugins/next-ssg-transform.ts
+++ b/packages/next/build/babel/plugins/next-ssg-transform.ts
@@ -12,7 +12,11 @@ const ssgExports = new Set([
   EXPORT_NAME_GET_STATIC_PATHS,
 ])
 
-type PluginState = { refs: Set<any>; isPrerender: boolean; done: boolean }
+type PluginState = {
+  refs: Set<NodePath<BabelTypes.Identifier>>
+  isPrerender: boolean
+  done: boolean
+}
 
 function decorateSsgExport(
   t: typeof BabelTypes,
@@ -106,7 +110,7 @@ export default function nextTransformSsg({
   ) {
     const ident = getIdentifier(path)
     if (ident && ident.node && isIdentifierReferenced(ident)) {
-      state.refs.add(ident.node.name)
+      state.refs.add(ident)
     }
   }
 
@@ -120,7 +124,7 @@ export default function nextTransformSsg({
   ) {
     const local = path.get('local')
     if (isIdentifierReferenced(local)) {
-      state.refs.add(local.node.name)
+      state.refs.add(local)
     }
   }
 
@@ -128,7 +132,7 @@ export default function nextTransformSsg({
     visitor: {
       Program: {
         enter(_, state) {
-          state.refs = new Set<string>()
+          state.refs = new Set<NodePath<BabelTypes.Identifier>>()
           state.isPrerender = false
           state.done = false
         },
@@ -147,7 +151,7 @@ export default function nextTransformSsg({
             if (
               ident &&
               ident.node &&
-              refs.has(ident.node.name) &&
+              refs.has(ident) &&
               !isIdentifierReferenced(ident)
             ) {
               ++count
@@ -171,7 +175,7 @@ export default function nextTransformSsg({
             >
           ) {
             const local = path.get('local')
-            if (refs.has(local.node.name) && !isIdentifierReferenced(local)) {
+            if (refs.has(local) && !isIdentifierReferenced(local)) {
               ++count
               path.remove()
               if (
@@ -195,10 +199,7 @@ export default function nextTransformSsg({
                 }
 
                 const local = path.get('id') as NodePath<BabelTypes.Identifier>
-                if (
-                  refs.has(local.node.name) &&
-                  !isIdentifierReferenced(local)
-                ) {
+                if (refs.has(local) && !isIdentifierReferenced(local)) {
                   ++count
                   path.remove()
                 }
@@ -224,7 +225,7 @@ export default function nextTransformSsg({
 
         const local = path.get('id') as NodePath<BabelTypes.Identifier>
         if (isIdentifierReferenced(local)) {
-          state.refs.add(path.node.id.name)
+          state.refs.add(local)
         }
       },
       FunctionDeclaration: markFunction,

--- a/test/unit/babel-plugin-next-ssg-transform.test.js
+++ b/test/unit/babel-plugin-next-ssg-transform.test.js
@@ -308,5 +308,26 @@ describe('babel plugin (next-ssg-transform)', () => {
         `"import keep_me from'hello';import{keep_me2}from'hello2';import*as keep_me3 from'hello3';import{but_not_me}from'bar';var leave_me_alone=1;function dont_bug_me_either(){}const __NEXT_COMP=function Test(){return __jsx(\\"div\\",null);};__NEXT_COMP.__NEXT_SPR=true export default __NEXT_COMP;"`
       )
     })
+
+    it('should not mix up bindings', () => {
+      const output = babel(trim`
+        function Function1() {
+          return {
+            a: function bug(a) {
+              return 2;
+            }
+          };
+        }
+
+        function Function2() {
+          var bug = 1;
+          return { bug };
+        }
+      `)
+
+      expect(output).toMatchInlineSnapshot(
+        `"function Function1(){return{a:function bug(a){return 2;}};}function Function2(){var bug=1;return{bug};}"`
+      )
+    })
   })
 })


### PR DESCRIPTION
Using the name of an identifier did not work when the same variable was found across different scopes.

For example, this code failed prior to this change:
```js
function Function1() {
  return {
    a: function bug(a) {
      //        ^ Function dec would try to be removed, because binding is "unused" (matched "bug" from below to be considered used)
      return 2;
    }
  };
}

function Function2() {
  // Variable dec (mark used)
  var bug = 1;
  return { bug };
}
```