### PR TITLE
Add check that dynamic route is API route in handleApiRequest

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -644,7 +644,7 @@ export default class Server {
     if (!pageFound && this.dynamicRoutes) {
       for (const dynamicRoute of this.dynamicRoutes) {
         params = dynamicRoute.match(pathname)
-        if (params) {
+        if (dynamicRoute.page.startsWith('/api') && params) {
           page = dynamicRoute.page
           pageFound = true
           break

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -61,6 +61,12 @@ function runTests(dev) {
     expect(html).toMatch(/blog post.*321.*comment.*123/i)
   })
 
+  it('should not error when requesting dynamic page with /api', async () => {
+    const res = await fetchViaHTTP(appPort, '/api')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toMatch(/this is.*?api/i)
+  })
+
   it('should render dynamic route with query', async () => {
     const browser = await webdriver(appPort, '/')
     await browser.elementByCss('#view-post-1-with-query').click()


### PR DESCRIPTION
As mentioned in https://github.com/zeit/next.js/issues/10359 when `/api` is requested and there is a dynamic route at the top level without `/api/index.js` it causes an error since it tries to treat the dynamic route as an API page

This makes sure the matched dynamic route is an API page before handling it as such

fixes: https://github.com/zeit/next.js/issues/10359