### PR TITLE
Fix Prerender Test Cases

### DIFF
--- a/test/integration/prerender/pages/index.js
+++ b/test/integration/prerender/pages/index.js
@@ -33,7 +33,7 @@ const Page = ({ world, time }) => {
       <Link href="/blog/[post]" as="/blog/post-100">
         <a id="broken-post">to broken</a>
       </Link>
-      <Link href="/blog/[post]" as="/blog/post-999">
+      <Link href="/blog/[post]" as="/blog/post-999" prefetch={false}>
         <a id="broken-at-first-post">to broken at first</a>
       </Link>
       <br />

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -377,10 +377,10 @@ const runTests = (dev = false, looseMode = false) => {
 
   it('should reload page on failed data request', async () => {
     const browser = await webdriver(appPort, '/')
-    await browser.eval('window.beforeClick = true')
+    await browser.eval('window.beforeClick = "abc"')
     await browser.elementByCss('#broken-post').click()
     await waitFor(1000)
-    expect(await browser.eval('window.beforeClick')).not.toBe('true')
+    expect(await browser.eval('window.beforeClick')).not.toBe('abc')
   })
 
   // TODO: dev currently renders this page as blocking, meaning it shows the
@@ -388,10 +388,10 @@ const runTests = (dev = false, looseMode = false) => {
   if (!dev) {
     it('should reload page on failed data request, and retry', async () => {
       const browser = await webdriver(appPort, '/')
-      await browser.eval('window.beforeClick = true')
+      await browser.eval('window.beforeClick = "abc"')
       await browser.elementByCss('#broken-at-first-post').click()
       await waitFor(3000)
-      expect(await browser.eval('window.beforeClick')).not.toBe('true')
+      expect(await browser.eval('window.beforeClick')).not.toBe('abc')
 
       const text = await browser.elementByCss('#params').text()
       expect(text).toMatch(/post.*?post-999/)


### PR DESCRIPTION
This test was incorrectly comparing `true` to `'true'`.

I've switched this to be a generic string.

Actual fix happened in https://github.com/zeit/next.js/pull/10862, but these tests kept failing for some reason.