### PR TITLE
Improve api-routes-apollo-server-and-client-auth Example

### DIFF
--- a/examples/api-routes-apollo-server-and-client-auth/pages/signin.js
+++ b/examples/api-routes-apollo-server-and-client-auth/pages/signin.js
@@ -31,15 +31,15 @@ function SignIn() {
     const passwordElement = event.currentTarget.elements.password
 
     try {
+      await client.resetStore()
       const { data } = await signIn({
         variables: {
           email: emailElement.value,
           password: passwordElement.value,
         },
       })
-      client.resetStore()
       if (data.signIn.user) {
-        router.push('/')
+        await router.push('/')
       }
     } catch (error) {
       setErrorMsg(getErrorMessage(error))

--- a/examples/api-routes-apollo-server-and-client-auth/pages/signout.js
+++ b/examples/api-routes-apollo-server-and-client-auth/pages/signout.js
@@ -16,12 +16,11 @@ function SignOut() {
   const [signOut] = useMutation(SignOutMutation)
 
   React.useEffect(() => {
-    if (typeof window !== 'undefined') {
-      signOut().then(() => {
-        client.resetStore()
+    signOut().then(() => {
+      client.resetStore().then(() => {
         router.push('/signin')
       })
-    }
+    })
   }, [signOut, router, client])
 
   return <p>Signing out...</p>


### PR DESCRIPTION
1. Prevent possible race conditions of cache pruning, refetching and redirects.

2. Note: the original code has the following defect.

SignOut action restarts the dev server effectively resetting the memory and erasing all the "registered users" data. You have to SignUp again after SignOut. I'm not sure how to properly fix it a.t.m, jus mentioning the case for the potential searchers.

3. React's `useEffect` hook is not called on the server so the `typeof window == "undefined"` check in `signOut` action is unnecessary.