### PR TITLE
Fix: Update shallow routing docs

### DIFF
--- a/docs/routing/shallow-routing.md
+++ b/docs/routing/shallow-routing.md
@@ -27,7 +27,7 @@ function Page() {
 
   useEffect(() => {
     // Always do navigations after the first render
-    router.push('/?counter=10', null, { shallow: true })
+    router.push('/?counter=10', undefined, { shallow: true })
   }, [])
 
   useEffect(() => {
@@ -43,7 +43,7 @@ If you don't need to add the router object to the page, you can also use the [Ro
 ```jsx
 import Router from 'next/router'
 // Inside your page
-Router.push('/?counter=10', null, { shallow: true })
+Router.push('/?counter=10', undefined, { shallow: true })
 ```
 
 The URL will get updated to `/?counter=10`. and the page won't get replaced, only the state of the route is changed.


### PR DESCRIPTION
This is to fix #11513

The second parameter of `Router.push` can be undefined (because it's optional), but not null, and the examples are using null.

So this PR updates the docs to use `undefined` instead

edit: I wonder if the docs should mention that, if passing undefined as the second argument (as it's optional) it will be initialized to the same value as the first argument