### PR TITLE
Don't include core-js for default _document

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -202,13 +202,12 @@ export async function pages_error(task) {
 export async function pages_document(task) {
   const babelOpts = {
     ...babelServerOpts,
+    presets: [...babelServerOpts.presets, '@babel/preset-react'],
   }
-
-  babelOpts.presets.push('@babel/preset-react')
 
   await task
     .source('pages/_document.tsx')
-    .babel(babelServerOpts)
+    .babel(babelOpts)
     .target('dist/pages')
 }
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -185,11 +185,35 @@ export async function nextbuildstatic(task, opts) {
   notify('Compiled export files')
 }
 
-export async function pages(task, opts) {
+export async function pages_app(task) {
   await task
-    .source(opts.src || 'pages/**/*.+(js|ts|tsx)')
+    .source('pages/_app.tsx')
     .babel(babelClientOpts)
     .target('dist/pages')
+}
+
+export async function pages_error(task) {
+  await task
+    .source('pages/_error.tsx')
+    .babel(babelClientOpts)
+    .target('dist/pages')
+}
+
+export async function pages_document(task) {
+  const babelOpts = {
+    ...babelServerOpts,
+  }
+
+  babelOpts.presets.push('@babel/preset-react')
+
+  await task
+    .source('pages/_document.tsx')
+    .babel(babelServerOpts)
+    .target('dist/pages')
+}
+
+export async function pages(task, opts) {
+  await task.parallel(['pages_app', 'pages_error', 'pages_document'])
 }
 
 export async function telemetry(task, opts) {


### PR DESCRIPTION
It's still added through `next/babel`, but this is the initial work to get rid of it for node.js code.