### PR TITLE
Add identifier to NEXT_DATA when custom server is used

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -80,6 +80,7 @@ export type NEXT_DATA = {
   err?: Error & { statusCode?: number }
   gsp?: boolean
   gssp?: boolean
+  customServer?: boolean
 }
 
 /**

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -91,6 +91,7 @@ export type ServerConstructor = {
    */
   conf?: NextConfig
   dev?: boolean
+  customServer?: boolean
 }
 
 export default class Server {
@@ -116,6 +117,7 @@ export default class Server {
     hasCssMode: boolean
     dev?: boolean
     previewProps: __ApiPreviewProps
+    customServer?: boolean
   }
   private compression?: Middleware
   private onErrorMiddleware?: ({ err }: { err: Error }) => Promise<void>
@@ -136,6 +138,7 @@ export default class Server {
     quiet = false,
     conf = null,
     dev = false,
+    customServer = true,
   }: ServerConstructor = {}) {
     this.dir = resolve(dir)
     this.quiet = quiet
@@ -167,6 +170,7 @@ export default class Server {
       buildId: this.buildId,
       generateEtags,
       previewProps: this.getPreviewProps(),
+      customServer: customServer === true ? true : undefined,
     }
 
     // Only the `publicRuntimeConfig` key is exposed to the client side

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -187,6 +187,7 @@ function renderDocument(
     headTags,
     gsp,
     gssp,
+    customServer,
   }: RenderOpts & {
     props: any
     docProps: DocumentInitialProps
@@ -209,6 +210,7 @@ function renderDocument(
     isFallback?: boolean
     gsp?: boolean
     gssp?: boolean
+    customServer?: boolean
   }
 ): string {
   return (
@@ -231,6 +233,7 @@ function renderDocument(
             err: err ? serializeError(dev, err) : undefined, // Error if one happened, otherwise don't sent in the resulting HTML
             gsp, // whether the page is getStaticProps
             gssp, // whether the page is getServerSideProps
+            customServer, // whether the user is using a custom server
           },
           dangerousAsPath,
           canonicalBase,

--- a/packages/next/server/lib/start-server.ts
+++ b/packages/next/server/lib/start-server.ts
@@ -6,7 +6,10 @@ export default async function start(
   port?: number,
   hostname?: string
 ) {
-  const app = next(serverOptions)
+  const app = next({
+    ...serverOptions,
+    customServer: false,
+  })
   const srv = http.createServer(app.getRequestHandler())
   await new Promise((resolve, reject) => {
     // This code catches EADDRINUSE error if the port is already in use

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -3,6 +3,7 @@
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 import getPort from 'get-port'
+import cheerio from 'cheerio'
 import clone from 'clone'
 import {
   initNextServerScript,
@@ -88,6 +89,12 @@ describe('Custom Server', () => {
     it('should render nested index', async () => {
       const html = await renderViaHTTP(appPort, '/dashboard')
       expect(html).toMatch(/made it to dashboard/)
+    })
+
+    it('should contain customServer in NEXT_DATA', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      const $ = cheerio.load(html)
+      expect(JSON.parse($('#__NEXT_DATA__').text()).customServer).toBe(true)
     })
   })
 

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -239,6 +239,14 @@ describe('Production Usage', () => {
         expect(html).toMatch(/404/)
       }
     })
+
+    it('should not contain customServer in NEXT_DATA', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      const $ = cheerio.load(html)
+      expect('customServer' in JSON.parse($('#__NEXT_DATA__').text())).toBe(
+        false
+      )
+    })
   })
 
   describe('API routes', () => {


### PR DESCRIPTION
Added `customServer` identifier to `NEXT_DATA` for detecting on client and added tests to ensure it's added/not added correctly