### PR TITLE
Allow top-level GitHub repo URLs as examples

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -54,7 +54,7 @@ export async function createApp({
         process.exit(1)
       }
 
-      repoInfo = getRepoInfo(repoUrl, examplePath)
+      repoInfo = await getRepoInfo(repoUrl, examplePath)
 
       if (!repoInfo) {
         console.error(
@@ -166,7 +166,7 @@ export async function createApp({
     await cpy('**', root, {
       parents: true,
       cwd: path.join(__dirname, 'templates', 'default'),
-      rename: name => {
+      rename: (name) => {
         switch (name) {
           case 'gitignore': {
             return '.'.concat(name)

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -166,7 +166,7 @@ export async function createApp({
     await cpy('**', root, {
       parents: true,
       cwd: path.join(__dirname, 'templates', 'default'),
-      rename: (name) => {
+      rename: name => {
         switch (name) {
           case 'gitignore': {
             return '.'.concat(name)

--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -10,7 +10,7 @@ export type RepoInfo = {
 }
 
 export async function isUrlOk(url: string) {
-  const res = await got(url).catch((e) => e)
+  const res = await got(url).catch(e => e)
   return res.statusCode === 200
 }
 
@@ -26,7 +26,7 @@ export async function getRepoInfo(
   if (t === undefined) {
     const infoResponse = await got(
       `https://api.github.com/repos/${username}/${name}`
-    ).catch((e) => e)
+    ).catch(e => e)
     if (infoResponse.statusCode !== 200) {
       return
     }

--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -10,16 +10,30 @@ export type RepoInfo = {
 }
 
 export async function isUrlOk(url: string) {
-  const res = await got(url).catch(e => e)
+  const res = await got(url).catch((e) => e)
   return res.statusCode === 200
 }
 
-export function getRepoInfo(
+export async function getRepoInfo(
   url: URL,
   examplePath?: string
-): RepoInfo | undefined {
+): Promise<RepoInfo | undefined> {
   const [, username, name, t, _branch, ...file] = url.pathname.split('/')
   const filePath = examplePath ? examplePath.replace(/^\//, '') : file.join('/')
+
+  // Support repos whose entire purpose is to be a NextJS example, e.g.
+  // https://github.com/:username/:my-cool-nextjs-example-repo-name.
+  if (t === undefined) {
+    const infoResponse = await got(
+      `https://api.github.com/repos/${username}/${name}`
+    ).catch((e) => e)
+    if (infoResponse.statusCode !== 200) {
+      return
+    }
+    const info = JSON.parse(infoResponse.body)
+    return { username, name, branch: info['default_branch'], filePath }
+  }
+
   // If examplePath is available, the branch name takes the entire path
   const branch = examplePath
     ? `${_branch}/${file.join('/')}`.replace(new RegExp(`/${filePath}|/$`), '')


### PR DESCRIPTION
Adds support for top-level GitHub repo URLs to create-next-app, e.g. https://github.com/username/my-cool-next-example.

This is already possible, but you have to enter "/tree/master" (or the desired branch name) after the repo URL.

The change itself just expands that URL to https://github.com/username/cool-next-example/tree/$DEFAULT_BRANCH_NAME where DEFAULT_BRANCH_NAME is the default branch configured for the repo in GitHub.
