### PR TITLE
Disable New CSS For Sass, Less, and Stylus

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -865,18 +865,31 @@ export default async function getBaseWebpackConfig(
       return false
     }
 
-    const fileName = '/tmp/test.css'
+    const fileNames = [
+      '/tmp/test.css',
+      '/tmp/test.scss',
+      '/tmp/test.sass',
+      '/tmp/test.less',
+      '/tmp/test.styl',
+    ]
 
-    if (rule instanceof RegExp && rule.test(fileName)) {
+    if (rule instanceof RegExp && fileNames.some(input => rule.test(input))) {
       return true
     }
 
     if (typeof rule === 'function') {
-      try {
-        if (rule(fileName)) {
-          return true
-        }
-      } catch (_) {}
+      if (
+        fileNames.some(input => {
+          try {
+            if (rule(input)) {
+              return true
+            }
+          } catch (_) {}
+          return false
+        })
+      ) {
+        return true
+      }
     }
 
     if (Array.isArray(rule) && rule.some(canMatchCss)) {
@@ -888,10 +901,9 @@ export default async function getBaseWebpackConfig(
 
   if (config.experimental.css) {
     const hasUserCssConfig =
-      webpackConfig.module &&
-      webpackConfig.module.rules.some(
+      webpackConfig.module?.rules.some(
         rule => canMatchCss(rule.test) || canMatchCss(rule.include)
-      )
+      ) ?? false
 
     if (hasUserCssConfig) {
       if (webpackConfig.module?.rules.length) {

--- a/test/integration/legacy-sass/next.config.js
+++ b/test/integration/legacy-sass/next.config.js
@@ -1,0 +1,2 @@
+const withSass = require('@zeit/next-sass')
+module.exports = withSass({})

--- a/test/integration/legacy-sass/pages/index.js
+++ b/test/integration/legacy-sass/pages/index.js
@@ -1,0 +1,3 @@
+import '../styles/style.scss'
+
+export default () => <div className="example">Hello World!</div>

--- a/test/integration/legacy-sass/styles/style.scss
+++ b/test/integration/legacy-sass/styles/style.scss
@@ -1,0 +1,4 @@
+$color: #2ecc71;
+.example {
+  background-color: $color;
+}

--- a/test/integration/legacy-sass/test/index.test.js
+++ b/test/integration/legacy-sass/test/index.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+/* global jasmine */
+import { remove } from 'fs-extra'
+import { nextBuild } from 'next-test-utils'
+import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
+import { join } from 'path'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+
+const appDir = join(__dirname, '../')
+
+describe('Legacy Sass Support Should Disable New CSS', () => {
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+    await nextBuild(appDir)
+  })
+
+  it(`should've emitted a single CSS file`, async () => {
+    const cssFiles = await recursiveReadDir(
+      join(appDir, '.next', 'static'),
+      /\.css$/
+    )
+
+    expect(cssFiles.length).toBe(1)
+  })
+})


### PR DESCRIPTION
The new CSS support needs to deactivate when any of our legacy plugins are present.

Fixes https://spectrum.chat/next-js/general/css-files-are-duplicated~17717433-3ba2-4889-93dd-ed7ef86278bc