### PR TITLE
Added support for process.env.PORT

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import { resolve } from 'path'
+
 import arg from 'next/dist/compiled/arg/index.js'
-import { existsSync } from 'fs'
-import startServer from '../server/lib/start-server'
-import { printAndExit } from '../server/lib/utils'
-import { startedDevelopmentServer } from '../build/output'
 import { cliCommand } from '../bin/next'
+import { existsSync } from 'fs'
+import { printAndExit } from '../server/lib/utils'
+import { resolve } from 'path'
+import startServer from '../server/lib/start-server'
+import { startedDevelopmentServer } from '../build/output'
 
 const nextDev: cliCommand = argv => {
   const args = arg(
@@ -51,7 +52,7 @@ const nextDev: cliCommand = argv => {
     printAndExit(`> No such directory exists as the project root: ${dir}`)
   }
 
-  const port = args['--port'] || 3000
+  const port = args['--port'] || (process.env.PORT && +process.env.PORT) || 3000
   const appUrl = `http://${args['--hostname'] || 'localhost'}:${port}`
 
   startedDevelopmentServer(appUrl)

--- a/packages/next/cli/next-start.ts
+++ b/packages/next/cli/next-start.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { resolve } from 'path'
 import arg from 'next/dist/compiled/arg/index.js'
-import startServer from '../server/lib/start-server'
 import { cliCommand } from '../bin/next'
+import { resolve } from 'path'
+import startServer from '../server/lib/start-server'
 
 const nextStart: cliCommand = argv => {
   const args = arg(
@@ -43,7 +43,7 @@ const nextStart: cliCommand = argv => {
   }
 
   const dir = resolve(args._[0] || '.')
-  const port = args['--port'] || 3000
+  const port = args['--port'] || (process.env.PORT && +process.env.PORT) || 3000
   startServer({ dir }, port, args['--hostname'])
     .then(async app => {
       // tslint:disable-next-line


### PR DESCRIPTION
Fixes #10338.

Adds capability of reading process.env.PORT for port argument. Especially useful in Docker containers, such as ones hosted in cloud computing.