### PR TITLE
Builds with Warnings Still Complete

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -388,17 +388,20 @@ export default async function build(dir: string, conf = null): Promise<void> {
       )
     }
     throw new Error('> Build failed because of webpack errors')
-  } else if (result.warnings.length > 0) {
-    console.warn(chalk.yellow('Compiled with warnings.\n'))
-    console.warn(result.warnings.join('\n\n'))
-    console.warn()
   } else {
-    console.log(chalk.green('Compiled successfully.\n'))
     telemetry.record(
       eventBuildCompleted(pagePaths, {
         durationInSeconds: webpackBuildEnd[0],
       })
     )
+
+    if (result.warnings.length > 0) {
+      console.warn(chalk.yellow('Compiled with warnings.\n'))
+      console.warn(result.warnings.join('\n\n'))
+      console.warn()
+    } else {
+      console.log(chalk.green('Compiled successfully.\n'))
+    }
   }
   const postBuildSpinner = createSpinner({
     prefixText: 'Automatically optimizing pages',

--- a/test/integration/telemetry/pages/warning.skip
+++ b/test/integration/telemetry/pages/warning.skip
@@ -1,0 +1,8 @@
+function a(v) {
+  return v
+}
+;['index.js'].forEach(f => {
+  require(a('./' + f))
+})
+
+export default () => 'Warn'

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -93,6 +93,26 @@ describe('Telemetry CLI', () => {
     expect(stderr2).toMatch(/isSrcDir.*?true/)
   })
 
+  it('logs completed `next build` with warnings', async () => {
+    await fs.rename(
+      path.join(appDir, 'pages', 'warning.skip'),
+      path.join(appDir, 'pages', 'warning.js')
+    )
+    const { stderr } = await runNextCommand(['build', appDir], {
+      stderr: true,
+      env: {
+        NEXT_TELEMETRY_DEBUG: 1,
+      },
+    })
+    await fs.rename(
+      path.join(appDir, 'pages', 'warning.js'),
+      path.join(appDir, 'pages', 'warning.skip')
+    )
+
+    expect(stderr).toMatch(/Compiled with warnings/)
+    expect(stderr).toMatch(/NEXT_BUILD_COMPLETED/)
+  })
+
   it('detects tests correctly for `next build`', async () => {
     await fs.rename(
       path.join(appDir, 'pages', 'hello.test.skip'),


### PR DESCRIPTION
This fixes the `NEXT_BUILD_COMPLETED` event being fired for a build with warnings.