### PR TITLE
Fix missing quotes around `in` operator check for PerformanceObserver

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -299,6 +299,10 @@ function renderReactElement(reactEl, domEl) {
         performance.getEntriesByType('paint').forEach(onPerfEntry)
       })
     } else {
+      performance.getEntriesByType('paint').forEach(onPerfEntry)
+
+      // Start an observer to catch any paint metrics which may fire _after_
+      // the load event is fired on the window
       const observer = new PerformanceObserver(list => {
         list.getEntries().forEach(onPerfEntry)
       })

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -294,7 +294,7 @@ function renderReactElement(reactEl, domEl) {
   }
 
   if (onPerfEntry && ST) {
-    if (!(PerformanceObserver in window)) {
+    if (!('PerformanceObserver' in window)) {
       window.addEventListener('load', () => {
         performance.getEntriesByType('paint').forEach(onPerfEntry)
       })


### PR DESCRIPTION
Closes #10016 by fixing missing quotes around the object property name in the support check for `PerformanceObserver`.

I can take a look at adding a test for this, but might take me a bit to familiarize myself with the suite.