### PR TITLE
Do not cache 404 responses (ssr-caching)

### DIFF
--- a/examples/ssr-caching/server.js
+++ b/examples/ssr-caching/server.js
@@ -10,9 +10,18 @@ const handle = app.getRequestHandler()
 
 const ssrCache = cacheableResponse({
   ttl: 1000 * 60 * 60, // 1hour
-  get: async ({ req, res, pagePath, queryParams }) => ({
-    data: await app.renderToHTML(req, res, pagePath, queryParams),
-  }),
+  get: async ({ req, res, pagePath, queryParams }) => {
+    const data = await app.renderToHTML(req, res, pagePath, queryParams)
+
+    // Add here custom logic for when you do not want to cache the page, for
+    // example when the page returns a 404 status code:
+    if (res.statusCode === 404) {
+      res.end(data)
+      return
+    }
+
+    return { data }
+  },
   send: ({ data, res }) => res.send(data),
 })
 


### PR DESCRIPTION
Following the discussion in #10551, I have updated the `ssr-caching` example to include logic for bypassing the cache when the server returns a 404 response.