### PR TITLE
Make sure to encode pathname for custom-route destination

### DIFF
--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -54,7 +54,8 @@ export const prepareDestination = (destination: string, params: Params) => {
   })
 
   try {
-    newUrl = destinationCompiler(params)
+    newUrl = encodeURI(destinationCompiler(params))
+
     const [pathname, hash] = newUrl.split('#')
     parsedDestination.pathname = pathname
     parsedDestination.hash = `${hash ? '#' : ''}${hash || ''}`

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -84,6 +84,11 @@ module.exports = {
     async redirects() {
       return [
         {
+          source: '/redirect/me/to-about/:lang',
+          destination: '/:lang/about',
+          permanent: false,
+        },
+        {
           source: '/docs/router-status/:code',
           destination: '/docs/v2/network/status-codes#:code',
           statusCode: 301,

--- a/test/integration/production/next.config.js
+++ b/test/integration/production/next.config.js
@@ -3,4 +3,15 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
   },
+  experimental: {
+    redirects() {
+      return [
+        {
+          source: '/redirect/me/to-about/:lang',
+          destination: '/:lang/about',
+          permanent: false,
+        },
+      ]
+    },
+  },
 }

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -1,8 +1,14 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
 import { readFileSync } from 'fs'
+import url from 'url'
 import { join, resolve as resolvePath } from 'path'
-import { renderViaHTTP, getBrowserBodyText, waitFor } from 'next-test-utils'
+import {
+  renderViaHTTP,
+  getBrowserBodyText,
+  waitFor,
+  fetchViaHTTP,
+} from 'next-test-utils'
 import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
 import { homedir } from 'os'
 
@@ -151,6 +157,42 @@ module.exports = context => {
       )
       await checkInjected(browser)
       await browser.close()
+    })
+
+    it('should handle encoded value in the pathname correctly \\', async () => {
+      const res = await fetchViaHTTP(
+        context.appPort,
+        '/redirect/me/to-about/' + encodeURI('\\google.com'),
+        undefined,
+        {
+          redirect: 'manual',
+        }
+      )
+
+      const { pathname, hostname } = url.parse(
+        res.headers.get('location') || ''
+      )
+      expect(res.status).toBe(307)
+      expect(pathname).toBe(encodeURI('/\\google.com/about'))
+      expect(hostname).not.toBe('google.com')
+    })
+
+    it('should handle encoded value in the pathname correctly %', async () => {
+      const res = await fetchViaHTTP(
+        context.appPort,
+        '/redirect/me/to-about/%25google.com',
+        undefined,
+        {
+          redirect: 'manual',
+        }
+      )
+
+      const { pathname, hostname } = url.parse(
+        res.headers.get('location') || ''
+      )
+      expect(res.status).toBe(307)
+      expect(pathname).toBe('/%25google.com/about')
+      expect(hostname).not.toBe('google.com')
     })
   })
 }


### PR DESCRIPTION
This makes sure to encode the pathname so that `/%5Cgoogle.com` is handled correctly when redirecting to a destination that uses the value at the base of the path `/:path`. I also added a test to prevent regressing on this to our custom-routes suite

x-ref: https://github.com/zeit/next.js/issues/9081