### PR TITLE
Send Credentials for `getServerSideProps` Requests

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -83,7 +83,21 @@ function fetchNextData(
         // @ts-ignore __NEXT_DATA__
         pathname: `/_next/data/${__NEXT_DATA__.buildId}${pathname}.json`,
         query,
-      })
+      }),
+      {
+        // Cookies are required to be present for Next.js' SSG "Preview Mode".
+        // Cookies may also be required for `getServerSideProps`.
+        //
+        // > `fetch` won’t send cookies, unless you set the credentials init
+        // > option.
+        // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
+        //
+        // > For maximum browser compatibility when it comes to sending &
+        // > receiving cookies, always supply the `credentials: 'same-origin'`
+        // > option instead of relying on the default.
+        // https://github.com/github/fetch#caveats
+        credentials: 'same-origin',
+      }
     ).then(res => {
       if (!res.ok) {
         if (--attempts > 0 && res.status >= 500) {

--- a/test/integration/getserversideprops-preview/pages/to-index.js
+++ b/test/integration/getserversideprops-preview/pages/to-index.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export function getServerProps() {
+export function getServerSideProps() {
   return { props: {} }
 }
 

--- a/test/integration/getserversideprops-preview/pages/to-index.js
+++ b/test/integration/getserversideprops-preview/pages/to-index.js
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export function getServerProps() {
+  return { props: {} }
+}
+
+export default function() {
+  return (
+    <main>
+      <Link href="/">
+        <a id="to-index">To Index</a>
+      </Link>
+    </main>
+  )
+}

--- a/test/integration/getserversideprops-preview/test/index.test.js
+++ b/test/integration/getserversideprops-preview/test/index.test.js
@@ -165,11 +165,23 @@ function runTests(startServer = nextStart) {
     )
   })
 
-  it('should fetch preview data', async () => {
+  it('should fetch preview data on SSR', async () => {
     await browser.get(`http://localhost:${appPort}/`)
     await browser.waitForElementByCss('#props-pre')
     // expect(await browser.elementById('props-pre').text()).toBe('Has No Props')
     // await new Promise(resolve => setTimeout(resolve, 2000))
+    expect(await browser.elementById('props-pre').text()).toBe(
+      'true and {"client":"mode"}'
+    )
+  })
+
+  it('should fetch preview data on CST', async () => {
+    await browser.get(`http://localhost:${appPort}/to-index`)
+    await browser.waitForElementByCss('#to-index')
+    await browser.eval('window.itdidnotrefresh = "hello"')
+    await browser.elementById('to-index').click()
+    await browser.waitForElementByCss('#props-pre')
+    expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
     expect(await browser.elementById('props-pre').text()).toBe(
       'true and {"client":"mode"}'
     )

--- a/test/integration/prerender-preview/pages/to-index.js
+++ b/test/integration/prerender-preview/pages/to-index.js
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export function getStaticProps() {
+  return { props: {} }
+}
+
+export default function() {
+  return (
+    <main>
+      <Link href="/">
+        <a id="to-index">To Index</a>
+      </Link>
+    </main>
+  )
+}

--- a/test/integration/prerender-preview/test/index.test.js
+++ b/test/integration/prerender-preview/test/index.test.js
@@ -165,11 +165,23 @@ function runTests(startServer = nextStart) {
     )
   })
 
-  it('should fetch preview data', async () => {
+  it('should fetch preview data on SSR', async () => {
     await browser.get(`http://localhost:${appPort}/`)
     await browser.waitForElementByCss('#props-pre')
     // expect(await browser.elementById('props-pre').text()).toBe('Has No Props')
     // await new Promise(resolve => setTimeout(resolve, 2000))
+    expect(await browser.elementById('props-pre').text()).toBe(
+      'true and {"client":"mode"}'
+    )
+  })
+
+  it('should fetch preview data on CST', async () => {
+    await browser.get(`http://localhost:${appPort}/to-index`)
+    await browser.waitForElementByCss('#to-index')
+    await browser.eval('window.itdidnotrefresh = "hello"')
+    await browser.elementById('to-index').click()
+    await browser.waitForElementByCss('#props-pre')
+    expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
     expect(await browser.elementById('props-pre').text()).toBe(
       'true and {"client":"mode"}'
     )


### PR DESCRIPTION
Requests to `getServerSideProps`, et al may require cookies to be present.

Per spec, we should not rely on default behavior and instead define it ourselves.

[NEXT-107]

[NEXT-107]: https://zeit.atlassian.net/browse/NEXT-107