### PR TITLE
upgrade from deprecated url.parse() since Node 11

### DIFF
--- a/examples/custom-server/server.js
+++ b/examples/custom-server/server.js
@@ -1,5 +1,4 @@
 const { createServer } = require('http')
-const { URL } = require('url')
 const next = require('next')
 
 const port = parseInt(process.env.PORT, 10) || 3000

--- a/examples/custom-server/server.js
+++ b/examples/custom-server/server.js
@@ -1,5 +1,5 @@
 const { createServer } = require('http')
-const { parse } = require('url')
+const { URL } = require('url')
 const next = require('next')
 
 const port = parseInt(process.env.PORT, 10) || 3000
@@ -9,7 +9,7 @@ const handle = app.getRequestHandler()
 
 app.prepare().then(() => {
   createServer((req, res) => {
-    const parsedUrl = parse(req.url, true)
+    const parsedUrl = new URL(req.url, `http://${req.headers.host}`)
     const { pathname, query } = parsedUrl
 
     if (pathname === '/a') {

--- a/examples/custom-server/server.js
+++ b/examples/custom-server/server.js
@@ -8,7 +8,7 @@ const handle = app.getRequestHandler()
 
 app.prepare().then(() => {
   createServer((req, res) => {
-    const parsedUrl = new URL(req.url, `http://${req.headers.host}`)
+    const parsedUrl = new URL(req.url, 'http://w.w')
     const { pathname, query } = parsedUrl
 
     if (pathname === '/a') {


### PR DESCRIPTION
`url.parse()` is now [deprecated](https://github.com/nodejs/node/issues/23694) as of Node.js 11.

This PR upgrades to the new, preferred method of URL parsing directly from [Node.js core documentation](https://nodejs.org/api/http.html#http_message_url).

```js
new URL(request.url, `http://${request.headers.host}`);
```
