### PR TITLE
[Example] Use getServerSideProps in api-routes

### DIFF
--- a/examples/api-routes/pages/index.js
+++ b/examples/api-routes/pages/index.js
@@ -9,7 +9,7 @@ const Index = ({ people }) => (
   </ul>
 )
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   const response = await fetch('http://localhost:3000/api/people')
   const people = await response.json()
 

--- a/examples/api-routes/pages/person/[id].js
+++ b/examples/api-routes/pages/person/[id].js
@@ -30,20 +30,7 @@ const Person = ({ data, status }) =>
     <p>{data.message}</p>
   )
 
-export async function getStaticPaths() {
-  const response = await fetch('http://localhost:3000/api/people')
-  const data = await response.json()
-
-  const paths = data.map(person => ({
-    params: {
-      id: person.id,
-    },
-  }))
-
-  return { paths, fallback: false }
-}
-
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
   const response = await fetch(`http://localhost:3000/api/people/${params.id}`)
   const data = await response.json()
 


### PR DESCRIPTION
`http://localhost:3000` is not available at build time and `getStaticProps` will fail because of that, changing it to `getServerSideProps` will disable SSG but it will not break the build.