### PR TITLE
Remove unnecessary exportPathMap from examples

### DIFF
--- a/examples/gh-pages/next.config.js
+++ b/examples/gh-pages/next.config.js
@@ -5,11 +5,5 @@
 const debug = process.env.NODE_ENV !== 'production'
 
 module.exports = {
-  exportPathMap: function() {
-    return {
-      '/': { page: '/' },
-      '/about': { page: '/about' },
-    }
-  },
   assetPrefix: !debug ? '/Next-gh-page-example/' : '',
 }

--- a/examples/with-dynamic-import/next.config.js
+++ b/examples/with-dynamic-import/next.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  exportPathMap: function() {
-    return {
-      '/': { page: '/', query: { showMore: false } },
-      '/about': { page: '/about' },
-    }
-  },
-}


### PR DESCRIPTION
@timneutkens pointed out that some examples had `exportPathMap` which seemed unnecessary. I took a look and they're indeed unnecessary. They were added [when `exportPathMap` didn't automatically include all the pages](https://github.com/zeit/next.js/pull/4066). `npm run build && npm run export` work fine without this config.