### PR TITLE
Update amp-first example to use GSSP

### DIFF
--- a/examples/amp-first/pages/index.js
+++ b/examples/amp-first/pages/index.js
@@ -234,10 +234,10 @@ const Home = props => (
 )
 
 // amp-script requires absolute URLs, so we create a property `host` which we can use to calculate the script URL.
-Home.getInitialProps = async ({ req }) => {
+export async function getServerSideProps({ req }) {
   // WARNING: This is a generally unsafe application unless you're deploying to a managed platform like ZEIT Now.
   // Be sure your load balancer is configured to not allow spoofed host headers.
-  return { host: `${getProtocol(req)}://${req.headers.host}` }
+  return { props: { host: `${getProtocol(req)}://${req.headers.host}` } }
 }
 
 function getProtocol(req) {


### PR DESCRIPTION
Relate to #11014

Using getServerSideProps instead of getInitialProps except _document.js