### PR TITLE
Fix Double URL Encoding for Serverless

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -301,7 +301,7 @@ const nextServerlessLoader: loader.Loader = function() {
                           return Object.keys(obj).reduce(
                             (prev, key) =>
                               Object.assign(prev, {
-                                [key]: encodeURIComponent(obj[key])
+                                [key]: obj[key]
                               }),
                             {}
                           );

--- a/test/integration/serverless/pages/catchall/[...slug].js
+++ b/test/integration/serverless/pages/catchall/[...slug].js
@@ -1,0 +1,5 @@
+const SlugPage = ({ query }) => <div>{JSON.stringify(query)}</div>
+
+SlugPage.getInitialProps = ({ query }) => ({ query })
+
+export default SlugPage

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -251,10 +251,30 @@ describe('Serverless', () => {
     expect(data.query).toEqual({ slug: paramRaw })
   })
 
-  it('should have the correct query string for a spr route', async () => {
+  it('should have the correct query string for a now route', async () => {
     const paramRaw = 'test % 123'
     const html = await fetchViaHTTP(appPort, `/dr/[slug]`, '', {
-      headers: { 'x-now-route-matches': qs.stringify({ 1: paramRaw }) },
+      headers: {
+        'x-now-route-matches': qs.stringify({
+          1: encodeURIComponent(paramRaw),
+        }),
+      },
+    }).then(res => res.text())
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#__NEXT_DATA__').html())
+
+    expect(data.query).toEqual({ slug: paramRaw })
+  })
+
+  it('should have the correct query string for a catch all now route', async () => {
+    const paramRaw = ['nested % 1', 'nested/2']
+
+    const html = await fetchViaHTTP(appPort, `/catchall/[...slug]`, '', {
+      headers: {
+        'x-now-route-matches': qs.stringify({
+          1: paramRaw.map(e => encodeURIComponent(e)).join('/'),
+        }),
+      },
     }).then(res => res.text())
     const $ = cheerio.load(html)
     const data = JSON.parse($('#__NEXT_DATA__').html())


### PR DESCRIPTION
Confirmed fix in prod:
![image](https://user-images.githubusercontent.com/616428/75178063-57efae80-5705-11ea-8f70-c54df50fab89.png)
![image](https://user-images.githubusercontent.com/616428/75178068-5a520880-5705-11ea-9e47-13934fe837c8.png)

Fixes #10598