### PR TITLE
Add Missing Hook for MainTemplate

### DIFF
--- a/packages/next/types/webpack.d.ts
+++ b/packages/next/types/webpack.d.ts
@@ -1044,6 +1044,7 @@ declare module 'webpack' {
       class MainTemplate extends Tapable {
         hooks: {
           jsonpScript?: SyncWaterfallHook<string, Chunk, string>
+          require: SyncWaterfallHook<string, Chunk, string>
           requireExtensions: SyncWaterfallHook<string, Chunk, string>
         }
         outputOptions: Output


### PR DESCRIPTION
This PR adds a missing hook to our webpack types for MainTemplate:
https://github.com/webpack/webpack/blob/4c644bf1f7cb067c748a52614500e0e2182b2700/lib/MainTemplate.js#L95

Required for upcoming the Fast Refresh PR that I'm trying to keep small!