### PR TITLE
Update to not modify req.url for getServerSideProps requests

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -429,7 +429,6 @@ export default class Server {
             .replace(/\.json$/, '')
             .replace(/\/index$/, '/')
 
-          req.url = pathname
           const parsedUrl = parseUrl(pathname, true)
           await this.render(
             req,
@@ -786,9 +785,14 @@ export default class Server {
   ): Promise<void> {
     const url: any = req.url
 
+    // we allow custom servers to call render for all URLs
+    // so check if we need to serve a static _next file or not.
+    // we don't modify the URL for _next/data request but still
+    // call render so we special case this to prevent an infinite loop
     if (
-      url.match(/^\/_next\//) ||
-      (this.hasStaticDir && url.match(/^\/static\//))
+      !query._nextDataReq &&
+      (url.match(/^\/_next\//) ||
+        (this.hasStaticDir && url.match(/^\/static\//)))
     ) {
       return this.handleRequest(req, res, parsedUrl)
     }
@@ -918,17 +922,6 @@ export default class Server {
     const isDataReq = !!query._nextDataReq
     delete query._nextDataReq
 
-    // Serverless requests need its URL transformed back into the original
-    // request path (to emulate lambda behavior in production)
-    if (isLikeServerless && isDataReq) {
-      let { pathname } = parseUrl(req.url || '', true)
-      pathname = !pathname || pathname === '/' ? '/index' : pathname
-      req.url = formatUrl({
-        pathname: `/_next/data/${this.buildId}${pathname}.json`,
-        query,
-      })
-    }
-
     let previewData: string | false | object | undefined
     let isPreviewMode = false
 
@@ -1001,10 +994,19 @@ export default class Server {
       return html
     }
 
-    // Compute the SPR cache key
-    const urlPathname = `${parseUrl(req.url || '').pathname!}${
+    // Compute the iSSG cache key
+    let urlPathname = `${parseUrl(req.url || '').pathname!}${
       query.amp ? '.amp' : ''
     }`
+
+    // remove /_next/data prefix from urlPathname so it matches
+    // for direct page visit and /_next/data visit
+    if (isDataReq && urlPathname.includes(this.buildId)) {
+      urlPathname = (urlPathname.split(this.buildId).pop() || '/')
+        .replace(/\.json$/, '')
+        .replace(/\/index$/, '/')
+    }
+
     const ssgCacheKey = isPreviewMode
       ? `__` + nanoid() // Preview mode uses a throw away key to not coalesce preview invokes
       : urlPathname

--- a/test/integration/getserversideprops/pages/_app.js
+++ b/test/integration/getserversideprops/pages/_app.js
@@ -1,0 +1,29 @@
+import App from 'next/app'
+
+class MyApp extends App {
+  static async getInitialProps(ctx) {
+    const { req, query, pathname, asPath } = ctx.ctx
+    let pageProps = {}
+
+    if (ctx.Component.getInitialProps) {
+      pageProps = await ctx.Component.getInitialProps(ctx.ctx)
+    }
+
+    return {
+      appProps: {
+        url: (req || {}).url,
+        query,
+        pathname,
+        asPath,
+      },
+      pageProps,
+    }
+  }
+
+  render() {
+    const { Component, pageProps, appProps } = this.props
+    return <Component {...pageProps} appProps={appProps} />
+  }
+}
+
+export default MyApp

--- a/test/integration/getserversideprops/pages/blog/[post]/index.js
+++ b/test/integration/getserversideprops/pages/blog/[post]/index.js
@@ -22,13 +22,15 @@ export async function getServerSideProps({ params }) {
   }
 }
 
-export default ({ post, time, params }) => {
+export default ({ post, time, params, appProps }) => {
   return (
     <>
       <p>Post: {post}</p>
       <span>time: {time}</span>
       <div id="params">{JSON.stringify(params)}</div>
       <div id="query">{JSON.stringify(useRouter().query)}</div>
+      <div id="app-query">{JSON.stringify(appProps.query)}</div>
+      <div id="app-url">{appProps.url}</div>
       <Link href="/">
         <a id="home">to home</a>
       </Link>

--- a/test/integration/getserversideprops/pages/something.js
+++ b/test/integration/getserversideprops/pages/something.js
@@ -14,7 +14,7 @@ export async function getServerSideProps({ params, query }) {
   }
 }
 
-export default ({ world, time, params, random, query }) => {
+export default ({ world, time, params, random, query, appProps }) => {
   return (
     <>
       <p>hello: {world}</p>
@@ -23,6 +23,8 @@ export default ({ world, time, params, random, query }) => {
       <div id="params">{JSON.stringify(params)}</div>
       <div id="initial-query">{JSON.stringify(query)}</div>
       <div id="query">{JSON.stringify(useRouter().query)}</div>
+      <div id="app-query">{JSON.stringify(appProps.query)}</div>
+      <div id="app-url">{appProps.url}</div>
       <Link href="/">
         <a id="home">to home</a>
       </Link>

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -260,6 +260,46 @@ const runTests = (dev = false) => {
     expect(data.pageProps.params).toEqual({ path: ['first'] })
   })
 
+  it('should have original req.url for /_next/data request dynamic page', async () => {
+    const curUrl = `/_next/data/${buildId}/blog/post-1.json`
+    const data = await renderViaHTTP(appPort, curUrl)
+    const { appProps } = JSON.parse(data)
+
+    expect(appProps).toEqual({
+      url: curUrl,
+      query: { post: 'post-1' },
+      asPath: curUrl,
+      pathname: '/blog/[post]',
+    })
+  })
+
+  it('should have original req.url for /_next/data request', async () => {
+    const curUrl = `/_next/data/${buildId}/something.json`
+    const data = await renderViaHTTP(appPort, curUrl)
+    const { appProps } = JSON.parse(data)
+
+    expect(appProps).toEqual({
+      url: curUrl,
+      query: {},
+      asPath: curUrl,
+      pathname: '/something',
+    })
+  })
+
+  it('should have correct req.url and query for direct visit dynamic page', async () => {
+    const html = await renderViaHTTP(appPort, '/blog/post-1')
+    const $ = cheerio.load(html)
+    expect($('#app-url').text()).toContain('/blog/post-1')
+    expect(JSON.parse($('#app-query').text())).toEqual({ post: 'post-1' })
+  })
+
+  it('should have correct req.url and query for direct visit', async () => {
+    const html = await renderViaHTTP(appPort, '/something')
+    const $ = cheerio.load(html)
+    expect($('#app-url').text()).toContain('/something')
+    expect(JSON.parse($('#app-query').text())).toEqual({})
+  })
+
   it('should return data correctly', async () => {
     const data = JSON.parse(
       await renderViaHTTP(appPort, `/_next/data/${buildId}/something.json`)


### PR DESCRIPTION
This fixes an inconsistency where we would modify `req.url` during internal routing for `/_next/data` routes but the `req.url` wouldn't be modified when deploying in `serverless` mode. To fix the inconsistency this makes sure we don't modify the `req.url` with `next start` to match us not modifying it after being deployed.

There is a potential inconsistency with `getStaticProps` and `req.url` still as we keep the HTML and JSON in sync so depending on which endpoint is visited first on a revalidate would dictate which version is used. Should this be normalized for `getStaticProps` or is it better to not modify `req.url` in this case either? 🤔 

This also adds tests to ensure the `query` is correctly passed to `_app.getInitialProps` for dynamic pages and `getServerSideProps` along with ensuring the correct `req.url` is present.
