### PR TITLE
Enable pages/404.js support

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -53,7 +53,7 @@ const defaultConfig: { [key: string]: any } = {
     workerThreads: false,
     basePath: '',
     static404: true,
-    pages404: false,
+    pages404: true,
   },
   future: {
     excludeDefaultMomentLocales: false,


### PR DESCRIPTION
Enables pages/404.js support which makes 404 always a static file (no serverless/server function). This improves performance and reduces cost in all cases as 404 is rendered for many urls that don't hold content. In a server deployment (`next start`) this would cause load on the server. In serverless it would cost execution time.