### PR TITLE
Correctly Dedupe Prefetching

### DIFF
--- a/test/integration/preload-viewport/pages/not-de-duped.js
+++ b/test/integration/preload-viewport/pages/not-de-duped.js
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default () => {
+  return (
+    <p>
+      <Link href="/first" as="/first#different">
+        <a>to /first</a>
+      </Link>
+    </p>
+  )
+}

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -228,4 +228,20 @@ describe('Prefetching Links in viewport', () => {
     const calledPrefetch = await browser.eval(`window.calledPrefetch`)
     expect(calledPrefetch).toBe(false)
   })
+
+  it('should prefetch with a different asPath for a prefetched page', async () => {
+    // info: both `/` and `/not-de-duped` ref the `/first` page, which we want
+    // to see prefetched twice.
+    const browser = await webdriver(appPort, '/')
+    await browser.eval(`(function() {
+      window.calledPrefetch = false
+      window.next.router.prefetch = function() {
+        window.calledPrefetch = true
+      }
+      window.next.router.push('/not-de-duped')
+    })()`)
+    await waitFor(2 * 1000)
+    const calledPrefetch = await browser.eval(`window.calledPrefetch`)
+    expect(calledPrefetch).toBe(true)
+  })
 })


### PR DESCRIPTION
`Router#prefetch` accepts both the `href` and `asPath` values, so we must ensure we dedupe prefetches on both of those values and not only `href`.