### PR TITLE
Defer Loading CSS Configuration

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -28,6 +28,7 @@ import {
   VALID_MIDDLEWARE,
 } from './plugins/collect-plugins'
 import { build as buildConfiguration } from './webpack/config'
+import { __overrideCssConfiguration } from './webpack/config/blocks/css'
 // @ts-ignore: JS file
 import { pluginLoaderOptions } from './webpack/loaders/next-plugin-loader'
 import BuildManifestPlugin from './webpack/plugins/build-manifest-plugin'
@@ -946,6 +947,8 @@ export default async function getBaseWebpackConfig(
           e => (e as any).__next_css_remove !== true
         )
       }
+    } else {
+      await __overrideCssConfiguration(dir, webpackConfig)
     }
   }
 

--- a/packages/next/build/webpack/config/blocks/css/plugins.ts
+++ b/packages/next/build/webpack/config/blocks/css/plugins.ts
@@ -88,12 +88,12 @@ function getDefaultPlugins(): CssPluginCollection {
 }
 
 export async function getPostCssPlugins(
-  dir: string
+  dir: string,
+  defaults: boolean = false
 ): Promise<import('postcss').AcceptedPlugin[]> {
-  let config = await findConfig<{ plugins: CssPluginCollection }>(
-    dir,
-    'postcss'
-  )
+  let config = defaults
+    ? null
+    : await findConfig<{ plugins: CssPluginCollection }>(dir, 'postcss')
 
   if (config == null) {
     config = { plugins: getDefaultPlugins() }

--- a/test/integration/css-customization/test/index.test.js
+++ b/test/integration/css-customization/test/index.test.js
@@ -71,6 +71,31 @@ describe('CSS Customization', () => {
   })
 })
 
+describe('Legacy Next-CSS Customization', () => {
+  const appDir = join(fixturesDir, 'custom-configuration-legacy')
+
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+  })
+
+  it('should build successfully', async () => {
+    await nextBuild(appDir)
+  })
+
+  it(`should've compiled and prefixed`, async () => {
+    const cssFolder = join(appDir, '.next/static/chunks')
+
+    const files = await readdir(cssFolder)
+    const cssFiles = files.filter(f => /\.css$/.test(f))
+
+    expect(cssFiles.length).toBe(1)
+    const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
+    expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatchInlineSnapshot(
+      `"@media (480px <= width < 768px){::placeholder{color:green}}.video{max-width:400px;max-height:300px}"`
+    )
+  })
+})
+
 describe('CSS Customization Array', () => {
   const appDir = join(fixturesDir, 'custom-configuration-arr')
 

--- a/test/integration/css-fixtures/custom-configuration-legacy/next.config.js
+++ b/test/integration/css-fixtures/custom-configuration-legacy/next.config.js
@@ -1,0 +1,15 @@
+const withCSS = require('@zeit/next-css')
+
+module.exports = withCSS({
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+  experimental: {
+    css: true,
+  },
+  webpack(cfg) {
+    cfg.devtool = 'source-map'
+    return cfg
+  },
+})

--- a/test/integration/css-fixtures/custom-configuration-legacy/pages/_app.js
+++ b/test/integration/css-fixtures/custom-configuration-legacy/pages/_app.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import App from 'next/app'
+import '../styles/global.css'
+
+class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props
+    return <Component {...pageProps} />
+  }
+}
+
+export default MyApp

--- a/test/integration/css-fixtures/custom-configuration-legacy/pages/index.js
+++ b/test/integration/css-fixtures/custom-configuration-legacy/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div />
+}

--- a/test/integration/css-fixtures/custom-configuration-legacy/postcss.config.js
+++ b/test/integration/css-fixtures/custom-configuration-legacy/postcss.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  // Use comments to test JSON5 support
+  plugins: [
+    // Test a non-standard feature that wouldn't be normally enabled
+    require('postcss-short-size')({
+      // Add a prefix to test that configuration is passed
+      prefix: 'xyz',
+    }),
+  ],
+}

--- a/test/integration/css-fixtures/custom-configuration-legacy/styles/global.css
+++ b/test/integration/css-fixtures/custom-configuration-legacy/styles/global.css
@@ -1,0 +1,11 @@
+/* this should pass through untransformed */
+@media (480px <= width < 768px) {
+  ::placeholder {
+    color: green;
+  }
+}
+
+/* this should be transformed to width/height */
+.video {
+  -xyz-max-size: 400px 300px;
+}


### PR DESCRIPTION
This defers loading the PostCSS customization until after we confirm the user did not self-configure CSS.

This is necessary as we have stricter PostCSS configuration shape rules than normal PostCSS.