### PR TITLE
Fix getStaticPaths example code

### DIFF
--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -192,7 +192,7 @@ export async function getStaticPaths() {
 
   // Get the paths we want to pre-render based on posts
   const paths = posts.map(post => ({
-    params: {id: `/posts/${post.id}`}
+    params: {id: post.id}
   }))
 
   // We'll pre-render only these paths at build time.

--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -191,7 +191,9 @@ export async function getStaticPaths() {
   const posts = await res.json()
 
   // Get the paths we want to pre-render based on posts
-  const paths = posts.map(post => `/posts/${post.id}`)
+  const paths = posts.map(post => ({
+    params: {id: `/posts/${post.id}`}
+  }))
 
   // We'll pre-render only these paths at build time.
   // { fallback: false } means other routes should 404.


### PR DESCRIPTION
In the upcoming `getStaticPaths` documentation, there seems to be a contradiction in what should be returned by this function.

In one place, it says it should look something like this:
```js
return {
  paths: [
    { params: { id: 1 } },
    { params: { id: 2 } }
  ],
  fallback: ...
}
```

So `paths` contains a list of objects, where each item has a `params` property, that are objects themselves.

Although, in the example below [`fallback`](https://github.com/zeit/next.js/blob/canary/docs/basic-features/data-fetching.md#the-fallback-key-required), `paths` was equal to posts mapped over to a list of strings (ids).

Closes #10894