### PR TITLE
Fix with-firebase-cloud-messaging example setup code

### DIFF
--- a/examples/with-firebase-cloud-messaging/static/firebase-messaging-sw.js
+++ b/examples/with-firebase-cloud-messaging/static/firebase-messaging-sw.js
@@ -1,9 +1,12 @@
 /* global importScripts, firebase */
-importScripts('https://www.gstatic.com/firebasejs/4.8.1/firebase-app.js')
-importScripts('https://www.gstatic.com/firebasejs/4.8.1/firebase-messaging.js')
+importScripts('https://www.gstatic.com/firebasejs/7.9.1/firebase-app.js')
+importScripts('https://www.gstatic.com/firebasejs/7.9.1/firebase-messaging.js')
 
 firebase.initializeApp({
-  messagingSenderId: 'your sender id',
+  apiKey: 'YOUR-API-KEY',
+  projectId: 'YOUR-PROJECT-ID',
+  messagingSenderId: 'YOUR-SENDER-ID',
+  appId: 'YOUR-APP-ID',
 })
 
 firebase.messaging()

--- a/examples/with-firebase-cloud-messaging/utils/webPush.js
+++ b/examples/with-firebase-cloud-messaging/utils/webPush.js
@@ -9,7 +9,10 @@ const firebaseCloudMessaging = {
 
   init: async function() {
     firebase.initializeApp({
-      messagingSenderId: 'your sender id',
+      apiKey: 'YOUR-API-KEY',
+      projectId: 'YOUR-PROJECT-ID',
+      messagingSenderId: 'YOUR-SENDER-ID',
+      appId: 'YOUR-APP-ID',
     })
 
     try {


### PR DESCRIPTION
This PR updates the FCM setup code which should fix the issue #10628. This change is needed after firebase `v7.0.0` because of a breaking change.

[Official docs](https://firebase.google.com/docs/cloud-messaging/js/receive) don't reflect this as of this moment. More details here. https://github.com/firebase/quickstart-js/pull/422
