### PR TITLE
Tweak export test to be more stable

### DIFF
--- a/test/integration/export-serverless/pages/index.js
+++ b/test/integration/export-serverless/pages/index.js
@@ -40,7 +40,7 @@ export default () => (
         <a id="level1-about-page">Level1 about page</a>
       </Link>
       <Link href="/dynamic-imports">
-        <a id="dynamic-imports-page">Dynamic imports page</a>
+        <a id="dynamic-imports-link">Dynamic imports page</a>
       </Link>
     </div>
     <p>This is the home page</p>

--- a/test/integration/export-serverless/test/browser.js
+++ b/test/integration/export-serverless/test/browser.js
@@ -133,12 +133,12 @@ export default function(context) {
     it('should render dynamic import components in the client', async () => {
       const browser = await webdriver(context.port, '/')
       await browser
-        .elementByCss('#dynamic-imports-page')
+        .elementByCss('#dynamic-imports-link')
         .click()
         .waitForElementByCss('#dynamic-imports-page')
 
       await check(
-        () => browser.elementByCss('#dynamic-imports-page p').text(),
+        () => getBrowserBodyText(browser),
         /Welcome to dynamic imports/
       )
 

--- a/test/integration/export/pages/index.js
+++ b/test/integration/export/pages/index.js
@@ -40,7 +40,7 @@ export default () => (
         <a id="level1-about-page">Level1 about page</a>
       </Link>
       <Link href="/dynamic-imports">
-        <a id="dynamic-imports-page">Dynamic imports page</a>
+        <a id="dynamic-imports-link">Dynamic imports page</a>
       </Link>
     </div>
     <p>This is the home page</p>

--- a/test/integration/export/test/browser.js
+++ b/test/integration/export/test/browser.js
@@ -140,12 +140,12 @@ export default function(context) {
     it('should render dynamic import components in the client', async () => {
       const browser = await webdriver(context.port, '/')
       await browser
-        .elementByCss('#dynamic-imports-page')
+        .elementByCss('#dynamic-imports-link')
         .click()
         .waitForElementByCss('#dynamic-imports-page')
 
       await check(
-        () => browser.elementByCss('#dynamic-imports-page p').text(),
+        () => getBrowserBodyText(browser),
         /Welcome to dynamic imports/
       )
 


### PR DESCRIPTION
This is failing on Azure randomly and seems like it could be due to the selectors being used in the test since it uses the same id for the page as the link to navigate to the page