### PR TITLE
Update tests running and add splitting by timings for Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,5 +62,5 @@ jobs:
         displayName: 'Install dependencies'
 
       - script: |
-          node run-tests.js -g $(group)
+          node run-tests.js -g $(group) --timings
         displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,5 +62,5 @@ jobs:
         displayName: 'Install dependencies'
 
       - script: |
-          node run-tests.js -g $(group) --timings
+          node run-tests.js -c 3 -g $(group) --timings
         displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,5 +62,5 @@ jobs:
         displayName: 'Install dependencies'
 
       - script: |
-          node run-tests.js -c 3 -g $(group) --timings
+          node run-tests.js -g $(group) --timings
         displayName: 'Run tests'

--- a/run-tests.js
+++ b/run-tests.js
@@ -12,7 +12,7 @@ const exec = promisify(execOrig)
 const NUM_RETRIES = 2
 const DEFAULT_CONCURRENCY = 2
 const timings = []
-const TIMINGS_API = 'http://next-timings.jjsweb.site/api/timings'
+const TIMINGS_API = 'https://next-timings.jjsweb.site/api/timings'
 
 ;(async () => {
   let concurrencyIdx = process.argv.indexOf('-c')

--- a/run-tests.js
+++ b/run-tests.js
@@ -126,9 +126,6 @@ const timings = []
         groupTimes[smallestGroupIdx] += prevTimings[testName] || 1
       }
 
-      console.log({ groupTimes })
-      console.log(JSON.stringify(groups, null, 2))
-
       const curGroupIdx = groupPos - 1
       testNames = groups[curGroupIdx]
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const _glob = require('glob')
 const fs = require('fs-extra')
+const fetch = require('node-fetch')
 const { promisify } = require('util')
 const { Sema } = require('async-sema')
 const { spawn, exec: execOrig } = require('child_process')
@@ -11,6 +12,7 @@ const exec = promisify(execOrig)
 const NUM_RETRIES = 2
 const DEFAULT_CONCURRENCY = 2
 const timings = []
+const TIMINGS_API = 'http://next-timings.jjsweb.site/api/timings'
 
 ;(async () => {
   let concurrencyIdx = process.argv.indexOf('-c')
@@ -23,12 +25,25 @@ const timings = []
 
   console.log('Running tests with concurrency:', concurrency)
   let tests = process.argv.filter(arg => arg.endsWith('.test.js'))
+  let prevTimings
 
   if (tests.length === 0) {
     tests = await glob('**/*.test.js', {
       nodir: true,
       cwd: path.join(__dirname, 'test'),
     })
+
+    if (outputTimings) {
+      console.log('Fetching previous timings data')
+      const res = await fetch(TIMINGS_API)
+
+      if (res.ok) {
+        prevTimings = await res.json()
+        console.log('Fetched previous timings data')
+      } else {
+        console.log('Failed to fetch previous timings status:', res.status)
+      }
+    }
   }
 
   let testNames = [
@@ -49,9 +64,43 @@ const timings = []
     let offset = groupPos === 1 ? 0 : (groupPos - 1) * numPerGroup - 1
     // if there's an odd number of suites give the first group the extra
     if (testNames.length % 2 !== 0 && groupPos !== 1) offset++
-    testNames = testNames.splice(offset, numPerGroup)
-  }
 
+    if (prevTimings) {
+      const groups = [[]]
+      const groupTimes = [0]
+
+      for (const testName of testNames) {
+        let smallestGroup = groupTimes[0]
+        let smallestGroupIdx = 0
+
+        // get the samllest group time to add current one to
+        for (let i = 1; i < groupTotal; i++) {
+          if (!groups[i]) {
+            groups[i] = []
+            groupTimes[i] = 0
+          }
+
+          const time = groupTimes[i]
+          if (time < smallestGroup) {
+            smallestGroup = time
+            smallestGroupIdx = i
+          }
+        }
+        groups[smallestGroupIdx].push(testName)
+        groupTimes[smallestGroupIdx] += prevTimings[testName] || 1
+      }
+
+      const curGroupIdx = groupPos - 1
+      testNames = groups[curGroupIdx]
+
+      console.log(
+        'Current group previous accumulated times:',
+        Math.round(groupTimes[curGroupIdx]) + 's'
+      )
+    } else {
+      testNames = testNames.splice(offset, numPerGroup)
+    }
+  }
   console.log('Running tests:', '\n', ...testNames.map(name => `${name}\n`))
 
   const sema = new Sema(concurrency, { capacity: testNames.length })
@@ -61,7 +110,7 @@ const timings = []
   )
   const children = new Set()
 
-  const runTest = (test = '') =>
+  const runTest = (test = '', usePolling) =>
     new Promise((resolve, reject) => {
       const start = new Date().getTime()
       const child = spawn(
@@ -69,6 +118,17 @@ const timings = []
         [jestPath, '--runInBand', '--forceExit', '--verbose', test],
         {
           stdio: 'inherit',
+          env: {
+            ...process.env,
+            ...(usePolling
+              ? {
+                  // Events can be finicky in CI. This switches to a more reliable
+                  // polling method.
+                  CHOKIDAR_USEPOLLING: 'true',
+                  CHOKIDAR_INTERVAL: 500,
+                }
+              : {}),
+          },
         }
       )
       children.add(child)
@@ -86,7 +146,7 @@ const timings = []
 
       for (let i = 0; i < NUM_RETRIES + 1; i++) {
         try {
-          const time = await runTest(test)
+          const time = await runTest(test, i > 0)
           timings.push({
             file: test,
             time,
@@ -113,6 +173,8 @@ const timings = []
   )
 
   if (outputTimings) {
+    const timings = {}
+
     let junitData = `<testsuites name="jest tests">`
     /*
       <testsuite name="/__tests__/bar.test.js" tests="1" errors="0" failures="0" skipped="0" timestamp="2017-10-10T21:56:49" time="0.323">
@@ -123,6 +185,8 @@ const timings = []
 
     for (const timing of timings) {
       const timeInSeconds = timing.time / 1000
+      timings[timing.file] = timeInSeconds
+
       junitData += `
         <testsuite name="${timing.file}" file="${
         timing.file
@@ -137,5 +201,21 @@ const timings = []
     junitData += `</testsuites>`
     await fs.writeFile('test/junit.xml', junitData, 'utf8')
     console.log('output timing data to junit.xml')
+
+    if (prevTimings) {
+      const res = await fetch(TIMINGS_API, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ timings }),
+      })
+
+      if (res.ok) {
+        console.log('Posted current timings successfully')
+      } else {
+        console.log('Failed to post current timings status:', res.status)
+      }
+    }
   }
 })()

--- a/run-tests.js
+++ b/run-tests.js
@@ -156,9 +156,10 @@ const TIMINGS_API = 'https://next-timings.jjsweb.site/api/timings'
         } catch (err) {
           if (i < NUM_RETRIES) {
             try {
-              console.log('Cleaning test files for', test)
-              await exec(`git clean -fdx "${path.join(__dirname, test)}"`)
-              await exec(`git checkout "${path.join(__dirname, test)}"`)
+              const testDir = path.dirname(path.join(__dirname, test))
+              console.log('Cleaning test files at', testDir)
+              await exec(`git clean -fdx "${testDir}"`)
+              await exec(`git checkout "${testDir}"`)
             } catch (err) {}
           }
         }

--- a/run-tests.js
+++ b/run-tests.js
@@ -173,7 +173,7 @@ const TIMINGS_API = 'https://next-timings.jjsweb.site/api/timings'
   )
 
   if (outputTimings) {
-    const timings = {}
+    const curTimings = {}
 
     let junitData = `<testsuites name="jest tests">`
     /*
@@ -185,7 +185,7 @@ const TIMINGS_API = 'https://next-timings.jjsweb.site/api/timings'
 
     for (const timing of timings) {
       const timeInSeconds = timing.time / 1000
-      timings[timing.file] = timeInSeconds
+      curTimings[timing.file] = timeInSeconds
 
       junitData += `
         <testsuite name="${timing.file}" file="${
@@ -208,11 +208,11 @@ const TIMINGS_API = 'https://next-timings.jjsweb.site/api/timings'
         headers: {
           'content-type': 'application/json',
         },
-        body: JSON.stringify({ timings }),
+        body: JSON.stringify({ timings: curTimings }),
       })
 
       if (res.ok) {
-        console.log('Posted current timings successfully')
+        console.log('Posted current timings successfully', await res.json())
       } else {
         console.log('Failed to post current timings status:', res.status)
       }

--- a/test/integration/create-next-app/index.test.js
+++ b/test/integration/create-next-app/index.test.js
@@ -20,7 +20,7 @@ const run = (...args) => execa('node', [cli, ...args], { cwd })
 
 describe('create next app', () => {
   beforeAll(async () => {
-    jest.setTimeout(1000 * 30)
+    jest.setTimeout(1000 * 60)
     await mkdirp(cwd)
   })
 


### PR DESCRIPTION
This adds custom test grouping using previous timings data to help speed up Azure tests. It also enables polling with chokidar when a test is being re-run and also fixes a test's directory not being cleaned/reset before re-trying