### PR TITLE
Add parsing of route source during checking

### DIFF
--- a/errors/invalid-route-source.md
+++ b/errors/invalid-route-source.md
@@ -2,8 +2,6 @@
 
 #### Why This Error Occurred
 
-When overriding `config.resolve.alias` incorrectly in `next.config.js` webpack will throw an error because private-next-pages is not defined.
-
 When defining custom routes a route was added that causes an error during parsing. This can be due to trying to use normal `RegExp` syntax like negative lookaheads (`?!exclude`) without following `path-to-regexp`'s syntax for it.
 
 #### Possible Ways to Fix It

--- a/errors/invalid-route-source.md
+++ b/errors/invalid-route-source.md
@@ -1,0 +1,34 @@
+# Invalid Custom Route `source`
+
+#### Why This Error Occurred
+
+When overriding `config.resolve.alias` incorrectly in `next.config.js` webpack will throw an error because private-next-pages is not defined.
+
+When defining custom routes a route was added that causes an error during parsing. This can be due to trying to use normal `RegExp` syntax like negative lookaheads (`?!exclude`) without following `path-to-regexp`'s syntax for it.
+
+#### Possible Ways to Fix It
+
+Wrap the `RegExp` part of your `source` as an un-named parameter.
+
+**Before**
+
+```js
+{
+  source: '/feedback/(?!general)',
+  destination: '/feedback/general'
+}
+```
+
+**After**
+
+```js
+{
+  source: '/feedback/((?!general).*)',
+  destination: '/feedback/general'
+}
+```
+
+### Useful Links
+
+- [path-to-regexp](https://github.com/pillarjs/path-to-regexp)
+- [un-named paramters](https://github.com/pillarjs/path-to-regexp#unnamed-parameters)

--- a/packages/next/lib/check-custom-routes.ts
+++ b/packages/next/lib/check-custom-routes.ts
@@ -1,3 +1,5 @@
+import { match as regexpMatch } from 'path-to-regexp'
+
 export type Rewrite = {
   source: string
   destination: string
@@ -54,6 +56,17 @@ export default function checkCustomRoutes(
         hadInvalidStatus = true
         invalidParts.push(`\`statusCode\` is not undefined or valid statusCode`)
       }
+    }
+
+    try {
+      // Make sure we can parse the source properly
+      regexpMatch(route.source)
+    } catch (err) {
+      // If there is an error show our err.sh but still show original error
+      console.error(
+        `\nError parsing ${route.source} https://err.sh/zeit/next.js/invalid-route-source`,
+        err
+      )
     }
 
     const hasInvalidKeys = invalidKeys.length > 0

--- a/test/integration/invalid-custom-routes/test/index.test.js
+++ b/test/integration/invalid-custom-routes/test/index.test.js
@@ -97,6 +97,10 @@ const invalidRewrites = [
     source: '/hello',
     destination: 'another',
   },
+  {
+    source: '/feedback/(?!general)',
+    destination: '/feedback/general',
+  },
 ]
 
 const invalidRewriteAssertions = (stderr = '') => {
@@ -118,6 +122,10 @@ const invalidRewriteAssertions = (stderr = '') => {
 
   expect(stderr).toContain(
     `\`destination\` does not start with / for route {"source":"/hello","destination":"another"}`
+  )
+
+  expect(stderr).toContain(
+    `Error parsing /feedback/(?!general) https://err.sh/zeit/next.js/invalid-route-source TypeError: Pattern cannot start with "?"`
   )
 
   expect(stderr).not.toContain(


### PR DESCRIPTION
This adds parsing of custom-routes' `source` to make sure it is valid during the checking step so that we can catch errors in it earlier and show an `err.sh` with information to help resolve the invalid `source` value