### PR TITLE
Minor cleaning of renderErrorToHTML

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1169,48 +1169,36 @@ export default class Server {
     _pathname: string,
     query: ParsedUrlQuery = {}
   ) {
-    let result: null | FindComponentsResult = null
-
     const { static404, pages404 } = this.nextConfig.experimental
     const is404 = res.statusCode === 404
-    let using404Page = false
+    const pages = [
+      is404 && static404 ? '/_errors/404' : null,
+      pages404 ? '/404' : null,
+      '/_error',
+    ].filter(Boolean)
 
-    // use static 404 page if available and is 404 response
-    if (is404) {
-      if (static404) {
-        result = await this.findPageComponents('/_errors/404')
-      }
-
-      // use 404 if /_errors/404 isn't available which occurs
-      // during development and when _app has getInitialProps
-      if (!result && pages404) {
-        result = await this.findPageComponents('/404')
-        using404Page = result !== null
-      }
-    }
-
-    if (!result) {
-      result = await this.findPageComponents('/_error', query)
-    }
-
-    let html
-    try {
-      html = await this.renderToHTMLWithComponents(
-        req,
-        res,
-        using404Page ? '/404' : '/_error',
-        result!,
-        {
-          ...this.renderOpts,
-          err,
+    for (const pathname of pages) {
+      const result = await this.findPageComponents('/_error', query)
+      if (result) {
+        try {
+          return await this.renderToHTMLWithComponents(
+            req,
+            res,
+            pathname!,
+            result,
+            {
+              ...this.renderOpts,
+              err,
+            }
+          )
+        } catch (err) {
+          console.error(err)
+          res.statusCode = 500
+          return 'Internal Server Error'
         }
-      )
-    } catch (err) {
-      console.error(err)
-      res.statusCode = 500
-      html = 'Internal Server Error'
+      }
     }
-    return html
+    return null
   }
 
   public async render404(

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1171,20 +1171,20 @@ export default class Server {
   ) {
     const { static404, pages404 } = this.nextConfig.experimental
     const is404 = res.statusCode === 404
-    const pages = [
-      is404 && static404 ? '/_errors/404' : null,
-      pages404 ? '/404' : null,
-      '/_error',
-    ].filter(Boolean)
+    const pages: string[] = [
+      is404 && static404 ? ['/_errors/404', '/_error'] : null,
+      pages404 ? ['/404', '/404'] : null,
+      ['/_error', '/_error'],
+    ].filter(Boolean) as any
 
-    for (const pathname of pages) {
-      const result = await this.findPageComponents('/_error', query)
+    for (const [searchPathName, renderPathName] of pages) {
+      const result = await this.findPageComponents(searchPathName, query)
       if (result) {
         try {
           return await this.renderToHTMLWithComponents(
             req,
             res,
-            pathname!,
+            renderPathName,
             result,
             {
               ...this.renderOpts,


### PR DESCRIPTION
Minor cleanup of `renderErrorToHTML`. This was just pulled out of a different diff.