### PR TITLE
Add demo URL for the DatoCMS example

### DIFF
--- a/docs/advanced-features/preview-mode.md
+++ b/docs/advanced-features/preview-mode.md
@@ -153,7 +153,7 @@ https://<your-site>/api/preview?secret=<token>&slug=<path>
 
 Take a look at the following examples to learn more:
 
-- [DatoCMS Example](https://github.com/zeit/next.js/tree/canary/examples/cms-datocms)
+- [DatoCMS Example](https://github.com/zeit/next.js/tree/canary/examples/cms-datocms) ([Demo](https://next-blog-datocms.now.sh/))
 
 ## More Details
 

--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -428,7 +428,7 @@ function Profile() {
 
 Take a look at the following examples to learn more:
 
-- [DatoCMS Example](https://github.com/zeit/next.js/tree/canary/examples/cms-datocms)
+- [DatoCMS Example](https://github.com/zeit/next.js/tree/canary/examples/cms-datocms) ([Demo](https://next-blog-datocms.now.sh/))
 
 ## Learn more
 

--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -246,7 +246,7 @@ We've discussed two forms of pre-rendering for Next.js.
 
 Take a look at the following examples to learn more:
 
-- [DatoCMS Example](https://github.com/zeit/next.js/tree/canary/examples/cms-datocms)
+- [DatoCMS Example](https://github.com/zeit/next.js/tree/canary/examples/cms-datocms) ([Demo](https://next-blog-datocms.now.sh/))
 
 ## Learn more
 

--- a/examples/cms-datocms/README.md
+++ b/examples/cms-datocms/README.md
@@ -2,6 +2,10 @@
 
 This example showcases Next.js's [Static Generation](/docs/basic-features/pages.md) feature using [DatoCMS](https://www.datocms.com/) as the data source.
 
+## Demo
+
+### [https://next-blog-datocms.now.sh/](https://next-blog-datocms.now.sh/)
+
 ## How to use
 
 ### Using `create-next-app`


### PR DESCRIPTION
This is a follow-up to the DatoCMS example: https://github.com/zeit/next.js/pull/10891 - adds the demo URL https://next-blog-datocms.now.sh/ to README and docs.