### PR TITLE
Disable core-js for server-side build

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -149,7 +149,7 @@ module.exports = (
           useBuiltIns: true,
         },
       ],
-      [
+      !isServer && [
         require('@babel/plugin-transform-runtime'),
         {
           corejs: 2,

--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -4,7 +4,7 @@ import hash from 'string-hash'
 
 // increment 'e' to invalidate cache
 // eslint-disable-next-line no-useless-concat
-const cacheKey = 'babel-cache-' + 'g' + '-'
+const cacheKey = 'babel-cache-' + 'h' + '-'
 const nextBabelPreset = require('../../babel/preset')
 
 const getModernOptions = (babelOptions = {}) => {


### PR DESCRIPTION
Speeds up compilation as the features core-js polyfills mostly already exist in Node.js by default.