### PR TITLE
Demo Sass capabilities in `with-next-sass` example

### DIFF
--- a/examples/with-next-sass/components/hello-world.module.scss
+++ b/examples/with-next-sass/components/hello-world.module.scss
@@ -1,5 +1,8 @@
+@use '@material/typography';
+
 $color: red;
 
 .hello {
   color: $color;
+  @include typography.typography('headline4');
 }

--- a/examples/with-next-sass/next.config.js
+++ b/examples/with-next-sass/next.config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+module.exports = {
+  experimental: {
+    sassOptions: {
+      includePaths: [
+        path.resolve(__dirname, 'node_modules'),
+      ],
+    },
+  },
+};

--- a/examples/with-next-sass/package.json
+++ b/examples/with-next-sass/package.json
@@ -5,6 +5,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@material/typography": "^5.1.0",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/examples/with-next-sass/pages/index.js
+++ b/examples/with-next-sass/pages/index.js
@@ -2,6 +2,9 @@ import HelloWorld from '../components/hello-world'
 
 export default () => (
   <div className="app">
+    <div className="mdc-typography mdc-typography--headline1">
+      This is a headline1.
+    </div>
     <HelloWorld />
   </div>
 )

--- a/examples/with-next-sass/styles.scss
+++ b/examples/with-next-sass/styles.scss
@@ -1,3 +1,5 @@
+@use '@material/typography/mdc-typography';
+
 $backgroundColor: #2ecc71;
 
 .app {


### PR DESCRIPTION
This addresses #11610 by demoing the [recently implemented fix](https://github.com/zeit/next.js/pull/11063) in the official [`with-next-sass` example](https://github.com/zeit/next.js/tree/canary/examples/with-next-sass).

I've used Google's [MDC](https://material.io/develop/web) [`@material/typography`](https://www.npmjs.com/package/@material/typography) package to demonstrate some common Sass functionality:
- `@use` and `@include` statements for scoped SCSS modules
- `@use` for including global Sass styling

I'd also **strongly suggest** updating your website's [Sass documentation](https://www.npmjs.com/package/@material/typography) with a link to this example. And make it clear what the best way to use Sass is (i.e. using `@zeit/next-sass` or the out-of-box stuff) as described in [this issue](https://github.com/zeit/next-plugins/issues/625).