### PR TITLE
Add tests ensuring auto-exported amphtml rel is valid

### DIFF
--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -151,6 +151,11 @@ describe('AMP Usage', () => {
       ).toBe('http://localhost:1234/use-amp-hook.amp')
     })
 
+    it('should render amphtml from provided rel link', async () => {
+      const html = await renderViaHTTP(appPort, '/use-amp-hook.amp')
+      await validateAMP(html)
+    })
+
     it('should render link rel amphtml with existing query', async () => {
       const html = await renderViaHTTP(appPort, '/use-amp-hook?hello=1')
       expect(html).not.toMatch(/&amp;amp=1/)

--- a/test/integration/serverless-trace/test/index.test.js
+++ b/test/integration/serverless-trace/test/index.test.js
@@ -76,6 +76,11 @@ describe('Serverless Trace', () => {
     expect(html).toMatch(/rel="canonical" href="\/some-amp"/)
   })
 
+  it('should have correct canonical link (auto-export link)', async () => {
+    const html = await renderViaHTTP(appPort, '/some-amp.amp')
+    expect(html).toMatch(/rel="canonical" href="\/some-amp"/)
+  })
+
   it('should render correctly when importing isomorphic-unfetch', async () => {
     const url = `http://localhost:${appPort}/fetch`
     const res = await fetch(url)

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -117,6 +117,11 @@ describe('Serverless', () => {
     expect(html).toMatch(/rel="canonical" href="\/some-amp"/)
   })
 
+  it('should have correct canonical link (auto-export link)', async () => {
+    const html = await renderViaHTTP(appPort, '/some-amp.amp')
+    expect(html).toMatch(/rel="canonical" href="\/some-amp"/)
+  })
+
   it('should render correctly when importing isomorphic-unfetch', async () => {
     const url = `http://localhost:${appPort}/fetch`
     const res = await fetch(url)


### PR DESCRIPTION
When we auto-export an AMP page we set the `amphtml` rel to `path.amp` since the `?amp=1` query can't provide the AMP page for an exported page. This ensures that the `path.amp` variant works in `next start` mode