### PR TITLE
Enable Link tests without Router (#9951)

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -133,9 +133,8 @@ class Link extends Component<LinkProps> {
   }
 
   handleRef(ref: Element) {
-    const isPrefetched = (Router.router as any).pageLoader.prefetched[
-      this.getHref()
-    ]
+    const isPrefetched =
+      Router.router && Router.router.pageLoader.prefetched[this.getHref()]
 
     if (this.p && IntersectionObserver && ref && ref.tagName) {
       this.cleanUpListeners()


### PR DESCRIPTION
`Link.handleRef` sometimes raises a `TypeError` because singleton router may not exist in unit tests. I think it should deal with the case without router. Would you be able to review this, please?

Fixes https://github.com/zeit/next.js/issues/9951
