### PR TITLE
cms-datocms SerializableError fixes

### DIFF
--- a/examples/cms-datocms/pages/index.js
+++ b/examples/cms-datocms/pages/index.js
@@ -36,7 +36,7 @@ export default function Index({ allPosts }) {
 }
 
 export async function getStaticProps({ preview }) {
-  const allPosts = await getAllPostsForHome(preview)
+  const allPosts = await getAllPostsForHome(preview) || []
   return {
     props: { allPosts },
   }

--- a/examples/cms-datocms/pages/posts/[slug].js
+++ b/examples/cms-datocms/pages/posts/[slug].js
@@ -50,7 +50,7 @@ export default function Post({ post, morePosts, preview }) {
   )
 }
 
-export async function getStaticProps({ params, preview }) {
+export async function getStaticProps({ params, preview = null }) {
   const data = await getPostAndMorePosts(params.slug, preview)
   const content = await markdownToHtml(data?.post?.content || '')
 


### PR DESCRIPTION
should fix 
```
SerializableError: Error serializing `.preview` returned from `getStaticProps` in "/posts/[slug]".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value all together.

```
which was introduced when the nice check when in here https://github.com/zeit/next.js/pull/10857
