### PR TITLE
[Fast Refresh] propagates a module that stops accepting in next version

### DIFF
--- a/test/acceptance/ReactRefreshRequire.test.js
+++ b/test/acceptance/ReactRefreshRequire.test.js
@@ -351,18 +351,18 @@ test('propagates a module that stops accepting in next version', async () => {
   // Accept in parent
   await session.write(
     './foo.js',
-    `globalThis.log.push('init FooV1'); import './bar'; export default function Foo() {};`
+    `;(typeof global !== 'undefined' ? global : window).log.push('init FooV1'); import './bar'; export default function Foo() {};`
   )
   // Accept in child
   await session.write(
     './bar.js',
-    `globalThis.log.push('init BarV1'); export default function Bar() {};`
+    `;(typeof global !== 'undefined' ? global : window).log.push('init BarV1'); export default function Bar() {};`
   )
 
   // Bootstrap:
   await session.patch(
     'index.js',
-    `globalThis.log = []; require('./foo'); export default () => null;`
+    `;(typeof global !== 'undefined' ? global : window).log = []; require('./foo'); export default () => null;`
   )
   expect(await session.evaluate(() => window.log)).toEqual([
     'init BarV1',
@@ -447,7 +447,7 @@ test('propagates a module that stops accepting in next version', async () => {
     !(await session.patch(
       './foo.js',
       `
-      if (globalThis.localStorage) {
+      if (typeof window !== 'undefined' && window.localStorage) {
         window.localStorage.setItem('init', 'init FooV2')
       }
       export function Foo() {};


### PR DESCRIPTION
tl;dr this pull request tests that we can propagate a module that stops accepting in next version.

---

This pull request tests that we can recover from a module that was previously a React Refresh Boundary, but is no longer one after an update:

The current version of a module must make the decision of whether or not to accept the **next** version of a module.

As a result, when a module is a Refresh Boundary, it must optimistically accept the next version of itself.

If the "next" accepted version of the module is no longer a valid Boundary, or has had its signature changed, we must traverse to the next Refresh Boundaries instead of doing a full reload.

To do this, we call webpack's `module.hot.invalidate()` API to re-propagate the update.

--- 

Implements tests for https://github.com/webpack/webpack/pull/10715

cc @gaearon @pmmmwh @sokra