### PR TITLE
Update actions config for canary jobs

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -83,14 +83,12 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
-      - run: if [[ -z "$BROWSERSTACK_ACCESS_KEY" ]];then exit 0;fi
-      - run: echo "val length ${#BROWSERSTACK_ACCESS_KEY}"
       - uses: actions/cache@v1
         id: restore-build
         with:
           path: '.'
           key: ${{ github.sha }}
-      - run: yarn testsafari --forceExit test/integration/production/
+      - run: '[[ -z "$BROWSERSTACK_ACCESS_KEY" ]] && echo "Skipping for PR" || yarn testsafari --forceExit test/integration/production/'
 
   publishRelease:
     name: Potentially publish release
@@ -106,5 +104,4 @@ jobs:
           path: '.'
           key: ${{ github.sha }}
 
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: ./publish-release.sh

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -83,7 +83,7 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
-      - run: if [ -z $BROWSERSTACK_ACCESS_KEY ];then exit 0;fi
+      - run: if [[ ${#BROWSERSTACK_ACCESS_KEY} == 0 ]];then exit 0;fi
       - uses: actions/cache@v1
         id: restore-build
         with:
@@ -98,7 +98,7 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - run: if [ -z $NPM_TOKEN ];then exit 0;fi
+      - run: if [[ ${#NPM_TOKEN} == 0 ]];then exit 0;fi
       - uses: actions/cache@v1
         id: restore-build
         with:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -9,12 +9,12 @@ name: Build, test, and deploy
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
     steps:
       - uses: actions/checkout@v2
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install --frozen-lockfile --check-files
-        env:
-          NEXT_TELEMETRY_DISABLED: 1
-
       - uses: actions/cache@v1
         id: cache-build
         with:
@@ -30,13 +30,15 @@ jobs:
         with:
           path: '.'
           key: ${{ github.sha }}
-
       - run: yarn lint
 
   testAll:
     name: Test All
     runs-on: ubuntu-latest
     needs: build
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      HEADLESS: true
     strategy:
       fail-fast: false
       matrix:
@@ -47,11 +49,7 @@ jobs:
         with:
           path: '.'
           key: ${{ github.sha }}
-
       - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3
-        env:
-          NEXT_TELEMETRY_DISABLED: 1
-          HEADLESS: true
 
   testsPass:
     name: thank you, next
@@ -64,48 +62,48 @@ jobs:
     name: Test Firefox (production)
     runs-on: ubuntu-latest
     needs: build
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      HEADLESS: true
     steps:
       - uses: actions/cache@v1
         id: restore-build
         with:
           path: '.'
           key: ${{ github.sha }}
-
       - run: yarn testfirefox --forceExit test/integration/production/
-        env:
-          NEXT_TELEMETRY_DISABLED: 1
-          HEADLESS: true
 
   testSafari:
     name: Test Safari (production)
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'canary'
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      BROWSERSTACK: true
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
+      - run: if [ -z $BROWSERSTACK_ACCESS_KEY ];then exit 0;fi
+      - uses: actions/cache@v1
+        id: restore-build
+        with:
+          path: '.'
+          key: ${{ github.sha }}
+      - run: yarn testsafari --forceExit test/integration/production/
+
+  publishRelease:
+    name: Potentially publish release
+    runs-on: ubuntu-latest
+    needs: [testsPass]
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - run: if [ -z $NPM_TOKEN ];then exit 0;fi
       - uses: actions/cache@v1
         id: restore-build
         with:
           path: '.'
           key: ${{ github.sha }}
 
-      - run: yarn testsafari --forceExit test/integration/production/
-        env:
-          NEXT_TELEMETRY_DISABLED: 1
-          BROWSERSTACK: true
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-
-  saveNpmToken:
-    name: Potentially save npm token
-    runs-on: ubuntu-latest
-    if: github.ref == 'canary'
-    needs: [build, testAll]
-    steps:
-      - run: ([[ ! -z $NPM_TOKEN ]] && echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc) || echo "Did not write npm token"
-
-  publishRelease:
-    name: Potentially publish release
-    runs-on: ubuntu-latest
-    needs: saveNpmToken
-    steps:
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: ./publish-release.sh

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -97,7 +97,6 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - run: if [[ -z "$NPM_TOKEN" ]];then exit 0;fi
       - uses: actions/cache@v1
         id: restore-build
         with:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -83,7 +83,7 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
-      - run: if [[ ${#BROWSERSTACK_ACCESS_KEY} < 5 ]];then exit 0;fi
+      - run: if [[ -z "$BROWSERSTACK_ACCESS_KEY" ]];then exit 0;fi
       - run: echo "val length ${#BROWSERSTACK_ACCESS_KEY}"
       - uses: actions/cache@v1
         id: restore-build
@@ -99,7 +99,7 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - run: if [[ ${#NPM_TOKEN} < 5 ]];then exit 0;fi
+      - run: if [[ -z "$NPM_TOKEN" ]];then exit 0;fi
       - uses: actions/cache@v1
         id: restore-build
         with:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -83,7 +83,8 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
-      - run: if [[ ${#BROWSERSTACK_ACCESS_KEY} == 0 ]];then exit 0;fi
+      - run: if [[ ${#BROWSERSTACK_ACCESS_KEY} < 5 ]];then exit 0;fi
+      - run: echo "val length ${#BROWSERSTACK_ACCESS_KEY}"
       - uses: actions/cache@v1
         id: restore-build
         with:
@@ -98,7 +99,7 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - run: if [[ ${#NPM_TOKEN} == 0 ]];then exit 0;fi
+      - run: if [[ ${#NPM_TOKEN} < 5 ]];then exit 0;fi
       - uses: actions/cache@v1
         id: restore-build
         with:

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -1,21 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 
-if
-  ls ~/.npmrc >/dev/null 2>&1 &&
-  [[ $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];
+git describe --exact-match
+
+if [[ ! $? -eq 0 ]];then
+  echo "Nothing to publish, exiting.."
+  exit 0;
+fi
+
+if [[ $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];
 then
-  # yarn run lerna publish from-git --npm-tag canary --yes
-  echo "publishing canary"
+  echo "Publishing canary"
+  yarn run lerna publish from-git --npm-tag canary --yes
 else
   echo "Did not publish canary"
 fi
 
-if
-  ls ~/.npmrc >/dev/null 2>&1 &&
-  [[ ! $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];
-then
-  # yarn run lerna publish from-git --yes
-  echo "publishing stable"
+if [[ ! $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];then
+  echo "Publishing stable"
+  yarn run lerna publish from-git --yes
 else
   echo "Did not publish stable"
 fi

--- a/publish-release.sh
+++ b/publish-release.sh
@@ -7,6 +7,13 @@ if [[ ! $? -eq 0 ]];then
   exit 0;
 fi
 
+if [[ -z "$NPM_TOKEN" ]];then
+  echo "No NPM_TOKEN, exiting.."
+  exit 0;
+fi
+
+echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+
 if [[ $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];
 then
   echo "Publishing canary"

--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -81,7 +81,7 @@ describe('Production response size', () => {
     )
 
     // These numbers are without gzip compression!
-    const delta = responseSizeKilobytes - 233
+    const delta = responseSizeKilobytes - 234
     expect(delta).toBeLessThanOrEqual(0) // don't increase size
     expect(delta).toBeGreaterThanOrEqual(-1) // don't decrease size without updating target
   })


### PR DESCRIPTION
This updates the steps for testing in safari on merge to `canary` since it relies on BrowserStack credentials still and updates our publishing step for GitHub actions.

Tested these in a private repo with dummy packages `@ijjk/...`
