### PR TITLE
Update to output jest data for posting failed tests comment

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -38,6 +38,7 @@ jobs:
     needs: build
     env:
       NEXT_TELEMETRY_DISABLED: 1
+      NEXT_TEST_JOB: 1
       HEADLESS: true
     strategy:
       fail-fast: false

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   testMatch: ['**/*.test.js'],
   verbose: true,
-  bail: true,
   rootDir: 'test',
   modulePaths: ['<rootDir>/lib'],
   globalSetup: '<rootDir>/jest-global-setup.js',

--- a/run-tests.js
+++ b/run-tests.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const _glob = require('glob')
+const fs = require('fs').promises
 const fetch = require('node-fetch')
 const { promisify } = require('util')
 const { Sema } = require('async-sema')
@@ -8,9 +9,11 @@ const { spawn, exec: execOrig } = require('child_process')
 const glob = promisify(_glob)
 const exec = promisify(execOrig)
 
-const NUM_RETRIES = 2
-const DEFAULT_CONCURRENCY = 2
 const timings = []
+const NUM_RETRIES = 0
+const DEFAULT_CONCURRENCY = 2
+const RESULTS_EXT = `.results.json`
+const isTestJob = !!process.env.NEXT_TEST_JOB
 const TIMINGS_API = `https://next-timings.jjsweb.site/api/timings`
 
 ;(async () => {
@@ -117,15 +120,24 @@ const TIMINGS_API = `https://next-timings.jjsweb.site/api/timings`
       const start = new Date().getTime()
       const child = spawn(
         'node',
-        [jestPath, '--runInBand', '--forceExit', '--verbose', test],
+        [
+          jestPath,
+          '--runInBand',
+          '--forceExit',
+          '--verbose',
+          ...(isTestJob
+            ? ['--json', `--outputFile=${test}${RESULTS_EXT}`]
+            : []),
+          test,
+        ],
         {
           stdio: 'inherit',
           env: {
             ...process.env,
             ...(usePolling
               ? {
-                  // Events can be finicky in CI. This switches to a more reliable
-                  // polling method.
+                  // Events can be finicky in CI. This switches to a more
+                  // reliable polling method.
                   CHOKIDAR_USEPOLLING: 'true',
                   CHOKIDAR_INTERVAL: 500,
                 }
@@ -169,6 +181,22 @@ const TIMINGS_API = `https://next-timings.jjsweb.site/api/timings`
       if (!passed) {
         console.error(`${test} failed to pass within ${NUM_RETRIES} retries`)
         children.forEach(child => child.kill())
+
+        if (isTestJob) {
+          try {
+            const testsOutput = await fs.readFile(
+              `${test}${RESULTS_EXT}`,
+              'utf8'
+            )
+            console.log(
+              `--test output start--`,
+              testsOutput,
+              `--test output end--`
+            )
+          } catch (err) {
+            console.log(`Failed to load test output`, err)
+          }
+        }
         process.exit(1)
       }
       sema.release()

--- a/run-tests.js
+++ b/run-tests.js
@@ -10,7 +10,7 @@ const glob = promisify(_glob)
 const exec = promisify(execOrig)
 
 const timings = []
-const NUM_RETRIES = 0
+const NUM_RETRIES = 2
 const DEFAULT_CONCURRENCY = 2
 const RESULTS_EXT = `.results.json`
 const isTestJob = !!process.env.NEXT_TEST_JOB

--- a/test/integration/app-document/test/index.test.js
+++ b/test/integration/app-document/test/index.test.js
@@ -38,7 +38,7 @@ describe('Document and App', () => {
 
   it('should not have any missing key warnings', async () => {
     await renderViaHTTP(context.appPort, '/')
-    expect(context.output).not.toMatch(
+    expect(context.output).toMatch(
       /Each child in a list should have a unique "key" prop/
     )
   })

--- a/test/integration/app-document/test/index.test.js
+++ b/test/integration/app-document/test/index.test.js
@@ -38,7 +38,7 @@ describe('Document and App', () => {
 
   it('should not have any missing key warnings', async () => {
     await renderViaHTTP(context.appPort, '/')
-    expect(context.output).toMatch(
+    expect(context.output).not.toMatch(
       /Each child in a list should have a unique "key" prop/
     )
   })


### PR DESCRIPTION
This adds the `outputFile` flag when running tests with `jest` to allow us to output this data in the logs so that our PR WebHook can post the output from jest in the failed tests comment 