### PR TITLE
Serialize JSON Warnings Before Event

### DIFF
--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -336,13 +336,15 @@ export function watchCompilers(
 
             stats.compilation.errors.push(...(filteredErrors || []))
             stats.compilation.warnings.push(...(filteredWarnings || []))
+            const {
+              errors: newErrors,
+              warnings: newWarnings,
+            } = formatWebpackMessages(
+              stats.toJson({ all: false, warnings: true, errors: true })
+            )
             onTypeChecked({
-              errors: stats.compilation.errors.length
-                ? stats.compilation.errors
-                : null,
-              warnings: stats.compilation.warnings.length
-                ? stats.compilation.warnings
-                : null,
+              errors: newErrors?.length ? newErrors : null,
+              warnings: newWarnings?.length ? newWarnings : null,
             })
 
             onEvent({


### PR DESCRIPTION
This fixes an edge-case where a webpack plugin that emits non-JSON serializable errors into the warnings object.

To fix this, we use webpack's special `.toJson` helper which knows how to serialize common cases of this.

```
[ info ]  ready on http://localhost:3000
(node:64229) UnhandledPromiseRejectionWarning: TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'NormalModule'
    |     property 'dependencies' -> object with constructor 'Array'
    |     index 0 -> object with constructor 'CommonJsRequireDependency'
    |     ...
    |     index 0 -> object with constructor 'ModuleReason'
    --- property 'module' closes the circle
    at JSON.stringify (<anonymous>)
    at /Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/compiled/webpack-hot-middleware/middleware.js:1:2018
    at /Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/compiled/webpack-hot-middleware/middleware.js:1:1337
    at Array.forEach (<anonymous>)
    at everyClient (/Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/compiled/webpack-hot-middleware/middleware.js:1:1317)
    at Object.publish (/Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/compiled/webpack-hot-middleware/middleware.js:1:1972)
    at Function.o.publish (/Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/compiled/webpack-hot-middleware/middleware.js:1:1154)
    at HotReloader.send (/Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/server/hot-reloader.js:5:678)
    at /Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/server/hot-reloader.js:15:508
    at /Users/joe/Documents/Development/Work/zeit/next.js/packages/next/dist/build/output/index.js:5:651
(node:64229) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 42)
```

---

Closes #8601
