### PR TITLE
Add API route to default CNA template

### DIFF
--- a/packages/create-next-app/templates/default/pages/api/hello.js
+++ b/packages/create-next-app/templates/default/pages/api/hello.js
@@ -1,0 +1,6 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default (req, res) => {
+  res.statusCode = 200
+  res.json({ name: 'John Doe' })
+}


### PR DESCRIPTION
As discussed this adds an API route to our default create next app template to showcase the API support in Next.js

