### PR TITLE
Update static check vars and fix types

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -53,6 +53,7 @@ import { generateBuildId } from './generate-build-id'
 import { isWriteable } from './is-writeable'
 import createSpinner from './spinner'
 import {
+  isPageStatic,
   collectPages,
   getPageSizeInKb,
   hasCustomAppGetInitialProps,
@@ -416,7 +417,8 @@ export default async function build(dir: string, conf = null): Promise<void> {
   const staticCheckWorkers = new Worker(staticCheckWorker, {
     numWorkers: config.experimental.cpus,
     enableWorkerThreads: config.experimental.workerThreads,
-  })
+  }) as Worker & { isPageStatic: typeof isPageStatic }
+
   staticCheckWorkers.getStdout().pipe(process.stdout)
   staticCheckWorkers.getStderr().pipe(process.stderr)
 
@@ -481,7 +483,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
 
       if (nonReservedPage) {
         try {
-          let result: any = await (staticCheckWorkers as any).isPageStatic(
+          let result = await staticCheckWorkers.isPageStatic(
             page,
             serverBundle,
             runtimeEnvConfig
@@ -492,7 +494,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
             hybridAmpPages.add(page)
           }
 
-          if (result.prerender) {
+          if (result.hasStaticProps) {
             ssgPages.add(page)
             isSsg = true
 
@@ -500,7 +502,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
               additionalSsgPaths.set(page, result.prerenderRoutes)
               ssgPageRoutes = result.prerenderRoutes
             }
-          } else if (result.static && customAppGetInitialProps === false) {
+          } else if (result.isStatic && customAppGetInitialProps === false) {
             staticPages.add(page)
             isStatic = true
           }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -479,9 +479,9 @@ export async function isPageStatic(
   serverBundle: string,
   runtimeEnvConfig: any
 ): Promise<{
-  static?: boolean
-  prerender?: boolean
+  isStatic?: boolean
   isHybridAmp?: boolean
+  hasStaticProps?: boolean
   prerenderRoutes?: string[] | undefined
 }> {
   try {
@@ -593,10 +593,10 @@ export async function isPageStatic(
 
     const config = mod.config || {}
     return {
-      static: !hasStaticProps && !hasGetInitialProps,
+      isStatic: !hasStaticProps && !hasGetInitialProps,
       isHybridAmp: config.amp === 'hybrid',
       prerenderRoutes: prerenderPaths,
-      prerender: hasStaticProps,
+      hasStaticProps,
     }
   } catch (err) {
     if (err.code === 'MODULE_NOT_FOUND') return {}


### PR DESCRIPTION
This updates the names returned from `isPageStatic` to be more clear and also fixes the type on the `staticCheckWorkers` to show the correct return type

x-ref: [comment](https://github.com/zeit/next.js/pull/10077/files/55e05fca05d79190bc8f3ee720f9d2c99d236ef2#r370820332)