### PR TITLE
Fix hot-reloader returning undefined

### DIFF
--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -181,7 +181,7 @@ export default class HotReloader {
       }
 
       if (params.buildId !== this.buildId) {
-        return
+        return {}
       }
 
       const page = `/${params.path.join('/')}`


### PR DESCRIPTION
This fixes the following error:
"TypeError: Cannot destructure property `finished` of 'undefined' or 'null'."