### PR TITLE
Adjust `postcss-modules` Message

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/plugins.ts
+++ b/packages/next/build/webpack/config/blocks/css/plugins.ts
@@ -66,6 +66,7 @@ export async function getPostCssPlugins(dir: string): Promise<unknown[]> {
       'postcss-modules-scope',
       'postcss-modules-extract-imports',
       'postcss-modules-local-by-default',
+      'postcss-modules',
     ].forEach(plugin => {
       if (!plugins.hasOwnProperty(plugin)) {
         return
@@ -79,21 +80,6 @@ export async function getPostCssPlugins(dir: string): Promise<unknown[]> {
       )
       delete plugins[plugin]
     })
-
-    // Next.js doesn't support CSS Modules yet. When we do, we should respect the
-    // options passed to this plugin (even though we need to remove the plugin
-    // itself).
-    if (plugins['postcss-modules']) {
-      delete plugins['postcss-modules']
-
-      console.warn(
-        `${chalk.yellow.bold(
-          'Warning'
-        )}: Next.js does not support CSS Modules (yet). The ${chalk.underline(
-          'postcss-modules'
-        )} plugin will have no effect.`
-      )
-    }
 
     target = load(plugins as { [key: string]: object })
   }

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -299,6 +299,7 @@ describe('CSS Support', () => {
         'postcss-modules-scope',
         'postcss-modules-extract-imports',
         'postcss-modules-local-by-default',
+        'postcss-modules',
       ].forEach(plugin => {
         expect(stderr).toMatch(
           new RegExp(`Please remove the.*?${escapeStringRegexp(plugin)}`)


### PR DESCRIPTION
We don't currently permit configuring how our CSS Modules support works.

However, we support CSS Modules now so this plugin shouldn't get a special message saying CSS Modules aren't supported.

Also added this plugin to the "noop list" test.

---

For readers:

The only behavior that would be desirable to customize is `getLocalIdent`  (or `generateScopedName`). We're not sure how we want to expose this yet, or if we should require users edit their webpack config manually.