### PR TITLE
Make sure to exit publish script with correct code

### DIFF
--- a/publish-release.sh
+++ b/publish-release.sh
@@ -18,6 +18,11 @@ if [[ $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];
 then
   echo "Publishing canary"
   yarn run lerna publish from-git --npm-tag canary --yes
+
+  # Make sure to exit script with code 1 if publish failed
+  if [[ ! $? -eq 0 ]];then
+    exit 1;
+  fi
 else
   echo "Did not publish canary"
 fi
@@ -25,6 +30,11 @@ fi
 if [[ ! $(git describe --exact-match 2> /dev/null || :) =~ -canary ]];then
   echo "Publishing stable"
   yarn run lerna publish from-git --yes
+
+  # Make sure to exit script with code 1 if publish failed
+  if [[ ! $? -eq 0 ]];then
+    exit 1;
+  fi
 else
   echo "Did not publish stable"
 fi


### PR DESCRIPTION
If the publish fails the publish job should be marked as failed instead of passing this makes sure we honor the exit code from yarn for the `publish-release` script