### PR TITLE
Simplify config in with-jest-typescript example

### DIFF
--- a/examples/with-jest-typescript/jest.config.js
+++ b/examples/with-jest-typescript/jest.config.js
@@ -1,12 +1,3 @@
-const TEST_REGEX = '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|js?|tsx?|ts?)$'
-
 module.exports = {
   setupFiles: ['<rootDir>/jest.setup.js'],
-  testRegex: TEST_REGEX,
-  transform: {
-    '^.+\\.tsx?$': 'babel-jest',
-  },
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  collectCoverage: false,
 }

--- a/examples/with-jest-typescript/package.json
+++ b/examples/with-jest-typescript/package.json
@@ -13,14 +13,14 @@
     "react-dom": "^16.8.4"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.11",
+    "@types/jest": "^24.0.23",
     "@types/react": "^16.8.8",
     "@types/react-dom": "^16.8.2",
     "babel-core": "^6.26.3",
-    "babel-jest": "^24.5.0",
+    "babel-jest": "^24.9.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
-    "jest": "^24.5.0",
+    "jest": "^24.9.0",
     "react-addons-test-utils": "^15.6.2",
     "react-test-renderer": "^16.8.4",
     "typescript": "^3.3.3333"


### PR DESCRIPTION
jest didn't include TS extensions by default, now it does. Also seems to use `babel-jest` if it exists. (See also: https://github.com/facebook/jest/tree/master/examples/typescript )

Other things:
- `collectCoverage` is `false` by default anyway.
- Excluding `.next` explicitly - since jest merely looks for test files, the performance difference should be negligible and a slimmer config file improves maintainability.
But feel free to change that back or tell me to do it. :)
