### PR TITLE
fix: typo in `isStaging` in `with-env` example

### DIFF
--- a/examples/with-env-from-next-config-js/next.config.js
+++ b/examples/with-env-from-next-config-js/next.config.js
@@ -10,7 +10,7 @@ module.exports = phase => {
   // when `next build` or `npm run build` is used
   const isProd = phase === PHASE_PRODUCTION_BUILD && process.env.STAGING !== '1'
   // when `next build` or `npm run build` is used
-  const isStaging = phase ==== PHASE_PRODUCTION_BUILD && process.env.STAGING === '1'
+  const isStaging = phase === PHASE_PRODUCTION_BUILD && process.env.STAGING === '1'
 
   console.log(`isDev:${isDev}  isProd:${isProd}   isStaging:${isStaging}`)
 

--- a/examples/with-env-from-next-config-js/next.config.js
+++ b/examples/with-env-from-next-config-js/next.config.js
@@ -10,7 +10,7 @@ module.exports = phase => {
   // when `next build` or `npm run build` is used
   const isProd = phase === PHASE_PRODUCTION_BUILD && process.env.STAGING !== '1'
   // when `next build` or `npm run build` is used
-  const isStaging = PHASE_PRODUCTION_BUILD && process.env.STAGING === '1'
+  const isStaging = phase ==== PHASE_PRODUCTION_BUILD && process.env.STAGING === '1'
 
   console.log(`isDev:${isDev}  isProd:${isProd}   isStaging:${isStaging}`)
 

--- a/examples/with-env-from-next-config-js/next.config.js
+++ b/examples/with-env-from-next-config-js/next.config.js
@@ -10,7 +10,8 @@ module.exports = phase => {
   // when `next build` or `npm run build` is used
   const isProd = phase === PHASE_PRODUCTION_BUILD && process.env.STAGING !== '1'
   // when `next build` or `npm run build` is used
-  const isStaging = phase === PHASE_PRODUCTION_BUILD && process.env.STAGING === '1'
+  const isStaging =
+    phase === PHASE_PRODUCTION_BUILD && process.env.STAGING === '1'
 
   console.log(`isDev:${isDev}  isProd:${isProd}   isStaging:${isStaging}`)
 


### PR DESCRIPTION
add missing `phase ===` statement when checking for _staging_ env in `isStaging`