### PR TITLE
Add routing example with dynamic `as` prop

### DIFF
--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -84,6 +84,24 @@ function Home() {
 export default Home
 ```
 
+The `as` prop can also be generated dynamically. For example, to show a list of posts which have been passed to the page as a prop:
+
+```jsx
+function Home({ posts }) {
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.id}>
+          <Link href="/blog/[slug]" as={`/blog/${post.slug}`}>
+            <a>{post.title}</a>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
 ## Injecting the router
 
 <details>


### PR DESCRIPTION
Inspired by the dynamic `as` prop example in [the `next/link` documentation](https://nextjs.org/docs/api-reference/next/link#dynamic-routes) and seeing that this pattern was not in any of the docs pages under Routing, I thought it may be a good idea to surface this common, useful pattern in the regular Routing documentation intro.

If  you have a different idea of where to put it within the Routing section, glad to move it too!