### PR TITLE
Enable catchAllRouting by default

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -546,13 +546,6 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
   await writeBuildId(distDir, buildId)
 
-  if (config.experimental.catchAllRouting !== true) {
-    if (dynamicRoutes.some(page => /\/\[\.{3}[^/]+?\](?=\/|$)/.test(page))) {
-      throw new Error(
-        'Catch-all routing is still experimental. You cannot use it yet.'
-      )
-    }
-  }
   const finalPrerenderRoutes: { [route: string]: SprRoute } = {}
   const tbdPrerenderRoutes: string[] = []
 

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -42,7 +42,6 @@ const defaultConfig: { [key: string]: any } = {
       (Number(process.env.CIRCLE_NODE_TOTAL) ||
         (os.cpus() || { length: 1 }).length) - 1
     ),
-    catchAllRouting: false,
     css: false,
     documentMiddleware: false,
     granularChunks: false,

--- a/test/integration/dynamic-routing/next.config.js
+++ b/test/integration/dynamic-routing/next.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   experimental: {
     modern: true,
-    catchAllRouting: true,
   },
 }

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -461,8 +461,7 @@ describe('Dynamic Routing', () => {
           `
           module.exports = {
             experimental: {
-              modern: true,
-              catchAllRouting: true
+              modern: true
             }
           }
         `
@@ -487,8 +486,7 @@ describe('Dynamic Routing', () => {
         module.exports = {
           target: 'serverless',
           experimental: {
-            modern: true,
-            catchAllRouting: true
+            modern: true
           }
         }
       `


### PR DESCRIPTION
For some reason one of the tests for the routes manifest broke even though I didn't really change the output, just removed the warning.

