### PR TITLE
Remove `dangerousAsPath` from `RenderOpts`

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -129,7 +129,6 @@ type RenderOpts = LoadComponentsReturnType & {
   buildId: string
   canonicalBase: string
   runtimeConfig?: { [key: string]: any }
-  dangerousAsPath: string
   assetPrefix?: string
   hasCssMode: boolean
   err?: Error | null


### PR DESCRIPTION
This removes `dangerousAsPath` from `RenderOpts`, as it's not necessary to be provided by the rendering request pipeline.

This option is one of the reasons `next-server` uses the `any` type instead of a concrete type.

This property is already a part of `DocumentProps`, which is already unconditionally injected at the callsite of `renderDocument`:
![image](https://user-images.githubusercontent.com/616428/75629833-7e08c900-5bb3-11ea-9a95-cdc5b13a9467.png)
