### PR TITLE
[WIP] Update publish script and checks for jobs

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -102,12 +102,14 @@ jobs:
     # needs: [build, testAll]
     steps:
       - run: ([[ ! -z $NPM_TOKEN ]] && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc) || echo "Did not write npm token"
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publishRelease:
     name: Potentially publish release
     runs-on: ubuntu-latest
     needs: saveNpmToken
     steps:
-      - run: if [ -z "${{ secrets.NPM_TOKEN }}" ];then exit 0;fi
+      - run: if [ -z "" ];then exit 0;fi
       # - run: ./publish-release.sh
       - run: echo 'publishing release'

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -110,5 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: saveNpmToken
     steps:
-      - run: if [ -z "" ];then exit 0;fi
+      - run: if [ -z $NPM_TOKEN ];then exit 0;fi
       - run: ./publish-release.sh
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [canary]
+    branches: [canary, test-actions]
   pull_request:
     types: [opened, synchronize]
 
@@ -108,4 +108,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: saveNpmToken
     steps:
-      - run: ./publish-release.sh
+      # - run: ./publish-release.sh
+      - run: echo 'publishing release'

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -99,7 +99,7 @@ jobs:
   saveNpmToken:
     name: Potentially save npm token
     runs-on: ubuntu-latest
-    needs: [build, testAll]
+    # needs: [build, testAll]
     steps:
       - run: ([[ ! -z $NPM_TOKEN ]] && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc) || echo "Did not write npm token"
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -80,7 +80,7 @@ jobs:
     name: Test Safari (production)
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'canary'
+    if: secrets.BROWSERSTACK_ACCESS_KEY
     steps:
       - uses: actions/cache@v1
         id: restore-build
@@ -98,7 +98,7 @@ jobs:
   saveNpmToken:
     name: Potentially save npm token
     runs-on: ubuntu-latest
-    if: github.ref == 'canary'
+    if: secrets.NPM_TOKEN
     needs: [build, testAll]
     steps:
       - run: ([[ ! -z $NPM_TOKEN ]] && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc) || echo "Did not write npm token"

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -80,8 +80,9 @@ jobs:
     name: Test Safari (production)
     runs-on: ubuntu-latest
     needs: build
-    if: secrets.BROWSERSTACK_ACCESS_KEY
     steps:
+      - run: if [ -z "${{ secrets.BROWSERSTACK_ACCESS_KEY }}" ];then exit 0;fi
+
       - uses: actions/cache@v1
         id: restore-build
         with:
@@ -98,7 +99,6 @@ jobs:
   saveNpmToken:
     name: Potentially save npm token
     runs-on: ubuntu-latest
-    if: secrets.NPM_TOKEN
     needs: [build, testAll]
     steps:
       - run: ([[ ! -z $NPM_TOKEN ]] && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc) || echo "Did not write npm token"
@@ -108,5 +108,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: saveNpmToken
     steps:
+      - run: if [ -z "${{ secrets.NPM_TOKEN }}" ];then exit 0;fi
       # - run: ./publish-release.sh
       - run: echo 'publishing release'

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - run: if [ -z "${{ secrets.BROWSERSTACK_ACCESS_KEY }}" ];then exit 0;fi
+      - run: if [ -z $BROWSERSTACK_ACCESS_KEY ];then exit 0;fi
 
       - uses: actions/cache@v1
         id: restore-build
@@ -99,7 +99,7 @@ jobs:
   saveNpmToken:
     name: Potentially save npm token
     runs-on: ubuntu-latest
-    # needs: [build, testAll]
+    needs: [build, testAll]
     steps:
       - run: ([[ ! -z $NPM_TOKEN ]] && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc) || echo "Did not write npm token"
     env:
@@ -111,5 +111,4 @@ jobs:
     needs: saveNpmToken
     steps:
       - run: if [ -z "" ];then exit 0;fi
-      # - run: ./publish-release.sh
-      - run: echo 'publishing release'
+      - run: ./publish-release.sh

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [canary, test-actions]
+    branches: [canary]
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - run: if [ -z $BROWSERSTACK_ACCESS_KEY ];then exit 0;fi
+      - run: if [ -z $BROWSERSTACK_ACCESS_KEY ];then exit 0;else echo 'not empty';fi
 
       - uses: actions/cache@v1
         id: restore-build
@@ -111,6 +111,7 @@ jobs:
     needs: saveNpmToken
     steps:
       - run: if [ -z $NPM_TOKEN ];then exit 0;fi
-      - run: ./publish-release.sh
+      - run: echo 'running publish'
+      # - run: ./publish-release.sh
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -4,8 +4,8 @@ if
   ls ~/.npmrc >/dev/null 2>&1 &&
   [[ $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];
 then
-  # yarn run lerna publish from-git --npm-tag canary --yes
-  echo "publishing canary"
+  echo "Publishing canary"
+  yarn run lerna publish from-git --npm-tag canary --yes
 else
   echo "Did not publish canary"
 fi
@@ -14,8 +14,8 @@ if
   ls ~/.npmrc >/dev/null 2>&1 &&
   [[ ! $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];
 then
-  # yarn run lerna publish from-git --yes
-  echo "publishing stable"
+  echo "Publishing stable"
+  yarn run lerna publish from-git --yes
 else
   echo "Did not publish stable"
 fi

--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -81,7 +81,7 @@ describe('Production response size', () => {
     )
 
     // These numbers are without gzip compression!
-    const delta = responseSizeKilobytes - 233
+    const delta = responseSizeKilobytes - 234
     expect(delta).toBeLessThanOrEqual(0) // don't increase size
     expect(delta).toBeGreaterThanOrEqual(-1) // don't decrease size without updating target
   })


### PR DESCRIPTION
This updates the jobs to run on canary successfully since the `github.ref` value appears to be the tag which makes it harder to check against so instead we check if our secrets are available since they are not for pull requests