### PR TITLE
TypeScript documentation for _app.tsx

### DIFF
--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -10,7 +10,7 @@ Next.js uses the `App` component to initialize pages. You can override it and co
 - Keeping state when navigating pages
 - Custom error handling using `componentDidCatch`
 - Inject additional data into pages
-- [Add global CSS](https://nextjs.org/docs/basic-features/built-in-css-support#adding-a-global-stylesheet)
+- [Add global CSS](/docs/basic-features/built-in-css-support#adding-a-global-stylesheet)
 
 To override the default `App`, create the file `./pages/_app.js` as shown below:
 

--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -10,6 +10,7 @@ Next.js uses the `App` component to initialize pages. You can override it and co
 - Keeping state when navigating pages
 - Custom error handling using `componentDidCatch`
 - Inject additional data into pages
+- [Add global CSS](https://nextjs.org/docs/basic-features/built-in-css-support#adding-a-global-stylesheet)
 
 To override the default `App`, create the file `./pages/_app.js` as shown below:
 
@@ -40,6 +41,10 @@ The `Component` prop is the active `page`, so whenever you navigate between rout
 `pageProps` is an object with the initial props that were preloaded for your page, it's an empty object if the page is not using [`getInitialProps`](/docs/api-reference/data-fetching/getInitialProps.md).
 
 > Adding a custom `getInitialProps` in your `App` will disable [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md).
+
+### TypeScript
+
+If you’re using TypeScript, take a look at [our TypeScript documentation](/docs/basic-features/typescript#custom-app).
 
 ## Related
 

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -118,3 +118,17 @@ export default (req: NextApiRequest, res: NextApiResponse<Data>) => {
   res.status(200).json({ name: 'John Doe' })
 }
 ```
+
+## Custom `App` using `_app.tsx`
+
+If you’d like to [customize the `App` component](https://nextjs.org/docs/advanced-features/custom-app) in TypeScript, create `pages/_app.tsx`:
+
+```ts
+import { AppProps } from 'next/app'
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}
+
+export default MyApp
+```

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -121,7 +121,7 @@ export default (req: NextApiRequest, res: NextApiResponse<Data>) => {
 
 ## Custom `App` using `_app.tsx`
 
-If you’d like to [customize the `App` component](https://nextjs.org/docs/advanced-features/custom-app) in TypeScript, create `pages/_app.tsx`:
+If you’d like to [customize the `App` component](/docs/advanced-features/custom-app) in TypeScript, create `pages/_app.tsx`:
 
 ```ts
 import { AppProps } from 'next/app'

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -121,7 +121,7 @@ export default (req: NextApiRequest, res: NextApiResponse<Data>) => {
 
 ## Custom `App`
 
-If you’d like to [customize the `App` component](/docs/advanced-features/custom-app) in TypeScript, create `pages/_app.tsx`:
+If you have a [custom `App` ](/docs/advanced-features/custom-app), you can use the built-in type `AppProps`, like so:
 
 ```ts
 import { AppProps } from 'next/app'

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -119,7 +119,7 @@ export default (req: NextApiRequest, res: NextApiResponse<Data>) => {
 }
 ```
 
-## Custom `App` using `_app.tsx`
+## Custom `App`
 
 If you’d like to [customize the `App` component](/docs/advanced-features/custom-app) in TypeScript, create `pages/_app.tsx`:
 


### PR DESCRIPTION
- Updates [our TypeScript documentation](https://nextjs.org/docs/basic-features/typescript) to include how to write `_app.tsx`
- Updates [our custom `App` documentation](https://nextjs.org/docs/advanced-features/custom-app) to link to TypeScript and also global CSS import support
- Note: [Our custom `Document` documentation](https://nextjs.org/docs/advanced-features/custom-document) page shouldn't need to be updated because it's using `class` and by importing `class` it automatically gets the type info.