### PR TITLE
Update _next/data URL handling in serverless-loader

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -215,13 +215,14 @@ const nextServerlessLoader: loader.Loader = function() {
       }
       let _nextData = false
 
-      if (req.url.match(/_next\\/data/)) {
+      const parsedUrl = handleRewrites(parse(req.url, true))
+
+      if (parsedUrl.pathname.match(/_next\\/data/)) {
         _nextData = true
-        req.url = req.url
+        parsedUrl.pathname = parsedUrl.pathname
           .replace(new RegExp('/_next/data/${escapedBuildId}/'), '/')
           .replace(/\\.json$/, '')
       }
-      const parsedUrl = handleRewrites(parse(req.url, true))
 
       const renderOpts = Object.assign(
         {

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -264,6 +264,16 @@ const runTests = (dev = false) => {
     expect(JSON.parse(params)).toEqual({})
   })
 
+  it('should not supply query values to params in /_next/data request', async () => {
+    const data = JSON.parse(
+      await renderViaHTTP(
+        appPort,
+        `/_next/data/${buildId}/something.json?hello=world`
+      )
+    )
+    expect(data.pageProps.params).toEqual({})
+  })
+
   it('should not supply query values to params or useRouter dynamic page SSR', async () => {
     const html = await renderViaHTTP(appPort, '/blog/post-1?hello=world')
     const $ = cheerio.load(html)
@@ -579,7 +589,7 @@ describe('SPR Prerender', () => {
       await nextBuild(appDir)
       stderr = ''
       appPort = await findPort()
-      app = nextStart(appDir, appPort, {
+      app = await nextStart(appDir, appPort, {
         onStderr: msg => {
           stderr += msg
         },


### PR DESCRIPTION
This updates to run the URL through `handleRewrites` before we handle stripping the `_next/data` path from the URL. I also added a test to make sure the query is ignored for `_next/data` requests in the prerender suite

x-ref: [comment](https://github.com/zeit/next.js/pull/10077/files/55e05fca05d79190bc8f3ee720f9d2c99d236ef2#r370820968)