### PR TITLE
fix(performance-relayer): properly clean up event listeners

### DIFF
--- a/packages/next/client/performance-relayer.js
+++ b/packages/next/client/performance-relayer.js
@@ -25,7 +25,7 @@ export function observeLayoutShift(onPerfEntry) {
           // Force any pending records to be dispatched.
           observer.takeRecords()
           observer.disconnect()
-          removeEventListener('visibilitychange', clsObserver, true)
+          document.removeEventListener('visibilitychange', clsObserver, true)
           onPerfEntry({
             name: 'cumulative-layout-shift',
             value: cumulativeScore,
@@ -55,7 +55,7 @@ export function observeLargestContentfulPaint(onPerfEntry) {
       'visibilitychange',
       function lcpObserver() {
         if (lcp && document.visibilityState === 'hidden') {
-          removeEventListener('visibilitychange', lcpObserver, true)
+          document.removeEventListener('visibilitychange', lcpObserver, true)
           onPerfEntry({
             name: 'largest-contentful-paint',
             value: lcp,


### PR DESCRIPTION
Properly cleaning up event listener on document object to prevent memory leaks