### PR TITLE
Updated example to match babel 7 recommendation.

### DIFF
--- a/examples/with-custom-babel-config/.babelrc
+++ b/examples/with-custom-babel-config/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "next/babel"
-  ],
-  "plugins": [
-    "@babel/plugin-proposal-do-expressions"
-  ]
-}

--- a/examples/with-custom-babel-config/babel.config.js
+++ b/examples/with-custom-babel-config/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['next/babel'],
+  plugins: ['@babel/plugin-proposal-do-expressions'],
+}


### PR DESCRIPTION
# Reason

After working on a project, I had issues adding Jest for testing. After research I realized `babel.config.js` is the recommended way on configuring babel after Babel 7 which jest also [recommends](https://github.com/facebook/jest/commit/1818d84b2cf20ecb8db2215b3ad6b5e397ab2673)

Other people had this problem and this [comment](https://github.com/facebook/jest/issues/6229#issuecomment-403539460) shows that changing to `babel.config.js` solved the problem for many developers.

To show that you can use `babel.config.js` for custom babel configuration, I updated the example.

Please, note that the [docs](https://nextjs.org/docs/advanced-features/customizing-babel-config) should be updated accordingly, to let people know they can also use `babel.config.js` (not sure if I should have created an issue for that).