### PR TITLE
Update to make sure to respond with 400 for invalid URLs

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -151,6 +151,7 @@ const nextServerlessLoader: loader.Loader = function() {
       ${rewriteImports}
 
       ${dynamicRouteMatcher}
+
       ${handleRewrites}
 
       export default async (req, res) => {
@@ -186,7 +187,12 @@ const nextServerlessLoader: loader.Loader = function() {
         } catch (err) {
           console.error(err)
           await onError(err)
-          res.statusCode = 500
+
+          if (err.code === 'DECODE_FAILED') {
+            res.statusCode = 400
+          } else {
+            res.statusCode = 500
+          }
           res.end('Internal Server Error')
         }
       }
@@ -261,26 +267,37 @@ const nextServerlessLoader: loader.Loader = function() {
         ..._renderOpts
       }
       let _nextData = false
+      let parsedUrl
 
-      const parsedUrl = handleRewrites(parse(req.url, true))
-
-      if (parsedUrl.pathname.match(/_next\\/data/)) {
-        _nextData = true
-        parsedUrl.pathname = parsedUrl.pathname
-          .replace(new RegExp('/_next/data/${escapedBuildId}/'), '/')
-          .replace(/\\.json$/, '')
-      }
-
-      const renderOpts = Object.assign(
-        {
-          Component,
-          pageConfig: config,
-          nextExport: fromExport
-        },
-        options,
-      )
       try {
-        ${page === '/_error' ? `res.statusCode = 404` : ''}
+        parsedUrl = handleRewrites(parse(req.url, true))
+
+        if (parsedUrl.pathname.match(/_next\\/data/)) {
+          _nextData = true
+          parsedUrl.pathname = parsedUrl.pathname
+            .replace(new RegExp('/_next/data/${escapedBuildId}/'), '/')
+            .replace(/\\.json$/, '')
+        }
+
+        const renderOpts = Object.assign(
+          {
+            Component,
+            pageConfig: config,
+            nextExport: fromExport
+          },
+          options,
+        )
+
+        ${
+          page === '/_error'
+            ? `
+          if (!res.statusCode) {
+            res.statusCode = 404
+          }
+        `
+            : ''
+        }
+
         ${
           pageIsDynamicRoute
             ? `const params = fromExport && !getStaticProps && !getServerSideProps ? {} : dynamicRouteMatcher(parsedUrl.pathname) || {};`
@@ -349,27 +366,27 @@ const nextServerlessLoader: loader.Loader = function() {
         if (renderMode) return { html: result, renderOpts }
         return result
       } catch (err) {
+        if (!parsedUrl) {
+          parsedUrl = parse(req.url, true)
+        }
+
         if (err.code === 'ENOENT') {
           res.statusCode = 404
-          const result = await renderToHTML(req, res, "/_error", parsedUrl.query, Object.assign({}, options, {
-            getStaticProps: undefined,
-            getStaticPaths: undefined,
-            getServerSideProps: undefined,
-            Component: Error
-          }))
-          return result
+        } else if (err.code === 'DECODE_FAILED') {
+          res.statusCode = 400
         } else {
           console.error(err)
           res.statusCode = 500
-          const result = await renderToHTML(req, res, "/_error", parsedUrl.query, Object.assign({}, options, {
-            getStaticProps: undefined,
-            getStaticPaths: undefined,
-            getServerSideProps: undefined,
-            Component: Error,
-            err
-          }))
-          return result
         }
+
+        const result = await renderToHTML(req, res, "/_error", parsedUrl.query, Object.assign({}, options, {
+          getStaticProps: undefined,
+          getStaticPaths: undefined,
+          getServerSideProps: undefined,
+          Component: Error,
+          err: res.statusCode === 404 ? undefined : err
+        }))
+        return result
       }
     }
     export async function render (req, res) {

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -190,10 +190,11 @@ const nextServerlessLoader: loader.Loader = function() {
 
           if (err.code === 'DECODE_FAILED') {
             res.statusCode = 400
+            res.end('Bad Request')
           } else {
             res.statusCode = 500
+            res.end('Internal Server Error')
           }
-          res.end('Internal Server Error')
         }
       }
     `

--- a/packages/next/next-server/lib/router/utils/route-matcher.ts
+++ b/packages/next/next-server/lib/router/utils/route-matcher.ts
@@ -8,7 +8,17 @@ export function getRouteMatcher(routeRegex: ReturnType<typeof getRouteRegex>) {
       return false
     }
 
-    const decode = decodeURIComponent
+    const decode = (param: string) => {
+      try {
+        return decodeURIComponent(param)
+      } catch (_) {
+        const err: Error & { code?: string } = new Error(
+          'failed to decode param'
+        )
+        err.code = 'DECODE_FAILED'
+        throw err
+      }
+    }
     const params: { [paramName: string]: string | string[] } = {}
 
     Object.keys(groups).forEach((slugName: string) => {

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -471,6 +471,11 @@ function runTests(dev) {
     expect(res.status).toBe(200)
   })
 
+  it('should respond with bad request with invalid encoding', async () => {
+    const res = await fetchViaHTTP(appPort, '/%')
+    expect(res.status).toBe(400)
+  })
+
   if (dev) {
     it('should work with HMR correctly', async () => {
       const browser = await webdriver(appPort, '/post-1/comments')


### PR DESCRIPTION
When an improperly encoded URL is visited such as http://localhost:3000/% it causes an error to be thrown from failing to decode the URL params. 

As discussed when we receive an invalid URL like this we should respond with either 400 or 404. This updates to make sure we respond with 400 consistently when we fail to decode. It also adds a test case to our dynamic-routing suite to compliment the [existing invalid encoding test](https://github.com/zeit/next.js/blob/5db180b221cb36dbbb560b54811bd9047829339a/test/integration/production/test/index.test.js#L630-L634) in our production suite  

x-ref: https://github.com/zeit/next.js/pull/11533