### PR TITLE
Resolve TypeScript Extension in Correct Order

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -247,17 +247,17 @@ export default async function getBaseWebpackConfig(
     // Disable .mjs for node_modules bundling
     extensions: isServer
       ? [
-          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.js',
           '.mjs',
+          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.jsx',
           '.json',
           '.wasm',
         ]
       : [
-          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.mjs',
           '.js',
+          ...(useTypeScript ? ['.tsx', '.ts'] : []),
           '.jsx',
           '.json',
           '.wasm',

--- a/test/integration/typescript/extension-order/js-first.js
+++ b/test/integration/typescript/extension-order/js-first.js
@@ -1,0 +1,1 @@
+export const value = 'OK'

--- a/test/integration/typescript/extension-order/js-first.ts
+++ b/test/integration/typescript/extension-order/js-first.ts
@@ -1,0 +1,1 @@
+export const value = 'WRONG FILE'

--- a/test/integration/typescript/pages/hello.tsx
+++ b/test/integration/typescript/pages/hello.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
 import { useRouter } from 'next/router'
+import React from 'react'
 import { hello } from '../components/hello'
-import { World } from '../components/world'
-import Router from '../components/router'
 import Link from '../components/link'
+import Router from '../components/router'
+import { World } from '../components/world'
+import { value as resolveOrderValue } from '../extension-order/js-first'
 
 export default function HelloPage(): JSX.Element {
   const router = useRouter()
@@ -12,6 +13,7 @@ export default function HelloPage(): JSX.Element {
   return (
     <div>
       <p>One trillion dollars: {1_000_000_000_000}</p>
+      <p id="imported-value">{resolveOrderValue}</p>
       {hello()} <World />
       <Router />
       <Link />

--- a/test/integration/typescript/test/index.test.js
+++ b/test/integration/typescript/test/index.test.js
@@ -46,6 +46,11 @@ describe('TypeScript Features', () => {
       expect($('body').text()).toMatch(/1000000000000/)
     })
 
+    it('should resolve files in correct order', async () => {
+      const $ = await get$('/hello')
+      expect($('#imported-value').text()).toBe('OK')
+    })
+
     it('should report type checking to stdout', async () => {
       expect(output).toContain('waiting for typecheck results...')
     })


### PR DESCRIPTION
This fixes the order that we resolve JavaScript & TypeScript files in.

This change brings broader ecosystem compatibility and should speed up overall resolving (`node_modules` are primarily JS, vs first-party files in smaller quantity).

This also fixes the errors in #12008.

---

Comment re-requesting this change: https://github.com/zeit/next.js/pull/9953#issuecomment-609806749
Related: #9953