### PR TITLE
Error on CSS in Custom Document

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/messages.ts
+++ b/packages/next/build/webpack/config/blocks/css/messages.ts
@@ -25,3 +25,9 @@ export function getLocalModuleImportError() {
     'node_modules'
   )}.\nRead more: https://err.sh/next.js/css-modules-npm`
 }
+
+export function getCustomDocumentError() {
+  return `CSS ${chalk.bold('cannot')} be imported within ${chalk.cyan(
+    'pages/_document.js'
+  )}. Please move global styles to ${chalk.cyan('pages/_app.js')}.`
+}

--- a/test/integration/css-fixtures/invalid-module-document/pages/_document.js
+++ b/test/integration/css-fixtures/invalid-module-document/pages/_document.js
@@ -1,0 +1,23 @@
+import Document, { Head, Html, Main, NextScript } from 'next/document'
+import styles from '../styles.module.css'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body className={styles['red-text']}>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/test/integration/css-fixtures/invalid-module-document/pages/index.js
+++ b/test/integration/css-fixtures/invalid-module-document/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Hello</div>
+}

--- a/test/integration/css-fixtures/invalid-module-document/styles.module.css
+++ b/test/integration/css-fixtures/invalid-module-document/styles.module.css
@@ -1,0 +1,3 @@
+.red-text {
+  color: red;
+}

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -205,6 +205,26 @@ describe('CSS Support', () => {
     })
   })
 
+  describe('Invalid CSS in _document', () => {
+    const appDir = join(fixturesDir, 'invalid-module-document')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    it('should fail to build', async () => {
+      const { stderr } = await nextBuild(appDir, [], {
+        stderr: true,
+      })
+      expect(stderr).toContain('Failed to compile')
+      expect(stderr).toContain('styles.module.css')
+      expect(stderr).toMatch(
+        /CSS.*cannot.*be imported within.*pages[\\/]_document\.js/
+      )
+      expect(stderr).toMatch(/Location:.*pages[\\/]_document\.js/)
+    })
+  })
+
   describe('Invalid Global CSS', () => {
     const appDir = join(fixturesDir, 'invalid-global')
 


### PR DESCRIPTION
This pull request adds an error when you import CSS within your Custom Document.

Without this error, the styles would just disappear / not work in dev, as this isn't a client-side entry point.