### PR TITLE
Add Bitbucket Pipelines to errors/no-cache.md

### DIFF
--- a/errors/no-cache.md
+++ b/errors/no-cache.md
@@ -85,7 +85,7 @@ definitions:
     nextcache: .next/cache
 ```
 
-Then reference it in the `step` section of your pipeline: 
+Then reference it in the `caches` section of your pipeline's `step`: 
 
 ```yaml 
 - step:

--- a/errors/no-cache.md
+++ b/errors/no-cache.md
@@ -74,3 +74,23 @@ cache:
     - 'node_modules/**/*' # Cache `node_modules` for faster `yarn` or `npm i`
     - '.next/cache/**/*' # Cache Next.js for faster application rebuilds
 ```
+
+**Bitbucket Pipelines**
+
+Add or merge the following into your `bitbucket-pipelines.yml` at the top level (same level as `pipelines`):
+
+```yaml
+definitions:
+  caches:
+    nextcache: .next/cache
+```
+
+Then reference it in the `step` section of your pipeline: 
+
+```yaml 
+- step:
+    name: your_step_name
+    caches:
+      - node
+      - nextcache
+```


### PR DESCRIPTION
Adds a section on how to configure Bitbucket Pipelines to cache .next/cache on consecutive builds. 