### PR TITLE
fixed typo: libraray -> library

### DIFF
--- a/examples/custom-server-actionhero/README.md
+++ b/examples/custom-server-actionhero/README.md
@@ -103,7 +103,7 @@ module.exports = class CreateChatRoom extends Action {
 
 3. Tell ActionHero to use the api rather than the file server as the top-level route in `api.config.servers.web.rootEndpointType = 'api'`. This will allows "/" to listen to API requests. Also update `api.config.general.paths.public = [ path.join(__dirname, '/../static') ]`. In this configuration, the next 'static' renderer will take priority over the ActionHero 'public file' api. Note that any static assets (CSS, fonts, etc) will need to be in "./static" rather than "./public".
 
-Note that this is where the websocket server, if you enable it, will place the `ActionheroWebsocketClient` libraray.<br>
+Note that this is where the websocket server, if you enable it, will place the `ActionheroWebsocketClient` library.<br>
 
 4.  Configure a wild-card route at the lowest priority of your GET handler to catch all web requests that aren't caught by other actions:
 


### PR DESCRIPTION
Fixed a minor spelling error. I corrected "libraray" with "library".