### PR TITLE
"with-google-analytics" Example - Fix Issue #10045

### DIFF
--- a/examples/with-google-analytics/pages/_document.js
+++ b/examples/with-google-analytics/pages/_document.js
@@ -20,7 +20,9 @@ export default class extends Document {
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
 
-            gtag('config', '${GA_TRACKING_ID}');
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
           `,
             }}
           />


### PR DESCRIPTION
This PR fixes #10045. I tested using Zeit Now, since Google Analytics did not seem to work with localhost:3000. @ViktorQvarfordt suggested using `window.location.href` as the `page_path`, but I've found that GA is expecting a relative URL path, because the domain name is already linked to the GA Property's Tracking Id. After testing, GA is receiving the correct relative URL on page load, and when clicking on links.