### PR TITLE
Separate Low Priority Files from Main Files

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -153,6 +153,7 @@ export type DocumentProps = DocumentInitialProps & {
   hasCssMode: boolean
   devFiles: string[]
   files: string[]
+  lowPriorityFiles: string[]
   polyfillFiles: string[]
   dynamicImports: ManifestItem[]
   assetPrefix?: string

--- a/packages/next/next-server/server/get-page-files.ts
+++ b/packages/next/next-server/server/get-page-files.ts
@@ -2,7 +2,9 @@ import { normalizePagePath } from './normalize-page-path'
 
 export type BuildManifest = {
   devFiles: string[]
+  lowPriorityFiles: string[]
   pages: {
+    '/_app': string[]
     [page: string]: string[]
   }
 }

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -174,6 +174,7 @@ function renderDocument(
     staticMarkup,
     devFiles,
     files,
+    lowPriorityFiles,
     polyfillFiles,
     dynamicImports,
     htmlProps,
@@ -191,8 +192,9 @@ function renderDocument(
     hybridAmp: boolean
     dynamicImportsIds: string[]
     dynamicImports: ManifestItem[]
-    files: string[]
     devFiles: string[]
+    files: string[]
+    lowPriorityFiles: string[]
     polyfillFiles: string[]
     htmlProps: any
     bodyTags: any
@@ -229,6 +231,7 @@ function renderDocument(
           staticMarkup,
           devFiles,
           files,
+          lowPriorityFiles,
           polyfillFiles,
           dynamicImports,
           assetPrefix,
@@ -579,6 +582,7 @@ export async function renderToHTML(
       ...getPageFiles(buildManifest, pathname),
     ]),
   ]
+  const lowPriorityFiles = buildManifest.lowPriorityFiles
   const polyfillFiles = getPageFiles(buildManifest, '/_polyfills')
 
   const renderElementToString = staticMarkup
@@ -674,8 +678,9 @@ export async function renderToHTML(
     hybridAmp,
     dynamicImportsIds,
     dynamicImports,
-    files,
     devFiles,
+    files,
+    lowPriorityFiles,
     polyfillFiles,
   })
 

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -44,10 +44,6 @@ function getOptionalModernScriptVariant(path: string) {
   return path
 }
 
-function isLowPriority(file: string) {
-  return file.includes('_buildManifest')
-}
-
 /**
  * `Document` component handles the initial `document` markup and renders only on the server side.
  * Commonly used for implementing server side rendering for `css-in-js` libraries.
@@ -260,13 +256,7 @@ export class Head extends Component<
             // `dynamicImports` will contain both `.js` and `.module.js` when
             // the feature is enabled. This clause will filter down to the
             // modern variants only.
-            //
-            // Also filter out low priority files because they should not be
-            // preloaded for performance reasons.
-            return (
-              file.endsWith(getOptionalModernScriptVariant('.js')) &&
-              !isLowPriority(file)
-            )
+            return file.endsWith(getOptionalModernScriptVariant('.js'))
           })
         : []
 
@@ -589,17 +579,12 @@ export class NextScript extends Component<OriginProps> {
   }
 
   getScripts() {
-    const { assetPrefix, files } = this.context._documentProps
-    if (!files || files.length === 0) {
-      return null
-    }
+    const { assetPrefix, files, lowPriorityFiles } = this.context._documentProps
     const { _devOnlyInvalidateCacheQueryString } = this.context
 
-    const normalScripts = files.filter(
-      file => file.endsWith('.js') && !isLowPriority(file)
-    )
-    const lowPriorityScripts = files.filter(
-      file => file.endsWith('.js') && isLowPriority(file)
+    const normalScripts = files?.filter(file => file.endsWith('.js'))
+    const lowPriorityScripts = lowPriorityFiles?.filter(file =>
+      file.endsWith('.js')
     )
 
     return [...normalScripts, ...lowPriorityScripts].map(file => {

--- a/test/integration/chunking/test/index.test.js
+++ b/test/integration/chunking/test/index.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 /* global jasmine */
-import { join } from 'path'
+import cheerio from 'cheerio'
 import express from 'express'
+import { access, readdir, readFile, unlink } from 'fs-extra'
 import http from 'http'
 import { nextBuild, nextServer, promiseCall, stopApp } from 'next-test-utils'
-import { readdir, readFile, unlink, access } from 'fs-extra'
-import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
+import { join } from 'path'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
 
@@ -86,6 +86,20 @@ describe('Chunking', () => {
       [].slice
         .call($('link[rel="preload"][as="script"]'))
         .map(e => e.attribs.href)
+        .some(entry => entry.includes('_buildManifest'))
+    ).toBe(false)
+  })
+
+  it('should execute the build manifest', async () => {
+    const indexPage = await readFile(
+      join(appDir, '.next', 'server', 'static', buildId, 'pages', 'index.html')
+    )
+
+    const $ = cheerio.load(indexPage)
+    expect(
+      [].slice
+        .call($('script'))
+        .map(e => e.attribs.src)
         .some(entry => entry.includes('_buildManifest'))
     ).toBe(false)
   })

--- a/test/integration/chunking/test/index.test.js
+++ b/test/integration/chunking/test/index.test.js
@@ -97,11 +97,10 @@ describe('Chunking', () => {
 
     const $ = cheerio.load(indexPage)
     expect(
-      [].slice
-        .call($('script'))
+      Array.from($('script'))
         .map(e => e.attribs.src)
-        .some(entry => entry.includes('_buildManifest'))
-    ).toBe(false)
+        .some(entry => entry && entry.includes('_buildManifest'))
+    ).toBe(true)
   })
 
   it('should not include more than one instance of react-dom', async () => {


### PR DESCRIPTION
Instead of maintaining a whitelist of low-priority files:
```js
// actual deleted code:
function isLowPriority(file: string) {	
  return file.includes('_buildManifest') // imagine this growing: `|| file.includes('...')`
}
```

... the build manifest now contains an entry for `lowPriorityFiles`. I also deduped a type and added an additional test that we were missing before.