### PR TITLE
Skip paths that are routed to a .d.ts file

### DIFF
--- a/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
@@ -174,6 +174,12 @@ export class JsConfigPathsPlugin implements ResolvePlugin {
 
           for (const subst of paths[matchedPatternText]) {
             const path = matchedStar ? subst.replace('*', matchedStar) : subst
+
+            // Ensure .d.ts is not matched
+            if (path.endsWith('.d.ts')) {
+              continue
+            }
+
             const candidate = join(baseDirectory, path)
             const [err, result] = await new Promise((resolve, reject) => {
               const obj = Object.assign({}, request, {

--- a/test/integration/typescript-paths/components/alias-to-d-ts.d.ts
+++ b/test/integration/typescript-paths/components/alias-to-d-ts.d.ts
@@ -1,0 +1,1 @@
+export default () => any

--- a/test/integration/typescript-paths/components/alias-to-d-ts.tsx
+++ b/test/integration/typescript-paths/components/alias-to-d-ts.tsx
@@ -1,0 +1,3 @@
+export default () => {
+  return <>Not aliased to d.ts file</>
+}

--- a/test/integration/typescript-paths/pages/alias-to-d-ts.tsx
+++ b/test/integration/typescript-paths/pages/alias-to-d-ts.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import NotAliasedToDTS from 'd-ts-alias'
+
+export default function HelloPage(): JSX.Element {
+  return (
+    <div>
+      <NotAliasedToDTS />
+    </div>
+  )
+}

--- a/test/integration/typescript-paths/test/index.test.js
+++ b/test/integration/typescript-paths/test/index.test.js
@@ -42,5 +42,10 @@ describe('TypeScript Features', () => {
       const $ = await get$('/single-alias')
       expect($('body').text()).toMatch(/Hello/)
     })
+
+    it('should not resolve to .d.ts files', async () => {
+      const $ = await get$('/alias-to-d-ts')
+      expect($('body').text()).toMatch(/Not aliased to d\.ts file/)
+    })
   })
 })

--- a/test/integration/typescript-paths/tsconfig.json
+++ b/test/integration/typescript-paths/tsconfig.json
@@ -2,9 +2,14 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "isomorphic-unfetch": ["types/unfetch.d.ts"],
       "@c/*": ["components/*"],
       "@lib/*": ["lib/a/*", "lib/b/*"],
-      "@mycomponent": ["components/hello.tsx"]
+      "@mycomponent": ["components/hello.tsx"],
+      "d-ts-alias": [
+        "components/alias-to-d-ts.d.ts",
+        "components/alias-to-d-ts.tsx"
+      ]
     },
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
Ran into this issue when adding the new resolver to zeit.co.