### PR TITLE
Allowing skipping local selenium server when not needed

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -63,7 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     env:
-      SKIP_LOCAL_SELENIUM_SERVER: true
       NEXT_TELEMETRY_DISABLED: 1
       HEADLESS: true
     steps:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     env:
+      SKIP_LOCAL_SELENIUM_SERVER: true
       NEXT_TELEMETRY_DISABLED: 1
       HEADLESS: true
     steps:
@@ -80,6 +81,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       BROWSERSTACK: true
+      SKIP_LOCAL_SELENIUM_SERVER: true
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:

--- a/test/jest-environment.js
+++ b/test/jest-environment.js
@@ -4,7 +4,10 @@ const getPort = require('get-port')
 const seleniumServer = require('selenium-standalone')
 const NodeEnvironment = require('jest-environment-node')
 
-const { BROWSER_NAME: browserName = 'chrome' } = process.env
+const {
+  BROWSER_NAME: browserName = 'chrome',
+  SKIP_LOCAL_SELENIUM_SERVER,
+} = process.env
 
 const newTabPg = `
 <!DOCTYPE html>
@@ -38,7 +41,7 @@ class CustomEnvironment extends NodeEnvironment {
 
     let seleniumServerPort
 
-    if (browserName !== 'chrome') {
+    if (browserName !== 'chrome' && SKIP_LOCAL_SELENIUM_SERVER !== 'true') {
       console.log('Installing selenium server')
       await new Promise((resolve, reject) => {
         seleniumServer.install(err => {


### PR DESCRIPTION
The local server is mainly needed when you don't have the drivers already installed or when testing in ie11 since it requires extra handling so this allows skipping it when we do meet these requirements since it's an extra step for each request to go through 