### PR TITLE
docs(example): Load basic-css example on codesandbox

### DIFF
--- a/examples/basic-css/README.md
+++ b/examples/basic-css/README.md
@@ -40,3 +40,8 @@ yarn dev
 ```
 
 Deploy it to the cloud with [ZEIT Now](https://zeit.co/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
+
+
+### Try it on CodeSandbox
+
+[Open this example on CodeSandbox](https://codesandbox.io/s/github/zeit/next.js/tree/canary/examples/basic-css)

--- a/examples/basic-css/README.md
+++ b/examples/basic-css/README.md
@@ -10,6 +10,8 @@ Deploy the example using [ZEIT Now](https://zeit.co/now):
 
 ## How to use
 
+[Try it on CodeSandbox](https://codesandbox.io/s/github/zeit/next.js/tree/canary/examples/basic-css)
+
 ### Using `create-next-app`
 
 Execute [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
@@ -40,8 +42,3 @@ yarn dev
 ```
 
 Deploy it to the cloud with [ZEIT Now](https://zeit.co/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
-
-
-### Try it on CodeSandbox
-
-[Open this example on CodeSandbox](https://codesandbox.io/s/github/zeit/next.js/tree/canary/examples/basic-css)


### PR DESCRIPTION
Just a quick PR to add the "Try it on CodeSandbox" link at the bottom of the README.

View the example here: https://codesandbox.io/s/github/zeit/next.js/tree/canary/examples/basic-css