### PR TITLE
Make sure to handle rejection when prefetching pages

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -209,9 +209,10 @@ class Link extends Component<LinkProps> {
     if (!this.p || typeof window === 'undefined') return
     // Prefetch the JSON page if asked (only in the client)
     const [href, asPath] = this.getPaths()
-    // make sure to catch here since we should have an unhandledRejection
+    // make sure to catch here since we should handle an unhandledRejection
     // since we're doing this automatically and we don't want to reload the
-    // page while automatically prefetching for the user
+    // page while automatically prefetching for the user and this only occurs
+    // when doing an actual navigation
     Router.prefetch(href, asPath, options).catch(() => {})
     prefetched[href] = true
   }

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -209,11 +209,15 @@ class Link extends Component<LinkProps> {
     if (!this.p || typeof window === 'undefined') return
     // Prefetch the JSON page if asked (only in the client)
     const [href, asPath] = this.getPaths()
-    // make sure to catch here since we should handle an unhandledRejection
-    // since we're doing this automatically and we don't want to reload the
-    // page while automatically prefetching for the user and this only occurs
-    // when doing an actual navigation
-    Router.prefetch(href, asPath, options).catch(() => {})
+    // We need to handle a prefetch error here since we may be
+    // loading with priority which can reject but we don't
+    // want to force navigation since this is only a prefetch
+    Router.prefetch(href, asPath, options).catch(err => {
+      if (process.env.NODE_ENV !== 'production') {
+        // rethrow to show invalid URL errors
+        throw err
+      }
+    })
     prefetched[href] = true
   }
 

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -209,7 +209,10 @@ class Link extends Component<LinkProps> {
     if (!this.p || typeof window === 'undefined') return
     // Prefetch the JSON page if asked (only in the client)
     const [href, asPath] = this.getPaths()
-    Router.prefetch(href, asPath, options)
+    // make sure to catch here since we should have an unhandledRejection
+    // since we're doing this automatically and we don't want to reload the
+    // page while automatically prefetching for the user
+    Router.prefetch(href, asPath, options).catch(() => {})
     prefetched[href] = true
   }
 

--- a/test/integration/preload-viewport/pages/invalid-prefetch.js
+++ b/test/integration/preload-viewport/pages/invalid-prefetch.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default () => (
+  <>
+    <Link href="/something-invalid-oops">
+      <a id="invalid-link">I'm broken...</a>
+    </Link>
+  </>
+)

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -163,6 +163,21 @@ describe('Prefetching Links in viewport', () => {
     }
   })
 
+  it('should not have unhandledRejection when failing to prefetch on link', async () => {
+    const browser = await webdriver(appPort, '/')
+    await browser.eval(`(function() {
+      window.addEventListener('unhandledrejection', function (err) {
+        window.hadUnhandledReject = true;
+      })
+      window.next.router.push('/invalid-prefetch');
+    })()`)
+
+    expect(await browser.eval('window.hadUnhandledReject')).toBeFalsy()
+
+    await browser.elementByCss('#invalid-link').moveTo()
+    expect(await browser.eval('window.hadUnhandledReject')).toBeFalsy()
+  })
+
   it('should not prefetch when prefetch is explicitly set to false', async () => {
     const browser = await webdriver(appPort, '/opt-out')
 


### PR DESCRIPTION
Since we now do high priority loading of pages on hovering a link we need to handle the prefetch being rejected so that an `unhandledrejection` isn't thrown. This fixes it by adding a `.catch(() => {})` on our automatic `prefetch` in `next/link` and adds a regression test to our `preload-viewport` suite

x-ref: https://github.com/zeit/next.js/pull/10560 