### PR TITLE
Increase watch limit for GitHub actions testing

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -49,6 +49,10 @@ jobs:
         with:
           path: '.'
           key: ${{ github.sha }}
+
+      # TODO: remove after we fix watchpack watching too much
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
       - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3
 
   testsPass:

--- a/.github/workflows/test_react_next.yml
+++ b/.github/workflows/test_react_next.yml
@@ -47,4 +47,7 @@ jobs:
 
       - run: yarn upgrade react@next react-dom@next -W --dev
 
+      # TODO: remove after we fix watchpack watching too much
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
       - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3


### PR DESCRIPTION
While running our tests in GitHub actions it appears `watchpack` is trying to watch too many files causing the below errors. This increases the watch limit until we can sort out why too many files are being watched 

`Watchpack Error (watcher): Error: ENOSPC: System limit for number of file watchers reached, watch '/home/runner'`
`Watchpack Error (watcher): Error: ENOSPC: System limit for number of file watchers reached, watch '/home'`