### PR TITLE
Request types check by user provided types

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -164,24 +164,26 @@ export type DocumentProps = DocumentInitialProps & {
   headTags: any[]
 }
 
+ /**
+  * Default types of query and cookies
+  */
+type defaultQuery = { [key: string]: string | string[] }
+type defaultCookies = { [key: string]: string }
+  
 /**
  * Next `API` route request
  */
-export type NextApiRequest = IncomingMessage & {
+export type NextApiRequest<B = any, Q = defaultQuery, C = defaultCookies> = IncomingMessage & {
   /**
    * Object of `query` values from url
    */
-  query: {
-    [key: string]: string | string[]
-  }
+  query: Q
   /**
    * Object of `cookies` from header
    */
-  cookies: {
-    [key: string]: string
-  }
+  cookies: C
 
-  body: any
+  body: B
 }
 
 /**

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -164,16 +164,20 @@ export type DocumentProps = DocumentInitialProps & {
   headTags: any[]
 }
 
- /**
-  * Default types of query and cookies
-  */
+/**
+ * Default types of query and cookies
+ */
 type defaultQuery = { [key: string]: string | string[] }
 type defaultCookies = { [key: string]: string }
-  
+
 /**
  * Next `API` route request
  */
-export type NextApiRequest<B = any, Q = defaultQuery, C = defaultCookies> = IncomingMessage & {
+export type NextApiRequest<
+  B = any,
+  Q = defaultQuery,
+  C = defaultCookies
+> = IncomingMessage & {
   /**
    * Object of `query` values from url
    */


### PR DESCRIPTION
In current types version we can only check response:

```
type MyResponse = { test: string }

export default (req: NextApiRequest, res: NextApiResponse<MyResponse>) => {
  res.json({ test: 'ss' }) // object is of type MyResponse, ok
  res.json({ test: 1 }) // object is of type MyResponse, error - Type 'number' is not assignable to type 'string'
}
```

It's very helpful for you to get typescript tips if you send something that you should not.

And it's will be hepfull to do the same for request:

```
type MyBody = { test: string }
type MyQuery = { test: string }
type MyCookies = { test: string }

export default (req: NextApiRequest<MyBody, MyQuery, MyCookies>, res: NextApiResponse) => {
  console.log(req.body.test) // of type MyBody
  console.log(req.query) // of type MyQuery
  console.log(req.cookies) // of type MyCookies

  console.log(req.body.x) // Type error: Property 'x' does not exist on type 'MyBody'
}
```

This PR update types for this to happen. All the types is optional, so you can not use them and get default types.