### PR TITLE
Update minimum required node version to be more specific in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ If you have questions about anything related to Next.js, you're always welcome t
 
 #### System Requirements
 
-- [Node.js 10](https://nodejs.org/) or later
+- [Node.js 10.13](https://nodejs.org/) or later
 - MacOS, Windows (including WSL), and Linux are supported
 
 ## Setup


### PR DESCRIPTION
This makes sure to specify the exact minimum Node.js version to prevent conflicts

x-ref: https://github.com/zeit/next.js/issues/11601