### PR TITLE
Defer Page Registration

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -57,7 +57,9 @@ const asPath = getURL()
 const pageLoader = new PageLoader(buildId, prefix)
 const register = ([r, f]) => pageLoader.registerPage(r, f)
 if (window.__NEXT_P) {
-  window.__NEXT_P.map(register)
+  // Defer page registration for another tick. This will increase the overall
+  // latency in hydrating the page, but reduce the total blocking time.
+  window.__NEXT_P.map(p => setTimeout(() => register(p), 0))
 }
 window.__NEXT_P = []
 window.__NEXT_P.push = register


### PR DESCRIPTION
Previously, we would synchronously register any pages that happened to be loaded when Next initializes. This could reduce the latency of hydrating the page, but at the cost of potentially blocking the main thread for a noticeable time.

This should ideally integrate with a scheduler in the future so that when a page is registered is based on priority, but in the meantime we can just defer it to a future tick.