### PR TITLE
Retry Static Data Fetch on Hydration

### DIFF
--- a/test/integration/prerender/pages/blog/[post]/index.js
+++ b/test/integration/prerender/pages/blog/[post]/index.js
@@ -16,6 +16,8 @@ export async function unstable_getStaticPaths() {
   }
 }
 
+let counter = 0
+
 // eslint-disable-next-line camelcase
 export async function unstable_getStaticProps({ params }) {
   if (params.post === 'post-10') {
@@ -26,6 +28,12 @@ export async function unstable_getStaticProps({ params }) {
 
   if (params.post === 'post-100') {
     throw new Error('such broken..')
+  }
+
+  if (params.post === 'post-999') {
+    if (++counter < 3) {
+      throw new Error('try again..')
+    }
   }
 
   return {

--- a/test/integration/prerender/pages/index.js
+++ b/test/integration/prerender/pages/index.js
@@ -32,6 +32,9 @@ const Page = ({ world, time }) => {
       <Link href="/blog/[post]" as="/blog/post-100">
         <a id="broken-post">to broken</a>
       </Link>
+      <Link href="/blog/[post]" as="/blog/post-999">
+        <a id="broken-at-first-post">to broken at first</a>
+      </Link>
       <br />
       <Link href="/blog/[post]/[comment]" as="/blog/post-1/comment-1">
         <a id="comment-1">to another dynamic</a>

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -348,6 +348,21 @@ const runTests = (dev = false) => {
     expect(await browser.eval('window.beforeClick')).not.toBe('true')
   })
 
+  // TODO: dev currently renders this page as blocking, meaning it shows the
+  // server error instead of continously retrying. Do we want to change this?
+  if (!dev) {
+    it('should reload page on failed data request, and retry', async () => {
+      const browser = await webdriver(appPort, '/')
+      await browser.eval('window.beforeClick = true')
+      await browser.elementByCss('#broken-at-first-post').click()
+      await waitFor(3000)
+      expect(await browser.eval('window.beforeClick')).not.toBe('true')
+
+      const text = await browser.elementByCss('#params').text()
+      expect(text).toMatch(/post.*?post-999/)
+    })
+  }
+
   it('should support prerendered catchall route', async () => {
     const html = await renderViaHTTP(appPort, '/catchall/another/value')
     const $ = cheerio.load(html)


### PR DESCRIPTION
This retries fetching the static data for the server-rendered skeleton file.

The client-transition still only tries once, and on failure, requests the last known good copy from server.

x-ref: #9524 