### PR TITLE
added amp-img example with fallback attribute

### DIFF
--- a/examples/amp/pages/index.js
+++ b/examples/amp/pages/index.js
@@ -18,6 +18,22 @@ export default () => {
       <h1>The Cat (AMP-first Page)</h1>
       <Byline author="Dan Zajdband" />
       <p className="caption">Meowwwwwwww</p>
+      <amp-img
+        alt="Mountains"
+        width="550"
+        height="368"
+        layout="responsive"
+        src="https://amp.dev/static/inline-examples/images/mountains.webp"
+      >
+        <amp-img
+          alt="Mountains"
+          fallback=""
+          width="550"
+          height="368"
+          layout="responsive"
+          src="https://amp.dev/static/inline-examples/images/mountains.jpg"
+        ></amp-img>
+      </amp-img>
       <p>
         Cat ipsum dolor <a href={isAmp ? '/dog?amp=1' : '/dog'}>sit amet</a>,
         eat grass, throw it back up but refuse to leave cardboard box or groom


### PR DESCRIPTION
Adding amp-img example with fallback image that passes AMP validation.

Fixes issue [#10000](https://github.com/zeit/next.js/issues/10000)