### PR TITLE
Ignore CSS Ordering Warnings

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -35,7 +35,6 @@ import BuildManifestPlugin from './webpack/plugins/build-manifest-plugin'
 import ChunkNamesPlugin from './webpack/plugins/chunk-names-plugin'
 import { CssMinimizerPlugin } from './webpack/plugins/css-minimizer-plugin'
 import { importAutoDllPlugin } from './webpack/plugins/dll-import'
-import MiniCssExtractPlugin from './webpack/plugins/mini-css-extract-plugin'
 import { DropClientPage } from './webpack/plugins/next-drop-client-page-plugin'
 import NextEsmPlugin from './webpack/plugins/next-esm-plugin'
 import NextJsSsrImportPlugin from './webpack/plugins/nextjs-ssr-import'
@@ -780,14 +779,6 @@ export default async function getBaseWebpackConfig(
           buildId,
           clientManifest: config.experimental.granularChunks,
           modern: config.experimental.modern,
-        }),
-      // Extract CSS as CSS file(s) in the client-side production bundle.
-      config.experimental.css &&
-        !isServer &&
-        !dev &&
-        new MiniCssExtractPlugin({
-          filename: 'static/css/[contenthash].css',
-          chunkFilename: 'static/css/[contenthash].chunk.css',
         }),
       tracer &&
         new ProfilingPlugin({

--- a/packages/next/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/build/webpack/config/blocks/css/index.ts
@@ -2,7 +2,7 @@ import curry from 'lodash.curry'
 import path from 'path'
 import webpack, { Configuration, RuleSetRule } from 'webpack'
 import MiniCssExtractPlugin from '../../../plugins/mini-css-extract-plugin'
-import { loader } from '../../helpers'
+import { loader, plugin } from '../../helpers'
 import { ConfigurationContext, ConfigurationFn, pipe } from '../../utils'
 import { getCssModuleLocalIdent } from './getCssModuleLocalIdent'
 import {
@@ -322,6 +322,27 @@ export const css = curry(async function css(
           },
         ],
       })
+    )
+  }
+
+  if (ctx.isClient && ctx.isProduction) {
+    // Extract CSS as CSS file(s) in the client-side production bundle.
+    fns.push(
+      plugin(
+        new MiniCssExtractPlugin({
+          filename: 'static/css/[contenthash].css',
+          chunkFilename: 'static/css/[contenthash].css',
+          // Next.js guarantees that CSS order doesn't matter, due to imposed
+          // restrictions:
+          // 1. Global CSS can only be defined in a single entrypoint (_app)
+          // 2. CSS Modules generate scoped class names by default and cannot
+          //    include Global CSS (:global() selector).
+          //
+          // If this warning were to trigger, it'd be unactionable by the user,
+          // but also not valid -- so we disable it.
+          ignoreOrder: true,
+        })
+      )
     )
   }
 

--- a/packages/next/build/webpack/config/helpers.ts
+++ b/packages/next/build/webpack/config/helpers.ts
@@ -1,5 +1,5 @@
 import curry from 'lodash.curry'
-import { Configuration, RuleSetRule } from 'webpack'
+import { Configuration, Plugin, RuleSetRule } from 'webpack'
 
 export const loader = curry(function loader(
   rule: RuleSetRule,
@@ -38,5 +38,13 @@ export const unshiftLoader = curry(function loader(
   }
 
   config.module.rules.unshift(rule)
+  return config
+})
+
+export const plugin = curry(function plugin(p: Plugin, config: Configuration) {
+  if (!config.plugins) {
+    config.plugins = []
+  }
+  config.plugins.push(p)
   return config
 })


### PR DESCRIPTION
This pull request sets the `ignoreOrder: true` property on `MiniCssExtractPlugin`.

This is desirable because the option exists for use-cases where users import Global CSS throughout their entire application.

Since this behavior is disallowed in Next.js, it would potentially trigger when it doesn't matter (CSS Modules). The official docs of `MiniCssExtractPlugin` suggest ignoring warnings if strictly using CSS Modules, which we are!

The big driver behind this change is that the warning would be unactionable by the user — and the warning itself isn't valid.