### PR TITLE
Add error message when rewriting to dynamic SSG page

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -297,6 +297,7 @@ export async function renderToHTML(
   const bodyTags = (...args: any) => callMiddleware('bodyTags', args)
   const htmlProps = (...args: any) => callMiddleware('htmlProps', args, true)
 
+  const didRewrite = (req as any)._nextDidRewrite
   const isFallback = !!query.__nextFallback
   delete query.__nextFallback
 
@@ -314,15 +315,19 @@ export async function renderToHTML(
 
   if (
     process.env.NODE_ENV !== 'production' &&
-    isAutoExport &&
+    (isAutoExport || isFallback) &&
     isDynamicRoute(pathname) &&
-    (req as any)._nextDidRewrite
+    didRewrite
   ) {
     // TODO: add err.sh when rewrites go stable
     // Behavior might change before then (prefer SSR in this case)
     throw new Error(
-      `Rewrites don't support auto-exported dynamic pages yet. ` +
-        `Using this will cause the page to fail to parse the params on the client`
+      `Rewrites don't support${
+        isFallback ? ' ' : ' auto-exported '
+      }dynamic pages${isFallback ? ' with getStaticProps ' : ' '}yet. ` +
+        `Using this will cause the page to fail to parse the params on the client${
+          isFallback ? ' for the fallback page ' : ''
+        }`
     )
   }
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -320,7 +320,9 @@ export async function renderToHTML(
     didRewrite
   ) {
     // TODO: add err.sh when rewrites go stable
-    // Behavior might change before then (prefer SSR in this case)
+    // Behavior might change before then (prefer SSR in this case).
+    // If we decide to ship rewrites to the client we could solve this
+    // by running over the rewrites and getting the params.
     throw new Error(
       `Rewrites don't support${
         isFallback ? ' ' : ' auto-exported '


### PR DESCRIPTION
This makes sure to show an error message when rewriting to dynamic SSG page as this could cause the fallback to fail to fetch the `/_next/data` route which causes the `/_error` page to show.

Currently we use the `asPath` when fetching the `/_next/data` route for SSG and `getServerProps`. This can cause problems since they may be rewritten to and the `/_next/data` route might not have the same rewrite causing the data request to fail. 

One solution is to ship the rewrites to the client so we can know what the destination should be and use that for the data request. This would also solve rewriting to auto-exported dynamic pages since we could then know how to parse the params.

Another potential solution for the `/_next/data` route rewrite error specifically is we could attempt all the rewrites with the `/_next/data/BUILD_ID/` prefix stripped and use the destination instead.