### PR TITLE
[fix:typo] - Fixing a typo in the typescript example

### DIFF
--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -49,7 +49,7 @@ This example shows how to integrate the TypeScript type system into Next.js. Sin
 npm install --save-dev typescript
 ```
 
-To enable TypeScript's features, we install the type declaratons for React and Node.
+To enable TypeScript's features, we install the type declarations for React and Node.
 
 ```
 npm install --save-dev @types/react @types/react-dom @types/node


### PR DESCRIPTION
The word declarations was misspelled.