### PR TITLE
Add explanation about persistent variables

### DIFF
--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -34,7 +34,7 @@ For an API route to work, you need to export as default a function (a.k.a **requ
 - `req`: An instance of [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage), plus some pre-built middlewares you can see [here](/docs/api-routes/api-middlewares.md)
 - `res`: An instance of [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse), plus some helper functions you can see [here](/docs/api-routes/response-helpers.md)
 
-The code that is located outside of the default export will only be run one time. It is executed the first time the API endpoint is called. In the following example, the counter will start at 0 and will increment each time the endpoint is called:
+The code that is located outside of the default export will only run once. It is executed the first time the API endpoint is called. In the following example, the counter will start at 0 and will increment each time the endpoint is called:
 
 ```js
 let counter = 0

--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -34,6 +34,21 @@ For an API route to work, you need to export as default a function (a.k.a **requ
 - `req`: An instance of [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage), plus some pre-built middlewares you can see [here](/docs/api-routes/api-middlewares.md)
 - `res`: An instance of [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse), plus some helper functions you can see [here](/docs/api-routes/response-helpers.md)
 
+The code that is located outside of the default export will only be run one time. It is executed the first time the api endpoint is called. In the following example, the counter will start at 0 and will increment each time the endpoint is called:
+
+```js
+let counter = 0
+
+export default (req, res) => {
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify({ counter }))
+  counter++
+}
+
+```
+
+
 To handle different HTTP methods in an API route, you can use `req.method` in your request handler, like so:
 
 ```js

--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -34,7 +34,7 @@ For an API route to work, you need to export as default a function (a.k.a **requ
 - `req`: An instance of [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage), plus some pre-built middlewares you can see [here](/docs/api-routes/api-middlewares.md)
 - `res`: An instance of [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse), plus some helper functions you can see [here](/docs/api-routes/response-helpers.md)
 
-The code that is located outside of the default export will only be run one time. It is executed the first time the api endpoint is called. In the following example, the counter will start at 0 and will increment each time the endpoint is called:
+The code that is located outside of the default export will only be run one time. It is executed the first time the API endpoint is called. In the following example, the counter will start at 0 and will increment each time the endpoint is called:
 
 ```js
 let counter = 0


### PR DESCRIPTION
I added an explanation to the API Routes documentation about variables persisting between requests. 