### PR TITLE
Fix bug in data-fetching.md's example

### DIFF
--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -34,7 +34,7 @@ import useSWR from 'swr'
 
 const API_URL = 'https://api.github.com'
 async function fetcher(path) {
-  const res = fetch(API_URL + path)
+  const res = await fetch(API_URL + path)
   const json = await res.json()
   return json
 }


### PR DESCRIPTION
Add missing `await` keyword in the Static Generation example
____

Hi there!

While testing out the examples in data-fetching.md, I've noticed that there is a minor bug. The `fetch(API_URL + path)` in the Static Generation example needs an `await` in front of it.

Best,
Konstantin
