### PR TITLE
Fix TypeError in with-graphql-hooks example

### DIFF
--- a/examples/with-graphql-hooks/lib/with-graphql-client.js
+++ b/examples/with-graphql-hooks/lib/with-graphql-client.js
@@ -7,7 +7,7 @@ export default App => {
   return class GraphQLHooks extends React.Component {
     static displayName = 'GraphQLHooks(App)'
     static async getInitialProps(ctx) {
-      const { Component, router } = ctx
+      const { AppTree } = ctx
 
       let appProps = {}
       if (App.getInitialProps) {
@@ -22,14 +22,7 @@ export default App => {
         try {
           // Run all GraphQL queries
           graphQLState = await getInitialState({
-            App: (
-              <App
-                {...appProps}
-                Component={Component}
-                router={router}
-                graphQLClient={graphQLClient}
-              />
-            ),
+            App: <AppTree {...appProps} graphQLClient={graphQLClient} />,
             client: graphQLClient,
           })
         } catch (error) {


### PR DESCRIPTION
Reported at https://github.com/zeit/next.js/issues/9617

Use `AppTree` so that `withRouter` works correctly.