### PR TITLE
Update Preact Example

### DIFF
--- a/examples/using-preact/README.md
+++ b/examples/using-preact/README.md
@@ -1,6 +1,6 @@
 # Preact example
 
-This example uses [Preact](https://github.com/developit/preact) instead of React. It's a React like UI framework which is fast and small. Here we've customized Next.js to use Preact instead of React.
+This example uses [Preact](https://github.com/preactjs/preact) instead of React. It's a React like UI framework which is fast and small. Here we've customized Next.js to use Preact instead of React.
 
 Here's how we did it:
 

--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "module-alias": "2.2.2",
     "next": "latest",
-    "preact": "10.0.0",
-    "preact-render-to-string": "5.0.7"
+    "preact": "10.2.1",
+    "preact-render-to-string": "5.1.4"
   },
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
Preact example occurs this error.

```
TypeError: Cannot destructure property `inAmpMode` of 'undefined' or 'null'.
```

This is due to `preact-render-to-string`.
`preact-render-to-string` was fixed.
https://github.com/preactjs/preact-render-to-string/pull/122

This fixes this error.