### PR TITLE
Fix just headers not being applied in dev mode

### DIFF
--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -237,9 +237,9 @@ export default class DevServer extends Server {
     await this.loadCustomRoutes()
 
     if (this.customRoutes) {
-      const { redirects, rewrites } = this.customRoutes
+      const { redirects, rewrites, headers } = this.customRoutes
 
-      if (redirects.length || rewrites.length) {
+      if (redirects.length || rewrites.length || headers.length) {
         this.router = new Router(this.generateRoutes())
       }
     }


### PR DESCRIPTION
While responding to https://github.com/zeit/next.js/issues/11752 I noticed that headers aren't applied in dev mode when you only have headers and no rewrites or redirects. This fixes that and adds test cases to ensure each custom route mode works individually 