### PR TITLE
Revert "feat(build): Transpile assuming higher version of runtime"

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -156,7 +156,6 @@ module.exports = (
           helpers: true,
           regenerator: true,
           useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
-          version: require('@babel/runtime-corejs2/package.json').version,
           absoluteRuntime: (process.versions as any).pnp
             ? __dirname
             : undefined,


### PR DESCRIPTION
Reverts zeit/next.js#9511

This [removes the polyfillying of the `Math` object](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-runtime/src/runtime-corejs2-definitions.js#L6).

This has never been polyfilled previously, nor in a stable.