### PR TITLE
fix(export): fallback to empty string for basePath

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -238,7 +238,7 @@ export default async function(
     dev: false,
     staticMarkup: false,
     hotReloader: null,
-    basePath: nextConfig.experimental.basePath || '',
+    basePath: nextConfig.experimental.basePath,
     canonicalBase: nextConfig.amp?.canonicalBase || '',
     isModern: nextConfig.experimental.modern,
     ampValidatorPath: nextConfig.experimental.amp?.validator || undefined,

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -238,7 +238,7 @@ export default async function(
     dev: false,
     staticMarkup: false,
     hotReloader: null,
-    basePath: nextConfig.experimental.basePath,
+    basePath: nextConfig.experimental.basePath || '',
     canonicalBase: nextConfig.amp?.canonicalBase || '',
     isModern: nextConfig.experimental.modern,
     ampValidatorPath: nextConfig.experimental.amp?.validator || undefined,

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -16,7 +16,7 @@ import { isDynamicRoute } from './utils/is-dynamic'
 import { getRouteMatcher } from './utils/route-matcher'
 import { getRouteRegex } from './utils/route-regex'
 
-const basePath = process.env.__NEXT_ROUTER_BASEPATH as string
+const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
 export function addBasePath(path: string): string {
   return path.indexOf(basePath) !== 0 ? basePath + path : path

--- a/test/unit/router-add-base-path.test.js
+++ b/test/unit/router-add-base-path.test.js
@@ -1,0 +1,9 @@
+/* eslint-env jest */
+import { addBasePath } from 'next/dist/next-server/lib/router/router'
+
+describe('router addBasePath', () => {
+  it('should add basePath correctly when no basePath', () => {
+    const result = addBasePath('/hello')
+    expect(result).toBe('/hello')
+  })
+})


### PR DESCRIPTION
#9988 break my test.
The `basePath` is undefined by default so when it converts to string, it become `'undefined'` and lead to `<a href="undefinedhttps://xxx.xxx.xxx">`