### PR TITLE
Handle Potential Promise Rejection in Serverless

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -177,7 +177,7 @@ const nextServerlessLoader: loader.Loader = function() {
           }
 
           const resolver = require('${absolutePagePath}')
-          apiResolver(
+          await apiResolver(
             req,
             res,
             Object.assign({}, parsedUrl.query, params ),


### PR DESCRIPTION
While I was combing through the serverless loader, I noticed we don't await the `apiResolver` like we do for server mode.

While this function is mostly self-contained, we should still await it in case it ever rejects.