### PR TITLE
Fix not detecting legacy getStaticParams in serverless mode

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -99,12 +99,9 @@ const nextServerlessLoader: loader.Loader = function() {
     const Component = ComponentInfo.default
     export default Component
     export const unstable_getStaticProps = ComponentInfo['unstable_getStaticProp' + 's']
+    export const unstable_getStaticParams = ComponentInfo['unstable_getStaticParam' + 's']
+    export const unstable_getStaticPaths = ComponentInfo['unstable_getStaticPath' + 's']
 
-    ${
-      isDynamicRoute(page)
-        ? "export const unstable_getStaticPaths = ComponentInfo['unstable_getStaticPath' + 's']"
-        : 'export const unstable_getStaticPaths = undefined'
-    }
     export const config = ComponentInfo['confi' + 'g'] || {}
     export const _app = App
     export async function renderReqToHTML(req, res, fromExport) {

--- a/test/integration/prerender-legacy/test/index.test.js
+++ b/test/integration/prerender-legacy/test/index.test.js
@@ -18,7 +18,7 @@ describe('Legacy Prerender', () => {
       )
     })
 
-    it('should fail the build in server mode', async () => {
+    it('should fail the build in serverless mode', async () => {
       await fs.writeFile(
         nextConfig,
         `module.exports = { target: 'serverless' }`

--- a/test/integration/prerender-legacy/test/index.test.js
+++ b/test/integration/prerender-legacy/test/index.test.js
@@ -1,15 +1,30 @@
 /* eslint-env jest */
 /* global jasmine */
+import fs from 'fs-extra'
 import { join } from 'path'
 import { nextBuild } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 const appDir = join(__dirname, '..')
+const nextConfig = join(appDir, 'next.config.js')
 
 describe('Legacy Prerender', () => {
   describe('handles old getStaticParams', () => {
-    it('should fail the build', async () => {
+    it('should fail the build in server mode', async () => {
       const out = await nextBuild(appDir, [], { stderr: true })
+      expect(out.stderr).toMatch(`Build error occurred`)
+      expect(out.stderr).toMatch(
+        'unstable_getStaticParams was replaced with unstable_getStaticPaths. Please update your code.'
+      )
+    })
+
+    it('should fail the build in server mode', async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { target: 'serverless' }`
+      )
+      const out = await nextBuild(appDir, [], { stderr: true })
+      await fs.remove(nextConfig)
       expect(out.stderr).toMatch(`Build error occurred`)
       expect(out.stderr).toMatch(
         'unstable_getStaticParams was replaced with unstable_getStaticPaths. Please update your code.'


### PR DESCRIPTION
This unblocks something for product team since this was causing `@now/next` tests to fail without explanation