### PR TITLE
export: Don't add a slash on hash links

### DIFF
--- a/packages/next/next-server/lib/router/rewrite-url-for-export.ts
+++ b/packages/next/next-server/lib/router/rewrite-url-for-export.ts
@@ -2,9 +2,11 @@ export function rewriteUrlForNextExport(url: string): string {
   const [pathname, hash] = url.split('#')
   // tslint:disable-next-line
   let [path, qs] = pathname.split('?')
-  path = path.replace(/\/$/, '')
-  // Append a trailing slash if this path does not have an extension
-  if (!/\.[^/]+\/?$/.test(path)) path += `/`
+  if (path) {
+    path = path.replace(/\/$/, '')
+    // Append a trailing slash if this path does not have an extension
+    if (!/\.[^/]+\/?$/.test(path)) path += `/`
+  }
   if (qs) path += '?' + qs
   if (hash) path += '#' + hash
   return path

--- a/test/integration/export/next.config.js
+++ b/test/integration/export/next.config.js
@@ -15,6 +15,7 @@ module.exports = phase => {
         '/': { page: '/' },
         '/about': { page: '/about' },
         '/button-link': { page: '/button-link' },
+        '/hash-link': { page: '/hash-link' },
         '/get-initial-props-with-no-query': {
           page: '/get-initial-props-with-no-query',
         },

--- a/test/integration/export/pages/hash-link.js
+++ b/test/integration/export/pages/hash-link.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default () => (
+  <div id="hash-link-page">
+    <Link href="#hash">
+      <a id="hash-link">Hash link</a>
+    </Link>
+  </div>
+)

--- a/test/integration/export/test/browser.js
+++ b/test/integration/export/test/browser.js
@@ -21,6 +21,13 @@ export default function(context) {
       expect(link.substr(link.length - 1)).toBe('/')
     })
 
+    it('should not add any slash on hash Link', async () => {
+      const browser = await webdriver(context.port, '/hash-link')
+      const link = await browser.elementByCss('#hash-link').getAttribute('href')
+
+      expect(link).toMatch(/\/hash-link\/#hash$/)
+    })
+
     it('should not add trailing slash on Link when disabled', async () => {
       const browser = await webdriver(context.portNoTrailSlash, '/')
       const link = await browser


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/9678

> Might not be worth fixing with regards to bundle size.

If I'm not mistaken this code is only included during export with trailing slash. So the impact on the bundle size should be acceptable. 