### PR TITLE
Add error when attempting to export GSSP page

### DIFF
--- a/errors/gssp-export.md
+++ b/errors/gssp-export.md
@@ -1,0 +1,16 @@
+# getServerSideProps Export Error
+
+#### Why This Error Occurred
+
+You attempted to export a page with `getServerSideProps` which is not allowed. `getServerSideProps` is meant for requesting up to date information on every request which means exporting it defeats the purpose of the method.
+
+#### Possible Ways to Fix It
+
+If you would like the page be static you can leverage the new `getStaticProps` method instead.
+
+If you are attempting to export specific pages and didn't mean to export a page with `getServerSideProps` you can leverage `exportPathMap` in your `next.config.js` to export the specific pages.
+
+### Useful Links
+
+- [`getStaticProps` documentation](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation)
+- [`exportPathMap` documentation](https://nextjs.org/docs/api-reference/next.config.js/exportPathMap)

--- a/errors/gssp-export.md
+++ b/errors/gssp-export.md
@@ -8,7 +8,6 @@ You attempted to export a page with `getServerSideProps` which is not allowed. `
 
 If you would like the page be static you can leverage the `getStaticProps` method instead.
 
-
 ### Useful Links
 
 - [`getStaticProps` documentation](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation)

--- a/errors/gssp-export.md
+++ b/errors/gssp-export.md
@@ -6,7 +6,7 @@ You attempted to export a page with `getServerSideProps` which is not allowed. `
 
 #### Possible Ways to Fix It
 
-If you would like the page be static you can leverage the new `getStaticProps` method instead.
+If you would like the page be static you can leverage the `getStaticProps` method instead.
 
 If you are attempting to export specific pages and didn't mean to export a page with `getServerSideProps` you can leverage `exportPathMap` in your `next.config.js` to export the specific pages.
 

--- a/errors/gssp-export.md
+++ b/errors/gssp-export.md
@@ -8,7 +8,6 @@ You attempted to export a page with `getServerSideProps` which is not allowed. `
 
 If you would like the page be static you can leverage the `getStaticProps` method instead.
 
-If you are attempting to export specific pages and didn't mean to export a page with `getServerSideProps` you can leverage `exportPathMap` in your `next.config.js` to export the specific pages.
 
 ### Useful Links
 

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -10,6 +10,7 @@ import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
 import { getRouteMatcher } from '../next-server/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../next-server/lib/router/utils/route-regex'
 import { normalizePagePath } from '../next-server/server/normalize-page-path'
+import { SERVER_PROPS_EXPORT_ERROR } from '../lib/constants'
 
 const envConfig = require('../next-server/lib/runtime-config')
 const writeFileP = promisify(writeFile)
@@ -131,12 +132,16 @@ export default async function({
           ...query,
         },
       })
-      const { Component: mod } = await loadComponents(
+      const { Component: mod, getServerSideProps } = await loadComponents(
         distDir,
         buildId,
         page,
         serverless
       )
+
+      if (getServerSideProps) {
+        throw new Error(`Error for page ${page}: ${SERVER_PROPS_EXPORT_ERROR}`)
+      }
 
       // if it was auto-exported the HTML is loaded here
       if (typeof mod === 'string') {
@@ -175,6 +180,10 @@ export default async function({
         page,
         serverless
       )
+
+      if (components.getServerSideProps) {
+        throw new Error(`Error for page ${page}: ${SERVER_PROPS_EXPORT_ERROR}`)
+      }
 
       // for non-dynamic SSG pages we should have already
       // prerendered the file

--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -30,4 +30,6 @@ export const SERVER_PROPS_GET_INIT_PROPS_CONFLICT = `You can not use getInitialP
 
 export const SERVER_PROPS_SSG_CONFLICT = `You can not use getStaticProps with getServerSideProps. To use SSG, please remove getServerSideProps`
 
-export const PAGES_404_GET_INITIAL_PROPS_ERROR = `\`pages/404\` can not have getInitialProps/getServerSideProps, https://err.sh/zeit/next.js/404-get-initial-props`
+export const PAGES_404_GET_INITIAL_PROPS_ERROR = `\`pages/404\` can not have getInitialProps/getServerSideProps, https://err.sh/next.js/404-get-initial-props`
+
+export const SERVER_PROPS_EXPORT_ERROR = `pages with \`getServerSideProps\` can not be exported. See more info here: https://err.sh/next.js/gss-export`

--- a/test/integration/getserversideprops-export-error/pages/index.js
+++ b/test/integration/getserversideprops-export-error/pages/index.js
@@ -1,0 +1,9 @@
+export async function getServerSideProps() {
+  return {
+    props: {
+      idk: 'oops',
+    },
+  }
+}
+
+export default () => 'hi'

--- a/test/integration/getserversideprops-export-error/test/index.test.js
+++ b/test/integration/getserversideprops-export-error/test/index.test.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { nextBuild, nextExport } from 'next-test-utils'
+import { join } from 'path'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '..')
+const nextConfig = join(appDir, 'next.config.js')
+
+const runTests = () => {
+  it('should build successfully', async () => {
+    const { stdout, code } = await nextBuild(appDir, [], { stdout: true })
+    expect(code).toBe(0)
+    expect(stdout).toMatch(/Compiled successfully/)
+  })
+
+  it('should show error for GSSP during export', async () => {
+    const { stderr, code } = await nextExport(
+      appDir,
+      { outdir: join(appDir, 'out') },
+      { stderr: true }
+    )
+
+    expect(code).toBe(1)
+    expect(stderr).toMatch(
+      /pages with `getServerSideProps` can not be exported. See more info here: https/
+    )
+  })
+}
+
+describe('getServerSideProps', () => {
+  describe('serverless mode', () => {
+    beforeAll(async () => {
+      await fs.remove(join(appDir, '.next'))
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { target: 'experimental-serverless-trace' }`,
+        'utf8'
+      )
+    })
+
+    runTests()
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await fs.remove(nextConfig)
+      await fs.remove(join(appDir, '.next'))
+    })
+
+    runTests()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,7 +1100,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.8.3":
+"@babel/types@7.8.3", "@babel/types@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
   integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
@@ -3859,24 +3859,6 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-types@6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
 babylon@^6.15.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
@@ -5264,7 +5246,7 @@ core-js@3.6.4:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
   integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
 
-core-js@^2.4.0, core-js@^2.6.5:
+core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -13957,11 +13939,6 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
 regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
@@ -15599,13 +15576,13 @@ style-loader@1.0.0:
     loader-utils "^1.2.3"
     schema-utils "^2.0.1"
 
-styled-jsx@3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.4.tgz#cbcdedcfb81d717fd355c4a0d8443f8e74527b60"
-  integrity sha512-UMclQzI1lss38RhyjTf7SmtXJEMbB6Q9slDz8adGtzHjirYb1PPgeWLSP8SlZc8c9f3LF6axmtv+6K/553ANdg==
+styled-jsx@3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.5.tgz#0172a3e13a0d6d8bf09167dcaf32cf7102d932ca"
+  integrity sha512-prEahkYwQHomUljJzXzrFnBmQrSMtWOBbXn8QeEkpfFkqMZQGshxzzp4H8ebBIsbVlHF/3+GSXMnmK/fp7qVYQ==
   dependencies:
+    "@babel/types" "7.8.3"
     babel-plugin-syntax-jsx "6.18.0"
-    babel-types "6.26.0"
     convert-source-map "1.7.0"
     loader-utils "1.2.3"
     source-map "0.7.3"
@@ -16056,11 +16033,6 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
-
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
As discussed this adds an error when a user tries to export a page with `getServerSideProps`