### PR TITLE
[examples/with-react-intl] Fix issues with Intl.js polyfill 

### DIFF
--- a/examples/with-react-intl/package.json
+++ b/examples/with-react-intl/package.json
@@ -15,6 +15,7 @@
     "full-icu": "^1.3.0",
     "glob": "^7.1.4",
     "intl": "^1.2.5",
+    "intl-locales-supported": "1.8.4",
     "next": "latest",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/examples/with-react-intl/server.js
+++ b/examples/with-react-intl/server.js
@@ -4,6 +4,12 @@ const IntlPolyfill = require('intl')
 Intl.NumberFormat = IntlPolyfill.NumberFormat
 Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat
 
+// Fix: https://github.com/zeit/next.js/issues/11777
+// See related issue: https://github.com/andyearnshaw/Intl.js/issues/308
+if (IntlPolyfill.__disableRegExpRestore) {
+  IntlPolyfill.__disableRegExpRestore()
+}
+
 // Polyfill DOMParser for **pre-v4** react-intl used by formatjs.
 // Only needed when using FormattedHTMLMessage. Make sure to install `xmldom`.
 // See: https://github.com/zeit/next.js/issues/10533

--- a/examples/with-react-intl/server.js
+++ b/examples/with-react-intl/server.js
@@ -1,13 +1,33 @@
+const { basename } = require('path')
+const glob = require('glob')
+const areIntlLocalesSupported = require('intl-locales-supported').default
+
+// Get the supported languages by looking for translations in the `lang/` dir.
+const supportedLanguages = glob
+  .sync('./lang/*.json')
+  .map(f => basename(f, '.json'))
+
 // Polyfill Node with `Intl` that has data for all locales.
 // See: https://formatjs.io/guides/runtime-environments/#server
-const IntlPolyfill = require('intl')
-Intl.NumberFormat = IntlPolyfill.NumberFormat
-Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat
+if (global.Intl) {
+  // Determine if the built-in `Intl` has the locale data we need.
+  if (!areIntlLocalesSupported(supportedLanguages)) {
+    // `Intl` exists, but it doesn't have the data we need, so load the
+    // polyfill and patch the constructors we need with the polyfills.
+    const IntlPolyfill = require('intl')
+    Intl.NumberFormat = IntlPolyfill.NumberFormat
+    Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat
+    Intl.__disableRegExpRestore = IntlPolyfill.__disableRegExpRestore
+  }
+} else {
+  // No `Intl`, so use and load the polyfill.
+  global.Intl = require('intl')
+}
 
 // Fix: https://github.com/zeit/next.js/issues/11777
 // See related issue: https://github.com/andyearnshaw/Intl.js/issues/308
-if (IntlPolyfill.__disableRegExpRestore) {
-  IntlPolyfill.__disableRegExpRestore()
+if (Intl.__disableRegExpRestore) {
+  Intl.__disableRegExpRestore()
 }
 
 // Polyfill DOMParser for **pre-v4** react-intl used by formatjs.
@@ -17,21 +37,14 @@ if (IntlPolyfill.__disableRegExpRestore) {
 // global.DOMParser = DOMParser
 
 const { readFileSync } = require('fs')
-const { basename } = require('path')
 const { createServer } = require('http')
 const accepts = require('accepts')
-const glob = require('glob')
 const next = require('next')
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const handle = app.getRequestHandler()
-
-// Get the supported languages by looking for translations in the `lang/` dir.
-const supportedLanguages = glob
-  .sync('./lang/*.json')
-  .map(f => basename(f, '.json'))
 
 // We need to expose React Intl's locale data on the request for the user's
 // locale. This function will also cache the scripts by lang in memory.


### PR DESCRIPTION
This pull request addresses two issues with the `Intl`  polyfill that we use for the `react-intl` example:

1. It fails for versions > 1.2.4 with RegEx errors (#11777). This is solved by disabling the RegEx restore functionality.
2. It loads the polyfill unconditionally, even if the Node environment supports the requested languages. This is solved by selectively enabling the polyfill when either `Intl` is not available or it does not support the requested languages.