### PR TITLE
Serverless loader: handle empty request url

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -262,7 +262,7 @@ const nextServerlessLoader: loader.Loader = function() {
 
       const parsedUrl = handleRewrites(parse(req.url, true))
 
-      if (parsedUrl.pathname.match(/_next\\/data/)) {
+      if (parsedUrl.pathname && parsedUrl.pathname.match(/_next\\/data/)) {
         _nextData = true
         parsedUrl.pathname = parsedUrl.pathname
           .replace(new RegExp('/_next/data/${escapedBuildId}/'), '/')

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -315,6 +315,11 @@ const runTests = (dev = false, looseMode = false) => {
     expect(data.pageProps.params).toEqual({})
   })
 
+  it('should not error at the root with no trailing slash', async () => {
+    const html = await renderViaHTTP(appPort, '')
+    expect(html).toMatch(/hello.*?world/)
+  })
+
   it('should not supply query values to params or useRouter dynamic page SSR', async () => {
     const html = await renderViaHTTP(appPort, '/blog/post-1?hello=world')
     const $ = cheerio.load(html)


### PR DESCRIPTION
I found this when deploying to AWS API Gateway (via https://github.com/vincent-herlemont/next-aws-lambda-webpack-plugin to generate code for each AWS Lambda).

I found that the value of `req.url` could be `''`, and that this meant that `parsedUrl.pathname` was null, and so this errored. I think this was introduced in #10261, so this issue exists from 9.2.2 onward.

For a bit more context: AWS API Gateway gives a URL like `https://identifier123.execute-api.eu-west-1.amazonaws.com/prod/` where "prod" here is the "stage name". Requests both with and without the trailing slash invoke the root Lambda function, with the value of `req.url` being `'/'` and `''` respectively.

It might be that this is an oddity specific to API Gateway (or how I have deployed code to API Gateway) or it could be something that occurs more widely.