### PR TITLE
Update prerender test for Windows

### DIFF
--- a/test/integration/prerender/pages/something.js
+++ b/test/integration/prerender/pages/something.js
@@ -9,16 +9,18 @@ export async function unstable_getStaticProps({ params }) {
       world: 'world',
       params: params || {},
       time: new Date().getTime(),
+      random: Math.random(),
     },
     revalidate: false,
   }
 }
 
-export default ({ world, time, params }) => {
+export default ({ world, time, params, random }) => {
   return (
     <>
       <p>hello: {world}</p>
       <span>time: {time}</span>
+      <div>{random}</div>
       <div id="params">{JSON.stringify(params)}</div>
       <div id="query">{JSON.stringify(useRouter().query)}</div>
       <Link href="/">

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -322,6 +322,17 @@ const runTests = (dev = false) => {
       )
       const escapedBuildId = buildId.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&')
 
+      Object.keys(manifest.dynamicRoutes).forEach(key => {
+        const item = manifest.dynamicRoutes[key]
+
+        if (item.dataRouteRegex) {
+          item.dataRouteRegex = normalizeRegEx(item.dataRouteRegex)
+        }
+        if (item.routeRegex) {
+          item.routeRegex = normalizeRegEx(item.routeRegex)
+        }
+      })
+
       expect(manifest.version).toBe(1)
       expect(manifest.routes).toEqual(expectedManifestRoutes())
       expect(manifest.dynamicRoutes).toEqual({

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -401,5 +401,5 @@ export function getBrowserBodyText(browser) {
 }
 
 export function normalizeRegEx(src) {
-  return new RegExp(src).source
+  return new RegExp(src).source.replace(/\^\//g, '^\\/')
 }


### PR DESCRIPTION
The `should always call getStaticProps without caching in dev` test fails in Azure intermittently and isn't able to be reproduced in a local Windows instance so may be due to the usage of `new Date().getTime()`. This attempts to address it by using `Math.random()` also 