### PR TITLE
Add Back Comments

### DIFF
--- a/packages/next/taskfile-babel.js
+++ b/packages/next/taskfile-babel.js
@@ -30,7 +30,7 @@ module.exports = function(task) {
     // Workaround for noop.js loading
     if (file.base === 'next-dev.js') {
       output.code = output.code.replace(
-        '__REPLACE_NOOP_IMPORT__',
+        /__REPLACE_NOOP_IMPORT__/g,
         `import('./dev/noop');`
       )
     }

--- a/packages/next/taskfile-babel.js
+++ b/packages/next/taskfile-babel.js
@@ -10,7 +10,8 @@ module.exports = function(task) {
     const options = {
       ...babelOpts,
       compact: true,
-      comments: false,
+      // Important to keep comments for /*#__PURE__*/ annotations
+      comments: true,
       babelrc: false,
       configFile: false,
       filename: file.base,

--- a/packages/next/taskfile-babel.js
+++ b/packages/next/taskfile-babel.js
@@ -10,8 +10,6 @@ module.exports = function(task) {
     const options = {
       ...babelOpts,
       compact: true,
-      // Important to keep comments for /*#__PURE__*/ annotations
-      comments: true,
       babelrc: false,
       configFile: false,
       filename: file.base,


### PR DESCRIPTION
Accidental change made in #9927 landing — this was when I was testing a variant without comments.

This was not related to #9927 removing the use of a comment, that's a separate Babel bug where it loses them unintentionally (even with `comments: true`).

I just didn't revert this before the merge bot landed the PR. 😄 