### PR TITLE
Update Serverless Note in Docs

### DIFF
--- a/docs/api-reference/next.config.js/build-target.md
+++ b/docs/api-reference/next.config.js/build-target.md
@@ -16,7 +16,7 @@ Your application will be built and deployed as a monolith. This is the default t
 
 ## `serverless` target
 
-> Deployments to [ZEIT Now](https://zeit.co) will automatically enable this target. You do not need to opt-into it yourself, but you can.
+> Deployments to [ZEIT Now](https://zeit.co) will automatically enable this target. You should not opt-into it yourself.
 
 This target will output independent pages that don't require a monolithic server.
 


### PR DESCRIPTION
This updates our documentation to discourage users from configuring `target: 'serverless'` in their projects if deploying to ZEIT Now.

Setting this target can result in confusing **local** build errors, as ZEIT Now actually uses `experimental-serverless-trace` (forces it), which is more widely compatible w/ NPM packages than `serverless`.

---

Closes https://github.com/zeit/next.js/issues/11860