### PR TITLE
Add displayName property to React Context objects

### DIFF
--- a/packages/next/next-server/lib/amp-context.ts
+++ b/packages/next/next-server/lib/amp-context.ts
@@ -1,3 +1,7 @@
 import * as React from 'react'
 
 export const AmpStateContext: React.Context<any> = React.createContext({})
+
+if (process.env.NODE_ENV !== 'production') {
+  AmpStateContext.displayName = 'AmpStateContext'
+}

--- a/packages/next/next-server/lib/document-context.ts
+++ b/packages/next/next-server/lib/document-context.ts
@@ -7,3 +7,7 @@ type DocumentContext = {
 }
 
 export const DocumentContext = React.createContext<DocumentContext>(null as any)
+
+if (process.env.NODE_ENV !== 'production') {
+  DocumentContext.displayName = 'DocumentContext'
+}

--- a/packages/next/next-server/lib/head-manager-context.ts
+++ b/packages/next/next-server/lib/head-manager-context.ts
@@ -1,3 +1,7 @@
 import * as React from 'react'
 
 export const HeadManagerContext: React.Context<any> = React.createContext(null)
+
+if (process.env.NODE_ENV !== 'production') {
+  HeadManagerContext.displayName = 'HeadManagerContext'
+}

--- a/packages/next/next-server/lib/loadable-context.ts
+++ b/packages/next/next-server/lib/loadable-context.ts
@@ -3,3 +3,7 @@ import * as React from 'react'
 type CaptureFn = (moduleName: string) => void
 
 export const LoadableContext = React.createContext<CaptureFn | null>(null)
+
+if (process.env.NODE_ENV !== 'production') {
+  LoadableContext.displayName = 'LoadableContext'
+}

--- a/packages/next/next-server/lib/request-context.ts
+++ b/packages/next/next-server/lib/request-context.ts
@@ -1,3 +1,7 @@
 import * as React from 'react'
 
 export const RequestContext: React.Context<any> = React.createContext(null)
+
+if (process.env.NODE_ENV !== 'production') {
+  RequestContext.displayName = 'RequestContext'
+}

--- a/packages/next/next-server/lib/router-context.ts
+++ b/packages/next/next-server/lib/router-context.ts
@@ -2,3 +2,7 @@ import * as React from 'react'
 import { NextRouter } from './router/router'
 
 export const RouterContext = React.createContext<NextRouter>(null as any)
+
+if (process.env.NODE_ENV !== 'production') {
+  RouterContext.displayName = 'RouterContext'
+}


### PR DESCRIPTION
https://reactjs.org/docs/context.html#contextdisplayname

Use the `.displayName` property to show distinct component names in React
DevTools. For example, `DocumentContext.Provider` and `RouterContext.Provider` instead of
each appearing as `Context.Provider`.