### PR TITLE
Make sure to handle "next" import gracefully

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -473,10 +473,17 @@ export default async function getBaseWebpackConfig(
   )
   let webpackConfig: webpack.Configuration = {
     externals: !isServer
-      ? undefined
+      ? // make sure importing "next" is handled gracefully for client
+        // bundles in case a user imported types and it wasn't removed
+        // TODO: should we warn/error for this instead?
+        ['next']
       : !isServerless
       ? [
           (context, request, callback) => {
+            if (request === 'next') {
+              return callback(undefined, `commonjs ${request}`)
+            }
+
             const notExternalModules = [
               'next/app',
               'next/document',

--- a/test/integration/production/pages/index/index.js
+++ b/test/integration/production/pages/index/index.js
@@ -1,4 +1,8 @@
 import Link from 'next/link'
+// Leave below import, testing that importing "next"
+// doesn't stall the build
+// eslint-disable-next-line no-unused-vars
+import next from 'next'
 
 export default () => (
   <div>

--- a/test/integration/production/pages/next-import.js
+++ b/test/integration/production/pages/next-import.js
@@ -1,4 +1,8 @@
 import Link from 'next/link'
+// Leave below import, testing that importing "next"
+// doesn't stall the build
+// eslint-disable-next-line no-unused-vars
+import next from 'next'
 
 export default () => (
   <div>


### PR DESCRIPTION
Before this change if a user imported "next" as one of their page's dependencies the build would stall. After this change the build is able to complete and then our page checks can run during the build optimization phase.

Closes: https://github.com/zeit/next.js/issues/11716