### PR TITLE
Change api routes match criteria

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -456,7 +456,7 @@ export default class Server {
     }
 
     routes.push({
-      match: route('/api/:path*'),
+      match: route('/api/:path+'),
       type: 'route',
       name: 'API Route',
       fn: async (req, res, params, parsedUrl) => {


### PR DESCRIPTION
It forces that API routes must have at least one parameter, allowing to use /api as a page, this PR is related to issue #9529.