### PR TITLE
Prefer JS over TS in extension resolve

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -210,19 +210,19 @@ export default async function getBaseWebpackConfig(
     // Disable .mjs for node_modules bundling
     extensions: isServer
       ? [
-          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.js',
           '.mjs',
           '.jsx',
           '.json',
+          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.wasm',
         ]
       : [
-          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.mjs',
           '.js',
           '.jsx',
           '.json',
+          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.wasm',
         ],
     modules: [


### PR DESCRIPTION
this fixes an issue when next.js is loading packages using typescript that compile their typescript code in-line with their .ts files.

e.g.

```
./
./a.ts => ./a.js
./b.ts => ./b.js
```

which would result in

```
./
./a.js
./a.ts
./b.js
./b.ts
```