### PR TITLE
Externalize `next-server` from Server Builds

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -497,24 +497,26 @@ export default async function getBaseWebpackConfig(
               return callback()
             }
 
-            // make sure we don't externalize anything that is
-            // supposed to be transpiled
-            if (babelIncludeRegexes.some(r => r.test(request))) {
-              return callback()
-            }
+            // We need to externalize internal requests for files intended to
+            // not be bundled.
+
+            const isLocal: boolean =
+              request.startsWith('.') || request.startsWith('/')
+            const isLikelyNextExternal =
+              isLocal && /[/\\]next-server[/\\]/.test(request)
 
             // Relative requires don't need custom resolution, because they
             // are relative to requests we've already resolved here.
             // Absolute requires (require('/foo')) are extremely uncommon, but
             // also have no need for customization as they're already resolved.
-            if (request.startsWith('.') || request.startsWith('/')) {
+            if (isLocal && !isLikelyNextExternal) {
               return callback()
             }
 
             // Resolve the import with the webpack provided context, this
             // ensures we're resolving the correct version when multiple
             // exist.
-            let res
+            let res: string
             try {
               res = resolveRequest(request, `${context}/`)
             } catch (err) {
@@ -530,20 +532,36 @@ export default async function getBaseWebpackConfig(
               return callback()
             }
 
-            // Bundled Node.js code is relocated without its node_modules tree.
-            // This means we need to make sure its request resolves to the same
-            // package that'll be available at runtime. If it's not identical,
-            // we need to bundle the code (even if it _should_ be external).
-            let baseRes
-            try {
-              baseRes = resolveRequest(request, `${dir}/`)
-            } catch (err) {}
+            let isNextExternal: boolean = false
+            if (isLocal) {
+              isNextExternal = /next[/\\]dist[/\\]next-server[/\\]/.test(res)
+              if (!isNextExternal) {
+                return callback()
+              }
+            }
 
-            // Same as above: if the package, when required from the root,
-            // would be different from what the real resolution would use, we
-            // cannot externalize it.
-            if (baseRes !== res) {
-              return callback()
+            // `isNextExternal` special cases Next.js' internal requires that
+            // should not be bundled. We need to skip the base resolve routine
+            // to prevent it from being bundled (assumes Next.js version cannot
+            // mismatch).
+            if (!isNextExternal) {
+              // Bundled Node.js code is relocated without its node_modules tree.
+              // This means we need to make sure its request resolves to the same
+              // package that'll be available at runtime. If it's not identical,
+              // we need to bundle the code (even if it _should_ be external).
+              let baseRes: string | null
+              try {
+                baseRes = resolveRequest(request, `${dir}/`)
+              } catch (err) {
+                baseRes = null
+              }
+
+              // Same as above: if the package, when required from the root,
+              // would be different from what the real resolution would use, we
+              // cannot externalize it.
+              if (baseRes !== res) {
+                return callback()
+              }
             }
 
             // Default pages have to be transpiled
@@ -566,8 +584,24 @@ export default async function getBaseWebpackConfig(
 
             // Anything else that is standard JavaScript within `node_modules`
             // can be externalized.
-            if (res.match(/node_modules[/\\].*\.js$/)) {
-              return callback(undefined, `commonjs ${request}`)
+            if (isNextExternal || res.match(/node_modules[/\\].*\.js$/)) {
+              const externalRequest = isNextExternal
+                ? // Generate Next.js external import
+                  path.posix.join(
+                    'next',
+                    'dist',
+                    path
+                      .relative(
+                        // Root of Next.js package:
+                        path.join(__dirname, '..'),
+                        res
+                      )
+                      // Windows path normalization
+                      .replace(/\\/g, '/')
+                  )
+                : request
+
+              return callback(undefined, `commonjs ${externalRequest}`)
             }
 
             // Default behavior: bundle the code!

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -503,7 +503,7 @@ export default async function getBaseWebpackConfig(
             const isLocal: boolean =
               request.startsWith('.') ||
               path.posix.isAbsolute(request) ||
-              path.win32.isAbsolute(request)
+              (process.platform === 'win32' && path.win32.isAbsolute(request))
             const isLikelyNextExternal =
               isLocal && /[/\\]next-server[/\\]/.test(request)
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -501,7 +501,9 @@ export default async function getBaseWebpackConfig(
             // not be bundled.
 
             const isLocal: boolean =
-              request.startsWith('.') || request.startsWith('/')
+              request.startsWith('.') ||
+              path.posix.isAbsolute(request) ||
+              path.win32.isAbsolute(request)
             const isLikelyNextExternal =
               isLocal && /[/\\]next-server[/\\]/.test(request)
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -502,7 +502,11 @@ export default async function getBaseWebpackConfig(
 
             const isLocal: boolean =
               request.startsWith('.') ||
+              // Always check for unix-style path, as webpack sometimes
+              // normalizes as posix.
               path.posix.isAbsolute(request) ||
+              // When on Windows, we also want to check for Windows-specific
+              // absolute paths.
               (process.platform === 'win32' && path.win32.isAbsolute(request))
             const isLikelyNextExternal =
               isLocal && /[/\\]next-server[/\\]/.test(request)

--- a/test/integration/externalize-next-server/app/node_modules/comps/index.js
+++ b/test/integration/externalize-next-server/app/node_modules/comps/index.js
@@ -1,0 +1,5 @@
+const react = require('react')
+
+module.exports = function() {
+  return react.createElement('p', null, 'MyComp:', typeof window)
+}

--- a/test/integration/externalize-next-server/app/node_modules/comps/package.json
+++ b/test/integration/externalize-next-server/app/node_modules/comps/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "comps",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/test/integration/externalize-next-server/app/package.json
+++ b/test/integration/externalize-next-server/app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "externalize-next-server-app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/test/integration/externalize-next-server/app/pages/index.js
+++ b/test/integration/externalize-next-server/app/pages/index.js
@@ -1,0 +1,12 @@
+import MyComp from 'comps'
+
+const Page = () => (
+  <>
+    <p>Hello {typeof window}</p>
+    <MyComp />
+  </>
+)
+
+Page.getInitialProps = () => ({})
+
+export default Page

--- a/test/integration/externalize-next-server/test/index.test.js
+++ b/test/integration/externalize-next-server/test/index.test.js
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import path from 'path'
+import { nextBuild } from 'next-test-utils'
+import escapeStringRegexp from 'escape-string-regexp'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
+
+const appDir = path.join(__dirname, '../app')
+let buildId
+
+describe('externalize next/dist/next-server', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    buildId = await fs.readFile(path.join(appDir, '.next/BUILD_ID'), 'utf8')
+  })
+
+  it('Does not bundle next/dist/next-server/lib/head.js in _error', async () => {
+    const content = await fs.readFile(
+      path.join(appDir, '.next/server/static', buildId, 'pages/_error.js'),
+      'utf8'
+    )
+    expect(content).toMatch(
+      new RegExp(
+        '^' +
+          escapeStringRegexp(
+            `module.exports = require("next/dist/next-server/lib/head.js");`
+          ) +
+          '$',
+        'm'
+      )
+    )
+  })
+})


### PR DESCRIPTION
This pull request fixes a few problems causing `next-server` to be bundled in the server-bundles:

- Removes including files that match `babelIncludeRegexes` for the server, as these were already published for Node compatibility.
- Because `next-server` imports are now local, the `isLocal` check short circuited them from being external: we now exclude these from the check.
- The `commonjs` external callback now generates an appropriate external import reference for the now-localized files (before, we imported `next-server/lib/foo`—now, we import `../../next-server/lib/foo`).

This pull request re-externalizes the following modules, allowing v8's TurboFan to optimize the code execution paths and share them across pages:
```
next/dist/next-server/lib/utils.js
next/dist/next-server/lib/head.js
next/dist/next-server/lib/constants.js
next/dist/next-server/lib/document-context.js
next/dist/next-server/lib/utils.js
next/dist/next-server/server/utils.js
next/dist/next-server/lib/utils.js
next/dist/next-server/lib/router/router.js
next/dist/next-server/lib/router-context.js
```

---

Closes #11526
Closes #11724
x-ref #8613