### PR TITLE
Remove old eslint-ignores from unstable_ prefix

### DIFF
--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -118,9 +118,7 @@ export default async function({
     let curRenderOpts = {}
     let renderMethod = renderToHTML
 
-    // eslint-disable-next-line camelcase
     const renderedDuringBuild = getStaticProps => {
-      // eslint-disable-next-line camelcase
       return !buildExport && getStaticProps && !isDynamicRoute(path)
     }
 

--- a/test/integration/client-navigation/pages/nav/url-prop-change.js
+++ b/test/integration/client-navigation/pages/nav/url-prop-change.js
@@ -10,7 +10,6 @@ export default class UrlPropChange extends React.Component {
     }
   }
 
-  // eslint-disable-next-line camelcase
   componentDidUpdate(prevProps) {
     if (prevProps.url !== this.props.url) {
       this.setState(() => {

--- a/test/integration/getserversideprops/pages/another/index.js
+++ b/test/integration/getserversideprops/pages/another/index.js
@@ -2,7 +2,6 @@ import Link from 'next/link'
 import fs from 'fs'
 import findUp from 'find-up'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps() {
   const text = fs
     .readFileSync(

--- a/test/integration/getserversideprops/pages/blog/[post]/[comment].js
+++ b/test/integration/getserversideprops/pages/blog/[post]/[comment].js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps({ query }) {
   return {
     props: {

--- a/test/integration/getserversideprops/pages/blog/[post]/index.js
+++ b/test/integration/getserversideprops/pages/blog/[post]/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps({ params }) {
   if (params.post === 'post-10') {
     await new Promise(resolve => {

--- a/test/integration/getserversideprops/pages/blog/index.js
+++ b/test/integration/getserversideprops/pages/blog/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps() {
   return {
     props: {

--- a/test/integration/getserversideprops/pages/catchall/[...path].js
+++ b/test/integration/getserversideprops/pages/catchall/[...path].js
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps({ params }) {
   return {
     props: {

--- a/test/integration/getserversideprops/pages/default-revalidate.js
+++ b/test/integration/getserversideprops/pages/default-revalidate.js
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps() {
   return {
     props: {

--- a/test/integration/getserversideprops/pages/index.js
+++ b/test/integration/getserversideprops/pages/index.js
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps() {
   return {
     props: {

--- a/test/integration/getserversideprops/pages/invalid-keys.js
+++ b/test/integration/getserversideprops/pages/invalid-keys.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps({ params, query }) {
   return {
     world: 'world',

--- a/test/integration/getserversideprops/pages/something.js
+++ b/test/integration/getserversideprops/pages/something.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps({ params, query }) {
   return {
     props: {

--- a/test/integration/getserversideprops/pages/user/[user]/profile.js
+++ b/test/integration/getserversideprops/pages/user/[user]/profile.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getServerSideProps({ query }) {
   return {
     props: {

--- a/test/integration/prerender-invalid-catchall-params/pages/[...slug].js
+++ b/test/integration/prerender-invalid-catchall-params/pages/[...slug].js
@@ -1,11 +1,9 @@
 import React from 'react'
 
-// eslint-disable-next-line camelcase
 export async function getStaticPaths() {
   return { paths: [{ params: { slug: 'hello' } }], fallback: true }
 }
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps({ params }) {
   return {
     props: {

--- a/test/integration/prerender-invalid-paths/pages/[foo]/[post].js
+++ b/test/integration/prerender-invalid-paths/pages/[foo]/[post].js
@@ -1,11 +1,9 @@
 import React from 'react'
 
-// eslint-disable-next-line camelcase
 export async function getStaticPaths() {
   return { paths: [{ foo: 'bad', baz: 'herro' }], fallback: true }
 }
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps({ params }) {
   return {
     props: {

--- a/test/integration/prerender-legacy/pages/blog/[post].js
+++ b/test/integration/prerender-legacy/pages/blog/[post].js
@@ -1,11 +1,9 @@
 import React from 'react'
 
-// eslint-disable-next-line camelcase
 export async function unstable_getStaticParams() {
   return ['/blog/post-1']
 }
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps({ params }) {
   return {
     props: {

--- a/test/integration/prerender/pages/another/index.js
+++ b/test/integration/prerender/pages/another/index.js
@@ -2,7 +2,6 @@ import Link from 'next/link'
 import fs from 'fs'
 import findUp from 'find-up'
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps() {
   const text = fs
     .readFileSync(

--- a/test/integration/prerender/pages/blog/[post]/[comment].js
+++ b/test/integration/prerender/pages/blog/[post]/[comment].js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getStaticPaths() {
   return {
     paths: [
@@ -12,7 +11,6 @@ export async function getStaticPaths() {
   }
 }
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps({ params }) {
   return {
     props: {

--- a/test/integration/prerender/pages/blog/[post]/index.js
+++ b/test/integration/prerender/pages/blog/[post]/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-// eslint-disable-next-line camelcase
 export async function getStaticPaths() {
   return {
     paths: [
@@ -19,7 +18,6 @@ export async function getStaticPaths() {
 
 let counter = 0
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps({ params }) {
   if (params.post === 'post-10') {
     await new Promise(resolve => {

--- a/test/integration/prerender/pages/blog/index.js
+++ b/test/integration/prerender/pages/blog/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps() {
   return {
     props: {

--- a/test/integration/prerender/pages/default-revalidate.js
+++ b/test/integration/prerender/pages/default-revalidate.js
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps() {
   return {
     props: {

--- a/test/integration/prerender/pages/index.js
+++ b/test/integration/prerender/pages/index.js
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps() {
   // throw new Error('oops from getStaticProps')
   return {

--- a/test/integration/prerender/pages/something.js
+++ b/test/integration/prerender/pages/something.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps({ params }) {
   return {
     props: {

--- a/test/integration/prerender/pages/user/[user]/profile.js
+++ b/test/integration/prerender/pages/user/[user]/profile.js
@@ -1,12 +1,10 @@
 import React from 'react'
 import Link from 'next/link'
 
-// eslint-disable-next-line camelcase
 export async function getStaticPaths() {
   return { paths: [], fallback: true }
 }
 
-// eslint-disable-next-line camelcase
 export async function getStaticProps({ params }) {
   return {
     props: {


### PR DESCRIPTION
Now that we've removed this prefix we no longer need these ignores so this removes them as we're following the rule correctly now