### PR TITLE
babelPresetPlugins coerced to an array

### DIFF
--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -57,7 +57,7 @@ module.exports = babelLoader.custom(babel => {
         isModern: opts.isModern,
         pagesDir: opts.pagesDir,
         hasModern: opts.hasModern,
-        babelPresetPlugins: opts.babelPresetPlugins,
+        babelPresetPlugins: opts.babelPresetPlugins || [],
         development: opts.development,
       }
       const filename = join(opts.cwd, 'noop.js')


### PR DESCRIPTION
I was seeing the following error when using a `monorepo` style repository with a shared components directory outside of the `src/*` within the next application.

```
[ error ] /home/jtoft/src/pack/web/components/markdown/index.ts
TypeError: babelPresetPlugins is not iterable
    at Generator.next (<anonymous>)
    at runMicrotasks (<anonymous>)
ModuleBuildError: Module build failed (from ./node_modules/next/dist/build/webpack/loaders/next-babel-loader.js):
TypeError: babelPresetPlugins is not iterable
    at Object.config (/home/jtoft/src/pack/web/sites/website/node_modules/next/dist/build/webpack/loaders/next-babel-loader.js:9:193)
    at Object.<anonymous> (/home/jtoft/src/pack/web/node_modules/babel-loader/lib/index.js:150:42)
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/home/jtoft/src/pack/web/node_modules/babel-loader/lib/index.js:3:103)
    at _next (/home/jtoft/src/pack/web/node_modules/babel-loader/lib/index.js:5:194)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at /home/jtoft/src/pack/web/sites/website/node_modules/next/node_modules/webpack/lib/NormalModule.js:316:20
    at /home/jtoft/src/pack/web/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at /home/jtoft/src/pack/web/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at context.callback (/home/jtoft/src/pack/web/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/jtoft/src/pack/web/node_modules/babel-loader/lib/index.js:55:103
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

```

It works fine with `9.1.2` and below, but this doesn't seem to work afterwards.

I'm not sure if this is the best way to solve this or if there's really a good way to write a test to validate this problem; but I'm happy to do it if I can get some direction.

I'm assuming that the actual error is likely because the options for paths outside of the `pages` or `src` directories don't include a set of sane default options.

The included patch addresses the failure I was seeing and also produces proper production // static builds afterwards.