### PR TITLE
Add check for invalid assetPrefix

### DIFF
--- a/errors/invalid-assetprefix.md
+++ b/errors/invalid-assetprefix.md
@@ -1,0 +1,17 @@
+# Invalid assetPrefix
+
+#### Why This Error Occurred
+
+The value of `assetPrefix` in `next.config.js` is set to something that is not a `string`.
+
+#### Possible Ways to Fix It
+
+Ensure that `assetPrefix` is a `string`.
+
+Example:
+
+```js
+module.exports = {
+  assetPrefix: '/',
+}
+```

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -100,6 +100,12 @@ function assignDefaults(userConfig: { [key: string]: any }) {
   })
 
   const result = { ...defaultConfig, ...userConfig }
+
+  if (typeof result.assetPrefix !== 'string') {
+    throw new Error(
+      `Specified assetPrefix is not a string, found type "${typeof result.assetPrefix}" https://err.sh/zeit/next.js/invalid-assetprefix`
+    )
+  }
   if (result.experimental && result.experimental.css) {
     // The new CSS support requires granular chunks be enabled.
     result.experimental.granularChunks = true

--- a/test/integration/invalid-config-values/pages/index.js
+++ b/test/integration/invalid-config-values/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi'

--- a/test/integration/invalid-config-values/test/index.test.js
+++ b/test/integration/invalid-config-values/test/index.test.js
@@ -1,0 +1,63 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+const nextConfigPath = join(appDir, 'next.config.js')
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const cleanUp = () => fs.remove(nextConfigPath)
+
+describe('Serverless runtime configs', () => {
+  beforeAll(() => cleanUp())
+  afterAll(() => cleanUp())
+
+  it('should not error without usage of assetPrefix', async () => {
+    await fs.writeFile(
+      nextConfigPath,
+      `module.exports = {
+      }`
+    )
+
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).not.toMatch(/Specified assetPrefix is not a string/)
+  })
+
+  it('should not error when assetPrefix is a string', async () => {
+    await fs.writeFile(
+      nextConfigPath,
+      `module.exports = {
+        assetPrefix: '/hello'
+      }`
+    )
+
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).not.toMatch(/Specified assetPrefix is not a string/)
+  })
+
+  it('should error on wrong usage of assetPrefix', async () => {
+    await fs.writeFile(
+      nextConfigPath,
+      `module.exports = {
+        assetPrefix: null
+      }`
+    )
+
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).toMatch(/Specified assetPrefix is not a string/)
+  })
+
+  it('should error on usage of assetPrefix with undefined as value', async () => {
+    await fs.writeFile(
+      nextConfigPath,
+      `module.exports = {
+        assetPrefix: undefined
+      }`
+    )
+
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).toMatch(/Specified assetPrefix is not a string/)
+  })
+})

--- a/test/integration/invalid-config-values/test/index.test.js
+++ b/test/integration/invalid-config-values/test/index.test.js
@@ -10,7 +10,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 
 const cleanUp = () => fs.remove(nextConfigPath)
 
-describe('Serverless runtime configs', () => {
+describe('Handles valid/invalid assetPrefix', () => {
   beforeAll(() => cleanUp())
   afterAll(() => cleanUp())
 


### PR DESCRIPTION
The issue itself is not a bug, it's providing `undefined` by accident.
However I found that this could be handled clearer so I've added a message for it.

Fixes #9720