### PR TITLE
[Experimental] Add basePath support

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -77,6 +77,7 @@ export function createEntrypoints(
     generateEtags: config.generateEtags,
     ampBindInitData: config.experimental.ampBindInitData,
     canonicalBase: config.canonicalBase,
+    basePath: config.experimental.basePath,
   }
 
   Object.keys(pages).forEach(page => {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -724,6 +724,9 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_REACT_MODE': JSON.stringify(
           config.experimental.reactMode
         ),
+        'process.env.__NEXT_ROUTER_BASEPATH': JSON.stringify(
+          config.experimental.basePath
+        ),
         ...(isServer
           ? {
               // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -135,8 +135,8 @@ const nextServerlessLoader: loader.Loader = function() {
           ${
             basePath
               ? `
-          if(req.url.startsWith(${basePath})) {
-            req.url = req.url.replace(${basePath}, '')
+          if(req.url.startsWith('${basePath}')) {
+            req.url = req.url.replace('${basePath}', '')
           }
           `
               : ''
@@ -197,8 +197,8 @@ const nextServerlessLoader: loader.Loader = function() {
       ${
         basePath
           ? `
-      if(req.url.startsWith(${basePath})) {
-        req.url = req.url.replace(${basePath}, '')
+      if(req.url.startsWith('${basePath}')) {
+        req.url = req.url.replace('${basePath}', '')
       }
       `
           : ''

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -21,6 +21,7 @@ export type ServerlessLoaderQuery = {
   ampBindInitData: boolean | string
   generateEtags: string
   canonicalBase: string
+  basePath: string
 }
 
 const nextServerlessLoader: loader.Loader = function() {
@@ -36,6 +37,7 @@ const nextServerlessLoader: loader.Loader = function() {
     absoluteDocumentPath,
     absoluteErrorPath,
     generateEtags,
+    basePath,
   }: ServerlessLoaderQuery =
     typeof this.query === 'string' ? parse(this.query.substr(1)) : this.query
   const buildManifest = join(distDir, BUILD_MANIFEST).replace(/\\/g, '/')
@@ -128,6 +130,10 @@ const nextServerlessLoader: loader.Loader = function() {
       export default async (req, res) => {
         try {
           await initServer()
+
+          if(req.url.startsWith(${basePath})) {
+            req.url = req.url.replace(${basePath}, '')
+          }
           const parsedUrl = parse(req.url, true)
 
           const params = ${

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -40,6 +40,7 @@ const nextServerlessLoader: loader.Loader = function() {
     basePath,
   }: ServerlessLoaderQuery =
     typeof this.query === 'string' ? parse(this.query.substr(1)) : this.query
+
   const buildManifest = join(distDir, BUILD_MANIFEST).replace(/\\/g, '/')
   const reactLoadableManifest = join(distDir, REACT_LOADABLE_MANIFEST).replace(
     /\\/g,
@@ -131,8 +132,14 @@ const nextServerlessLoader: loader.Loader = function() {
         try {
           await initServer()
 
+          ${
+            basePath
+              ? `
           if(req.url.startsWith(${basePath})) {
             req.url = req.url.replace(${basePath}, '')
+          }
+          `
+              : ''
           }
           const parsedUrl = parse(req.url, true)
 
@@ -187,6 +194,15 @@ const nextServerlessLoader: loader.Loader = function() {
     export const config = ComponentInfo['confi' + 'g'] || {}
     export const _app = App
     export async function renderReqToHTML(req, res, fromExport, _renderOpts, _params) {
+      ${
+        basePath
+          ? `
+      if(req.url.startsWith(${basePath})) {
+        req.url = req.url.replace(${basePath}, '')
+      }
+      `
+          : ''
+      }
       const options = {
         App,
         Document,

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -18,6 +18,12 @@ import { isDynamicRoute } from './utils/is-dynamic'
 import { getRouteMatcher } from './utils/route-matcher'
 import { getRouteRegex } from './utils/route-regex'
 
+function addBasePath(path: string): string {
+  // @ts-ignore variable is always a string
+  const p: string = process.env.__NEXT_ROUTER_BASEPATH
+  return path.indexOf(p) !== 0 ? p + path : path
+}
+
 function toRoute(path: string): string {
   return path.replace(/\/$/, '') || '/'
 }
@@ -284,7 +290,7 @@ export default class Router implements BaseRouter {
       if (!options._h && this.onlyAHashChange(as)) {
         this.asPath = as
         Router.events.emit('hashChangeStart', as)
-        this.changeState(method, url, as)
+        this.changeState(method, url, addBasePath(as))
         this.scrollToHash(as)
         Router.events.emit('hashChangeComplete', as)
         return resolve(true)
@@ -346,7 +352,7 @@ export default class Router implements BaseRouter {
         }
 
         Router.events.emit('beforeHistoryChange', as)
-        this.changeState(method, url, as, options)
+        this.changeState(method, url, addBasePath(as), options)
         const hash = window.location.hash.substring(1)
 
         if (process.env.NODE_ENV !== 'production') {

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -53,6 +53,7 @@ const defaultConfig: { [key: string]: any } = {
     deferScripts: false,
     reactMode: 'legacy',
     workerThreads: false,
+    basePath: '',
   },
   future: {
     excludeDefaultMomentLocales: false,
@@ -106,9 +107,44 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       `Specified assetPrefix is not a string, found type "${typeof result.assetPrefix}" https://err.sh/zeit/next.js/invalid-assetprefix`
     )
   }
-  if (result.experimental && result.experimental.css) {
-    // The new CSS support requires granular chunks be enabled.
-    result.experimental.granularChunks = true
+  if (result.experimental) {
+    if (result.experimental.css) {
+      // The new CSS support requires granular chunks be enabled.
+      result.experimental.granularChunks = true
+    }
+
+    if (typeof result.experimental.basePath !== 'string') {
+      throw new Error(
+        `Specified basePath is not a string, found type "${typeof result
+          .experimental.basePath}"`
+      )
+    }
+
+    if (result.experimental.basePath !== '') {
+      if (result.experimental.basePath === '/') {
+        throw new Error(
+          `Specified basePath /. basePath has to be either an empty string or a path prefix"`
+        )
+      }
+
+      if (!result.experimental.basePath.startsWith('/')) {
+        throw new Error(
+          `Specified basePath has to start with a /, found "${result.experimental.basePath}"`
+        )
+      }
+
+      if (result.experimental.basePath !== '/') {
+        if (result.experimental.basePath.endsWith('/')) {
+          throw new Error(
+            `Specified basePath should not end with /, found "${result.experimental.basePath}"`
+          )
+        }
+
+        if (result.assetPrefix === '') {
+          result.assetPrefix = result.experimental.basePath
+        }
+      }
+    }
   }
   return result
 }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -232,6 +232,16 @@ export default class Server {
       parsedUrl.query = parseQs(parsedUrl.query)
     }
 
+    if (parsedUrl.pathname!.startsWith(this.nextConfig.experimental.basePath)) {
+      // If replace ends up replacing the full url it'll be `undefined`, meaning we have to default it to `/`
+      parsedUrl.pathname =
+        parsedUrl.pathname!.replace(
+          this.nextConfig.experimental.basePath,
+          ''
+        ) || '/'
+      req.url = req.url!.replace(this.nextConfig.experimental.basePath, '')
+    }
+
     res.statusCode = 200
     return this.run(req, res, parsedUrl).catch(err => {
       this.logError(err)

--- a/test/integration/basepath/components/hello-chunkfilename.js
+++ b/test/integration/basepath/components/hello-chunkfilename.js
@@ -1,0 +1,1 @@
+export default () => <div>test chunkfilename</div>

--- a/test/integration/basepath/components/hello-context.js
+++ b/test/integration/basepath/components/hello-context.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class extends React.Component {
+  static contextTypes = {
+    data: PropTypes.object,
+  }
+
+  render() {
+    const { data } = this.context
+    return <div>{data.title}</div>
+  }
+}

--- a/test/integration/basepath/components/hello1.js
+++ b/test/integration/basepath/components/hello1.js
@@ -1,0 +1,1 @@
+export default () => <p>Hello World 1</p>

--- a/test/integration/basepath/components/hello2.js
+++ b/test/integration/basepath/components/hello2.js
@@ -1,0 +1,1 @@
+export default () => <p>Hello World 2</p>

--- a/test/integration/basepath/components/hello3.js
+++ b/test/integration/basepath/components/hello3.js
@@ -1,0 +1,1 @@
+export default () => <p>Hello World 1</p>

--- a/test/integration/basepath/components/hello4.js
+++ b/test/integration/basepath/components/hello4.js
@@ -1,0 +1,1 @@
+export default () => <p>Hello World 2</p>

--- a/test/integration/basepath/components/hmr/dynamic.js
+++ b/test/integration/basepath/components/hmr/dynamic.js
@@ -1,0 +1,12 @@
+export default () => {
+  return (
+    <div id="dynamic-component">
+      Dynamic Component
+      <style jsx>{`
+        div {
+          font-size: 100px;
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/test/integration/basepath/components/nested1.js
+++ b/test/integration/basepath/components/nested1.js
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic'
+
+const Nested2 = dynamic(() => import('./nested2'))
+
+export default () => (
+  <div>
+    Nested 1
+    <Nested2 />
+  </div>
+)

--- a/test/integration/basepath/components/nested2.js
+++ b/test/integration/basepath/components/nested2.js
@@ -1,0 +1,12 @@
+import dynamic from 'next/dynamic'
+
+const BrowserLoaded = dynamic(async () => () => <div>Browser hydrated</div>, {
+  ssr: false,
+})
+
+export default () => (
+  <div>
+    <div>Nested 2</div>
+    <BrowserLoaded />
+  </div>
+)

--- a/test/integration/basepath/components/welcome.js
+++ b/test/integration/basepath/components/welcome.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export default class Welcome extends React.Component {
+  state = { name: null }
+
+  componentDidMount() {
+    const { name } = this.props
+    this.setState({ name })
+  }
+
+  render() {
+    const { name } = this.state
+    if (!name) return null
+
+    return <p>Welcome, {name}</p>
+  }
+}

--- a/test/integration/basepath/next.config.js
+++ b/test/integration/basepath/next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+  experimental: {
+    basePath: '/docs',
+  },
+}

--- a/test/integration/basepath/pages/hello.js
+++ b/test/integration/basepath/pages/hello.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default () => (
+  <Link href="/other-page">
+    <a id="other-page-link">
+      <h1>Hello World</h1>
+    </a>
+  </Link>
+)

--- a/test/integration/basepath/pages/hmr/about.js
+++ b/test/integration/basepath/pages/hmr/about.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/about1.js
+++ b/test/integration/basepath/pages/hmr/about1.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/about2.js
+++ b/test/integration/basepath/pages/hmr/about2.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/about3.js
+++ b/test/integration/basepath/pages/hmr/about3.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/about4.js
+++ b/test/integration/basepath/pages/hmr/about4.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/about5.js
+++ b/test/integration/basepath/pages/hmr/about5.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/about6.js
+++ b/test/integration/basepath/pages/hmr/about6.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/about7.js
+++ b/test/integration/basepath/pages/hmr/about7.js
@@ -1,0 +1,7 @@
+export default () => {
+  return (
+    <div className="hmr-about-page">
+      <p>This is the about page.</p>
+    </div>
+  )
+}

--- a/test/integration/basepath/pages/hmr/contact.js
+++ b/test/integration/basepath/pages/hmr/contact.js
@@ -1,0 +1,5 @@
+export default () => (
+  <div className="hmr-contact-page">
+    <p>This is the contact page.</p>
+  </div>
+)

--- a/test/integration/basepath/pages/hmr/counter.js
+++ b/test/integration/basepath/pages/hmr/counter.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default class Counter extends React.Component {
+  state = { count: 0 }
+
+  incr() {
+    const { count } = this.state
+    this.setState({ count: count + 1 })
+  }
+
+  render() {
+    return (
+      <div>
+        <p>COUNT: {this.state.count}</p>
+        <button onClick={() => this.incr()}>Increment</button>
+      </div>
+    )
+  }
+}

--- a/test/integration/basepath/pages/hmr/error-in-gip.js
+++ b/test/integration/basepath/pages/hmr/error-in-gip.js
@@ -1,0 +1,11 @@
+import React from 'react'
+export default class extends React.Component {
+  static getInitialProps() {
+    const error = new Error('an-expected-error-in-gip')
+    throw error
+  }
+
+  render() {
+    return <div>Hello</div>
+  }
+}

--- a/test/integration/basepath/pages/hmr/index.js
+++ b/test/integration/basepath/pages/hmr/index.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default () => (
+  <div>
+    <Link href="/hmr/error-in-gip">
+      <a id="error-in-gip-link">Bad Page</a>
+    </Link>
+  </div>
+)

--- a/test/integration/basepath/pages/hmr/style-dynamic-component.js
+++ b/test/integration/basepath/pages/hmr/style-dynamic-component.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import dynamic from 'next/dynamic'
+
+const HmrDynamic = dynamic(import('../../components/hmr/dynamic'))
+
+export default () => {
+  return <HmrDynamic />
+}

--- a/test/integration/basepath/pages/hmr/style-stateful-component.js
+++ b/test/integration/basepath/pages/hmr/style-stateful-component.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react'
+
+export default class StyleStateFul extends Component {
+  render() {
+    return (
+      <React.Fragment>
+        <div className="hmr-style-page">
+          <p>
+            This is the style page.
+            <style jsx>{`
+              p {
+                font-size: 100px;
+              }
+            `}</style>
+          </p>
+        </div>
+      </React.Fragment>
+    )
+  }
+}

--- a/test/integration/basepath/pages/hmr/style.js
+++ b/test/integration/basepath/pages/hmr/style.js
@@ -1,0 +1,17 @@
+import React from 'react'
+export default () => {
+  return (
+    <React.Fragment>
+      <div className="hmr-style-page">
+        <p>
+          This is the style page.
+          <style jsx>{`
+            p {
+              font-size: 100px;
+            }
+          `}</style>
+        </p>
+      </div>
+    </React.Fragment>
+  )
+}

--- a/test/integration/basepath/pages/other-page.js
+++ b/test/integration/basepath/pages/other-page.js
@@ -1,0 +1,1 @@
+export default () => <h1 id="other-page-title">Hello Other</h1>

--- a/test/integration/basepath/pages/ssr.js
+++ b/test/integration/basepath/pages/ssr.js
@@ -1,0 +1,11 @@
+function SSRPage({ test }) {
+  return <h1>{test}</h1>
+}
+
+SSRPage.getInitialProps = () => {
+  return {
+    test: 'hello',
+  }
+}
+
+export default SSRPage

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -1,0 +1,452 @@
+/* eslint-env jest */
+/* global jasmine */
+import webdriver from 'next-webdriver'
+import { join } from 'path'
+import {
+  // nextServer,
+  launchApp,
+  findPort,
+  killApp,
+  // nextBuild,
+  // startApp,
+  // stopApp,
+  waitFor,
+  check,
+  getBrowserBodyText,
+  renderViaHTTP,
+} from 'next-test-utils'
+import { readFileSync, writeFileSync, renameSync, existsSync } from 'fs'
+import cheerio from 'cheerio'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+describe('basePath development', () => {
+  let server
+
+  let context = {}
+
+  beforeAll(async () => {
+    context.appPort = await findPort()
+    server = await launchApp(join(__dirname, '..'), context.appPort)
+  })
+  afterAll(async () => {
+    await killApp(server)
+  })
+
+  it('should show the hello page under the /docs prefix', async () => {
+    const browser = await webdriver(context.appPort, '/docs/hello')
+    try {
+      const text = await browser.elementByCss('h1').text()
+      expect(text).toBe('Hello World')
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('should show the other-page page under the /docs prefix', async () => {
+    const browser = await webdriver(context.appPort, '/docs/other-page')
+    try {
+      const text = await browser.elementByCss('h1').text()
+      expect(text).toBe('Hello Other')
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('should navigate to the page without refresh', async () => {
+    const browser = await webdriver(context.appPort, '/docs/hello')
+    try {
+      await browser.eval('window.itdidnotrefresh = "hello"')
+      const text = await browser
+        .elementByCss('#other-page-link')
+        .click()
+        .waitForElementByCss('#other-page-title')
+        .elementByCss('h1')
+        .text()
+
+      expect(text).toBe('Hello Other')
+      expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
+    } finally {
+      await browser.close()
+    }
+  })
+
+  describe('Hot Module Reloading', () => {
+    describe('delete a page and add it back', () => {
+      it('should load the page properly', async () => {
+        const contactPagePath = join(
+          __dirname,
+          '../',
+          'pages',
+          'hmr',
+          'contact.js'
+        )
+        const newContactPagePath = join(
+          __dirname,
+          '../',
+          'pages',
+          'hmr',
+          '_contact.js'
+        )
+        let browser
+        try {
+          browser = await webdriver(context.appPort, '/docs/hmr/contact')
+          const text = await browser.elementByCss('p').text()
+          expect(text).toBe('This is the contact page.')
+
+          // Rename the file to mimic a deleted page
+          renameSync(contactPagePath, newContactPagePath)
+
+          await check(
+            () => getBrowserBodyText(browser),
+            /This page could not be found/
+          )
+
+          // Rename the file back to the original filename
+          renameSync(newContactPagePath, contactPagePath)
+
+          // wait until the page comes back
+          await check(
+            () => getBrowserBodyText(browser),
+            /This is the contact page/
+          )
+        } finally {
+          if (browser) {
+            await browser.close()
+          }
+          if (existsSync(newContactPagePath)) {
+            renameSync(newContactPagePath, contactPagePath)
+          }
+        }
+      })
+    })
+
+    describe('editing a page', () => {
+      it('should detect the changes and display it', async () => {
+        let browser
+        try {
+          browser = await webdriver(context.appPort, '/docs/hmr/about')
+          const text = await browser.elementByCss('p').text()
+          expect(text).toBe('This is the about page.')
+
+          const aboutPagePath = join(
+            __dirname,
+            '../',
+            'pages',
+            'hmr',
+            'about.js'
+          )
+
+          const originalContent = readFileSync(aboutPagePath, 'utf8')
+          const editedContent = originalContent.replace(
+            'This is the about page',
+            'COOL page'
+          )
+
+          // change the content
+          writeFileSync(aboutPagePath, editedContent, 'utf8')
+
+          await check(() => getBrowserBodyText(browser), /COOL page/)
+
+          // add the original content
+          writeFileSync(aboutPagePath, originalContent, 'utf8')
+
+          await check(
+            () => getBrowserBodyText(browser),
+            /This is the about page/
+          )
+        } finally {
+          if (browser) {
+            await browser.close()
+          }
+        }
+      })
+
+      it('should not reload unrelated pages', async () => {
+        let browser
+        try {
+          browser = await webdriver(context.appPort, '/docs/hmr/counter')
+          const text = await browser
+            .elementByCss('button')
+            .click()
+            .elementByCss('button')
+            .click()
+            .elementByCss('p')
+            .text()
+          expect(text).toBe('COUNT: 2')
+
+          const aboutPagePath = join(
+            __dirname,
+            '../',
+            'pages',
+            'hmr',
+            'about.js'
+          )
+
+          const originalContent = readFileSync(aboutPagePath, 'utf8')
+          const editedContent = originalContent.replace(
+            'This is the about page',
+            'COOL page'
+          )
+
+          // Change the about.js page
+          writeFileSync(aboutPagePath, editedContent, 'utf8')
+
+          // wait for 5 seconds
+          await waitFor(5000)
+
+          // Check whether the this page has reloaded or not.
+          const newText = await browser.elementByCss('p').text()
+          expect(newText).toBe('COUNT: 2')
+
+          // restore the about page content.
+          writeFileSync(aboutPagePath, originalContent, 'utf8')
+        } finally {
+          if (browser) {
+            await browser.close()
+          }
+        }
+      })
+
+      // Added because of a regression in react-hot-loader, see issues: #4246 #4273
+      // Also: https://github.com/zeit/styled-jsx/issues/425
+      it('should update styles correctly', async () => {
+        let browser
+        try {
+          browser = await webdriver(context.appPort, '/docs/hmr/style')
+          const pTag = await browser.elementByCss('.hmr-style-page p')
+          const initialFontSize = await pTag.getComputedCss('font-size')
+
+          expect(initialFontSize).toBe('100px')
+
+          const pagePath = join(__dirname, '../', 'pages', 'hmr', 'style.js')
+
+          const originalContent = readFileSync(pagePath, 'utf8')
+          const editedContent = originalContent.replace('100px', '200px')
+
+          // Change the page
+          writeFileSync(pagePath, editedContent, 'utf8')
+
+          try {
+            // Check whether the this page has reloaded or not.
+            await check(async () => {
+              const editedPTag = await browser.elementByCss('.hmr-style-page p')
+              return editedPTag.getComputedCss('font-size')
+            }, /200px/)
+          } finally {
+            // Finally is used so that we revert the content back to the original regardless of the test outcome
+            // restore the about page content.
+            writeFileSync(pagePath, originalContent, 'utf8')
+          }
+        } finally {
+          if (browser) {
+            await browser.close()
+          }
+        }
+      })
+
+      // Added because of a regression in react-hot-loader, see issues: #4246 #4273
+      // Also: https://github.com/zeit/styled-jsx/issues/425
+      it('should update styles in a stateful component correctly', async () => {
+        let browser
+        const pagePath = join(
+          __dirname,
+          '../',
+          'pages',
+          'hmr',
+          'style-stateful-component.js'
+        )
+        const originalContent = readFileSync(pagePath, 'utf8')
+        try {
+          browser = await webdriver(
+            context.appPort,
+            '/docs/hmr/style-stateful-component'
+          )
+          const pTag = await browser.elementByCss('.hmr-style-page p')
+          const initialFontSize = await pTag.getComputedCss('font-size')
+
+          expect(initialFontSize).toBe('100px')
+          const editedContent = originalContent.replace('100px', '200px')
+
+          // Change the page
+          writeFileSync(pagePath, editedContent, 'utf8')
+
+          // Check whether the this page has reloaded or not.
+          await check(async () => {
+            const editedPTag = await browser.elementByCss('.hmr-style-page p')
+            return editedPTag.getComputedCss('font-size')
+          }, /200px/)
+        } finally {
+          if (browser) {
+            await browser.close()
+          }
+          writeFileSync(pagePath, originalContent, 'utf8')
+        }
+      })
+
+      // Added because of a regression in react-hot-loader, see issues: #4246 #4273
+      // Also: https://github.com/zeit/styled-jsx/issues/425
+      it('should update styles in a dynamic component correctly', async () => {
+        let browser = null
+        let secondBrowser = null
+        const pagePath = join(
+          __dirname,
+          '../',
+          'components',
+          'hmr',
+          'dynamic.js'
+        )
+        const originalContent = readFileSync(pagePath, 'utf8')
+        try {
+          browser = await webdriver(
+            context.appPort,
+            '/docs/hmr/style-dynamic-component'
+          )
+          const div = await browser.elementByCss('#dynamic-component')
+          const initialClientClassName = await div.getAttribute('class')
+          const initialFontSize = await div.getComputedCss('font-size')
+
+          expect(initialFontSize).toBe('100px')
+
+          const initialHtml = await renderViaHTTP(
+            context.appPort,
+            '/docs/hmr/style-dynamic-component'
+          )
+          expect(initialHtml.includes('100px')).toBeTruthy()
+
+          const $initialHtml = cheerio.load(initialHtml)
+          const initialServerClassName = $initialHtml(
+            '#dynamic-component'
+          ).attr('class')
+
+          expect(initialClientClassName === initialServerClassName).toBeTruthy()
+
+          const editedContent = originalContent.replace('100px', '200px')
+
+          // Change the page
+          writeFileSync(pagePath, editedContent, 'utf8')
+
+          // wait for 5 seconds
+          await waitFor(5000)
+
+          secondBrowser = await webdriver(
+            context.appPort,
+            '/docs/hmr/style-dynamic-component'
+          )
+          // Check whether the this page has reloaded or not.
+          const editedDiv = await secondBrowser.elementByCss(
+            '#dynamic-component'
+          )
+          const editedClientClassName = await editedDiv.getAttribute('class')
+          const editedFontSize = await editedDiv.getComputedCss('font-size')
+          const browserHtml = await secondBrowser
+            .elementByCss('html')
+            .getAttribute('innerHTML')
+
+          expect(editedFontSize).toBe('200px')
+          expect(browserHtml.includes('font-size:200px;')).toBe(true)
+          expect(browserHtml.includes('font-size:100px;')).toBe(false)
+
+          const editedHtml = await renderViaHTTP(
+            context.appPort,
+            '/docs/hmr/style-dynamic-component'
+          )
+          expect(editedHtml.includes('200px')).toBeTruthy()
+          const $editedHtml = cheerio.load(editedHtml)
+          const editedServerClassName = $editedHtml('#dynamic-component').attr(
+            'class'
+          )
+
+          expect(editedClientClassName === editedServerClassName).toBe(true)
+        } finally {
+          // Finally is used so that we revert the content back to the original regardless of the test outcome
+          // restore the about page content.
+          writeFileSync(pagePath, originalContent, 'utf8')
+
+          if (browser) {
+            await browser.close()
+          }
+
+          if (secondBrowser) {
+            secondBrowser.close()
+          }
+        }
+      })
+    })
+  })
+})
+
+// describe('basePath production', () => {
+//   const appDir = join(__dirname, '../')
+//   let appPort
+//   let server
+//   let app
+
+//   beforeAll(async () => {
+//     await nextBuild(appDir)
+//     app = nextServer({
+//       dir: join(__dirname, '../'),
+//       dev: false,
+//       quiet: true,
+//     })
+
+//     server = await startApp(app)
+//     appPort = server.address().port
+//   })
+
+//   afterAll(() => stopApp(server))
+
+//   it('allows observation of navigation events using withRouter', async () => {
+//     const browser = await webdriver(appPort, '/a')
+//     await browser.waitForElementByCss('#page-a')
+
+//     let activePage = await browser.elementByCss('.active').text()
+//     expect(activePage).toBe('Foo')
+
+//     await browser.elementByCss('button').click()
+//     await browser.waitForElementByCss('#page-b')
+
+//     activePage = await browser.elementByCss('.active').text()
+//     expect(activePage).toBe('Bar')
+
+//     await browser.close()
+//   })
+
+//   it('allows observation of navigation events using top level Router', async () => {
+//     const browser = await webdriver(appPort, '/a')
+//     await browser.waitForElementByCss('#page-a')
+
+//     let activePage = await browser
+//       .elementByCss('.active-top-level-router')
+//       .text()
+//     expect(activePage).toBe('Foo')
+
+//     await browser.elementByCss('button').click()
+//     await browser.waitForElementByCss('#page-b')
+
+//     activePage = await browser.elementByCss('.active-top-level-router').text()
+//     expect(activePage).toBe('Bar')
+
+//     await browser.close()
+//   })
+
+//   it('allows observation of navigation events using top level Router deprecated behavior', async () => {
+//     const browser = await webdriver(appPort, '/a')
+//     await browser.waitForElementByCss('#page-a')
+
+//     let activePage = await browser
+//       .elementByCss('.active-top-level-router-deprecated-behavior')
+//       .text()
+//     expect(activePage).toBe('Foo')
+
+//     await browser.elementByCss('button').click()
+//     await browser.waitForElementByCss('#page-b')
+
+//     activePage = await browser
+//       .elementByCss('.active-top-level-router-deprecated-behavior')
+//       .text()
+//     expect(activePage).toBe('Bar')
+
+//     await browser.close()
+//   })
+// })


### PR DESCRIPTION
- Experimental, don't use it yet.
- Adds support for `basePath` that prefixes urls with the provided path.
- `<Link>` should use the normal path, excluding the `basePath`
  - Eg when `basePath` is `/dashboard` and you have `pages/blog.js` and `pages/about.js` the `href` would be `/about` and **not** `/dashboard/about`

Ref #4998