### PR TITLE
Fix assignment of props in WithApollo.getInitialProps

### DIFF
--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -137,9 +137,9 @@ export const withApollo = ({ ssr = false } = {}) => PageComponent => {
             // we need to modify their props a little.
             let props
             if (inAppContext) {
-              props = { ...pageProps, apolloClient }
-            } else {
               props = { pageProps: { ...pageProps, apolloClient } }
+            } else {
+              props = { ...pageProps, apolloClient }
             }
 
             // Take the Next.js AppTree, determine which queries are needed to render,


### PR DESCRIPTION
The props are being assigned incorrectly based on the `inAppContext`, they should be wrapped in `pageProps` when `inAppContext` is true, not the other way around. This bug will cause a new apollo client to be created during `getDataFromTree` instead of using the one that has already been created on the server.