### PR TITLE
Disable caching for react@next workflow as its not supported

### DIFF
--- a/.github/workflows/test_react_next.yml
+++ b/.github/workflows/test_react_next.yml
@@ -1,4 +1,6 @@
 on:
+  pull_request:
+    types: [opened, synchronize]
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 0,12 * * *'
@@ -6,39 +8,43 @@ on:
 name: Test react@next
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+  # build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - run: yarn install --frozen-lockfile --check-files
-        env:
-          NEXT_TELEMETRY_DISABLED: 1
+  #     - run: yarn install --frozen-lockfile --check-files
+  #       env:
+  #         NEXT_TELEMETRY_DISABLED: 1
 
-      - run: yarn upgrade react@next react-dom@next -W --dev
+  #     - run: yarn upgrade react@next react-dom@next -W --dev
 
-      - uses: actions/cache@v1
-        id: cache-build
-        with:
-          path: '.'
-          key: ${{ github.sha }}
+  #     - uses: actions/cache@v1
+  #       id: cache-build
+  #       with:
+  #         path: '.'
+  #         key: ${{ github.sha }}
 
   testAll:
     name: Test All
     runs-on: ubuntu-latest
     needs: build
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      HEADLESS: true
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5, 6]
     steps:
-      - uses: actions/cache@v1
-        id: restore-build
-        with:
-          path: '.'
-          key: ${{ github.sha }}
+      # - uses: actions/cache@v1
+      #   id: restore-build
+      #   with:
+      #     path: '.'
+      #     key: ${{ github.sha }}
+
+      - run: yarn install --frozen-lockfile --check-files
+
+      - run: yarn upgrade react@next react-dom@next -W --dev
 
       - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3
-        env:
-          NEXT_TELEMETRY_DISABLED: 1
-          HEADLESS: true

--- a/.github/workflows/test_react_next.yml
+++ b/.github/workflows/test_react_next.yml
@@ -28,7 +28,7 @@ jobs:
   testAll:
     name: Test All
     runs-on: ubuntu-latest
-    needs: build
+    # needs: build
     env:
       NEXT_TELEMETRY_DISABLED: 1
       HEADLESS: true

--- a/.github/workflows/test_react_next.yml
+++ b/.github/workflows/test_react_next.yml
@@ -1,6 +1,4 @@
 on:
-  pull_request:
-    types: [opened, synchronize]
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 0,12 * * *'

--- a/.github/workflows/test_react_next.yml
+++ b/.github/workflows/test_react_next.yml
@@ -43,6 +43,8 @@ jobs:
       #     path: '.'
       #     key: ${{ github.sha }}
 
+      - uses: actions/checkout@v2
+
       - run: yarn install --frozen-lockfile --check-files
 
       - run: yarn upgrade react@next react-dom@next -W --dev


### PR DESCRIPTION
We currently can't use `actions/cache` to re-use a build step for our scheduled `react@next` tests since the `actions/cache` step isn't supported for scheduled jobs in GitHub actions

> [warning]Event Validation Error: The event type schedule is not supported. Only push, pull_request events are supported at this time.
