### PR TITLE
Add Layout prop for NextComponent

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -20,6 +20,7 @@ export type NextComponentType<
    * @param ctx Context of `page`
    */
   getInitialProps?(context: C): IP | Promise<IP>
+  Layout?: () => React.ReactElement
 }
 
 export type DocumentType = NextComponentType<

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -20,7 +20,7 @@ export type NextComponentType<
    * @param ctx Context of `page`
    */
   getInitialProps?(context: C): IP | Promise<IP>
-  Layout?: () => React.ReactElement
+  Layout?: (props: { children: React.ReactElement }) => React.ReactElement
 }
 
 export type DocumentType = NextComponentType<


### PR DESCRIPTION
There's great example of layouting, though it assumes you have a Layout prop under Component:

https://github.com/zeit/next.js/blob/30cf4d5ab6b1665da2de322b6dbbc3f7b57216f9/examples/with-dynamic-app-layout/pages/_app.js#L4-L11

In TypeScript you'll get this error:

<img width="920" alt="Screenshot 2020-03-16 at 04 44 54" src="https://user-images.githubusercontent.com/13215662/76713196-e376c100-6740-11ea-85fc-1f973094e168.png">

This PR adds Layout as a potential prop. After the changes, it's now compatible with this example (and more convenient in overall, because doesn't require too much mess with overwriting NextJS types):

<img width="935" alt="Screenshot 2020-03-16 at 05 08 45" src="https://user-images.githubusercontent.com/13215662/76713677-39993380-6744-11ea-9fa6-a458cbd81631.png">
