### PR TITLE
Remove outdated sentence from static-export example

### DIFF
--- a/examples/with-static-export/README.md
+++ b/examples/with-static-export/README.md
@@ -25,9 +25,6 @@ curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 
 cd with-static-export
 ```
 
-> This example requires [Node.js 8](https://nodejs.org/en/download/current/) or a later version.<br>
-> (That's for the use of "async await" in the `next.config.js`.)
-
 Install it and run:
 
 ```bash


### PR DESCRIPTION
I removed outdated sentences because Next.js now require Node10 or later and this example has no next.config.js.