### PR TITLE
Minor change in README.md

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -10,7 +10,7 @@
   <a aria-label="License" href="https://github.com/zeit/next.js/blob/canary/license.md">
     <img alt="" src="https://img.shields.io/npm/l/next.svg?style=for-the-badge&labelColor=000000">
   </a>
-  <a aria-label="join us in spectrum" href="https://spectrum.chat/next-js?tab=posts">
+  <a aria-label="Join the community on GitHub" href="https://github.com/zeit/next.js/discussions">
     <img alt="" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=Next.js&labelColor=000000&logoWidth=20">
   </a>
 </p>

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -10,7 +10,7 @@
   <a aria-label="License" href="https://github.com/zeit/next.js/blob/canary/license.md">
     <img alt="" src="https://img.shields.io/npm/l/next.svg?style=for-the-badge&labelColor=000000">
   </a>
-  <a aria-label="join us in spectrum" href="https://github.com/zeit/next.js/discussions">
+  <a aria-label="join us in spectrum" href="https://spectrum.chat/next-js?tab=posts">
     <img alt="" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=Next.js&labelColor=000000&logoWidth=20">
   </a>
 </p>


### PR DESCRIPTION
I changed the link for "JOIN THE COMMUNITY" to [spectrum chat channel](https://spectrum.chat/next-js?tab=posts). 

It was orginally directed to the [Discussions](https://github.com/zeit/next.js/discussions), but the label says "join us in spectrum".

I noticed that "alpha" branch does has the correct link to the spectrum chat. I think it would be better for the master branch to also have correct link.