### PR TITLE
Add Prerender Bypass Header to Data Request

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -83,7 +83,14 @@ function fetchNextData(
         // @ts-ignore __NEXT_DATA__
         pathname: `/_next/data/${__NEXT_DATA__.buildId}${pathname}.json`,
         query,
-      })
+      }),
+      {
+        headers: {
+          // This header is ignored when not in Preview mode, so we can always
+          // include it and still get the cached response.
+          'X-Prerender-Bypass-Mode': 'Blocking',
+        },
+      }
     ).then(res => {
       if (!res.ok) {
         if (--attempts > 0 && res.status >= 500) {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1010,7 +1010,7 @@ export default class Server {
     const isDynamicPathname = isDynamicRoute(pathname)
     const didRespond = isResSent(res)
     // const isForcedBlocking =
-    //   req.headers['X-Prerender-Bypass-Mode'] !== 'Blocking'
+    //   isPreviewMode && req.headers['X-Prerender-Bypass-Mode'] !== 'Blocking'
 
     // When we did not respond from cache, we need to choose to block on
     // rendering or return a skeleton.


### PR DESCRIPTION
This adds the prerender bypass header.

I'm not sure if we can test this header presence with Selenium, but, I can see how we can adjust the router behavior to not block without this behavior.