### PR TITLE
Update with-sentry example to not use sentry-testkit

### DIFF
--- a/examples/with-sentry/utils/sentry.js
+++ b/examples/with-sentry/utils/sentry.js
@@ -14,12 +14,8 @@ module.exports = (release = process.env.SENTRY_RELEASE) => {
 
   // When we're developing locally
   if (process.env.NODE_ENV !== 'production') {
-    /* eslint-disable-next-line global-require */
-    const sentryTestkit = require('sentry-testkit')
-    const { sentryTransport } = sentryTestkit()
-
     // Don't actually send the errors to Sentry
-    sentryOptions.transport = sentryTransport
+    sentryOptions.beforeSend = () => null
 
     // Instead, dump the errors to the console
     sentryOptions.integrations = [


### PR DESCRIPTION
With an update to sentry-testkit to depend on native node modules
this example no longer works in the browser. Sentry-testkit is made
for a node server not to work in the browser. However, with this
change we no longer require sentry-testkit in our setup for sentry.
Before this change with the update of sentry-testkit to 3.1 we were
encountering errors when trying to run the next.js local development
server because it was trying to load sentry-testkit in the browser.

Thank you to @ohana54 for his example found here https://github.com/wix/sentry-testkit/issues/43
this will now close this issue https://github.com/zeit/next.js/issues/9768
as well.