### PR TITLE
Fix with-next-offline example caching

### DIFF
--- a/examples/with-next-offline/next.config.js
+++ b/examples/with-next-offline/next.config.js
@@ -5,6 +5,18 @@ module.exports = withOffline({
     swDest: process.env.NEXT_EXPORT
       ? 'service-worker.js'
       : 'static/service-worker.js',
+    runtimeCaching: [
+      {
+        urlPattern: /^https?.*/,
+        handler: 'NetworkFirst',
+        options: {
+          cacheName: 'offlineCache',
+          expiration: {
+            maxEntries: 200,
+          },
+        },
+      },
+    ],
   },
   experimental: {
     async rewrites() {


### PR DESCRIPTION
Next-offline doesn't pass the default values to `workbox-webpack-plugin` if you modify a `workboxOpts`'s property [docs](https://github.com/hanford/next-offline#cache-strategies)

The default config
```
{
  runtimeCaching: [
    {
      urlPattern: /^https?.*/,
      handler: 'NetworkFirst',
      options: {
        cacheName: 'offlineCache',
        expiration: {
          maxEntries: 200
        }
      }
    }
  ]
}
```

### Before passing the default config

Deployment: https://with-next-offline-app-m2m0wlgb8.now.sh/

<img width="1279" alt="Screenshot 2020-01-01 at 22 22 51" src="https://user-images.githubusercontent.com/13942717/71646239-4e3d6200-2ce5-11ea-9594-58da96f9eb79.png">


### After passing the default config

Deployment: with-next-offline-app.sarkurd.now.sh
<img width="1279" alt="Screenshot 2020-01-01 at 22 11 03" src="https://user-images.githubusercontent.com/13942717/71646252-880e6880-2ce5-11ea-8fdd-dfaea23e2ca6.png">


Fixes #9897
