### PR TITLE
Improves with-cookie-auth example

### DIFF
--- a/examples/with-cookie-auth/components/header.js
+++ b/examples/with-cookie-auth/components/header.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { logout } from '../utils/auth'
 
-const Header = () => (
+const Header = props => (
   <header>
     <nav>
       <ul>
@@ -20,9 +20,14 @@ const Header = () => (
             <a>Profile</a>
           </Link>
         </li>
-        <li>
-          <button onClick={logout}>Logout</button>
-        </li>
+        {props.token && (
+          <>
+            <li>Token: {props.token}</li>
+            <li>
+              <button onClick={logout}>Logout</button>
+            </li>
+          </>
+        )}
       </ul>
     </nav>
     <style jsx>{`

--- a/examples/with-cookie-auth/components/layout.js
+++ b/examples/with-cookie-auth/components/layout.js
@@ -29,7 +29,7 @@ const Layout = props => (
         padding-right: 1rem;
       }
     `}</style>
-    <Header />
+    <Header token={props.token} />
 
     <main>
       <div className="container">{props.children}</div>

--- a/examples/with-cookie-auth/pages/_app.js
+++ b/examples/with-cookie-auth/pages/_app.js
@@ -1,14 +1,18 @@
 import React from 'react'
 import App from 'next/app'
 import Layout from '../components/layout'
+import { withAuth } from '../utils/auth'
 
-export default class MyApp extends App {
+class MyApp extends App {
   render() {
-    const { Component, pageProps } = this.props
+    const { Component, pageProps, token } = this.props
+
     return (
-      <Layout>
+      <Layout token={token}>
         <Component {...pageProps} />
       </Layout>
     )
   }
 }
+
+export default withAuth(MyApp)

--- a/examples/with-cookie-auth/pages/_app.js
+++ b/examples/with-cookie-auth/pages/_app.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import App from 'next/app'
+import Layout from '../components/layout'
+
+export default class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props
+    return (
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    )
+  }
+}

--- a/examples/with-cookie-auth/pages/index.js
+++ b/examples/with-cookie-auth/pages/index.js
@@ -1,8 +1,7 @@
 import React from 'react'
-import Layout from '../components/layout'
 
 const Home = () => (
-  <Layout>
+  <>
     <h1>Cookie-based authentication example</h1>
 
     <p>Steps to test the functionality:</p>
@@ -23,7 +22,7 @@ const Home = () => (
         margin-bottom: 0.5rem;
       }
     `}</style>
-  </Layout>
+  </>
 )
 
 export default Home

--- a/examples/with-cookie-auth/pages/login.js
+++ b/examples/with-cookie-auth/pages/login.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react'
 import fetch from 'isomorphic-unfetch'
 import { login } from '../utils/auth'
+import Link from 'next/link'
 
-const Login = () => {
+const Login = props => {
+  const { token } = props
   const [userData, setUserData] = useState({ username: '', error: '' })
 
   const handleSubmit = async event => {
@@ -47,6 +49,14 @@ const Login = () => {
   return (
     <>
       <div className="login">
+        {token && (
+          <>
+            <h1>You are already logged in.</h1>
+            <Link href="/profile">
+              <a>Go to Profile.</a>
+            </Link>
+          </>
+        )}
         <form onSubmit={handleSubmit}>
           <label htmlFor="username">GitHub username</label>
 
@@ -95,6 +105,16 @@ const Login = () => {
         .error {
           margin: 0.5rem 0 0;
           color: brown;
+        }
+
+        h1 {
+          font-size: 20px;
+          margin: 0;
+        }
+
+        a {
+          display: inline-block;
+          margin-bottom: 1rem;
         }
       `}</style>
     </>

--- a/examples/with-cookie-auth/pages/login.js
+++ b/examples/with-cookie-auth/pages/login.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import fetch from 'isomorphic-unfetch'
-import Layout from '../components/layout'
 import { login } from '../utils/auth'
 
 const Login = () => {
@@ -46,7 +45,7 @@ const Login = () => {
   }
 
   return (
-    <Layout>
+    <>
       <div className="login">
         <form onSubmit={handleSubmit}>
           <label htmlFor="username">GitHub username</label>
@@ -98,7 +97,7 @@ const Login = () => {
           color: brown;
         }
       `}</style>
-    </Layout>
+    </>
   )
 }
 

--- a/examples/with-cookie-auth/pages/profile.js
+++ b/examples/with-cookie-auth/pages/profile.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Router from 'next/router'
 import fetch from 'isomorphic-unfetch'
-import nextCookie from 'next-cookies'
 import { withAuthSync } from '../utils/auth'
 import getHost from '../utils/get-host'
 
@@ -41,7 +40,7 @@ const Profile = props => {
 }
 
 Profile.getInitialProps = async ctx => {
-  const { token } = nextCookie(ctx)
+  const { token } = ctx
   const apiUrl = getHost(ctx.req) + '/api/profile'
 
   const redirectOnError = () =>

--- a/examples/with-cookie-auth/pages/profile.js
+++ b/examples/with-cookie-auth/pages/profile.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Router from 'next/router'
 import fetch from 'isomorphic-unfetch'
 import nextCookie from 'next-cookies'
-import Layout from '../components/layout'
 import { withAuthSync } from '../utils/auth'
 import getHost from '../utils/get-host'
 
@@ -10,7 +9,7 @@ const Profile = props => {
   const { name, login, bio, avatarUrl } = props.data
 
   return (
-    <Layout>
+    <>
       <img src={avatarUrl} alt="Avatar" />
       <h1>{name}</h1>
       <p className="lead">{login}</p>
@@ -37,7 +36,7 @@ const Profile = props => {
           color: #6a737d;
         }
       `}</style>
-    </Layout>
+    </>
   )
 }
 

--- a/examples/with-cookie-auth/utils/auth.js
+++ b/examples/with-cookie-auth/utils/auth.js
@@ -64,3 +64,21 @@ export const withAuthSync = WrappedComponent => {
 
   return Wrapper
 }
+
+export const withAuth = App => {
+  const Wrapper = props => {
+    return <App {...props} />
+  }
+
+  Wrapper.getInitialProps = async ctx => {
+    const { token } = nextCookie(ctx.ctx)
+
+    const appProps = App.getInitialProps && (await App.getInitialProps(ctx))
+
+    if (appProps.pageProps) appProps.pageProps.token = token
+
+    return { ...appProps, token }
+  }
+
+  return Wrapper
+}

--- a/examples/with-cookie-auth/utils/auth.js
+++ b/examples/with-cookie-auth/utils/auth.js
@@ -73,6 +73,8 @@ export const withAuth = App => {
   Wrapper.getInitialProps = async ctx => {
     const { token } = nextCookie(ctx.ctx)
 
+    ctx.ctx.token = token
+
     const appProps = App.getInitialProps && (await App.getInitialProps(ctx))
 
     if (appProps.pageProps) appProps.pageProps.token = token


### PR DESCRIPTION
Access user data (token in this case) on the header or other Layout components its a real necessity.

To make this more easily, I created a HOC called withAuth that get the user from the cookie and enable that in pageProps and in the context of the pages.

To exemplify the use of HOC, I added in login page a message warning the user that he is already logged in and in the header I show the token and the logout button only if the user is logged.