### PR TITLE
Add Array.flat polyfill to nomodule-polyfills

### DIFF
--- a/packages/next-polyfill-nomodule/src/index.js
+++ b/packages/next-polyfill-nomodule/src/index.js
@@ -3,6 +3,7 @@ import 'core-js/features/array/fill'
 import 'core-js/features/array/find'
 import 'core-js/features/array/find-index'
 import 'core-js/features/array/flat-map'
+import "core-js/features/array/flat"
 import 'core-js/features/array/from'
 import 'core-js/features/array/includes'
 import 'core-js/features/array/iterator'

--- a/packages/next-polyfill-nomodule/src/index.js
+++ b/packages/next-polyfill-nomodule/src/index.js
@@ -3,7 +3,7 @@ import 'core-js/features/array/fill'
 import 'core-js/features/array/find'
 import 'core-js/features/array/find-index'
 import 'core-js/features/array/flat-map'
-import "core-js/features/array/flat"
+import 'core-js/features/array/flat'
 import 'core-js/features/array/from'
 import 'core-js/features/array/includes'
 import 'core-js/features/array/iterator'


### PR DESCRIPTION
This PR adds an `Array.flat` polyfill, which is commonly used in applications and not supported in nomodule browsers:

[https://caniuse.com/#feat=array-flat](https://caniuse.com/#feat=array-flat)