### PR TITLE
Fix Browserslist Integration for CSS

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -917,7 +917,7 @@ export default async function getBaseWebpackConfig(
         )
       }
     } else {
-      await __overrideCssConfiguration(dir, webpackConfig)
+      await __overrideCssConfiguration(dir, !dev, webpackConfig)
     }
   }
 

--- a/packages/next/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/build/webpack/config/blocks/css/index.ts
@@ -70,9 +70,10 @@ function getClientStyleLoader({
 
 export async function __overrideCssConfiguration(
   rootDirectory: string,
+  isProduction: boolean,
   config: Configuration
 ) {
-  const postCssPlugins = await getPostCssPlugins(rootDirectory)
+  const postCssPlugins = await getPostCssPlugins(rootDirectory, isProduction)
 
   function patch(rule: RuleSetRule) {
     if (
@@ -123,6 +124,7 @@ export const css = curry(async function css(
 
   const postCssPlugins = await getPostCssPlugins(
     ctx.rootDirectory,
+    ctx.isProduction,
     // TODO: In the future, we should stop supporting old CSS setups and
     // unconditionally inject ours. When that happens, we should remove this
     // function argument.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -81,6 +81,7 @@
     "babel-plugin-syntax-jsx": "6.18.0",
     "babel-plugin-transform-define": "2.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+    "browserslist": "4.8.3",
     "cache-loader": "4.1.0",
     "chalk": "2.4.2",
     "ci-info": "2.0.0",

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -5,6 +5,7 @@ declare module 'unfetch'
 declare module 'launch-editor'
 declare module 'styled-jsx/server'
 declare module 'async-retry'
+declare module 'browserslist'
 
 declare module 'cssnano-simple' {
   import { Plugin } from 'postcss'

--- a/test/integration/css-features/fixtures/browsers-new/package.json
+++ b/test/integration/css-features/fixtures/browsers-new/package.json
@@ -1,0 +1,5 @@
+{
+  "browserslist": [
+    "last 1 chrome version"
+  ]
+}

--- a/test/integration/css-features/fixtures/browsers-new/pages/_app.js
+++ b/test/integration/css-features/fixtures/browsers-new/pages/_app.js
@@ -1,0 +1,12 @@
+import App from 'next/app'
+import React from 'react'
+import './styles.css'
+
+class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props
+    return <Component {...pageProps} />
+  }
+}
+
+export default MyApp

--- a/test/integration/css-features/fixtures/browsers-new/pages/index.js
+++ b/test/integration/css-features/fixtures/browsers-new/pages/index.js
@@ -1,0 +1,3 @@
+export default function() {
+  return <div />
+}

--- a/test/integration/css-features/fixtures/browsers-new/pages/styles.css
+++ b/test/integration/css-features/fixtures/browsers-new/pages/styles.css
@@ -1,0 +1,8 @@
+a {
+  all: initial;
+}
+@media (min-resolution: 2dppx) {
+  .image {
+    background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==);
+  }
+}

--- a/test/integration/css-features/fixtures/browsers-old/package.json
+++ b/test/integration/css-features/fixtures/browsers-old/package.json
@@ -1,0 +1,7 @@
+{
+  "browserslist": [
+    "ie 11",
+    "safari 4",
+    "chrome 28"
+  ]
+}

--- a/test/integration/css-features/fixtures/browsers-old/pages/_app.js
+++ b/test/integration/css-features/fixtures/browsers-old/pages/_app.js
@@ -1,0 +1,12 @@
+import App from 'next/app'
+import React from 'react'
+import './styles.css'
+
+class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props
+    return <Component {...pageProps} />
+  }
+}
+
+export default MyApp

--- a/test/integration/css-features/fixtures/browsers-old/pages/index.js
+++ b/test/integration/css-features/fixtures/browsers-old/pages/index.js
@@ -1,0 +1,3 @@
+export default function() {
+  return <div />
+}

--- a/test/integration/css-features/fixtures/browsers-old/pages/styles.css
+++ b/test/integration/css-features/fixtures/browsers-old/pages/styles.css
@@ -1,0 +1,8 @@
+a {
+  all: initial;
+}
+@media (min-resolution: 2dppx) {
+  .image {
+    background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==);
+  }
+}

--- a/test/integration/css-features/fixtures/next.config.js
+++ b/test/integration/css-features/fixtures/next.config.js
@@ -1,0 +1,1 @@
+module.exports = { experimental: { css: true } }

--- a/test/integration/css-features/test/index.test.js
+++ b/test/integration/css-features/test/index.test.js
@@ -25,9 +25,9 @@ describe('Browserslist: Old', () => {
     expect(cssFiles.length).toBe(1)
     const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
 
-    expect(
-      cssContent.replace(/\/\*.*?\*\//g, '').trim()
-    ).toMatchInlineSnapshot()
+    expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatchInlineSnapshot(
+      `"a{-webkit-animation:none 0s ease 0s 1 normal none running;animation:none 0s ease 0s 1 normal none running;-webkit-backface-visibility:visible;backface-visibility:visible;background:transparent none repeat 0 0/auto auto padding-box border-box scroll;border:none;border-collapse:separate;-webkit-border-image:none;border-image:none;-webkit-border-radius:0;border-radius:0;border-spacing:0;bottom:auto;-webkit-box-shadow:none;box-shadow:none;-webkit-box-sizing:content-box;box-sizing:content-box;caption-side:top;clear:none;clip:auto;color:#000;-webkit-columns:auto;-webkit-column-count:auto;-webkit-column-fill:balance;column-fill:balance;grid-column-gap:normal;-webkit-column-gap:normal;column-gap:normal;-webkit-column-rule:medium none currentColor;column-rule:medium none currentColor;-webkit-column-span:1;column-span:1;-webkit-column-width:auto;columns:auto;content:normal;counter-increment:none;counter-reset:none;cursor:auto;direction:ltr;display:inline;empty-cells:show;float:none;font-family:serif;font-size:medium;font-style:normal;-webkit-font-feature-settings:normal;font-feature-settings:normal;font-variant:normal;font-weight:400;font-stretch:normal;line-height:normal;height:auto;-ms-hyphens:none;hyphens:none;left:auto;letter-spacing:normal;list-style:disc outside none;margin:0;max-height:none;max-width:none;min-height:0;min-width:0;opacity:1;orphans:2;outline:medium none invert;overflow:visible;overflow-x:visible;overflow-y:visible;padding:0;page-break-after:auto;page-break-before:auto;page-break-inside:auto;-webkit-perspective:none;perspective:none;-webkit-perspective-origin:50% 50%;perspective-origin:50% 50%;position:static;right:auto;tab-size:8;table-layout:auto;text-align:left;text-align-last:auto;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;top:auto;-webkit-transform:none;transform:none;-webkit-transform-origin:50% 50% 0;transform-origin:50% 50% 0;-webkit-transform-style:flat;transform-style:flat;-webkit-transition:none 0s ease 0s;transition:none 0s ease 0s;unicode-bidi:normal;vertical-align:baseline;visibility:visible;white-space:normal;widows:2;width:auto;word-spacing:normal;z-index:auto;all:initial}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.image{background-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==)}}"`
+    )
   })
 })
 
@@ -48,8 +48,8 @@ describe('Browserslist: New', () => {
     expect(cssFiles.length).toBe(1)
     const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
 
-    expect(
-      cssContent.replace(/\/\*.*?\*\//g, '').trim()
-    ).toMatchInlineSnapshot()
+    expect(cssContent.replace(/\/\*.*?\*\//g, '').trim()).toMatchInlineSnapshot(
+      `"a{all:initial}@media (min-resolution:2dppx){.image{background-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==)}}"`
+    )
   })
 })

--- a/test/integration/css-features/test/index.test.js
+++ b/test/integration/css-features/test/index.test.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+/* global jasmine */
+import { readdir, readFile, remove } from 'fs-extra'
+import { nextBuild } from 'next-test-utils'
+import { join } from 'path'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+
+const fixturesDir = join(__dirname, '../fixtures')
+
+describe('Browserslist: Old', () => {
+  const appDir = join(fixturesDir, 'browsers-old')
+
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+    await nextBuild(appDir)
+  })
+
+  it(`should've emitted a single CSS file`, async () => {
+    const cssFolder = join(appDir, '.next/static/css')
+
+    const files = await readdir(cssFolder)
+    const cssFiles = files.filter(f => /\.css$/.test(f))
+
+    expect(cssFiles.length).toBe(1)
+    const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
+
+    expect(
+      cssContent.replace(/\/\*.*?\*\//g, '').trim()
+    ).toMatchInlineSnapshot()
+  })
+})
+
+describe('Browserslist: New', () => {
+  const appDir = join(fixturesDir, 'browsers-new')
+
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+    await nextBuild(appDir)
+  })
+
+  it(`should've emitted a single CSS file`, async () => {
+    const cssFolder = join(appDir, '.next/static/css')
+
+    const files = await readdir(cssFolder)
+    const cssFiles = files.filter(f => /\.css$/.test(f))
+
+    expect(cssFiles.length).toBe(1)
+    const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
+
+    expect(
+      cssContent.replace(/\/\*.*?\*\//g, '').trim()
+    ).toMatchInlineSnapshot()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3846,7 +3846,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.0.0, browserslist@^4.3.6, browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3:
+browserslist@4.8.3, browserslist@^4.0.0, browserslist@^4.3.6, browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.3.tgz#65802fcd77177c878e015f0e3189f2c4f627ba44"
   integrity sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==


### PR DESCRIPTION
This fixes the Browserslist integration for our CSS support.

Previously, only `autoprefixer` was being set, but `postcss-preset-env` acted as if no versions were specified. That fixes this behavior.