### PR TITLE
Ensure an accessible default viewport meta tag

### DIFF
--- a/packages/next/next-server/lib/head.tsx
+++ b/packages/next/next-server/lib/head.tsx
@@ -12,10 +12,7 @@ export function defaultHead(inAmpMode = false) {
   const head = [<meta charSet="utf-8" />]
   if (!inAmpMode) {
     head.push(
-      <meta
-        name="viewport"
-        content="width=device-width,minimum-scale=1,initial-scale=1"
-      />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
     )
   }
   return head

--- a/packages/next/next-server/lib/head.tsx
+++ b/packages/next/next-server/lib/head.tsx
@@ -11,9 +11,7 @@ type WithInAmpMode = {
 export function defaultHead(inAmpMode = false) {
   const head = [<meta charSet="utf-8" />]
   if (!inAmpMode) {
-    head.push(
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-    )
+    head.push(<meta name="viewport" content="width=device-width" />)
   }
   return head
 }

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -52,7 +52,7 @@ export default function(render, fetch) {
     test('header renders default viewport', async () => {
       const html = await render('/default-head')
       expect(html).toContain(
-        '<meta name="viewport" content="width=device-width, initial-scale=1"/>'
+        '<meta name="viewport" content="width=device-width"/>'
       )
     })
 

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -52,7 +52,7 @@ export default function(render, fetch) {
     test('header renders default viewport', async () => {
       const html = await render('/default-head')
       expect(html).toContain(
-        '<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/>'
+        '<meta name="viewport" content="width=device-width, ,initial-scale=1"/>'
       )
     })
 

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -52,7 +52,7 @@ export default function(render, fetch) {
     test('header renders default viewport', async () => {
       const html = await render('/default-head')
       expect(html).toContain(
-        '<meta name="viewport" content="width=device-width, ,initial-scale=1"/>'
+        '<meta name="viewport" content="width=device-width, initial-scale=1"/>'
       )
     })
 


### PR DESCRIPTION
Setting `minimum-scale` can disable the user's ability to zoom the viewport and potentially causing accessibility issues according to the following resources:

- https://webhint.io/docs/user-guide/hints/hint-meta-viewport/
- https://developers.google.com/web/fundamentals/design-and-ux/responsive/#set-the-viewport
- https://web.dev/viewport/
- https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag#Viewport_basics