### PR TITLE
Update sentry example

### DIFF
--- a/examples/with-sentry-simple/next.config.js
+++ b/examples/with-sentry-simple/next.config.js
@@ -1,4 +1,10 @@
+// Use the hidden-source-map option when you don't want the source maps to be
+// publicly available on the servers, only to the error reporting
 const withSourceMaps = require('@zeit/next-source-maps')()
+
+// Use the SentryWebpack plugin to upload the source maps during build step
+const SentryWebpackPlugin = require('@sentry/webpack-plugin')
+const { SENTRY_DNS, SENTRY_ORG, SENTRY_PROJECT } = process.env
 
 module.exports = withSourceMaps({
   webpack: (config, options) => {
@@ -18,6 +24,20 @@ module.exports = withSourceMaps({
     // building the browser's bundle
     if (!options.isServer) {
       config.resolve.alias['@sentry/node'] = '@sentry/browser'
+    }
+
+    // When all the Sentry configuration env variables are available/configured
+    // The Sentry webpack plugin gets pushed to the webpack plugins to build
+    // and upload the source maps to sentry.
+    // This is an alternative to manually uploading the source maps
+    if (SENTRY_DNS && SENTRY_ORG && SENTRY_PROJECT) {
+      config.plugins.push(
+        new SentryWebpackPlugin({
+          include: '.next',
+          ignore: ['node_modules'],
+          urlPrefix: '~/_next',
+        })
+      )
     }
 
     return config

--- a/examples/with-sentry-simple/next.config.js
+++ b/examples/with-sentry-simple/next.config.js
@@ -4,7 +4,7 @@ const withSourceMaps = require('@zeit/next-source-maps')()
 
 // Use the SentryWebpack plugin to upload the source maps during build step
 const SentryWebpackPlugin = require('@sentry/webpack-plugin')
-const { SENTRY_DNS, SENTRY_ORG, SENTRY_PROJECT } = process.env
+const { SENTRY_DSN, SENTRY_ORG, SENTRY_PROJECT } = process.env
 
 module.exports = withSourceMaps({
   webpack: (config, options) => {
@@ -30,7 +30,7 @@ module.exports = withSourceMaps({
     // The Sentry webpack plugin gets pushed to the webpack plugins to build
     // and upload the source maps to sentry.
     // This is an alternative to manually uploading the source maps
-    if (SENTRY_DNS && SENTRY_ORG && SENTRY_PROJECT) {
+    if (SENTRY_DSN && SENTRY_ORG && SENTRY_PROJECT) {
       config.plugins.push(
         new SentryWebpackPlugin({
           include: '.next',

--- a/examples/with-sentry-simple/package.json
+++ b/examples/with-sentry-simple/package.json
@@ -10,11 +10,10 @@
   "dependencies": {
     "@sentry/browser": "^5.1.0",
     "@sentry/node": "^5.6.2",
+    "@sentry/webpack-plugin": "^1.10.0",
+    "@zeit/next-source-maps": "0.0.4-canary.1",
     "next": "latest",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
-  },
-  "devDependencies": {
-    "@zeit/next-source-maps": "0.0.4-canary.1"
   }
 }

--- a/examples/with-sentry-simple/pages/_app.js
+++ b/examples/with-sentry-simple/pages/_app.js
@@ -3,8 +3,8 @@ import App from 'next/app'
 import * as Sentry from '@sentry/node'
 
 Sentry.init({
-  // Replace with your project's Sentry DSN
-  dsn: 'https://00000000000000000000000000000000@sentry.io/1111111',
+  enabled: process.env.NODE_ENV === 'production',
+  dsn: process.env.SENTRY_DSN,
 })
 
 class MyApp extends App {


### PR DESCRIPTION
Fix the `with-sentry-simple` example configuration code and upload the source maps during build time so that the reported errors show correctly instead of showing the uglify version of the code.

Fixes #8873 
Fixes #11642 
Fixes #11632