### PR TITLE
Upgrade koa router in example

### DIFF
--- a/examples/custom-server-koa/package.json
+++ b/examples/custom-server-koa/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "cross-env": "^5.2.0",
     "koa": "^2.0.1",
-    "koa-router": "^7.1.0",
+    "@koa/router": "^8.0.7",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/examples/custom-server-koa/server.js
+++ b/examples/custom-server-koa/server.js
@@ -1,6 +1,6 @@
 const Koa = require('koa')
 const next = require('next')
-const Router = require('koa-router')
+const Router = require('@koa/router')
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'


### PR DESCRIPTION
A very small change : koa-router is now deprecated, and has been integrated into koa project itself under the package name `@koa/router`.

As a reference, please see the [call for maintainers](https://github.com/koajs/router#call-for-maintainers) part of README.md

