### PR TITLE
Update error-load-fail test to use check to handle reload taking longer on windows

### DIFF
--- a/test/integration/error-load-fail/test/index.test.js
+++ b/test/integration/error-load-fail/test/index.test.js
@@ -2,13 +2,7 @@
 /* global jasmine */
 import path from 'path'
 import webdriver from 'next-webdriver'
-import {
-  nextBuild,
-  nextStart,
-  findPort,
-  killApp,
-  waitFor,
-} from 'next-test-utils'
+import { nextBuild, nextStart, findPort, killApp, check } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
 const appDir = path.join(__dirname, '..')
@@ -29,8 +23,11 @@ describe('Failing to load _error', () => {
     await killApp(app)
 
     await browser.elementByCss('#to-broken').click()
-    await waitFor(2000)
 
-    expect(await browser.eval('window.beforeNavigate')).toBeFalsy()
+    await check(async () => {
+      return !(await browser.eval('window.beforeNavigate'))
+        ? 'reloaded'
+        : 'fail'
+    }, /reloaded/)
   })
 })


### PR DESCRIPTION
Noticed this was failing in Azure [here](https://dev.azure.com/nextjs/next.js/_build/results?buildId=11506&view=logs&jobId=3749cca0-f3be-5f0b-32a0-2c678fa6f943&j=3749cca0-f3be-5f0b-32a0-2c678fa6f943&t=acd2e3c9-a743-5a6b-2b37-15477dd44e52) and [here](https://dev.azure.com/nextjs/next.js/_build/results?buildId=11504&view=logs&jobId=d9ce86fb-87f0-553d-3342-3c6f10bf2a76&j=d9ce86fb-87f0-553d-3342-3c6f10bf2a76&t=c444cdf2-ce11-5ded-b5e6-d1ef45569b18) so I updated it to use `check` instead of an arbitrary `waitFor()`