### PR TITLE
Any elements must be direct children of next/head

### DIFF
--- a/docs/api-reference/next/head.md
+++ b/docs/api-reference/next/head.md
@@ -67,4 +67,5 @@ In this case only the second `<meta name="viewport" />` is rendered.
 
 > The contents of `head` get cleared upon unmounting the component, so make sure each page completely defines what it needs in `head`, without making assumptions about what other pages added.
 
-> `title` and `meta` elements need to be contained as **direct** children of the `Head` element, or wrapped into maximum one level of `<React.Fragment>`, otherwise the meta tags won't be correctly picked up on client-side navigations.
+`title`, `meta` or any other elements (e.g.`script`) need to be contained as **direct** children of the `Head` element,
+or wrapped into maximum one level of `<React.Fragment>`, otherwise the tags won't be correctly picked up on client-side navigations.


### PR DESCRIPTION
I think it would be nice to mention that absolutely any children elements of `next/head` must be direct descendants, not just `meta` or `title`. This information may prevent the [issue #8921](https://github.com/zeit/next.js/issues/8921).

It is any elements and not only `meta` or `title` because the children of `next/head` are generated [here]( https://github.com/zeit/next.js/blob/8c899ee5e4cadc0a1cb47918613c1f6028b26314/packages/next/next-server/lib/head.tsx#L139)
where `React.cloneElement` is called without the third parameter which is needed to clone the children (https://reactjs.org/docs/react-api.html#cloneelement). The elements are generated this way [client-side](https://github.com/zeit/next.js/blob/8c899ee5e4cadc0a1cb47918613c1f6028b26314/packages/next/next-server/lib/side-effect.tsx#L46), so server-side the issue will not be experienced.