### PR TITLE
Do Not Run File Loader on Server

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/build/webpack/config/blocks/css/index.ts
@@ -230,29 +230,31 @@ export const css = curry(async function css(
     })
   )
 
-  // Automatically transform references to files (i.e. url()) into URLs
-  // e.g. url(./logo.svg)
-  fns.push(
-    loader({
-      oneOf: [
-        {
-          // This should only be applied to CSS files
-          issuer: { test: /\.css$/ },
-          // Exclude extensions that webpack handles by default
-          exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
-          use: {
-            // `file-loader` always emits a URL reference, where `url-loader`
-            // might inline the asset as a data URI
-            loader: require.resolve('file-loader'),
-            options: {
-              // Hash the file for immutable cacheability
-              name: 'static/media/[name].[hash].[ext]',
+  if (ctx.isClient) {
+    // Automatically transform references to files (i.e. url()) into URLs
+    // e.g. url(./logo.svg)
+    fns.push(
+      loader({
+        oneOf: [
+          {
+            // This should only be applied to CSS files
+            issuer: { test: /\.css$/ },
+            // Exclude extensions that webpack handles by default
+            exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+            use: {
+              // `file-loader` always emits a URL reference, where `url-loader`
+              // might inline the asset as a data URI
+              loader: require.resolve('file-loader'),
+              options: {
+                // Hash the file for immutable cacheability
+                name: 'static/media/[name].[hash].[ext]',
+              },
             },
           },
-        },
-      ],
-    })
-  )
+        ],
+      })
+    )
+  }
 
   const fn = pipe(...fns)
   return fn(config)


### PR DESCRIPTION
Not that there's a specific bug currently, but `file-loader` should only ever activate for the client-side.

All tests should remain passing.