### PR TITLE
Remove Old Records

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -579,7 +579,6 @@ export default async function getBaseWebpackConfig(
           }),
       ].filter(Boolean),
     },
-    recordsPath: path.join(outputPath, 'records.json'),
     context: dir,
     // Kept as function to be backwards compatible
     entry: async () => {


### PR DESCRIPTION
This removes an old webpack configuration option before builds were deterministic.

This option has occasionally required clearing `.next` (distDir), which should never be required.