### PR TITLE
Fix next/config module mismatch in new serverless mode

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -62,7 +62,7 @@ const nextServerlessLoader: loader.Loader = function() {
 
   const runtimeConfigImports = runtimeConfig
     ? `
-      const { setConfig } = require('next/dist/next-server/lib/runtime-config')
+      const { setConfig } = require('next/config')
     `
     : ''
 

--- a/test/integration/serverless-runtime-configs/test/index.test.js
+++ b/test/integration/serverless-runtime-configs/test/index.test.js
@@ -31,15 +31,16 @@ const nextStart = async (appDir, appPort) => {
   )
 }
 
-describe('Serverless runtime configs', () => {
-  beforeAll(() => cleanUp())
-  afterAll(() => cleanUp())
+const runTests = (oldServerless = false) => {
+  const serverlessMode = oldServerless
+    ? 'serverless'
+    : 'experimental-serverless-trace'
 
   it('should not error on usage of publicRuntimeConfig', async () => {
     await fs.writeFile(
       nextConfigPath,
       `module.exports = {
-      target: 'serverless',
+      target: '${serverlessMode}',
       publicRuntimeConfig: {
         hello: 'world'
       }
@@ -59,7 +60,7 @@ describe('Serverless runtime configs', () => {
     await fs.writeFile(
       nextConfigPath,
       `module.exports = {
-      target: 'serverless',
+      target: '${serverlessMode}',
       serverRuntimeConfig: {
         hello: 'world'
       }
@@ -130,7 +131,7 @@ describe('Serverless runtime configs', () => {
     await fs.writeFile(
       nextConfigPath,
       `module.exports = {
-        target: 'serverless',
+        target: '${serverlessMode}',
         serverRuntimeConfig: {
           hello: 'world'
         },
@@ -150,7 +151,7 @@ describe('Serverless runtime configs', () => {
     await fs.writeFile(
       nextConfigPath,
       `module.exports = {
-        target: 'serverless',
+        target: '${serverlessMode}',
         serverRuntimeConfig: {
           hello: 'world'
         },
@@ -163,5 +164,18 @@ describe('Serverless runtime configs', () => {
     const appPort = await findPort()
     const app = await launchApp(appDir, appPort)
     await testRuntimeConfig(app, appPort)
+  })
+}
+
+describe('Serverless runtime configs', () => {
+  beforeAll(() => cleanUp())
+  afterAll(() => cleanUp())
+
+  describe('legacy serverless mode', () => {
+    runTests(true)
+  })
+
+  describe('experimental-serverless-trace mode', () => {
+    runTests()
   })
 })


### PR DESCRIPTION
In the new `experimental-serverless-trace` mode when requiring the exact path for `next/config` it was causing it to be bundled while `next/config` was not bundled which caused the config to be set to the wrong instance of the config module. I updated the `serverless-loader` to require the correct path to prevent the mismatch and also added tests for runtime-config with the `experimental-serverless-trace`

Fixes: https://github.com/zeit/next.js/issues/10791