### PR TITLE
Fix with-orbit-components's name in package.json

### DIFF
--- a/examples/with-orbit-components/package.json
+++ b/examples/with-orbit-components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "with-styled-components",
+  "name": "with-orbit-components",
   "version": "1.0.0",
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
This is to be more consistent with other examples.