### PR TITLE
Add support for baseUrl option in tsconfig and jsconfig

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -217,13 +217,13 @@ export default async function getBaseWebpackConfig(
     ? config.typescript?.ignoreDevErrors
     : config.typescript?.ignoreBuildErrors
 
-  const jsConfigPath = path.join(dir, 'jsconfig.json')
   let jsConfig
   // jsconfig is a subset of tsconfig
   if (useTypeScript) {
     jsConfig = require(tsConfigPath)
   }
 
+  const jsConfigPath = path.join(dir, 'jsconfig.json')
   if (!useTypeScript && (await fileExists(jsConfigPath))) {
     jsConfig = require(jsConfigPath)
   }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -255,7 +255,7 @@ export default async function getBaseWebpackConfig(
     modules: [
       'node_modules',
       ...nodePathList, // Support for NODE_PATH environment variable
-    ].filter(Boolean),
+    ],
     alias: {
       // These aliases make sure the wrapper module is not included in the bundles
       // Which makes bundles slightly smaller, but also skips parsing a module that we know will result in this alias

--- a/test/integration/jsconfig-baseurl/components/world.js
+++ b/test/integration/jsconfig-baseurl/components/world.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function World() {
+  return <>World</>
+}

--- a/test/integration/jsconfig-baseurl/jsconfig.json
+++ b/test/integration/jsconfig-baseurl/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/test/integration/jsconfig-baseurl/next.config.js
+++ b/test/integration/jsconfig-baseurl/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+}

--- a/test/integration/jsconfig-baseurl/pages/hello.js
+++ b/test/integration/jsconfig-baseurl/pages/hello.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import { World } from 'components/world'
+export default function HelloPage() {
+  return (
+    <div>
+      <World />
+    </div>
+  )
+}

--- a/test/integration/jsconfig-baseurl/test/index.test.js
+++ b/test/integration/jsconfig-baseurl/test/index.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = join(__dirname, '..')
+let appPort
+let app
+
+async function get$(path, query) {
+  const html = await renderViaHTTP(appPort, path, query)
+  return cheerio.load(html)
+}
+
+describe('TypeScript Features', () => {
+  describe('default behavior', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {})
+    })
+    afterAll(() => killApp(app))
+
+    it('should render the page', async () => {
+      const $ = await get$('/hello')
+      expect($('body').text()).toMatch(/World/)
+    })
+  })
+})

--- a/test/integration/typescript-baseurl/components/world.tsx
+++ b/test/integration/typescript-baseurl/components/world.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function World(): JSX.Element {
+  return <>World</>
+}

--- a/test/integration/typescript-baseurl/next.config.js
+++ b/test/integration/typescript-baseurl/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+}

--- a/test/integration/typescript-baseurl/pages/hello.tsx
+++ b/test/integration/typescript-baseurl/pages/hello.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { World } from 'components/world'
+export default function HelloPage(): JSX.Element {
+  return (
+    <div>
+      <World />
+    </div>
+  )
+}

--- a/test/integration/typescript-baseurl/test/index.test.js
+++ b/test/integration/typescript-baseurl/test/index.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = join(__dirname, '..')
+let appPort
+let app
+
+async function get$(path, query) {
+  const html = await renderViaHTTP(appPort, path, query)
+  return cheerio.load(html)
+}
+
+describe('TypeScript Features', () => {
+  describe('default behavior', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {})
+    })
+    afterAll(() => killApp(app))
+
+    it('should render the page', async () => {
+      const $ = await get$('/hello')
+      expect($('body').text()).toMatch(/World/)
+    })
+  })
+})

--- a/test/integration/typescript-baseurl/tsconfig.json
+++ b/test/integration/typescript-baseurl/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "module": "esnext",
+    "jsx": "preserve",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "components", "pages"]
+}


### PR DESCRIPTION
Adds support for `compilerOptions.baseUrl` in `tsconfig.json` and `jsconfig.json`.

Note: this does not support `paths` yet.