### PR TITLE
Add additional check for segments in destination but not source

### DIFF
--- a/test/integration/invalid-custom-routes/test/index.test.js
+++ b/test/integration/invalid-custom-routes/test/index.test.js
@@ -386,7 +386,7 @@ const runTests = () => {
     const stderr = await getStderr()
 
     expect(stderr).toContain(
-      `invalid segments used in destination but not source (id) for route {"source":"/feedback/:type","destination":"/feedback/:id"}`
+      `\`destination\` has segments not in \`source\` (id) for route {"source":"/feedback/:type","destination":"/feedback/:id"}`
     )
   })
 }

--- a/test/integration/invalid-custom-routes/test/index.test.js
+++ b/test/integration/invalid-custom-routes/test/index.test.js
@@ -371,6 +371,24 @@ const runTests = () => {
 
     expect(stderr).toContain(`headers must return an array, received undefined`)
   })
+
+  it('should show valid error when segments not in source are used in destination', async () => {
+    await writeConfig(
+      [
+        {
+          source: '/feedback/:type',
+          destination: '/feedback/:id',
+        },
+      ],
+      'rewrites'
+    )
+
+    const stderr = await getStderr()
+
+    expect(stderr).toContain(
+      `invalid segments used in destination but not source (id) for route {"source":"/feedback/:type","destination":"/feedback/:id"}`
+    )
+  })
 }
 
 describe('Errors on invalid custom routes', () => {


### PR DESCRIPTION
This adds another check to our custom routes checks to ensure a destination doesn't attempt to use segments that aren't in the source

<details>
<summary>Screenshot</summary>

<img width="927" alt="Screen Shot 2020-04-20 at 16 17 59" src="https://user-images.githubusercontent.com/22380829/79801596-fbcf9200-8323-11ea-90ff-273332aaba2b.png">
</details>

x-ref: https://github.com/zeit/now/pull/4105