### PR TITLE
feat: adding bundle analyzer options

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,13 +1,15 @@
-module.exports = ({ enabled = true, ...bundleAnalyzerOptions } = {}) => (nextConfig = {}) => {
+module.exports = ({ enabled = true, ...bundleAnalyzerOptions } = {}) => (
+  nextConfig = {}
+) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (enabled) {
         // compatible with 'next-bundle-analyzer options
         const { analyzeServer, analyzeBrowser } = bundleAnalyzerOptions
         const {
-          bundleAnalyzerConfig: { browser = {}, server = {} } = {}
+          bundleAnalyzerConfig: { browser = {}, server = {} } = {},
         } = bundleAnalyzerOptions
-        
+
         const { isServer } = options
 
         if ((isServer && analyzeServer) || (!isServer && analyzeBrowser)) {
@@ -19,7 +21,9 @@ module.exports = ({ enabled = true, ...bundleAnalyzerOptions } = {}) => (nextCon
                 {
                   analyzerMode: 'server',
                   analyzerPort: isServer ? 8888 : 8889,
-                  openAnalyzer: isServer ? server.openAnalyzer : browser.openAnalyzer
+                  openAnalyzer: isServer
+                    ? server.openAnalyzer
+                    : browser.openAnalyzer,
                 },
                 isServer ? server : browser
               )

--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,16 +1,31 @@
-module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
+module.exports = ({ enabled = true, ...bundleAnalyzerOptions } = {}) => (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (enabled) {
-        const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
-        config.plugins.push(
-          new BundleAnalyzerPlugin({
-            analyzerMode: 'static',
-            reportFilename: options.isServer
-              ? '../analyze/server.html'
-              : './analyze/client.html',
-          })
-        )
+        // compatible with 'next-bundle-analyzer options
+        const { analyzeServer, analyzeBrowser } = bundleAnalyzerOptions
+        const {
+          bundleAnalyzerConfig: { browser = {}, server = {} } = {}
+        } = bundleAnalyzerOptions
+        
+        const { isServer } = options
+
+        if ((isServer && analyzeServer) || (!isServer && analyzeBrowser)) {
+          const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+          config.plugins.push(
+            new BundleAnalyzerPlugin(
+              Object.assign(
+                {},
+                {
+                  analyzerMode: 'server',
+                  analyzerPort: isServer ? 8888 : 8889,
+                  openAnalyzer: isServer ? server.openAnalyzer : browser.openAnalyzer
+                },
+                isServer ? server : browser
+              )
+            )
+          )
+        }
       }
 
       if (typeof nextConfig.webpack === 'function') {


### PR DESCRIPTION
Feature Request:
The previous version of bundle analyzer had the configuration at the nextConfig object.
Adding this to the initializer to accept custom configuration for webpack-bundle-analyzer

The bundle analyzer will accept custom options. This is an example:

```javascript
const withBundleAnalyzer = require('@next/bundle-analyzer')({
    enabled: process.env.ANALYZE === 'true',
    analyzeServer: ['server', 'both'].includes(process.env.BUNDLE_ANALYZE),
    analyzeBrowser: ['browser', 'both'].includes(process.env.BUNDLE_ANALYZE),
    bundleAnalyzerConfig: {
      server: {
        analyzerMode: 'static',
        defaultSizes: 'stat',
        reportFilename: `bundle-report/server-stats.html`,
        generateStatsFile: true,
        statsFilename: `bundle-report/server-stats.json`,
        statsOptions: { exclude: /node_modules/ },
        openAnalyzer: true,
      },
      browser: {
        analyzerMode: 'static',
        defaultSizes: 'stat',
        reportFilename: `bundle-report/client-stats.html`,
        generateStatsFile: true,
        statsFilename: `bundle-report/client-stats.json`,
        statsOptions: { exclude: /node_modules/ },
        openAnalyzer: true,
      },
    },
  })
```