### PR TITLE
Update FaunaDB Example Instructions

### DIFF
--- a/examples/with-graphql-faunadb/README.md
+++ b/examples/with-graphql-faunadb/README.md
@@ -16,7 +16,7 @@ By importing a `.gql` or `.graphql` schema into FaunaDB ([see our sample schema 
 
 You can start with this template [using `create-next-app`](#using-create-next-app) or by [downloading the repository manually](#download-manually).
 
-To use a live FaunaDB database, create a database at [dashboard.fauna.com](https://dashboard.fauna.com/) and generate a server token by going to the **Security** tab on the left and then click **New Key**. Give the new key a name and select the 'Server' Role. Copy the token since the setup script will ask for it. Do not use it in the frontend, it has superpowers which you don't want to give to your users.
+To use a live FaunaDB database, create a database at [dashboard.fauna.com](https://dashboard.fauna.com/) and generate an admin token by going to the **Security** tab on the left and then click **New Key**. Give the new key a name and select the 'Admin' Role. Copy the token since the setup script will ask for it. Do not use it in the frontend, it has superpowers which you don't want to give to your users.
 
 The database can then be set up with the delivered setup by running:
 
@@ -24,7 +24,7 @@ The database can then be set up with the delivered setup by running:
 yarn setup
 ```
 
-This script will ask for the server token. Once you provide it with a valid token, this is what the script automatically does for you:
+This script will ask for the admin token. Once you provide it with a valid token, this is what the script automatically does for you:
 
 - **Import the GraphQL schema**, by importing a GraphQL schema in FaunaDB, FaunaDB automatically sets up collections and indexes to support your queries. This is now done for you with this script but can also be done from the [dashboard.fauna.com](https://dashboard.fauna.com/) UI by going to the GraphQL tab
 - **Create a role suitable for the Client**, FaunaDB has a security system that allows you to define which resources can be accessed for a specific token. That's how we limit our clients powers, feel free to look at the scripts/setup.js script to see how we make roles and tokens.

--- a/examples/with-graphql-faunadb/scripts/setup.js
+++ b/examples/with-graphql-faunadb/scripts/setup.js
@@ -11,13 +11,13 @@ const readline = require('readline').createInterface({
   output: process.stdout,
 })
 
-// In order to set up a database, we need a server key, so let's ask the user for a key.
-readline.question(`Please provide the FaunaDB server key\n`, serverKey => {
+// In order to set up a database, we need an admin key, so let's ask the user for a key.
+readline.question(`Please provide the FaunaDB admin key\n`, adminKey => {
   // A graphql schema can be imported in override or merge mode: 'https://docs.fauna.com/fauna/current/api/graphql/endpoints#import'
   const options = {
     model: 'merge',
     uri: 'https://graphql.fauna.com/import',
-    headers: { Authorization: `Bearer ${serverKey}` },
+    headers: { Authorization: `Bearer ${adminKey}` },
   }
   const stream = fs.createReadStream('./schema.gql').pipe(request.post(options))
 
@@ -44,7 +44,7 @@ readline.question(`Please provide the FaunaDB server key\n`, serverKey => {
     .then(res => {
       // The GraphQL schema is important, this means that we now have a GuestbookEntry Colleciton and an entries index.
       // Then we create a token that can only read and write to that index and collection
-      var client = new faunadb.Client({ secret: serverKey })
+      var client = new faunadb.Client({ secret: adminKey })
       return client
         .query(
           q.CreateRole({
@@ -81,7 +81,7 @@ readline.question(`Please provide the FaunaDB server key\n`, serverKey => {
     .then(res => {
       // The GraphQL schema is important, this means that we now have a GuestbookEntry Colleciton and an entries index.
       // Then we create a token that can only read and write to that index and collection
-      var client = new faunadb.Client({ secret: serverKey })
+      var client = new faunadb.Client({ secret: adminKey })
       return client
         .query(
           q.CreateKey({


### PR DESCRIPTION
This PR updates the instructions in the FaunaDB example to use an 'Admin' rather than 'Server' key.