### PR TITLE
Fix error message typo: "Keys that need moved"

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -472,7 +472,7 @@ export async function isPageStatic(
                 `\n\n\treturn { params: { ${_validParamKeys
                   .map(k => `${k}: ...`)
                   .join(', ')} } }` +
-                `\n\nKeys that need moved: ${invalidKeys.join(', ')}.\n`
+                `\n\nKeys that need to be moved: ${invalidKeys.join(', ')}.\n`
             )
           }
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -433,7 +433,7 @@ export async function renderToHTML(
         throw new Error(
           `Additional keys were returned from \`getStaticProps\`. Properties intended for your component must be nested under the \`props\` key, e.g.:` +
             `\n\n\treturn { props: { title: 'My Title', content: '...' } }` +
-            `\n\nKeys that need moved: ${invalidKeys.join(', ')}.`
+            `\n\nKeys that need to be moved: ${invalidKeys.join(', ')}.`
         )
       }
 

--- a/test/integration/prerender-invalid-paths/test/index.test.js
+++ b/test/integration/prerender-invalid-paths/test/index.test.js
@@ -13,7 +13,7 @@ describe('Legacy Prerender', () => {
       expect(out.stderr).toMatch(`Build error occurred`)
       expect(out.stderr).toMatch('Additional keys were returned from')
       expect(out.stderr).toMatch('return { params: { foo: ..., post: ... } }')
-      expect(out.stderr).toMatch('Keys that need moved: foo, baz.')
+      expect(out.stderr).toMatch('Keys that need to be moved: foo, baz.')
     })
   })
 })


### PR DESCRIPTION
Grammatically, "to be moved" or "moving" :)