### PR TITLE
Add error for invalid distDir value

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -83,10 +83,24 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       experimentalWarning()
     }
 
-    if (key === 'distDir' && userConfig[key] === 'public') {
-      throw new Error(
-        `The 'public' directory is reserved in Next.js and can not be set as the 'distDir'. https://err.sh/zeit/next.js/can-not-output-to-public`
-      )
+    if (key === 'distDir') {
+      const userDistDir =
+        typeof userConfig[key] === 'string' ? userConfig[key].trim() : '.next'
+
+      // don't allow public as the distDir as this is a reserved folder for
+      // public files
+      if (userDistDir === 'public') {
+        throw new Error(
+          `The 'public' directory is reserved in Next.js and can not be set as the 'distDir'. https://err.sh/zeit/next.js/can-not-output-to-public`
+        )
+      }
+      // make sure distDir isn't an empty string which can result the provided
+      // directory being deleted in development mode
+      if (userDistDir.length === 0) {
+        throw new Error(
+          `Invalid distDir provided, distDir can not be an empty string. Please remove this config or set it to undefined`
+        )
+      }
     }
 
     const maybeObject = userConfig[key]

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -84,8 +84,10 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     }
 
     if (key === 'distDir') {
-      const userDistDir =
-        typeof userConfig[key] === 'string' ? userConfig[key].trim() : '.next'
+      if (typeof userConfig[key] !== 'string') {
+        userConfig[key] = defaultConfig.distDir
+      }
+      const userDistDir = userConfig[key].trim()
 
       // don't allow public as the distDir as this is a reserved folder for
       // public files

--- a/test/integration/dist-dir/test/index.test.js
+++ b/test/integration/dist-dir/test/index.test.js
@@ -1,53 +1,56 @@
 /* eslint-env jest */
 /* global jasmine */
+import fs from 'fs-extra'
 import { join } from 'path'
-import { existsSync } from 'fs'
 import { BUILD_ID_FILE } from 'next/constants'
 import {
-  nextServer,
+  nextStart,
   nextBuild,
-  startApp,
-  stopApp,
+  findPort,
+  killApp,
   renderViaHTTP,
 } from 'next-test-utils'
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 const appDir = join(__dirname, '../')
+const nextConfig = join(appDir, 'next.config.js')
 let appPort
-let server
 let app
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 
 describe('Production Usage', () => {
-  beforeAll(async () => {
-    await nextBuild(appDir)
-    app = nextServer({
-      dir: join(__dirname, '../'),
-      dev: false,
-      quiet: true,
-    })
-
-    server = await startApp(app)
-    appPort = server.address().port
-  })
-  afterAll(() => stopApp(server))
-
   describe('With basic usage', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
     it('should render the page', async () => {
       const html = await renderViaHTTP(appPort, '/')
       expect(html).toMatch(/Hello World/)
     })
-  })
 
-  describe('File locations', () => {
-    it('should build the app within the given `dist` directory', () => {
+    it('should build the app within the given `dist` directory', async () => {
       expect(
-        existsSync(join(__dirname, `/../dist/${BUILD_ID_FILE}`))
+        await fs.exists(join(__dirname, `/../dist/${BUILD_ID_FILE}`))
       ).toBeTruthy()
     })
-    it('should not build the app within the default `.next` directory', () => {
+    it('should not build the app within the default `.next` directory', async () => {
       expect(
-        existsSync(join(__dirname, `/../.next/${BUILD_ID_FILE}`))
+        await fs.exists(join(__dirname, `/../.next/${BUILD_ID_FILE}`))
       ).toBeFalsy()
     })
+  })
+
+  it('should throw error with invalid distDir', async () => {
+    const origNextConfig = await fs.readFile(nextConfig, 'utf8')
+    await fs.writeFile(nextConfig, `module.exports = { distDir: '' }`)
+    const { stderr } = await nextBuild(appDir, [], { stderr: true })
+    await fs.writeFile(nextConfig, origNextConfig)
+
+    expect(stderr).toContain(
+      'Invalid distDir provided, distDir can not be an empty string. Please remove this config or set it to undefined'
+    )
   })
 })

--- a/test/integration/dist-dir/test/index.test.js
+++ b/test/integration/dist-dir/test/index.test.js
@@ -53,4 +53,13 @@ describe('Production Usage', () => {
       'Invalid distDir provided, distDir can not be an empty string. Please remove this config or set it to undefined'
     )
   })
+
+  it('should handle null/undefined distDir', async () => {
+    const origNextConfig = await fs.readFile(nextConfig, 'utf8')
+    await fs.writeFile(nextConfig, `module.exports = { distDir: null }`)
+    const { stderr } = await nextBuild(appDir, [], { stderr: true })
+    await fs.writeFile(nextConfig, origNextConfig)
+
+    expect(stderr.length).toBe(0)
+  })
 })


### PR DESCRIPTION
If this value is an empty string it results in the `distDir` being the same as the application's directory which can have bad side-effects and is not valid

Closes: #10135