### PR TITLE
Fix SSG tests failing on windows

### DIFF
--- a/packages/next/next-server/server/spr-cache.ts
+++ b/packages/next/next-server/server/spr-cache.ts
@@ -37,7 +37,7 @@ export const calculateRevalidate = (pathname: string): number | false => {
   // in development we don't have a prerender-manifest
   // and default to always revalidating to allow easier debugging
   const curTime = new Date().getTime()
-  if (sprOptions.dev) return curTime
+  if (sprOptions.dev) return curTime - 1000
 
   const { initialRevalidateSeconds } = prerenderManifest.routes[pathname] || {
     initialRevalidateSeconds: 1,

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -105,6 +105,17 @@ const expectedManifestRoutes = () => ({
 
 const navigateTest = () => {
   it('should navigate between pages successfully', async () => {
+    const toBuild = [
+      '/',
+      '/another',
+      '/something',
+      '/normal',
+      '/blog/post-1',
+      '/blog/post-1/comment-1',
+    ]
+
+    await Promise.all(toBuild.map(pg => renderViaHTTP(appPort, pg)))
+
     const browser = await webdriver(appPort, '/')
     let text = await browser.elementByCss('p').text()
     expect(text).toMatch(/hello.*?world/)


### PR DESCRIPTION
The navigation tests were failing locally from them not building before the element selector timeout so adding pre-building and the cache was being re-used in dev on windows so set expire time to a time in the past instead of current time