### PR TITLE
Adds a missing dependency

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -73,6 +73,7 @@
     "@babel/preset-typescript": "7.7.2",
     "@babel/runtime": "7.7.2",
     "@babel/runtime-corejs2": "7.7.2",
+    "@babel/types": "7.7.4",
     "@next/polyfill-nomodule": "9.2.2",
     "amphtml-validator": "1.0.23",
     "async-retry": "1.2.3",


### PR DESCRIPTION
The latest release contains a file that makes a require to `@babel/types`:
`dist/build/babel/plugins/next-page-config.js`

Full details here:
https://github.com/yarnpkg/berry/runs/452627273?check_suite_focus=true