### PR TITLE
Make sure to copy AMP SSG files during export

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -3,6 +3,7 @@ import findUp from 'find-up'
 import {
   copyFile as copyFileOrig,
   existsSync,
+  exists as existsOrig,
   mkdir as mkdirOrig,
   readFileSync,
   writeFileSync,
@@ -37,6 +38,7 @@ import { normalizePagePath } from '../next-server/server/normalize-page-path'
 
 const copyFile = promisify(copyFileOrig)
 const mkdir = promisify(mkdirOrig)
+const exists = promisify(existsOrig)
 
 const createProgress = (total: number, label = 'Exporting') => {
   let curProgress = 0
@@ -363,12 +365,21 @@ export default async function(
             subFolders && route !== '/index' ? `${sep}index` : ''
           }.html`
         )
+        const ampHtmlDest = join(
+          outDir,
+          `${route}.amp${subFolders ? `${sep}index` : ''}.html`
+        )
         const jsonDest = join(pagesDataDir, `${route}.json`)
 
         await mkdir(dirname(htmlDest), { recursive: true })
         await mkdir(dirname(jsonDest), { recursive: true })
         await copyFile(`${orig}.html`, htmlDest)
         await copyFile(`${orig}.json`, jsonDest)
+
+        if (await exists(`${orig}.amp.html`)) {
+          await mkdir(dirname(ampHtmlDest), { recursive: true })
+          await copyFile(`${orig}.amp.html`, ampHtmlDest)
+        }
       })
     )
   }


### PR DESCRIPTION
Follow-up to https://github.com/zeit/next.js/pull/11205 this makes sure we copy SSG AMP files correctly during `next export`

Closes: https://github.com/zeit/next.js/issues/11332