### PR TITLE
Make sure to handle error from SSG data fetch correctly

### DIFF
--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -352,6 +352,12 @@ const runTests = (dev = false) => {
     await browser.elementByCss('#broken-post').click()
     await waitFor(1000)
     expect(await browser.eval('window.beforeClick')).not.toBe('true')
+
+    if (!dev) {
+      expect(
+        await browser.eval('document.documentElement.innerHTML')
+      ).toContain('Internal Server Error')
+    }
   })
 
   it('should support prerendered catchall route', async () => {


### PR DESCRIPTION
This makes sure we render the error page correctly when fetching data from `/_next/data` fails. Current behavior just stalls the page transition with an unhandled rejection. 

We might want to maintain the previous behavior of reloading the page on a 404 if the request fails on a client transition and but not on an initial fetch for a fallback page as reloading for an initial fetch on the fallback page could cause an endless reload loop