### PR TITLE
Add Numeric Separator Support for TypeScript

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -49,7 +49,7 @@ type BabelPreset = {
   presets?: PluginItem[] | null
   plugins?: PluginItem[] | null
   sourceType?: 'script' | 'module' | 'unambiguous'
-  overrides?: any[]
+  overrides?: Array<{ test: RegExp } & Omit<BabelPreset, 'overrides'>>
 }
 
 // Taken from https://github.com/babel/babel/commit/d60c5e1736543a6eac4b549553e107a9ba967051#diff-b4beead8ad9195361b4537601cc22532R158
@@ -177,6 +177,13 @@ module.exports = (
       require('@babel/plugin-proposal-optional-chaining'),
       require('@babel/plugin-proposal-nullish-coalescing-operator'),
       isServer && require('@babel/plugin-syntax-bigint'),
+      [require('@babel/plugin-proposal-numeric-separator').default, false],
     ].filter(Boolean),
+    overrides: [
+      {
+        test: /\.tsx?$/,
+        plugins: [require('@babel/plugin-proposal-numeric-separator').default],
+      },
+    ],
   }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -61,6 +61,7 @@
     "@babel/core": "7.7.2",
     "@babel/plugin-proposal-class-properties": "7.7.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "7.7.4",
+    "@babel/plugin-proposal-numeric-separator": "7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "7.6.2",
     "@babel/plugin-proposal-optional-chaining": "7.7.4",
     "@babel/plugin-syntax-bigint": "7.8.3",

--- a/test/integration/typescript-numeric-sep-exclusive/pages/index.js
+++ b/test/integration/typescript-numeric-sep-exclusive/pages/index.js
@@ -1,0 +1,1 @@
+export default () => `hello ${1_000}`

--- a/test/integration/typescript-numeric-sep-exclusive/test/index.test.js
+++ b/test/integration/typescript-numeric-sep-exclusive/test/index.test.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+/* global jasmine */
+import { nextBuild } from 'next-test-utils'
+import { join } from 'path'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+
+const appDir = join(__dirname, '../')
+
+describe('TypeScript Exclusivity of Numeric Separator', () => {
+  it('should fail to build for a JavaScript file', async () => {
+    const { code, stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+    })
+
+    expect(code).toBe(1)
+
+    expect(stderr).toContain('Failed to compile.')
+    expect(stderr).toContain('SyntaxError:')
+    expect(stderr).toContain('Identifier directly after number')
+  })
+})

--- a/test/integration/typescript/pages/hello.tsx
+++ b/test/integration/typescript/pages/hello.tsx
@@ -9,9 +9,9 @@ export default function HelloPage(): JSX.Element {
   const router = useRouter()
   console.log(process.browser)
   console.log(router.pathname)
-  console.log('one trillion dollars', 1_000_000_000_000)
   return (
     <div>
+      <p>One trillion dollars: {1_000_000_000_000}</p>
       {hello()} <World />
       <Router />
       <Link />

--- a/test/integration/typescript/pages/hello.tsx
+++ b/test/integration/typescript/pages/hello.tsx
@@ -9,6 +9,7 @@ export default function HelloPage(): JSX.Element {
   const router = useRouter()
   console.log(process.browser)
   console.log(router.pathname)
+  console.log('one trillion dollars', 1_000_000_000_000)
   return (
     <div>
       {hello()} <World />

--- a/test/integration/typescript/test/index.test.js
+++ b/test/integration/typescript/test/index.test.js
@@ -43,6 +43,7 @@ describe('TypeScript Features', () => {
     it('should render the page', async () => {
       const $ = await get$('/hello')
       expect($('body').text()).toMatch(/Hello World/)
+      expect($('body').text()).toMatch(/1000000000000/)
     })
 
     it('should report type checking to stdout', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,6 +481,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.7.4"
 
+"@babel/plugin-proposal-numeric-separator@7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz#5d6769409699ec9b3b68684cd8116cedff93bad8"
+  integrity sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.3"
+
 "@babel/plugin-proposal-object-rest-spread@7.6.2":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz#8ffccc8f3a6545e9f78988b6bf4fe881b88e8096"
@@ -576,6 +584,13 @@
   integrity sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-numeric-separator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz#0e3fb63e09bea1b11e96467271c8308007e7c41f"
+  integrity sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0", "@babel/plugin-syntax-object-rest-spread@^7.7.4":
   version "7.7.4"


### PR DESCRIPTION
Numeric separator support was added in TypeScript 2.7:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#numeric-separators

This feature is still stage 3, so I've only turned it on for TypeScript and not JavaScript files.