### PR TITLE
Make sure runtime config works in dev mode for serverless target

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -163,12 +163,10 @@ export default class Server {
     }
 
     // Initialize next/config with the environment configuration
-    if (this.nextConfig.target === 'server') {
-      envConfig.setConfig({
-        serverRuntimeConfig,
-        publicRuntimeConfig,
-      })
-    }
+    envConfig.setConfig({
+      serverRuntimeConfig,
+      publicRuntimeConfig,
+    })
 
     this.serverBuildDir = join(
       this.distDir,


### PR DESCRIPTION
This removes the restriction for only setting runtime config in `server` target in `next-server` since the `serverless` target still uses `server` bundles during development. It also adds an additional test

Closes: https://github.com/zeit/next.js/issues/10395