### PR TITLE
Drop url dependency

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -93,7 +93,6 @@
     "sass-loader": "8.0.2",
     "style-loader": "1.0.0",
     "styled-jsx": "3.2.5",
-    "url": "0.11.0",
     "use-subscription": "1.1.1",
     "watchpack": "2.0.0-beta.13",
     "webpack": "4.42.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16652,7 +16652,7 @@ url-to-options@^1.0.1:
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
   integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
 
-url@0.11.0, url@^0.11.0:
+url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=


### PR DESCRIPTION
This removes the unused `url` dependency from next, which seems like it is mostly replaced with `native-url` at this point.