### PR TITLE
[example] Added AMP Google Analytics example

### DIFF
--- a/examples/with-google-analytics-amp/README.md
+++ b/examples/with-google-analytics-amp/README.md
@@ -1,0 +1,45 @@
+# Example app with google analytics & amp
+
+## Deploy your own
+
+Deploy the example using [ZEIT Now](https://zeit.co/now):
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/next.js/tree/canary/examples/with-google-analytics-amp)
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-google-analytics-amp with-google-analytics-amp-app
+# or
+yarn create next-app --example with-google-analytics-amp with-google-analytics-amp-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-google-analytics-amp
+cd with-google-analytics-amp
+```
+
+Install it and run:
+
+```bash
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download)):
+
+```bash
+now
+```
+
+## The idea behind the example
+
+This example shows how to use [Next.js](https://github.com/zeit/next.js) along with [Google Analytics](https://developers.google.com/analytics/devguides/collection/gtagjs/) in conjunction with [AMP](https://nextjs.org/docs#amp-support). A custom [\_document](https://github.com/zeit/next.js/#custom-document) is used to inject [tracking snippet](https://developers.google.com/analytics/devguides/collection/gtagjs/) and track [pageviews](https://developers.google.com/analytics/devguides/collection/gtagjs/pages) and [event](https://developers.google.com/analytics/devguides/collection/gtagjs/events). There are two separate initializations of the Google Analytics tracking code; one for AMP and one for non-AMP pages.

--- a/examples/with-google-analytics-amp/components/Header.js
+++ b/examples/with-google-analytics-amp/components/Header.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import Link from 'next/link'
+
+export default () => (
+  <header>
+    <nav>
+      <ul>
+        <li>
+          <Link href="/">
+            <a>Home</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/about">
+            <a>About</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/contact">
+            <a>Contact</a>
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  </header>
+)

--- a/examples/with-google-analytics-amp/components/Page.js
+++ b/examples/with-google-analytics-amp/components/Page.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import Header from './Header'
+
+export default ({ children }) => (
+  <div>
+    <Header />
+    {children}
+  </div>
+)

--- a/examples/with-google-analytics-amp/components/amp/AmpAnalytics.js
+++ b/examples/with-google-analytics-amp/components/amp/AmpAnalytics.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import AmpIncludeCustomElement from './AmpIncludeCustomElement'
+
+export default props => (
+  <>
+    <AmpIncludeCustomElement name="amp-analytics" version="0.1" />
+    <amp-analytics type={props.type}>
+      {props.script && (
+        <script
+          type="application/json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(props.script),
+          }}
+        />
+      )}
+    </amp-analytics>
+  </>
+)

--- a/examples/with-google-analytics-amp/components/amp/AmpIncludeCustomElement.js
+++ b/examples/with-google-analytics-amp/components/amp/AmpIncludeCustomElement.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import Head from 'next/head'
+
+export default props => (
+  <Head>
+    <script
+      async
+      custom-element={props.name}
+      src={
+        'https://cdn.ampproject.org/v0/' +
+        props.name +
+        '-' +
+        props.version +
+        '.js'
+      }
+      key={props.name}
+    />
+  </Head>
+)

--- a/examples/with-google-analytics-amp/lib/gtag.js
+++ b/examples/with-google-analytics-amp/lib/gtag.js
@@ -1,0 +1,17 @@
+export const GA_TRACKING_ID = '<YOUR_GA_TRACKING_ID>'
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = url => {
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  })
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}

--- a/examples/with-google-analytics-amp/package.json
+++ b/examples/with-google-analytics-amp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "with-google-analytics-amp",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  }
+}

--- a/examples/with-google-analytics-amp/pages/_app.js
+++ b/examples/with-google-analytics-amp/pages/_app.js
@@ -1,0 +1,8 @@
+import App from 'next/app'
+import Router from 'next/router'
+
+import * as gtag from '../lib/gtag'
+
+Router.events.on('routeChangeComplete', url => gtag.pageview(url))
+
+export default App

--- a/examples/with-google-analytics-amp/pages/_document.js
+++ b/examples/with-google-analytics-amp/pages/_document.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import Document, { Head, Main, NextScript } from 'next/document'
+import { useAmp } from 'next/amp'
+
+import { GA_TRACKING_ID } from '../lib/gtag'
+
+function AmpWrap({ ampOnly, nonAmp }) {
+  const isAmp = useAmp()
+  if (ampOnly) return isAmp && ampOnly
+  return !isAmp && nonAmp
+}
+
+export default class extends Document {
+  render() {
+    return (
+      <html>
+        <Head>
+          <AmpWrap
+            ampOnly={
+              <script
+                async
+                key="amp-analytics"
+                custom-element="amp-analytics"
+                src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
+              />
+            }
+          />
+          <AmpWrap
+            ampOnly={
+              <script
+                async
+                custom-element="amp-form"
+                src="https://cdn.ampproject.org/v0/amp-form-0.1.js"
+              />
+            }
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+
+          {/* AMP - Google Analytics */}
+          <AmpWrap
+            ampOnly={
+              <amp-analytics
+                type="googleanalytics"
+                id="analytics1"
+                data-credentials="include"
+              >
+                <script
+                  type="application/json"
+                  dangerouslySetInnerHTML={{
+                    __html: JSON.stringify({
+                      vars: {
+                        account: GA_TRACKING_ID,
+                        gtag_id: GA_TRACKING_ID,
+                        config: {
+                          GA_TRACKING_ID: { groups: 'default' },
+                        },
+                      },
+                      triggers: {
+                        trackPageview: {
+                          on: 'visible',
+                          request: 'pageview',
+                        },
+                      },
+                    }),
+                  }}
+                />
+              </amp-analytics>
+            }
+          />
+
+          {/* Non-AMP - Google Analytics */}
+          <AmpWrap
+            nonAmp={
+              <>
+                <script
+                  async
+                  src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+                />
+                <script
+                  dangerouslySetInnerHTML={{
+                    __html: `
+                      window.dataLayer = window.dataLayer || [];
+                      function gtag(){dataLayer.push(arguments);}
+                      gtag('js', new Date());
+
+                      gtag('config', '${GA_TRACKING_ID}');
+                    `,
+                  }}
+                />
+              </>
+            }
+          />
+        </body>
+      </html>
+    )
+  }
+}

--- a/examples/with-google-analytics-amp/pages/_document.js
+++ b/examples/with-google-analytics-amp/pages/_document.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import Document, { Head, Main, NextScript } from 'next/document'
+import Document, { Main, NextScript } from 'next/document'
 import { useAmp } from 'next/amp'
 
 import { GA_TRACKING_ID } from '../lib/gtag'
+import AmpAnalytics from '../components/amp/AmpAnalytics'
 
 function AmpWrap({ ampOnly, nonAmp }) {
   const isAmp = useAmp()
@@ -14,27 +15,6 @@ export default class extends Document {
   render() {
     return (
       <html>
-        <Head>
-          <AmpWrap
-            ampOnly={
-              <script
-                async
-                key="amp-analytics"
-                custom-element="amp-analytics"
-                src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
-              />
-            }
-          />
-          <AmpWrap
-            ampOnly={
-              <script
-                async
-                custom-element="amp-form"
-                src="https://cdn.ampproject.org/v0/amp-form-0.1.js"
-              />
-            }
-          />
-        </Head>
         <body>
           <Main />
           <NextScript />
@@ -42,32 +22,24 @@ export default class extends Document {
           {/* AMP - Google Analytics */}
           <AmpWrap
             ampOnly={
-              <amp-analytics
+              <AmpAnalytics
                 type="googleanalytics"
-                id="analytics1"
-                data-credentials="include"
-              >
-                <script
-                  type="application/json"
-                  dangerouslySetInnerHTML={{
-                    __html: JSON.stringify({
-                      vars: {
-                        account: GA_TRACKING_ID,
-                        gtag_id: GA_TRACKING_ID,
-                        config: {
-                          GA_TRACKING_ID: { groups: 'default' },
-                        },
-                      },
-                      triggers: {
-                        trackPageview: {
-                          on: 'visible',
-                          request: 'pageview',
-                        },
-                      },
-                    }),
-                  }}
-                />
-              </amp-analytics>
+                script={{
+                  vars: {
+                    account: GA_TRACKING_ID,
+                    gtag_id: GA_TRACKING_ID,
+                    config: {
+                      [GA_TRACKING_ID]: { groups: 'default' },
+                    },
+                  },
+                  triggers: {
+                    trackPageview: {
+                      on: 'visible',
+                      request: 'pageview',
+                    },
+                  },
+                }}
+              />
             }
           />
 

--- a/examples/with-google-analytics-amp/pages/about.js
+++ b/examples/with-google-analytics-amp/pages/about.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import Page from '../components/Page'
+
+export default () => (
+  <Page>
+    <h1>This is the About page</h1>
+  </Page>
+)

--- a/examples/with-google-analytics-amp/pages/contact.js
+++ b/examples/with-google-analytics-amp/pages/contact.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react'
+import Page from '../components/Page'
+
+import * as gtag from '../lib/gtag'
+
+export default class extends Component {
+  state = { message: '' }
+
+  handleInput = e => {
+    this.setState({ message: e.target.value })
+  }
+
+  handleSubmit = e => {
+    e.preventDefault()
+
+    gtag.event({
+      action: 'submit_form',
+      category: 'Contact',
+      label: this.state.message,
+    })
+
+    this.setState({ message: '' })
+  }
+
+  render() {
+    return (
+      <Page>
+        <h1>This is the Contact page</h1>
+        <form onSubmit={this.handleSubmit}>
+          <label>
+            <span>Message:</span>
+            <textarea onChange={this.handleInput} value={this.state.message} />
+          </label>
+          <button type="submit">submit</button>
+        </form>
+      </Page>
+    )
+  }
+}

--- a/examples/with-google-analytics-amp/pages/index.js
+++ b/examples/with-google-analytics-amp/pages/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import Page from '../components/Page'
+
+export default () => (
+  <Page>
+    <h1>This is the Home page</h1>
+  </Page>
+)


### PR DESCRIPTION
Added an AMP Google Analytics example based on a suggestion from #9290. Much of the integration example was taken from [next-site](https://github.com/zeit/next-site/blob/d16f39a20bbdcaf821480817bc283ab2ead3aa64/pages/_document.js).

If it would be better, I could instead combine this with the current [with-google-analytics](https://github.com/zeit/next.js/blob/canary/examples/with-google-analytics/README.md) example, but I felt that with some of the AMP specific logic it would be bettered served to be a separate example.