### PR TITLE
Fix RenderOpts in `next-server`

### DIFF
--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -260,6 +260,7 @@ const COOKIE_NAME_PRERENDER_BYPASS = `__prerender_bypass`
 const COOKIE_NAME_PRERENDER_DATA = `__next_preview_data`
 
 export const SYMBOL_PREVIEW_DATA = Symbol(COOKIE_NAME_PRERENDER_DATA)
+const SYMBOL_CLEARED_COOKIES = Symbol(COOKIE_NAME_PRERENDER_BYPASS)
 
 export function tryGetPreviewData(
   req: IncomingMessage,
@@ -405,6 +406,10 @@ function setPreviewData<T>(
 }
 
 function clearPreviewData<T>(res: NextApiResponse<T>): NextApiResponse<T> {
+  if (SYMBOL_CLEARED_COOKIES in res) {
+    return res
+  }
+
   const { serialize } = require('cookie') as typeof import('cookie')
   const previous = res.getHeader('Set-Cookie')
   res.setHeader(`Set-Cookie`, [
@@ -432,6 +437,11 @@ function clearPreviewData<T>(res: NextApiResponse<T>): NextApiResponse<T> {
       path: '/',
     }),
   ])
+
+  Object.defineProperty(res, SYMBOL_CLEARED_COOKIES, {
+    value: true,
+    enumerable: false,
+  })
   return res
 }
 

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1028,8 +1028,9 @@ export default class Server {
         renderResult = await renderToHTML(req, res, pathname, query, renderOpts)
 
         html = renderResult
-        pageData = renderOpts.pageData
-        sprRevalidate = renderOpts.revalidate
+        // TODO: change this to a different passing mechanism
+        pageData = (renderOpts as any).pageData
+        sprRevalidate = (renderOpts as any).revalidate
       }
 
       return { html, pageData, sprRevalidate }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1231,7 +1231,10 @@ export default class Server {
         res,
         using404Page ? '/404' : '/_error',
         result!,
-        { ...this.renderOpts, err }
+        {
+          ...this.renderOpts,
+          err,
+        }
       )
       if (result2 === false) {
         throw new Error('invariant: failed to render error page')

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -519,6 +519,7 @@ export async function renderToHTML(
 
       props.pageProps = data.props
       // pass up revalidate and props for export
+      // TODO: change this to a different passing mechanism
       ;(renderOpts as any).revalidate = data.revalidate
       ;(renderOpts as any).pageData = props
     }

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -124,12 +124,11 @@ function render(
   return { html, head }
 }
 
-type RenderOpts = LoadComponentsReturnType & {
+export type RenderOptsPartial = {
   staticMarkup: boolean
   buildId: string
   canonicalBase: string
   runtimeConfig?: { [key: string]: any }
-  dangerousAsPath: string
   assetPrefix?: string
   hasCssMode: boolean
   err?: Error | null
@@ -147,6 +146,8 @@ type RenderOpts = LoadComponentsReturnType & {
   params?: ParsedUrlQuery
   previewProps: __ApiPreviewProps
 }
+
+export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial
 
 function renderDocument(
   Document: DocumentType,
@@ -469,7 +470,7 @@ export async function renderToHTML(
       // Reads of this are cached on the `req` object, so this should resolve
       // instantly. There's no need to pass this data down from a previous
       // invoke, where we'd have to consider server & serverless.
-      const previewData = tryGetPreviewData(req, res, previewProps)
+      const previewData = tryGetPreviewData(req, res, previewProps) // TODO: null check
       const data = await getStaticProps!({
         ...(pageIsDynamic ? { params: query as ParsedUrlQuery } : undefined),
         ...(previewData !== false

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -470,7 +470,7 @@ export async function renderToHTML(
       // Reads of this are cached on the `req` object, so this should resolve
       // instantly. There's no need to pass this data down from a previous
       // invoke, where we'd have to consider server & serverless.
-      const previewData = tryGetPreviewData(req, res, previewProps) // TODO: null check
+      const previewData = tryGetPreviewData(req, res, previewProps)
       const data = await getStaticProps!({
         ...(pageIsDynamic ? { params: query as ParsedUrlQuery } : undefined),
         ...(previewData !== false


### PR DESCRIPTION
This pull request correctly types the `RenderOpts` arguments in `next-server`.

As a side effect, it caught a couple situations:

- `previewProps` were not passed in all scenarios (assign in shared object instead of on individual call sites)
- `isDataReq` was of the wrong type (added `!!` to booleanify)
- Revealed we're sharing the object for `pageData` and `sprRevalidate` (added TODOs to fix)

I've added a test to ensure this does not regress. I also fixed a double cookie setting issue identified as a result of this new test.