### PR TITLE
Keep Chunk Hash in Build Output

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -172,7 +172,7 @@ export async function printTreeView(
         // Re-add `static/` for root files
         .replace(/^<buildId>/, 'static')
         // Remove file hash
-        .replace(/[.-][0-9a-z]{20}(?=\.)/, '')
+        .replace(/[.-]([0-9a-z]{6})[0-9a-z]{14}(?=\.)/, '.$1')
 
       messages.push([
         `  ${innerSymbol} ${cleanName}`,

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -24,8 +24,8 @@ describe('Build Output', () => {
 
       expect(stdout).toMatch(/\/ [ ]* \d{1,} B/)
       expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ chunks\/framework\.js [ 0-9. ]* kB/)
+      expect(stdout).toMatch(/ runtime\/main\.[0-9a-z]{6}\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/framework\.[0-9a-z]{6}\.js [ 0-9. ]* kB/)
 
       expect(stdout).not.toContain(' /_document')
       expect(stdout).not.toContain(' /_app')
@@ -50,8 +50,8 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/ [ ]* \d{1,} B/)
       expect(stdout).toMatch(/\/_app [ ]* \d{1,} B/)
       expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ chunks\/framework\.js [ 0-9. ]* kB/)
+      expect(stdout).toMatch(/ runtime\/main\.[0-9a-z]{6}\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/framework\.[0-9a-z]{6}\.js [ 0-9. ]* kB/)
 
       expect(stdout).not.toContain(' /_document')
       expect(stdout).not.toContain(' /_error')
@@ -77,8 +77,8 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/amp .* AMP/)
       expect(stdout).toMatch(/\/hybrid [ 0-9.]* B/)
       expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ chunks\/framework\.js [ 0-9. ]* kB/)
+      expect(stdout).toMatch(/ runtime\/main\.[0-9a-z]{6}\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/framework\.[0-9a-z]{6}\.js [ 0-9. ]* kB/)
 
       expect(stdout).not.toContain(' /_document')
       expect(stdout).not.toContain(' /_error')
@@ -102,8 +102,8 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/ [ ]* \d{1,} B/)
       expect(stdout).toMatch(/λ \/_error [ ]* \d{1,} B/)
       expect(stdout).toMatch(/\+ shared by all [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ runtime\/main\.js [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ chunks\/framework\.js [ 0-9. ]* kB/)
+      expect(stdout).toMatch(/ runtime\/main\.[0-9a-z]{6}\.js [ 0-9.]* kB/)
+      expect(stdout).toMatch(/ chunks\/framework\.[0-9a-z]{6}\.js [ 0-9. ]* kB/)
 
       expect(stdout).not.toContain(' /_document')
       expect(stdout).not.toContain(' /_app')


### PR DESCRIPTION
This adds the chunk hash to the build output so users don't think it's non-hashed.

![image](https://user-images.githubusercontent.com/616428/72104337-35dad200-32f9-11ea-99c1-93474ff2f63b.png)
