### PR TITLE
Enable "paths" support by default

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1005,11 +1005,7 @@ export default async function getBaseWebpackConfig(
     webpackConfig.resolve?.modules?.push(resolvedBaseUrl)
   }
 
-  if (
-    config.experimental.jsconfigPaths &&
-    jsConfig?.compilerOptions?.paths &&
-    resolvedBaseUrl
-  ) {
+  if (jsConfig?.compilerOptions?.paths && resolvedBaseUrl) {
     webpackConfig.resolve?.plugins?.push(
       new JsConfigPathsPlugin(jsConfig.compilerOptions.paths, resolvedBaseUrl)
     )

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -768,17 +768,15 @@ export default async function getBaseWebpackConfig(
       // This plugin makes sure `output.filename` is used for entry chunks
       new ChunkNamesPlugin(),
       new webpack.DefinePlugin({
-        ...(config.experimental.pageEnv
-          ? Object.keys(process.env).reduce(
-              (prev: { [key: string]: string }, key: string) => {
-                if (key.startsWith('NEXT_PUBLIC_')) {
-                  prev[`process.env.${key}`] = JSON.stringify(process.env[key]!)
-                }
-                return prev
-              },
-              {}
-            )
-          : {}),
+        ...Object.keys(process.env).reduce(
+          (prev: { [key: string]: string }, key: string) => {
+            if (key.startsWith('NEXT_PUBLIC_')) {
+              prev[`process.env.${key}`] = JSON.stringify(process.env[key]!)
+            }
+            return prev
+          },
+          {}
+        ),
         ...Object.keys(config.env).reduce((acc, key) => {
           if (/^(?:NODE_.+)|^(?:__.+)$/i.test(key)) {
             throw new Error(

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -41,7 +41,6 @@ const defaultConfig: { [key: string]: any } = {
       (Number(process.env.CIRCLE_NODE_TOTAL) ||
         (os.cpus() || { length: 1 }).length) - 1
     ),
-    jsconfigPaths: false,
     css: true,
     scss: true,
     documentMiddleware: false,

--- a/test/integration/env-config/app/next.config.js
+++ b/test/integration/env-config/app/next.config.js
@@ -1,7 +1,5 @@
 module.exports = {
   experimental: {
-    pageEnv: true,
-
     async redirects() {
       return [
         {

--- a/test/integration/jsconfig-paths/next.config.js
+++ b/test/integration/jsconfig-paths/next.config.js
@@ -1,7 +1,4 @@
 module.exports = {
-  experimental: {
-    jsconfigPaths: true,
-  },
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,

--- a/test/integration/typescript-paths/next.config.js
+++ b/test/integration/typescript-paths/next.config.js
@@ -1,7 +1,4 @@
 module.exports = {
-  experimental: {
-    jsconfigPaths: true,
-  },
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,


### PR DESCRIPTION
This enables the tsconfig.json and jsconfig.json "paths" support to do module aliases for first-party code, note that node_modules is excluded.