### PR TITLE
Add basePath to routes-manifest

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -249,6 +249,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     path.join(distDir, ROUTES_MANIFEST),
     JSON.stringify({
       version: 1,
+      basePath: config.experimental.basePath,
       redirects: redirects.map(r => buildCustomRoute(r, true)),
       rewrites: rewrites.map(r => buildCustomRoute(r)),
       dynamicRoutes: getSortedRoutes(dynamicRoutes).map(page => ({

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -248,7 +248,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   await fsWriteFile(
     path.join(distDir, ROUTES_MANIFEST),
     JSON.stringify({
-      version: 1,
+      version: 2,
       basePath: config.experimental.basePath,
       redirects: redirects.map(r => buildCustomRoute(r, true)),
       rewrites: rewrites.map(r => buildCustomRoute(r)),

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -199,6 +199,7 @@ const runTests = (isDev = false) => {
 
       expect(manifest).toEqual({
         version: 1,
+        basePath: '',
         redirects: [
           {
             source: '/docs/router-status/:code',

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -198,7 +198,7 @@ const runTests = (isDev = false) => {
       }
 
       expect(manifest).toEqual({
-        version: 1,
+        version: 2,
         basePath: '',
         redirects: [
           {

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -390,7 +390,7 @@ function runTests(dev) {
       )
 
       expect(manifest).toEqual({
-        version: 1,
+        version: 2,
         basePath: '',
         rewrites: [],
         redirects: [],

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -391,6 +391,7 @@ function runTests(dev) {
 
       expect(manifest).toEqual({
         version: 1,
+        basePath: '',
         rewrites: [],
         redirects: [],
         dynamicRoutes: [


### PR DESCRIPTION
This exposes the `basePath` in the `routes-manifest` so that we can detect and apply it in environments like Now