### PR TITLE
Disable SSG Transform on Non-SSG Pages

### DIFF
--- a/packages/next/build/babel/plugins/next-ssg-transform.ts
+++ b/packages/next/build/babel/plugins/next-ssg-transform.ts
@@ -133,6 +133,10 @@ export default function nextTransformSsg({
           state.done = false
         },
         exit(path, state) {
+          if (!state.isPrerender) {
+            return
+          }
+
           const refs = state.refs
           let count: number
 
@@ -212,9 +216,7 @@ export default function nextTransformSsg({
             })
           } while (count)
 
-          if (state.isPrerender) {
-            decorateSsgExport(t, path, state)
-          }
+          decorateSsgExport(t, path, state)
         },
       },
       VariableDeclarator(path, state) {

--- a/test/unit/babel-plugin-next-ssg-transform.test.js
+++ b/test/unit/babel-plugin-next-ssg-transform.test.js
@@ -323,6 +323,8 @@ describe('babel plugin (next-ssg-transform)', () => {
           var bug = 1;
           return { bug };
         }
+
+        export { unstable_getStaticProps } from 'a'
       `)
 
       expect(output).toMatchInlineSnapshot(


### PR DESCRIPTION
As a performance optimization, this transform should not re-crawl scope or traverse the program unless the page was detected to be a SSG page.