### PR TITLE
Move upgrading guide to /docs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,1 +1,1 @@
-This document has been moved to [nextjs.org/docs/upgrading](https://nextjs.org/docs/upgrading)
+This document has been moved to [nextjs.org/docs/upgrading](https://nextjs.org/docs/upgrading). It's also available in this repository on [/docs/upgrading.md](/docs/upgrading.md).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,1 @@
+This document has been moved to [docs/upgrading.md](docs/upgrading.md). It can also be viewed on [our documentation page](https://nextjs.org/docs/upgrading).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,1 +1,1 @@
-This document has been moved to [docs/upgrading.md](docs/upgrading.md). It can also be viewed on [our documentation page](https://nextjs.org/docs/upgrading).
+This document has been moved to [nextjs.org/docs/upgrading](https://nextjs.org/docs/upgrading)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -149,7 +149,7 @@
         },
         {
           "title": "Upgrade Guide",
-          "path": "/docs/faq.md"
+          "path": "/docs/upgrading.md"
         },
         { "title": "FAQ", "path": "/docs/faq.md" }
       ]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -149,12 +149,7 @@
         },
         {
           "title": "Upgrade Guide",
-          "routes": [
-            {
-              "title": "From Version 8",
-              "path": "/docs/upgrading/from-v8.md"
-            }
-          ]
+          "path": "/docs/faq.md"
         },
         { "title": "FAQ", "path": "/docs/faq.md" }
       ]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -148,7 +148,7 @@
           ]
         },
         {
-          "title": "Upgrading",
+          "title": "Upgrade Guide",
           "routes": [
             {
               "title": "From Version 8",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -147,6 +147,15 @@
             }
           ]
         },
+        {
+          "title": "Upgrading",
+          "routes": [
+            {
+              "title": "From Version 8",
+              "path": "/docs/upgrading/from-v8.md"
+            }
+          ]
+        },
         { "title": "FAQ", "path": "/docs/faq.md" }
       ]
     },

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,10 +1,12 @@
 ---
-description: Learn how to upgrade Next.js from version 8 to 9.0.x.
+description: Learn how to upgrade Next.js.
 ---
 
-# Upgrading Next.js from version 8 to 9.0.x
+# Upgrade Guide
 
-## Preamble
+## Upgrading from version 8 to 9.0.x
+
+### Preamble
 
 #### Production Deployment on ZEIT Now v2
 
@@ -41,7 +43,7 @@ class MyApp extends App {
 }
 ```
 
-## Breaking Changes
+### Breaking Changes
 
 #### `@zeit/next-typescript` is no longer necessary
 

--- a/docs/upgrading/from-v8.md
+++ b/docs/upgrading/from-v8.md
@@ -1,4 +1,8 @@
-# Migrating from v8 to v9
+---
+description: Learn how to upgrade Next.js from version 8 to 9.0.x.
+---
+
+# Upgrading Next.js from version 8 to 9.0.x
 
 ## Preamble
 


### PR DESCRIPTION
As @timneutkens suggested, this PR moves `UPGRADING.md` to `docs` so it'll be on the documentation site. I modified the title to say version 9.0.x instead of version 9 because versions >= 9.1.x have more changes than outlined here. This allows us to add more upgrading guides in the future.