### PR TITLE
Group CSS files in shared build output separate from JS files

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -204,9 +204,21 @@ export async function printTreeView(
   const sharedFiles = sizeData.sizeCommonFile
 
   messages.push(['+ shared by all', getPrettySize(sharedFilesSize), ''])
-  Object.keys(sharedFiles)
+  const sharedFileKeys = Object.keys(sharedFiles)
+  const sharedCssFiles: string[] = []
+  ;[
+    ...sharedFileKeys
+      .filter(file => {
+        if (file.endsWith('.css')) {
+          sharedCssFiles.push(file)
+          return false
+        }
+        return true
+      })
+      .sort(),
+    ...sharedCssFiles.sort(),
+  ]
     .map(e => e.replace(buildId, '<buildId>'))
-    .sort()
     .forEach((fileName, index, { length }) => {
       const innerSymbol = index === length - 1 ? '└' : '├'
 

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -215,22 +215,21 @@ export async function printTreeView(
         }
         return true
       })
+      .map(e => e.replace(buildId, '<buildId>'))
       .sort(),
-    ...sharedCssFiles.sort(),
-  ]
-    .map(e => e.replace(buildId, '<buildId>'))
-    .forEach((fileName, index, { length }) => {
-      const innerSymbol = index === length - 1 ? '└' : '├'
+    ...sharedCssFiles.map(e => e.replace(buildId, '<buildId>')).sort(),
+  ].forEach((fileName, index, { length }) => {
+    const innerSymbol = index === length - 1 ? '└' : '├'
 
-      const originalName = fileName.replace('<buildId>', buildId)
-      const cleanName = getCleanName(originalName)
+    const originalName = fileName.replace('<buildId>', buildId)
+    const cleanName = getCleanName(fileName)
 
-      messages.push([
-        `  ${innerSymbol} ${cleanName}`,
-        prettyBytes(sharedFiles[originalName]),
-        '',
-      ])
-    })
+    messages.push([
+      `  ${innerSymbol} ${cleanName}`,
+      prettyBytes(sharedFiles[originalName]),
+      '',
+    ])
+  })
 
   console.log(
     textTable(messages, {


### PR DESCRIPTION
Per https://github.com/zeit/next.js/pull/11145#pullrequestreview-376661211 this sorts the CSS files to the bottom of the build output so they are grouped separately from the JS files. Also fixes, the buildId not being replaced correctly in shared by all section

<img width="927" alt="Screen Shot 2020-03-18 at 15 01 20" src="https://user-images.githubusercontent.com/22380829/77002366-6195bc00-6929-11ea-9323-1fd96b31e00d.png">

