### PR TITLE
fix paths.params.type in getStaticPaths(document)

### DIFF
--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -152,8 +152,8 @@ The `paths` key determines which paths will be pre-rendered. For example, suppos
 ```js
 return {
   paths: [
-    { params: { id: 1 } },
-    { params: { id: 2 } }
+    { params: { id: '1' } },
+    { params: { id: '2' } }
   ],
   fallback: ...
 }


### PR DESCRIPTION
```
return {
  paths: [
    { params: { id: 1 } }, -> { params: { id: '1' } }
    { params: { id: 2 } } -> { params: { id: '2' } }
  ],
  fallback: ...
}
```

Fixed as it seems to be a number type though it is a string type