### PR TITLE
[custom-server-typescript] Remove deprecated static folder

### DIFF
--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "watch": ["server", "static"],
+  "watch": ["server"],
   "exec": "ts-node --project tsconfig.server.json server/index.ts",
   "ext": "js ts"
 }


### PR DESCRIPTION
Having the assets folder in the `watch` array wasn't useful anyway because nodemon is configured to only watch files with `.js` and `.ts` extensions, and it is not required to restart the server to pick up the changes on the public folder.