### PR TITLE
Strictly match `next/dist` in externals configuration

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -476,7 +476,7 @@ export default async function getBaseWebpackConfig(
             // Default pages have to be transpiled
             if (
               !res.match(/next[/\\]dist[/\\]next-server[/\\]/) &&
-              (res.match(/next[/\\]dist[/\\]/) ||
+              (res.match(/[/\\]next[/\\]dist[/\\]/) ||
                 res.match(/node_modules[/\\]@babel[/\\]runtime[/\\]/) ||
                 res.match(/node_modules[/\\]@babel[/\\]runtime-corejs2[/\\]/))
             ) {


### PR DESCRIPTION
such as `i18next`, `next-i18next`, `react-i18next` to be external
![image](https://user-images.githubusercontent.com/9304194/71781848-09167a00-2fdc-11ea-8278-eb5fdde52174.png)
fixes #9022