### PR TITLE
Run runtime config side-effect before other serverless imports

### DIFF
--- a/test/integration/serverless-runtime-configs/pages/_app.js
+++ b/test/integration/serverless-runtime-configs/pages/_app.js
@@ -1,0 +1,10 @@
+import getConfig from 'next/config'
+
+const config = getConfig()
+
+export default ({ Component, pageProps }) => (
+  <>
+    <p id="app-config">{JSON.stringify(config)}</p>
+    <Component {...pageProps} />
+  </>
+)

--- a/test/integration/serverless-runtime-configs/pages/_document.js
+++ b/test/integration/serverless-runtime-configs/pages/_document.js
@@ -1,0 +1,26 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import getConfig from 'next/config'
+
+const config = getConfig()
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <div id="doc-config">{JSON.stringify(config)}</div>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/test/integration/serverless-runtime-configs/pages/api/config.js
+++ b/test/integration/serverless-runtime-configs/pages/api/config.js
@@ -1,0 +1,7 @@
+import getConfig from 'next/config'
+
+const config = getConfig()
+
+export default (req, res) => {
+  res.json(config)
+}

--- a/test/integration/serverless-runtime-configs/pages/config.js
+++ b/test/integration/serverless-runtime-configs/pages/config.js
@@ -2,4 +2,8 @@ import getConfig from 'next/config'
 
 const config = getConfig()
 
-export default () => <p id="config">{JSON.stringify(config)}</p>
+const page = () => <p id="config">{JSON.stringify(config)}</p>
+
+page.getInitialProps = () => ({ a: 'b' })
+
+export default page

--- a/test/integration/serverless-runtime-configs/server.js
+++ b/test/integration/serverless-runtime-configs/server.js
@@ -1,0 +1,31 @@
+const path = require('path')
+const http = require('http')
+const send = require('send')
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/config') {
+    return require('./.next/serverless/pages/config.js').render(req, res)
+  }
+
+  if (req.url === '/') {
+    return send(
+      req,
+      path.join(__dirname, '.next/serverless/pages/index.html')
+    ).pipe(res)
+  }
+
+  if (req.url === '/api/config') {
+    return require('./.next/serverless/pages/api/config.js').default(req, res)
+  }
+
+  if (req.url.startsWith('/_next')) {
+    send(
+      req,
+      path.join(__dirname, '.next', req.url.split('/_next').pop())
+    ).pipe(res)
+  }
+})
+
+server.listen(process.env.PORT, () => {
+  console.log('ready on', process.env.PORT)
+})


### PR DESCRIPTION
This makes sure we set the config before importing `_app`, `_error`, or `_document` in the `serverless-loader` since runtime configs can be used there also. 

I added additional tests for this and also added a test to ensure it also works for API routes

Closes: https://github.com/zeit/next.js/issues/10385