### PR TITLE
docs: Fix Some Syntax Highlighting

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,13 +66,13 @@ You can link your project in [GitHub](https://zeit.co/new), [GitLab](https://zei
 
 You can install the command line tool using npm:
 
-```
+```bash
 npm install -g now
 ```
 
 You can deploy your application by running the following command in the root of the project directory:
 
-```
+```bash
 now
 ```
 


### PR DESCRIPTION
Fixes #10012

The new docs site is amazing. Thanks for all the great work there.

A minor nitpick is that the text color of the code snippets on this page is set to black.

Page: https://nextjs.org/docs/deployment#through-the-zeit-now-cli


## Expected behavior

The code should be syntax-highlighted.

## Screenshots

Before

![](https://on.ahmda.ws/1151b7/c)

