### PR TITLE
Support static export and server hosted build and update docs

### DIFF
--- a/examples/with-next-offline/README.md
+++ b/examples/with-next-offline/README.md
@@ -12,7 +12,7 @@ npx create-next-app --example with-next-offline with-next-offline-app
 yarn create next-app --example with-next-offline with-next-offline-app
 ```
 
-### Download manually
+### Download
 
 Download the example:
 
@@ -21,19 +21,47 @@ curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 
 cd with-next-offline
 ```
 
-Install it and run:
+### Install dependecies
 
 ```bash
 npm install
-npm run dev
-npm run export
-serve -s out
 # or
 yarn
-yarn dev
-yarn export
-serve -s out
 ```
+
+### Build
+
+#### Static export
+
+```bash
+npm run export
+# or
+yarn export
+```
+
+To serve it yourself, you can run:
+
+```bash
+npx serve -s out
+```
+
+#### Server hosted
+
+```bash
+npm run build
+# or
+yarn build
+```
+
+To serve it yourself, run:
+
+```bash
+npm start
+# or
+yarn start
+```
+
+### Deploy
 
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
 

--- a/examples/with-next-offline/next.config.js
+++ b/examples/with-next-offline/next.config.js
@@ -2,7 +2,9 @@ const withOffline = require('next-offline')
 
 module.exports = withOffline({
   workboxOpts: {
-    swDest: 'static/service-worker.js',
+    swDest: process.env.NEXT_EXPORT
+      ? 'service-worker.js'
+      : 'static/service-worker.js',
   },
   experimental: {
     async rewrites() {

--- a/examples/with-next-offline/package.json
+++ b/examples/with-next-offline/package.json
@@ -6,13 +6,15 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "export": "next build && next export"
+    "export": "cross-env NEXT_EXPORT=true next build && cross-env NEXT_EXPORT=true next export"
   },
   "dependencies": {
     "next": "canary",
     "next-offline": "4.0.6",
     "react": "16.12.0",
-    "react-dom": "16.12.0",
-    "serve": "11.2.0"
+    "react-dom": "16.12.0"
+  },
+  "devDependencies": {
+    "cross-env": "6.0.3"
   }
 }


### PR DESCRIPTION
To support both use cases (static exported and server hosted), I've modified the build to send an environment variable which will tell `next-offline` where to put the service worker in each case.

Also updated the readme to make sure there is no confusions. 

Related with
https://github.com/zeit/next.js/issues/9439