### PR TITLE
Add params to getStaticProps on err.sh

### DIFF
--- a/errors/invalid-getstaticprops-value.md
+++ b/errors/invalid-getstaticprops-value.md
@@ -9,7 +9,11 @@ In one of the page's `getStaticProps` the return value had the incorrect shape.
 Make sure to return the following shape from `getStaticProps`:
 
 ```js
-export async function getStaticProps({ params }) {
+export async function getStaticProps(ctx: {
+  params?: ParsedUrlQuery
+  preview?: boolean
+  previewData?: any
+}) {
   return {
     props: { [key: string]: any }
   }

--- a/errors/invalid-getstaticprops-value.md
+++ b/errors/invalid-getstaticprops-value.md
@@ -9,7 +9,7 @@ In one of the page's `getStaticProps` the return value had the incorrect shape.
 Make sure to return the following shape from `getStaticProps`:
 
 ```js
-export async function getStaticProps() {
+export async function getStaticProps({ params }) {
   return {
     props: { [key: string]: any }
   }


### PR DESCRIPTION
`getStaticProps` takes `{ params }` and I think it'd be helpful to mention that on this `err.sh` doc. https://github.com/zeit/next.js/issues/9524