### PR TITLE
De-dupe escape-regex with escape-string-regexp

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../next-server/lib/constants'
 import { isDynamicRoute } from '../../../next-server/lib/router/utils'
 import { API_ROUTE } from '../../../lib/constants'
+import escapeRegexp from 'escape-string-regexp'
 
 export type ServerlessLoaderQuery = {
   page: string
@@ -46,7 +47,7 @@ const nextServerlessLoader: loader.Loader = function() {
   )
   const routesManifest = join(distDir, ROUTES_MANIFEST).replace(/\\/g, '/')
 
-  const escapedBuildId = buildId.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&')
+  const escapedBuildId = escapeRegexp(buildId)
   const pageIsDynamicRoute = isDynamicRoute(page)
 
   const dynamicRouteImports = pageIsDynamicRoute

--- a/packages/next/next-server/lib/router/utils/route-regex.ts
+++ b/packages/next/next-server/lib/router/utils/route-regex.ts
@@ -1,3 +1,5 @@
+import escapeRegexp from 'escape-string-regexp'
+
 export function getRouteRegex(
   normalizedRoute: string
 ): {
@@ -5,10 +7,7 @@ export function getRouteRegex(
   groups: { [groupName: string]: { pos: number; repeat: boolean } }
 } {
   // Escape all characters that could be considered RegEx
-  const escapedRoute = (normalizedRoute.replace(/\/$/, '') || '/').replace(
-    /[|\\{}()[\]^$+*?.-]/g,
-    '\\$&'
-  )
+  const escapedRoute = escapeRegexp(normalizedRoute.replace(/\/$/, '') || '/')
 
   const groups: { [groupName: string]: { pos: number; repeat: boolean } } = {}
   let groupIndex = 1

--- a/packages/next/next-server/lib/router/utils/route-regex.ts
+++ b/packages/next/next-server/lib/router/utils/route-regex.ts
@@ -1,5 +1,3 @@
-import escapeRegexp from 'escape-string-regexp'
-
 export function getRouteRegex(
   normalizedRoute: string
 ): {
@@ -7,7 +5,10 @@ export function getRouteRegex(
   groups: { [groupName: string]: { pos: number; repeat: boolean } }
 } {
   // Escape all characters that could be considered RegEx
-  const escapedRoute = escapeRegexp(normalizedRoute.replace(/\/$/, '') || '/')
+  const escapedRoute = (normalizedRoute.replace(/\/$/, '') || '/').replace(
+    /[|\\{}()[\]^$+*?.-]/g,
+    '\\$&'
+  )
 
   const groups: { [groupName: string]: { pos: number; repeat: boolean } } = {}
   let groupIndex = 1

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -92,6 +92,7 @@
     "css-loader": "3.3.0",
     "cssnano-simple": "1.0.0",
     "devalue": "2.0.1",
+    "escape-string-regexp": "2.0.0",
     "etag": "1.8.1",
     "file-loader": "4.2.0",
     "find-up": "4.0.0",

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -6,6 +6,7 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
+import escapeRegex from 'escape-string-regexp'
 import {
   launchApp,
   killApp,
@@ -28,8 +29,6 @@ let buildId
 let stdout = ''
 let appPort
 let app
-
-const escapeRegex = str => str.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&')
 
 const runTests = (isDev = false) => {
   it('should handle one-to-one rewrite successfully', async () => {

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -2,8 +2,9 @@
 /* global jasmine */
 import fs from 'fs-extra'
 import { join } from 'path'
-import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'
+import webdriver from 'next-webdriver'
+import escapeRegex from 'escape-string-regexp'
 import {
   renderViaHTTP,
   fetchViaHTTP,
@@ -410,7 +411,7 @@ const runTests = (dev = false) => {
       const manifest = JSON.parse(
         await fs.readFile(join(appDir, '.next/prerender-manifest.json'), 'utf8')
       )
-      const escapedBuildId = buildId.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&')
+      const escapedBuildId = escapeRegex(buildId)
 
       Object.keys(manifest.dynamicRoutes).forEach(key => {
         const item = manifest.dynamicRoutes[key]


### PR DESCRIPTION
We were duplicating the regex for escaping in multiple places so it looks like it's time to use the package to de-dupe these

x-ref: https://github.com/zeit/next.js/pull/10077#discussion_r370819967