### PR TITLE
Fix typo (change `imperatively` to `imperative`)

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1057,7 +1057,7 @@ export default function MyLink() {
 }
 ```
 
-`router` methods should be only used inside the client side of your app though. In order to prevent any error regarding this subject use the imperatively `prefetch` method in the `useEffect()` hook:
+`router` methods should be only used inside the client side of your app though. In order to prevent any error regarding this subject use the imperative `prefetch` method in the `useEffect()` hook:
 
 ```jsx
 import { useRouter } from 'next/router'


### PR DESCRIPTION
This PR corrects a small typo in the Next.js docs by changing `imperatively` to `imperative`.