### PR TITLE
Make missing param error message more specific

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -586,7 +586,7 @@ export async function isPageStatic(
               throw new Error(
                 `A required parameter (${validParamKey}) was not provided as ${
                   repeat ? 'an array' : 'a string'
-                }.`
+                } in unstable_getStaticPaths for ${page}`
               )
             }
 

--- a/test/integration/prerender-invalid-catchall-params/test/index.test.js
+++ b/test/integration/prerender-invalid-catchall-params/test/index.test.js
@@ -11,7 +11,7 @@ describe('Invalid Prerender Catchall Params', () => {
     const out = await nextBuild(appDir, [], { stderr: true })
     expect(out.stderr).toMatch(`Build error occurred`)
     expect(out.stderr).toMatch(
-      'A required parameter (slug) was not provided as an array'
+      'A required parameter (slug) was not provided as an array in unstable_getStaticPaths for /[...slug]'
     )
   })
 })


### PR DESCRIPTION
This makes sure to mention where the missing param is expected from since the build error previously didn't mention the page that caused the build to fail which can make debugging more difficult