### PR TITLE
Add NextApiHandler type

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -222,8 +222,10 @@ export type NextApiResponse<T = any> = ServerResponse & {
 /**
  * Next `API` route handler
  */
-export type NextApiHandler<T = any> = (req: NextApiRequest, res: NextApiResponse<T>) => void;
-
+export type NextApiHandler<T = any> = (
+  req: NextApiRequest,
+  res: NextApiResponse<T>
+) => void
 
 /**
  * Utils

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -220,6 +220,12 @@ export type NextApiResponse<T = any> = ServerResponse & {
 }
 
 /**
+ * Next `API` route handler
+ */
+export type NextApiHandler<T = any> = (req: NextApiRequest, res: NextApiResponse<T>) => void;
+
+
+/**
  * Utils
  */
 export function execOnce(this: any, fn: (...args: any) => any) {

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -9,6 +9,7 @@ import {
   NextComponentType,
   NextApiResponse,
   NextApiRequest,
+  NextApiHandler,
   // @ts-ignore This path is generated at build time and conflicts otherwise
 } from '../dist/next-server/lib/utils'
 
@@ -53,6 +54,12 @@ export type PageConfig = {
   }
 }
 
-export { NextPageContext, NextComponentType, NextApiResponse, NextApiRequest }
+export {
+  NextPageContext,
+  NextComponentType,
+  NextApiResponse,
+  NextApiRequest,
+  NextApiHandler,
+}
 
 export default next


### PR DESCRIPTION
Add a `NextApiHandler` type, so we can type API routes the following:

```ts
import { NextApiHandler } from 'next';

const healthCheckHandler: NextApiHandler = (_req, res) => {
  res.status(200).json({ message: 'ok' });
};

export default healthCheckHandler;
```

instead of 

```ts
import { NextApiResponse, NextApiRequest } from 'next';

const healthCheckHandler = (_req: NextApiRequest, res: NextApiResponse) => {
  res.status(200).json({ message: 'ok' });
};

export default healthCheckHandler;

```