### PR TITLE
Fix Cookie Expiration

### DIFF
--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -414,13 +414,19 @@ function clearPreviewData<T>(res: NextApiResponse<T>): NextApiResponse<T> {
       ? previous
       : []),
     serialize(COOKIE_NAME_PRERENDER_BYPASS, '', {
-      maxAge: 0,
+      // To delete a cookie, set `expires` to a date in the past:
+      // https://tools.ietf.org/html/rfc6265#section-4.1.1
+      // `Max-Age: 0` is not valid, thus ignored, and the cookie is persisted.
+      expires: new Date(0),
       httpOnly: true,
       sameSite: 'strict',
       path: '/',
     }),
     serialize(COOKIE_NAME_PRERENDER_DATA, '', {
-      maxAge: 0,
+      // To delete a cookie, set `expires` to a date in the past:
+      // https://tools.ietf.org/html/rfc6265#section-4.1.1
+      // `Max-Age: 0` is not valid, thus ignored, and the cookie is persisted.
+      expires: new Date(0),
       httpOnly: true,
       sameSite: 'strict',
       path: '/',

--- a/test/integration/prerender-preview/test/index.test.js
+++ b/test/integration/prerender-preview/test/index.test.js
@@ -106,6 +106,7 @@ function runTests() {
 
     const cookies = res.headers
       .get('set-cookie')
+      .replace(/(=\w{3}),/g, '$1')
       .split(',')
       .map(cookie.parse)
 
@@ -113,15 +114,17 @@ function runTests() {
     expect(cookies[0]).toMatchObject({
       Path: '/',
       SameSite: 'Strict',
-      'Max-Age': '0',
+      Expires: 'Thu 01 Jan 1970 00:00:00 GMT',
     })
     expect(cookies[0]).toHaveProperty('__prerender_bypass')
+    expect(cookies[0]).not.toHaveProperty('Max-Age')
     expect(cookies[1]).toMatchObject({
       Path: '/',
       SameSite: 'Strict',
-      'Max-Age': '0',
+      Expires: 'Thu 01 Jan 1970 00:00:00 GMT',
     })
     expect(cookies[1]).toHaveProperty('__next_preview_data')
+    expect(cookies[1]).not.toHaveProperty('Max-Age')
   })
 
   /** @type import('next-webdriver').Chain */


### PR DESCRIPTION
`Max-Age: 0` is not valid to expire a cookie per spec.