### PR TITLE
Add refresh header for 308 redirect for IE11 compatibility

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -485,17 +485,23 @@ export default class Server {
 
               if (route.type === 'redirect') {
                 const parsedNewUrl = parseUrl(newUrl)
-                res.setHeader(
-                  'Location',
-                  formatUrl({
-                    ...parsedDestination,
-                    pathname: parsedNewUrl.pathname,
-                    hash: parsedNewUrl.hash,
-                    search: undefined,
-                  })
-                )
+                const updatedDestination = formatUrl({
+                  ...parsedDestination,
+                  pathname: parsedNewUrl.pathname,
+                  hash: parsedNewUrl.hash,
+                  search: undefined,
+                })
+
+                res.setHeader('Location', updatedDestination)
                 res.statusCode =
                   (route as Redirect).statusCode || DEFAULT_REDIRECT_STATUS
+
+                // Since IE11 doesn't support the 308 header add backwards
+                // compatibility using refresh header
+                if (res.statusCode === 308) {
+                  res.setHeader('Refresh', `0;url=${updatedDestination}`)
+                }
+
                 res.end()
                 return {
                   finished: true,

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -229,6 +229,14 @@ const runTests = (isDev = false) => {
     expect(res.headers.get('x-second-header')).toBe('second')
   })
 
+  it('should add refresh header for 308 redirect', async () => {
+    const res = await fetchViaHTTP(appPort, '/redirect4', undefined, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(308)
+    expect(res.headers.get('refresh')).toBe(`0;url=/`)
+  })
+
   if (!isDev) {
     it('should output routes-manifest successfully', async () => {
       const manifest = await fs.readJSON(


### PR DESCRIPTION
Since IE11 doesn't support the `308` redirect by itself we add the `Refresh` header as a fallback to ensure backwards compatibility. I also added another test ensuring this header is added for a `308` redirect 