### PR TITLE
Improve Link documentation

### DIFF
--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -74,12 +74,36 @@ const pids = ['id1', 'id2', 'id3']
 }
 ```
 
-## Example with `React.forwardRef`
+## If the child is a custom component that wraps an `<a>` tag
 
-If the child component in `Link` is a function component, you'll need to wrap it in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref) like in the following example:
+If the child of `Link` is a custom component that wraps an `<a>` tag, you must add `passHref` to `Link`. This is necessary if you’re using libraries like [styled-components](https://styled-components.com/). Without this, the `<a>` tag will not have the `href` attribute, which might hurt your site’s SEO.
 
 ```jsx
-import React from 'react'
+import Link from 'next/link'
+import styled from 'styled-components'
+
+const RedLink = styled.a`
+  color: red;
+`
+
+function NavLink({ href, name }) {
+  return (
+    <Link href={href} passHref>
+      <RedLink>{name}</RedLink>
+    </Link>
+  )
+}
+
+export default NavLink
+```
+
+> **Note:** If you’re using [emotion](https://emotion.sh/)’s JSX pragma feature (`@jsx jsx`), you must use `passHref` even if you use an `<a>` tag directly.
+
+## If the child is a function component
+
+If the child of `Link` is a function component, in addition to using `passHref`, you must wrap the component in [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref):
+
+```jsx
 import Link from 'next/link'
 
 // `onClick`, `href`, and `ref` need to be passed to the DOM element
@@ -94,7 +118,7 @@ const MyButton = React.forwardRef(({ onClick, href }, ref) => {
 
 function Home() {
   return (
-    <Link href="/about">
+    <Link href="/about" passHref>
       <MyButton />
     </Link>
   )
@@ -146,29 +170,6 @@ The default behavior of the `Link` component is to `push` a new URL into the `hi
 ```
 
 The child of `Link` is `<img>` instead of `<a>`. `Link` will send the `onClick` property to `<img>` but won't pass the `href` property.
-
-## Forcing `Link` to expose `href` to its child
-
-If the child is an `<a>` tag and doesn't have a `href` attribute we specify it so that the repetition is not needed by the user. However, sometimes, you’ll want to pass an `<a>` tag inside of a wrapper and `Link` won’t recognize it as a _hyperlink_, and, consequently, won’t transfer its `href` to the child.
-
-In cases like that, you can add the `passHref` property to `Link`, forcing it to expose its `href` property to the child. Take a look at the following example:
-
-```jsx
-import Link from 'next/link'
-import Unexpected_A from 'third-library'
-
-function NavLink({ href, name }) {
-  return (
-    <Link href={href} passHref>
-      <Unexpected_A>{name}</Unexpected_A>
-    </Link>
-  )
-}
-
-export default NavLink
-```
-
-> **Please note**: using a tag other than `<a>` and failing to pass `passHref` may result in links that appear to navigate correctly, but, when being crawled by search engines, will not be recognized as links (owing to the lack of `href` attribute). This may result in negative effects on your sites SEO.
 
 ## Disable scrolling to the top of the page
 

--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -82,11 +82,13 @@ If the child of `Link` is a custom component that wraps an `<a>` tag, you must a
 import Link from 'next/link'
 import styled from 'styled-components'
 
+// This creates a custom component that wraps an <a> tag
 const RedLink = styled.a`
   color: red;
 `
 
 function NavLink({ href, name }) {
+  // Must add passHref to Link
   return (
     <Link href={href} passHref>
       <RedLink>{name}</RedLink>


### PR DESCRIPTION
This PR improves [the next/link API documentation](https://nextjs.org/docs/api-reference/next/link) in general.

**First,** I grouped two sections about `forwardRef` and `passHref` next to each other because they both talk about gotchas when using custom chidlren. This made `passHref` to appear earlier in the page, which I think is good because a lot of people seem to run into this issue.

**Second,** I explicitly used `styled-components` as an example for `passHref`. Previously it was using `Unexpected_A`, which was a very strange name (what’s unexpected?). `styled-components` is popular enough (see [this comment](https://github.com/zeit/next.js/issues/1942#issuecomment-437680021) which got a lot of upvotes), and even if the user's using some other libraries, they'll probably understand the `styled-components` example better than `Unexpected_A`. 

**Third,** I tightened the wording for `passHref` doc. The earlier version (from https://github.com/zeit/next.js/pull/2503) was too wordy.

**Fourth,** I added a note about emotion - if you use emotion, even if you use the `<a>` tag directly, you’ll still need `passHref` because emotion’s custom JSX pragma [strips away the `type` attribute from each element](https://github.com/emotion-js/emotion/blob/d0b2a94ab9d5648667447dbd78e7a2e3e93de42a/packages/core/src/jsx.js#L13). Emotion is pretty popular, and you basically would have to find [this issue](https://github.com/zeit/next.js/issues/9609#issuecomment-561240595) to figure out why this is happening, so I thought adding a note here would help.

**Fifth,** the `forwardRef` example (from https://github.com/zeit/next.js/pull/8428/) was missing `passHref` on `MyButton`.