### PR TITLE
Fix preview-mode docs/examples typo

### DIFF
--- a/docs/advanced-features/preview-mode.md
+++ b/docs/advanced-features/preview-mode.md
@@ -74,7 +74,7 @@ Your headless CMS might allow you to include a variable in the preview URL so th
 ```js
 export default async (req, res) => {
   // Check the secret and next parameters
-  // This secret should only be know to this API route and the CMS
+  // This secret should only be known to this API route and the CMS
   if (req.query.secret !== 'MY_SECRET_TOKEN' || !req.query.slug) {
     return res.status(401).json({ message: 'Invalid token' })
   }

--- a/examples/cms-datocms/pages/api/preview.js
+++ b/examples/cms-datocms/pages/api/preview.js
@@ -2,7 +2,7 @@ import { getPreviewPostBySlug } from '../../lib/api'
 
 export default async (req, res) => {
   // Check the secret and next parameters
-  // This secret should only be know to this API route and the CMS
+  // This secret should only be known to this API route and the CMS
   if (
     req.query.secret !== process.env.NEXT_EXAMPLE_CMS_DATOCMS_PREVIEW_SECRET ||
     !req.query.slug

--- a/examples/cms-sanity/pages/api/preview.js
+++ b/examples/cms-sanity/pages/api/preview.js
@@ -2,7 +2,7 @@ import { getPreviewPostBySlug } from '../../lib/api'
 
 export default async (req, res) => {
   // Check the secret and next parameters
-  // This secret should only be know to this API route and the CMS
+  // This secret should only be known to this API route and the CMS
   if (
     req.query.secret !== process.env.NEXT_EXAMPLE_CMS_SANITY_PREVIEW_SECRET ||
     !req.query.slug

--- a/examples/cms-takeshape/pages/api/preview.js
+++ b/examples/cms-takeshape/pages/api/preview.js
@@ -2,7 +2,7 @@ import { getPreviewPostBySlug } from '../../lib/api'
 
 export default async (req, res) => {
   // Check the secret and next parameters
-  // This secret should only be know to this API route and the CMS
+  // This secret should only be known to this API route and the CMS
   if (
     req.query.secret !==
       process.env.NEXT_EXAMPLE_CMS_TAKESHAPE_PREVIEW_SECRET ||


### PR DESCRIPTION
Changing  `This secret should only be know` to `This secret should only be known`.