### PR TITLE
Transpile packages in react-intl example

### DIFF
--- a/examples/with-react-intl/README.md
+++ b/examples/with-react-intl/README.md
@@ -71,3 +71,7 @@ global.DOMParser = DOMParser
 ```
 
 [react intl]: https://github.com/yahoo/react-intl
+
+### Transpile react-intl
+
+According to [react-intl docs](https://github.com/formatjs/react-intl/blob/53f2c826c7b1e50ad37215ce46b5e1c6f5d142cc/docs/Getting-Started.md#esm-build), react-intl and its underlying libraries must be transpiled to support older browsers (eg IE11). This is done by [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules) in next.config.js.

--- a/examples/with-react-intl/next.config.js
+++ b/examples/with-react-intl/next.config.js
@@ -1,0 +1,10 @@
+const withTM = require('next-transpile-modules')([
+  '@formatjs/intl-relativetimeformat',
+  '@formatjs/intl-utils',
+  'react-intl',
+  'intl-format-cache',
+  'intl-messageformat-parser',
+  'intl-messageformat',
+])
+
+module.exports = withTM()

--- a/examples/with-react-intl/package.json
+++ b/examples/with-react-intl/package.json
@@ -20,5 +20,8 @@
     "react-dom": "^16.9.0",
     "react-intl": "^3.1.12"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "next-transpile-modules": "^3.2.0"
+  }
 }


### PR DESCRIPTION
We noticed that our Next.js app shipped code containing `const`, which broke some older browsers. Turns out that [react-intl docs](https://github.com/formatjs/react-intl/blob/53f2c826c7b1e50ad37215ce46b5e1c6f5d142cc/docs/Getting-Started.md#esm-build), react-intl and its underlying libraries must be transpiled to support older browsers.

To verify this we used [es-check](https://www.npmjs.com/package/es-check): `npm run build && npx es-check --module es5 ./.next/static/**/*.js`.

There is probably other ways to solve this, but I found [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules) being the easiest solution.