### PR TITLE
Vertically align code and label on baseline

### DIFF
--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -74,7 +74,7 @@ const styles: { [k: string]: React.CSSProperties } = {
     textAlign: 'left',
     lineHeight: '49px',
     height: '49px',
-    verticalAlign: 'middle',
+    verticalAlign: 'baseline',
   },
 
   h1: {
@@ -85,7 +85,7 @@ const styles: { [k: string]: React.CSSProperties } = {
     padding: '10px 23px 10px 0',
     fontSize: '24px',
     fontWeight: 500,
-    verticalAlign: 'top',
+    verticalAlign: 'baseline',
   },
 
   h2: {


### PR DESCRIPTION
Wouldn't it be nicer to align HTTP status codes with their label on the baseline?

**Before**

<img width="294" alt="Screenshot 2020-02-28 at 20 29 08" src="https://user-images.githubusercontent.com/491123/75581102-2b22fa80-5a69-11ea-9351-64bcb43a76c7.png">

**After**

<img width="282" alt="Screenshot 2020-02-28 at 20 29 27" src="https://user-images.githubusercontent.com/491123/75581124-36762600-5a69-11ea-8739-5b6bbc3023f9.png">

Note: baseline is normally the default alignment.
