### PR TITLE
Update optimize event with static 404 status

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -773,6 +773,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       durationInSeconds: analysisEnd[0],
       staticPageCount: staticPages.size,
       ssrPageCount: pagePaths.length - staticPages.size,
+      hasStatic404: useStatic404,
     })
   )
 

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -40,6 +40,7 @@ type EventBuildOptimized = {
   ssrPageCount: number
   hasDunderPages: boolean
   hasTestPages: boolean
+  hasStatic404: boolean
 }
 
 export function eventBuildOptimize(

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -8,6 +8,7 @@ import {
   findPort,
   killApp,
   waitFor,
+  nextBuild,
 } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
@@ -115,6 +116,16 @@ describe('Telemetry CLI', () => {
     const event2 = /NEXT_BUILD_OPTIMIZED[\s\S]+?{([\s\S]+?)}/.exec(stderr).pop()
     expect(event2).toMatch(/hasDunderPages.*?true/)
     expect(event2).toMatch(/hasTestPages.*?true/)
+  })
+
+  it('detect static 404 correctly for `next build`', async () => {
+    const { stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+      env: { NEXT_TELEMETRY_DEBUG: 1 },
+    })
+
+    const event1 = /NEXT_BUILD_OPTIMIZED[\s\S]+?{([\s\S]+?)}/.exec(stderr).pop()
+    expect(event1).toMatch(/hasStatic404.*?true/)
   })
 
   it('detects isSrcDir dir correctly for `next dev`', async () => {


### PR DESCRIPTION
This updates the optimize event to include whether a static 404 page is being used