### PR TITLE
Fix with-aphrodite typo in README

### DIFF
--- a/examples/with-aphrodite/README.md
+++ b/examples/with-aphrodite/README.md
@@ -1,6 +1,6 @@
 # Example app with aphrodite
 
-This example features how yo use a different styling solution than [styled-jsx](https://github.com/zeit/styled-jsx) that also supports universal styles. That means we can serve the required styles for the first render within the HTML and then load the rest in the client. In this case we are using [Aphrodite](https://github.com/Khan/aphrodite/).
+This example features how to use a different styling solution than [styled-jsx](https://github.com/zeit/styled-jsx) that also supports universal styles. That means we can serve the required styles for the first render within the HTML and then load the rest in the client. In this case we are using [Aphrodite](https://github.com/Khan/aphrodite/).
 
 For this purpose we are extending the `<Document />` and injecting the server side rendered styles into the `<head>`.
 


### PR DESCRIPTION
Changing `This example features how yo use` to `This example features how to use`.