### PR TITLE
Upgrade next-transpile-modules in workspace examples

### DIFF
--- a/examples/with-yarn-workspaces/packages/web-app/next.config.js
+++ b/examples/with-yarn-workspaces/packages/web-app/next.config.js
@@ -1,7 +1,5 @@
-const withTM = require('next-transpile-modules')
-
-// Tell webpack to compile the "bar" package
+// Tell webpack to compile the "bar" package, necessary if you're using the export statement for example
 // https://www.npmjs.com/package/next-transpile-modules
-module.exports = withTM({
-  transpileModules: ['bar'],
-})
+const withTM = require('next-transpile-modules')(['bar'])
+
+module.exports = withTM()

--- a/examples/with-yarn-workspaces/packages/web-app/package.json
+++ b/examples/with-yarn-workspaces/packages/web-app/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "next": "latest",
-    "next-transpile-modules": "^2.0.0",
+    "next-transpile-modules": "^3.0.0",
     "react": "^16.8.3",
     "react-dom": "^16.8.3"
   },


### PR DESCRIPTION
The latest major release of next-transpile-module (v3) changed the way the
module is used, see: https://github.com/martpie/next-transpile-modules/releases/tag/3.0.0