### PR TITLE
Update release stats with different name from pr stats

### DIFF
--- a/.github/workflows/release_stats.yml
+++ b/.github/workflows/release_stats.yml
@@ -4,10 +4,9 @@ name: Generate Release Stats
 
 jobs:
   prStats:
-    name: PR Stats
+    name: Release Stats
     runs-on: ubuntu-latest
     steps:
-      - name: PR Stats
-        uses: zeit/next-stats-action@master
+      - uses: zeit/next-stats-action@master
         env:
           PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}


### PR DESCRIPTION
The name of the job is used to ignore non-actionable WebHook events so this needs to have a different name from PR Stats so we know to ignore it