### PR TITLE
Update hello-world example React version & name for CodeSandbox

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world",
+  "name": "nextjs-hello-world",
   "version": "1.0.0",
   "scripts": {
     "dev": "next",
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
The "official" Next.js example on CodeSandbox pulls from the `hello-world` example. React was outdated by a few minor versions and the name was rather ambiguous when looking at it on CodeSandbox (aside from the logo). 

![Screen Shot 2020-03-31 at 2 05 00 PM](https://user-images.githubusercontent.com/2854919/78139898-3023f280-73f7-11ea-883f-c35e871db4dd.png)
