### PR TITLE
Make sure to pass through query values for custom routes

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -103,7 +103,8 @@ const nextServerlessLoader: loader.Loader = function() {
         if (params) {
           const { parsedDestination } = prepareDestination(
             rewrite.destination,
-            params
+            params,
+            parsedUrl.query
           )
           Object.assign(parsedUrl.query, parsedDestination.query, params)
           delete parsedDestination.query

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -496,10 +496,11 @@ export default class Server {
           match: route.match,
           statusCode: route.statusCode,
           name: `Redirect route`,
-          fn: async (_req, res, params, _parsedUrl) => {
+          fn: async (_req, res, params, parsedUrl) => {
             const { parsedDestination } = prepareDestination(
               route.destination,
               params,
+              parsedUrl.query,
               true
             )
             const updatedDestination = formatUrl(parsedDestination)
@@ -528,10 +529,11 @@ export default class Server {
           type: route.type,
           name: `Rewrite route`,
           match: route.match,
-          fn: async (req, res, params, _parsedUrl) => {
+          fn: async (req, res, params, parsedUrl) => {
             const { newUrl, parsedDestination } = prepareDestination(
               route.destination,
-              params
+              params,
+              parsedUrl.query
             )
 
             // external rewrite, proxy it


### PR DESCRIPTION
As noticed in https://github.com/zeit/next.js/issues/9081#issuecomment-611886787 query values weren't always being passed through for redirects and external rewrites. 

This corrects the behavior to make sure we pass through the query values following the correct merge order and also adds additional tests for this behavior