### PR TITLE
examples: react-native-web: fix config to prefer .web.* exts

### DIFF
--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,11 +1,16 @@
 module.exports = {
-  webpack: (config, { defaultLoaders }) => {
+  webpack: (config) => {
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
       // Transform all direct `react-native` imports to `react-native-web`
       'react-native$': 'react-native-web',
     }
-    config.resolve.extensions.push('.web.js', '.web.ts', '.web.tsx')
+    config.resolve.extensions = [
+      ".web.js",
+      ".web.ts",
+      ".web.tsx",
+      ...config.resolve.extensions,
+    ];
     return config
   },
 }

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,16 +1,16 @@
 module.exports = {
-  webpack: (config) => {
+  webpack: config => {
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
       // Transform all direct `react-native` imports to `react-native-web`
       'react-native$': 'react-native-web',
     }
     config.resolve.extensions = [
-      ".web.js",
-      ".web.ts",
-      ".web.tsx",
+      '.web.js',
+      '.web.ts',
+      '.web.tsx',
       ...config.resolve.extensions,
-    ];
+    ]
     return config
   },
 }


### PR DESCRIPTION
Simple issue if you have `Compo.js` & `Compo.web.js` (eg 1st for iOS/android & second for web): with current config, .web are resolved after.
My change change this situation so web extensions are resolved before the others.

I removed the `defaultLoaders` since it was not used. Tell me if that was intentional so I can add it back.