### PR TITLE
Ensure module not found error is shown with jsconfig paths

### DIFF
--- a/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/jsconfig-paths-plugin.ts
@@ -204,11 +204,6 @@ export class JsConfigPathsPlugin implements ResolvePlugin {
 
             return result
           }
-
-          throw new Error(`
-      Request "${moduleName}" matched tsconfig.json or jsconfig.json "paths" pattern ${matchedPatternText} but could not be resolved.
-      Tried paths: ${triedPaths.join(' ')}
-      `)
         }
       )
   }

--- a/test/integration/jsconfig-baseurl/test/index.test.js
+++ b/test/integration/jsconfig-baseurl/test/index.test.js
@@ -1,8 +1,15 @@
 /* eslint-env jest */
 /* global jasmine */
+import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
-import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+import {
+  renderViaHTTP,
+  findPort,
+  launchApp,
+  killApp,
+  waitFor,
+} from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 
@@ -17,15 +24,41 @@ async function get$(path, query) {
 
 describe('TypeScript Features', () => {
   describe('default behavior', () => {
+    let output = ''
+
     beforeAll(async () => {
       appPort = await findPort()
-      app = await launchApp(appDir, appPort, {})
+      app = await launchApp(appDir, appPort, {
+        onStdout(msg) {
+          output += msg || ''
+        },
+        onStderr(msg) {
+          output += msg || ''
+        },
+      })
     })
     afterAll(() => killApp(app))
 
     it('should render the page', async () => {
       const $ = await get$('/hello')
       expect($('body').text()).toMatch(/World/)
+    })
+
+    it('should have correct module not found error', async () => {
+      const basicPage = join(appDir, 'pages/hello.js')
+      const contents = await fs.readFile(basicPage, 'utf8')
+
+      await fs.writeFile(
+        basicPage,
+        contents.replace('components/world', 'components/worldd')
+      )
+      await renderViaHTTP(appPort, '/hello')
+
+      await waitFor(2 * 1000)
+      await fs.writeFile(basicPage, contents)
+      expect(output).toContain(
+        `Module not found: Can't resolve 'components/worldd' in`
+      )
     })
   })
 })


### PR DESCRIPTION
This fixes an empty `module not found` error being shown when failing to resolve a path from `jsconfig` or `tsconfig`. The error is empty here since we were throwing an error from the plugin which isn't handled by `webpack` so this removes it in favor of `webpack`'s handling. It also seems we can't cleanly log from there or else the log will be repeated multiple times since multiple resolutions are occurring

<details>
<summary><strong>Before</strong></summary>

<img width="927" alt="before" src="https://user-images.githubusercontent.com/22380829/79259656-acd0bb00-7e52-11ea-92e8-c5c37b7f0168.png">
</details>

<details>
<summary><strong>After</strong></summary>

<img width="927" alt="after" src="https://user-images.githubusercontent.com/22380829/79259663-af331500-7e52-11ea-9ae5-7d14554a1d65.png">
</details>
