### PR TITLE
 Implement static 404 page with experimental pages/404.js

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -419,7 +419,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   staticCheckWorkers.getStderr().pipe(process.stderr)
 
   const analysisBegin = process.hrtime()
-  const reservedPagesRegex = /^\/(_app|_document|api)/
+  const reservedPagesRegex = /^\/(_app|_error|_document|api)/
   const runtimeEnvConfig = {
     publicRuntimeConfig: config.publicRuntimeConfig,
     serverRuntimeConfig: config.serverRuntimeConfig,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -431,14 +431,17 @@ export default async function build(dir: string, conf = null): Promise<void> {
       : `${SERVER_DIRECTORY}/static/${buildId}`,
     `/pages`
   )
-  const customAppGetInitialProps = hasCustomGetInitialProps(
-    path.join(
-      distPagesDir,
-      // if in serverless mode check first page's bundle for _app export
-      isLikeServerless ? normalizePagePath(pageKeys[0]) : `/_app.js`
-    ),
-    runtimeEnvConfig
-  )
+  const nonReservedPage = pageKeys.find(key => !key.match(reservedPagesRegex))
+  const customAppGetInitialProps =
+    nonReservedPage &&
+    hasCustomGetInitialProps(
+      path.join(
+        distPagesDir,
+        // if in serverless mode check first page's bundle for _app export
+        isLikeServerless ? normalizePagePath(nonReservedPage!) : `/_app.js`
+      ),
+      runtimeEnvConfig
+    )
   const customErrorGetInitialProps = hasCustomGetInitialProps(
     path.join(distPagesDir, `/_error.js`),
     runtimeEnvConfig

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -590,14 +590,14 @@ export async function isPageStatic(
   }
 }
 
-export function hasCustomAppGetInitialProps(
-  _appBundle: string,
+export function hasCustomGetInitialProps(
+  bundlePath: string,
   runtimeEnvConfig: any
 ): boolean {
   require('../next-server/lib/runtime-config').setConfig(runtimeEnvConfig)
-  let mod = require(_appBundle)
+  let mod = require(bundlePath)
 
-  if (_appBundle.endsWith('_app.js')) {
+  if (bundlePath.endsWith('_app.js') || bundlePath.endsWith('_error.js')) {
     mod = mod.default || mod
   } else {
     // since we don't output _app in serverless mode get it from a page

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -601,8 +601,7 @@ export function hasCustomGetInitialProps(
     mod = mod.default || mod
   } else {
     // since we don't output _app in serverless mode get it from a page
-    // if only an API page exists this won't be available
-    mod = mod._app || {}
+    mod = mod._app
   }
   return mod.getInitialProps !== mod.origGetInitialProps
 }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -601,7 +601,8 @@ export function hasCustomGetInitialProps(
     mod = mod.default || mod
   } else {
     // since we don't output _app in serverless mode get it from a page
-    mod = mod._app
+    // if only an API page exists this won't be available
+    mod = mod._app || {}
   }
   return mod.getInitialProps !== mod.origGetInitialProps
 }

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -51,6 +51,7 @@ const defaultConfig: { [key: string]: any } = {
     reactMode: 'legacy',
     workerThreads: false,
     basePath: '',
+    pages404: false,
   },
   future: {
     excludeDefaultMomentLocales: false,

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1052,7 +1052,7 @@ export default class Server {
   ) {
     let result: LoadComponentsReturnType | undefined = undefined
 
-    if (this.customRoutes?.static404) {
+    if (this.customRoutes?.static404 && res.statusCode === 404) {
       try {
         result = await this.findPageComponents('/404', query)
       } catch (err) {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -110,6 +110,7 @@ export default class Server {
     rewrites: Rewrite[]
     redirects: Redirect[]
     headers: Header[]
+    static404: boolean
   }
 
   public constructor({
@@ -1050,7 +1051,22 @@ export default class Server {
     _pathname: string,
     query: ParsedUrlQuery = {}
   ) {
-    const result = await this.findPageComponents('/_error', query)
+    let result: LoadComponentsReturnType | undefined = undefined
+
+    if (this.customRoutes?.static404) {
+      try {
+        result = await this.findPageComponents('/404', query)
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          throw err
+        }
+      }
+    }
+
+    if (!result) {
+      result = await this.findPageComponents('/_error', query)
+    }
+
     let html
     try {
       html = await this.renderToHTMLWithComponents(

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -110,7 +110,7 @@ export default class Server {
     rewrites: Rewrite[]
     redirects: Redirect[]
     headers: Header[]
-    static404: boolean
+    static404?: boolean
   }
 
   public constructor({

--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -14,20 +14,23 @@ export type ErrorProps = {
   title?: string
 }
 
+function getInitialProps({
+  res,
+  err,
+}: NextPageContext): Promise<ErrorProps> | ErrorProps {
+  const statusCode =
+    res && res.statusCode ? res.statusCode : err ? err.statusCode! : 404
+  return { statusCode }
+}
+
 /**
  * `Error` component used for handling errors.
  */
 export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   static displayName = 'ErrorPage'
 
-  static getInitialProps({
-    res,
-    err,
-  }: NextPageContext): Promise<ErrorProps> | ErrorProps {
-    const statusCode =
-      res && res.statusCode ? res.statusCode : err ? err.statusCode! : 404
-    return { statusCode }
-  }
+  static getInitialProps = getInitialProps
+  static origGetInitialProps = getInitialProps
 
   render() {
     const { statusCode } = this.props

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -250,6 +250,7 @@ const runTests = (isDev = false) => {
       expect(manifest).toEqual({
         version: 1,
         basePath: '',
+        static404: true,
         redirects: [
           {
             source: '/docs/router-status/:code',

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -427,6 +427,7 @@ function runTests(dev) {
         headers: [],
         rewrites: [],
         redirects: [],
+        static404: true,
         dynamicRoutes: [
           {
             page: '/blog/[name]/comment/[id]',

--- a/test/integration/pages-404/pages/404.js
+++ b/test/integration/pages-404/pages/404.js
@@ -1,0 +1,1 @@
+export default () => <p>page not found</p>

--- a/test/integration/pages-404/pages/_error.js
+++ b/test/integration/pages-404/pages/_error.js
@@ -1,0 +1,16 @@
+function Error({ statusCode }) {
+  return (
+    <p>
+      {statusCode
+        ? `An error ${statusCode} occurred on server`
+        : 'An error occurred on client'}
+    </p>
+  )
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  return { statusCode }
+}
+
+export default Error

--- a/test/integration/pages-404/pages/index.js
+++ b/test/integration/pages-404/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'hello world'

--- a/test/integration/pages-404/test/index.test.js
+++ b/test/integration/pages-404/test/index.test.js
@@ -1,0 +1,78 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  nextBuild,
+  nextStart,
+  findPort,
+  killApp,
+  renderViaHTTP,
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+const appDir = join(__dirname, '../')
+const nextConfig = join(appDir, 'next.config.js')
+const routesManifest = join(appDir, '.next/routes-manifest.json')
+let appPort
+let app
+
+describe('404.js page handling', () => {
+  describe('with config disabled', () => {
+    beforeAll(async () => {
+      await fs.remove(nextConfig)
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    it('should not use 404.js for 404 page', async () => {
+      const html = await renderViaHTTP(appPort, '/non-existent')
+      expect(html).not.toContain('page not found')
+      expect(html).toContain('An error 404 occurred')
+    })
+
+    it('should still render 404.js when visited directly', async () => {
+      const html = await renderViaHTTP(appPort, '/404')
+      expect(html).toContain('page not found')
+    })
+
+    it('should set static404 in routes-manifest correctly', async () => {
+      const data = await fs.readJSON(routesManifest)
+      expect(data.static404).toBe(false)
+    })
+  })
+
+  describe('with config enabled', () => {
+    beforeAll(async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { experimental: { pages404: true } }`
+      )
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(async () => {
+      await killApp(app)
+      await fs.remove(nextConfig)
+    })
+
+    it('should use 404.js for 404 page', async () => {
+      const html = await renderViaHTTP(appPort, '/non-existent')
+      expect(html).toContain('page not found')
+      expect(html).not.toContain('An error occurred')
+    })
+
+    it('should still render 404.js when visited directly', async () => {
+      const html = await renderViaHTTP(appPort, '/404')
+      expect(html).toContain('page not found')
+    })
+
+    it('should set static404 in routes-manifest correctly', async () => {
+      const data = await fs.readJSON(routesManifest)
+      expect(data.static404).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
This implements the static 404 page when either the user:

a) doesn't have a custom `getInitialProps` in their `_error` or `_app`
b) has a `pages/404.js` and `_app` without `getInitialProps` and enables `experimental.pages404`

x-ref: #8514
x-ref: #9612