### PR TITLE
Add support for RegExp custom-route source

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -640,7 +640,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   const buildCustomRoute = (
     r: {
-      source: string
+      source: string | RegExp
       statusCode?: number
     },
     isRedirect = false
@@ -656,6 +656,12 @@ export default async function build(dir: string, conf = null): Promise<void> {
       ...r,
       ...(isRedirect
         ? {
+            ...((r.source as any) instanceof RegExp
+              ? {
+                  source: undefined,
+                  regexSource: (r.source as RegExp).source,
+                }
+              : {}),
             statusCode: r.statusCode || DEFAULT_REDIRECT_STATUS,
           }
         : {}),
@@ -667,7 +673,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   await fsWriteFile(
     path.join(distDir, ROUTES_MANIFEST),
     JSON.stringify({
-      version: 1,
+      version: 2,
       redirects: redirects.map(r => buildCustomRoute(r, true)),
       rewrites: rewrites.map(r => buildCustomRoute(r)),
       dynamicRoutes: getSortedRoutes(dynamicRoutes).map(page => ({

--- a/packages/next/lib/check-custom-routes.ts
+++ b/packages/next/lib/check-custom-routes.ts
@@ -1,5 +1,5 @@
 export type Rewrite = {
-  source: string
+  source: string | RegExp
   destination: string
 }
 
@@ -30,9 +30,17 @@ export default function checkCustomRoutes(
     // TODO: investigate allowing RegExp directly
     if (!route.source) {
       invalidParts.push('`source` is missing')
-    } else if (typeof route.source !== 'string') {
-      invalidParts.push('`source` is not a string')
-    } else if (!route.source.startsWith('/')) {
+    } else if (
+      !(
+        typeof route.source === 'string' ||
+        (route.source as any) instanceof RegExp
+      )
+    ) {
+      invalidParts.push('`source` is not a string or RegExp instance')
+    } else if (
+      typeof route.source === 'string' &&
+      !route.source.startsWith('/')
+    ) {
       invalidParts.push('`source` does not start with /')
     }
 

--- a/packages/next/next-server/server/lib/path-match.ts
+++ b/packages/next/next-server/server/lib/path-match.ts
@@ -1,7 +1,7 @@
 import { match } from 'path-to-regexp'
 
 export default (customRoute = false) => {
-  return (path: string) => {
+  return (path: string | RegExp) => {
     const matcher = match(path, {
       sensitive: false,
       delimiter: '/',

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -253,7 +253,17 @@ export default class Server {
   }
 
   protected getCustomRoutes() {
-    return require(join(this.distDir, ROUTES_MANIFEST))
+    const routes = require(join(this.distDir, ROUTES_MANIFEST))
+    // convert regexSource's to RegExp instances
+    routes.redirects = routes.redirects.map(
+      (r: Redirect & { regexSource: RegExp | undefined }) => {
+        if (r.regexSource) {
+          r.source = new RegExp(r.regexSource)
+        }
+        return r
+      }
+    )
+    return routes
   }
 
   protected generateRoutes(): Route[] {
@@ -383,7 +393,11 @@ export default class Server {
       const { redirects, rewrites } = this.customRoutes
 
       const getCustomRoute = (
-        r: { source: string; destination: string; statusCode?: number },
+        r: {
+          source: string | RegExp
+          destination: string
+          statusCode?: number
+        },
         type: 'redirect' | 'rewrite'
       ) => ({
         ...r,

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -96,6 +96,11 @@ module.exports = {
           source: '/to-external',
           destination: 'https://google.com',
         },
+        {
+          source: /\/feedback(?!\/general$).*/,
+          statusCode: 302,
+          destination: '/feedback/general',
+        },
       ]
     },
   },

--- a/test/integration/custom-routes/pages/feedback/general.js
+++ b/test/integration/custom-routes/pages/feedback/general.js
@@ -1,0 +1,1 @@
+export default () => 'hello from feedback'

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -390,7 +390,7 @@ function runTests(dev) {
       )
 
       expect(manifest).toEqual({
-        version: 1,
+        version: 2,
         rewrites: [],
         redirects: [],
         dynamicRoutes: [

--- a/test/integration/invalid-custom-routes/test/index.test.js
+++ b/test/integration/invalid-custom-routes/test/index.test.js
@@ -54,7 +54,7 @@ const invalidRedirectAssertions = (stderr = '') => {
   )
 
   expect(stderr).toContain(
-    `\`source\` is not a string for route {"source":123,"destination":"/another"}`
+    `\`source\` is not a string or RegExp instance for route {"source":123,"destination":"/another"}`
   )
 
   expect(stderr).toContain(
@@ -105,7 +105,7 @@ const invalidRewriteAssertions = (stderr = '') => {
   )
 
   expect(stderr).toContain(
-    `\`source\` is not a string for route {"source":123,"destination":"/another"}`
+    `\`source\` is not a string or RegExp instance for route {"source":123,"destination":"/another"}`
   )
 
   expect(stderr).toContain(


### PR DESCRIPTION
For advanced route matching a user may need to use a RegExp instance as the source since `path-to-regexp` doesn't handle all use cases out of the box.

One case that would need a RegExp instance is a route used on `front`:
```
{
      "source": "/feedback(.*)",
      "destination": "/feedback/general"
}
```

If we try to do this with `path-to-regexp` we aren't able to not match for `/feedback/general` itself which will cause an infinite redirect. If you can use RegExp itself you can achieve this with `/\/feedback(?!\/general$).*/` which is using a negative lookahead
