### PR TITLE
Fix with-strict-csp example

### DIFF
--- a/examples/with-strict-csp/README.md
+++ b/examples/with-strict-csp/README.md
@@ -1,6 +1,6 @@
 # Strict CSP example
 
-If you want to implement a CSP, the most effective way is to follow the [strict CSP](https://csp.withgoogle.com/docs/strict-csp.html) approach. For it to work, we need to generate a nonce on every request.
+If you want to implement a CSP, follow the [strict CSP](https://csp.withgoogle.com/docs/strict-csp.html) approach. For it to work, we need to generate a nonce on every request.
 
 This example uses [Helmet](https://github.com/helmetjs/helmet) to configure the CSP and add the appropriate headers to all server responses. The nonce is generated with [uuid](https://github.com/kelektiv/node-uuid). Then we can pass the nonce to `<Head>` and `<NextScript>` in the custom `<Document>`.
 

--- a/examples/with-strict-csp/pages/_document.js
+++ b/examples/with-strict-csp/pages/_document.js
@@ -11,6 +11,11 @@ const inlineScript = (body, nonce) => (
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx)
+
+    if (!ctx.res) {
+      throw new Error('Strict CSP only works on SSR pages!')
+    }
+
     const { nonce } = ctx.res.locals
     return { ...initialProps, nonce }
   }

--- a/examples/with-strict-csp/pages/index.js
+++ b/examples/with-strict-csp/pages/index.js
@@ -1,1 +1,9 @@
-export default () => <div>Hello World</div>
+const IndexPage = () => <div>Hello World</div>
+
+// Opt into SSR manually since we need
+// to generate a nonce on every request
+IndexPage.getInitialProps = () => ({
+  preventWarning: true,
+})
+
+export default IndexPage


### PR DESCRIPTION
The with-strict-csp example uses dynamic nonces that need to be generated on every request.
Since automatic-static optimization this example was broken, because static rendering doesn't work with this strategy.

This PR explicitly opts into ssr.

close #11929