### PR TITLE
Disable invalid security tests for safari

### DIFF
--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -718,5 +718,5 @@ describe('Production Usage', () => {
   dynamicImportTests(context, (p, q) => renderViaHTTP(context.appPort, p, q))
 
   processEnv(context)
-  security(context)
+  if (browserName !== 'safari') security(context)
 })


### PR DESCRIPTION
Looks like safari blocks these types of URLs so we can't test them in that one