### PR TITLE
Fix `getServerSideProps` Test Case

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -568,7 +568,7 @@ export async function renderToHTML(
       ;(renderOpts as any).pageData = props
     }
   } catch (err) {
-    if (!dev || !err) throw err
+    if (isDataReq || !dev || !err) throw err
     ctx.err = err
     renderOpts.err = err
     console.error(err)

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -295,10 +295,10 @@ const runTests = (dev = false) => {
   it('should reload page on failed data request', async () => {
     const browser = await webdriver(appPort, '/')
     await waitFor(500)
-    await browser.eval('window.beforeClick = true')
+    await browser.eval('window.beforeClick = "abc"')
     await browser.elementByCss('#broken-post').click()
     await waitFor(1000)
-    expect(await browser.eval('window.beforeClick')).not.toBe('true')
+    expect(await browser.eval('window.beforeClick')).not.toBe('abc')
   })
 
   it('should always call getServerSideProps without caching', async () => {


### PR DESCRIPTION
This test case was incorrectly checking `true === 'true'`.

The correct test was also failing, so this PR fixes the desired behavior.