### PR TITLE
A little bit of maintenance on the ReasonML examples

### DIFF
--- a/examples/with-reasonml-todo/.babelrc
+++ b/examples/with-reasonml-todo/.babelrc
@@ -2,7 +2,4 @@
   "presets": [
     "next/babel"
   ],
-  "plugins": [
-    "babel-plugin-bucklescript"
-  ]
 }

--- a/examples/with-reasonml-todo/package.json
+++ b/examples/with-reasonml-todo/package.json
@@ -10,7 +10,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "babel-plugin-bucklescript": "^0.5.3",
     "next": "latest",
     "next-transpile-modules": "^3.0.2",
     "react": "^16.8.6",
@@ -19,7 +18,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
-    "babel-types": "6.26.0",
     "bs-platform": "7.2.2",
     "concurrently": "^4.1.0"
   }

--- a/examples/with-reasonml-todo/package.json
+++ b/examples/with-reasonml-todo/package.json
@@ -19,7 +19,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
-    "bs-platform": "5.0.3",
+    "babel-types": "6.26.0",
+    "bs-platform": "7.2.2",
     "concurrently": "^4.1.0"
   }
 }

--- a/examples/with-reasonml/.babelrc
+++ b/examples/with-reasonml/.babelrc
@@ -1,8 +1,5 @@
 {
   "presets": [
     "next/babel"
-  ],
-  "plugins": [
-    "babel-plugin-bucklescript"
   ]
 }

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -10,7 +10,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "babel-plugin-bucklescript": "^0.5.3",
     "next": "latest",
     "next-transpile-modules": "^3.0.2",
     "react": "^16.12.0",
@@ -19,7 +18,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
-    "babel-types": "6.26.0",
     "bs-platform": "^7.1.0",
     "concurrently": "^5.1.0"
   }

--- a/examples/with-reasonml/package.json
+++ b/examples/with-reasonml/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
+    "babel-types": "6.26.0",
     "bs-platform": "^7.1.0",
     "concurrently": "^5.1.0"
   }


### PR DESCRIPTION
- [x] update the todo example to the latest bs-platform
- [x] add the babel-types package to both examples to fix the next compiler complaint.
- [x] remove extraneous babel-plugin-bucklescript dependency.