### PR TITLE
Fix shadowing of apolloClient

### DIFF
--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -6,7 +6,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import { HttpLink } from 'apollo-link-http'
 import fetch from 'isomorphic-unfetch'
 
-let apolloClient = null
+let globalApolloClient = null
 
 /**
  * Creates and provides the apolloContext
@@ -44,7 +44,7 @@ export function withApollo(PageComponent, { ssr = true } = {}) {
 
       // Initialize ApolloClient, add it to the ctx object so
       // we can use it in `PageComponent.getInitialProp`.
-      apolloClient = (ctx.apolloClient = initApolloClient())
+      globalApolloClient = ctx.apolloClient = initApolloClient()
 
       // Run wrapped getInitialProps methods
       let pageProps = {}
@@ -69,7 +69,7 @@ export function withApollo(PageComponent, { ssr = true } = {}) {
               <AppTree
                 pageProps={{
                   ...pageProps,
-                  apolloClient,
+                  globalApolloClient,
                 }}
               />
             )
@@ -87,7 +87,7 @@ export function withApollo(PageComponent, { ssr = true } = {}) {
       }
 
       // Extract query data from the Apollo store
-      const apolloState = apolloClient.cache.extract()
+      const apolloState = globalApolloClient.cache.extract()
 
       return {
         ...pageProps,
@@ -112,11 +112,11 @@ function initApolloClient(initialState) {
   }
 
   // Reuse client on the client-side
-  if (!apolloClient) {
-    apolloClient = createApolloClient(initialState)
+  if (!globalApolloClient) {
+    globalApolloClient = createApolloClient(initialState)
   }
 
-  return apolloClient
+  return globalApolloClient
 }
 
 /**

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -44,7 +44,7 @@ export function withApollo(PageComponent, { ssr = true } = {}) {
 
       // Initialize ApolloClient, add it to the ctx object so
       // we can use it in `PageComponent.getInitialProp`.
-      const apolloClient = (ctx.apolloClient = initApolloClient())
+      apolloClient = (ctx.apolloClient = initApolloClient())
 
       // Run wrapped getInitialProps methods
       let pageProps = {}


### PR DESCRIPTION
The definition of `apolloClient` on line 47 seems to be intended to be reassigning the `apolloClient` defined in global scope. That re-declaration of the `apolloClient` variable is removed in favor of changing the name of the global `apolloClient` to `globalApolloClient` and then assigning the return of `initApolloClient()` to `globalApolloClient`. This mends the shadowing issue brought up in #9813 and clarifies which `apolloClient` variable is being referenced throughout the file.

Fixes #9813