### PR TITLE
Bugfix: Enable render to string in middleware

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -449,10 +449,6 @@ export async function renderToHTML(
   }
   let props: any
 
-  if (documentMiddlewareEnabled && typeof DocumentMiddleware === 'function') {
-    await DocumentMiddleware(ctx)
-  }
-
   const ampState = {
     ampFirst: pageConfig.amp === true,
     hasQuery: Boolean(query.amp),
@@ -472,6 +468,10 @@ export async function renderToHTML(
       </AmpStateContext.Provider>
     </RouterContext.Provider>
   )
+
+  if (documentMiddlewareEnabled && typeof DocumentMiddleware === 'function') {
+    await DocumentMiddleware(ctx)
+  }
 
   try {
     props = await loadGetInitialProps(App, {


### PR DESCRIPTION
# Problem
It is useful to be able to render the AppTree to string within the context of middleware. One usecase might be to do query analysis for specialised data fetching components or hooks. Unfortunately currently this is not possible because middleware is run before `AppContainer` is initialized.
 

```js
import Document from "next/document";
import React from "react";
import { renderToString } from "react-dom/server";

export default Document;

export async function middleware(ctx) {
  const { AppTree } = ctx;
  renderToString(<AppTree />);
}
```

This throw a ReferenceError:

```
ReferenceError: Cannot access 'AppContainer' before initialization
```

# Solution
This PR moves the call to middleware until after `AppContainer` has been defined