### PR TITLE
Bump azure to Windows 2019 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
 
 variables:
   NEXT_TELEMETRY_DISABLED: '1'


### PR DESCRIPTION
We were previously using the win2016 so bumping to Windows 2019 as this might be more stable