### PR TITLE
De-dupe paths returned in getStaticPaths

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -535,15 +535,6 @@ export async function isPageStatic(
     if (hasStaticProps && hasStaticPaths) {
       prerenderPaths = new Set()
 
-      const addPrerenderPath = (entry: string) => {
-        if (prerenderPaths?.has(entry)) {
-          console.warn(
-            `Warning: duplicate entry returned in getStaticPaths of \`${page}\` \`${entry}\``
-          )
-        }
-        prerenderPaths?.add(entry)
-      }
-
       const _routeRegex = getRouteRegex(page)
       const _routeMatcher = getRouteMatcher(_routeRegex)
 
@@ -564,7 +555,7 @@ export async function isPageStatic(
             )
           }
 
-          addPrerenderPath(entry)
+          prerenderPaths?.add(entry)
         }
         // For the object-provided path, we must make sure it specifies all
         // required keys.
@@ -607,7 +598,7 @@ export async function isPageStatic(
             )
           })
 
-          addPrerenderPath(builtPage)
+          prerenderPaths?.add(builtPage)
         }
       })
     }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -531,9 +531,18 @@ export async function isPageStatic(
       )
     }
 
-    let prerenderPaths: string[] | undefined
+    let prerenderPaths: Set<string> | undefined
     if (hasStaticProps && hasStaticPaths) {
-      prerenderPaths = [] as string[]
+      prerenderPaths = new Set()
+
+      const addPrerenderPath = (entry: string) => {
+        if (prerenderPaths?.has(entry)) {
+          console.warn(
+            `Warning: duplicate entry returned in getStaticPaths of \`${page}\` \`${entry}\``
+          )
+        }
+        prerenderPaths?.add(entry)
+      }
 
       const _routeRegex = getRouteRegex(page)
       const _routeMatcher = getRouteMatcher(_routeRegex)
@@ -555,7 +564,7 @@ export async function isPageStatic(
             )
           }
 
-          prerenderPaths!.push(entry)
+          addPrerenderPath(entry)
         }
         // For the object-provided path, we must make sure it specifies all
         // required keys.
@@ -598,7 +607,7 @@ export async function isPageStatic(
             )
           })
 
-          prerenderPaths!.push(builtPage)
+          addPrerenderPath(builtPage)
         }
       })
     }
@@ -607,7 +616,7 @@ export async function isPageStatic(
     return {
       isStatic: !hasStaticProps && !hasGetInitialProps && !hasServerProps,
       isHybridAmp: config.amp === 'hybrid',
-      prerenderRoutes: prerenderPaths,
+      prerenderRoutes: prerenderPaths && [...prerenderPaths],
       hasStaticProps,
       hasServerProps,
     }

--- a/test/integration/prerender/pages/blog/[post]/index.js
+++ b/test/integration/prerender/pages/blog/[post]/index.js
@@ -10,6 +10,7 @@ export async function unstable_getStaticPaths() {
     '/blog/[post3]',
     '/blog/post-4',
     '/blog/post.1',
+    '/blog/post.1', // handle duplicates
   ]
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,7 +4133,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@4.8.3, browserslist@^4.0.0, browserslist@^4.3.6, browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3:
+browserslist@4.8.3, browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6, browserslist@^4.0.0, browserslist@^4.3.6, browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.3.tgz#65802fcd77177c878e015f0e3189f2c4f627ba44"
   integrity sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==
@@ -4141,14 +4141,6 @@ browserslist@4.8.3, browserslist@^4.0.0, browserslist@^4.3.6, browserslist@^4.6.
     caniuse-lite "^1.0.30001017"
     electron-to-chromium "^1.3.322"
     node-releases "^1.1.44"
-
-browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
-  integrity sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=
-  dependencies:
-    caniuse-db "^1.0.30000639"
-    electron-to-chromium "^1.2.7"
 
 browserstack-local@1.4.0:
   version "1.4.0"
@@ -4448,20 +4440,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001023.tgz#f856f71af16a5a44e81f1fcefc1673912a43da72"
   integrity sha512-EnlshvE6oAum+wWwKmJNVaoqJMjIc0bLUy4Dj77VVnz1o6bzSPr1Ze9iPy6g5ycg1xD6jGU6vBmo7pLEz2MbCQ==
 
-caniuse-db@^1.0.30000639:
-  version "1.0.30001025"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001025.tgz#33b6b126f3070a54fa8017bb5c4a0fd6b787d6f1"
-  integrity sha512-HtUBOYgagTFMOa8/OSVkXbDS/YiByZZoi4H+ksKgoDfNmMVoodxnH373bXleumM1kg1IXvLspLMKIS7guWEBhg==
-
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001017, caniuse-lite@^1.0.30001019:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001017, caniuse-lite@^1.0.30001019, caniuse-lite@^1.0.30001020:
   version "1.0.30001019"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz#857e3fccaad2b2feb3f1f6d8a8f62d747ea648e1"
   integrity sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==
-
-caniuse-lite@^1.0.30001020:
-  version "1.0.30001025"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz#30336a8aca7f98618eb3cf38e35184e13d4e5fe6"
-  integrity sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==
 
 capitalize@1.0.0:
   version "1.0.0"
@@ -6219,11 +6201,6 @@ ejs@^2.6.1:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
-
-electron-to-chromium@^1.2.7:
-  version "1.3.345"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz#2569d0d54a64ef0f32a4b7e8c80afa5fe57c5d98"
-  integrity sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==
 
 electron-to-chromium@^1.3.322:
   version "1.3.327"


### PR DESCRIPTION
This makes sure to handle duplicate paths returned from `getStaticPaths` since currently this causes us to attempt to move the exported files twice which errors since we already moved them. It also shows a warning to help users correct this