### PR TITLE
Update handling for ENOENT from GSSP methods

### DIFF
--- a/packages/next/lib/coalesced-function.ts
+++ b/packages/next/lib/coalesced-function.ts
@@ -3,7 +3,7 @@ type CoalescedInvoke<T> = {
   value: T
 }
 
-type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
+export type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
 
 const globalInvokeCache = new Map<string, Promise<CoalescedInvoke<unknown>>>()
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -38,6 +38,8 @@ import { tryGetPreviewData, __ApiPreviewProps } from './api-utils'
 import { getPageFiles } from './get-page-files'
 import { LoadComponentsReturnType, ManifestItem } from './load-components'
 import optimizeAmp from './optimize-amp'
+import { UnwrapPromise } from '../../lib/coalesced-function'
+import { GetStaticProps, GetServerSideProps } from '../../types'
 
 function noRouter() {
   const message =
@@ -495,12 +497,23 @@ export async function renderToHTML(
     }
 
     if (isSSG && !isFallback) {
-      const data = await getStaticProps!({
-        ...(pageIsDynamic ? { params: query as ParsedUrlQuery } : undefined),
-        ...(previewData !== false
-          ? { preview: true, previewData: previewData }
-          : undefined),
-      })
+      let data: UnwrapPromise<ReturnType<GetStaticProps>>
+
+      try {
+        data = await getStaticProps!({
+          ...(pageIsDynamic ? { params: query as ParsedUrlQuery } : undefined),
+          ...(previewData !== false
+            ? { preview: true, previewData: previewData }
+            : undefined),
+        })
+      } catch (err) {
+        // remove not found error code to prevent triggering legacy
+        // 404 rendering
+        if (err.code === 'ENOENT') {
+          delete err.code
+        }
+        throw err
+      }
 
       const invalidKeys = Object.keys(data).filter(
         key => key !== 'revalidate' && key !== 'props'
@@ -563,15 +576,26 @@ export async function renderToHTML(
     }
 
     if (getServerSideProps && !isFallback) {
-      const data = await getServerSideProps({
-        req,
-        res,
-        query,
-        ...(pageIsDynamic ? { params: params as ParsedUrlQuery } : undefined),
-        ...(previewData !== false
-          ? { preview: true, previewData: previewData }
-          : undefined),
-      })
+      let data: UnwrapPromise<ReturnType<GetServerSideProps>>
+
+      try {
+        data = await getServerSideProps({
+          req,
+          res,
+          query,
+          ...(pageIsDynamic ? { params: params as ParsedUrlQuery } : undefined),
+          ...(previewData !== false
+            ? { preview: true, previewData: previewData }
+            : undefined),
+        })
+      } catch (err) {
+        // remove not found error code to prevent triggering legacy
+        // 404 rendering
+        if (err.code === 'ENOENT') {
+          delete err.code
+        }
+        throw err
+      }
 
       const invalidKeys = Object.keys(data).filter(key => key !== 'props')
 

--- a/test/integration/getserversideprops/pages/enoent.js
+++ b/test/integration/getserversideprops/pages/enoent.js
@@ -1,0 +1,7 @@
+export async function getServerSideProps() {
+  const error = new Error('oof')
+  error.code = 'ENOENT'
+  throw error
+}
+
+export default () => 'hi'

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -205,6 +205,19 @@ const runTests = (dev = false) => {
     expect(html).toMatch(/Post:.*?post-1/)
   })
 
+  it('should handle throw ENOENT correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/enoent')
+    const html = await res.text()
+
+    if (dev) {
+      expect(html).toContain('oof')
+    } else {
+      expect(res.status).toBe(500)
+      expect(html).toContain('Internal Server Error')
+      expect(html).not.toContain('This page could not be found')
+    }
+  })
+
   it('should have gssp in __NEXT_DATA__', async () => {
     const html = await renderViaHTTP(appPort, '/')
     const $ = cheerio.load(html)

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -80,6 +80,12 @@ const expectedManifestRoutes = () => [
   },
   {
     dataRouteRegex: normalizeRegEx(
+      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/enoent.json$`
+    ),
+    page: '/enoent',
+  },
+  {
+    dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/invalid-keys.json$`
     ),
     page: '/invalid-keys',


### PR DESCRIPTION
As discussed this adds handling for `ENOENT` being thrown from `getServerSideProps` to make sure we don't trigger the legacy 404 rendering