### PR TITLE
Update to close SSE connection before unload

### DIFF
--- a/packages/next/client/dev/on-demand-entries-client.js
+++ b/packages/next/client/dev/on-demand-entries-client.js
@@ -21,5 +21,9 @@ export default async ({ assetPrefix }) => {
         closePing()
       }
     })
+
+    window.addEventListener('beforeunload', () => {
+      closePing()
+    })
   }
 }


### PR DESCRIPTION
In development we use an SSE connection for HMR and `on-demand-entries` which Firefox shows an error for if we don't manually close before a page is reloaded. This updates the `on-demand-entries-client` to close our connection before the page is unloaded

**Before**
![before](https://user-images.githubusercontent.com/22380829/71279682-013db100-231f-11ea-8a61-1572aabfcdac.gif)

**After**
![after](https://user-images.githubusercontent.com/22380829/71279691-06026500-231f-11ea-8256-2c45ddf57b82.gif)


Closes: #9776