### PR TITLE
Fix npm/yarn install/run instructions

### DIFF
--- a/examples/with-higher-order-component/README.md
+++ b/examples/with-higher-order-component/README.md
@@ -30,16 +30,13 @@ Install it and run:
 ```bash
 npm install
 npm run dev
-# or
-yarn
-yarn dev
 ```
 
 **yarn**
 
 ```bash
-npm install
-npm run dev
+yarn
+yarn dev
 ```
 
 Deploy it to the cloud with [now](https://zeit.co/now)


### PR DESCRIPTION
**npm** section currently shows both npm and yarn, while **yarn** section shows just npm.