### PR TITLE
Update server.js

### DIFF
--- a/examples/with-firebase-authentication/server.js
+++ b/examples/with-firebase-authentication/server.js
@@ -28,8 +28,7 @@ app.prepare().then(() => {
       store: new FileStore({ secret: 'geheimnis' }),
       resave: false,
       rolling: true,
-      httpOnly: true,
-      cookie: { maxAge: 604800000 }, // week
+      cookie: { maxAge: 604800000, httpOnly: true }, // week
     })
   )
 


### PR DESCRIPTION
I think `httpOnly` property should set as `cookie`'s property.
This is because `SessionOptions` is following.

```
  interface SessionOptions {
    secret: string | string[];
    name?: string;
    store?: Store | MemoryStore;
    cookie?: {
      maxAge?: number;
      signed?: boolean;
      expires?: Date;
      httpOnly?: boolean;
      path?: string;
      domain?: string;
      secure?: boolean | 'auto';
      encode?: (val: string) => string;
      sameSite?: boolean | 'lax' | 'strict' | 'none';
    };
    genid?(req: express.Request): string;
    rolling?: boolean;
    resave?: boolean;
    proxy?: boolean;
    saveUninitialized?: boolean;
    unset?: string;
  }
```