### PR TITLE
Update the docker multistage to copy only the necessary files

### DIFF
--- a/examples/with-docker/Dockerfile.multistage
+++ b/examples/with-docker/Dockerfile.multistage
@@ -9,6 +9,8 @@ RUN yarn build && yarn --production
 # And then copy over node_modules, etc from that stage to the smaller base image
 FROM mhart/alpine-node:base
 WORKDIR /app
-COPY --from=builder /app .
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/next.config.js ./next.config.js
 EXPOSE 3000
 CMD ["node_modules/.bin/next", "start"]

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -30,7 +30,13 @@ docker build -t next-app .
 docker build -t next-app -f ./Dockerfile.multistage .
 ```
 
-Run it:
+Alternatively you can add these commands as scripts to your package.json and simply run
+
+`yarn build-docker`
+or
+`yarn build-docker-multistage`
+
+Run the docker image:
 
 ```bash
 docker run --rm -it \
@@ -38,6 +44,8 @@ docker run --rm -it \
   -e "API_URL=https://example.com" \
   next-app
 ```
+
+or use `yarn build-docker-multistage`
 
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download))
 

--- a/examples/with-docker/package.json
+++ b/examples/with-docker/package.json
@@ -4,7 +4,10 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "build-docker": "docker build -t next-app .",
+    "build-docker-multistage": "docker build -t next-app -f ./Dockerfile.multistage .",
+    "run-docker": "docker run --rm -it -p 3000:3000 -e 'API_URL=https://example.com' next-app"
   },
   "dependencies": {
     "next": "latest",


### PR DESCRIPTION
Enhancements:
* The current multistage docker file copies the entire app folder during the 2nd stage. This would bloat the docker image size in case of a large app that has a lot of files and folders.
This PR copies only the .next folder, node_modules and next.config file in the 2nd stage.
 * Added the docker build and run commands as scripts for easier execution.