### PR TITLE
[docs] Remove broken link to example api-routes-micro

### DIFF
--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -8,7 +8,6 @@ description: Next.js supports API Routes, which allow you to build your API with
   <summary><b>Examples</b></summary>
   <ul>
     <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes">Basic API Routes</a></li>
-    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-micro">API Routes with Micro</a></li>
     <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-middleware">API Routes with middleware</a></li>
     <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-graphql">API Routes with GraphQL</a></li>
     <li><a href="https://github.com/zeit/next.js/tree/canary/examples/api-routes-rest">API Routes with REST</a></li>


### PR DESCRIPTION
Looks like the example `api-routes-micro` doesn't exist anymore, so removing the link. Or should this example be added? I can give it a try if that's the case :) 