### PR TITLE
Add Node.js version to Bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1.Bug_report.md
@@ -31,6 +31,7 @@ If applicable, add screenshots to help explain your problem.
 - OS: [e.g. macOS, Windows]
 - Browser (if applies) [e.g. chrome, safari]
 - Version of Next.js: [e.g. 6.0.2]
+- Version of Node.js: [e.g. 10.10.0]
 
 ## Additional context
 


### PR DESCRIPTION
This adds asking for the Node.js version to our Bug template to help investigate issues faster instead of having to ask for it each time when we think it's related to the Node.js version.

x-ref: https://github.com/zeit/next.js/issues/11748
x-ref: https://github.com/zeit/next.js/issues/11601