### PR TITLE
Update to make sure preview mode works with getServerSideProps

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -905,12 +905,13 @@ export default class Server {
       })
     }
 
-    const previewData = tryGetPreviewData(
-      req,
-      res,
-      this.renderOpts.previewProps
-    )
-    const isPreviewMode = previewData !== false
+    let previewData: string | false | object | undefined
+    let isPreviewMode = false
+
+    if (isServerProps || isSSG) {
+      previewData = tryGetPreviewData(req, res, this.renderOpts.previewProps)
+      isPreviewMode = previewData !== false
+    }
 
     // non-spr requests should render like normal
     if (!isSSG) {
@@ -965,14 +966,14 @@ export default class Server {
         ...opts,
       })
 
-      if (html) {
+      if (html && isServerProps && isPreviewMode) {
         sendPayload(res, html, 'text/html; charset=utf-8', {
           revalidate: -1,
           private: isPreviewMode,
         })
       }
 
-      return null
+      return html
     }
 
     // Compute the SPR cache key

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -83,6 +83,8 @@ export type GetServerSideProps = (context: {
   res: ServerResponse
   params?: ParsedUrlQuery
   query: ParsedUrlQuery
+  preview?: boolean
+  previewData?: any
 }) => Promise<{ [key: string]: any }>
 
 export default next

--- a/test/integration/getserversideprops-preview/pages/api/preview.js
+++ b/test/integration/getserversideprops-preview/pages/api/preview.js
@@ -1,0 +1,4 @@
+export default (req, res) => {
+  res.setPreviewData(req.query)
+  res.status(200).end()
+}

--- a/test/integration/getserversideprops-preview/pages/api/reset.js
+++ b/test/integration/getserversideprops-preview/pages/api/reset.js
@@ -1,0 +1,4 @@
+export default (req, res) => {
+  res.clearPreviewData()
+  res.status(200).end()
+}

--- a/test/integration/getserversideprops-preview/pages/index.js
+++ b/test/integration/getserversideprops-preview/pages/index.js
@@ -1,0 +1,15 @@
+export function getServerSideProps({ preview, previewData }) {
+  return { props: { hasProps: true, preview, previewData } }
+}
+
+export default function({ hasProps, preview, previewData }) {
+  if (!hasProps) {
+    return <pre id="props-pre">Has No Props</pre>
+  }
+
+  return (
+    <pre id="props-pre">
+      {JSON.stringify(preview) + ' and ' + JSON.stringify(previewData)}
+    </pre>
+  )
+}

--- a/test/integration/getserversideprops-preview/server.js
+++ b/test/integration/getserversideprops-preview/server.js
@@ -1,0 +1,41 @@
+const http = require('http')
+const url = require('url')
+const fs = require('fs')
+const path = require('path')
+const server = http.createServer((req, res) => {
+  let { pathname } = url.parse(req.url)
+  if (pathname.startsWith('/_next/data')) {
+    pathname = pathname
+      .replace(`/_next/data/${process.env.BUILD_ID}/`, '/')
+      .replace(/\.json$/, '')
+  }
+  console.log('serving', pathname)
+
+  if (pathname === '/favicon.ico') {
+    res.statusCode = 404
+    return res.end()
+  }
+
+  if (pathname.startsWith('/_next/static/')) {
+    res.write(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          './.next/static/',
+          pathname.slice('/_next/static/'.length)
+        ),
+        'utf8'
+      )
+    )
+    return res.end()
+  } else {
+    const re = require(`./.next/serverless/pages${pathname}`)
+    return typeof re.render === 'function'
+      ? re.render(req, res)
+      : re.default(req, res)
+  }
+})
+
+server.listen(process.env.PORT, () => {
+  console.log('ready on', process.env.PORT)
+})

--- a/test/integration/getserversideprops-preview/test/index.test.js
+++ b/test/integration/getserversideprops-preview/test/index.test.js
@@ -1,0 +1,300 @@
+/* eslint-env jest */
+/* global jasmine */
+import cheerio from 'cheerio'
+import cookie from 'cookie'
+import fs from 'fs-extra'
+import {
+  fetchViaHTTP,
+  findPort,
+  initNextServerScript,
+  killApp,
+  launchApp,
+  nextBuild,
+  nextStart,
+  renderViaHTTP,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import os from 'os'
+import { join } from 'path'
+import qs from 'querystring'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '..')
+const nextConfigPath = join(appDir, 'next.config.js')
+
+async function getBuildId() {
+  return fs.readFile(join(appDir, '.next', 'BUILD_ID'), 'utf8')
+}
+
+function getData(html) {
+  const $ = cheerio.load(html)
+  const nextData = $('#__NEXT_DATA__')
+  const preEl = $('#props-pre')
+  return { nextData: JSON.parse(nextData.html()), pre: preEl.text() }
+}
+
+function runTests(startServer = nextStart) {
+  it('should compile successfully', async () => {
+    await fs.remove(join(appDir, '.next'))
+    const { code, stdout } = await nextBuild(appDir, [], {
+      stdout: true,
+    })
+    expect(code).toBe(0)
+    expect(stdout).toMatch(/Compiled successfully/)
+  })
+
+  let appPort, app
+  it('should start production application', async () => {
+    appPort = await findPort()
+    app = await startServer(appDir, appPort)
+  })
+
+  it('should return page on first request', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    const { nextData, pre } = getData(html)
+    expect(nextData).toMatchObject({ isFallback: false })
+    expect(pre).toBe('undefined and undefined')
+  })
+
+  it('should return page on second request', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    const { nextData, pre } = getData(html)
+    expect(nextData).toMatchObject({ isFallback: false })
+    expect(pre).toBe('undefined and undefined')
+  })
+
+  let previewCookieString
+  it('should enable preview mode', async () => {
+    const res = await fetchViaHTTP(appPort, '/api/preview', { lets: 'goooo' })
+    expect(res.status).toBe(200)
+
+    const cookies = res.headers
+      .get('set-cookie')
+      .split(',')
+      .map(cookie.parse)
+
+    expect(cookies.length).toBe(2)
+    expect(cookies[0]).toMatchObject({ Path: '/', SameSite: 'Strict' })
+    expect(cookies[0]).toHaveProperty('__prerender_bypass')
+    expect(cookies[0]).not.toHaveProperty('Max-Age')
+    expect(cookies[1]).toMatchObject({ Path: '/', SameSite: 'Strict' })
+    expect(cookies[1]).toHaveProperty('__next_preview_data')
+    expect(cookies[1]).not.toHaveProperty('Max-Age')
+
+    previewCookieString =
+      cookie.serialize('__prerender_bypass', cookies[0].__prerender_bypass) +
+      '; ' +
+      cookie.serialize('__next_preview_data', cookies[1].__next_preview_data)
+  })
+
+  it('should not return fallback page on preview request', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/',
+      {},
+      { headers: { Cookie: previewCookieString } }
+    )
+    const html = await res.text()
+
+    const { nextData, pre } = getData(html)
+    expect(res.headers.get('cache-control')).toBe(
+      'private, no-cache, no-store, max-age=0, must-revalidate'
+    )
+    expect(nextData).toMatchObject({ isFallback: false })
+    expect(pre).toBe('true and {"lets":"goooo"}')
+  })
+
+  it('should return correct caching headers for data preview request', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      `/_next/data/${encodeURI(await getBuildId())}/index.json`,
+      {},
+      { headers: { Cookie: previewCookieString } }
+    )
+    const json = await res.json()
+
+    expect(res.headers.get('cache-control')).toBe(
+      'private, no-cache, no-store, max-age=0, must-revalidate'
+    )
+    expect(json).toMatchObject({
+      pageProps: {
+        preview: true,
+        previewData: { lets: 'goooo' },
+      },
+    })
+  })
+
+  it('should return cookies to be expired on reset request', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/api/reset',
+      {},
+      { headers: { Cookie: previewCookieString } }
+    )
+    expect(res.status).toBe(200)
+
+    const cookies = res.headers
+      .get('set-cookie')
+      .replace(/(=\w{3}),/g, '$1')
+      .split(',')
+      .map(cookie.parse)
+
+    expect(cookies.length).toBe(2)
+    expect(cookies[0]).toMatchObject({
+      Path: '/',
+      SameSite: 'Strict',
+      Expires: 'Thu 01 Jan 1970 00:00:00 GMT',
+    })
+    expect(cookies[0]).toHaveProperty('__prerender_bypass')
+    expect(cookies[0]).not.toHaveProperty('Max-Age')
+    expect(cookies[1]).toMatchObject({
+      Path: '/',
+      SameSite: 'Strict',
+      Expires: 'Thu 01 Jan 1970 00:00:00 GMT',
+    })
+    expect(cookies[1]).toHaveProperty('__next_preview_data')
+    expect(cookies[1]).not.toHaveProperty('Max-Age')
+  })
+
+  /** @type import('next-webdriver').Chain */
+  let browser
+  it('should start the client-side browser', async () => {
+    browser = await webdriver(
+      appPort,
+      '/api/preview?' + qs.stringify({ client: 'mode' })
+    )
+  })
+
+  it('should fetch preview data', async () => {
+    await browser.get(`http://localhost:${appPort}/`)
+    await browser.waitForElementByCss('#props-pre')
+    // expect(await browser.elementById('props-pre').text()).toBe('Has No Props')
+    // await new Promise(resolve => setTimeout(resolve, 2000))
+    expect(await browser.elementById('props-pre').text()).toBe(
+      'true and {"client":"mode"}'
+    )
+  })
+
+  it('should fetch prerendered data', async () => {
+    await browser.get(`http://localhost:${appPort}/api/reset`)
+
+    await browser.get(`http://localhost:${appPort}/`)
+    await browser.waitForElementByCss('#props-pre')
+    expect(await browser.elementById('props-pre').text()).toBe(
+      'undefined and undefined'
+    )
+  })
+
+  afterAll(async () => {
+    await browser.close()
+    await killApp(app)
+  })
+}
+
+const startServerlessEmulator = async (dir, port) => {
+  const scriptPath = join(dir, 'server.js')
+  const env = Object.assign(
+    {},
+    { ...process.env },
+    { PORT: port, BUILD_ID: await getBuildId() }
+  )
+  return initNextServerScript(scriptPath, /ready on/i, env)
+}
+
+describe('Prerender Preview Mode', () => {
+  describe('Development Mode', () => {
+    beforeAll(async () => {
+      await fs.remove(nextConfigPath)
+    })
+
+    let appPort, app
+    it('should start development application', async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+
+    let previewCookieString
+    it('should enable preview mode', async () => {
+      const res = await fetchViaHTTP(appPort, '/api/preview', { lets: 'goooo' })
+      expect(res.status).toBe(200)
+
+      const cookies = res.headers
+        .get('set-cookie')
+        .split(',')
+        .map(cookie.parse)
+
+      expect(cookies.length).toBe(2)
+      previewCookieString =
+        cookie.serialize('__prerender_bypass', cookies[0].__prerender_bypass) +
+        '; ' +
+        cookie.serialize('__next_preview_data', cookies[1].__next_preview_data)
+    })
+
+    it('should return cookies to be expired after dev server reboot', async () => {
+      await killApp(app)
+      app = await launchApp(appDir, appPort)
+
+      const res = await fetchViaHTTP(
+        appPort,
+        '/',
+        {},
+        { headers: { Cookie: previewCookieString } }
+      )
+      expect(res.status).toBe(200)
+
+      const body = await res.text()
+      // "err":{"name":"TypeError","message":"Cannot read property 'previewModeId' of undefined"
+      expect(body).not.toContain('err')
+      expect(body).not.toContain('TypeError')
+      expect(body).not.toContain('previewModeId')
+
+      const cookies = res.headers
+        .get('set-cookie')
+        .replace(/(=\w{3}),/g, '$1')
+        .split(',')
+        .map(cookie.parse)
+
+      expect(cookies.length).toBe(2)
+    })
+
+    afterAll(async () => {
+      await killApp(app)
+    })
+  })
+
+  describe('Server Mode', () => {
+    beforeAll(async () => {
+      await fs.remove(nextConfigPath)
+    })
+
+    runTests()
+  })
+
+  describe('Serverless Mode', () => {
+    beforeAll(async () => {
+      await fs.writeFile(
+        nextConfigPath,
+        `module.exports = { target: 'experimental-serverless-trace' }` + os.EOL
+      )
+    })
+    afterAll(async () => {
+      await fs.remove(nextConfigPath)
+    })
+
+    runTests()
+  })
+
+  describe('Emulated Serverless Mode', () => {
+    beforeAll(async () => {
+      await fs.writeFile(
+        nextConfigPath,
+        `module.exports = { target: 'experimental-serverless-trace' }` + os.EOL
+      )
+    })
+    afterAll(async () => {
+      await fs.remove(nextConfigPath)
+    })
+
+    runTests(startServerlessEmulator)
+  })
+})


### PR DESCRIPTION
This makes sure preview mode works correctly with `getServerSideProps` also and that `previewData` and `preview` are exposed in it's context. I also migrated the existing preview mode tests over for `getServerSideProps`