### PR TITLE
Add required `permanent: boolean` field to redirect

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -247,6 +247,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       ...(type === 'redirect'
         ? {
             statusCode: getRedirectStatus(r as Redirect),
+            permanent: undefined,
           }
         : {}),
       regex: routeRegex.source,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -10,6 +10,7 @@ import { pathToRegexp } from 'path-to-regexp'
 import { promisify } from 'util'
 import formatWebpackMessages from '../client/dev/error-overlay/format-webpack-messages'
 import checkCustomRoutes, {
+  getRedirectStatus,
   RouteType,
   Redirect,
   Rewrite,
@@ -22,7 +23,6 @@ import { recursiveReadDir } from '../lib/recursive-readdir'
 import { verifyTypeScriptSetup } from '../lib/verifyTypeScriptSetup'
 import {
   BUILD_MANIFEST,
-  DEFAULT_REDIRECT_STATUS,
   EXPORT_DETAIL,
   EXPORT_MARKER,
   PAGES_MANIFEST,
@@ -246,7 +246,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       ...r,
       ...(type === 'redirect'
         ? {
-            statusCode: r.statusCode || DEFAULT_REDIRECT_STATUS,
+            statusCode: getRedirectStatus(r as Redirect),
           }
         : {}),
       regex: routeRegex.source,

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -4,11 +4,14 @@ import textTable from 'next/dist/compiled/text-table'
 import path from 'path'
 import { isValidElementType } from 'react-is'
 import stripAnsi from 'strip-ansi'
-import { Redirect, Rewrite } from '../lib/check-custom-routes'
+import {
+  Redirect,
+  Rewrite,
+  getRedirectStatus,
+} from '../lib/check-custom-routes'
 import { SPR_GET_INITIAL_PROPS_CONFLICT } from '../lib/constants'
 import prettyBytes from '../lib/pretty-bytes'
 import { recursiveReadDir } from '../lib/recursive-readdir'
-import { DEFAULT_REDIRECT_STATUS } from '../next-server/lib/constants'
 import { getRouteMatcher, getRouteRegex } from '../next-server/lib/router/utils'
 import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
 import { findPageFile } from '../server/lib/find-page-file'
@@ -250,10 +253,7 @@ export function printCustomRoutes({
               route.source,
               route.destination,
               ...(isRedirects
-                ? [
-                    ((route as Redirect).statusCode ||
-                      DEFAULT_REDIRECT_STATUS) + '',
-                  ]
+                ? [getRedirectStatus(route as Redirect) + '']
                 : []),
             ]
           }),

--- a/packages/next/next-server/lib/constants.ts
+++ b/packages/next/next-server/lib/constants.ts
@@ -32,4 +32,5 @@ export const IS_BUNDLED_PAGE_REGEX = /^static[/\\][^/\\]+[/\\]pages.*\.js$/
 // matches static/<buildid>/pages/:page*.js
 export const ROUTE_NAME_REGEX = /^static[/\\][^/\\]+[/\\]pages[/\\](.*)\.js$/
 export const SERVERLESS_ROUTE_NAME_REGEX = /^pages[/\\](.*)\.js$/
-export const DEFAULT_REDIRECT_STATUS = 307
+export const TEMPORARY_REDIRECT_STATUS = 307
+export const PERMANENT_REDIRECT_STATUS = 308

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -17,7 +17,6 @@ import {
   ROUTES_MANIFEST,
   SERVER_DIRECTORY,
   SERVERLESS_DIRECTORY,
-  DEFAULT_REDIRECT_STATUS,
 } from '../lib/constants'
 import {
   getRouteMatcher,
@@ -50,6 +49,7 @@ import {
   Rewrite,
   RouteType,
   Header,
+  getRedirectStatus,
 } from '../../lib/check-custom-routes'
 
 const getCustomRouteMatcher = pathMatch(true)
@@ -494,8 +494,8 @@ export default class Server {
                     search: undefined,
                   })
                 )
-                res.statusCode =
-                  (route as Redirect).statusCode || DEFAULT_REDIRECT_STATUS
+                const redir = route as Redirect
+                res.statusCode = getRedirectStatus(redir)
                 res.end()
                 return {
                   finished: true,

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -77,10 +77,12 @@ module.exports = {
         {
           source: '/hello/:id/another',
           destination: '/blog/:id',
+          permanent: false,
         },
         {
           source: '/redirect1',
           destination: '/',
+          permanent: false,
         },
         {
           source: '/redirect2',
@@ -95,7 +97,7 @@ module.exports = {
         {
           source: '/redirect4',
           destination: '/',
-          statusCode: 308,
+          permanent: true,
         },
         {
           source: '/redir-chain1',
@@ -115,10 +117,12 @@ module.exports = {
         {
           source: '/to-external',
           destination: 'https://google.com',
+          permanent: false,
         },
         {
           source: '/query-redirect/:section/:name',
           destination: '/with-params?first=:section&second=:name',
+          permanent: false,
         },
       ]
     },

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -65,7 +65,7 @@ const runTests = (isDev = false) => {
     expect(res3location).toBe('/')
   })
 
-  it('should redirect successfully with default statusCode', async () => {
+  it('should redirect successfully with permanent: false', async () => {
     const res = await fetchViaHTTP(appPort, '/redirect1', undefined, {
       redirect: 'manual',
     })
@@ -270,6 +270,7 @@ const runTests = (isDev = false) => {
             statusCode: 307,
             regex: normalizeRegEx('^\\/hello(?:\\/([^\\/]+?))\\/another$'),
             regexKeys: ['id'],
+            permanent: false,
           },
           {
             source: '/redirect1',
@@ -277,6 +278,7 @@ const runTests = (isDev = false) => {
             statusCode: 307,
             regex: normalizeRegEx('^\\/redirect1$'),
             regexKeys: [],
+            permanent: false,
           },
           {
             source: '/redirect2',
@@ -298,6 +300,7 @@ const runTests = (isDev = false) => {
             statusCode: 308,
             regex: normalizeRegEx('^\\/redirect4$'),
             regexKeys: [],
+            permanent: true,
           },
           {
             source: '/redir-chain1',
@@ -326,6 +329,7 @@ const runTests = (isDev = false) => {
             regexKeys: [],
             source: '/to-external',
             statusCode: 307,
+            permanent: false,
           },
           {
             destination: '/with-params?first=:section&second=:name',
@@ -335,6 +339,7 @@ const runTests = (isDev = false) => {
             regexKeys: ['section', 'name'],
             source: '/query-redirect/:section/:name',
             statusCode: 307,
+            permanent: false,
           },
         ],
         headers: [

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -278,7 +278,6 @@ const runTests = (isDev = false) => {
             statusCode: 307,
             regex: normalizeRegEx('^\\/hello(?:\\/([^\\/]+?))\\/another$'),
             regexKeys: ['id'],
-            permanent: false,
           },
           {
             source: '/redirect1',
@@ -286,7 +285,6 @@ const runTests = (isDev = false) => {
             statusCode: 307,
             regex: normalizeRegEx('^\\/redirect1$'),
             regexKeys: [],
-            permanent: false,
           },
           {
             source: '/redirect2',
@@ -308,7 +306,6 @@ const runTests = (isDev = false) => {
             statusCode: 308,
             regex: normalizeRegEx('^\\/redirect4$'),
             regexKeys: [],
-            permanent: true,
           },
           {
             source: '/redir-chain1',
@@ -337,7 +334,6 @@ const runTests = (isDev = false) => {
             regexKeys: [],
             source: '/to-external',
             statusCode: 307,
-            permanent: false,
           },
           {
             destination: '/with-params?first=:section&second=:name',
@@ -347,7 +343,6 @@ const runTests = (isDev = false) => {
             regexKeys: ['section', 'name'],
             source: '/query-redirect/:section/:name',
             statusCode: 307,
-            permanent: false,
           },
         ],
         headers: [

--- a/test/integration/invalid-custom-routes/test/index.test.js
+++ b/test/integration/invalid-custom-routes/test/index.test.js
@@ -28,11 +28,13 @@ const invalidRedirects = [
   {
     // missing destination
     source: '/hello',
+    permanent: false,
   },
   {
     // invalid source
     source: 123,
     destination: '/another',
+    permanent: false,
   },
   {
     // invalid statusCode type
@@ -46,15 +48,21 @@ const invalidRedirects = [
     destination: '/another',
     statusCode: 404,
   },
+  {
+    // invalid permanent value
+    source: '/hello',
+    destination: '/another',
+    permanent: 'yes',
+  },
 ]
 
 const invalidRedirectAssertions = (stderr = '') => {
   expect(stderr).toContain(
-    `\`destination\` is missing for route {"source":"/hello"}`
+    `\`destination\` is missing for route {"source":"/hello","permanent":false}`
   )
 
   expect(stderr).toContain(
-    `\`source\` is not a string for route {"source":123,"destination":"/another"}`
+    `\`source\` is not a string for route {"source":123,"destination":"/another","permanent":false}`
   )
 
   expect(stderr).toContain(
@@ -63,6 +71,10 @@ const invalidRedirectAssertions = (stderr = '') => {
 
   expect(stderr).toContain(
     `\`statusCode\` is not undefined or valid statusCode for route {"source":"/hello","destination":"/another","statusCode":404}`
+  )
+
+  expect(stderr).toContain(
+    `\`permanent\` is not set to \`true\` or \`false\` for route {"source":"/hello","destination":"/another","permanent":"yes"}`
   )
 
   expect(stderr).toContain(


### PR DESCRIPTION
As discussed this requires a `permanent: true/false` value be specified if a `statusCode` isn't. This helps prevent us from inaccurately assuming a default redirect status for the user. 

Allowing the user to tell us whether it's `permanent` or not creates a safer config than having them try to figure out the correct status code to use