### PR TITLE
Add example with-sentry-easy

### DIFF
--- a/examples/with-sentry-easy/.gitignore
+++ b/examples/with-sentry-easy/.gitignore
@@ -1,0 +1,20 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+
+# Next.js
+/.next
+package-lock.json

--- a/examples/with-sentry-easy/README.md
+++ b/examples/with-sentry-easy/README.md
@@ -1,0 +1,115 @@
+[![Deploy To Now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/zeit/next.js/tree/master/examples/with-sentry-simple)
+
+# Sentry-Easy-Demo
+
+A Next.js Sentry Demo catches && reports client/server/fetch error.
+
+## How To Use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npm init next-app --example with-sentry-simple with-sentry-simple
+# or
+yarn create next-app --example with-sentry-simple with-sentry-simple
+```
+
+### Download Manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-sentry-easy
+cd with-sentry-easy
+```
+
+Install it and run:
+
+**NPM**
+
+```bash
+npm install
+npm run dev
+```
+
+**Yarn**
+
+```bash
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [Now](https://zeit.co/now) ([Download](https://zeit.co/download))
+
+```bash
+now
+```
+
+## About Example
+
+This is a simple example showing how to use [Sentry](https://sentry.io) to catch & report errors on client/server/fetch side.
+
+> This demo is based on the [with-sentry-simple](https://github.com/zeit/next.js/tree/canary/examples/with-sentry-simple). It did some minor optimizations and added some configuration.
+
+- `_app.js` renders on both the server and client. It initializes Sentry to catch any unhandled exceptions
+
+- `_error.js` is rendered by Next.js while handling certain types of exceptions for you. It is overriden so those exceptions can be passed along to Sentry
+
+- `next.config.js` config the envionment variables && enables source maps in production for Sentry and swaps out `@sentry/node` for `@sentry/browser` when building the client bundle
+
+**Note**: Source maps will not be sent to Sentry when running locally (because Sentry cannot access your `localhost`). To accurately test client-side source maps, please deploy to Now.
+
+**Note**: Server-side source maps will not work unless you [manually upload them to Sentry](https://docs.sentry.io/platforms/node/sourcemaps/#making-source-maps-available-to-sentry).
+
+**Note**: Error handling [works differently in production](https://nextjs.org/docs#custom-error-handling). Some exceptions will not be sent to Sentry in development mode (i.e. `npm run dev`).
+
+**Note**: The build output will contain warning about unhandled Promise rejections. This caused by the test pages, and is expected.
+
+**Note**: The version of `@zeit/next-source-maps` (`0.0.4-canary.1`) is important and must be specified since it is not yet the default. Otherwise [source maps will not be generated for the server](https://github.com/zeit/next-plugins/issues/377).
+
+### Configuration
+
+You will need a _Sentry DSN_ for your project. You can get it from the settings of your project in **Client Keys (DSN)**. Then, copy the string labeled **DSN (Public)**.
+
+The Sentry DSN should then be updated in `_app.js`.
+
+```js
+// next.config.js
+env: {
+  SENTRY_DSN: '' // your sentry dsn
+}
+
+// _app.js
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+})
+```
+
+### Disabling Sentry during development
+
+An easy way to disable Sentry while developing is to set its `enabled` flag based off of the `NODE_ENV` environment variable, which is [properly configured by the `next` subcommands](https://nextjs.org/docs#production-deployment).
+
+```js
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  enabled: process.env.NODE_ENV === 'production',
+})
+```
+
+### Hosting source maps vs. uploading them to Sentry
+
+This example shows how to generate your own source maps, which are hosted alongside your JavaScript bundles in production. But that has the potential for innaccurate results in Sentry.
+
+Sentry will attempt to [fetch the source map](https://docs.sentry.io/platforms/javascript/sourcemaps/#hosting--uploading) when it is processing an exception, as long as the "Enable JavaScript source fetching" setting is turned on for your Sentry project.
+
+However, there are some disadvantages with this approach. Sentry has written a blog post about them here: https://blog.sentry.io/2018/07/17/source-code-fetching
+
+If you decide that uploading source maps to Sentry would be better, one approach is to define a custom `now-build` script in your `package.json`. Zeit Now's `@now/next` builder will [call this script](https://github.com/zeit/now/blob/canary/packages/now-next/src/index.ts#L270) for you. You can define what to do after a build there:
+
+```
+"now-build": "next build && node ./post-build.js"
+```
+
+In `./post-build.js` you can `require('@sentry/cli')` and go through the process of creating a Sentry release and [uploading source maps](https://docs.sentry.io/cli/releases/#sentry-cli-sourcemaps), and optionally deleting the `.js.map` files so they are not made public.

--- a/examples/with-sentry-easy/next.config.js
+++ b/examples/with-sentry-easy/next.config.js
@@ -1,0 +1,14 @@
+const withSourceMaps = require('@zeit/next-source-maps')
+
+module.exports = withSourceMaps({
+  env: {
+    SENTRY_DSN: '', // your sentry dsn
+  },
+  webpack: (config, options) => {
+    if (!options.isServer) {
+      config.resolve.alias['@sentry/node'] = '@sentry/browser'
+    }
+
+    return config
+  },
+})

--- a/examples/with-sentry-easy/now.json
+++ b/examples/with-sentry-easy/now.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "name": "with-sentry-easy",
+  "builds": [{ "src": "package.json", "use": "@now/next" }]
+}

--- a/examples/with-sentry-easy/package.json
+++ b/examples/with-sentry-easy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "next-sentry-easy",
+  "version": "1.0.0",
+  "license": "ISC",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@sentry/browser": "^5.11.0",
+    "@sentry/node": "^5.11.0",
+    "isomorphic-unfetch": "^3.0.0",
+    "next": "latest",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "swr": "^0.1.16"
+  },
+  "devDependencies": {
+    "@zeit/next-source-maps": "latest"
+  }
+}

--- a/examples/with-sentry-easy/pages/_app.js
+++ b/examples/with-sentry-easy/pages/_app.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import App from 'next/app'
+import Head from 'next/head'
+import * as Sentry from '@sentry/node'
+
+Sentry.init({
+  // Replace with your project's Sentry DSN
+  dsn: process.env.SENTRY_DSN,
+})
+
+class MyApp extends App {
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {}
+    try {
+      if (Component.getInitialProps) {
+        pageProps = await Component.getInitialProps({ ctx })
+      }
+      return { pageProps }
+    } catch (err) {
+      // This will work on both client and server sides.
+      console.log(
+        'The Error happened in: ',
+        typeof window === 'undefined' ? 'Server' : 'Client'
+      )
+      Sentry.captureException(err)
+      return { pageProps }
+    }
+  }
+
+  render() {
+    const { Component, pageProps, err } = this.props
+    // Pass err to component
+    const modifiedPageProps = { ...pageProps, err }
+    return (
+      <>
+        <style jsx global>{`
+          * {
+            margin: 0;
+            padding: 0;
+          }
+          html,
+          body {
+            background: #e2e3e4;
+          }
+        `}</style>
+        <Head>
+          <title>🐞Next-Sentry-Ease-Demo</title>
+        </Head>
+        <Component {...modifiedPageProps} />
+      </>
+    )
+  }
+}
+
+export default MyApp

--- a/examples/with-sentry-easy/pages/_error.js
+++ b/examples/with-sentry-easy/pages/_error.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Error from 'next/error'
+import * as Sentry from '@sentry/node'
+
+const MyError = ({ statusCode, err }) => {
+  if (err) {
+    // This will work on both client and server sides in production.
+    Sentry.captureException(err)
+  }
+
+  return <Error statusCode={statusCode} />
+}
+
+export default MyError

--- a/examples/with-sentry-easy/pages/client/test1.js
+++ b/examples/with-sentry-easy/pages/client/test1.js
@@ -1,0 +1,7 @@
+const Test1 = () => <h1>Client Test 1</h1>
+
+Test1.getInitialProps = () => {
+  throw new Error('Client Error 1 - initialProps Error')
+}
+
+export default Test1

--- a/examples/with-sentry-easy/pages/client/test2.js
+++ b/examples/with-sentry-easy/pages/client/test2.js
@@ -1,0 +1,6 @@
+const Test2 = () => <h1>Client Test 2</h1>
+
+Test2.getInitialProps = () =>
+  Promise.reject(new Error('Client Error 2 - initialProps Promise Error'))
+
+export default Test2

--- a/examples/with-sentry-easy/pages/client/test3.js
+++ b/examples/with-sentry-easy/pages/client/test3.js
@@ -1,0 +1,12 @@
+const Test3 = () => <h1>Client Test 3</h1>
+
+Test3.getInitialProps = () => {
+  const doAsyncWork = () =>
+    Promise.reject(new Error('Client Error 3 - initialProps Async Error'))
+
+  doAsyncWork()
+
+  return {}
+}
+
+export default Test3

--- a/examples/with-sentry-easy/pages/client/test4.js
+++ b/examples/with-sentry-easy/pages/client/test4.js
@@ -1,0 +1,7 @@
+const doAsyncWork = () =>
+  Promise.reject(new Error('Client Error 4 - didMount Error'))
+doAsyncWork()
+
+const Test4 = () => <h1>Client Test 4</h1>
+
+export default Test4

--- a/examples/with-sentry-easy/pages/client/test5.js
+++ b/examples/with-sentry-easy/pages/client/test5.js
@@ -1,0 +1,15 @@
+import { useState } from 'react'
+export default () => {
+  const [count, setCount] = useState(0)
+  if (count === 5) {
+    throw Error('Client Error 5 - render Error')
+  }
+  return (
+    <div>
+      <h2>
+        Count: <span style={{ color: 'blue' }}>{count}</span>
+      </h2>
+      <button onClick={() => setCount(count => (count += 1))}>Add Count</button>
+    </div>
+  )
+}

--- a/examples/with-sentry-easy/pages/client/test6.js
+++ b/examples/with-sentry-easy/pages/client/test6.js
@@ -1,0 +1,30 @@
+import useSWR from 'swr'
+import unfetch from '../../util/unfetch'
+
+async function fetcher(path) {
+  const data = await unfetch.get(path)
+  return data
+}
+
+function HomePage() {
+  const { data, error } = useSWR(
+    'https://jsonplaceholder.typicode.com/users',
+    fetcher
+  )
+
+  if (error) return <div>failed to load</div>
+  if (!data) return <div>loading...</div>
+  return (
+    <>
+      <h1>If you want report error about xhr. You can follow this repo.</h1>
+      <div>User Total: {data.length}</div>
+      <button
+        onClick={() => unfetch.get('https://jsonplaceholder.typicode.com/user')}
+      >
+        A New Error Fetch
+      </button>
+    </>
+  )
+}
+
+export default HomePage

--- a/examples/with-sentry-easy/pages/index.js
+++ b/examples/with-sentry-easy/pages/index.js
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+
+const Home = () => (
+  <div className="container">
+    <style jsx>{`
+      .container {
+        max-width: 800px;
+        margin: 20px auto;
+        background: #fff;
+        padding: 20px 40px;
+      }
+      a {
+        display: block;
+      }
+    `}</style>
+    <h2>Next-Sentry-Ease</h2>
+    <h3>No Error Normal Page</h3>
+    <div className="link-container">
+      <Link href="/normal">
+        <a>Normal Page</a>
+      </Link>
+    </div>
+    <h3>Client Error</h3>
+    <div className="link-container">
+      <Link href="/client/test1">
+        <a>Client Error 1 - initialProps Error</a>
+      </Link>
+      <Link href="/client/test2">
+        <a>Client Error 2 - initialProps Promise Error</a>
+      </Link>
+      <Link href="/client/test3">
+        <a>Client Error 3 - initialProps Async Error</a>
+      </Link>
+      <Link href="/client/test4">
+        <a>Client Error 4 - didMount Error</a>
+      </Link>
+      <Link href="/client/test5">
+        <a>Client Error 5 - render Error</a>
+      </Link>
+      <Link href="/client/test6">
+        <a>Client Error 6 - client Fetch Error</a>
+      </Link>
+    </div>
+    <h3>Server Error</h3>
+    <div className="link-container">
+      <a target="_blank" href="/server/test1">
+        Server Error 1 - initialProps Error
+      </a>
+      <a target="_blank" href="/server/test2">
+        Server Error 2 - initialProps Promise Error
+      </a>
+      <a target="_blank" href="/server/test3">
+        Server Error 3 - initialProps Async Error
+      </a>
+      <a target="_blank" href="/server/test4">
+        Server Error 4 - server Fetch Error
+      </a>
+    </div>
+  </div>
+)
+export default Home

--- a/examples/with-sentry-easy/pages/normal.js
+++ b/examples/with-sentry-easy/pages/normal.js
@@ -1,0 +1,1 @@
+export default () => <h1>I'm normal Page～</h1>

--- a/examples/with-sentry-easy/pages/server/test1.js
+++ b/examples/with-sentry-easy/pages/server/test1.js
@@ -1,0 +1,7 @@
+const Test1 = () => <h1>Server Test 1</h1>
+
+Test1.getInitialProps = () => {
+  throw new Error('Server Test 1')
+}
+
+export default Test1

--- a/examples/with-sentry-easy/pages/server/test2.js
+++ b/examples/with-sentry-easy/pages/server/test2.js
@@ -1,0 +1,5 @@
+const Test2 = () => <h1>Server Test 2 - Promise Error</h1>
+
+Test2.getInitialProps = () => Promise.reject(new Error('Server Test 2'))
+
+export default Test2

--- a/examples/with-sentry-easy/pages/server/test3.js
+++ b/examples/with-sentry-easy/pages/server/test3.js
@@ -1,0 +1,11 @@
+const Test3 = () => <h1>Server Test 3 - initialProps Async Error</h1>
+
+Test3.getInitialProps = () => {
+  const doAsyncWork = () => Promise.reject(new Error('Server Test 3'))
+
+  doAsyncWork()
+
+  return {}
+}
+
+export default Test3

--- a/examples/with-sentry-easy/pages/server/test4.js
+++ b/examples/with-sentry-easy/pages/server/test4.js
@@ -1,0 +1,12 @@
+import unfetch from '../../util/unfetch'
+
+function HomePage({ user }) {
+  return <div>user count: {user.length}</div>
+}
+
+HomePage.getInitialProps = async () => {
+  const data = await unfetch.get('https://jsonplaceholder.typicode.com/user')
+  return { user: data }
+}
+
+export default HomePage

--- a/examples/with-sentry-easy/util/FetchError.js
+++ b/examples/with-sentry-easy/util/FetchError.js
@@ -1,0 +1,20 @@
+class FetchError extends Error {
+  constructor(url = 'http://localhost', props) {
+    super(props)
+    const { message, traceId, userId } = props
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, FetchError)
+    }
+
+    this.name = 'FetchError'
+    // Custom debugging information
+    this.url = url
+    this.message = message
+    traceId && (this.traceId = traceId)
+    userId && (this.userId = userId)
+    this.date = new Date()
+  }
+}
+
+export default FetchError

--- a/examples/with-sentry-easy/util/unfetch.js
+++ b/examples/with-sentry-easy/util/unfetch.js
@@ -1,0 +1,55 @@
+import fetch from 'isomorphic-unfetch'
+import * as Sentry from '@sentry/node'
+import FetchError from './FetchError'
+
+function dealStatus(res) {
+  if (res.status !== 200) {
+    const err = new FetchError(res.url, {
+      traceId: Math.random() * 10000, // create your application traceId
+      userId: 26,
+      message: `${
+        typeof window !== 'undefined' ? 'Client' : 'Server'
+      } fetch error: ${res.status}`,
+    })
+    // This will work on both client and server sides in production.
+    Sentry.captureException(err)
+  }
+  return res
+}
+
+// initial fetch
+const unfetch = Object.create(null)
+
+// ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PATCH', 'PUT']
+const HTTP_METHOD = ['get', 'post', 'put', 'patch', 'delete']
+
+// can send data method
+const BODY_METHOD = ['post', 'put', 'delete', 'patch']
+
+HTTP_METHOD.forEach(method => {
+  // is can send data in opt.body
+  const bodyData = BODY_METHOD.includes(method)
+  unfetch[method] = (path, { data } = {}) => {
+    let url = path
+    const opts = {
+      method,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      mode: 'cors',
+      cache: 'no-cache',
+    }
+
+    if (bodyData && data) {
+      opts.body = JSON.stringify(data)
+    }
+
+    console.info('Request Url:', url)
+
+    return fetch(url, opts)
+      .then(dealStatus)
+      .then(res => res.json())
+  }
+})
+
+export default unfetch


### PR DESCRIPTION
Hello,
This demo is based on the [with-sentry-simple](https://github.com/zeit/next.js/tree/canary/examples/with-sentry-simple) and make some optimizations && config. The reasons for adding this demo are as follows：

 - [with-sentry-simple](https://github.com/zeit/next.js/tree/canary/examples/with-sentry-simple) - The demo did not successfully report the server error. Only client errors can be reported after configuration.

 -  Sentry did not catch && report fetch error. So i config a simple fetch error demo both client/server simply.

The following screenshots are some of the Demo screenshots that I ran locally：

- issue list - client/server/fetch error
<img width="1209" alt="图片" src="https://user-images.githubusercontent.com/17840558/72978810-10c68300-3e12-11ea-9b31-13985d74bce4.png">

- issue detail
<img width="840" alt="图片" src="https://user-images.githubusercontent.com/17840558/72979587-a282c000-3e13-11ea-8cd5-dc8cede77946.png">

- email alert
<img width="1112" alt="图片" src="https://user-images.githubusercontent.com/17840558/72979645-c3e3ac00-3e13-11ea-9252-1ed580b47a20.png">


