### PR TITLE
[Examples] Use next-connect in the with-passport example

### DIFF
--- a/examples/with-passport/package.json
+++ b/examples/with-passport/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@hapi/iron": "6.0.0",
     "cookie": "0.4.0",
-    "express": "4.17.1",
     "next": "latest",
+    "next-connect": "0.6.1",
     "passport": "0.4.1",
     "passport-local": "1.0.0",
     "react": "latest",

--- a/examples/with-passport/pages/api/login.js
+++ b/examples/with-passport/pages/api/login.js
@@ -1,10 +1,9 @@
-import express from 'express'
 import passport from 'passport'
+import nextConnect from 'next-connect'
 import { localStrategy } from '../../lib/password-local'
 import { encryptSession } from '../../lib/iron'
 import { setTokenCookie } from '../../lib/auth-cookies'
 
-const app = express()
 const authenticate = (method, req, res) =>
   new Promise((resolve, reject) => {
     passport.authenticate(method, { session: false }, (error, token) => {
@@ -16,26 +15,22 @@ const authenticate = (method, req, res) =>
     })(req, res)
   })
 
-app.disable('x-powered-by')
-
-app.use(passport.initialize())
-
 passport.use(localStrategy)
 
-app.post('/api/login', async (req, res) => {
-  try {
-    const user = await authenticate('local', req, res)
-    // session is the payload to save in the token, it may contain basic info about the user
-    const session = { ...user }
-    // The token is a string with the encrypted session
-    const token = await encryptSession(session)
+export default nextConnect()
+  .use(passport.initialize())
+  .post(async (req, res) => {
+    try {
+      const user = await authenticate('local', req, res)
+      // session is the payload to save in the token, it may contain basic info about the user
+      const session = { ...user }
+      // The token is a string with the encrypted session
+      const token = await encryptSession(session)
 
-    setTokenCookie(res, token)
-    res.status(200).send({ done: true })
-  } catch (error) {
-    console.error(error)
-    res.status(401).send(error.message)
-  }
-})
-
-export default app
+      setTokenCookie(res, token)
+      res.status(200).send({ done: true })
+    } catch (error) {
+      console.error(error)
+      res.status(401).send(error.message)
+    }
+  })


### PR DESCRIPTION
Express.js doesn't have to be used for serverless functions, [next-connect](https://github.com/hoangvvo/next-connect) looks like a better, more lightweight alternative.

@hoangvvo Thank you for `next-connect` :100: 