### PR TITLE
Update example "with-typescript-graphql"

### DIFF
--- a/examples/with-typescript-graphql/.gitignore
+++ b/examples/with-typescript-graphql/.gitignore
@@ -1,1 +1,3 @@
+.next
+node_modules
 __generated__

--- a/examples/with-typescript-graphql/.graphql-let.yml
+++ b/examples/with-typescript-graphql/.graphql-let.yml
@@ -5,3 +5,4 @@ plugins:
   - typescript
   - typescript-operations
   - typescript-react-apollo
+respectGitIgnore: true

--- a/examples/with-typescript-graphql/lib/resolvers.ts
+++ b/examples/with-typescript-graphql/lib/resolvers.ts
@@ -1,11 +1,9 @@
-import { IResolvers } from 'apollo-server-micro'
+import { QueryResolvers } from './type-defs.graphqls'
 
-const resolvers: IResolvers = {
-  Query: {
-    viewer(_parent, _args, _context, _info) {
-      return { id: 1, name: 'John Smith', status: 'cached' }
-    },
+const Query: Required<QueryResolvers> = {
+  viewer(_parent, _args, _context, _info) {
+    return { id: String(1), name: 'John Smith', status: 'cached' }
   },
 }
 
-export default resolvers
+export default { Query }

--- a/examples/with-typescript-graphql/package.json
+++ b/examples/with-typescript-graphql/package.json
@@ -27,6 +27,8 @@
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
+    "@graphql-codegen/cli": "1.12.2",
+    "@graphql-codegen/plugin-helpers": "1.12.2",
     "@graphql-codegen/typescript": "^1.9.1",
     "@graphql-codegen/typescript-operations": "^1.9.1",
     "@graphql-codegen/typescript-react-apollo": "^1.9.1",

--- a/examples/with-typescript-graphql/package.json
+++ b/examples/with-typescript-graphql/package.json
@@ -18,10 +18,10 @@
     "apollo-client": "2.6.8",
     "apollo-link-http": "1.5.16",
     "apollo-link-schema": "1.2.4",
-    "apollo-server-micro": "2.9.14",
+    "apollo-server-micro": "2.10.1",
     "apollo-utilities": "^1.3.3",
-    "graphql": "^14.5.8",
-    "graphql-tag": "^2.10.1",
+    "graphql": "^14.6.0",
+    "graphql-tag": "^2.10.3",
     "next": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
@@ -29,11 +29,12 @@
   "devDependencies": {
     "@graphql-codegen/cli": "1.12.2",
     "@graphql-codegen/plugin-helpers": "1.12.2",
-    "@graphql-codegen/typescript": "^1.9.1",
-    "@graphql-codegen/typescript-operations": "^1.9.1",
-    "@graphql-codegen/typescript-react-apollo": "^1.9.1",
-    "@types/react": "^16.9.17",
+    "@graphql-codegen/typescript": "^1.12.2",
+    "@graphql-codegen/typescript-operations": "^1.12.2",
+    "@graphql-codegen/typescript-react-apollo": "^1.12.2",
+    "@types/react": "^16.9.22",
+    "@types/react-dom": "^16.9.5",
     "graphql-let": "0.x",
-    "typescript": "^3.7.4"
+    "typescript": "^3.8.2"
   }
 }

--- a/examples/with-typescript-graphql/package.json
+++ b/examples/with-typescript-graphql/package.json
@@ -32,6 +32,7 @@
     "@graphql-codegen/typescript": "^1.12.2",
     "@graphql-codegen/typescript-operations": "^1.12.2",
     "@graphql-codegen/typescript-react-apollo": "^1.12.2",
+    "@graphql-codegen/typescript-resolvers": "1.12.2",
     "@types/react": "^16.9.22",
     "@types/react-dom": "^16.9.5",
     "graphql-let": "0.x",


### PR DESCRIPTION
* Utilize resolver types by `@graphql-codegen/typescript-resolvers` to implement resolvers robustly
* Enable `respectGitIgnore` option to ignore directories easily
* Preparing graphql-let 0.9.0 update that will move `@graphql-codegen/cli` to peerDependencies
* Update other deps