### PR TITLE
Update error checking for AMP validator tests

### DIFF
--- a/test/integration/amp-export-validation/test/index.test.js
+++ b/test/integration/amp-export-validation/test/index.test.js
@@ -6,7 +6,7 @@ import { promisify } from 'util'
 import { validateAMP } from 'amp-test-utils'
 import { File, nextBuild, nextExport, runNextCommand } from 'next-test-utils'
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 const access = promisify(fs.access)
 const readFile = promisify(fs.readFile)
 const appDir = join(__dirname, '../')
@@ -27,13 +27,13 @@ describe('AMP Validation on Export', () => {
 
   it('should have shown errors during build', async () => {
     expect(buildOutput).toMatch(
-      /error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/
+      /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'\./
     )
     expect(buildOutput).toMatch(
-      /error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/
+      /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'/
     )
     expect(buildOutput).toMatch(
-      /warn.*The tag 'amp-video extension \.js script' is missing/
+      /warn.*The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'/
     )
   })
 
@@ -90,7 +90,7 @@ describe('AMP Validation on Export', () => {
         stderr: true,
       })
       expect(stdout).toMatch(
-        /error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/
+        /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'/
       )
       await expect(access(join(outDir, 'dog.html'))).resolves.toBe(undefined)
       await expect(stderr).not.toMatch(
@@ -117,10 +117,10 @@ describe('AMP Validation on Export', () => {
         stderr: true,
       })
       expect(stdout).toMatch(
-        /warn.*The tag 'amp-video extension \.js script' is missing/
+        /warn.*The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'/
       )
       expect(stdout).toMatch(
-        /error.*The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'\?/
+        /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'/
       )
       await expect(access(join(outDir, 'dog-cat.html'))).resolves.toBe(
         undefined


### PR DESCRIPTION
It looks like the AMP validator changed their error messages and our tests need to be updated for them, so this updates for the new wording