### PR TITLE
Add "noreferrer" to the prerender indicator doc link

### DIFF
--- a/packages/next/client/dev/prerender-indicator.js
+++ b/packages/next/client/dev/prerender-indicator.js
@@ -94,7 +94,7 @@ function createContainer(prefix) {
     <button id="${prefix}close" title="Hide indicator for session">
       <span>×</span>
     </button>
-    <a href="https://nextjs.org/docs#automatic-static-optimization-indicator" target="_blank">
+    <a href="https://nextjs.org/docs#automatic-static-optimization-indicator" target="_blank" rel="noreferrer">
       <div id="${prefix}icon-wrapper">
           <svg width="15" height="20" viewBox="0 0 60 80" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M36 3L30.74 41H8L36 3Z" fill="black"/>


### PR DESCRIPTION
This is mainly to avoid errors in lighthouse report on development environment:

![image](https://user-images.githubusercontent.com/95120/76535947-f442e080-647b-11ea-8724-3b1dec090299.png)

In bonus, it add a layer of anonymity between our dev/staging environment and the zeit organisation.