### PR TITLE
fixing commented out getInitialProps

### DIFF
--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -28,7 +28,7 @@ function MyApp({ Component, pageProps }) {
 //
 // MyApp.getInitialProps = async (appContext) => {
 //   // calls page's `getInitialProps` and fills `appProps.pageProps`
-//   const appProps = await App.getInitialProps(appContext);
+//   const appProps = await MyApp.getInitialProps(appContext);
 //
 //   return { ...appProps }
 // }


### PR DESCRIPTION
The call to App instead of MyApp will fail if you modify the props of MyApp. This is common in the case of adding something like a Redux wrapper.