### PR TITLE
Fix/improve test for deduplication of tags with same key in Head

### DIFF
--- a/test/integration/client-navigation/pages/head-duplicate-default-keys.js
+++ b/test/integration/client-navigation/pages/head-duplicate-default-keys.js
@@ -6,17 +6,14 @@ export default () => (
     <Head>
       {/* this will not render */}
       <meta charSet="utf-8" key="charSet" />
-      {/* this will override the default (same key as the default) */}
-      <meta charSet="iso-8859-5" key="charSet" />
-
       {/* this will not render */}
-      <meta name="viewport" content="width=device-width" key="viewport" />
-      {/* this will override the default (same key as the default) */}
-      <meta
-        name="viewport"
-        content="width=device-width,initial-scale=1"
-        key="viewport"
-      />
+      <meta charSet="iso-8859-5" key="charSet" />
+      {/* this will render instead of the default */}
+      <meta name="viewport" content="width=500" key="viewport" />
+    </Head>
+    <Head>
+      {/* this will override the the above */}
+      <meta charSet="iso-8859-1" key="charSet" />
     </Head>
     <h1>Meta tags with same keys as default get deduped</h1>
   </div>

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -90,12 +90,12 @@ export default function(render, fetch) {
 
     test('header helper dedupes tags with the same key as the default', async () => {
       const html = await render('/head-duplicate-default-keys')
-      expect(html).toContain('<meta charSet="iso-8859-5"/>')
-      expect(html).not.toContain('<meta charSet="utf-8"/>')
-      expect(html).toContain(
-        '<meta name="viewport" content="width=device-width,initial-scale=1"/>'
-      )
-      expect(html).not.toContain('<meta name="width=device-width"/>')
+      // Expect exactly one `charSet`
+      expect((html.match(/charSet=/g) || []).length).toBe(1)
+      // Expect exactly one `viewport`
+      expect((html.match(/name="viewport"/g) || []).length).toBe(1)
+      expect(html).toContain('<meta charSet="iso-8859-1"/>')
+      expect(html).toContain('<meta name="viewport" content="width=500"/>')
     })
 
     test('header helper avoids dedupe of specific tags', async () => {


### PR DESCRIPTION
This is a small fix and improvement for a test. I'm currently investigating an issue I'm having with `<Head>` and stumbled across a wrong test, so I took the opportunity to improve the test slightly. The result is the same, but it should make the test more reliable in the future.

Main problem is that the test previously checked for the rendered HTML **not** to contain a certain string, but the string doesn't really make sense (I think it's a typo in #8960) and would never appear in the HTML anyway: `<meta name="width=device-width"/>`

My proposal for this test is, instead of checking for all kinds of strings that are not supposed to be in the rendered HTML, I think it's better to count and check the number of occurrences.

I will shortly submit another test more related to my actual issue, which this test does not cover.