### PR TITLE
Update legacy safari test for GitHub actions

### DIFF
--- a/test/integration/production-nav/test/index.test.js
+++ b/test/integration/production-nav/test/index.test.js
@@ -1,12 +1,7 @@
 /* eslint-env jest */
 /* global jasmine */
-import {
-  nextBuild,
-  findPort,
-  nextStart,
-  killApp,
-  waitFor,
-} from 'next-test-utils'
+import { nextBuild, nextStart, killApp, waitFor } from 'next-test-utils'
+import getPort from 'get-port'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -18,7 +13,10 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
 describe('Production Usage', () => {
   beforeAll(async () => {
     await nextBuild(appDir)
-    appPort = await findPort()
+    // use compatible port: https://www.browserstack.com/question/664
+    appPort = await getPort({
+      port: [8080, 8081, 8888, 8899],
+    })
     app = await nextStart(appDir, appPort)
   })
   afterAll(() => killApp(app))

--- a/test/jest-environment.js
+++ b/test/jest-environment.js
@@ -76,7 +76,11 @@ class CustomEnvironment extends NodeEnvironment {
       this.server.close()
     }
     if (this.global.wd) {
-      await this.global.wd.quit()
+      try {
+        await this.global.wd.quit()
+      } catch (err) {
+        console.log(`Failed to quit webdriver instance`, err)
+      }
     }
     // must come after wd.quit()
     if (this.seleniumServer) {

--- a/test/lib/next-webdriver.js
+++ b/test/lib/next-webdriver.js
@@ -105,16 +105,6 @@ let browser = new Builder()
 
 global.wd = browser
 
-/*
-  # Methods to match
-
-  - elementByCss
-  - elementsByCss
-  - waitForElementByCss
-  - elementByCss.text
-  - elementByCss.click
-*/
-
 let initialWindow
 let deviceIP = 'localhost'
 
@@ -166,7 +156,7 @@ export default async (appPort, path, waitHydration = true) => {
   if (!initialWindow) {
     initialWindow = await browser.getWindowHandle()
   }
-  if (isBrowserStack && deviceIP === 'localhost') {
+  if (isBrowserStack && deviceIP === 'localhost' && !LEGACY_SAFARI) {
     await getDeviceIP()
   }
   // browser.switchTo().window() fails with `missing field `handle``


### PR DESCRIPTION
It looks like testing with older safari versions is limited based on the port and hostname being used when in specific environments so this updates the test to restrict to compatible settings for testing with safari 10.1 in BrowserStack

x-ref: https://github.com/zeit/next.js/pull/10616