### PR TITLE
Fixes #10333 `with-next-seo` sample issues

### DIFF
--- a/examples/with-next-seo/pages/_app.js
+++ b/examples/with-next-seo/pages/_app.js
@@ -3,30 +3,16 @@
  * that will apply to every page. Full info on how the default works
  * can be found here: https://github.com/garmeeh/next-seo#default-seo-configuration
  */
-import App from 'next/app'
-import React from 'react'
-import NextSeo from 'next-seo'
+import { DefaultSeo } from 'next-seo'
 
 import SEO from '../next-seo.config'
 
-export default class MyApp extends App {
-  static async getInitialProps({ Component, ctx }) {
-    let pageProps = {}
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx)
-    }
-
-    return { pageProps }
-  }
-
-  render() {
-    const { Component, pageProps } = this.props
-    return (
-      /* Here we call NextSeo and pass our default configuration to it  */
-      <>
-        <NextSeo config={SEO} />
-        <Component {...pageProps} />
-      </>
-    )
-  }
+export default function MyApp({ Component, pageProps }) {
+  return (
+    /* Here we call NextSeo and pass our default configuration to it  */
+    <>
+      <DefaultSeo {...SEO} />
+      <Component {...pageProps} />
+    </>
+  )
 }

--- a/examples/with-next-seo/pages/index.js
+++ b/examples/with-next-seo/pages/index.js
@@ -1,5 +1,4 @@
-import React from 'react'
-import NextSeo from 'next-seo'
+import { NextSeo } from 'next-seo'
 import Link from 'next/link'
 
 export default () => (

--- a/examples/with-next-seo/pages/jsonld.js
+++ b/examples/with-next-seo/pages/jsonld.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ArticleJsonLd } from 'next-seo'
 
 // See all available JSON-LD here:


### PR DESCRIPTION
Fixes #10333 import syntax, default config, and clean up.

- When import `next-seo` package, need to use object destructuring assignment syntax.
- When use a default SEO config in `pages/_app.js`, need to import `DefaultSeo` and use spread syntax.
- Also removed `getInitialProps` in `pages/_app` for the benefit of Automatic Static Optimization.
