### PR TITLE
Update next/head docs to clarify duplicate tags.

### DIFF
--- a/docs/api-reference/next/head.md
+++ b/docs/api-reference/next/head.md
@@ -43,16 +43,16 @@ function IndexPage() {
       <Head>
         <title>My page title</title>
         <meta
-          name="viewport"
-          content="initial-scale=1.0, width=device-width"
-          key="viewport"
+          property="og:title"
+          content="My page title"
+          key="title"
         />
       </Head>
       <Head>
         <meta
-          name="viewport"
-          content="initial-scale=1.2, width=device-width"
-          key="viewport"
+          property="og:title"
+          content="My new title"
+          key="title"
         />
       </Head>
       <p>Hello world!</p>
@@ -63,7 +63,7 @@ function IndexPage() {
 export default IndexPage
 ```
 
-In this case only the second `<meta name="viewport" />` is rendered.
+In this case only the second `<meta property="og:title" />` is rendered. `meta` tags with duplicate `name` attributes are automatically handled.
 
 > The contents of `head` get cleared upon unmounting the component, so make sure each page completely defines what it needs in `head`, without making assumptions about what other pages added.
 


### PR DESCRIPTION
Closes https://github.com/zeit/next.js/issues/10836.

When overriding `Head` in a child component, `meta` tags with the same `name` attribute are de-duplicated by default. Tags with `property` (e.g., [open-graph](https://ogp.me/)) are not. 

This PR updates the `next/head` docs to clarify usage for `key`. It also adds a note about Next handling `name` by default, as suggested by @Timer.

## Example

**Parent**
```js
<Head>
  <title>Home</title>
  <link rel="icon" href="/favicon.ico" />
  <meta name="viewport" content="initial-scale=1.0, width=device-width" />
  <meta property="og:title" content="My page title" key="title" />
</Head>
```

**Parent**
```js
<Head>
  <title>Home</title>
  <link rel="icon" href="/favicon.ico" />
  <meta name="viewport" content="initial-scale=1.5" />
  <meta property="og:title" content="My new title" key="title" />
</Head>
```

**Result**
<img width="478" alt="Screen Shot 2020-04-19 at 8 30 50 PM" src="https://user-images.githubusercontent.com/9113740/79705838-adb38380-827c-11ea-865c-51e621b70eff.png">

