### PR TITLE
Refine Pages Output

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -8,8 +8,8 @@ import nanoid from 'next/dist/compiled/nanoid/index.js'
 import path from 'path'
 import { pathToRegexp } from 'path-to-regexp'
 import { promisify } from 'util'
-
 import formatWebpackMessages from '../client/dev/error-overlay/format-webpack-messages'
+import checkCustomRoutes from '../lib/check-custom-routes'
 import { PUBLIC_DIR_MIDDLEWARE_CONFLICT } from '../lib/constants'
 import { findPagesDir } from '../lib/find-pages-dir'
 import { recursiveDelete } from '../lib/recursive-delete'
@@ -22,8 +22,8 @@ import {
   PHASE_PRODUCTION_BUILD,
   PRERENDER_MANIFEST,
   ROUTES_MANIFEST,
-  SERVER_DIRECTORY,
   SERVERLESS_DIRECTORY,
+  SERVER_DIRECTORY,
 } from '../next-server/lib/constants'
 import {
   getRouteRegex,
@@ -55,7 +55,6 @@ import {
 } from './utils'
 import getBaseWebpackConfig from './webpack-config'
 import { writeBuildId } from './write-build-id'
-import checkCustomRoutes from '../lib/check-custom-routes'
 
 const fsAccess = promisify(fs.access)
 const fsUnlink = promisify(fs.unlink)
@@ -722,7 +721,15 @@ export default async function build(dir: string, conf = null): Promise<void> {
     allPageInfos.set(key, info)
   })
 
-  printTreeView(Object.keys(mappedPages), allPageInfos, isLikeServerless)
+  await printTreeView(
+    Object.keys(mappedPages),
+    allPageInfos,
+    isLikeServerless,
+    {
+      pagesDir,
+      pageExtensions: config.pageExtensions,
+    }
+  )
   printCustomRoutes({ redirects, rewrites })
 
   if (tracer) {

--- a/test/integration/build-output/fixtures/basic-app/pages/index.js
+++ b/test/integration/build-output/fixtures/basic-app/pages/index.js
@@ -1,0 +1,3 @@
+export default function() {
+  return <div />
+}

--- a/test/integration/build-output/fixtures/with-app/pages/_app.js
+++ b/test/integration/build-output/fixtures/with-app/pages/_app.js
@@ -1,0 +1,3 @@
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/test/integration/build-output/fixtures/with-app/pages/index.js
+++ b/test/integration/build-output/fixtures/with-app/pages/index.js
@@ -1,0 +1,3 @@
+export default function() {
+  return <div />
+}

--- a/test/integration/build-output/fixtures/with-error/pages/_error.js
+++ b/test/integration/build-output/fixtures/with-error/pages/_error.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+function Error({ statusCode }) {
+  return (
+    <p>
+      {statusCode
+        ? `An error ${statusCode} occurred on server`
+        : 'An error occurred on client'}
+    </p>
+  )
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  return { statusCode }
+}
+
+export default Error

--- a/test/integration/build-output/fixtures/with-error/pages/index.js
+++ b/test/integration/build-output/fixtures/with-error/pages/index.js
@@ -1,0 +1,3 @@
+export default function() {
+  return <div />
+}

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -1,0 +1,72 @@
+/* eslint-env jest */
+/* global jasmine */
+import 'flat-map-polyfill'
+import { remove } from 'fs-extra'
+import { nextBuild } from 'next-test-utils'
+import { join } from 'path'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const fixturesDir = join(__dirname, '..', 'fixtures')
+
+describe('Build Output', () => {
+  describe('Basic Application Output', () => {
+    const appDir = join(fixturesDir, 'basic-app')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    it('should not include internal pages', async () => {
+      const { stdout } = await nextBuild(appDir, [], {
+        stdout: true,
+      })
+
+      expect(stdout).not.toContain('/_document')
+      expect(stdout).not.toContain('/_app')
+      expect(stdout).not.toContain('/_error')
+
+      expect(stdout).toContain('○ /')
+    })
+  })
+
+  describe('Custom App Output', () => {
+    const appDir = join(fixturesDir, 'with-app')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    it('should not include internal pages', async () => {
+      const { stdout } = await nextBuild(appDir, [], {
+        stdout: true,
+      })
+
+      expect(stdout).not.toContain('/_document')
+      expect(stdout).not.toContain('/_error')
+
+      expect(stdout).toContain('/_app')
+      expect(stdout).toContain('○ /')
+    })
+  })
+
+  describe('Custom Error Output', () => {
+    const appDir = join(fixturesDir, 'with-error')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    it('should not include internal pages', async () => {
+      const { stdout } = await nextBuild(appDir, [], {
+        stdout: true,
+      })
+
+      expect(stdout).not.toContain('/_document')
+      expect(stdout).not.toContain('/_app')
+
+      expect(stdout).toContain('/_error')
+      expect(stdout).toContain('○ /')
+    })
+  })
+})


### PR DESCRIPTION
This cleans up the pages output by:

- Removing `/_document` -- it was unnecessary noise with no information
- Hiding `/_app` when the user does not have a Custom App
- Hiding `/_error` when the user does not have a Custom Error page

![image](https://user-images.githubusercontent.com/616428/70728541-99a8b580-1ccf-11ea-9670-9d5082b44e4c.png)
