### PR TITLE
[docs] Added related links to next.config.js

### DIFF
--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -48,7 +48,7 @@ For more information on what to do next, we recommend the following sections:
 <div class="card">
   <a href="/docs/advanced-features/automatic-static-optimization.md">
     <b>Automatic Static Optimization:</b>
-    <small>Learn more about how Next.js automatically optimizes your pages.</small>
+    <small>Next.js automatically optimizes your app to be static HTML whenever possible. Learn how it works here.</small>
   </a>
 </div>
 

--- a/docs/api-reference/next.config.js/build-target.md
+++ b/docs/api-reference/next.config.js/build-target.md
@@ -27,3 +27,19 @@ module.exports = {
   target: 'serverless',
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/deployment.md">
+    <b>Deployment:</b>
+    <small>Compile and deploy your Next.js app to production.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md
+++ b/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md
@@ -18,3 +18,19 @@ module.exports = {
 ```
 
 Next.js will automatically use your prefix in the scripts it loads, but this has no effect whatsoever on the [public](/docs/basic-features/static-file-serving.md) folder; if you want to serve those assets over a CDN, you'll have to introduce the prefix yourself. One way of introducing a prefix that works inside your components and varies by environment is documented [in this example](https://github.com/zeit/next.js/tree/canary/examples/with-universal-configuration-build-time).
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/static-file-serving.md">
+    <b>Static File Serving:</b>
+    <small>Serve static files, like images, in the public directory.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/compression.md
+++ b/docs/api-reference/next.config.js/compression.md
@@ -13,3 +13,12 @@ module.exports = {
   compress: false,
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/configuring-onDemandEntries.md
+++ b/docs/api-reference/next.config.js/configuring-onDemandEntries.md
@@ -18,3 +18,12 @@ module.exports = {
   },
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/configuring-the-build-id.md
+++ b/docs/api-reference/next.config.js/configuring-the-build-id.md
@@ -16,3 +16,12 @@ module.exports = {
   },
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/custom-page-extensions.md
+++ b/docs/api-reference/next.config.js/custom-page-extensions.md
@@ -13,3 +13,12 @@ module.exports = {
   pageExtensions: ['mdx', 'jsx', 'js', 'ts', 'tsx'],
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/custom-webpack-config.md
+++ b/docs/api-reference/next.config.js/custom-webpack-config.md
@@ -65,3 +65,12 @@ module.exports = {
   },
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/disabling-etag-generation.md
+++ b/docs/api-reference/next.config.js/disabling-etag-generation.md
@@ -13,3 +13,12 @@ module.exports = {
   generateEtags: false,
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/disabling-x-powered-by.md
+++ b/docs/api-reference/next.config.js/disabling-x-powered-by.md
@@ -11,3 +11,12 @@ module.exports = {
   poweredByHeader: false,
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/environment-variables.md
+++ b/docs/api-reference/next.config.js/environment-variables.md
@@ -45,3 +45,12 @@ Will end up being:
 ```jsx
 return <h1>The value of customKey is: {'my-value'}</h1>
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/exportPathMap.md
+++ b/docs/api-reference/next.config.js/exportPathMap.md
@@ -66,3 +66,19 @@ module.exports = {
   exportTrailingSlash: true,
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/static-html-export.md">
+    <b>Static HTML Export:</b>
+    <small>Export your Next.js app to static HTML.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/ignoring-typescript-errors.md
+++ b/docs/api-reference/next.config.js/ignoring-typescript-errors.md
@@ -40,3 +40,19 @@ module.exports = {
   },
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/basic-features/typescript.md">
+    <b>TypeScript:</b>
+    <small>Get started with TypeScript in Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -52,3 +52,19 @@ function MyImage() {
 
 export default MyImage
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/environment-variables.md">
+    <b>Environment Variables:</b>
+    <small>Access environment variables in your Next.js application at build time.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/setting-a-custom-build-directory.md
+++ b/docs/api-reference/next.config.js/setting-a-custom-build-directory.md
@@ -17,3 +17,12 @@ module.exports = {
 Now if you run `next build` Next.js will use `build` instead of the default `.next` folder.
 
 > `distDir` **should not** leave your project directory. For example, `../build` is an **invalid** directory.
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/docs/api-reference/next.config.js/static-optimization-indicator.md
+++ b/docs/api-reference/next.config.js/static-optimization-indicator.md
@@ -17,3 +17,19 @@ module.exports = {
   },
 }
 ```
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>
+
+<div class="card">
+  <a href="/docs/advanced-features/automatic-static-optimization.md">
+    <b>Automatic Static Optimization:</b>
+    <small>Next.js automatically optimizes your app to be static HTML whenever possible. Learn how it works here.</small>
+  </a>
+</div>

--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -71,6 +71,6 @@ For more information on what to do next, we recommend the following sections:
 <div class="card">
   <a href="/docs/basic-features/typescript.md#api-routes">
     <b>TypeScript:</b>
-    <small>Add TypeScript to your API Routes</small>
+    <small>Add TypeScript to your API Routes.</small>
   </a>
 </div>

--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -106,13 +106,13 @@ For more information on what to do next, we recommend the following sections:
 <div class="card">
   <a href="/docs/routing/introduction.md">
     <b>Routing:</b>
-    <small>Learn more about routing in Next.js</small>
+    <small>Learn more about routing in Next.js.</small>
   </a>
 </div>
 
 <div class="card">
   <a href="/docs/basic-features/typescript.md#pages">
     <b>TypeScript:</b>
-    <small>Add TypeScript to your pages</small>
+    <small>Add TypeScript to your pages.</small>
   </a>
 </div>

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -1,5 +1,5 @@
 ---
-description: Next.js supports TypeScript by default and has built-in types for pages and the API. You can get started with Next.js and TypeScript here.
+description: Next.js supports TypeScript by default and has built-in types for pages and the API. You can get started with TypeScript in Next.js here.
 ---
 
 # TypeScript

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,13 +73,13 @@ For more information on what to do next, we recommend the following sections:
 <div class="card">
   <a href="/docs/basic-features/pages.md">
     <b>Pages:</b>
-    <small>Learn more about what pages are in Next.js</small>
+    <small>Learn more about what pages are in Next.js.</small>
   </a>
 </div>
 
 <div class="card">
   <a href="/docs/basic-features/built-in-css-support.md">
     <b>CSS Support:</b>
-    <small>Use the built-in CSS support to add custom styles to your app</small>
+    <small>Use the built-in CSS support to add custom styles to your app.</small>
   </a>
 </div>


### PR DESCRIPTION
You may feel a little lost in the sidebar for `next.config.js` if you end up in one of its sections but haven't checked the introduction to it.

Also added links to sections related to specific configs.