### PR TITLE
Add documentation on `next build` output.

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -38,3 +38,12 @@ NODE_OPTIONS='--throw-deprecation' next
 NODE_OPTIONS='-r esm' next
 NODE_OPTIONS='--inspect' next
 ```
+
+## Build
+
+`next build` creates an optimized production build of your application. The output displays information about each route.
+
+- **Size** – The number of assets downloaded when navigating to the page client-side. The size for each route only includes its dependencies.
+- **First Load JS** – The number of assets downloaded when visiting the page from the server. The amount of JS shared by all is shown as a separate metric.
+
+The first load is colored green, yellow, or red. Aim for green for performant applications.


### PR DESCRIPTION
Closes https://github.com/zeit/next.js/issues/10565.

This PR adds documentation on `next/build` to clarify the meaning of "Size" and "First Load JS". Please let me know if more details are necessary. 

Related:
- https://github.com/zeit/next.js/pull/10014
- https://github.com/zeit/next.js/pull/11401
- https://github.com/zeit/next.js/issues/11389