### PR TITLE
Update exiting after tests for Azure

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -224,4 +224,7 @@ const TIMINGS_API = `https://next-timings.jjsweb.site/api/timings`
       }
     }
   }
+  // Make sure to exit cleanly since all tests should have passed
+  // by this point and Azure seems to hang here
+  process.exit(0)
 })()


### PR DESCRIPTION
It seems Azure sometimes hangs after running tests so this attempts to correct that by exiting the process with a clean status manually

Examples of hanging in Azure after passed tests:
https://dev.azure.com/nextjs/next.js/_build/results?buildId=10679&view=logs&j=3749cca0-f3be-5f0b-32a0-2c678fa6f943
https://dev.azure.com/nextjs/next.js/_build/results?buildId=10677&view=logs&jobId=1fe7eece-edc1-55e3-9374-3ca58f5db4df