### PR TITLE
Allow Empty API Body

### DIFF
--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -104,6 +104,11 @@ export async function parseBody(req: NextApiRequest, limit: string | number) {
  * @param str `JSON` string
  */
 function parseJson(str: string) {
+  if (str.length === 0) {
+    // special-case empty json body, as it's a common client-side mistake
+    return {}
+  }
+
   try {
     return JSON.parse(str)
   } catch (e) {

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -75,6 +75,17 @@ function runTests(dev = false) {
     expect(data).toEqual([{ title: 'Nextjs' }])
   })
 
+  it('should special-case empty JSON body', async () => {
+    const data = await fetchViaHTTP(appPort, '/api/parse', null, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+    }).then(res => res.ok && res.json())
+
+    expect(data).toEqual({})
+  })
+
   it('should return error with invalid JSON', async () => {
     const data = await fetchViaHTTP(appPort, '/api/parse', null, {
       method: 'POST',


### PR DESCRIPTION
This matches the behavior of Express (`body-parser`) and special-cases an empty body.

---

Fixes #9127
Fixes #9834