### PR TITLE
Typo: res.end should be res.send

### DIFF
--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -25,7 +25,7 @@ For example, the following API route `pages/api/user.js` handles a simple `json`
 export default (req, res) => {
   res.statusCode = 200
   res.setHeader('Content-Type', 'application/json')
-  res.end(JSON.stringify({ name: 'John Doe' }))
+  res.send(JSON.stringify({ name: 'John Doe' }))
 }
 ```
 


### PR DESCRIPTION
I noticed this while reading the documentation.

Response helpers mention `res.send` so I think this is a typo.
https://nextjs.org/docs/api-routes/response-helpers