### PR TITLE
Update to make sure AMP only bundles are always removed in production

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -547,6 +547,25 @@ export default async function build(dir: string, conf = null): Promise<void> {
             hybridAmpPages.add(page)
           }
 
+          if (result.isAmpOnly) {
+            // ensure all AMP only bundles got removed
+            try {
+              await fsUnlink(
+                path.join(
+                  distDir,
+                  'static',
+                  buildId,
+                  'pages',
+                  actualPage + '.js'
+                )
+              )
+            } catch (err) {
+              if (err.code !== 'ENOENT') {
+                throw err
+              }
+            }
+          }
+
           if (result.hasStaticProps) {
             ssgPages.add(page)
             isSsg = true

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -665,6 +665,7 @@ export async function isPageStatic(
   runtimeEnvConfig: any
 ): Promise<{
   isStatic?: boolean
+  isAmpOnly?: boolean
   isHybridAmp?: boolean
   hasServerProps?: boolean
   hasStaticProps?: boolean
@@ -756,6 +757,7 @@ export async function isPageStatic(
     return {
       isStatic: !hasStaticProps && !hasGetInitialProps && !hasServerProps,
       isHybridAmp: config.amp === 'hybrid',
+      isAmpOnly: config.amp === true,
       prerenderRoutes,
       prerenderFallback,
       hasStaticProps,

--- a/test/integration/amphtml/pages/another-amp.js
+++ b/test/integration/amphtml/pages/another-amp.js
@@ -1,0 +1,8 @@
+import { useAmp } from 'next/amp'
+
+const config = {
+  amp: true,
+}
+
+export default () => (useAmp() ? 'AMP mode' : 'Normal mode')
+export { config }

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -66,7 +66,7 @@ describe('AMP Usage', () => {
 
     it('should not output client pages for AMP only', async () => {
       const buildId = readFileSync(join(appDir, '.next/BUILD_ID'), 'utf8')
-      const ampOnly = ['only-amp', 'root-hmr']
+      const ampOnly = ['only-amp', 'root-hmr', 'another-amp']
       for (const pg of ampOnly) {
         expect(() =>
           accessSync(join(appDir, '.next/static', buildId, 'pages', pg + '.js'))


### PR DESCRIPTION
In development we require the page's bundle in the [hot-reloader](https://github.com/zeit/next.js/blob/b307ed91868bd1d033b5a36571fcd8aa95a32b8e/packages/next/server/hot-reloader.ts#L208) to check the page config and ensure we 404 properly for AMP only client bundles. This makes sure we also use the page config from requiring the bundle during a production build to also make sure we remove any AMP only client bundles.

This fixes development and production mismatching behavior although was uncovered from the `next-page-config` babel transform not detecting the below export syntax. Since the transform there is mainly an optimization at this point and no longer required for detecting it can be updated in a follow-up PR after deciding which syntaxes should be supported for static analysis other than the normal `export const config = {...}`.

```js
const config = {...}
export { config }
```

Closes: https://github.com/zeit/next.js/issues/11521