### PR TITLE
updated example with typestyle

### DIFF
--- a/examples/with-typestyle/package.json
+++ b/examples/with-typestyle/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
-    "typestyle": "^2.0.1"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "typestyle": "2.0.4"
   },
   "license": "ISC"
 }

--- a/examples/with-typestyle/pages/_document.js
+++ b/examples/with-typestyle/pages/_document.js
@@ -2,7 +2,7 @@ import Document, { Head, Main, NextScript } from 'next/document'
 import { getStyles } from 'typestyle'
 
 export default class MyDocument extends Document {
-  static getInitialProps({ renderPage }) {
+  static getStaticProps({ renderPage }) {
     const page = renderPage()
     const styleTags = getStyles()
     return { ...page, styleTags }


### PR DESCRIPTION
In this pull request, I've updated the following 
- "with typestyle" example with latest react, react-dom and typestyle version 
- the `_document.js` was using `getInitialProps` method which is now deprecated and not recommended so used the `getStaticProps` method instead