### PR TITLE
fix(with-firebase-authentication): get initial message for SSR

### DIFF
--- a/examples/with-firebase-authentication/README.md
+++ b/examples/with-firebase-authentication/README.md
@@ -28,6 +28,7 @@ Set up firebase:
 - Create a project at the [Firebase console](https://console.firebase.google.com/).
 - Get your account credentials from the Firebase console at _project settings>service accounts_, where you can click on _generate new private key_ and download the credentials as a json file. It will contain keys such as `project_id`, `client_email` and `client_id`. Now copy them into your project in the `credentials/server.js` file.
 - Get your authentication credentials from the Firebase console under _project settings>general>your apps_ Add a new web app if you don't already have one. Under _Firebase SDK snippet_ choose _Config_ to get the configuration as JSON. It will include keys like `apiKey`, `authDomain` and `databaseUrl` and it goes into your project in `credentials/client.js`.
+- Replace the `'TODO: Add your databaseUrl here'` field in `server.js` with your `databaseUrl`.
 - Back at the Firebase web console, go to _Authentication>Sign-in method_ and enable _Google_.
 - Create a database in the "Database" tab and select Firestore. Then go to "rules" and set up your write, read rules to this:
 

--- a/examples/with-firebase-authentication/pages/index.js
+++ b/examples/with-firebase-authentication/pages/index.js
@@ -6,15 +6,14 @@ import 'isomorphic-unfetch'
 import clientCredentials from '../credentials/client'
 
 export async function getServerSideProps({ req, query }) {
-  const user = req && req.session ? req.session.decodedToken : null
+  const user = req && req.session && req.session.decodedToken ?
+    req.session.decodedToken : null
   // don't fetch anything from firebase if the user is not found
-  // const snap = user && await req.firebaseServer.database().ref('messages').once('value')
-  // const messages = snap && snap.val()
-  const messages = null
+  const snap = user && Object.fromEntries((await req.firebaseServer.firestore().collection('messages').get()).docs.map(doc => [doc.id, doc.data()]));
   return {
     props: {
       user,
-      messages,
+      messages: snap ? snap : null,
     },
   }
 }

--- a/examples/with-firebase-authentication/server.js
+++ b/examples/with-firebase-authentication/server.js
@@ -13,6 +13,7 @@ const handle = app.getRequestHandler()
 const firebase = admin.initializeApp(
   {
     credential: admin.credential.cert(require('./credentials/server')),
+    databaseURL: 'TODO: Add your databaseUrl here',
   },
   'server'
 )


### PR DESCRIPTION
We fetch the initial messages from the Firestore `messages` collection during SSR (in `getServerSideProps`) **only if** the user is authenticated.