### PR TITLE
Stabilize HMR tests on CI

### DIFF
--- a/packages/next/client/dev/error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev/error-overlay/hot-dev-client.js
@@ -213,6 +213,12 @@ function handleErrors(errors) {
 
   // Do not attempt to reload now.
   // We will reload on next success instead.
+  if (process.env.__NEXT_TEST_MODE) {
+    if (self.__NEXT_HMR_CB) {
+      self.__NEXT_HMR_CB(formatted.errors[0])
+      self.__NEXT_HMR_CB = null
+    }
+  }
 }
 
 function tryDismissErrorOverlay() {

--- a/test/acceptance/helpers.js
+++ b/test/acceptance/helpers.js
@@ -69,7 +69,7 @@ export async function sandbox(id = nanoid()) {
 
             console.log('Application re-loaded.')
             // Slow down tests a bit:
-            await new Promise(resolve => setTimeout(resolve, 250))
+            await new Promise(resolve => setTimeout(resolve, 750))
             return false
           }
           if (status === 'success') {
@@ -83,8 +83,8 @@ export async function sandbox(id = nanoid()) {
           await new Promise(resolve => setTimeout(resolve, 30))
         }
 
-        // Slow down tests a bit:
-        await new Promise(resolve => setTimeout(resolve, 250))
+        // Slow down tests a bit (we don't know how long re-rendering takes):
+        await new Promise(resolve => setTimeout(resolve, 750))
         return true
       },
       async remove(fileName) {
@@ -102,6 +102,16 @@ export async function sandbox(id = nanoid()) {
             `You must pass a function to be evaluated in the browser.`
           )
         }
+      },
+      async getOverlayContent() {
+        await browser.waitForElementByCss('iframe', 10000)
+        const hasIframe = await browser.hasElementByCssSelector('iframe')
+        if (!hasIframe) {
+          throw new Error('Unable to find overlay')
+        }
+        return browser.eval(
+          `document.querySelector('iframe').contentWindow.document.body.innerHTML`
+        )
       },
     },
     function cleanup() {


### PR DESCRIPTION
This PR attempts to stabilize the new acceptance tests by increasing the delay post-HMR event.

Unfortunately, we don't know how long a re-render really takes. 750ms should be sufficient for the browser to re-render the DOM.