### PR TITLE
Update basic-export to use zero config support

### DIFF
--- a/examples/basic-export/README.md
+++ b/examples/basic-export/README.md
@@ -40,8 +40,6 @@ yarn dev
 Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download)):
 
 ```bash
-npm run export
-cd out
 now
 ```
 

--- a/examples/basic-export/package.json
+++ b/examples/basic-export/package.json
@@ -3,9 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "next",
-    "build": "next build",
-    "start": "next start",
-    "export": "next export"
+    "build": "next build && next export",
+    "start": "next start"
   },
   "dependencies": {
     "next": "latest",


### PR DESCRIPTION
[Next 9.1.7](https://nextjs.org/blog/next-9-1-7) added zero-config deployment support for `next export` applications. This updates `basic-export` example to use this support by updating the `build` command. It no longer needs to run `npm run export` and `cd out` before doing `now`.

## Question

Should we update the [learn pages](https://nextjs.org/learn/excel/static-html-export/export-the-index-page) as well? Right now, the learn pages:

- [Separates `build` and `export` scripts](https://nextjs.org/learn/excel/static-html-export/export-the-index-page)
- [Teaches that you can `export` without `build` in certain cases](https://nextjs.org/learn/excel/static-html-export/no-need-to-build-always)
- [Teaches that you should `cd out` before `now`](https://nextjs.org/learn/excel/static-html-export/deploying-the-app)

...and we might want to rewrite them (use `"build": "next build && next export"`, don't talk about when you don't need `build`, remove `cd out`, etc)