### PR TITLE
Optimize Prefetching

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -677,9 +677,6 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_EXPORT_TRAILING_SLASH': JSON.stringify(
           config.exportTrailingSlash
         ),
-        'process.env.__NEXT_PREFETCH_PRELOAD': JSON.stringify(
-          config.experimental.prefetchPreload
-        ),
         'process.env.__NEXT_DEFER_SCRIPTS': JSON.stringify(
           config.experimental.deferScripts
         ),

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -124,7 +124,10 @@ export default class PageLoader {
                 /\.css$/.test(d) &&
                 !document.querySelector(`link[rel=stylesheet][href^="${d}"]`)
               ) {
-                appendLink(d, 'stylesheet') // FIXME: handle failure
+                appendLink(d, 'stylesheet').catch(() => {
+                  // FIXME: handle failure
+                  // Right now, this is needed to prevent an unhandled rejection.
+                })
               }
             })
             this.loadRoute(route)

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -4,9 +4,7 @@ function hasPrefetch(link) {
   try {
     link = document.createElement('link')
     return link.relList.supports('prefetch')
-  } catch {
-    return false
-  }
+  } catch {}
 }
 
 const relPrefetch = hasPrefetch()

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -1,34 +1,31 @@
 /* global document, window */
 import mitt from '../next-server/lib/mitt'
 
-const prefetchOrPreload = process.env.__NEXT_PREFETCH_PRELOAD
-  ? 'prefetch'
-  : 'preload'
-
-function supportsPreload(el) {
+function hasPrefetch(link) {
   try {
-    return el.relList.supports(prefetchOrPreload)
+    link = document.createElement('link')
+    return link.relList.supports('prefetch')
   } catch {
     return false
   }
 }
 
-const hasPreload = supportsPreload(document.createElement('link'))
+const relPrefetch = hasPrefetch()
+  ? // https://caniuse.com/#feat=link-rel-prefetch
+    // IE 11, Edge 12+, nearly all evergreen
+    'prefetch'
+  : // https://caniuse.com/#feat=link-rel-preload
+    // macOS and iOS (Safari does not support prefetch)
+    'preload'
 
-function preloadLink(url, resourceType) {
-  const link = document.createElement('link')
-  link.rel = prefetchOrPreload
-  link.crossOrigin = process.crossOrigin
-  link.href = url
-  link.as = resourceType
-  document.head.appendChild(link)
-}
+const hasNoModule = 'noModule' in document.createElement('script')
 
-function loadStyle(url) {
+function appendLink(href, rel, as) {
   const link = document.createElement('link')
-  link.rel = 'stylesheet'
   link.crossOrigin = process.crossOrigin
-  link.href = url
+  link.href = href
+  link.rel = rel
+  if (as) link.as = as
   document.head.appendChild(link)
 }
 
@@ -122,7 +119,7 @@ export default class PageLoader {
                 /\.css$/.test(d) &&
                 !document.querySelector(`link[rel=stylesheet][href^="${d}"]`)
               ) {
-                loadStyle(d) // FIXME: handle failure
+                appendLink(d, 'stylesheet') // FIXME: handle failure
               }
             })
             this.loadRoute(route)
@@ -148,7 +145,7 @@ export default class PageLoader {
 
   loadScript(url, route, isPage) {
     const script = document.createElement('script')
-    if (process.env.__NEXT_MODERN_BUILD && 'noModule' in script) {
+    if (process.env.__NEXT_MODERN_BUILD && hasNoModule) {
       script.type = 'module'
       // Only page bundle scripts need to have .module added to url,
       // dependencies already have it added during build manifest creation
@@ -200,76 +197,47 @@ export default class PageLoader {
     register()
   }
 
-  async prefetch(route, isDependency) {
-    route = this.normalizeRoute(route)
-    let scriptRoute = `${route === '/' ? '/index' : route}.js`
-
-    if (
-      process.env.__NEXT_MODERN_BUILD &&
-      'noModule' in document.createElement('script')
-    ) {
-      scriptRoute = scriptRoute.replace(/\.js$/, '.module.js')
+  prefetch(route, isDependency) {
+    // https://github.com/GoogleChromeLabs/quicklink/blob/453a661fa1fa940e2d2e044452398e38c67a98fb/src/index.mjs#L115-L118
+    // License: Apache 2.0
+    let cn
+    if ((cn = navigator.connection)) {
+      // Don't prefetch if using 2G or if Save-Data is enabled.
+      if (cn.saveData || /2g/.test(cn.effectiveType)) return
     }
-    const url =
-      this.assetPrefix +
-      (isDependency
-        ? route
-        : `/_next/static/${encodeURIComponent(this.buildId)}/pages${encodeURI(
-            scriptRoute
-          )}`)
 
-    // n.b. If preload is not supported, we fall back to `loadPage` which has
-    // its own deduping mechanism.
+    let url = this.assetPrefix
+    if (isDependency) {
+      url += route
+    } else {
+      route = this.normalizeRoute(route)
+      this.prefetched[route] = true
+
+      let scriptRoute = `${route === '/' ? '/index' : route}.js`
+      if (process.env.__NEXT_MODERN_BUILD && hasNoModule) {
+        scriptRoute = scriptRoute.replace(/\.js$/, '.module.js')
+      }
+
+      url += `/_next/static/${encodeURIComponent(
+        this.buildId
+      )}/pages${encodeURI(scriptRoute)}`
+    }
+
     if (
-      this.prefetched[route] ||
       document.querySelector(
-        `link[rel="${prefetchOrPreload}"][href^="${url}"], script[data-next-page="${route}"]`
+        `link[rel="${relPrefetch}"][href^="${url}"], script[data-next-page="${route}"]`
       )
     ) {
       return
     }
-    this.prefetched[route] = true
 
-    // Inspired by quicklink, license: https://github.com/GoogleChromeLabs/quicklink/blob/master/LICENSE
-    let cn
-    if ((cn = navigator.connection)) {
-      // Don't prefetch if the user is on 2G or if Save-Data is enabled.
-      if ((cn.effectiveType || '').indexOf('2g') !== -1 || cn.saveData) {
-        return
-      }
-    }
-
+    appendLink(url, relPrefetch, url.match(/\.css$/) ? 'style' : 'script')
     if (process.env.__NEXT_GRANULAR_CHUNKS && !isDependency) {
-      ;(await this.getDependencies(route)).forEach(url => {
-        this.prefetch(url, true)
-      })
-    }
-
-    // Feature detection is used to see if preload is supported
-    // If not fall back to loading script tags before the page is loaded
-    // https://caniuse.com/#feat=link-rel-preload
-    if (hasPreload) {
-      preloadLink(url, url.match(/\.css$/) ? 'style' : 'script')
-      return
-    }
-
-    if (isDependency) {
-      // loadPage will automatically handle dependencies, so no need to
-      // preload them manually
-      return
-    }
-
-    if (document.readyState === 'complete') {
-      return this.loadPage(route).catch(() => {})
-    } else {
-      return new Promise(resolve => {
-        window.addEventListener('load', () => {
-          this.loadPage(route).then(
-            () => resolve(),
-            () => resolve()
-          )
+      this.getDependencies(route).then(urls =>
+        urls.forEach(url => {
+          this.prefetch(url, true)
         })
-      })
+      )
     }
   }
 }

--- a/test/integration/css-client-nav/test/index.test.js
+++ b/test/integration/css-client-nav/test/index.test.js
@@ -74,6 +74,9 @@ describe('CSS Module client-side navigation in Production', () => {
     const serverCssPreloads = $('link[rel="preload"][as="style"]')
     expect(serverCssPreloads.length).toBe(1)
 
+    const serverCssPrefetches = $('link[rel="prefetch"][as="style"]')
+    expect(serverCssPrefetches.length).toBe(0)
+
     let browser
     try {
       browser = await webdriver(appPort, '/blue')
@@ -89,9 +92,9 @@ describe('CSS Module client-side navigation in Production', () => {
 
       // Check that Red was preloaded
       const result = await browser.eval(
-        `[].slice.call(document.querySelectorAll('link[rel="preload"][as="style"]')).map(e=>({href:e.href})).sort()`
+        `[].slice.call(document.querySelectorAll('link[rel="prefetch"][as="style"]')).map(e=>({href:e.href})).sort()`
       )
-      expect(result.length).toBe(2)
+      expect(result.length).toBe(1)
 
       // Check that CSS was not loaded as script
       const cssPreloads = await browser.eval(

--- a/test/integration/css-client-nav/test/index.test.js
+++ b/test/integration/css-client-nav/test/index.test.js
@@ -101,6 +101,10 @@ describe('CSS Module client-side navigation in Production', () => {
         `[].slice.call(document.querySelectorAll('link[rel=preload][href*=".css"]')).map(e=>e.as)`
       )
       expect(cssPreloads.every(e => e === 'style')).toBe(true)
+      const cssPreloads2 = await browser.eval(
+        `[].slice.call(document.querySelectorAll('link[rel=prefetch][href*=".css"]')).map(e=>e.as)`
+      )
+      expect(cssPreloads2.every(e => e === 'style')).toBe(true)
 
       await browser.elementByCss('#link-red').click()
 

--- a/test/integration/link-ref/test/index.test.js
+++ b/test/integration/link-ref/test/index.test.js
@@ -33,10 +33,10 @@ const noError = async pathname => {
   await browser.close()
 }
 
-const didPreload = async pathname => {
+const didPrefetch = async pathname => {
   const browser = await webdriver(appPort, pathname)
   await waitFor(500)
-  const links = await browser.elementsByCss('link[rel=preload]')
+  const links = await browser.elementsByCss('link[rel=prefetch]')
   let found = false
 
   for (const link of links) {
@@ -84,15 +84,15 @@ describe('Invalid hrefs', () => {
     afterAll(() => killApp(app))
 
     it('should preload with forwardRef', async () => {
-      await didPreload('/functional')
+      await didPrefetch('/functional')
     })
 
     it('should preload with child ref with React.createRef', async () => {
-      await didPreload('/child-ref')
+      await didPrefetch('/child-ref')
     })
 
     it('should preload with child ref with function', async () => {
-      await didPreload('/child-ref-func')
+      await didPrefetch('/child-ref-func')
     })
   })
 })

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -37,7 +37,7 @@ describe('Prefetching Links in viewport', () => {
     try {
       browser = await webdriver(appPort, '/')
       await waitFor(2 * 1000)
-      const links = await browser.elementsByCss('link[rel=preload]')
+      const links = await browser.elementsByCss('link[rel=prefetch]')
       let found = false
 
       for (const link of links) {
@@ -60,7 +60,7 @@ describe('Prefetching Links in viewport', () => {
       await browser.elementByCss('button').click()
       await waitFor(2 * 1000)
 
-      const links = await browser.elementsByCss('link[rel=preload]')
+      const links = await browser.elementsByCss('link[rel=prefetch]')
       let foundFirst = false
       let foundAnother = false
 
@@ -83,7 +83,7 @@ describe('Prefetching Links in viewport', () => {
       await browser.elementByCss('#scroll-to-another').click()
       await waitFor(2 * 1000)
 
-      const links = await browser.elementsByCss('link[rel=preload]')
+      const links = await browser.elementsByCss('link[rel=prefetch]')
       let found = false
 
       for (const link of links) {
@@ -106,7 +106,7 @@ describe('Prefetching Links in viewport', () => {
       await browser.elementByCss('#btn-link').moveTo()
       await waitFor(2 * 1000)
 
-      const links = await browser.elementsByCss('link[rel=preload]')
+      const links = await browser.elementsByCss('link[rel=prefetch]')
       let found = false
 
       for (const link of links) {
@@ -126,7 +126,7 @@ describe('Prefetching Links in viewport', () => {
     const browser = await webdriver(appPort, '/opt-out')
     await waitFor(2 * 1000)
 
-    const links = await browser.elementsByCss('link[rel=preload]')
+    const links = await browser.elementsByCss('link[rel=prefetch]')
     let found = false
 
     for (const link of links) {
@@ -143,7 +143,7 @@ describe('Prefetching Links in viewport', () => {
     const browser = await webdriver(appPort, '/multi-prefetch')
     await waitFor(2 * 1000)
 
-    const links = await browser.elementsByCss('link[rel=preload]')
+    const links = await browser.elementsByCss('link[rel=prefetch]')
 
     const hrefs = []
     for (const link of links) {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -441,86 +441,82 @@ describe('Production Usage', () => {
       }
     })
 
-    if (browserName === 'chrome') {
-      it('should add preload tags when Link prefetch prop is used', async () => {
-        const browser = await webdriver(appPort, '/prefetch')
-        await waitFor(2000)
-        const elements = await browser.elementsByCss('link[rel=preload]')
+    it('should add prefetch tags when Link prefetch prop is used', async () => {
+      const browser = await webdriver(appPort, '/prefetch')
+      await waitFor(2000)
+      const elements = await browser.elementsByCss('link[rel=prefetch]')
 
-        expect(elements.length).toBe(9)
-        await Promise.all(
-          elements.map(async element => {
-            const rel = await element.getAttribute('rel')
-            const as = await element.getAttribute('as')
-            expect(rel).toBe('preload')
-            expect(as).toBe('script')
-          })
-        )
-        await browser.close()
-      })
-
-      // This is a workaround to fix https://github.com/zeit/next.js/issues/5860
-      // TODO: remove this workaround when https://bugs.webkit.org/show_bug.cgi?id=187726 is fixed.
-      it('It does not add a timestamp to link tags with preload attribute', async () => {
-        const browser = await webdriver(appPort, '/prefetch')
-        const links = await browser.elementsByCss('link[rel=preload]')
-        await Promise.all(
-          links.map(async element => {
-            const href = await element.getAttribute('href')
-            expect(href).not.toMatch(/\?ts=/)
-          })
-        )
-        const scripts = await browser.elementsByCss('script[src]')
-        await Promise.all(
-          scripts.map(async element => {
-            const src = await element.getAttribute('src')
-            expect(src).not.toMatch(/\?ts=/)
-          })
-        )
-        await browser.close()
-      })
-
-      it('should reload the page on page script error with prefetch', async () => {
-        const browser = await webdriver(appPort, '/counter')
-        if (global.browserName !== 'chrome') return
-        const counter = await browser
-          .elementByCss('#increase')
-          .click()
-          .click()
-          .elementByCss('#counter')
-          .text()
-        expect(counter).toBe('Counter: 2')
-
-        // Let the browser to prefetch the page and error it on the console.
-        await waitFor(3000)
-        const browserLogs = await browser.log('browser')
-        let foundLog = false
-        browserLogs.forEach(log => {
-          if (
-            log.message.match(/\/no-such-page\.js - Failed to load resource/)
-          ) {
-            foundLog = true
-          }
+      expect(elements.length).toBe(9)
+      await Promise.all(
+        elements.map(async element => {
+          const rel = await element.getAttribute('rel')
+          const as = await element.getAttribute('as')
+          expect(rel).toBe('prefetch')
+          expect(as).toBe('script')
         })
-        expect(foundLog).toBe(true)
+      )
+      await browser.close()
+    })
 
-        // When we go to the 404 page, it'll do a hard reload.
-        // So, it's possible for the front proxy to load a page from another zone.
-        // Since the page is reloaded, when we go back to the counter page again,
-        // previous counter value should be gone.
-        const counterAfter404Page = await browser
-          .elementByCss('#no-such-page-prefetch')
-          .click()
-          .waitForElementByCss('h1')
-          .back()
-          .waitForElementByCss('#counter-page')
-          .elementByCss('#counter')
-          .text()
-        expect(counterAfter404Page).toBe('Counter: 0')
+    // This is a workaround to fix https://github.com/zeit/next.js/issues/5860
+    // TODO: remove this workaround when https://bugs.webkit.org/show_bug.cgi?id=187726 is fixed.
+    it('It does not add a timestamp to link tags with prefetch attribute', async () => {
+      const browser = await webdriver(appPort, '/prefetch')
+      const links = await browser.elementsByCss('link[rel=prefetch]')
+      await Promise.all(
+        links.map(async element => {
+          const href = await element.getAttribute('href')
+          expect(href).not.toMatch(/\?ts=/)
+        })
+      )
+      const scripts = await browser.elementsByCss('script[src]')
+      await Promise.all(
+        scripts.map(async element => {
+          const src = await element.getAttribute('src')
+          expect(src).not.toMatch(/\?ts=/)
+        })
+      )
+      await browser.close()
+    })
 
-        await browser.close()
+    it('should reload the page on page script error with prefetch', async () => {
+      const browser = await webdriver(appPort, '/counter')
+      if (global.browserName !== 'chrome') return
+      const counter = await browser
+        .elementByCss('#increase')
+        .click()
+        .click()
+        .elementByCss('#counter')
+        .text()
+      expect(counter).toBe('Counter: 2')
+
+      // Let the browser to prefetch the page and error it on the console.
+      await waitFor(3000)
+      const browserLogs = await browser.log('browser')
+      let foundLog = false
+      browserLogs.forEach(log => {
+        if (log.message.match(/\/no-such-page\.js - Failed to load resource/)) {
+          foundLog = true
+        }
       })
-    }
+      expect(foundLog).toBe(true)
+
+      // When we go to the 404 page, it'll do a hard reload.
+      // So, it's possible for the front proxy to load a page from another zone.
+      // Since the page is reloaded, when we go back to the counter page again,
+      // previous counter value should be gone.
+      const counterAfter404Page = await browser
+        .elementByCss('#no-such-page-prefetch')
+        .click()
+        .waitForElementByCss('h1')
+        .back()
+        .waitForElementByCss('#counter-page')
+        .elementByCss('#counter')
+        .text()
+      expect(counterAfter404Page).toBe('Counter: 0')
+
+      await browser.close()
+    })
   })
 
   it('should not expose the compiled page file in development', async () => {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -446,7 +446,7 @@ describe('Production Usage', () => {
       await waitFor(2000)
       const elements = await browser.elementsByCss('link[rel=prefetch]')
 
-      expect(elements.length).toBe(9)
+      expect(elements.length).toBe(4)
       await Promise.all(
         elements.map(async element => {
           const rel = await element.getAttribute('rel')


### PR DESCRIPTION
This pull request optimizes our page loader's prefetching by changing the following:

- Uses `prefetch` instead of `preload` when available (so resource loads as low-priority). This lessens CPU load during hydration. 
    * `preload` is still required for macOS (Safari) and iOS (iOS Safari).
    * https://caniuse.com/#feat=link-rel-prefetch (standard, new default)
    * https://caniuse.com/#feat=link-rel-preload (proposal, old default)
- A smaller data saver detection snippet was copied from [`quicklink`](https://github.com/GoogleChromeLabs/quicklink)
- Fallback-`<script>` preloading loading was removed as it was for backwards compat, which is now covered by wider-supported `prefetch`
- Other code golfing techniques to reduce footprint

Contrary to an assumption we were operating on (IIRC), `preload` does not preparse the script. In fact, `prefetch` should actually have better caching characteristics (forces storage in disk cache instead of in-memory, meaning less data transferred on n+1 visit).

Only `<link rel="modulepreload">` (Chrome + ESModules only) parses a script prior to execution.