### PR TITLE
Stabilize New Dev Test

### DIFF
--- a/test/integration/invalid-href/test/index.test.js
+++ b/test/integration/invalid-href/test/index.test.js
@@ -64,6 +64,7 @@ const showsError = async (
 
 const noError = async (pathname, click = false) => {
   const browser = await webdriver(appPort, '/')
+  await waitFor(2000)
   await browser.eval(`(function() {
     window.caughtErrors = []
     window.addEventListener('error', function (error) {
@@ -74,7 +75,8 @@ const noError = async (pathname, click = false) => {
     })
     window.next.router.replace('${pathname}')
   })()`)
-  await waitFor(250)
+  // wait for page to be built and navigated to
+  await waitFor(3000)
   if (click) {
     await browser.elementByCss('a').click()
   }


### PR DESCRIPTION
This tries to fix the following error:
```
does not throw error when dynamic route mismatch is used on Link and params are manually provided (715ms)
```

Currently breaking PRs: #10186, #10187, etc.