### PR TITLE
Update wording for custom server

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,7 +21,7 @@ Then, follow these steps:
 
 Congratulations! You’ve just deployed your Next.js app! If you have questions, take a look at the [ZEIT Now documentation](https://zeit.co/docs).
 
-> If you’re using a [custom server](/docs/advanced-features/custom-server.md) (which we don’t recommend), consider [other hosting options](#other-hosting-options).
+> If you’re using a [custom server](/docs/advanced-features/custom-server.md), we strongly recommend migrating away from it (for example, by using [dynamic routing](/docs/routing/dynamic-routes.md)) or [considering other hosting options](#other-hosting-options).
 
 ### DPS: Develop, Preview, Ship
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,7 +21,7 @@ Then, follow these steps:
 
 Congratulations! You’ve just deployed your Next.js app! If you have questions, take a look at the [ZEIT Now documentation](https://zeit.co/docs).
 
-> If you’re using a [custom server](/docs/advanced-features/custom-server.md), we strongly recommend migrating away from it (for example, by using [dynamic routing](/docs/routing/dynamic-routes.md)) or [considering other hosting options](#other-hosting-options).
+> If you’re using a [custom server](/docs/advanced-features/custom-server.md), we strongly recommend migrating away from it (for example, by using [dynamic routing](/docs/routing/dynamic-routes.md)). If you cannot migrate, consider [other hosting options](#other-hosting-options).
 
 ### DPS: Develop, Preview, Ship
 


### PR DESCRIPTION
This is a minor fix for [the new deployment guide](https://nextjs.org/docs/deployment): https://github.com/zeit/next.js/pull/10412

We should be more explicit about recommending the user to migrate away from a custom server. Since we don't have a migration guide yet, I linked to our dynamic routing documentation because [according to our blog](https://nextjs.org/blog/next-9):

> We spoke with users and examined many of their applications, finding that many of them had a custom server. A pattern emerged: the most prominent reason for the custom server was dynamic routing.