### PR TITLE
Fix On Demand Types in Hot Reloader

### DIFF
--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -1,10 +1,10 @@
 import { NextHandleFunction } from 'connect'
 import { IncomingMessage, ServerResponse } from 'http'
+import WebpackDevMiddleware from 'next/dist/compiled/webpack-dev-middleware'
+import WebpackHotMiddleware from 'next/dist/compiled/webpack-hot-middleware'
 import { join, normalize, relative as relativePath, sep } from 'path'
 import { UrlObject } from 'url'
 import webpack from 'webpack'
-import WebpackDevMiddleware from 'next/dist/compiled/webpack-dev-middleware'
-import WebpackHotMiddleware from 'next/dist/compiled/webpack-hot-middleware'
 import { createEntrypoints, createPagesMapping } from '../build/entries'
 import { watchCompilers } from '../build/output'
 import getBaseWebpackConfig from '../build/webpack-config'
@@ -484,15 +484,14 @@ export default class HotReloader {
       webpackDevMiddleware,
       multiCompiler,
       {
-        dir: this.dir,
         buildId: this.buildId,
         pagesDir: this.pagesDir,
-        distDir: this.config.distDir,
         reload: this.reload.bind(this),
         pageExtensions: this.config.pageExtensions,
-        publicRuntimeConfig: this.config.publicRuntimeConfig,
-        serverRuntimeConfig: this.config.serverRuntimeConfig,
-        ...this.config.onDemandEntries,
+        ...(this.config.onDemandEntries as {
+          maxInactiveAge: number
+          pagesBufferLength: number
+        }),
       }
     )
 


### PR DESCRIPTION
We were previously spreading an `any` object, breaking type checks for this function call.

As a result, I've removed invalid fields from being passed. Found as part of Fast Refresh work.