### PR TITLE
Update auto export opt-out warning and err.sh

### DIFF
--- a/errors/opt-out-auto-static-optimization.md
+++ b/errors/opt-out-auto-static-optimization.md
@@ -4,7 +4,7 @@
 
 You are using `getInitialProps` in your [Custom `<App>`](https://nextjs.org/docs#custom-app).
 
-This causes **all pages** to be executed on the server -- disabling [Automatic Static Optimization](https://nextjs.org/docs#automatic-static-optimization).
+This causes **all non-getStaticProps pages** to be executed on the server -- disabling [Automatic Static Optimization](https://nextjs.org/docs#automatic-static-optimization).
 
 #### Possible Ways to Fix It
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -525,7 +525,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
           console.warn(
             chalk.bold.yellow(`Warning: `) +
               chalk.yellow(
-                `You have opted-out of Automatic Static Optimization due to \`getInitialProps\` in \`pages/_app\`.`
+                `You have opted-out of Automatic Static Optimization due to \`getInitialProps\` in \`pages/_app\`. This does not opt-out pages with \`getStaticProps\``
               )
           )
           console.warn(


### PR DESCRIPTION
This updates the warning and err.sh for `getInitialProps` in `_app` opting out of the automatic static optimization to mention that it does not opt-out SSG pages