### PR TITLE
Update to only apply experimental process.env stub in development

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -867,15 +867,10 @@ export default async function getBaseWebpackConfig(
             }
           : undefined),
         // stub process.env with proxy to warn a missing value is
-        // being accessed
-        ...(config.experimental.pageEnv
+        // being accessed in development mode
+        ...(config.experimental.pageEnv && process.env.NODE_ENV !== 'production'
           ? {
-              'process.env':
-                process.env.NODE_ENV === 'production'
-                  ? isServer
-                    ? 'process.env'
-                    : '{}'
-                  : `
+              'process.env': `
             new Proxy(${isServer ? 'process.env' : '{}'}, {
               get(target, prop) {
                 if (typeof target[prop] === 'undefined') {

--- a/test/integration/process-env-stub/components/hello.js
+++ b/test/integration/process-env-stub/components/hello.js
@@ -1,0 +1,11 @@
+import { PHASE_PRODUCTION_BUILD } from 'next/constants'
+
+const { NODE_ENV } = process.env
+const { NEXT_PHASE } = process.env
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+if (NODE_ENV !== 'development' && NEXT_PHASE !== PHASE_PRODUCTION_BUILD) {
+  console.log('next start', SENTRY_DSN)
+}
+
+export default () => process.env.HELLO || 'hi'

--- a/test/integration/process-env-stub/pages/missing.js
+++ b/test/integration/process-env-stub/pages/missing.js
@@ -1,4 +1,15 @@
+import dynamic from 'next/dynamic'
+
+const Hello = dynamic(() => import('../components/hello'), { ssr: true })
+
 export default () => {
-  console.log(process.env.hi)
-  return <p>hi there 👋</p>
+  // make sure we handle this syntax correctly
+  const { hi } = process.env
+  console.log(hi)
+  return (
+    <>
+      <p>hi there 👋</p>
+      <Hello />
+    </>
+  )
 }


### PR DESCRIPTION
This updates to not modify `process.env` in production mode as weren't changing the behavior with the stub there yet anyways and were only adding the stub to warn in development mode initially. We plan to make the stub only apply to files outside of `node_modules` in a follow-up PR

x-ref: https://github.com/zeit/next.js/pull/11893