### PR TITLE
Remove unused devdependency @types/babel-types

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -159,7 +159,6 @@
     "@taskr/esnext": "1.1.0",
     "@taskr/watch": "1.1.0",
     "@types/amphtml-validator": "1.0.0",
-    "@types/babel-types": "7.0.7",
     "@types/babel__core": "7.1.3",
     "@types/babel__generator": "7.6.0",
     "@types/babel__template": "7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,11 +2427,6 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
-"@types/babel-types@7.0.7":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-7.0.7.tgz#667eb1640e8039436028055737d2b9986ee336e3"
-  integrity sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==
-
 "@types/babel__core@7.1.3", "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"


### PR DESCRIPTION
`@types/babel-types` doesn't seem to be in use anymore. `babel-types` is not used anywhere and `@babel/types` has its own typings included.