### PR TITLE
fix getting data docs in class based example

### DIFF
--- a/docs/api-reference/data-fetching/getInitialProps.md
+++ b/docs/api-reference/data-fetching/getInitialProps.md
@@ -37,6 +37,7 @@ Or using a class component:
 
 ```jsx
 import React from 'react'
+import fetch from 'isomorphic-unfetch'
 
 class Page extends React.Component {
   static async getInitialProps(ctx) {
@@ -46,7 +47,7 @@ class Page extends React.Component {
   }
 
   render() {
-    return <div>Next stars: {stars}</div>
+    return <div>Next stars: {this.props.stars}</div>
   }
 }
 


### PR DESCRIPTION
Check me if i'm wrong but don't we also need to `import fetch from 'isomorphic-unfetch'` in class based example too?
Currently it's just in function based component.

Also I think we should access `stars` from props at first right?

I had test it in CodeSandbox before https://codesandbox.io/s/small-brook-y7gm2