### PR TITLE
Update start script in preact example

### DIFF
--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "next start"
   },
   "dependencies": {
     "next": "^9.2.3-canary.21",


### PR DESCRIPTION
As far as I understand using preact in Next.js no longer requires a custom server. The current start command `"start": "NODE_ENV=production node server.js"` references a file that no longer exists.