### PR TITLE
Redesign custom-routes output and show headers in output

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -839,7 +839,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       isModern: config.experimental.modern,
     }
   )
-  printCustomRoutes({ redirects, rewrites })
+  printCustomRoutes({ redirects, rewrites, headers })
 
   if (tracer) {
     const parsedResults = await tracer.profiler.stopProfiling()

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -7,7 +7,6 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import escapeRegex from 'escape-string-regexp'
 import {
   launchApp,
   killApp,
@@ -548,14 +547,22 @@ const runTests = (isDev = false) => {
       const cleanStdout = stripAnsi(stdout)
       expect(cleanStdout).toContain('Redirects')
       expect(cleanStdout).toContain('Rewrites')
-      expect(cleanStdout).toMatch(/Source.*?Destination.*?statusCode/i)
+      expect(cleanStdout).toContain('Headers')
+      expect(cleanStdout).toMatch(/source.*?/i)
+      expect(cleanStdout).toMatch(/destination.*?/i)
 
       for (const route of [...manifest.redirects, ...manifest.rewrites]) {
-        expect(cleanStdout).toMatch(
-          new RegExp(
-            `${escapeRegex(route.source)}.*?${escapeRegex(route.destination)}`
-          )
-        )
+        expect(cleanStdout).toContain(route.source)
+        expect(cleanStdout).toContain(route.destination)
+      }
+
+      for (const route of manifest.headers) {
+        expect(cleanStdout).toContain(route.source)
+
+        for (const header of route.headers) {
+          expect(cleanStdout).toContain(header.key)
+          expect(cleanStdout).toContain(header.value)
+        }
       }
     })
   } else {


### PR DESCRIPTION
This redesigns the routes build output with a more readable structure and also adds headers to the output

<details>
<summary>Screenshots (Before)</summary>

<img width="927" alt="before-1" src="https://user-images.githubusercontent.com/22380829/73970969-b6cebe80-48e3-11ea-8840-a002871df375.png">
<img width="927" alt="before-2" src="https://user-images.githubusercontent.com/22380829/73970978-ba624580-48e3-11ea-8383-51dc7a8f5fe1.png">

</details> 

<details>
<summary>Screenshots (After)</summary>

<img width="927" alt="after-1" src="https://user-images.githubusercontent.com/22380829/73970807-6a837e80-48e3-11ea-9101-67dc39e71440.png">
<img width="927" alt="after-2" src="https://user-images.githubusercontent.com/22380829/73970914-9b63b380-48e3-11ea-8f03-9b0e5aaf1a47.png">
</details> 