### PR TITLE
Minor update for the "with-react-ga" example

### DIFF
--- a/examples/with-react-ga/pages/_app.js
+++ b/examples/with-react-ga/pages/_app.js
@@ -17,7 +17,7 @@ export default class MyApp extends App {
   componentDidMount() {
     initGA()
     logPageView()
-    Router.router.events.on('routeChangeComplete', logPageView)
+    Router.events.on('routeChangeComplete', logPageView)
   }
 
   render() {


### PR DESCRIPTION
Looks like `next/router` no longer requires you to go through "router.events", you can now access "events" directly. Updating the example for `with-react-ga` so that it matches `with-google-analytics`.