### PR TITLE
Add an `antd@4` example with `next@9.2`

### DIFF
--- a/examples/with-antd-4/README.md
+++ b/examples/with-antd-4/README.md
@@ -1,0 +1,56 @@
+# With Antd@4 example
+
+This example shows a way to use [antd@4](https://next.ant.design/) with next.js.
+
+## Deploy your own
+
+Deploy the example using [ZEIT Now](https://zeit.co/now):
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/next.js/tree/canary/examples/with-antd-4)
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npm init next-app --example with-antd-4 with-antd-4-app
+# or
+yarn create next-app --example with-antd-4 with-antd-4-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-antd-4
+cd with-antd-4
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Build it and run:
+
+```bash
+npm run build
+npm run start
+# or
+yarn build
+yarn start
+```
+
+Deploy it to the cloud with [now](https://zeit.co/now) ([download](https://zeit.co/download)):
+
+```bash
+now
+```

--- a/examples/with-antd-4/package.json
+++ b/examples/with-antd-4/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "with-antd-4",
+  "version": "1.0.0",
+  "description": "Next.js example with antd@4",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "antd": "4.0.0-rc.3",
+    "next": "9.2.1",
+    "react": "16.12.0",
+    "react-dom": "16.12.0"
+  }
+}

--- a/examples/with-antd-4/src/main.css
+++ b/examples/with-antd-4/src/main.css
@@ -1,0 +1,1 @@
+@import '~antd/dist/antd.css';

--- a/examples/with-antd-4/src/pages/_app.js
+++ b/examples/with-antd-4/src/pages/_app.js
@@ -1,0 +1,9 @@
+import { ConfigProvider } from 'antd'
+
+import '../main.css'
+
+export default ({ Component, pageProps }) => (
+  <ConfigProvider>
+    <Component {...pageProps} />
+  </ConfigProvider>
+)

--- a/examples/with-antd-4/src/pages/index.js
+++ b/examples/with-antd-4/src/pages/index.js
@@ -1,0 +1,22 @@
+import { Button } from 'antd'
+
+import * as styles from './index.module.css'
+
+const Index = () => (
+  <div>
+    <p>
+      Basic primary button
+      <br />
+      <Button type="primary">Button</Button>
+    </p>
+    <p>
+      Modified primary button
+      <br />
+      <Button type="primary" className={styles.specialStyle}>
+        Button
+      </Button>
+    </p>
+  </div>
+)
+
+export default Index

--- a/examples/with-antd-4/src/pages/index.module.css
+++ b/examples/with-antd-4/src/pages/index.module.css
@@ -1,0 +1,6 @@
+.specialStyle {
+  color: green;
+  font-weight: bold;
+  background-color: purple;
+  border-color: purple;
+}


### PR DESCRIPTION
This is an example using [antd@4](https://next.ant.design/) version, and `next@9.2.x`.

As you can see in the screenshot, I am using its components and even overriding them, without the use of `next/css` plugin.

![2020-02-05_22-34_1](https://user-images.githubusercontent.com/1678801/73885114-81848b00-4867-11ea-94bd-65cc97424812.png)

***

**Note** One detail though, when loading a page the first time, I experience a blink on DEV mode, where I see my styles applied and then disappear (it may be related to https://github.com/zeit/next.js/issues/10148, but not sure).

Otherwise when,
 - you modify CSS and hot reload,
 - or build and start

there are no issues.

Fixes https://github.com/zeit/next.js/issues/9830