### PR TITLE
Use clearInterval instead of clearTimer on a timer

### DIFF
--- a/packages/next/client/dev/error-overlay/eventsource.js
+++ b/packages/next/client/dev/error-overlay/eventsource.js
@@ -46,7 +46,7 @@ function EventSourceWrapper(options) {
 
   return {
     close: () => {
-      clearTimeout(timer)
+      clearInterval(timer)
       source.close()
     },
     addMessageListener: function(fn) {


### PR DESCRIPTION
This "timer" is created via `setInterval`, not `setTimeout`, but being cleared via `clearTimeout`.
https://github.com/TheRusskiy/next.js/blob/a480e6344793c54ae2b8c89ac5783a77095155b8/packages/next/client/dev/error-overlay/eventsource.js#L13

Sinon was complaining about it, and I traced back the source of the error back to next.js
https://github.com/sinonjs/sinon/blob/c8901e7bdfd95bc34daf509fa3cc56d3100fb206/docs/releases/sinon-1.17.7.js#L1046-L1056