### PR TITLE
Add handling for external redirects

### DIFF
--- a/packages/next/lib/check-custom-routes.ts
+++ b/packages/next/lib/check-custom-routes.ts
@@ -40,7 +40,7 @@ export default function checkCustomRoutes(
       invalidParts.push('`destination` is missing')
     } else if (typeof route.destination !== 'string') {
       invalidParts.push('`destination` is not a string')
-    } else if (!route.destination.startsWith('/')) {
+    } else if (type === 'rewrite' && !route.destination.startsWith('/')) {
       invalidParts.push('`destination` does not start with /')
     }
 

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -404,7 +404,10 @@ export default class Server {
             statusCode: route.statusCode,
             name: `${route.type} ${route.source} route`,
             fn: async (_req, res, params, _parsedUrl) => {
-              let destinationCompiler = compilePathToRegex(route.destination)
+              const parsedDestination = parseUrl(route.destination, true)
+              let destinationCompiler = compilePathToRegex(
+                `${parsedDestination.pathname!}${parsedDestination.hash || ''}`
+              )
               let newUrl
 
               try {
@@ -423,7 +426,15 @@ export default class Server {
               }
 
               if (route.type === 'redirect') {
-                res.setHeader('Location', newUrl)
+                const parsedNewUrl = parseUrl(newUrl)
+                res.setHeader(
+                  'Location',
+                  formatUrl({
+                    ...parsedDestination,
+                    pathname: parsedNewUrl.pathname,
+                    hash: parsedNewUrl.hash,
+                  })
+                )
                 res.statusCode = route.statusCode || DEFAULT_REDIRECT_STATUS
                 res.end()
                 return {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -92,6 +92,10 @@ module.exports = {
           destination: '/',
           statusCode: 303,
         },
+        {
+          source: '/to-external',
+          destination: 'https://google.com',
+        },
       ]
     },
   },

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -152,6 +152,15 @@ const runTests = (isDev = false) => {
     expect(await getBrowserBodyText(browser)).toMatch(/Hello again/)
   })
 
+  it('should allow redirecting to external resource', async () => {
+    const res = await fetchViaHTTP(appPort, '/to-external', undefined, {
+      redirect: 'manual',
+    })
+    const location = res.headers.get('location')
+    expect(res.status).toBe(307)
+    expect(location).toBe('https://google.com/')
+  })
+
   if (!isDev) {
     it('should output routes-manifest successfully', async () => {
       const manifest = await fs.readJSON(
@@ -236,6 +245,13 @@ const runTests = (isDev = false) => {
             statusCode: 303,
             regex: normalizeRegEx('^\\/redir-chain3$'),
             regexKeys: [],
+          },
+          {
+            destination: 'https://google.com',
+            regex: normalizeRegEx('^\\/to-external$'),
+            regexKeys: [],
+            source: '/to-external',
+            statusCode: 307,
           },
         ],
         rewrites: [


### PR DESCRIPTION
This allows custom-routes redirect destinations to be full URLs e.g. `https://google.com`