### PR TITLE
Make sure to log errors from data fetching in dev mode in the console

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -526,6 +526,7 @@ export async function renderToHTML(
     if (!dev || !err) throw err
     ctx.err = err
     renderOpts.err = err
+    console.error(err)
   }
 
   if (unstable_getServerProps && !isFallback) {

--- a/test/integration/prerender/pages/index.js
+++ b/test/integration/prerender/pages/index.js
@@ -2,6 +2,7 @@ import Link from 'next/link'
 
 // eslint-disable-next-line camelcase
 export async function unstable_getStaticProps() {
+  // throw new Error('oops from getStaticProps')
   return {
     props: { world: 'world', time: new Date().getTime() },
     // bad-prop
@@ -12,6 +13,7 @@ export async function unstable_getStaticProps() {
 const Page = ({ world, time }) => {
   return (
     <>
+      {/* <div id='after-change'>idk</div> */}
       <p>hello {world}</p>
       <span>time: {time}</span>
       <Link href="/another?hello=world" as="/another/?hello=world">


### PR DESCRIPTION
As noticed by @leo, when an error occurs in `getStaticProps` in development the error will be sent to the browser and shown in the error overlay but won't be shown in the terminal. This updates to make sure we also show the error in the console. 

I also added a test to make sure the error is shown in the console and the browser in development 