### PR TITLE
Add example for polyfilling DOMParser in Node

### DIFF
--- a/examples/with-react-intl/README.md
+++ b/examples/with-react-intl/README.md
@@ -57,4 +57,17 @@ $ npm start
 
 You can then switch your browser's language preferences to French and refresh the page to see the UI update accordingly.
 
+### FormattedHTMLMessage support (react-intl pre-v4)
+
+Out of the box, this example does not support the use of the `FormattedHTMLMessage` component on the server due to `DOMParser` not being present in a Node environment.
+This functionality is deprecated and has been removed as of react-intl 4.0
+If you still want to enable this feature, you should install a `DOMParser` implementation (e.g. `xmldom` or `jsdom`) and enable the polyfill in `server.js`:
+
+```js
+// Polyfill Node with `DOMParser` required by formatjs.
+// See: https://github.com/zeit/next.js/issues/10533
+const { DOMParser } = require('xmldom')
+global.DOMParser = DOMParser
+```
+
 [react intl]: https://github.com/yahoo/react-intl

--- a/examples/with-react-intl/server.js
+++ b/examples/with-react-intl/server.js
@@ -4,6 +4,12 @@ const IntlPolyfill = require('intl')
 Intl.NumberFormat = IntlPolyfill.NumberFormat
 Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat
 
+// Polyfill DOMParser for **pre-v4** react-intl used by formatjs.
+// Only needed when using FormattedHTMLMessage. Make sure to install `xmldom`.
+// See: https://github.com/zeit/next.js/issues/10533
+// const { DOMParser } = require('xmldom')
+// global.DOMParser = DOMParser
+
 const { readFileSync } = require('fs')
 const { basename } = require('path')
 const { createServer } = require('http')


### PR DESCRIPTION
This pull request addresses #10533 and updates the `with-react-intl` example to show the user how they can enable support for `FormattedHTMLMessage` on the server by polyfilling `DOMParser`.

I have disabled the polyfill by default since the dependency on `xmldom` (or `jsdom`) might be a little heavy if you are not using `FormattedHTMLMessage` (which is a legacy feature and not recommended anyway). Though, this dependency is only included on the server so that might be not as big of an issue. What do you think?

Fixes #10533