### PR TITLE
Fix routeChangeStart to routeChangeComplete in Docs

### DIFF
--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -247,7 +247,7 @@ useEffect(() => {
     console.log('App is changing to: ', url)
   }
 
-  Router.events.on('routeChangeStart', handleRouteChange)
+  Router.events.on('routeChangeComplete', handleRouteChange)
   return () => {
     Router.events.off('routeChangeStart', handleRouteChange)
   }


### PR DESCRIPTION
`routeChangeStart` is executed when the transition starts, so I think `routeChangeComplete` is appropriate here.
