### PR TITLE
fix(cli): inspect flag is deprecated

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -25,17 +25,16 @@ Available commands
 
 Options
   --version, -v   Version number
-  --inspect       Enable the Node.js inspector
   --help, -h      Displays this message
 
 For more information run a command with the --help flag
   $ next build --help
 ```
 
-You can pass any node arguments to `next` commands:
+You can pass any [node arguments](https://nodejs.org/api/cli.html#cli_node_options_options) to `next` commands:
 
 ```bash
-NODE_OPTIONS="--throw-deprecation" next
-NODE_OPTIONS="-r esm" next
-NODE_OPTIONS="--inspect" next
+NODE_OPTIONS='--throw-deprecation' next
+NODE_OPTIONS='-r esm' next
+NODE_OPTIONS='--inspect' next
 ```

--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -63,7 +63,6 @@ if (!foundCommand && args['--help']) {
 
     Options
       --version, -v   Version number
-      --inspect       Enable the Node.js inspector
       --help, -h      Displays this message
 
     For more information run a command with the --help flag
@@ -77,7 +76,7 @@ const forwardedArgs = foundCommand ? args._.slice(1) : args._
 
 if (args['--inspect'])
   throw new Error(
-    `Use env variable NODE_OPTIONS instead: NODE_OPTIONS="--inspect" next ${command}`
+    `--inspect flag is deprecated. Use env variable NODE_OPTIONS instead: NODE_OPTIONS='--inspect' next ${command}`
   )
 
 // Make sure the `next <subcommand> --help` case is covered


### PR DESCRIPTION
This commit effectively removes the --inspect flag from the CLI help and better inform on the deprecation.
