### PR TITLE
Enable security tests cross browser

### DIFF
--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -718,5 +718,5 @@ describe('Production Usage', () => {
   dynamicImportTests(context, (p, q) => renderViaHTTP(context.appPort, p, q))
 
   processEnv(context)
-  if (browserName === 'chrome') security(context)
+  security(context)
 })


### PR DESCRIPTION
These were disabled from when we were relying on Browser Stack for all browsers and each browser would have to wait on the previous to finish. Now that we're only using Browser Stack for the safari tests we can re-enable these cross browser