### PR TITLE
Use filter for create-next-app template

### DIFF
--- a/packages/create-next-app/templates/default/pages/index.js
+++ b/packages/create-next-app/templates/default/pages/index.js
@@ -37,7 +37,7 @@ const Home = () => (
         </a>
 
         <a
-          href="https://zeit.co/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+          href="https://zeit.co/new?filter=next.js&utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
           className="card"
         >
           <h3>Deploy &rarr;</h3>


### PR DESCRIPTION
Use [filter query params](https://zeit.co/new?filter=next.js&utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app) for the create-next-app template so it only shows Next.js.