### PR TITLE
docs: clarify how to customize next/babel presets

### DIFF
--- a/docs/advanced-features/customizing-babel-config.md
+++ b/docs/advanced-features/customizing-babel-config.md
@@ -34,7 +34,7 @@ The `next/babel` presets includes:
 - plugin-transform-runtime
 - styled-jsx
 
-These presets/plugins **should not** be added to your custom `.babelrc`. Instead, you can configure them on the `next/babel` preset, like so:
+To configure these presets/plugins, **do not** add them as their own presets or plugins in your custom `.babelrc`. Instead, configure them on the `next/babel` preset, like so:
 
 ```json
 {

--- a/docs/advanced-features/customizing-babel-config.md
+++ b/docs/advanced-features/customizing-babel-config.md
@@ -34,7 +34,7 @@ The `next/babel` presets includes:
 - plugin-transform-runtime
 - styled-jsx
 
-To configure these presets/plugins, **do not** add them as their own presets or plugins in your custom `.babelrc`. Instead, configure them on the `next/babel` preset, like so:
+To configure these presets/plugins, **do not** add them to `presets` or `plugins` in your custom `.babelrc`. Instead, configure them on the `next/babel` preset, like so:
 
 ```json
 {


### PR DESCRIPTION
The current language confused me, because it says the presets/plugins should not be added to .babelrc, but then they are "added" (in a sense) to .babelrc in the subsequent example. Clarify that they shouldn't be added _as their own presets/plugins_.