### PR TITLE
Fix Shared Sizes Missing Commons

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -384,8 +384,9 @@ export default async function build(dir: string, conf = null): Promise<void> {
         bundleRelative
       )
 
-      let isStatic = false
       let isSsg = false
+      let isStatic = false
+      let isHybridAmp = false
       let ssgPageRoutes: string[] | null = null
 
       pagesManifest[page] = bundleRelative.replace(/\\/g, '/')
@@ -430,6 +431,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
           )
 
           if (result.isHybridAmp) {
+            isHybridAmp = true
             hybridAmpPages.add(page)
           }
 
@@ -456,6 +458,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
         serverBundle,
         static: isStatic,
         isSsg,
+        isHybridAmp,
         ssgPageRoutes,
       })
     })

--- a/test/integration/build-output/fixtures/with-amp/pages/amp.js
+++ b/test/integration/build-output/fixtures/with-amp/pages/amp.js
@@ -1,0 +1,2 @@
+export const config = { amp: true }
+export default () => 'hi'

--- a/test/integration/build-output/fixtures/with-amp/pages/hybrid.js
+++ b/test/integration/build-output/fixtures/with-amp/pages/hybrid.js
@@ -1,0 +1,2 @@
+export const config = { amp: 'hybrid' }
+export default () => 'hi'

--- a/test/integration/build-output/fixtures/with-amp/pages/index.js
+++ b/test/integration/build-output/fixtures/with-amp/pages/index.js
@@ -1,0 +1,3 @@
+export default function() {
+  return <div />
+}

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -25,6 +25,7 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/ [ ]* \d{1,} B/)
       expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
       expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/commons\.js [ 0-9. ]* kB/)
 
       expect(stdout).not.toContain('/_document')
       expect(stdout).not.toContain('/_app')
@@ -50,11 +51,38 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/_app [ ]* \d{1,} B/)
       expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
       expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/commons\.js [ 0-9. ]* kB/)
 
       expect(stdout).not.toContain('/_document')
       expect(stdout).not.toContain('/_error')
 
       expect(stdout).toContain('/_app')
+      expect(stdout).toContain('○ /')
+    })
+  })
+
+  describe('With AMP Output', () => {
+    const appDir = join(fixturesDir, 'with-amp')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    it('should not include custom error', async () => {
+      const { stdout } = await nextBuild(appDir, [], {
+        stdout: true,
+      })
+
+      expect(stdout).toMatch(/\/ [ 0-9.]* kB/)
+      expect(stdout).toMatch(/\/amp .* AMP/)
+      expect(stdout).toMatch(/\/hybrid [ 0-9.]* B/)
+      expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/commons\.js [ 0-9. ]* kB/)
+
+      expect(stdout).not.toContain('/_document')
+      expect(stdout).not.toContain('/_error')
+
       expect(stdout).toContain('○ /')
     })
   })
@@ -75,6 +103,7 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/λ \/_error [ ]* \d{1,} B/)
       expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
       expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/commons\.js [ 0-9. ]* kB/)
 
       expect(stdout).not.toContain('/_document')
       expect(stdout).not.toContain('/_app')


### PR DESCRIPTION
Looks like the commons chunk was being omitted due to AMP pages not listing it as a dependency so it was being marked as not shared. This filters AMP pages from the shared sizes calculation to resolve them interfering with the calculation

<img width="927" alt="Screen Shot 2019-12-14 at 12 53 24" src="https://user-images.githubusercontent.com/22380829/70853249-09a27180-1e71-11ea-9039-4cda5af857f1.png">
