### PR TITLE
Add tests for optional chaining and nullish coalescing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "lerna run build --stream --parallel",
     "dev2": "while true; do yarn --check-files && yarn dev; done",
     "testonly": "jest --runInBand",
+    "testheadless": "HEADLESS=true yarn testonly",
     "testall": "yarn run testonly -- --ci --forceExit",
     "pretest": "yarn run lint",
     "git-reset": "git reset --hard HEAD",

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -95,7 +95,7 @@ module.exports = (
     }
   }
 
-  // spefify a preset to use instead of @babel/preset-env:
+  // specify a preset to use instead of @babel/preset-env:
   const customModernPreset =
     isLaxModern && options['experimental-modern-preset']
 

--- a/test/integration/optional-chaining-nullish-coalescing/pages/nullish-coalescing.js
+++ b/test/integration/optional-chaining-nullish-coalescing/pages/nullish-coalescing.js
@@ -1,0 +1,9 @@
+let hello
+let another = ''
+
+export default () => (
+  <>
+    <p>result1: {hello ?? 'fallback'}</p>
+    <p>result2: {another ?? 'fallback'}</p>
+  </>
+)

--- a/test/integration/optional-chaining-nullish-coalescing/pages/optional-chaining.js
+++ b/test/integration/optional-chaining-nullish-coalescing/pages/optional-chaining.js
@@ -1,0 +1,9 @@
+let hello
+let another = { thing: 1 }
+
+export default () => (
+  <>
+    <p>result1: {hello?.world ? 'something' : 'nothing'}</p>
+    <p>result2: {another?.thing ? 'something' : 'nothing'}</p>
+  </>
+)

--- a/test/integration/optional-chaining-nullish-coalescing/test/index.test.js
+++ b/test/integration/optional-chaining-nullish-coalescing/test/index.test.js
@@ -1,0 +1,75 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  renderViaHTTP,
+  launchApp,
+  nextBuild,
+  nextStart,
+  killApp,
+  findPort,
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = join(__dirname, '..')
+const nextConfig = join(appDir, 'next.config.js')
+let appPort
+let app
+
+const runTests = () => {
+  it('should support optional chaining', async () => {
+    const html = await renderViaHTTP(appPort, '/optional-chaining')
+    expect(html).toMatch(/result1:.*?nothing/)
+    expect(html).toMatch(/result2:.*?something/)
+  })
+
+  it('should support nullish coalescing', async () => {
+    const html = await renderViaHTTP(appPort, '/nullish-coalescing')
+    expect(html).toMatch(/result1:.*?fallback/)
+    expect(html).not.toMatch(/result2:.*?fallback/)
+  })
+}
+
+describe('Optional chaining and nullish coalescing support', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('server mode', () => {
+    beforeAll(async () => {
+      await fs.remove(nextConfig)
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('serverless mode', () => {
+    beforeAll(async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { target: 'serverless' }`
+      )
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(async () => {
+      await killApp(app)
+      await fs.remove(nextConfig)
+    })
+
+    runTests()
+  })
+})

--- a/test/unit/next-babel-loader.test.js
+++ b/test/unit/next-babel-loader.test.js
@@ -221,6 +221,7 @@ describe('next-babel-loader', () => {
     })
 
     const pageFile = path.resolve(dir, 'pages', 'index.js')
+    const tsPageFile = pageFile.replace(/\.js$/, '.ts')
 
     it('should not drop unused exports by default in a page', async () => {
       const code = await babel(
@@ -325,6 +326,76 @@ describe('next-babel-loader', () => {
       )
       expect(code).toMatchInlineSnapshot(
         `"var __jsx=React.createElement;import\\"core-js\\";import{bar}from\\"a\\";import baz from\\"b\\";import*as React from\\"react\\";import{yeet}from\\"c\\";import baz3,{cats}from\\"d\\";import{c,d}from\\"e\\";import{e as ee}from\\"f\\";const __NEXT_COMP=function(){return __jsx(\\"div\\",null,cats+bar());};__NEXT_COMP.__NEXT_SPR=true export default __NEXT_COMP;"`
+      )
+    })
+
+    it('should support optional chaining for JS file', async () => {
+      const code = await babel(
+        `let hello;` +
+          `export default () => hello?.world ? 'something' : 'nothing' `,
+        {
+          resourcePath: pageFile,
+        }
+      )
+      expect(code).toMatchInlineSnapshot(
+        `"var hello;export default(function(){return(hello===null||hello===void 0?void 0:hello.world)?'something':'nothing';});"`
+      )
+    })
+
+    it('should support optional chaining for TS file', async () => {
+      const code = await babel(
+        `let hello;` +
+          `export default () => hello?.world ? 'something' : 'nothing' `,
+        {
+          resourcePath: tsPageFile,
+        }
+      )
+      expect(code).toMatchInlineSnapshot(
+        `"var hello;export default(function(){return(hello===null||hello===void 0?void 0:hello.world)?'something':'nothing';});"`
+      )
+    })
+
+    it('should support nullish coalescing for JS file', async () => {
+      const code = await babel(
+        `const res = {
+          status: 0,
+          nullVal: null,
+          statusText: '',
+
+        }
+        const status = res.status ?? 999
+        const nullVal = res.nullVal ?? 'another'
+        const statusText = res.nullVal ?? 'not found'
+        export default () => 'hello'
+        `,
+        {
+          resourcePath: pageFile,
+        }
+      )
+      expect(code).toMatchInlineSnapshot(
+        `"var _res$status,_res$nullVal,_res$nullVal2;var res={status:0,nullVal:null,statusText:''};var status=(_res$status=res.status)!==null&&_res$status!==void 0?_res$status:999;var nullVal=(_res$nullVal=res.nullVal)!==null&&_res$nullVal!==void 0?_res$nullVal:'another';var statusText=(_res$nullVal2=res.nullVal)!==null&&_res$nullVal2!==void 0?_res$nullVal2:'not found';export default(function(){return'hello';});"`
+      )
+    })
+
+    it('should support nullish coalescing for TS file', async () => {
+      const code = await babel(
+        `const res = {
+          status: 0,
+          nullVal: null,
+          statusText: '',
+
+        }
+        const status = res.status ?? 999
+        const nullVal = res.nullVal ?? 'another'
+        const statusText = res.nullVal ?? 'not found'
+        export default () => 'hello'
+        `,
+        {
+          resourcePath: tsPageFile,
+        }
+      )
+      expect(code).toMatchInlineSnapshot(
+        `"var _res$status,_res$nullVal,_res$nullVal2;var res={status:0,nullVal:null,statusText:''};var status=(_res$status=res.status)!==null&&_res$status!==void 0?_res$status:999;var nullVal=(_res$nullVal=res.nullVal)!==null&&_res$nullVal!==void 0?_res$nullVal:'another';var statusText=(_res$nullVal2=res.nullVal)!==null&&_res$nullVal2!==void 0?_res$nullVal2:'not found';export default(function(){return'hello';});"`
       )
     })
   })


### PR DESCRIPTION
Follow-up to #9615 adding tests. Also added a `testheadless` script to avoid having to add the `HEADLESS=true` env var when testing locally