### PR TITLE
Add gip identifiers to NEXT_DATA

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -82,6 +82,8 @@ export type NEXT_DATA = {
   gsp?: boolean
   gssp?: boolean
   customServer?: boolean
+  gip?: boolean
+  appGip?: boolean
 }
 
 /**

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -195,6 +195,8 @@ function renderDocument(
     gsp,
     gssp,
     customServer,
+    gip,
+    appGip,
   }: RenderOpts & {
     props: any
     docProps: DocumentInitialProps
@@ -218,6 +220,8 @@ function renderDocument(
     gsp?: boolean
     gssp?: boolean
     customServer?: boolean
+    gip?: boolean
+    appGip?: boolean
   }
 ): string {
   return (
@@ -241,6 +245,8 @@ function renderDocument(
             gsp, // whether the page is getStaticProps
             gssp, // whether the page is getServerSideProps
             customServer, // whether the user is using a custom server
+            gip, // whether the page has getInitialProps
+            appGip, // whether the _app has getInitialProps
           },
           dangerousAsPath,
           canonicalBase,
@@ -777,6 +783,8 @@ export async function renderToHTML(
     polyfillFiles,
     gsp: !!getStaticProps ? true : undefined,
     gssp: !!getServerSideProps ? true : undefined,
+    gip: hasPageGetInitialProps ? true : undefined,
+    appGip: !defaultAppGetInitialProps ? true : undefined,
   })
 
   if (inAmpMode && html) {

--- a/test/integration/gip-identifier/pages/index.js
+++ b/test/integration/gip-identifier/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'hi'

--- a/test/integration/gip-identifier/test/index.test.js
+++ b/test/integration/gip-identifier/test/index.test.js
@@ -1,0 +1,97 @@
+/* eslint-env jest */
+/* global jasmine */
+import cheerio from 'cheerio'
+import fs from 'fs-extra'
+import {
+  findPort,
+  killApp,
+  launchApp,
+  nextBuild,
+  nextStart,
+  renderViaHTTP,
+} from 'next-test-utils'
+import { join } from 'path'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '..')
+const appPage = join(appDir, 'pages/_app.js')
+const indexPage = join(appDir, 'pages/index.js')
+
+let app
+let appPort
+let indexPageContent
+
+const runTests = isDev => {
+  const getData = async () => {
+    if (isDev) {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    } else {
+      const { code } = await nextBuild(appDir)
+      if (code !== 0) throw new Error(`build faild, exit code: ${code}`)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    }
+    const html = await renderViaHTTP(appPort, '/')
+    await killApp(app)
+    const $ = cheerio.load(html)
+    return JSON.parse($('#__NEXT_DATA__').text())
+  }
+
+  it('should not have gip in NEXT_DATA for page without getInitialProps', async () => {
+    const data = await getData()
+    expect(data.gip).toBe(undefined)
+  })
+
+  it('should not have gip in NEXT_DATA for page with getInitialProps', async () => {
+    indexPageContent = await fs.readFile(indexPage, 'utf8')
+    await fs.writeFile(
+      indexPage,
+      `
+      const Page = () => 'hi'
+      Page.getInitialProps = () => ({ hello: 'world' })
+      export default Page
+    `
+    )
+    const data = await getData()
+    expect(data.gip).toBe(true)
+  })
+
+  it('should have gip and appGip in NEXT_DATA for page with getInitialProps and _app with getInitialProps', async () => {
+    await fs.writeFile(
+      appPage,
+      `
+      const App = ({ Component, pageProps }) => <Component {...pageProps} />
+      App.getInitialProps = async (ctx) => {
+        let pageProps = {}
+        if (ctx.Component.getInitialProps) {
+          pageProps = await ctx.Component.getInitialProps(ctx.ctx)
+        }
+        return { pageProps }
+      }
+      export default App
+    `
+    )
+    const data = await getData()
+    expect(data.gip).toBe(true)
+    expect(data.appGip).toBe(true)
+  })
+
+  it('should only have appGip in NEXT_DATA for page without getInitialProps and _app with getInitialProps', async () => {
+    await fs.writeFile(indexPage, indexPageContent)
+    const data = await getData()
+    await fs.remove(appPage)
+    expect(data.gip).toBe(undefined)
+    expect(data.appGip).toBe(true)
+  })
+}
+
+describe('gip identifiers', () => {
+  describe('dev mode', () => {
+    runTests(true)
+  })
+
+  describe('production mode', () => {
+    runTests()
+  })
+})

--- a/test/integration/gip-identifier/test/index.test.js
+++ b/test/integration/gip-identifier/test/index.test.js
@@ -38,12 +38,13 @@ const runTests = isDev => {
     return JSON.parse($('#__NEXT_DATA__').text())
   }
 
-  it('should not have gip in NEXT_DATA for page without getInitialProps', async () => {
+  it('should not have gip or appGip in NEXT_DATA for page without getInitialProps', async () => {
     const data = await getData()
     expect(data.gip).toBe(undefined)
+    expect(data.appGip).toBe(undefined)
   })
 
-  it('should not have gip in NEXT_DATA for page with getInitialProps', async () => {
+  it('should have gip in NEXT_DATA for page with getInitialProps', async () => {
     indexPageContent = await fs.readFile(indexPage, 'utf8')
     await fs.writeFile(
       indexPage,


### PR DESCRIPTION
As discussed this adds `gip` and `appGip` identifiers to `NEXT_DATA` when a page is leveraging `getInitialProps` or they have a custom `_app` that leverages `getInitialProps`