### PR TITLE
Fix `static/` file name encoding

### DIFF
--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -9,6 +9,7 @@ import errorRecovery from './error-recovery'
 import dynamic from './dynamic'
 import processEnv from './process-env'
 import publicFolder from './public-folder'
+import security from './security'
 
 const context = {}
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
@@ -35,4 +36,5 @@ describe('Basic Features', () => {
   errorRecovery(context, (p, q) => renderViaHTTP(context.appPort, p, q))
   processEnv(context)
   publicFolder(context)
+  security(context)
 })

--- a/test/integration/basic/test/security.js
+++ b/test/integration/basic/test/security.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+import { fetchViaHTTP } from 'next-test-utils'
+
+module.exports = context => {
+  describe('With Security Related Issues', () => {
+    it('should not allow accessing files outside .next/static and .next/server directory', async () => {
+      const pathsToCheck = [
+        `/_next/static/../BUILD_ID`,
+        `/_next/static/../routes-manifest.json`,
+      ]
+      for (const path of pathsToCheck) {
+        const res = await fetchViaHTTP(context.appPort, path)
+        const text = await res.text()
+        try {
+          expect(res.status).toBe(404)
+          expect(text).toMatch(/This page could not be found/)
+        } catch (err) {
+          throw new Error(`Path ${path} accessible from the browser`)
+        }
+      }
+    })
+  })
+}

--- a/test/integration/dynamic-routing/static/hello copy.txt
+++ b/test/integration/dynamic-routing/static/hello copy.txt
@@ -1,0 +1,1 @@
+hello world copy

--- a/test/integration/dynamic-routing/static/hello%20copy.txt
+++ b/test/integration/dynamic-routing/static/hello%20copy.txt
@@ -1,0 +1,1 @@
+hello world %20

--- a/test/integration/dynamic-routing/static/hello+copy.txt
+++ b/test/integration/dynamic-routing/static/hello+copy.txt
@@ -1,0 +1,1 @@
+hello world +

--- a/test/integration/dynamic-routing/static/hello.txt
+++ b/test/integration/dynamic-routing/static/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -443,6 +443,34 @@ function runTests(dev) {
     expect(res.status).toBe(200)
   })
 
+  it('should serve file with space from static folder', async () => {
+    const res = await fetchViaHTTP(appPort, '/static/hello copy.txt')
+    const text = (await res.text()).trim()
+    expect(text).toBe('hello world copy')
+    expect(res.status).toBe(200)
+  })
+
+  it('should serve file with plus from static folder', async () => {
+    const res = await fetchViaHTTP(appPort, '/static/hello+copy.txt')
+    const text = (await res.text()).trim()
+    expect(text).toBe('hello world +')
+    expect(res.status).toBe(200)
+  })
+
+  it('should serve file from static folder encoded', async () => {
+    const res = await fetchViaHTTP(appPort, '/static/hello%20copy.txt')
+    const text = (await res.text()).trim()
+    expect(text).toBe('hello world copy')
+    expect(res.status).toBe(200)
+  })
+
+  it('should serve file with %20 from static folder', async () => {
+    const res = await fetchViaHTTP(appPort, '/static/hello%2520copy.txt')
+    const text = (await res.text()).trim()
+    expect(text).toBe('hello world %20')
+    expect(res.status).toBe(200)
+  })
+
   if (dev) {
     it('should work with HMR correctly', async () => {
       const browser = await webdriver(appPort, '/post-1/comments')

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -50,6 +50,25 @@ module.exports = context => {
       }
     })
 
+    it('should not allow accessing files outside .next/static directory', async () => {
+      const pathsToCheck = [
+        `/_next/static/../server/pages-manifest.json`,
+        `/_next/static/../server/build-manifest.json`,
+        `/_next/static/../BUILD_ID`,
+        `/_next/static/../routes-manifest.json`,
+      ]
+      for (const path of pathsToCheck) {
+        const res = await fetchViaHTTP(context.appPort, path)
+        const text = await res.text()
+        try {
+          expect(res.status).toBe(404)
+          expect(text).toMatch(/This page could not be found/)
+        } catch (err) {
+          throw new Error(`Path ${path} accessible from the browser`)
+        }
+      }
+    })
+
     it("should not leak the user's home directory into the build", async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
 


### PR DESCRIPTION
This pull request fixes `static/` files with special file names.

This is a follow-up to the `public/` fix that was landed in this PR: #10022 (fixing #10004).

For ease of review, here's the test cases: https://github.com/zeit/next.js/commit/995b62e17992f2e30e3892ad76e94064f2b4a63b

---

Fixes #11371