### PR TITLE
Add an example for Fauna using cookie based auth.

### DIFF
--- a/examples/with-cookie-auth-fauna/.env
+++ b/examples/with-cookie-auth-fauna/.env
@@ -1,0 +1,6 @@
+FAUNA_SERVER_KEY="<ENTER YOU FAUNA SERVER KEY>"
+
+// This key should have minimum permissions since it will be deployed
+// to all frontends. It should only have read permission on the 
+// users_by_email index, for the purposes of logging in user.
+FAUNA_CLIENT_KEY = "<ENTER YOU FAUNA CLIENT KEY>";

--- a/examples/with-cookie-auth-fauna/README.md
+++ b/examples/with-cookie-auth-fauna/README.md
@@ -1,0 +1,59 @@
+# Example app utilizing cookie-based authentication
+
+## Deploy your own
+
+Deploy the example using [ZEIT Now](https://zeit.co/now):
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/next.js/tree/canary/examples/with-cookie-auth-fauna)
+
+## How to use
+
+### Using `create-next-app`
+
+Download [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app) to bootstrap the example:
+
+```
+npm i -g create-next-app
+create-next-app --example with-cookie-auth-fauna with-cookie-auth-fauna-app
+```
+
+### Download manually
+
+Download the example [or clone the repo](https://github.com/zeit/next.js):
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-cookie-auth-fauna
+cd with-cookie-auth-fauna
+```
+
+### Run locally
+
+After you clone the repository you can install the dependencies. You'll need to create an account on [Fauna](https://fauna.com/) and create a database, a `User` collection, a `users_by_email` index, and a server and client key. For more information on how to do that, please refer to the [Authentication tutorial](https://app.fauna.com/tutorials/authentication). Add your server and client key to the `.env` file at the project root.
+
+Then run `yarn dev` and start hacking! You'll be able to see the application running locally as if it were deployed.
+
+```bash
+$ cd with-cookie-auth-fauna
+$ (with-cookie-auth-fauna/) yarn install
+$ (with-cookie-auth-fauna/) yarn dev
+```
+
+### Deploy
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download)):
+
+```bash
+now
+```
+
+## The idea behind the example
+
+In this example, we authenticate users and store a token in a cookie. The example only shows how the user session works, keeping a user logged in between pages.
+
+This example uses Fauna(https://fauna.com/) as the auth service and DB.
+
+The repo includes a minimal auth backend built with the new [API Routes support](https://github.com/zeit/next.js/pull/7296) (`pages/api`), [Micro](https://www.npmjs.com/package/micro), [Fauna for Auth](https://app.fauna.com/tutorials/authentication) and [dotenv](https://github.com/zeit/next.js/tree/canary/examples/with-dotenv) for environment variables. The backend allows the user to create an account (a User document), login, and see their user id (User ref id).
+
+Session is synchronized across tabs. If you logout your session gets removed on all the windows as well. We use the HOC `withAuthSync` for this.
+
+The helper function `auth` helps to retrieve the token across pages and redirects the user if not token was found.

--- a/examples/with-cookie-auth-fauna/components/header.js
+++ b/examples/with-cookie-auth-fauna/components/header.js
@@ -1,0 +1,63 @@
+import Link from 'next/link'
+import { logout } from '../utils/auth'
+
+const Header = props => (
+  <header>
+    <nav>
+      <ul>
+        <li>
+          <Link href="/">
+            <a>Home</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/login">
+            <a>Login</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/signup">
+            <a>Signup</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/profile">
+            <a>Profile</a>
+          </Link>
+        </li>
+        <li>
+          <button onClick={logout}>Logout</button>
+        </li>
+      </ul>
+    </nav>
+    <style jsx>{`
+      ul {
+        display: flex;
+        list-style: none;
+        margin-left: 0;
+        padding-left: 0;
+      }
+
+      li {
+        margin-right: 1rem;
+      }
+
+      li:first-child {
+        margin-left: auto;
+      }
+
+      a {
+        color: #fff;
+        text-decoration: none;
+      }
+
+      header {
+        padding: 0.2rem;
+        color: #fff;
+        background-color: #333;
+      }
+    `}</style>
+  </header>
+)
+
+export default Header

--- a/examples/with-cookie-auth-fauna/components/layout.js
+++ b/examples/with-cookie-auth-fauna/components/layout.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import Head from 'next/head'
+import Header from './header'
+
+const Layout = props => (
+  <React.Fragment>
+    <Head>
+      <title>With Cookies</title>
+    </Head>
+    <style jsx global>{`
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        color: #333;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Helvetica Neue', Arial, Noto Sans, sans-serif, 'Apple Color Emoji',
+          'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+      }
+
+      .container {
+        max-width: 65rem;
+        margin: 1.5rem auto;
+        padding-left: 1rem;
+        padding-right: 1rem;
+      }
+    `}</style>
+    <Header />
+
+    <main>
+      <div className="container">{props.children}</div>
+    </main>
+  </React.Fragment>
+)
+
+export default Layout

--- a/examples/with-cookie-auth-fauna/next.config.js
+++ b/examples/with-cookie-auth-fauna/next.config.js
@@ -1,0 +1,7 @@
+require('dotenv').config()
+module.exports = {
+  env: {
+    // Set the fauna server key in the .env file and make it available at Build Time.
+    FAUNA_SERVER_KEY: process.env.FAUNA_SERVER_KEY,
+  },
+}

--- a/examples/with-cookie-auth-fauna/package.json
+++ b/examples/with-cookie-auth-fauna/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "with-cookie-auth",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "dotenv": "8.2.0",
+    "faunadb": "2.10.0",
+    "isomorphic-unfetch": "^3.0.0",
+    "js-cookie": "^2.2.0",
+    "next": "^9.0.1",
+    "next-cookies": "^1.0.4",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
+  }
+}

--- a/examples/with-cookie-auth-fauna/pages/api/profile.js
+++ b/examples/with-cookie-auth-fauna/pages/api/profile.js
@@ -1,0 +1,33 @@
+import fetch from 'isomorphic-unfetch'
+
+export default async (req, res) => {
+  if (!('authorization' in req.headers)) {
+    return res.status(401).send('Authorization header missing')
+  }
+
+  const auth = await req.headers.authorization
+
+  try {
+    const { token } = JSON.parse(auth)
+    const url = `https://api.github.com/user/${token}`
+
+    const response = await fetch(url)
+
+    if (response.ok) {
+      const js = await response.json()
+      // Need camelcase in the frontend
+      const data = Object.assign({}, { avatarUrl: js.avatar_url }, js)
+      return res.status(200).json({ data })
+    } else {
+      // https://github.com/developit/unfetch#caveats
+      const error = new Error(response.statusText)
+      error.response = response
+      throw error
+    }
+  } catch (error) {
+    const { response } = error
+    return response
+      ? res.status(response.status).json({ message: response.statusText })
+      : res.status(400).json({ message: error.message })
+  }
+}

--- a/examples/with-cookie-auth-fauna/pages/api/signup.js
+++ b/examples/with-cookie-auth-fauna/pages/api/signup.js
@@ -1,0 +1,45 @@
+import faunadb, { query as q } from 'faunadb'
+
+export const serverClient = new faunadb.Client({
+  secret: process.env.FAUNA_SERVER_KEY,
+})
+
+export default async (req, res) => {
+  const { email, password } = await req.body
+
+  try {
+    if (!email || !password) {
+      throw new Error('Email and password must be provided.')
+    }
+    console.log(`email: ${email} trying to create user.`)
+    let createRes
+    try {
+      createRes = await serverClient.query(
+        q.Create(q.Collection('User'), {
+          credentials: { password },
+          data: { email },
+        })
+      )
+    } catch (err) {
+      throw new Error('User already exists.');
+    }
+    if (!createRes.ref) {
+      throw new Error('No ref present in create query response.');
+    }
+    const loginRes = (await serverClient.query(
+      q.Login(createRes.ref, {
+        password,
+      })
+    ))
+    if (!loginRes.secret) {
+      throw new Error('No secret present in login query response.');
+    }
+    
+    return res.status(200).json({ token: loginRes.secret})
+  } catch (error) {
+    const { response } = error
+    return response
+      ? res.status(response.status).json({ message: response.statusText })
+      : res.status(400).json({ message: error.message })
+  }
+}

--- a/examples/with-cookie-auth-fauna/pages/index.js
+++ b/examples/with-cookie-auth-fauna/pages/index.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import Layout from '../components/layout'
+
+const Home = () => (
+  <Layout>
+    <h1>Cookie-based authentication example</h1>
+
+    <p>Steps to test the functionality:</p>
+
+    <ol>
+      <li>Click signup and create an account, this will also log you in.</li>
+      <li>
+        Click home and click profile again, notice how your session is being
+        used through a token stored in a cookie.
+      </li>
+      <li>
+        Click logout and try to go to profile again. You'll get redirected to
+        the `/login` route.
+      </li>
+    </ol>
+    <style jsx>{`
+      li {
+        margin-bottom: 0.5rem;
+      }
+    `}</style>
+  </Layout>
+)
+
+export default Home

--- a/examples/with-cookie-auth-fauna/pages/login.js
+++ b/examples/with-cookie-auth-fauna/pages/login.js
@@ -1,0 +1,116 @@
+import React, { useState } from 'react'
+import {query as q} from 'faunadb'
+import Layout from '../components/layout'
+import { login, faunaClient } from '../utils/auth'
+
+const signin = async (email, password) => {
+  const loginRes = (await faunaClient().query(
+    q.Login(q.Match(q.Index('users_by_email'), email), {
+      password,
+    })
+  ))
+  if (!loginRes.secret) {
+    throw new Error('No secret present in login query response.');
+  }
+  return loginRes.secret;
+};
+
+function Login() {
+  const [userData, setUserData] = useState({ email: '', password: '', error: '' })
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    setUserData(Object.assign({}, userData, { error: '' }))
+
+    const email = userData.email
+    const password = userData.password
+
+    try {
+      const token = await signin(email, password)
+      login({ token })
+    } catch (error) {
+      console.error(
+        'You have an error in your code or there are Network issues.',
+        error
+      )
+
+      const { response } = error
+      setUserData(
+        Object.assign({}, userData, {
+          error: response ? response.statusText : error.message,
+        })
+      )
+    }
+  }
+
+  return (
+    <Layout>
+      <div className="login">
+        <form onSubmit={handleSubmit}>
+          <label htmlFor="email">Email</label>
+
+          <input
+            type="text"
+            id="email"
+            name="email"
+            value={userData.email}
+            onChange={event =>
+              setUserData(
+                Object.assign({}, userData, { email: event.target.value })
+              )
+            }
+          />
+
+          <label htmlFor="password">Password</label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            value={userData.password}
+            onChange={event =>
+              setUserData(
+                Object.assign({}, userData, { password: event.target.value })
+              )
+            }
+          />
+
+          <button type="submit">Login</button>
+
+          {userData.error && <p className="error">Error: {userData.error}</p>}
+        </form>
+      </div>
+      <style jsx>{`
+        .login {
+          max-width: 340px;
+          margin: 0 auto;
+          padding: 1rem;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+        }
+
+        form {
+          display: flex;
+          flex-flow: column;
+        }
+
+        label {
+          font-weight: 600;
+        }
+
+        input {
+          padding: 8px;
+          margin: 0.3rem 0 1rem;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+        }
+
+        .error {
+          margin: 0.5rem 0 0;
+          color: brown;
+        }
+      `}</style>
+    </Layout>
+  )
+}
+
+export default Login

--- a/examples/with-cookie-auth-fauna/pages/profile.js
+++ b/examples/with-cookie-auth-fauna/pages/profile.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import Router from 'next/router'
+import nextCookie from 'next-cookies'
+import Layout from '../components/layout'
+import {query as q} from 'faunadb'
+import { withAuthSync, faunaClient } from '../utils/auth'
+
+const Profile = props => {
+  const { userId } = props
+
+  return (
+    <Layout>
+      <h1>Your user id is {userId}</h1>
+
+      <style jsx>{`
+
+        h1 {
+          margin-bottom: 0;
+        }
+      `}</style>
+    </Layout>
+  )
+}
+
+Profile.getInitialProps = async ctx => {
+  const { token } = nextCookie(ctx)
+
+  const redirectOnError = () =>
+    typeof window !== 'undefined'
+      ? Router.push('/login')
+      : ctx.res.writeHead(302, { Location: '/login' }).end()
+
+  try {
+    const ref = await faunaClient(token).query(q.Identity())
+    return {userId: ref.id}
+  } catch (error) {
+    console.log(error)
+    // Implementation or Network error
+    return redirectOnError()
+  }
+}
+
+export default withAuthSync(Profile)

--- a/examples/with-cookie-auth-fauna/pages/signup.js
+++ b/examples/with-cookie-auth-fauna/pages/signup.js
@@ -1,0 +1,117 @@
+import React, { useState } from 'react'
+import fetch from 'isomorphic-unfetch'
+import Layout from '../components/layout'
+import { login } from '../utils/auth'
+
+function Signup() {
+  const [userData, setUserData] = useState({ email: '', password: '', error: '' })
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    setUserData(Object.assign({}, userData, { error: '' }))
+
+    const email = userData.email
+    const password = userData.password
+    const url = '/api/signup'
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+      if (response.status === 200) {
+        const { token } = await response.json()
+        login({ token })
+      } else {
+        console.log('Signup failed.')
+        // https://github.com/developit/unfetch#caveats
+        const { message } = await response.json()
+        let error = new Error(message ? message : response.statusText)
+        throw error
+      }
+    } catch (error) {
+      console.error(
+        'You have an error in your code or there are Network issues.',
+        error
+      )
+      setUserData(
+        Object.assign({}, userData, {
+          error: error.message,
+        })
+      )
+    }
+  }
+
+  return (
+    <Layout>
+      <div className="signup">
+        <form onSubmit={handleSubmit}>
+          <label htmlFor="email">Email</label>
+
+          <input
+            type="text"
+            id="email"
+            name="email"
+            value={userData.email}
+            onChange={event =>
+              setUserData(
+                Object.assign({}, userData, { email: event.target.value })
+              )
+            }
+          />
+
+          <label htmlFor="password">Password</label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            value={userData.password}
+            onChange={event =>
+              setUserData(
+                Object.assign({}, userData, { password: event.target.value })
+              )
+            }
+          />
+
+          <button type="submit">Sign up</button>
+
+          {userData.error && <p className="error">Error: {userData.error}</p>}
+        </form>
+      </div>
+      <style jsx>{`
+        .signup {
+          max-width: 340px;
+          margin: 0 auto;
+          padding: 1rem;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+        }
+
+        form {
+          display: flex;
+          flex-flow: column;
+        }
+
+        label {
+          font-weight: 600;
+        }
+
+        input {
+          padding: 8px;
+          margin: 0.3rem 0 1rem;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+        }
+
+        .error {
+          margin: 0.5rem 0 0;
+          color: brown;
+        }
+      `}</style>
+    </Layout>
+  )
+}
+
+export default Signup

--- a/examples/with-cookie-auth-fauna/utils/auth.js
+++ b/examples/with-cookie-auth-fauna/utils/auth.js
@@ -1,0 +1,71 @@
+import { useEffect } from 'react'
+import Router from 'next/router'
+import nextCookie from 'next-cookies'
+import cookie from 'js-cookie'
+import faunadb from 'faunadb'
+
+export const faunaClient = (secret = process.env.FAUNA_CLIENT_KEY) => new faunadb.Client({
+  secret: secret,
+});
+
+export const login = ({ token }) => {
+  cookie.set('token', token, { expires: 1 })
+  Router.push('/profile')
+}
+
+export const auth = ctx => {
+  const { token } = nextCookie(ctx)
+
+  // If there's no token, it means the user is not logged in.
+  if (!token) {
+    if (typeof window === 'undefined') {
+      ctx.res.writeHead(302, { Location: '/login' })
+      ctx.res.end()
+    } else {
+      Router.push('/login')
+    }
+  }
+
+  return token
+}
+
+export const logout = () => {
+  cookie.remove('token')
+  // to support logging out from all windows
+  window.localStorage.setItem('logout', Date.now())
+  Router.push('/login')
+}
+
+export const withAuthSync = WrappedComponent => {
+  const Wrapper = props => {
+    const syncLogout = event => {
+      if (event.key === 'logout') {
+        console.log('logged out from storage!')
+        Router.push('/login')
+      }
+    }
+
+    useEffect(() => {
+      window.addEventListener('storage', syncLogout)
+
+      return () => {
+        window.removeEventListener('storage', syncLogout)
+        window.localStorage.removeItem('logout')
+      }
+    }, [])
+
+    return <WrappedComponent {...props} />
+  }
+
+  Wrapper.getInitialProps = async ctx => {
+    const token = auth(ctx)
+
+    const componentProps =
+      WrappedComponent.getInitialProps &&
+      (await WrappedComponent.getInitialProps(ctx))
+
+    return { ...componentProps, token }
+  }
+
+  return Wrapper
+}

--- a/examples/with-cookie-auth-fauna/utils/get-host.js
+++ b/examples/with-cookie-auth-fauna/utils/get-host.js
@@ -1,0 +1,14 @@
+// This is not production ready, (except with providers that ensure a secure host, like Now)
+// For production consider the usage of environment variables and NODE_ENV
+function getHost(req) {
+  if (!req) return ''
+
+  const { host } = req.headers
+
+  if (host.startsWith('localhost')) {
+    return `http://${host}`
+  }
+  return `https://${host}`
+}
+
+export default getHost


### PR DESCRIPTION
Fixes #9501 

Heavily based on with-cookie-auth example and uses `dotenv` for environment variables. Demonstrates Fauna's auth service (https://app.fauna.com/tutorials/authentication) by only requiring a single API route for signup (using a privileged key) while all subsequent requests are done directly to Fauna using client/user keys.