### PR TITLE
Fix SSG data request failing with trailing slash

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -668,6 +668,11 @@ export default class Router implements BaseRouter {
     let pathname = parse(asPath).pathname
     pathname = !pathname || pathname === '/' ? '/index' : pathname
 
+    // remove trailing slash from path
+    if (pathname.substr(pathname.length - 1) === '/') {
+      pathname = pathname.substr(0, pathname.length - 1)
+    }
+
     return process.env.NODE_ENV === 'production' &&
       (_cachedData = this.sdc[pathname])
       ? Promise.resolve(_cachedData)

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -666,12 +666,7 @@ export default class Router implements BaseRouter {
 
   _getStaticData = (asPath: string, _cachedData?: object): Promise<object> => {
     let pathname = parse(asPath).pathname
-    pathname = !pathname || pathname === '/' ? '/index' : pathname
-
-    // remove trailing slash from path
-    if (pathname.substr(pathname.length - 1) === '/') {
-      pathname = pathname.substr(0, pathname.length - 1)
-    }
+    pathname = toRoute(!pathname || pathname === '/' ? '/index' : pathname)
 
     return process.env.NODE_ENV === 'production' &&
       (_cachedData = this.sdc[pathname])

--- a/test/integration/prerender/pages/index.js
+++ b/test/integration/prerender/pages/index.js
@@ -14,7 +14,7 @@ const Page = ({ world, time }) => {
     <>
       <p>hello {world}</p>
       <span>time: {time}</span>
-      <Link href="/another">
+      <Link href="/another?hello=world" as="/another/?hello=world">
         <a id="another">to another</a>
       </Link>
       <br />

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -134,9 +134,11 @@ const navigateTest = (dev = false) => {
 
     // go to /another
     async function goFromHomeToAnother() {
+      await browser.eval('window.beforeAnother = true')
       await browser.elementByCss('#another').click()
       await browser.waitForElementByCss('#home')
       text = await browser.elementByCss('p').text()
+      expect(await browser.eval('window.beforeAnother')).toBe(true)
       expect(text).toMatch(/hello.*?world/)
     }
     await goFromHomeToAnother()


### PR DESCRIPTION
This makes sure to remove the trailing slash before making the data request for an SSG page. It also adds a test to prevent regression

Fixes: #9929