### PR TITLE
Make apollo HOC composable

### DIFF
--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -12,11 +12,8 @@ let globalApolloClient = null
  * Creates and provides the apolloContext
  * to a next.js PageTree. Use it by wrapping
  * your PageComponent via HOC pattern.
- * @param {Function|Class} PageComponent
- * @param {Object} [config]
- * @param {Boolean} [config.ssr=true]
  */
-export function withApollo(PageComponent, { ssr = true } = {}) {
+export const withApollo = ({ ssr = true } = {}) => PageComponent => {
   const WithApollo = ({ apolloClient, apolloState, ...pageProps }) => {
     const client = apolloClient || initApolloClient(apolloState)
     return (
@@ -104,7 +101,7 @@ export function withApollo(PageComponent, { ssr = true } = {}) {
  * Creates or reuses apollo client in the browser.
  * @param  {Object} initialState
  */
-function initApolloClient(initialState) {
+const initApolloClient = initialState => {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (typeof window === 'undefined') {
@@ -123,7 +120,7 @@ function initApolloClient(initialState) {
  * Creates and configures the ApolloClient
  * @param  {Object} [initialState={}]
  */
-function createApolloClient(initialState = {}) {
+const createApolloClient = (initialState = {}) => {
   // Check out https://github.com/zeit/next.js/pull/4611 if you want to use the AWSAppSyncClient
   return new ApolloClient({
     ssrMode: typeof window === 'undefined', // Disables forceFetch on the server (so queries are only run once)

--- a/examples/with-apollo/pages/client-only.js
+++ b/examples/with-apollo/pages/client-only.js
@@ -26,7 +26,5 @@ const ClientOnlyPage = props => (
   </App>
 )
 
-export default withApollo(ClientOnlyPage, {
-  // Disable apollo ssr fetching in favour of automatic static optimization
-  ssr: false,
-})
+// Disable apollo ssr fetching in favour of automatic static optimization
+export default withApollo({ ssr: false })(ClientOnlyPage)

--- a/examples/with-apollo/pages/index.js
+++ b/examples/with-apollo/pages/index.js
@@ -26,4 +26,4 @@ const IndexPage = props => (
   </App>
 )
 
-export default withApollo(IndexPage)
+export default withApollo()(IndexPage)


### PR DESCRIPTION
* Wraps config in higher-order function

## Benefit

Composing HOCs is a common pattern and actually [recommended by the React team](https://reactjs.org/docs/higher-order-components.html#convention-maximizing-composability). In order to be still able to configure `withApollo` for Next.js-specific options like SSR, this PR wraps the higher-order component in a higher-order function to define these options.

An example with [`compose` from Recompose](https://github.com/acdlite/recompose/blob/master/docs/API.md#compose):

```javascript
compose(
  withApollo({ ssr: false }),
  withGlitter
)(MyPage)
```