### PR TITLE
Fix 'user undefined' error with ssr profile in auth0 example

### DIFF
--- a/examples/auth0/pages/advanced/ssr-profile.js
+++ b/examples/auth0/pages/advanced/ssr-profile.js
@@ -21,7 +21,7 @@ export async function getServerSideProps({ req, res }) {
   // Here you can check authentication status directly before rendering the page,
   // however the page would be a serverless function, which is more expensive and
   // slower than a static page with client side authentication
-  const session = await auth0.getSession(req);
+  const session = await auth0.getSession(req)
 
   if (!session || !session.user) {
     res.writeHead(302, {
@@ -31,7 +31,7 @@ export async function getServerSideProps({ req, res }) {
     return
   }
 
-  return { props: { user } }
+  return { props: { user: session.user } }
 }
 
 export default Profile

--- a/examples/auth0/pages/advanced/ssr-profile.js
+++ b/examples/auth0/pages/advanced/ssr-profile.js
@@ -21,9 +21,9 @@ export async function getServerSideProps({ req, res }) {
   // Here you can check authentication status directly before rendering the page,
   // however the page would be a serverless function, which is more expensive and
   // slower than a static page with client side authentication
-  const { user } = await auth0.getSession(req)
+  const session = await auth0.getSession(req);
 
-  if (!user) {
+  if (!session || !session.user) {
     res.writeHead(302, {
       Location: '/api/login',
     })


### PR DESCRIPTION
When a user is not logged in and attempts to navigate to the SSR profile route under `/advanced/ssr-profile`, they're treated with a TypeError of user being undefined.

This fix replaces the destructuring of the user from a non-existent session - it instead checks for an existing session AND user within session.

![Screen Shot 2020-04-16 at 3 27 12 pm](https://user-images.githubusercontent.com/3255371/79418248-784a3400-7ff7-11ea-9dd2-78b9d380cb7c.png)
