### PR TITLE
Remove `next/link` from Example: With Chakra UI

### DIFF
--- a/examples/with-chakra-ui/src/components/CTA.js
+++ b/examples/with-chakra-ui/src/components/CTA.js
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import { Link as ChakraLink, Button } from '@chakra-ui/core'
 
 import { Container } from './Container'
@@ -12,27 +11,21 @@ export const CTA = () => (
     maxWidth="48rem"
     py={2}
   >
-    <Link isExternal href="https://chakra-ui.com">
-      <ChakraLink isExternal href="https://chakra-ui.com" flexGrow={1} mx={2}>
-        <Button width="100%" variant="outline" variantColor="green">
-          chakra-ui
-        </Button>
-      </ChakraLink>
-    </Link>
-    <Link
+    <ChakraLink isExternal href="https://chakra-ui.com" flexGrow={1} mx={2}>
+      <Button width="100%" variant="outline" variantColor="green">
+        chakra-ui
+      </Button>
+    </ChakraLink>
+
+    <ChakraLink
       isExternal
       href="https://github.com/zeit/next.js/blob/canary/examples/with-chakra-ui"
+      flexGrow={3}
+      mx={2}
     >
-      <ChakraLink
-        isExternal
-        href="https://github.com/zeit/next.js/blob/canary/examples/with-chakra-ui"
-        flexGrow={3}
-        mx={2}
-      >
-        <Button width="100%" variant="solid" variantColor="green">
-          View Repo
-        </Button>
-      </ChakraLink>
-    </Link>
+      <Button width="100%" variant="solid" variantColor="green">
+        View Repo
+      </Button>
+    </ChakraLink>
   </Container>
 )

--- a/examples/with-chakra-ui/src/pages/index.js
+++ b/examples/with-chakra-ui/src/pages/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import Link from 'next/link'
 import { withTheme } from 'emotion-theming'
 import {
   Link as ChakraLink,
@@ -29,29 +28,20 @@ const Index = () => (
       <List spacing={3} my={0}>
         <ListItem>
           <ListIcon icon="check-circle" color="green.500" />
-          <Link href="https://chakra-ui.com">
-            <ChakraLink
-              isExternal
-              href="https://chakra-ui.com"
-              flexGrow={1}
-              mr={2}
-            >
-              Chakra UI <Icon name="external-link" mx="2px" />
-            </ChakraLink>
-          </Link>
+          <ChakraLink
+            isExternal
+            href="https://chakra-ui.com"
+            flexGrow={1}
+            mr={2}
+          >
+            Chakra UI <Icon name="external-link" mx="2px" />
+          </ChakraLink>
         </ListItem>
         <ListItem>
           <ListIcon icon="check-circle" color="green.500" />
-          <Link href="https://nextjs.org">
-            <ChakraLink
-              isExternal
-              href="https://nextjs.org"
-              flexGrow={1}
-              mr={2}
-            >
-              Next.js <Icon name="external-link" mx="2px" />
-            </ChakraLink>
-          </Link>
+          <ChakraLink isExternal href="https://nextjs.org" flexGrow={1} mr={2}>
+            Next.js <Icon name="external-link" mx="2px" />
+          </ChakraLink>
         </ListItem>
       </List>
     </Main>


### PR DESCRIPTION
# Why
When the example is run, it'll show an error that tells an invalid `href` in `<Link>` from the `next/link` component.

# Culprit
At first, I thought it has a connection with the Next version in the example dependencies.

But it turns out because, in the example, it used two `Link` components:
- From `next/link`
- From `@chakra-ui/core`

# So
Because the intention from the original creator of the example is to make the link to redirect to another page (not SPA). So I think, removing the `next/link` and only use the `Link` from `@chakra-ui-core` is sufficient. 

## Screenshot
![image](https://user-images.githubusercontent.com/27177332/75013444-e3273500-54b6-11ea-9655-cb20541ff877.png)

