### PR TITLE
Extract getStaticPaths helper

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -662,7 +662,7 @@ export default class Server {
 
     if (!this.renderOpts.dev && this._isLikeServerless) {
       if (typeof pageModule.default === 'function') {
-        this.prepareServerlessUrl(req, query)
+        prepareServerlessUrl(req, query)
         await pageModule.default(req, res)
         return true
       }
@@ -823,50 +823,6 @@ export default class Server {
     return null
   }
 
-  private __sendPayload(
-    res: ServerResponse,
-    payload: any,
-    type: string,
-    options?: { revalidate: number | false; private: boolean }
-  ) {
-    // TODO: ETag? Cache-Control headers? Next-specific headers?
-    res.setHeader('Content-Type', type)
-    res.setHeader('Content-Length', Buffer.byteLength(payload))
-    if (!this.renderOpts.dev) {
-      if (options?.private) {
-        res.setHeader(
-          'Cache-Control',
-          `private, no-cache, no-store, max-age=0, must-revalidate`
-        )
-      } else if (options?.revalidate) {
-        res.setHeader(
-          'Cache-Control',
-          options.revalidate < 0
-            ? `no-cache, no-store, must-revalidate`
-            : `s-maxage=${options.revalidate}, stale-while-revalidate`
-        )
-      } else if (options?.revalidate === false) {
-        res.setHeader(
-          'Cache-Control',
-          `s-maxage=31536000, stale-while-revalidate`
-        )
-      }
-    }
-    res.end(payload)
-  }
-
-  private prepareServerlessUrl(req: IncomingMessage, query: ParsedUrlQuery) {
-    const curUrl = parseUrl(req.url!, true)
-    req.url = formatUrl({
-      ...curUrl,
-      search: undefined,
-      query: {
-        ...curUrl.query,
-        ...query,
-      },
-    })
-  }
-
   private async getStaticPaths(
     pathname: string
   ): Promise<{
@@ -959,18 +915,20 @@ export default class Server {
             true
           )
 
-          this.__sendPayload(
+          sendPayload(
             res,
             JSON.stringify(renderResult?.renderOpts?.pageData),
             'application/json',
-            {
-              revalidate: -1,
-              private: false, // Leave to user-land caching
-            }
+            !this.renderOpts.dev
+              ? {
+                  revalidate: -1,
+                  private: false, // Leave to user-land caching
+                }
+              : undefined
           )
           return null
         }
-        this.prepareServerlessUrl(req, query)
+        prepareServerlessUrl(req, query)
         return (components.Component as any).renderReqToHTML(req, res)
       }
 
@@ -980,10 +938,17 @@ export default class Server {
           ...opts,
           isDataReq,
         })
-        this.__sendPayload(res, JSON.stringify(props), 'application/json', {
-          revalidate: -1,
-          private: false, // Leave to user-land caching
-        })
+        sendPayload(
+          res,
+          JSON.stringify(props),
+          'application/json',
+          !this.renderOpts.dev
+            ? {
+                revalidate: -1,
+                private: false, // Leave to user-land caching
+              }
+            : undefined
+        )
         return null
       }
 
@@ -1013,11 +978,11 @@ export default class Server {
         ? JSON.stringify(cachedData.pageData)
         : cachedData.html
 
-      this.__sendPayload(
+      sendPayload(
         res,
         data,
         isDataReq ? 'application/json' : 'text/html; charset=utf-8',
-        cachedData.curRevalidate !== undefined
+        cachedData.curRevalidate !== undefined && !this.renderOpts.dev
           ? { revalidate: cachedData.curRevalidate, private: isPreviewMode }
           : undefined
       )
@@ -1119,7 +1084,7 @@ export default class Server {
       else {
         query.__nextFallback = 'true'
         if (isLikeServerless) {
-          this.prepareServerlessUrl(req, query)
+          prepareServerlessUrl(req, query)
           html = await (components.Component as any).renderReqToHTML(req, res)
         } else {
           html = (await renderToHTML(req, res, pathname, query, {
@@ -1129,7 +1094,7 @@ export default class Server {
         }
       }
 
-      this.__sendPayload(res, html, 'text/html; charset=utf-8')
+      sendPayload(res, html, 'text/html; charset=utf-8')
     }
 
     const {
@@ -1137,11 +1102,13 @@ export default class Server {
       value: { html, pageData, sprRevalidate },
     } = await doRender(ssgCacheKey, [])
     if (!isResSent(res)) {
-      this.__sendPayload(
+      sendPayload(
         res,
         isDataReq ? JSON.stringify(pageData) : html,
         isDataReq ? 'application/json' : 'text/html; charset=utf-8',
-        { revalidate: sprRevalidate, private: isPreviewMode }
+        !this.renderOpts.dev
+          ? { revalidate: sprRevalidate, private: isPreviewMode }
+          : undefined
       )
     }
 
@@ -1362,4 +1329,48 @@ export default class Server {
   private get _isLikeServerless(): boolean {
     return isTargetLikeServerless(this.nextConfig.target)
   }
+}
+
+function sendPayload(
+  res: ServerResponse,
+  payload: any,
+  type: string,
+  options?: { revalidate: number | false; private: boolean }
+) {
+  // TODO: ETag? Cache-Control headers? Next-specific headers?
+  res.setHeader('Content-Type', type)
+  res.setHeader('Content-Length', Buffer.byteLength(payload))
+  if (options != null) {
+    if (options?.private) {
+      res.setHeader(
+        'Cache-Control',
+        `private, no-cache, no-store, max-age=0, must-revalidate`
+      )
+    } else if (options?.revalidate) {
+      res.setHeader(
+        'Cache-Control',
+        options.revalidate < 0
+          ? `no-cache, no-store, must-revalidate`
+          : `s-maxage=${options.revalidate}, stale-while-revalidate`
+      )
+    } else if (options?.revalidate === false) {
+      res.setHeader(
+        'Cache-Control',
+        `s-maxage=31536000, stale-while-revalidate`
+      )
+    }
+  }
+  res.end(payload)
+}
+
+function prepareServerlessUrl(req: IncomingMessage, query: ParsedUrlQuery) {
+  const curUrl = parseUrl(req.url!, true)
+  req.url = formatUrl({
+    ...curUrl,
+    search: undefined,
+    query: {
+      ...curUrl.query,
+      ...query,
+    },
+  })
 }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -867,6 +867,47 @@ export default class Server {
     })
   }
 
+  private async getStaticPaths(
+    pathname: string
+  ): Promise<{
+    staticPaths: string[] | undefined
+    hasStaticFallback: boolean
+  }> {
+    // we lazy load the staticPaths to prevent the user
+    // from waiting on them for the page to load in dev mode
+    let staticPaths: string[] | undefined
+    let hasStaticFallback = false
+
+    if (!this.renderOpts.dev) {
+      // `staticPaths` is intentionally set to `undefined` as it should've
+      // been caught when checking disk data.
+      staticPaths = undefined
+
+      // Read whether or not fallback should exist from the manifest.
+      hasStaticFallback =
+        typeof this.getPrerenderManifest().dynamicRoutes[pathname].fallback ===
+        'string'
+    } else {
+      const __getStaticPaths = async () => {
+        const paths = await this.staticPathsWorker!.loadStaticPaths(
+          this.distDir,
+          this.buildId,
+          pathname,
+          !this.renderOpts.dev && this._isLikeServerless
+        )
+        return paths
+      }
+      ;({ paths: staticPaths, fallback: hasStaticFallback } = (
+        await withCoalescedInvoke(__getStaticPaths)(
+          `staticPaths-${pathname}`,
+          []
+        )
+      ).value)
+    }
+
+    return { staticPaths, hasStaticFallback }
+  }
+
   private async renderToHTMLWithComponents(
     req: IncomingMessage,
     res: ServerResponse,
@@ -1029,39 +1070,9 @@ export default class Server {
     const isDynamicPathname = isDynamicRoute(pathname)
     const didRespond = isResSent(res)
 
-    // we lazy load the staticPaths to prevent the user
-    // from waiting on them for the page to load in dev mode
-    let staticPaths: string[] | undefined
-    let hasStaticFallback = false
-
-    if (hasStaticPaths) {
-      if (isProduction) {
-        // `staticPaths` is intentionally set to `undefined` as it should've
-        // been caught above when checking disk data.
-        staticPaths = undefined
-
-        // Read whether or not fallback should exist from the manifest.
-        hasStaticFallback =
-          typeof this.getPrerenderManifest().dynamicRoutes[pathname]
-            .fallback === 'string'
-      } else {
-        const __getStaticPaths = async () => {
-          const paths = await this.staticPathsWorker!.loadStaticPaths(
-            this.distDir,
-            this.buildId,
-            pathname,
-            !this.renderOpts.dev && this._isLikeServerless
-          )
-          return paths
-        }
-        ;({ paths: staticPaths, fallback: hasStaticFallback } = (
-          await withCoalescedInvoke(__getStaticPaths)(
-            `staticPaths-${pathname}`,
-            []
-          )
-        ).value)
-      }
-    }
+    const { staticPaths, hasStaticFallback } = hasStaticPaths
+      ? await this.getStaticPaths(pathname)
+      : { staticPaths: undefined, hasStaticFallback: false }
 
     // const isForcedBlocking =
     //   req.headers['X-Prerender-Bypass-Mode'] !== 'Blocking'

--- a/test/integration/getserversideprops/pages/url-prop.js
+++ b/test/integration/getserversideprops/pages/url-prop.js
@@ -1,9 +1,0 @@
-export async function getServerSideProps() {
-  return {
-    props: {
-      url: 'something',
-    },
-  }
-}
-
-export default ({ url }) => <p>url: {url}</p>


### PR DESCRIPTION
This is a step towards having `renderToHTMLWithComponents` _behind_ the page interface. The `getStaticPaths` will just be passed down instead.