### PR TITLE
fix publicFileRoutes on dev-server (#9962)

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -654,7 +654,7 @@ export default class Server {
       const unixPath = path.replace(/\\/g, '/')
       // Only include public files that will not replace a page path
       // this should not occur now that we check this during build
-      if (!this.pagesManifest![unixPath]) {
+      if (!this.pagesManifest || !this.pagesManifest![unixPath]) {
         routes.push({
           match: route(unixPath),
           type: 'route',

--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -362,11 +362,6 @@ export default class DevServer extends Server {
     return { routes, fsRoutes, catchAllRoute, dynamicRoutes, pageChecker }
   }
 
-  // In development public files are not added to the router but handled as a fallback instead
-  protected generatePublicRoutes() {
-    return []
-  }
-
   // In development dynamic routes cannot be known ahead of time
   protected getDynamicRoutes() {
     return []


### PR DESCRIPTION
fix #9962 

#9962 says when we set
```js
module.exports = {
  useFileSystemPublicRoutes: false
}
```
in next.config.js,  images (and most likely other file types) are also `NOT` served from the /public directory on dev-server.

This PR fixes that behavior.