### PR TITLE
updating links to dynamic-routes section of docs

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,11 +10,11 @@ description: Learn how to upgrade Next.js.
 
 #### Production Deployment on ZEIT Now v2
 
-If you previously configured `routes` in your `now.json` file for dynamic routes, these rules can be removed when leveraging Next.js 9's new [Dynamic Routing feature](https://github.com/zeit/next.js#dynamic-routing).
+If you previously configured `routes` in your `now.json` file for dynamic routes, these rules can be removed when leveraging Next.js 9's new [Dynamic Routing feature](https://nextjs.org/docs/routing/dynamic-routes).
 
 Next.js 9's dynamic routes are **automatically configured on [Now](https://zeit.co/now)** and do not require any `now.json` customization.
 
-You can read more about [Dynamic Routing here](https://github.com/zeit/next.js#dynamic-routing).
+You can read more about [Dynamic Routing here](https://nextjs.org/docs/routing/dynamic-routes).
 
 #### Check your Custom <App> (`pages/_app.js`)
 


### PR DESCRIPTION
This link:

https://github.com/zeit/next.js#dynamic-routing

doesn't link anywhere.

Updating it to link to the dynamic-routes section in the docs:

https://nextjs.org/docs/routing/dynamic-routes
