### PR TITLE
[Examples] Update styled-components to v5 in with-styled-components

### DIFF
--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
-    "styled-components": "^4.0.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "styled-components": "^5.0.0"
   },
   "devDependencies": {
     "babel-plugin-styled-components": "^1.8.0"


### PR DESCRIPTION
I updated styled-components to v5 in exmaples/with-styled-components.
This update has no breaking changes, but require react@16.8(hooks) so I update also react and react-dom.

https://medium.com/styled-components/announcing-styled-components-v5-beast-mode-389747abd987