### PR TITLE
Update size-limit test to be more fine grained

### DIFF
--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -81,8 +81,8 @@ describe('Production response size', () => {
 
     // These numbers are without gzip compression!
     const delta = responseSizesBytes - 226 * 1024
-    expect(delta).toBeLessThanOrEqual(512) // don't increase size more than 512 bytes
-    expect(delta).toBeGreaterThanOrEqual(-512) // don't decrease size more than 512 bytes without updating target
+    expect(delta).toBeLessThanOrEqual(1024) // don't increase size more than 1kb
+    expect(delta).toBeGreaterThanOrEqual(-1024) // don't decrease size more than 1kb without updating target
   })
 
   it('should not increase the overall response size of modern build', async () => {
@@ -101,7 +101,7 @@ describe('Production response size', () => {
 
     // These numbers are without gzip compression!
     const delta = responseSizesBytes - 195 * 1024
-    expect(delta).toBeLessThanOrEqual(512) // don't increase size more than 512 bytes
-    expect(delta).toBeGreaterThanOrEqual(-512) // don't decrease size more than 512 bytes without updating target
+    expect(delta).toBeLessThanOrEqual(1024) // don't increase size more than 1kb
+    expect(delta).toBeGreaterThanOrEqual(-1024) // don't decrease size more than 1kb without updating target
   })
 })

--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -5,7 +5,7 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import fetch from 'node-fetch'
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 
 let server
 let scriptsUrls
@@ -23,12 +23,11 @@ function getResponseSizes(resourceUrls) {
   )
 }
 
-function getResponseSizesKB(responseSizes) {
-  const responseSizeBytes = responseSizes.reduce(
+function getResponseSizesBytes(responseSizes) {
+  return responseSizes.reduce(
     (accumulator, responseSizeObj) => accumulator + responseSizeObj.bytes,
     0
   )
-  return Math.ceil(responseSizeBytes / 1024)
 }
 
 describe('Production response size', () => {
@@ -73,17 +72,17 @@ describe('Production response size', () => {
         scriptsUrls.filter(path => !path.endsWith('.module.js'))
       )),
     ]
-    const responseSizeKilobytes = getResponseSizesKB(responseSizes)
+    const responseSizesBytes = getResponseSizesBytes(responseSizes)
     console.log(
       `Response Sizes for default:\n${responseSizes
         .map(obj => ` ${obj.url}: ${obj.bytes} (bytes)`)
-        .join('\n')} \nOverall: ${responseSizeKilobytes} KB`
+        .join('\n')} \nOverall: ${responseSizesBytes} KB`
     )
 
     // These numbers are without gzip compression!
-    const delta = responseSizeKilobytes - 227
-    expect(delta).toBeLessThanOrEqual(0) // don't increase size
-    expect(delta).toBeGreaterThanOrEqual(-1) // don't decrease size without updating target
+    const delta = responseSizesBytes - 227 * 1024
+    expect(delta).toBeLessThanOrEqual(512) // don't increase size more than 512 bytes
+    expect(delta).toBeGreaterThanOrEqual(-512) // don't decrease size more than 512 bytes without updating target
   })
 
   it('should not increase the overall response size of modern build', async () => {
@@ -93,16 +92,16 @@ describe('Production response size', () => {
         scriptsUrls.filter(path => path.endsWith('.module.js'))
       )),
     ]
-    const responseSizeKilobytes = getResponseSizesKB(responseSizes)
+    const responseSizesBytes = getResponseSizesBytes(responseSizes)
     console.log(
       `Response Sizes for modern:\n${responseSizes
         .map(obj => ` ${obj.url}: ${obj.bytes} (bytes)`)
-        .join('\n')} \nOverall: ${responseSizeKilobytes} KB`
+        .join('\n')} \nOverall: ${responseSizesBytes} bytes`
     )
 
     // These numbers are without gzip compression!
-    const delta = responseSizeKilobytes - 195
-    expect(delta).toBeLessThanOrEqual(0) // don't increase size
-    expect(delta).toBeGreaterThanOrEqual(-1) // don't decrease size without updating target
+    const delta = responseSizesBytes - 195 * 1024
+    expect(delta).toBeLessThanOrEqual(512) // don't increase size more than 512 bytes
+    expect(delta).toBeGreaterThanOrEqual(-512) // don't decrease size more than 512 bytes without updating target
   })
 })

--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -80,7 +80,7 @@ describe('Production response size', () => {
     )
 
     // These numbers are without gzip compression!
-    const delta = responseSizesBytes - 227 * 1024
+    const delta = responseSizesBytes - 226 * 1024
     expect(delta).toBeLessThanOrEqual(512) // don't increase size more than 512 bytes
     expect(delta).toBeGreaterThanOrEqual(-512) // don't decrease size more than 512 bytes without updating target
   })


### PR DESCRIPTION
While updating https://github.com/zeit/next.js/pull/10424 the size-limit test failed for modern bundles from them increasing 4 bytes from the expected size. We don't want to fail the test from such a small change so this updates the test to track changes on the byte level instead of kilobytes.

This will also allow us to see exactly how many bytes it increased or decrease when it does fail instead of whether 1 byte caused it to get bumped to the next kilobyte 