### PR TITLE
[Docs] Remove the custom configuration page

### DIFF
--- a/docs/advanced-features/custom-configuration.md
+++ b/docs/advanced-features/custom-configuration.md
@@ -1,3 +1,0 @@
-# Custom Configuration
-
-Next.js can be enhanced with the usage of `next.config.js`. To learn more about it please refer to the [`next.config.js` documentation](/docs/api-reference/next.config.js/introduction.md).

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -81,10 +81,6 @@
           "title": "Advanced Features",
           "routes": [
             {
-              "title": "Custom Configuration",
-              "path": "/docs/advanced-features/custom-configuration.md"
-            },
-            {
               "title": "Dynamic Import",
               "path": "/docs/advanced-features/dynamic-import.md"
             },


### PR DESCRIPTION
Initially it made sense because the documentation for `next.config.js` was nested, but right now it's a first class item in the API reference docs.

Removed page: https://nextjs.org/docs/advanced-features/custom-configuration