### PR TITLE
[Examples] Fix typo in with-draft-js

### DIFF
--- a/examples/with-draft-js/README.md
+++ b/examples/with-draft-js/README.md
@@ -1,6 +1,6 @@
 # DraftJS Medium editor inspiration
 
-Have you ever wanted to have an editor like medium.com in your Next.js app? DraftJS is avalaible for SSR, but some plugins like the toolbar are using `window`, which does not work when doing SSR.
+Have you ever wanted to have an editor like medium.com in your Next.js app? DraftJS is available for SSR, but some plugins like the toolbar are using `window`, which does not work when doing SSR.
 
 This example aims to provides a fully customizable example of the famous medium editor with DraftJS. The goal was to get it as customizable as possible, and fully working with Next.js without using the react-no-ssr package.
 


### PR DESCRIPTION
Fix typo:
avalaible -> available