### PR TITLE
Fix Potential Duplication of Page Loading

### DIFF
--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -110,6 +110,7 @@ export default class PageLoader {
       }
 
       if (!this.loadingRoutes[route]) {
+        this.loadingRoutes[route] = true
         if (process.env.__NEXT_GRANULAR_CHUNKS) {
           this.getDependencies(route).then(deps => {
             deps.forEach(d => {
@@ -130,11 +131,9 @@ export default class PageLoader {
               }
             })
             this.loadRoute(route)
-            this.loadingRoutes[route] = true
           })
         } else {
           this.loadRoute(route)
-          this.loadingRoutes[route] = true
         }
       }
     })


### PR DESCRIPTION
This fixes an edge case where `getDependencies` would not be loaded yet, and `loadingRoutes` wouldn't be set until after another page load request may come in.

In that scenario, we would've double down on `<script>` tags.