### PR TITLE
Add identifier to NEXT_DATA for gs(s)p

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -78,6 +78,8 @@ export type NEXT_DATA = {
   isFallback?: boolean
   dynamicIds?: string[]
   err?: Error & { statusCode?: number }
+  gsp?: boolean
+  gssp?: boolean
 }
 
 /**

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -181,6 +181,8 @@ function renderDocument(
     htmlProps,
     bodyTags,
     headTags,
+    gsp,
+    gssp,
   }: RenderOpts & {
     props: any
     docProps: DocumentInitialProps
@@ -201,6 +203,8 @@ function renderDocument(
     bodyTags: any
     headTags: any
     isFallback?: boolean
+    gsp?: boolean
+    gssp?: boolean
   }
 ): string {
   return (
@@ -221,6 +225,8 @@ function renderDocument(
             dynamicIds:
               dynamicImportsIds.length === 0 ? undefined : dynamicImportsIds,
             err: err ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
+            gsp, // whether the page is getStaticProps
+            gssp, // whether the page is getServerSideProps
           },
           dangerousAsPath,
           canonicalBase,
@@ -680,6 +686,8 @@ export async function renderToHTML(
     files,
     lowPriorityFiles,
     polyfillFiles,
+    gsp: !!getStaticProps ? true : undefined,
+    gssp: !!getServerSideProps ? true : undefined,
   })
 
   if (inAmpMode && html) {

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -200,7 +200,7 @@ const runTests = (dev = false) => {
   it('should not have gssp in __NEXT_DATA__ for non-GSSP page', async () => {
     const html = await renderViaHTTP(appPort, '/normal')
     const $ = cheerio.load(html)
-    expect('gssp' in JSON.parse($('#__NEXT_DATA__').text())).toBe(false);
+    expect('gssp' in JSON.parse($('#__NEXT_DATA__').text())).toBe(false)
   })
 
   it('should supply query values SSR', async () => {

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -191,6 +191,18 @@ const runTests = (dev = false) => {
     expect(html).toMatch(/Post:.*?post-1/)
   })
 
+  it('should have gssp in __NEXT_DATA__', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    const $ = cheerio.load(html)
+    expect(JSON.parse($('#__NEXT_DATA__').text()).gssp).toBe(true)
+  })
+
+  it('should not have gssp in __NEXT_DATA__ for non-GSSP page', async () => {
+    const html = await renderViaHTTP(appPort, '/normal')
+    const $ = cheerio.load(html)
+    expect(JSON.parse($('#__NEXT_DATA__').text()).gssp).toBeFalsy()
+  })
+
   it('should supply query values SSR', async () => {
     const html = await renderViaHTTP(appPort, '/blog/post-1?hello=world')
     const $ = cheerio.load(html)

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -200,7 +200,7 @@ const runTests = (dev = false) => {
   it('should not have gssp in __NEXT_DATA__ for non-GSSP page', async () => {
     const html = await renderViaHTTP(appPort, '/normal')
     const $ = cheerio.load(html)
-    expect(JSON.parse($('#__NEXT_DATA__').text()).gssp).toBeFalsy()
+    expect('gssp' in JSON.parse($('#__NEXT_DATA__').text())).toBe(false);
   })
 
   it('should supply query values SSR', async () => {

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -291,7 +291,7 @@ const runTests = (dev = false, looseMode = false) => {
   it('should not have gsp in __NEXT_DATA__ for non-GSP page', async () => {
     const html = await renderViaHTTP(appPort, '/normal')
     const $ = cheerio.load(html)
-    expect(JSON.parse($('#__NEXT_DATA__').text()).gsp).toBeFalsy()
+    expect('gsp' in JSON.parse($('#__NEXT_DATA__').text())).toBe(false)
   })
 
   it('should not supply query values to params or useRouter non-dynamic page SSR', async () => {

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -282,6 +282,18 @@ const runTests = (dev = false, looseMode = false) => {
     expect(html).toMatch(/Post:.*?post-1/)
   })
 
+  it('should have gsp in __NEXT_DATA__', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    const $ = cheerio.load(html)
+    expect(JSON.parse($('#__NEXT_DATA__').text()).gsp).toBe(true)
+  })
+
+  it('should not have gsp in __NEXT_DATA__ for non-GSP page', async () => {
+    const html = await renderViaHTTP(appPort, '/normal')
+    const $ = cheerio.load(html)
+    expect(JSON.parse($('#__NEXT_DATA__').text()).gsp).toBeFalsy()
+  })
+
   it('should not supply query values to params or useRouter non-dynamic page SSR', async () => {
     const html = await renderViaHTTP(appPort, '/something?hello=world')
     const $ = cheerio.load(html)


### PR DESCRIPTION
This adds a `gsp` or `gssp` field to `__NEXT_DATA__` to allow detecting whether a page is using `getStaticProps` or `getServerSideProps`. I added tests to the respective test suites to ensure this is set correctly 

[NEXT-98]

[NEXT-98]: https://zeit.atlassian.net/browse/NEXT-98