### PR TITLE
Speculate Navigations for Client-Side JS

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -1,13 +1,13 @@
 declare const __NEXT_DATA__: any
 
-import { resolve, parse, UrlObject } from 'url'
-import React, { Component, Children } from 'react'
-import Router from './router'
+import React, { Children, Component } from 'react'
+import { parse, resolve, UrlObject } from 'url'
 import {
   execOnce,
   formatWithValidation,
   getLocationOrigin,
 } from '../next-server/lib/utils'
+import Router from './router'
 
 function isLocal(href: string) {
   const url = parse(href, false, true)
@@ -127,14 +127,18 @@ class Link extends Component<LinkProps> {
     this.cleanUpListeners()
   }
 
-  getHref() {
+  getPaths() {
     const { pathname } = window.location
-    const { href: parsedHref } = this.formatUrls(this.props.href, this.props.as)
-    return resolve(pathname, parsedHref)
+    const { href: parsedHref, as: parsedAs } = this.formatUrls(
+      this.props.href,
+      this.props.as
+    )
+    const resolvedHref = resolve(pathname, parsedHref)
+    return [resolvedHref, parsedAs ? resolve(pathname, parsedAs) : resolvedHref]
   }
 
   handleRef(ref: Element) {
-    const isPrefetched = prefetched[this.getHref()]
+    const isPrefetched = prefetched[this.getPaths()[0]]
     if (this.p && IntersectionObserver && ref && ref.tagName) {
       this.cleanUpListeners()
 
@@ -201,11 +205,11 @@ class Link extends Component<LinkProps> {
     })
   }
 
-  prefetch() {
+  prefetch(options: { priority?: boolean } = {}) {
     if (!this.p || typeof window === 'undefined') return
     // Prefetch the JSON page if asked (only in the client)
-    const href = this.getHref()
-    Router.prefetch(href)
+    const [href, asPath] = this.getPaths()
+    Router.prefetch(href, asPath, { priority: options.priority })
     prefetched[href] = true
   }
 
@@ -239,7 +243,7 @@ class Link extends Component<LinkProps> {
         if (child.props && typeof child.props.onMouseEnter === 'function') {
           child.props.onMouseEnter(e)
         }
-        this.prefetch()
+        this.prefetch({ priority: true })
       },
       onClick: (e: React.MouseEvent) => {
         if (child.props && typeof child.props.onClick === 'function') {

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -2,6 +2,7 @@ declare const __NEXT_DATA__: any
 
 import React, { Children, Component } from 'react'
 import { parse, resolve, UrlObject } from 'url'
+import { PrefetchOptions } from '../next-server/lib/router/router'
 import {
   execOnce,
   formatWithValidation,
@@ -205,11 +206,11 @@ class Link extends Component<LinkProps> {
     })
   }
 
-  prefetch(options: { priority?: boolean } = {}) {
+  prefetch(options?: PrefetchOptions) {
     if (!this.p || typeof window === 'undefined') return
     // Prefetch the JSON page if asked (only in the client)
     const [href, asPath] = this.getPaths()
-    Router.prefetch(href, asPath, { priority: options.priority })
+    Router.prefetch(href, asPath, options)
     prefetched[href] = true
   }
 

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -51,6 +51,10 @@ export type NextRouter = BaseRouter &
     | 'isFallback'
   >
 
+export type PrefetchOptions = {
+  priority?: boolean
+}
+
 type RouteInfo = {
   Component: ComponentType
   props?: any
@@ -659,7 +663,7 @@ export default class Router implements BaseRouter {
   prefetch(
     url: string,
     asPath: string = url,
-    options: { priority?: boolean } = {}
+    options: PrefetchOptions = {}
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       const { pathname, protocol } = parse(url)

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -3,7 +3,6 @@
 import { ParsedUrlQuery } from 'querystring'
 import { ComponentType } from 'react'
 import { parse, UrlObject } from 'url'
-
 import mitt, { MittEmitter } from '../mitt'
 import {
   AppContextType,
@@ -652,11 +651,16 @@ export default class Router implements BaseRouter {
   }
 
   /**
-   * Prefetch `page` code, you may wait for the data during `page` rendering.
+   * Prefetch page code, you may wait for the data during page rendering.
    * This feature only works in production!
-   * @param url of prefetched `page`
+   * @param url the href of prefetched page
+   * @param asPath the as path of the prefetched page
    */
-  prefetch(url: string): Promise<void> {
+  prefetch(
+    url: string,
+    asPath: string = url,
+    options: { priority?: boolean } = {}
+  ): Promise<void> {
     return new Promise((resolve, reject) => {
       const { pathname, protocol } = parse(url)
 
@@ -674,8 +678,9 @@ export default class Router implements BaseRouter {
         return
       }
 
-      const route = toRoute(pathname)
-      this.pageLoader.prefetch(route).then(resolve, reject)
+      this.pageLoader[options.priority ? 'loadPage' : 'prefetch'](
+        toRoute(pathname)
+      ).then(() => resolve(), reject)
     })
   }
 

--- a/test/integration/preload-viewport/pages/index.js
+++ b/test/integration/preload-viewport/pages/index.js
@@ -22,7 +22,7 @@ export default () => {
       />
       <p id="scroll-to-me">Hi 👋</p>
       <Link href="/another">
-        <a>to /another</a>
+        <a id="link-another">to /another</a>
       </Link>
     </div>
   )


### PR DESCRIPTION
Our router has a `prefetch` method that accepts an `href` argument. However, other route-related methods accept a `href` and `as` argument.

This pull request unifies the router interface by allowing the user to pass `href` and `as`, like they would to other methods.
It also adds optional options to the end, allowing users to specify if the fetch is [`priority` or not](https://github.com/GoogleChromeLabs/quicklink/blob/836f170df4007c05c24b1300e0faf04fb823168b/src/index.mjs#L47).

On mouse enter, we trigger a higher-priority loading of the page by injecting its `<script>` tags. This makes the files immediately jump to the front of the Network queue, and starts the script parsing early (prior to navigation).