### PR TITLE
Decrease number of expected preloads in safari

### DIFF
--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -477,7 +477,7 @@ describe('Production Usage', () => {
       if (browserName === 'safari') {
         const elements = await browser.elementsByCss('link[rel=preload]')
         // 4 page preloads and 5 existing preloads for _app, commons, main, etc
-        expect(elements.length).toBe(13)
+        expect(elements.length).toBe(11)
       } else {
         const elements = await browser.elementsByCss('link[rel=prefetch]')
         expect(elements.length).toBe(4)


### PR DESCRIPTION
After https://github.com/zeit/next.js/commit/0222a09cd0f631f54a15a91ac01512e97269426e the number of chunks created decreased by two so the number of preloads expected in safari also decreased