### PR TITLE
Fix query values being passed in dev mode for SSG

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -774,9 +774,8 @@ export default class Server {
 
     // Toggle whether or not this is an SPR Data request
     const isSprData = isSpr && query._nextSprData
-    if (isSprData) {
-      delete query._nextSprData
-    }
+    delete query._nextSprData
+
     // Compute the SPR cache key
     const sprCacheKey = parseUrl(req.url || '').pathname!
 
@@ -890,7 +889,9 @@ export default class Server {
             req,
             res,
             pathname,
-            query,
+            result.unstable_getStaticProps
+              ? { _nextSprData: query._nextSprData }
+              : query,
             result,
             { ...this.renderOpts, amphtml, hasAmp, dataOnly }
           )

--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -414,13 +414,8 @@ export default class DevServer extends Server {
             continue
           }
 
-          // eslint-disable-next-line no-loop-func
-          return this.hotReloader!.ensurePage(dynamicRoute.page).then(() => {
-            pathname = dynamicRoute.page
-            query = Object.assign({}, query, params)
-          })
+          return this.hotReloader!.ensurePage(dynamicRoute.page)
         }
-
         throw err
       })
     } catch (err) {

--- a/test/integration/prerender/pages/blog/[post]/index.js
+++ b/test/integration/prerender/pages/blog/[post]/index.js
@@ -27,6 +27,7 @@ export async function unstable_getStaticProps({ params }) {
 
   return {
     props: {
+      params,
       post: params.post,
       time: (await import('perf_hooks')).performance.now(),
     },
@@ -34,11 +35,12 @@ export async function unstable_getStaticProps({ params }) {
   }
 }
 
-export default ({ post, time }) => {
+export default ({ post, time, params }) => {
   return (
     <>
       <p>Post: {post}</p>
       <span>time: {time}</span>
+      <div id="params">{JSON.stringify(params)}</div>
       <div id="query">{JSON.stringify(useRouter().query)}</div>
       <Link href="/">
         <a id="home">to home</a>

--- a/test/integration/prerender/pages/something.js
+++ b/test/integration/prerender/pages/something.js
@@ -1,22 +1,26 @@
 import React from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 // eslint-disable-next-line camelcase
-export async function unstable_getStaticProps() {
+export async function unstable_getStaticProps({ params }) {
   return {
     props: {
       world: 'world',
+      params: params || {},
       time: new Date().getTime(),
     },
     revalidate: false,
   }
 }
 
-export default ({ world, time }) => {
+export default ({ world, time, params }) => {
   return (
     <>
       <p>hello: {world}</p>
       <span>time: {time}</span>
+      <div id="params">{JSON.stringify(params)}</div>
+      <div id="query">{JSON.stringify(useRouter().query)}</div>
       <Link href="/">
         <a id="home">to home</a>
       </Link>

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -3,6 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
+import cheerio from 'cheerio'
 import {
   renderViaHTTP,
   fetchViaHTTP,
@@ -188,6 +189,24 @@ const runTests = (dev = false) => {
   it('should SSR SPR page correctly', async () => {
     const html = await renderViaHTTP(appPort, '/blog/post-1')
     expect(html).toMatch(/Post:.*?post-1/)
+  })
+
+  it('should not have query values with useRouter SSR', async () => {
+    const html = await renderViaHTTP(appPort, '/something?hello=world')
+    const $ = cheerio.load(html)
+    const query = $('#query').text()
+    expect(JSON.parse(query)).toEqual({})
+    const params = $('#params').text()
+    expect(JSON.parse(params)).toEqual({})
+  })
+
+  it('should not supply query values to params SSR', async () => {
+    const html = await renderViaHTTP(appPort, '/blog/post-1?hello=world')
+    const $ = cheerio.load(html)
+    const params = $('#params').text()
+    expect(JSON.parse(params)).toEqual({ post: 'post-1' })
+    const query = $('#query').text()
+    expect(JSON.parse(query)).toEqual({ post: 'post-1' })
   })
 
   it('should return data correctly', async () => {

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -191,7 +191,7 @@ const runTests = (dev = false) => {
     expect(html).toMatch(/Post:.*?post-1/)
   })
 
-  it('should not have query values with useRouter SSR', async () => {
+  it('should not supply query values to params or useRouter non-dynamic page SSR', async () => {
     const html = await renderViaHTTP(appPort, '/something?hello=world')
     const $ = cheerio.load(html)
     const query = $('#query').text()
@@ -200,7 +200,7 @@ const runTests = (dev = false) => {
     expect(JSON.parse(params)).toEqual({})
   })
 
-  it('should not supply query values to params SSR', async () => {
+  it('should not supply query values to params or useRouter dynamic page SSR', async () => {
     const html = await renderViaHTTP(appPort, '/blog/post-1?hello=world')
     const $ = cheerio.load(html)
     const params = $('#params').text()


### PR DESCRIPTION
Currently `query` values can not be used during SSR for an SSG page in production so we need to make sure they are not available to the user in development either.

Fixes: #9732