### PR TITLE
Remove old env from workflow since it is replaced with WebHook

### DIFF
--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -10,5 +10,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: zeit/next-stats-action@master
-        env:
-          COMMENT_ENDPOINT: https://next-stats.jjsweb.site/api/comment


### PR DESCRIPTION
As discussed this removes the custom comment endpoint API in favor of a WebHook that posts our PR Stats and failed tests so that you don't have to go through the logs to find out which ones failed.

Tested the WebHook against a separate repo [here](https://github.com/ijjk/test-next-hook/pull/1) which will be deleted after this is merged