### PR TITLE
Make sure to not show _error without 404 warning in some cases

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1321,7 +1321,8 @@ export default class Server {
     if (
       process.env.NODE_ENV !== 'production' &&
       !using404Page &&
-      (await this.hasPage('/_error'))
+      (await this.hasPage('/_error')) &&
+      !(await this.hasPage('/404'))
     ) {
       this.customErrorNo404Warn()
     }


### PR DESCRIPTION
This makes sure to not show the `/_error` without `/404` warning when an error is triggered in development

Closes: https://github.com/zeit/next.js/issues/12060