### PR TITLE
Add missing faunadb create permission example

### DIFF
--- a/examples/with-graphql-faunadb/scripts/setup.js
+++ b/examples/with-graphql-faunadb/scripts/setup.js
@@ -52,7 +52,7 @@ readline.question(`Please provide the FaunaDB admin key\n`, adminKey => {
             privileges: [
               {
                 resource: q.Collection('GuestbookEntry'),
-                actions: { read: true, write: true },
+                actions: { read: true, write: true, create: true },
               },
               {
                 resource: q.Index('entries'),


### PR DESCRIPTION
Add create permission for _with-graphql-faunadb_ example https://github.com/zeit/next.js/tree/canary/examples/with-graphql-faunadb

Fix #10540 issue 

