### PR TITLE
examples: Add import react to with-styled-components _document.js

### DIFF
--- a/examples/with-styled-components/pages/_document.js
+++ b/examples/with-styled-components/pages/_document.js
@@ -1,4 +1,5 @@
 import Document from 'next/document'
+import React from 'react'
 import { ServerStyleSheet } from 'styled-components'
 
 export default class MyDocument extends Document {


### PR DESCRIPTION
As I was converting the `examples/with-styled-components/pages/_document.js ` to `tsx`, I've noticed missing import which caused this message:
'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

Proposing to add  `import React from 'react'` which makes error go away in `tsx`
fwiw import is present in `examples/with-styled-components/pages/_app.js `