### PR TITLE
Fix type on NextApiHandler

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -237,7 +237,7 @@ export type NextApiResponse<T = any> = ServerResponse & {
 export type NextApiHandler<T = any> = (
   req: NextApiRequest,
   res: NextApiResponse<T>
-) => void
+) => void | Promise<void>
 
 /**
  * Utils

--- a/test/integration/typescript/pages/api/async.tsx
+++ b/test/integration/typescript/pages/api/async.tsx
@@ -1,0 +1,7 @@
+import { NextApiHandler } from 'next'
+
+const AsyncApiEndpoint: NextApiHandler = async (req, res) => {
+  res.status(200).json({ code: 'ok' })
+}
+
+export default AsyncApiEndpoint

--- a/test/integration/typescript/pages/api/sync.tsx
+++ b/test/integration/typescript/pages/api/sync.tsx
@@ -1,0 +1,7 @@
+import { NextApiHandler } from 'next'
+
+const SyncApiEndpoint: NextApiHandler = (req, res) => {
+  res.status(200).json({ code: 'ok' })
+}
+
+export default SyncApiEndpoint


### PR DESCRIPTION
The example [here](https://nextjs.org/docs/api-routes/api-middlewares#connectexpress-middleware-support) shows that `NextApiHandler` can be async, so the return type should be `void | Promise<void>`.