### PR TITLE
Mention <title> and styled-jsx caveats in Document's docs

### DIFF
--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -53,7 +53,7 @@ The `ctx` object is equivalent to the one received in [`getInitialProps`](/docs/
 - React components outside of `<Main />` will not be initialized by the browser. Do _not_ add application logic here. If you need shared components in all your pages (like a menu or a toolbar), take a look at the [`App`](/docs/advanced-features/custom-app.md) component instead
 - `Document`'s `getInitialProps` function is not called during client-side transitions, nor when a page is [statically optimized](/docs/advanced-features/automatic-static-optimization.md)
 - Make sure to check if `ctx.req` / `ctx.res` are defined in `getInitialProps`. Those variables will be `undefined` when a page is being statically exported by [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) or by [`next export`](/docs/advanced-features/static-html-export.md)
-- Common errors include adding a `<title>` in the `<Head />` tag or using `styled-jsx`. These should be avoided as they lead to unexpected behavior
+- Common errors include adding a `<title>` in the `<Head />` tag or using `styled-jsx`. These should be avoided in `pages/_document.js` as they lead to unexpected behavior
 
 ## Customizing `renderPage`
 

--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -53,6 +53,7 @@ The `ctx` object is equivalent to the one received in [`getInitialProps`](/docs/
 - React components outside of `<Main />` will not be initialized by the browser. Do _not_ add application logic here. If you need shared components in all your pages (like a menu or a toolbar), take a look at the [`App`](/docs/advanced-features/custom-app.md) component instead
 - `Document`'s `getInitialProps` function is not called during client-side transitions, nor when a page is [statically optimized](/docs/advanced-features/automatic-static-optimization.md)
 - Make sure to check if `ctx.req` / `ctx.res` are defined in `getInitialProps`. Those variables will be `undefined` when a page is being statically exported by [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) or by [`next export`](/docs/advanced-features/static-html-export.md)
+- Common errors include adding a `<title>` in the `<Head />` tag or using `styled-jsx`. These should be avoided as they lead to unexpected behavior
 
 ## Customizing `renderPage`
 


### PR DESCRIPTION
- [`styled-jsx` should not be used in `_document`](https://github.com/zeit/next.js/issues/8522)
- [`<title>` tag should not be set in the `<Head />` of `_document`](https://github.com/zeit/next.js/issues/4596)

I think these should be mentioned in the docs.
