### PR TITLE
Fix bug in catch-all routes with SSG

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -592,11 +592,9 @@ export async function isPageStatic(
 
             builtPage = builtPage.replace(
               `[${repeat ? '...' : ''}${validParamKey}]`,
-              encodeURIComponent(
-                repeat
-                  ? (paramValue as string[]).join('/')
-                  : (paramValue as string)
-              )
+              repeat
+                ? (paramValue as string[]).map(encodeURIComponent).join('/')
+                : encodeURIComponent(paramValue as string)
             )
           })
 

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -109,8 +109,8 @@ const expectedManifestRoutes = () => ({
     initialRevalidateSeconds: false,
     srcRoute: null,
   },
-  '/catchall/another%2Fvalue': {
-    dataRoute: `/_next/data/${buildId}/catchall/another%2Fvalue.json`,
+  '/catchall/another/value': {
+    dataRoute: `/_next/data/${buildId}/catchall/another/value.json`,
     initialRevalidateSeconds: 1,
     srcRoute: '/catchall/[...slug]',
   },


### PR DESCRIPTION
The catch-all routes in SSG wasn't working because it was escaping the '/' characters used to join the parameters instead of joining the parameters escaped individually.