### PR TITLE
Added react imports to typescript examples

### DIFF
--- a/examples/with-typescript-graphql/pages/about.tsx
+++ b/examples/with-typescript-graphql/pages/about.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Link from 'next/link'
 
 export default () => (

--- a/examples/with-typescript-graphql/pages/index.tsx
+++ b/examples/with-typescript-graphql/pages/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import withApollo from '../lib/with-apollo'
 import Link from 'next/link'
 import { useViewerQuery } from '../lib/viewer.graphql'

--- a/examples/with-typescript-styled-components/pages/_document.tsx
+++ b/examples/with-typescript-styled-components/pages/_document.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Document, { DocumentContext } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 

--- a/examples/with-typescript/pages/index.tsx
+++ b/examples/with-typescript/pages/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Link from 'next/link'
 import Layout from '../components/Layout'
 

--- a/examples/with-typescript/pages/users/index.tsx
+++ b/examples/with-typescript/pages/users/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { GetStaticProps } from 'next'
 import Link from 'next/link'
 

--- a/examples/with-typestyle/pages/_document.js
+++ b/examples/with-typestyle/pages/_document.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import Document, { Head, Main, NextScript } from 'next/document'
 import { getStyles } from 'typestyle'
 


### PR DESCRIPTION
Problem:

* In normal usage it's just a linting error using default sane eslint/tslint configuration: 'React' must be in scope when using JSX using eslint-typescript defaults

* Might cause issues with exotic typescript/webpack configurations which would prevent build (default next.js configuration)

* (Minor) Coding-style persistency across examples

Reproduction:

* Create new next-app using with-typescript example

```
yarn create next-app (pick with-typescript example)
```

* Add .eslintrc.js to your project

```
module.exports = {
  parser: "@typescript-eslint/parser",
  extends: [
    "plugin:react/recommended",
    "plugin:@typescript-eslint/recommended",
  ],
  parserOptions: {
    ecmaVersion: 2018,
    sourceType: "module",
    ecmaFeatures: {
      jsx: true,
    },
  },
  settings: {
    react: {
      version: "detect",
    },
  },
};
```

* Install dependencies for that config:

```
yarn add --dev @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-plugin-react
```

* Go to `pages/index.tsx`

* You'll see an error in red if you use an editor with ESLint enabled, e. g. VSCode with ESLint plugin, or you'll get in error in the console by manually running eslint `./node_modules/bin/eslint pages/index.tsx`

<img width="689" alt="Screen Shot 2020-04-19 at 9 38 16 AM" src="https://user-images.githubusercontent.com/376065/79682317-84193e80-8221-11ea-8975-472552f5b9c7.png">
