### PR TITLE
Remove unused dependencies from with-tailwindcss example

### DIFF
--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -14,8 +14,6 @@
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^1.3.0",
     "autoprefixer": "^9.6.5",
-    "cssnano": "^4.1.0",
-    "postcss-easy-import": "^3.0.0",
     "tailwindcss": "^1.0.1"
   }
 }


### PR DESCRIPTION
This PR removes the following unused dependencies from the `with-tailwindcss` example:
- cssnano
- postcss-easy-import