### PR TITLE
Update CLI custom config documentation link

### DIFF
--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -29,7 +29,7 @@ const nextBuild: cliCommand = argv => {
 
       <dir> represents where the compiled dist folder should go.
       If no directory is provided, the dist folder will be created in the current directory.
-      You can set a custom folder in config https://github.com/zeit/next.js#custom-configuration, otherwise it will be created inside '.next'
+      You can set a custom folder in config https://nextjs.org/docs/api-reference/next.config.js/setting-a-custom-build-directory, otherwise it will be created inside '.next'
     `,
       0
     )

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -35,7 +35,7 @@ const nextDev: cliCommand = argv => {
 
       <dir> represents where the compiled folder should go.
       If no directory is provided, the folder will be created in the current directory.
-      You can set a custom folder in config https://github.com/zeit/next.js#custom-configuration.
+      You can set a custom folder in config https://nextjs.org/docs/api-reference/next.config.js/setting-a-custom-build-directory.
 
       Options
         --port, -p      A port number on which to start the application

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -35,7 +35,7 @@ const nextDev: cliCommand = argv => {
 
       <dir> represents where the compiled folder should go.
       If no directory is provided, the folder will be created in the current directory.
-      You can set a custom folder in config https://nextjs.org/docs/api-reference/next.config.js/setting-a-custom-build-directory.
+      You can set a custom folder in config https://nextjs.org/docs/api-reference/next.config.js/setting-a-custom-build-directory
 
       Options
         --port, -p      A port number on which to start the application

--- a/packages/next/cli/next-start.ts
+++ b/packages/next/cli/next-start.ts
@@ -34,7 +34,7 @@ const nextStart: cliCommand = argv => {
       <dir> is the directory that contains the compiled dist folder
       created by running \`next build\`.
       If no directory is provided, the current directory will be assumed.
-      You can set a custom dist folder in config https://github.com/zeit/next.js#custom-configuration
+      You can set a custom dist folder in config https://nextjs.org/docs/api-reference/next.config.js/setting-a-custom-build-directory
 
       Options
         --port, -p      A port number on which to start the application


### PR DESCRIPTION
This is for the CLI help output for `next build/dev/start` related to changing the build output directory (`.next`) to a custom one. 

- Before: [`https://github.com/zeit/next.js#custom-configuration`](https://github.com/zeit/next.js#custom-configuration)
- After: [`https://nextjs.org/docs/api-reference/next.config.js/setting-a-custom-build-directory`](https://nextjs.org/docs/api-reference/next.config.js/setting-a-custom-build-directory)