### PR TITLE
Make sure to not override initial navigation when refreshing static page's query

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -99,9 +99,10 @@ class Container extends React.Component {
     // If page was exported and has a querystring
     // If it's a dynamic route or has a querystring
     if (
-      (data.nextExport &&
+      router.isSsr &&
+      ((data.nextExport &&
         (isDynamicRoute(router.pathname) || location.search)) ||
-      (Component && Component.__N_SSG && location.search)
+        (Component && Component.__N_SSG && location.search))
     ) {
       // update query on mount for exported pages
       router.replace(

--- a/test/integration/dynamic-routing/pages/[name]/on-mount-redir.js
+++ b/test/integration/dynamic-routing/pages/[name]/on-mount-redir.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Router from 'next/router'
+
+class Page extends React.Component {
+  componentDidMount() {
+    Router.push('/')
+  }
+
+  render() {
+    return <p>redirecting..</p>
+  }
+}
+
+export default Page

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -463,6 +463,12 @@ function runTests(dev) {
             regex: normalizeRegEx('^\\/([^\\/]+?)\\/comments(?:\\/)?$'),
           },
           {
+            page: '/[name]/on-mount-redir',
+            regex: normalizeRegEx(
+              '^\\/([^\\/]+?)\\/on\\-mount\\-redir(?:\\/)?$'
+            ),
+          },
+          {
             page: '/[name]/[comment]',
             regex: normalizeRegEx('^\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$'),
           },

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -83,6 +83,12 @@ function runTests(dev) {
     }
   })
 
+  it('should allow calling Router.push on mount successfully', async () => {
+    const browser = await webdriver(appPort, '/post-1/on-mount-redir')
+    waitFor(2000)
+    expect(await browser.elementByCss('h3').text()).toBe('My blog')
+  })
+
   // it('should navigate optional dynamic page', async () => {
   //   let browser
   //   try {
@@ -507,7 +513,10 @@ describe('Dynamic Routing', () => {
   })
 
   describe('serverless mode', () => {
+    let origNextConfig
+
     beforeAll(async () => {
+      origNextConfig = await fs.readFile(nextConfig, 'utf8')
       await fs.writeFile(
         nextConfig,
         `
@@ -526,7 +535,10 @@ describe('Dynamic Routing', () => {
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
     })
-    afterAll(() => killApp(app))
+    afterAll(async () => {
+      await fs.writeFile(nextConfig, origNextConfig)
+      await killApp(app)
+    })
     runTests()
   })
 })


### PR DESCRIPTION
This updates our check for refreshing the query for auto-exported pages to make sure a navigation hasn't already occurred that would make the refreshing invalid. 

This check is needed since a `Router.push` that is called lower in the tree in `componentDidMount` will be cancelled out by the `componentDidMount` at the top of the tree that we use for refreshing the query for auto-exported pages.

fixes: https://github.com/zeit/next.js/issues/10340