### PR TITLE
Make Missing Prerender Manifest Fatal

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -806,6 +806,17 @@ export default async function build(dir: string, conf = null): Promise<void> {
       JSON.stringify(prerenderManifest),
       'utf8'
     )
+  } else {
+    const prerenderManifest: PrerenderManifest = {
+      version: 1,
+      routes: {},
+      dynamicRoutes: {},
+    }
+    await fsWriteFile(
+      path.join(distDir, PRERENDER_MANIFEST),
+      JSON.stringify(prerenderManifest),
+      'utf8'
+    )
   }
 
   await fsWriteFile(

--- a/packages/next/next-server/server/spr-cache.ts
+++ b/packages/next/next-server/server/spr-cache.ts
@@ -1,11 +1,11 @@
 import fs from 'fs'
-import path from 'path'
 import LRUCache from 'lru-cache'
+import mkdirpOrig from 'mkdirp'
+import path from 'path'
 import { promisify } from 'util'
 import { PrerenderManifest } from '../../build'
 import { PRERENDER_MANIFEST } from '../lib/constants'
 import { normalizePagePath } from './normalize-page-path'
-import mkdirpOrig from 'mkdirp'
 
 const mkdirp = promisify(mkdirpOrig)
 const readFile = promisify(fs.readFile)
@@ -72,14 +72,12 @@ export function initializeSprCache({
       !dev && (typeof flushToDisk !== 'undefined' ? flushToDisk : true),
   }
 
-  try {
-    prerenderManifest = dev
-      ? { routes: {}, dynamicRoutes: [] }
-      : JSON.parse(
-          fs.readFileSync(path.join(distDir, PRERENDER_MANIFEST), 'utf8')
-        )
-  } catch (_) {
-    prerenderManifest = { version: 1, routes: {}, dynamicRoutes: {} }
+  if (dev) {
+    prerenderManifest = { version: -1, routes: {}, dynamicRoutes: {} }
+  } else {
+    prerenderManifest = JSON.parse(
+      fs.readFileSync(path.join(distDir, PRERENDER_MANIFEST), 'utf8')
+    )
   }
 
   cache = new LRUCache({

--- a/test/integration/error-in-error/pages/index.js
+++ b/test/integration/error-in-error/pages/index.js
@@ -1,10 +1,16 @@
 import Link from 'next/link'
 
-export default () => (
-  <>
-    <h3>Hi 👋</h3>
-    <Link href="/a-non-existing-page">
-      <a>a lnik to no-where</a>
-    </Link>
-  </>
-)
+function Index() {
+  return (
+    <>
+      <h3>Hi 👋</h3>
+      <Link href="/a-non-existing-page">
+        <a>a link to no-where</a>
+      </Link>
+    </>
+  )
+}
+
+Index.getInitialProps = () => ({})
+
+export default Index


### PR DESCRIPTION
Now that we're on the road to stabilizing SSG, the prerender manifest not loading in Production must be a fatal error.

This file contains critical information for the app to function as expected.