### PR TITLE
Add stats config for load tests

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -142,6 +142,15 @@ module.exports = {
         'http://localhost:$PORT/link',
         'http://localhost:$PORT/withRouter',
       ],
+      pagesToBench: [
+        'http://localhost:$PORT/',
+        'http://localhost:$PORT/error-in-render',
+      ],
+      benchOptions: {
+        reqTimeout: 60,
+        concurrency: 50,
+        numRequests: 2500,
+      },
     },
     {
       title: 'Serverless Mode',


### PR DESCRIPTION
This adds the config to load test specific pages with `next start` in our PR stats. This will help us prevent regressing on page load performance without catching it since we will be able to see it at a PR level before merging. 

x-ref: https://github.com/zeit/next.js/pull/11819
x-ref: https://github.com/zeit/next.js/pull/11867