### PR TITLE
Update to prevent re-using workers for getStaticPaths in dev mode

### DIFF
--- a/test/integration/prerender/pages/blog/[post]/index.js
+++ b/test/integration/prerender/pages/blog/[post]/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import 'firebase/firestore'
 
 export async function getStaticPaths() {
   return {


### PR DESCRIPTION
This removes clearing the cache in the `getStaticPaths` worker used in development in favor of killing the worker after it has been used so that we ensure we're always calling `getStaticPaths` in a clean environment. This was initially [suggested here](https://github.com/zeit/next.js/pull/10611#discussion_r382890539) although didn't seem worth the extra boot-up time and `jest-worker` being able to handle the workers being killed in a stable way.

After further investigation it seems killing the worker after each use seems the most ideal to prevent side effects that can't properly be handled like importing specific modules e.g. `firebase` and properly preventing modules from being cached. It also seems `jest-worker` is able to handle the worker being killed stably as long as we do it on the next call and not before the current call has finished  

x-ref: https://github.com/zeit/next.js/pull/10611
x-ref: https://github.com/zeit/next.js/pull/10852
Fixes: https://github.com/zeit/next.js/issues/11339