### PR TITLE
Fix hydration with custom _app and granular chunks

### DIFF
--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -27,6 +27,7 @@ function replaceBundle(path: any, t: typeof BabelTypes) {
 }
 
 interface ConfigState {
+  filename: string
   bundleDropped?: boolean
 }
 
@@ -40,6 +41,17 @@ export default function nextPageConfig({
     visitor: {
       Program: {
         enter(path, state: ConfigState) {
+          // Make sure next/router is imported in _app or else granularChunks
+          // might cause the router to not be able to load causing hydration
+          // to fail
+          if (state.filename.match(/\/_app\./)) {
+            path.node.body.splice(
+              0,
+              0,
+              t.importDeclaration([], t.stringLiteral('next/router'))
+            )
+          }
+
           path.traverse(
             {
               ExportNamedDeclaration(

--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -27,7 +27,6 @@ function replaceBundle(path: any, t: typeof BabelTypes) {
 }
 
 interface ConfigState {
-  filename?: string
   bundleDropped?: boolean
 }
 
@@ -41,17 +40,6 @@ export default function nextPageConfig({
     visitor: {
       Program: {
         enter(path, state: ConfigState) {
-          // Make sure next/router is imported in _app or else granularChunks
-          // might cause the router to not be able to load causing hydration
-          // to fail
-          if (state.filename?.match(/(\\|\/)_app\./)) {
-            path.node.body.splice(
-              0,
-              0,
-              t.importDeclaration([], t.stringLiteral('next/router'))
-            )
-          }
-
           path.traverse(
             {
               ExportNamedDeclaration(

--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -44,7 +44,7 @@ export default function nextPageConfig({
           // Make sure next/router is imported in _app or else granularChunks
           // might cause the router to not be able to load causing hydration
           // to fail
-          if (state.filename?.match(/\/_app\./)) {
+          if (state.filename?.match(/(\\|\/)_app\./)) {
             path.node.body.splice(
               0,
               0,

--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -27,7 +27,7 @@ function replaceBundle(path: any, t: typeof BabelTypes) {
 }
 
 interface ConfigState {
-  filename: string
+  filename?: string
   bundleDropped?: boolean
 }
 
@@ -44,7 +44,7 @@ export default function nextPageConfig({
           // Make sure next/router is imported in _app or else granularChunks
           // might cause the router to not be able to load causing hydration
           // to fail
-          if (state.filename.match(/\/_app\./)) {
+          if (state.filename?.match(/\/_app\./)) {
             path.node.body.splice(
               0,
               0,

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -115,10 +115,19 @@ export function createEntrypoints(
     }
 
     if (!isApiRoute) {
-      client[bundlePath] = `next-client-pages-loader?${stringify({
+      const pageLoader = `next-client-pages-loader?${stringify({
         page,
         absolutePagePath,
       })}!`
+
+      // Make sure next/router is a dependency of _app or else granularChunks
+      // might cause the router to not be able to load causing hydration
+      // to fail
+
+      client[bundlePath] =
+        page === '/_app'
+          ? [pageLoader, require.resolve('../client/router')]
+          : pageLoader
     }
   })
 

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -7,7 +7,6 @@ import {
   AppPropsType,
 } from '../next-server/lib/utils'
 import { Router } from '../client/router'
-import '../client/router'
 
 export { AppInitialProps }
 

--- a/test/integration/hydration/pages/_app.js
+++ b/test/integration/hydration/pages/_app.js
@@ -1,0 +1,1 @@
+export default ({ Component, pageProps }) => <Component {...pageProps} />

--- a/test/integration/hydration/pages/_document.js
+++ b/test/integration/hydration/pages/_document.js
@@ -1,0 +1,16 @@
+import Document, { Head, Html, Main, NextScript } from 'next/document'
+import React from 'react'
+
+class WeddingDocument extends Document {
+  render() {
+    return (
+      <Html lang="en-GB">
+        <Head />
+        <Main />
+        <NextScript />
+      </Html>
+    )
+  }
+}
+
+export default WeddingDocument

--- a/test/integration/hydration/pages/details.js
+++ b/test/integration/hydration/pages/details.js
@@ -1,0 +1,6 @@
+export default () => {
+  if (typeof window !== 'undefined') {
+    window.didHydrate = true
+  }
+  return 'details'
+}

--- a/test/integration/hydration/pages/index.js
+++ b/test/integration/hydration/pages/index.js
@@ -1,0 +1,6 @@
+export default () => {
+  if (typeof window !== 'undefined') {
+    window.didHydrate = true
+  }
+  return 'index'
+}

--- a/test/integration/hydration/test/index.test.js
+++ b/test/integration/hydration/test/index.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+/* global jasmine */
+import path from 'path'
+import webdriver from 'next-webdriver'
+import {
+  nextBuild,
+  nextStart,
+  findPort,
+  waitFor,
+  killApp,
+} from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+const appDir = path.join(__dirname, '..')
+let app
+let appPort
+
+describe('Hydration', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+
+  it('Hydrates correctly', async () => {
+    const browser = await webdriver(appPort, '/')
+    await waitFor(2000)
+    expect(await browser.eval('window.didHydrate')).toBe(true)
+  })
+})

--- a/test/integration/hydration/test/index.test.js
+++ b/test/integration/hydration/test/index.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 /* global jasmine */
 import path from 'path'
+import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import {
   nextBuild,
@@ -17,6 +18,7 @@ let appPort
 
 describe('Hydration', () => {
   beforeAll(async () => {
+    await fs.remove(path.join(appDir, '.next'))
     await nextBuild(appDir)
     appPort = await findPort()
     app = await nextStart(appDir, appPort)


### PR DESCRIPTION
This fixes hydration failing when a user adds a custom `_app` and granular chunks causes the router to be moved separately making the router no longer able to be loaded since hydration relies on it. It makes sure the router is present now by adding an `import 'next/router'` automatically for custom `_app` usage

This also adds a test to prevent regression