### PR TITLE
Add TypeScript docs for SSG

### DIFF
--- a/docs/api-reference/data-fetching/getInitialProps.md
+++ b/docs/api-reference/data-fetching/getInitialProps.md
@@ -4,6 +4,14 @@ description: Enable Server-Side Rendering in a page and do initial data populati
 
 # getInitialProps
 
+## Recommended: Use `getStaticProps` or `getServerSideProps` instead
+
+If you're using Next.js 9.3 or newer, you should use `getStaticProps` or `getServerSideProps` instead of `getInitialProps`.
+
+Learn more on the [Pages documentation](/docs/basic-features/pages.md) and the [Data fetching documentation](/docs/basic-features/data-fetching.md):
+
+## `getInitialProps` (for older versions of Next.js)
+
 <details>
   <summary><b>Examples</b></summary>
   <ul>
@@ -75,6 +83,52 @@ For the initial page load, `getInitialProps` will execute on the server only. `g
 
 - `getInitialProps` can **not** be used in children components, only in the default export of every page
 - If you are using server-side only modules inside `getInitialProps`, make sure to [import them properly](https://arunoda.me/blog/ssr-and-server-only-modules), otherwise it'll slow down your app
+
+## TypeScript
+
+If you're using TypeScript, you can use the `NextPage` type for functional components:
+
+```jsx
+import { NextPage } from 'next'
+
+interface Props {
+  userAgent?: string;
+}
+
+const Page: NextPage<Props> = ({ userAgent }) => (
+  <main>Your user agent: {userAgent}</main>
+)
+
+Page.getInitialProps = async ({ req }) => {
+  const userAgent = req ? req.headers['user-agent'] : navigator.userAgent
+  return { userAgent }
+}
+
+export default Page
+```
+
+And for `React.Component`, you can use `NextPageContext`:
+
+```jsx
+import React from 'react'
+import { NextPageContext } from 'next'
+
+interface Props {
+  userAgent?: string;
+}
+
+export default class Page extends React.Component<Props> {
+  static async getInitialProps({ req }: NextPageContext) {
+    const userAgent = req ? req.headers['user-agent'] : navigator.userAgent
+    return { userAgent }
+  }
+
+  render() {
+    const { userAgent } = this.props
+    return <main>Your user agent: {userAgent}</main>
+  }
+}
+```
 
 ## Related
 

--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -80,6 +80,18 @@ You should use `getStaticProps` if:
 - The data can be publicly cached (not user-specific).
 - The page must be pre-rendered (for SEO) and be very fast — `getStaticProps` generates HTML and JSON files, both of which can be cached by a CDN for performance.
 
+### TypeScript: Use `GetStaticProps`
+
+For TypeScript, you can use the `GetStaticProps` type from `next`:
+
+```ts
+import { GetStaticProps } from 'next'
+
+export async function getStaticProps(context): GetStaticProps {
+  // ...
+}
+```
+
 ### Technical details
 
 #### Only runs at build time
@@ -265,6 +277,18 @@ This ensures that users always have a fast experience while preserving fast buil
 
 You should use `getStaticPaths` if you’re statically pre-rendering pages that use dynamic routes.
 
+### TypeScript: Use `GetStaticPaths`
+
+For TypeScript, you can use the `GetStaticPaths` type from `next`:
+
+```ts
+import { GetStaticPaths } from 'next'
+
+export async function getStaticPaths(): GetStaticPaths {
+  // ...
+}
+```
+
 ### Technical details
 
 #### Use together with `getStaticProps`
@@ -333,6 +357,18 @@ export default Page
 You should use `getServerSideProps` only if you need to pre-render a page whose data must be fetched at request time. Time to first byte (TTFB) will be slower than `getStaticProps` because the server must compute the result on every request, and the result cannot be cached by a CDN without extra .
 
 If you don’t need to pre-render the data, then you should consider fetching data on the client side. [Click here to learn more](#fetching-data-on-the-client-side).
+
+### TypeScript: Use `GetServerSideProps`
+
+For TypeScript, you can use the `GetServerSideProps` type from `next`:
+
+```ts
+import { GetServerSideProps } from 'next'
+
+export async function getServerSideProps(context): GetServerSideProps {
+  // ...
+}
+```
 
 ### Technical details
 

--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -87,7 +87,7 @@ For TypeScript, you can use the `GetStaticProps` type from `next`:
 ```ts
 import { GetStaticProps } from 'next'
 
-export async function getStaticProps(context): GetStaticProps {
+export const getStaticProps: GetStaticProps = async context => {
   // ...
 }
 ```
@@ -284,7 +284,7 @@ For TypeScript, you can use the `GetStaticPaths` type from `next`:
 ```ts
 import { GetStaticPaths } from 'next'
 
-export async function getStaticPaths(): GetStaticPaths {
+export const getStaticPaths: GetStaticPaths = async () => {
   // ...
 }
 ```
@@ -365,7 +365,7 @@ For TypeScript, you can use the `GetServerSideProps` type from `next`:
 ```ts
 import { GetServerSideProps } from 'next'
 
-export async function getServerSideProps(context): GetServerSideProps {
+export const getServerSideProps: GetServerSideProps = async context => {
   // ...
 }
 ```

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -54,15 +54,15 @@ For `getStaticProps`, `getStaticPaths`, and `getServerSideProps`, you can use th
 ```ts
 import { GetStaticProps, GetStaticPaths, GetServerSideProps } from 'next'
 
-export async function getStaticProps(context): GetStaticProps {
+export const getStaticProps: GetStaticProps = async context => {
   // ...
 }
 
-export async function getStaticPaths(): GetStaticPaths {
+export const getStaticPaths: GetStaticPaths = async () => {
   // ...
 }
 
-export async function getServerSideProps(context): GetServerSideProps {
+export const getServerSideProps: GetServerSideProps = async context => {
   // ...
 }
 ```

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -47,51 +47,27 @@ By default, Next.js reports TypeScript errors during development for pages you a
 
 If you want to silence the error reports, refer to the documentation for [Ignoring TypeScript errors](/docs/api-reference/next.config.js/ignoring-typescript-errors.md).
 
-## Pages
+## Static Generation and Server-side Rendering
 
-For function components the `NextPage` type is exported, here's how to use it:
+For `getStaticProps`, `getStaticPaths`, and `getServerSideProps`, you can use the `GetStaticProps`, `GetStaticPaths`, and `GetServerSideProps` types respectively:
 
-```jsx
-import { NextPage } from 'next'
+```ts
+import { GetStaticProps, GetStaticPaths, GetServerSideProps } from 'next'
 
-interface Props {
-  userAgent?: string;
+export async function getStaticProps(context): GetStaticProps {
+  // ...
 }
 
-const Page: NextPage<Props> = ({ userAgent }) => (
-  <main>Your user agent: {userAgent}</main>
-)
-
-Page.getInitialProps = async ({ req }) => {
-  const userAgent = req ? req.headers['user-agent'] : navigator.userAgent
-  return { userAgent }
+export async function getStaticPaths(): GetStaticPaths {
+  // ...
 }
 
-export default Page
-```
-
-And for `React.Component` you can use `NextPageContext`:
-
-```jsx
-import React from 'react'
-import { NextPageContext } from 'next'
-
-interface Props {
-  userAgent?: string;
-}
-
-export default class Page extends React.Component<Props> {
-  static async getInitialProps({ req }: NextPageContext) {
-    const userAgent = req ? req.headers['user-agent'] : navigator.userAgent
-    return { userAgent }
-  }
-
-  render() {
-    const { userAgent } = this.props
-    return <main>Your user agent: {userAgent}</main>
-  }
+export async function getServerSideProps(context): GetServerSideProps {
+  // ...
 }
 ```
+
+> If you're using `getInitialProps`, you can [follow the directions on this page](/docs/api-reference/data-fetching/getInitialProps.md#typescript).
 
 ## API Routes
 


### PR DESCRIPTION
[NEXT-113]

- Adds TypeScript documentation for `getStaticProps`, `getStaticPaths`, and `getServerSideProps` on the data fetching documentation and the typescript documentation
- Adds a message at the top of the `getInitialProps` API reference ([located here](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps)) to use `getStaticProps` or `getServerSideProps` instead
- Move the typescript documentation for `getInitialProps` to the `getInitialProps` API reference so it's less visible
- I used `export const getStaticProps: GetStaticProps ...` etc instead of using `function` so you can assign the types easily.

[NEXT-113]: https://zeit.atlassian.net/browse/NEXT-113