### PR TITLE
Improve Nested Catch-All Coverage

### DIFF
--- a/test/integration/prerender/pages/catchall/[...slug].js
+++ b/test/integration/prerender/pages/catchall/[...slug].js
@@ -29,5 +29,5 @@ export default ({ slug }) => {
   if (isFallback) {
     return <p id="catchall">fallback</p>
   }
-  return <p id="catchall">Hi {slug.join('/')}</p>
+  return <p id="catchall">Hi {slug.join(' ')}</p>
 }

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -1,26 +1,27 @@
 /* eslint-env jest */
 /* global jasmine */
-import fs from 'fs-extra'
-import { join, dirname } from 'path'
 import cheerio from 'cheerio'
-import webdriver from 'next-webdriver'
 import escapeRegex from 'escape-string-regexp'
+import fs from 'fs-extra'
 import {
-  renderViaHTTP,
+  check,
   fetchViaHTTP,
   findPort,
-  launchApp,
-  killApp,
-  waitFor,
-  nextBuild,
-  nextStart,
-  stopApp,
-  nextExport,
-  normalizeRegEx,
-  startStaticServer,
-  initNextServerScript,
   getReactErrorOverlayContent,
+  initNextServerScript,
+  killApp,
+  launchApp,
+  nextBuild,
+  nextExport,
+  nextStart,
+  normalizeRegEx,
+  renderViaHTTP,
+  startStaticServer,
+  stopApp,
+  waitFor,
 } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { dirname, join } from 'path'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 const appDir = join(__dirname, '..')
@@ -398,10 +399,10 @@ const runTests = (dev = false, looseMode = false) => {
       const text1 = await browser.elementByCss('#catchall').text()
       expect(text1).toBe('fallback')
 
-      await new Promise(resolve => setTimeout(resolve, 4000))
-
-      const text2 = await browser.elementByCss('#catchall').text()
-      expect(text2).toMatch(/Hi.*?delayby3s/)
+      await check(
+        () => browser.elementByCss('#catchall').text(),
+        /Hi.*?delayby3s/
+      )
     }
   })
 
@@ -430,10 +431,10 @@ const runTests = (dev = false, looseMode = false) => {
       const text1 = await browser.elementByCss('#catchall').text()
       expect(text1).toBe('fallback')
 
-      await new Promise(resolve => setTimeout(resolve, 4000))
-
-      const text2 = await browser.elementByCss('#catchall').text()
-      expect(text2).toMatch(/Hi.*?delayby3s nested/)
+      await check(
+        () => browser.elementByCss('#catchall').text(),
+        /Hi.*?delayby3s nested/
+      )
     }
   })
 

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -376,7 +376,7 @@ const runTests = (dev = false) => {
           .text()
       ).isFallback
     ).toBe(false)
-    expect($('#catchall').text()).toMatch(/Hi.*?another\/value/)
+    expect($('#catchall').text()).toMatch(/Hi.*?another value/)
   })
 
   it('should support lazy catchall route', async () => {
@@ -402,6 +402,38 @@ const runTests = (dev = false) => {
 
       const text2 = await browser.elementByCss('#catchall').text()
       expect(text2).toMatch(/Hi.*?delayby3s/)
+    }
+  })
+
+  it('should support nested lazy catchall route', async () => {
+    // Dev doesn't support fallback yet
+    if (dev) {
+      const html = await renderViaHTTP(
+        appPort,
+        '/catchall/notreturnedinpaths/nested'
+      )
+      const $ = cheerio.load(html)
+      expect($('#catchall').text()).toMatch(/Hi.*?notreturnedinpaths nested/)
+    }
+    // Production will render fallback for a "lazy" route
+    else {
+      const html = await renderViaHTTP(
+        appPort,
+        '/catchall/notreturnedinpaths/nested'
+      )
+      const $ = cheerio.load(html)
+      expect($('#catchall').text()).toBe('fallback')
+
+      // hydration
+      const browser = await webdriver(appPort, '/catchall/delayby3s/nested')
+
+      const text1 = await browser.elementByCss('#catchall').text()
+      expect(text1).toBe('fallback')
+
+      await new Promise(resolve => setTimeout(resolve, 4000))
+
+      const text2 = await browser.elementByCss('#catchall').text()
+      expect(text2).toMatch(/Hi.*?delayby3s nested/)
     }
   })
 


### PR DESCRIPTION
This PR improves the test coverage for catch-all routing to include nested variants.

It replaces the test from joining with `/` to a space (` `) instead to ensure we don't pass through the `/` from original request.

Related: #10598