### PR TITLE
Add support for paths in tsconfig.json and jsconfig.json

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -43,6 +43,7 @@ import { ProfilingPlugin } from './webpack/plugins/profiling-plugin'
 import { ReactLoadablePlugin } from './webpack/plugins/react-loadable-plugin'
 import { ServerlessPlugin } from './webpack/plugins/serverless-plugin'
 import { TerserPlugin } from './webpack/plugins/terser-webpack-plugin/src/index'
+import { JsConfigPathsPlugin } from './webpack/plugins/jsconfig-paths-plugin'
 import WebpackConformancePlugin, {
   MinificationConformanceCheck,
   ReactSyncScriptsConformanceCheck,
@@ -908,6 +909,12 @@ export default async function getBaseWebpackConfig(
   // Support tsconfig and jsconfig baseUrl
   if (resolvedBaseUrl) {
     webpackConfig.resolve?.modules?.push(resolvedBaseUrl)
+  }
+
+  if (jsConfig?.compilerOptions?.paths && resolvedBaseUrl) {
+    webpackConfig.resolve?.plugins?.push(
+      new JsConfigPathsPlugin(jsConfig, resolvedBaseUrl)
+    )
   }
 
   webpackConfig = await buildConfiguration(webpackConfig, {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -911,9 +911,13 @@ export default async function getBaseWebpackConfig(
     webpackConfig.resolve?.modules?.push(resolvedBaseUrl)
   }
 
-  if (jsConfig?.compilerOptions?.paths && resolvedBaseUrl) {
+  if (
+    config.experimental.jsconfigPaths &&
+    jsConfig?.compilerOptions?.paths &&
+    resolvedBaseUrl
+  ) {
     webpackConfig.resolve?.plugins?.push(
-      new JsConfigPathsPlugin(jsConfig, resolvedBaseUrl)
+      new JsConfigPathsPlugin(jsConfig.compilerOptions.paths, resolvedBaseUrl)
     )
   }
 

--- a/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
@@ -119,14 +119,18 @@ export function patternText({ prefix, suffix }: Pattern): string {
 
 const NODE_MODULES_REGEX = /node_modules/
 
+type Paths = { [match: string]: string[] }
+
 /**
  * Handles tsconfig.json or jsconfig.js "paths" option for webpack
  * Largely based on how the TypeScript compiler handles it:
  * https://github.com/microsoft/TypeScript/blob/1a9c8197fffe3dace5f8dca6633d450a88cba66d/src/compiler/moduleNameResolver.ts#L1362
  */
 export class JsConfigPathsPlugin implements ResolvePlugin {
-  constructor(jsConfig, resolvedBaseUrl) {
-    this.paths = jsConfig.compilerOptions.paths
+  paths: Paths
+  resolvedBaseUrl: string
+  constructor(paths: Paths, resolvedBaseUrl: string) {
+    this.paths = paths
 
     this.resolvedBaseUrl = resolvedBaseUrl
   }

--- a/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
@@ -246,6 +246,12 @@ export class JsConfigPathsPlugin implements ResolvePlugin {
   apply(resolver: any) {
     const paths = this.paths
     const pathsKeys = Object.keys(paths)
+
+    // If no aliases are added bail out
+    if (pathsKeys.length === 0) {
+      return
+    }
+
     const baseDirectory = this.resolvedBaseUrl
     const target = resolver.ensureHook('resolve')
     resolver

--- a/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
@@ -1,0 +1,309 @@
+import { ResolvePlugin } from 'webpack'
+import { join } from 'path'
+
+export interface Pattern {
+  prefix: string
+  suffix: string
+}
+
+const asterisk = 0x2a
+
+export function hasZeroOrOneAsteriskCharacter(str: string): boolean {
+  let seenAsterisk = false
+  for (let i = 0; i < str.length; i++) {
+    if (str.charCodeAt(i) === asterisk) {
+      if (!seenAsterisk) {
+        seenAsterisk = true
+      } else {
+        // have already seen asterisk
+        return false
+      }
+    }
+  }
+  return true
+}
+
+export function tryParsePattern(pattern: string): Pattern | undefined {
+  // This should be verified outside of here and a proper error thrown.
+  const indexOfStar = pattern.indexOf('*')
+  return indexOfStar === -1
+    ? undefined
+    : {
+        prefix: pattern.substr(0, indexOfStar),
+        suffix: pattern.substr(indexOfStar + 1),
+      }
+}
+
+export function startsWith(str: string, prefix: string): boolean {
+  return str.lastIndexOf(prefix, 0) === 0
+}
+
+export function endsWith(str: string, suffix: string): boolean {
+  const expectedPos = str.length - suffix.length
+  return expectedPos >= 0 && str.indexOf(suffix, expectedPos) === expectedPos
+}
+
+function isPatternMatch({ prefix, suffix }: Pattern, candidate: string) {
+  return (
+    candidate.length >= prefix.length + suffix.length &&
+    startsWith(candidate, prefix) &&
+    endsWith(candidate, suffix)
+  )
+}
+
+/** Return the object corresponding to the best pattern to match `candidate`. */
+export function findBestPatternMatch<T>(
+  values: readonly T[],
+  getPattern: (value: T) => Pattern,
+  candidate: string
+): T | undefined {
+  let matchedValue: T | undefined
+  // use length of prefix as betterness criteria
+  let longestMatchPrefixLength = -1
+
+  for (const v of values) {
+    const pattern = getPattern(v)
+    if (
+      isPatternMatch(pattern, candidate) &&
+      pattern.prefix.length > longestMatchPrefixLength
+    ) {
+      longestMatchPrefixLength = pattern.prefix.length
+      matchedValue = v
+    }
+  }
+
+  return matchedValue
+}
+
+/**
+ * patternStrings contains both pattern strings (containing "*") and regular strings.
+ * Return an exact match if possible, or a pattern match, or undefined.
+ * (These are verified by verifyCompilerOptions to have 0 or 1 "*" characters.)
+ */
+export function matchPatternOrExact(
+  patternStrings: readonly string[],
+  candidate: string
+): string | Pattern | undefined {
+  const patterns: Pattern[] = []
+  for (const patternString of patternStrings) {
+    if (!hasZeroOrOneAsteriskCharacter(patternString)) continue
+    const pattern = tryParsePattern(patternString)
+    if (pattern) {
+      patterns.push(pattern)
+    } else if (patternString === candidate) {
+      // pattern was matched as is - no need to search further
+      return patternString
+    }
+  }
+
+  return findBestPatternMatch(patterns, _ => _, candidate)
+}
+
+/**
+ * Tests whether a value is string
+ */
+export function isString(text: unknown): text is string {
+  return typeof text === 'string'
+}
+
+/**
+ * Given that candidate matches pattern, returns the text matching the '*'.
+ * E.g.: matchedText(tryParsePattern("foo*baz"), "foobarbaz") === "bar"
+ */
+export function matchedText(pattern: Pattern, candidate: string): string {
+  return candidate.substring(
+    pattern.prefix.length,
+    candidate.length - pattern.suffix.length
+  )
+}
+
+export function patternText({ prefix, suffix }: Pattern): string {
+  return `${prefix}*${suffix}`
+}
+
+/**
+ * Iterates through 'array' by index and performs the callback on each element of array until the callback
+ * returns a truthy value, then returns that value.
+ * If no such value is found, the callback is applied to each element of array and undefined is returned.
+ */
+export function forEach<T, U>(
+  array: readonly T[] | undefined,
+  callback: (element: T, index: number) => U | undefined
+): U | undefined {
+  if (array) {
+    for (let i = 0; i < array.length; i++) {
+      const result = callback(array[i], i)
+      if (result) {
+        return result
+      }
+    }
+  }
+  return undefined
+}
+
+export const directorySeparator = '/'
+const backslashRegExp = /\\/g
+
+/**
+ * Normalize path separators, converting `\` into `/`.
+ */
+export function normalizeSlashes(path: string): string {
+  return path.replace(backslashRegExp, directorySeparator)
+}
+
+/**
+ * Formats a parsed path consisting of a root component (at index 0) and zero or more path
+ * segments (at indices > 0).
+ *
+ * ```ts
+ * getPathFromPathComponents(["/", "path", "to", "file.ext"]) === "/path/to/file.ext"
+ * ```
+ */
+export function getPathFromPathComponents(pathComponents: readonly string[]) {
+  if (pathComponents.length === 0) return ''
+
+  const root =
+    pathComponents[0] && ensureTrailingDirectorySeparator(pathComponents[0])
+  return root + pathComponents.slice(1).join(directorySeparator)
+}
+
+const slash = 0x2f
+const backslash = 0x5c
+
+/**
+ * Determines whether a charCode corresponds to `/` or `\`.
+ */
+export function isAnyDirectorySeparator(charCode: number): boolean {
+  return charCode === slash || charCode === backslash
+}
+
+/**
+ * Determines whether a path has a trailing separator (`/` or `\\`).
+ */
+export function hasTrailingDirectorySeparator(path: string) {
+  return (
+    path.length > 0 && isAnyDirectorySeparator(path.charCodeAt(path.length - 1))
+  )
+}
+
+export function ensureTrailingDirectorySeparator(path: string) {
+  if (!hasTrailingDirectorySeparator(path)) {
+    return path + directorySeparator
+  }
+
+  return path
+}
+
+export function some<T>(
+  array: readonly T[] | undefined,
+  predicate?: (value: T) => boolean
+): boolean {
+  if (array) {
+    if (predicate) {
+      for (const v of array) {
+        if (predicate(v)) {
+          return true
+        }
+      }
+    } else {
+      return array.length > 0
+    }
+  }
+  return false
+}
+
+/**
+ * Reduce an array of path components to a more simplified path by navigating any
+ * `"."` or `".."` entries in the path.
+ */
+export function reducePathComponents(components: readonly string[]) {
+  if (!some(components)) return []
+  const reduced = [components[0]]
+  for (let i = 1; i < components.length; i++) {
+    const component = components[i]
+    if (!component) continue
+    if (component === '.') continue
+    if (component === '..') {
+      if (reduced.length > 1) {
+        if (reduced[reduced.length - 1] !== '..') {
+          reduced.pop()
+          continue
+        }
+      } else if (reduced[0]) continue
+    }
+    reduced.push(component)
+  }
+  return reduced
+}
+
+const NODE_MODULES_REGEX = /node_modules/
+export class JsConfigPathsPlugin implements ResolvePlugin {
+  constructor(jsConfig, resolvedBaseUrl) {
+    this.paths = jsConfig.compilerOptions.paths
+
+    this.resolvedBaseUrl = resolvedBaseUrl
+  }
+  apply(resolver: any) {
+    const paths = this.paths
+    const pathsKeys = Object.keys(paths)
+    const baseDirectory = this.resolvedBaseUrl
+    const target = resolver.ensureHook('resolve')
+    resolver
+      .getHook('described-resolve')
+      .tapPromise('JsConfigPathsPlugin', async (request, resolveContext) => {
+        // Exclude node_modules from paths support (speeds up resolving)
+        if (request.path.match(NODE_MODULES_REGEX)) {
+          return
+        }
+
+        const moduleName = request.request
+
+        // If the module name does not match any of the patterns in `paths` we hand off resolving to webpack
+        const matchedPattern = matchPatternOrExact(pathsKeys, moduleName)
+        if (!matchedPattern) {
+          return
+        }
+
+        const matchedStar = isString(matchedPattern)
+          ? undefined
+          : matchedText(matchedPattern, moduleName)
+        const matchedPatternText = isString(matchedPattern)
+          ? matchedPattern
+          : patternText(matchedPattern)
+
+        let triedPaths = []
+
+        for (const subst of paths[matchedPatternText]) {
+          const path = matchedStar ? subst.replace('*', matchedStar) : subst
+          const candidate = join(baseDirectory, path)
+          const [err, result] = await new Promise((resolve, reject) => {
+            const obj = Object.assign({}, request, {
+              request: candidate,
+            })
+            resolver.doResolve(
+              target,
+              obj,
+              `Aliased with tsconfig.json or jsconfig.json ${matchedPatternText} to ${candidate}`,
+              resolveContext,
+              (err, result) => {
+                resolve([err, result])
+              }
+            )
+          })
+
+          // There's multiple paths values possible, so we first have to iterate them all first before throwing an error
+          if (err || result === undefined) {
+            triedPaths.push(candidate)
+            continue
+          }
+
+          return result
+        }
+
+        throw new Error(`
+      Request "${moduleName}" matched tsconfig.json or jsconfig.json "paths" pattern ${matchedPatternText} but could not be resolved.
+      Tried paths: ${triedPaths.join(' ')}
+      `)
+      })
+  }
+}

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -41,6 +41,7 @@ const defaultConfig: { [key: string]: any } = {
       (Number(process.env.CIRCLE_NODE_TOTAL) ||
         (os.cpus() || { length: 1 }).length) - 1
     ),
+    jsconfigPaths: false,
     css: true,
     scss: true,
     documentMiddleware: false,

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -41,7 +41,7 @@ const defaultConfig: { [key: string]: any } = {
       (Number(process.env.CIRCLE_NODE_TOTAL) ||
         (os.cpus() || { length: 1 }).length) - 1
     ),
-    jsconfigPaths: true,
+    jsconfigPaths: false,
     css: true,
     scss: true,
     documentMiddleware: false,

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -41,7 +41,7 @@ const defaultConfig: { [key: string]: any } = {
       (Number(process.env.CIRCLE_NODE_TOTAL) ||
         (os.cpus() || { length: 1 }).length) - 1
     ),
-    jsconfigPaths: false,
+    jsconfigPaths: true,
     css: true,
     scss: true,
     documentMiddleware: false,

--- a/test/integration/jsconfig-paths/components/world.js
+++ b/test/integration/jsconfig-paths/components/world.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function World() {
+  return <>World</>
+}

--- a/test/integration/jsconfig-paths/jsconfig.json
+++ b/test/integration/jsconfig-paths/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@c/*": ["components/*"],
+      "@lib/*": ["lib/a/*", "lib/b/*"]
+    }
+  }
+}

--- a/test/integration/jsconfig-paths/lib/a/api.js
+++ b/test/integration/jsconfig-paths/lib/a/api.js
@@ -1,0 +1,1 @@
+export default () => 'Hello from a'

--- a/test/integration/jsconfig-paths/lib/b/api.js
+++ b/test/integration/jsconfig-paths/lib/b/api.js
@@ -1,0 +1,1 @@
+export default () => 'Hello from b'

--- a/test/integration/jsconfig-paths/lib/b/b-only.js
+++ b/test/integration/jsconfig-paths/lib/b/b-only.js
@@ -1,0 +1,1 @@
+export default () => 'Hello from only b'

--- a/test/integration/jsconfig-paths/next.config.js
+++ b/test/integration/jsconfig-paths/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+}

--- a/test/integration/jsconfig-paths/next.config.js
+++ b/test/integration/jsconfig-paths/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  experimental: {
+    jsconfigPaths: true,
+  },
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,

--- a/test/integration/jsconfig-paths/pages/basic-alias.js
+++ b/test/integration/jsconfig-paths/pages/basic-alias.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import { World } from '@c/world'
+export default function HelloPage() {
+  return (
+    <div>
+      <World />
+    </div>
+  )
+}

--- a/test/integration/jsconfig-paths/pages/resolve-fallback.js
+++ b/test/integration/jsconfig-paths/pages/resolve-fallback.js
@@ -1,0 +1,5 @@
+import React from 'react'
+import api from '@lib/b-only'
+export default function ResolveOrder() {
+  return <div>{api()}</div>
+}

--- a/test/integration/jsconfig-paths/pages/resolve-order.js
+++ b/test/integration/jsconfig-paths/pages/resolve-order.js
@@ -1,0 +1,5 @@
+import React from 'react'
+import api from '@lib/api'
+export default function ResolveOrder() {
+  return <div>{api()}</div>
+}

--- a/test/integration/jsconfig-paths/test/index.test.js
+++ b/test/integration/jsconfig-paths/test/index.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = join(__dirname, '..')
+let appPort
+let app
+
+async function get$(path, query) {
+  const html = await renderViaHTTP(appPort, path, query)
+  return cheerio.load(html)
+}
+
+describe('TypeScript Features', () => {
+  describe('default behavior', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {})
+    })
+    afterAll(() => killApp(app))
+
+    it('should alias components', async () => {
+      const $ = await get$('/basic-alias')
+      expect($('body').text()).toMatch(/World/)
+    })
+
+    it('should resolve the first item in the array first', async () => {
+      const $ = await get$('/resolve-order')
+      expect($('body').text()).toMatch(/Hello from a/)
+    })
+
+    it('should resolve the first item in the array first', async () => {
+      const $ = await get$('/resolve-fallback')
+      expect($('body').text()).toMatch(/Hello from only b/)
+    })
+  })
+})

--- a/test/integration/typescript-baseurl/components/hi.tsx
+++ b/test/integration/typescript-baseurl/components/hi.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Hi(): JSX.Element {
+  return <>Hi</>
+}

--- a/test/integration/typescript-paths/components/world.tsx
+++ b/test/integration/typescript-paths/components/world.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function World(): JSX.Element {
+  return <>World</>
+}

--- a/test/integration/typescript-paths/lib/a/api.ts
+++ b/test/integration/typescript-paths/lib/a/api.ts
@@ -1,0 +1,1 @@
+export default () => 'Hello from a'

--- a/test/integration/typescript-paths/lib/b/api.ts
+++ b/test/integration/typescript-paths/lib/b/api.ts
@@ -1,0 +1,1 @@
+export default () => 'Hello from b'

--- a/test/integration/typescript-paths/lib/b/b-only.ts
+++ b/test/integration/typescript-paths/lib/b/b-only.ts
@@ -1,0 +1,1 @@
+export default () => 'Hello from only b'

--- a/test/integration/typescript-paths/next.config.js
+++ b/test/integration/typescript-paths/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+}

--- a/test/integration/typescript-paths/next.config.js
+++ b/test/integration/typescript-paths/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  experimental: {
+    jsconfigPaths: true,
+  },
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,

--- a/test/integration/typescript-paths/pages/basic-alias.tsx
+++ b/test/integration/typescript-paths/pages/basic-alias.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { World } from '@c/world'
+export default function HelloPage(): JSX.Element {
+  return (
+    <div>
+      <World />
+    </div>
+  )
+}

--- a/test/integration/typescript-paths/pages/resolve-fallback.tsx
+++ b/test/integration/typescript-paths/pages/resolve-fallback.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+import api from '@lib/b-only'
+export default function ResolveOrder(): JSX.Element {
+  return <div>{api()}</div>
+}

--- a/test/integration/typescript-paths/pages/resolve-order.tsx
+++ b/test/integration/typescript-paths/pages/resolve-order.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+import api from '@lib/api'
+export default function ResolveOrder(): JSX.Element {
+  return <div>{api()}</div>
+}

--- a/test/integration/typescript-paths/test/index.test.js
+++ b/test/integration/typescript-paths/test/index.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = join(__dirname, '..')
+let appPort
+let app
+
+async function get$(path, query) {
+  const html = await renderViaHTTP(appPort, path, query)
+  return cheerio.load(html)
+}
+
+describe('TypeScript Features', () => {
+  describe('default behavior', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {})
+    })
+    afterAll(() => killApp(app))
+
+    it('should alias components', async () => {
+      const $ = await get$('/basic-alias')
+      expect($('body').text()).toMatch(/World/)
+    })
+
+    it('should resolve the first item in the array first', async () => {
+      const $ = await get$('/resolve-order')
+      expect($('body').text()).toMatch(/Hello from a/)
+    })
+
+    it('should resolve the first item in the array first', async () => {
+      const $ = await get$('/resolve-fallback')
+      expect($('body').text()).toMatch(/Hello from only b/)
+    })
+  })
+})

--- a/test/integration/typescript-paths/tsconfig.json
+++ b/test/integration/typescript-paths/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@c/*": ["components/*"],
+      "@lib/*": ["lib/a/*", "lib/b/*"]
+    },
+    "esModuleInterop": true,
+    "module": "esnext",
+    "jsx": "preserve",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "components", "pages"]
+}


### PR DESCRIPTION
Adds support for `"paths"` in both `tsconfig.json` or `jsconfig.json`.

Examples:

**Single module alias**

```json
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "mytheme": ["components/mytheme.js"]
    }
  }
}
```

**Wildcard alias**

```json
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "@c/*": ["components/*"],
    }
  }
}
```

**Fallback behavior**

```json
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "@mytheme/*": ["themes/theme-a/*", "lib/theme-b/*"]
    }
  }
}
```

Fixes #7779