### PR TITLE
Remove extra logging from on-demand-entries

### DIFF
--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -224,9 +224,7 @@ export default function onDemandEntryHandler(
 
     // If there's no entry, it may have been invalidated and needs to be re-built.
     if (!entryInfo) {
-      // if (page !== lastEntry) {
-        // client pings, but there's no entry for page
-      // }
+      // if (page !== lastEntry) client pings, but there's no entry for page
       lastEntry = page
       return { invalid: true }
     }

--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -65,7 +65,6 @@ export default function onDemandEntryHandler(
   let reloading = false
   let stopped = false
   let reloadCallbacks: EventEmitter | null = new EventEmitter()
-  let lastEntry: string | null = null
 
   for (const compiler of compilers) {
     compiler.hooks.make.tapPromise(
@@ -225,7 +224,6 @@ export default function onDemandEntryHandler(
     // If there's no entry, it may have been invalidated and needs to be re-built.
     if (!entryInfo) {
       // if (page !== lastEntry) client pings, but there's no entry for page
-      lastEntry = page
       return { invalid: true }
     }
 

--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -80,7 +80,7 @@ export default function onDemandEntryHandler(
           const { name, absolutePagePath } = entries[page]
           const pageExists = await isWriteable(absolutePagePath)
           if (!pageExists) {
-            Log.event('page was removed', page)
+            // page was removed
             delete entries[page]
             return
           }
@@ -225,7 +225,7 @@ export default function onDemandEntryHandler(
     // If there's no entry, it may have been invalidated and needs to be re-built.
     if (!entryInfo) {
       if (page !== lastEntry) {
-        Log.event(`client pings, but there's no entry for page: ${page}`)
+        // client pings, but there's no entry for page
       }
       lastEntry = page
       return { invalid: true }
@@ -402,7 +402,7 @@ function disposeInactiveEntries(
     disposingPages.forEach((page: any) => {
       delete entries[page]
     })
-    Log.event(`disposing inactive page(s): ${disposingPages.join(', ')}`)
+    // disposing inactive page(s)
     devMiddleware.invalidate()
   }
 }

--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -224,9 +224,9 @@ export default function onDemandEntryHandler(
 
     // If there's no entry, it may have been invalidated and needs to be re-built.
     if (!entryInfo) {
-      if (page !== lastEntry) {
+      // if (page !== lastEntry) {
         // client pings, but there's no entry for page
-      }
+      // }
       lastEntry = page
       return { invalid: true }
     }


### PR DESCRIPTION
After discussion it seems these logs aren't really helpful for the user and can be confusing so this removes them.

Closes: #9876