### PR TITLE
Add camelCase style of exported class names

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/loaders/global.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/global.ts
@@ -24,7 +24,11 @@ export function getGlobalCssLoader(
   // Resolve CSS `@import`s and `url()`s
   loaders.push({
     loader: require.resolve('css-loader'),
-    options: { importLoaders: 1 + preProcessors.length, sourceMap: true },
+    options: {
+      importLoaders: 1 + preProcessors.length,
+      localsConvention: "camelCase",
+      sourceMap: true
+    },
   })
 
   // Compile CSS

--- a/packages/next/build/webpack/config/blocks/css/loaders/global.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/global.ts
@@ -26,8 +26,8 @@ export function getGlobalCssLoader(
     loader: require.resolve('css-loader'),
     options: {
       importLoaders: 1 + preProcessors.length,
-      localsConvention: "camelCase",
-      sourceMap: true
+      localsConvention: 'camelCase',
+      sourceMap: true,
     },
   })
 

--- a/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
@@ -27,7 +27,7 @@ export function getCssModuleLoader(
     loader: require.resolve('css-loader'),
     options: {
       importLoaders: 1 + preProcessors.length,
-      localsConvention: "camelCase",
+      localsConvention: 'camelCase',
       sourceMap: true,
       onlyLocals: ctx.isServer,
       modules: {

--- a/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
@@ -27,6 +27,7 @@ export function getCssModuleLoader(
     loader: require.resolve('css-loader'),
     options: {
       importLoaders: 1 + preProcessors.length,
+      localsConvention: "camelCase",
       sourceMap: true,
       onlyLocals: ctx.isServer,
       modules: {


### PR DESCRIPTION
PR for css-modules

If using selectors like bem's `.block__element--modifier` code looks like
```js
import styles from "./Component.module.css"

const Component = () => <div className={styles["block__element--modifier"]} />;
```
Adding `localsConvention: "camelCase"` to options `css-loader` camelized class names and original class name **will not** to be removed from class names object ([css-loader doc](https://github.com/webpack-contrib/css-loader#localsconvention))

After that code may looks like
```js
import styles from "./Component.module.css"

const Component = () => <div className={styles.blockElementModifier} />;
```
Nothing will break on old code and IDE's hints and clicks fixed