### PR TITLE
Minor with-docker readme grammar fix

### DIFF
--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -1,6 +1,6 @@
 # With Docker
 
-This example shows you how to set custom environment variables for your **docker application** at runtime.
+This example shows how to set custom environment variables for your **docker application** at runtime.
 
 The `dockerfile` is the simplest way to run Next.js app in docker, and the size of output image is `173MB`. However, for an even smaller build, you can do multi-stage builds with `dockerfile.multistage`. The size of output image is `85MB`.
 

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -1,6 +1,6 @@
 # With Docker
 
-This example show how to set custom environment variables for your **docker application** at runtime.
+This example shows you how to set custom environment variables for your **docker application** at runtime.
 
 The `dockerfile` is the simplest way to run Next.js app in docker, and the size of output image is `173MB`. However, for an even smaller build, you can do multi-stage builds with `dockerfile.multistage`. The size of output image is `85MB`.
 


### PR DESCRIPTION
Changing `This example show how to set` to `This example shows you how to set`.