### PR TITLE
Fix _app global css import order

### DIFF
--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -64,6 +64,8 @@ export async function loadComponents(
   const DocumentMod = require(documentPath)
   const { middleware: DocumentMiddleware } = DocumentMod
 
+  const AppMod = require(appPath)
+
   const ComponentMod = requirePage(pathname, distDir, serverless)
 
   const [
@@ -77,7 +79,7 @@ export async function loadComponents(
     require(join(distDir, REACT_LOADABLE_MANIFEST)),
     interopDefault(ComponentMod),
     interopDefault(DocumentMod),
-    interopDefault(require(appPath)),
+    interopDefault(AppMod),
   ])
 
   return {

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -485,8 +485,8 @@ export async function renderToHTML(
   const devFiles = buildManifest.devFiles
   const files = [
     ...new Set([
-      ...getPageFiles(buildManifest, pathname),
       ...getPageFiles(buildManifest, '/_app'),
+      ...getPageFiles(buildManifest, pathname),
     ]),
   ]
   const polyfillFiles = getPageFiles(buildManifest, '/_polyfills')

--- a/test/integration/app-document-import-order/next.config.js
+++ b/test/integration/app-document-import-order/next.config.js
@@ -1,0 +1,35 @@
+module.exports = {
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      const optimization = config.optimization || {}
+      const splitChunks = optimization.splitChunks || {}
+      const cacheGroups = splitChunks.cacheGroups || {}
+
+      config.optimization = {
+        ...optimization,
+        splitChunks: {
+          ...splitChunks,
+          cacheGroups: {
+            ...cacheGroups,
+            requiredByApp: {
+              test: /requiredByApp.js/,
+              name: 'requiredByApp',
+              enforce: true,
+              priority: 10,
+              chunks: 'all',
+            },
+            requiredByPage: {
+              test: /requiredByPage.js/,
+              name: 'requiredByPage',
+              enforce: true,
+              priority: 10,
+              chunks: 'all',
+            },
+          },
+        },
+      }
+    }
+
+    return config
+  },
+}

--- a/test/integration/app-document-import-order/pages/_app.js
+++ b/test/integration/app-document-import-order/pages/_app.js
@@ -1,0 +1,9 @@
+import sideEffect from '../sideEffectModule'
+
+sideEffect('_app')
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+export default MyApp

--- a/test/integration/app-document-import-order/pages/_app.js
+++ b/test/integration/app-document-import-order/pages/_app.js
@@ -1,9 +1,16 @@
+import React from 'react'
+import RequiredByApp from '../requiredByApp'
 import sideEffect from '../sideEffectModule'
 
 sideEffect('_app')
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <React.Fragment>
+      <RequiredByApp />
+      <Component {...pageProps} />
+    </React.Fragment>
+  )
 }
 
 export default MyApp

--- a/test/integration/app-document-import-order/pages/_document.js
+++ b/test/integration/app-document-import-order/pages/_document.js
@@ -1,0 +1,28 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import sideEffect from '../sideEffectModule'
+
+sideEffect('_document')
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+
+    return {
+      ...initialProps,
+    }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/test/integration/app-document-import-order/pages/index.js
+++ b/test/integration/app-document-import-order/pages/index.js
@@ -1,0 +1,20 @@
+import sideEffect from '../sideEffectModule'
+
+const sideEffects = sideEffect('page')
+
+function Hi() {
+  return (
+    <div>
+      <p>Hello world!</p>
+      {sideEffects.map((arg, index) => (
+        <p key={arg} className="side-effect-calls">
+          {arg}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+Hi.getInitialProps = () => ({})
+
+export default Hi

--- a/test/integration/app-document-import-order/pages/index.js
+++ b/test/integration/app-document-import-order/pages/index.js
@@ -1,10 +1,12 @@
 import sideEffect from '../sideEffectModule'
+import RequiredByPage from '../requiredByPage'
 
 const sideEffects = sideEffect('page')
 
 function Hi() {
   return (
     <div>
+      <RequiredByPage />
       <p>Hello world!</p>
       {sideEffects.map((arg, index) => (
         <p key={arg} className="side-effect-calls">

--- a/test/integration/app-document-import-order/requiredByApp.js
+++ b/test/integration/app-document-import-order/requiredByApp.js
@@ -1,0 +1,9 @@
+function RequiredByApp() {
+  return (
+    <div>
+      <p>RequiredByApp!</p>
+    </div>
+  )
+}
+
+export default RequiredByApp

--- a/test/integration/app-document-import-order/requiredByPage.js
+++ b/test/integration/app-document-import-order/requiredByPage.js
@@ -1,0 +1,9 @@
+function RequiredByPage() {
+  return (
+    <div>
+      <p>RequiredByPage</p>
+    </div>
+  )
+}
+
+export default RequiredByPage

--- a/test/integration/app-document-import-order/sideEffectModule.js
+++ b/test/integration/app-document-import-order/sideEffectModule.js
@@ -1,0 +1,10 @@
+const sideEffect = arg => {
+  if (!sideEffect.callArguments) {
+    sideEffect.callArguments = []
+  }
+  sideEffect.callArguments.push(arg)
+
+  return sideEffect.callArguments
+}
+
+export default sideEffect

--- a/test/integration/app-document-import-order/test/index.test.js
+++ b/test/integration/app-document-import-order/test/index.test.js
@@ -1,0 +1,72 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import {
+  stopApp,
+  startApp,
+  nextBuild,
+  nextServer,
+  fetchViaHTTP,
+  findPort,
+  launchApp,
+  killApp,
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60
+const appDir = join(__dirname, '../')
+let appPort
+let server
+let app
+
+describe('Custom root components with side effects', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    app = nextServer({
+      dir: join(__dirname, '../'),
+      dev: false,
+      quiet: true,
+    })
+
+    server = await startApp(app)
+    appPort = server.address().port
+  })
+  afterAll(() => stopApp(server))
+
+  it('root components should be imported in this order _document > _app > page in order to respect side effects', async () => {
+    const res = await fetchViaHTTP(appPort, '/')
+    const html = await res.text()
+    const $ = cheerio.load(html)
+
+    const expectSideEffectsOrder = ['_document', '_app', 'page']
+
+    const sideEffectCalls = $('.side-effect-calls')
+
+    Array.from(sideEffectCalls).forEach((sideEffectCall, index) => {
+      expect($(sideEffectCall).text()).toEqual(expectSideEffectsOrder[index])
+    })
+  })
+
+  describe('on dev server', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(join(__dirname, '../'), appPort)
+    })
+
+    afterAll(() => killApp(app))
+
+    it('root components should be imported in this order _document > _app > page in order to respect side effects', async () => {
+      const res = await fetchViaHTTP(appPort, '/')
+      const html = await res.text()
+      const $ = cheerio.load(html)
+
+      const expectSideEffectsOrder = ['_document', '_app', 'page']
+
+      const sideEffectCalls = $('.side-effect-calls')
+
+      Array.from(sideEffectCalls).forEach((sideEffectCall, index) => {
+        expect($(sideEffectCall).text()).toEqual(expectSideEffectsOrder[index])
+      })
+    })
+  })
+})


### PR DESCRIPTION
Hello,

First of all, thanks for all the work you all have put into nextjs, I and my team really appreciate it.

We have recently configured our project to import css files directly from their respective react components and also got css splitting working.

The only problem we have is when importing global/third-party css. We import them in our custom _app file, but the split page css keeps getting added to page head before our global/third-party css. This causes our third-party customizations to be overwritten by their original styles.

After debugging and examining nextjs code I have found two points where, it seems, "root" components (like _document and _app) are imported after the page component and that's causing their chunks to be added after the page chunks, causing the problems I described above.

As custom _app and _document are supposed to act as root components for our nextjs apps, nextjs users expect that those components and their dependencies to be imported first. I say that based on
https://github.com/zeit/next-plugins/issues/399
https://spectrum.chat/next-js/general/control-the-placement-of-styles-chunk-css-in-nextjs7~0d91eec7-6a38-4943-98f6-0bb3a71d50f6
and a few other cases I found while looking for a solution for this.

We are currently using a custom extended HEAD component that reorder our css files attaching first our global styles as a workaround (not pretty at all xD).

The changes in this PR fix the issue.