### PR TITLE
Update SSG types and clean up RenderOpts type

### DIFF
--- a/packages/next/build/babel/plugins/next-page-config.ts
+++ b/packages/next/build/babel/plugins/next-page-config.ts
@@ -1,6 +1,6 @@
 import { NodePath, PluginObj } from '@babel/core'
 import * as BabelTypes from '@babel/types'
-import { PageConfig } from '../../../types'
+import { PageConfig } from 'next/types'
 
 const configKeys = new Set(['amp'])
 const STRING_LITERAL_DROP_BUNDLE = '__NEXT_DROP_CLIENT_FILE__'

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -3,7 +3,7 @@ import { ParsedUrlQuery } from 'querystring'
 import { ComponentType } from 'react'
 import { format, URLFormatOptions, UrlObject } from 'url'
 
-import { ManifestItem } from '../server/render'
+import { ManifestItem } from '../server/load-components'
 import { NextRouter } from './router/router'
 
 /**

--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -4,7 +4,7 @@ import { Stream } from 'stream'
 import getRawBody from 'raw-body'
 import { parse } from 'content-type'
 import { Params } from './router'
-import { PageConfig } from '../../types'
+import { PageConfig } from 'next/types'
 import { interopDefault } from './load-components'
 import { isResSent } from '../lib/utils'
 

--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -6,14 +6,10 @@ import {
 } from '../lib/constants'
 import { join } from 'path'
 import { requirePage } from './require'
+import { ParsedUrlQuery } from 'querystring'
 import { BuildManifest } from './get-page-files'
 import { AppType, DocumentType } from '../lib/utils'
-import {
-  PageConfig,
-  Unstable_getStaticPaths,
-  Unstable_getStaticProps,
-  NextPageContext,
-} from 'next/types'
+import { PageConfig, NextPageContext } from 'next/types'
 
 export function interopDefault(mod: any) {
   return mod.default || mod
@@ -27,6 +23,15 @@ export type ManifestItem = {
 }
 
 type ReactLoadableManifest = { [moduleId: string]: ManifestItem[] }
+
+type Unstable_getStaticProps = (params: {
+  params: ParsedUrlQuery | undefined
+}) => Promise<{
+  props: { [key: string]: any }
+  revalidate?: number | boolean
+}>
+
+type Unstable_getStaticPaths = () => Promise<Array<string | ParsedUrlQuery>>
 
 export type LoadComponentsReturnType = {
   Component: React.ComponentType

--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -5,28 +5,39 @@ import {
   SERVER_DIRECTORY,
 } from '../lib/constants'
 import { join } from 'path'
-import { PageConfig } from '../../types'
 import { requirePage } from './require'
+import { BuildManifest } from './get-page-files'
+import { AppType, DocumentType } from '../lib/utils'
+import {
+  PageConfig,
+  Unstable_getStaticPaths,
+  Unstable_getStaticProps,
+  NextPageContext,
+} from 'next/types'
 
 export function interopDefault(mod: any) {
   return mod.default || mod
 }
 
+export type ManifestItem = {
+  id: number | string
+  name: string
+  file: string
+  publicPath: string
+}
+
+type ReactLoadableManifest = { [moduleId: string]: ManifestItem[] }
+
 export type LoadComponentsReturnType = {
-  Component: any
-  pageConfig: PageConfig
-  unstable_getStaticProps?: (params: {
-    params: any
-  }) => {
-    props: any
-    revalidate?: number | boolean
-  }
-  unstable_getStaticPaths?: () => void
-  buildManifest?: any
-  reactLoadableManifest?: any
-  Document?: any
-  DocumentMiddleware?: any
-  App?: any
+  Component: React.ComponentType
+  pageConfig?: PageConfig
+  buildManifest: BuildManifest
+  reactLoadableManifest: ReactLoadableManifest
+  Document: DocumentType
+  DocumentMiddleware?: (ctx: NextPageContext) => void
+  App: AppType
+  unstable_getStaticProps?: Unstable_getStaticProps
+  unstable_getStaticPaths?: Unstable_getStaticPaths
 }
 
 export async function loadComponents(
@@ -42,7 +53,7 @@ export async function loadComponents(
       pageConfig: Component.config || {},
       unstable_getStaticProps: Component.unstable_getStaticProps,
       unstable_getStaticPaths: Component.unstable_getStaticPaths,
-    }
+    } as LoadComponentsReturnType
   }
   const documentPath = join(
     distDir,

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -863,7 +863,7 @@ export default class Server {
     // check request state
     const isLikeServerless =
       typeof result.Component === 'object' &&
-      typeof result.Component.renderReqToHTML === 'function'
+      typeof (result.Component as any).renderReqToHTML === 'function'
     const isSSG = !!result.unstable_getStaticProps
 
     // non-spr requests should render like normal
@@ -871,7 +871,7 @@ export default class Server {
       // handle serverless
       if (isLikeServerless) {
         this.prepareServerlessUrl(req, query)
-        return result.Component.renderReqToHTML(req, res)
+        return (result.Component as any).renderReqToHTML(req, res)
       }
 
       return renderToHTML(req, res, pathname, query, {
@@ -929,7 +929,11 @@ export default class Server {
       let renderResult
       // handle serverless
       if (isLikeServerless) {
-        renderResult = await result.Component.renderReqToHTML(req, res, true)
+        renderResult = await (result.Component as any).renderReqToHTML(
+          req,
+          res,
+          true
+        )
 
         html = renderResult.html
         pageData = renderResult.renderOpts.pageData

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -14,31 +14,19 @@ import {
   NextComponentType,
   DocumentType,
   AppType,
-  NextPageContext,
 } from '../lib/utils'
 import Head, { defaultHead } from '../lib/head'
-// @ts-ignore types will be added later as it's an internal module
 import Loadable from '../lib/loadable'
 import { LoadableContext } from '../lib/loadable-context'
 import { RouterContext } from '../lib/router-context'
-import { getPageFiles, BuildManifest } from './get-page-files'
+import { getPageFiles } from './get-page-files'
 import { AmpStateContext } from '../lib/amp-context'
 import optimizeAmp from './optimize-amp'
 import { isInAmpMode } from '../lib/amp'
-// Uses a module path because of the compiled output directory location
-import { PageConfig } from 'next/types'
 import { isDynamicRoute } from '../lib/router/utils/is-dynamic'
 import { SSG_GET_INITIAL_PROPS_CONFLICT } from '../../lib/constants'
 import { AMP_RENDER_TARGET } from '../lib/constants'
-
-export type ManifestItem = {
-  id: number | string
-  name: string
-  file: string
-  publicPath: string
-}
-
-type ReactLoadableManifest = { [moduleId: string]: ManifestItem[] }
+import { LoadComponentsReturnType, ManifestItem } from './load-components'
 
 function noRouter() {
   const message =
@@ -122,8 +110,7 @@ function render(
   return { html, head }
 }
 
-type RenderOpts = {
-  documentMiddlewareEnabled: boolean
+type RenderOpts = LoadComponentsReturnType & {
   staticMarkup: boolean
   buildId: string
   canonicalBase: string
@@ -139,22 +126,9 @@ type RenderOpts = {
   ampPath?: string
   inAmpMode?: boolean
   hybridAmp?: boolean
-  buildManifest: BuildManifest
-  reactLoadableManifest: ReactLoadableManifest
-  pageConfig: PageConfig
-  Component: React.ComponentType
-  Document: DocumentType
-  DocumentMiddleware: (ctx: NextPageContext) => void
-  App: AppType
   ErrorDebug?: React.ComponentType<{ error: Error }>
   ampValidator?: (html: string, pathname: string) => Promise<void>
-  unstable_getStaticProps?: (params: {
-    params: any | undefined
-  }) => {
-    props: any
-    revalidate?: number | boolean
-  }
-  unstable_getStaticPaths?: () => void
+  documentMiddlewareEnabled?: boolean
 }
 
 function renderDocument(

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -3,7 +3,6 @@
 /// <reference types="react-dom" />
 
 import React from 'react'
-import { ParsedUrlQuery } from 'querystring'
 
 import {
   NextPageContext,
@@ -55,16 +54,5 @@ export type PageConfig = {
 }
 
 export { NextPageContext, NextComponentType, NextApiResponse, NextApiRequest }
-
-export type Unstable_getStaticProps = (params: {
-  params: ParsedUrlQuery | undefined
-}) => Promise<{
-  props: { [key: string]: any }
-  revalidate?: number | boolean
-}>
-
-export type Unstable_getStaticPaths = () => Promise<
-  Array<string | { [key: string]: string | string[] }>
->
 
 export default next

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -3,6 +3,7 @@
 /// <reference types="react-dom" />
 
 import React from 'react'
+import { ParsedUrlQuery } from 'querystring'
 
 import {
   NextPageContext,
@@ -54,5 +55,16 @@ export type PageConfig = {
 }
 
 export { NextPageContext, NextComponentType, NextApiResponse, NextApiRequest }
+
+export type Unstable_getStaticProps = (params: {
+  params: ParsedUrlQuery | undefined
+}) => Promise<{
+  props: { [key: string]: any }
+  revalidate?: number | boolean
+}>
+
+export type Unstable_getStaticPaths = () => Promise<
+  Array<string | { [key: string]: string | string[] }>
+>
 
 export default next


### PR DESCRIPTION
This updates the SSG types and also exposes them under `next` so that they can be imported elsewhere. It also de-dupes the types between `LoadComponentsReturnType` and `RenderOpts`

x-ref: https://github.com/zeit/next.js/pull/10077#discussion_r370822860