### PR TITLE
Enable New Chunking for CSS

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -99,7 +99,12 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     }
   })
 
-  return { ...defaultConfig, ...userConfig }
+  const result = { ...defaultConfig, ...userConfig }
+  if (result.experimental && result.experimental.css) {
+    // The new CSS support requires granular chunks be enabled.
+    result.experimental.granularChunks = true
+  }
+  return result
 }
 
 function normalizeConfig(phase: string, config: any) {

--- a/test/integration/css/next.config.js
+++ b/test/integration/css/next.config.js
@@ -3,7 +3,7 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
   },
-  experimental: { css: true, granularChunks: true },
+  experimental: { css: true },
   webpack(cfg) {
     cfg.devtool = 'source-map'
     return cfg

--- a/test/integration/css/next.config.js
+++ b/test/integration/css/next.config.js
@@ -3,7 +3,11 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
   },
-  experimental: { css: true },
+  experimental: {
+    css: true,
+    // Intentionally set false to ensure we force to true.
+    granularChunks: false,
+  },
   webpack(cfg) {
     cfg.devtool = 'source-map'
     return cfg


### PR DESCRIPTION
The experimental CSS feature requires the new chunking behavior, otherwise, styles may be missing.

This was already tested in the integration suite (via having it on), so I've set it to `false` to ensure it's enabled automatically.