### PR TITLE
Test child_process with API route

### DIFF
--- a/test/integration/api-support/pages/api/child-process.js
+++ b/test/integration/api-support/pages/api/child-process.js
@@ -1,0 +1,8 @@
+import { execSync } from 'child_process'
+
+export default (req, res) => {
+  const output = execSync('echo "hi"')
+    .toString()
+    .trim()
+  res.end(output)
+}

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -322,6 +322,11 @@ function runTests(dev = false) {
     expect(data).toEqual({ post: 'post-1', id: '1' })
   })
 
+  it('should work with child_process correctly', async () => {
+    const data = await renderViaHTTP(appPort, '/api/child-process')
+    expect(data).toBe('hi')
+  })
+
   if (dev) {
     it('should compile only server code in development', async () => {
       await fetchViaHTTP(appPort, '/')


### PR DESCRIPTION
This adds an additional API route test for `child_process` usage to ensure it is working correctly. 

x-ref: https://github.com/zeit/next.js/discussions/10778