### PR TITLE
Fix documentation link in Basic API routes example

### DIFF
--- a/examples/api-routes/README.md
+++ b/examples/api-routes/README.md
@@ -1,6 +1,6 @@
 # Basic API routes example
 
-Next.js ships with [API routes](https://github.com/zeit/next.js#api-routes) which provides an easy solution to build your own `API`. This example shows how to create multiple `API` endpoints with serverless functions, which can execute independently.
+Next.js ships with [API routes](https://nextjs.org/docs/api-routes/introduction) which provides an easy solution to build your own `API`. This example shows how to create multiple `API` endpoints with serverless functions, which can execute independently.
 
 ## Deploy your own
 


### PR DESCRIPTION
Link to description of API Routes in the main README of the repo is broken. Replaced with a link to the documentation.