### PR TITLE
Fix with-yarn-workspaces example

### DIFF
--- a/examples/with-yarn-workspaces/README.md
+++ b/examples/with-yarn-workspaces/README.md
@@ -44,8 +44,6 @@ yarn dev
 
 Deploy it to the cloud with [ZEIT Now](https://zeit.co/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
 
-> Choose `packages/web-app` as root directory when deploying.
-
 ## Useful Links
 
 - [Documentation](https://yarnpkg.com/en/docs/workspaces)

--- a/examples/with-yarn-workspaces/next.config.js
+++ b/examples/with-yarn-workspaces/next.config.js
@@ -2,4 +2,6 @@
 // https://www.npmjs.com/package/next-transpile-modules
 const withTM = require('next-transpile-modules')(['bar'])
 
-module.exports = withTM()
+module.exports = withTM({
+  distDir: '../../.next', // Point the output directory to the root of the repo (for deploying with next with no additional config)
+})

--- a/examples/with-yarn-workspaces/package.json
+++ b/examples/with-yarn-workspaces/package.json
@@ -1,11 +1,16 @@
 {
+  "name": "withyarn",
   "private": true,
+  "dependencies": {
+    "next": "latest",
+    "next-transpile-modules": "^3.0.2"
+  },
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
-    "dev": "yarn --cwd packages/web-app dev",
-    "build": "yarn --cwd packages/web-app build",
-    "start": "yarn --cwd packages/web-app start"
+    "dev": "next dev packages/web-app",
+    "build": "next build packages/web-app",
+    "start": "next start packages/web-app"
   }
 }

--- a/examples/with-yarn-workspaces/packages/bar/package.json
+++ b/examples/with-yarn-workspaces/packages/bar/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bar",
+  "name": "@withyarn/bar",
   "version": "1.0.0",
   "license": "ISC",
   "peerDependencies": {

--- a/examples/with-yarn-workspaces/packages/foo/package.json
+++ b/examples/with-yarn-workspaces/packages/foo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "foo",
+  "name": "@withyarn/foo",
   "version": "1.0.0",
   "license": "ISC"
 }

--- a/examples/with-yarn-workspaces/packages/web-app/package.json
+++ b/examples/with-yarn-workspaces/packages/web-app/package.json
@@ -1,14 +1,9 @@
 {
-  "name": "web-app",
+  "name": "@withyarn/web-app",
   "version": "1.0.0",
-  "scripts": {
-    "dev": "next",
-    "build": "next build",
-    "start": "next start"
-  },
   "dependencies": {
-    "next": "latest",
-    "next-transpile-modules": "^3.0.2",
+    "@withyarn/foo": "*",
+    "@withyarn/bar": "*",
     "react": "^16.8.3",
     "react-dom": "^16.8.3"
   },

--- a/examples/with-yarn-workspaces/packages/web-app/pages/index.js
+++ b/examples/with-yarn-workspaces/packages/web-app/pages/index.js
@@ -1,5 +1,5 @@
-import foo from 'foo'
-import Bar from 'bar'
+import foo from '@withyarn/foo'
+import Bar from '@withyarn/bar'
 
 export default () => (
   <div>


### PR DESCRIPTION
closes: https://github.com/zeit/next.js/issues/10734

Issue:

The current `with-yarn-workspaces` example is broken. When building with zeit, the error I get is:

```
Module not found: Can't resolve 'bar'
```

In the example `bar` is a module used by the `web-app` module. In CI, `bar` can't be found because the application is deployed under `web-app`, which is just one of the modules from yarn workspaces. When CI is looking at just `web-app` it has no way of knowing about `bar` because yarn workspaces wasn't used to install deps. It does the install in `web-app` without seeing any workspace modules.

To fix this, I pulled  `next.config.js` and build commands to the workspaces root. I made the Next build commands point to the `web-app` folder so `web-app` is still what gets built. To deploy with Zeit, I added `distDir: ../../.next` to `next.config.js` to make the build output sit at the root of the app where it normally lives. 

Deployed example: https://next-js-with-yarn-workspaces-9v8nodujr.now.sh/
Repo: https://github.com/special-character/next-js-with-yarn-workspaces