### PR TITLE
Example: update netlify-cms to use SSG

### DIFF
--- a/examples/with-netlify-cms/README.md
+++ b/examples/with-netlify-cms/README.md
@@ -41,5 +41,4 @@ Sites take its content from markdown files in `/content`. Two of pages (`home` a
 
 Blog component loads all posts (during build!) and lists them out [How to load multiple md files](https://medium.com/@shawnstern/importing-multiple-markdown-files-into-a-react-component-with-webpack-7548559fce6f)
 
-Posts are separate static sites thanks to dynamically created export map. I took inspiration on how to do it from
-[here](https://medium.com/@joranquinten/for-my-own-website-i-used-next-js-725678e65b09)
+Updated to take advantange of the new `getStaticPaths` and `getStaticProps` data-fetching functions.

--- a/examples/with-netlify-cms/next.config.js
+++ b/examples/with-netlify-cms/next.config.js
@@ -1,31 +1,9 @@
-const fs = require('fs')
-const blogPostsFolder = './content/blogPosts'
-
-const getPathsForPosts = () =>
-  fs.readdirSync(blogPostsFolder).reduce((acc, blogName) => {
-    const trimmedName = blogName.substring(0, blogName.length - 3)
-    return Object.assign(acc, {
-      [`/blog/post/${trimmedName}`]: {
-        page: '/blog/post/[slug]',
-        query: {
-          slug: trimmedName,
-        },
-      },
-    })
-  }, {})
-
 module.exports = {
-  webpack: configuration => {
+  webpack: (configuration) => {
     configuration.module.rules.push({
       test: /\.md$/,
       use: 'frontmatter-markdown-loader',
     })
     return configuration
-  },
-  async exportPathMap(defaultPathMap) {
-    return {
-      ...defaultPathMap,
-      ...getPathsForPosts(),
-    }
   },
 }

--- a/examples/with-netlify-cms/next.config.js
+++ b/examples/with-netlify-cms/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  webpack: (configuration) => {
+  webpack: configuration => {
     configuration.module.rules.push({
       test: /\.md$/,
       use: 'frontmatter-markdown-loader',

--- a/examples/with-netlify-cms/pages/blog/index.js
+++ b/examples/with-netlify-cms/pages/blog/index.js
@@ -6,10 +6,10 @@ const importBlogPosts = async () => {
   const markdownFiles = require
     .context('../../content/blogPosts', false, /\.md$/)
     .keys()
-    .map(relativePath => relativePath.substring(2))
+    .map((relativePath) => relativePath.substring(2))
 
   return Promise.all(
-    markdownFiles.map(async path => {
+    markdownFiles.map(async (path) => {
       const markdown = await import(`../../content/blogPosts/${path}`)
       return { ...markdown, slug: path.substring(0, path.length - 3) }
     })
@@ -18,7 +18,7 @@ const importBlogPosts = async () => {
 
 const Blog = ({ postsList }) => (
   <Layout>
-    {postsList.map(post => (
+    {postsList.map((post) => (
       <div key={post.slug} className="post">
         <Link href="/blog/post/[slug]" as={`/blog/post/${post.slug}`}>
           <a>
@@ -40,9 +40,14 @@ const Blog = ({ postsList }) => (
   </Layout>
 )
 
-Blog.getInitialProps = async () => {
+export async function getStaticProps() {
   const postsList = await importBlogPosts()
-  return { postsList }
+
+  return {
+    props: {
+      postsList,
+    }, // will be passed to the page component as props
+  }
 }
 
 export default Blog

--- a/examples/with-netlify-cms/pages/blog/index.js
+++ b/examples/with-netlify-cms/pages/blog/index.js
@@ -6,10 +6,10 @@ const importBlogPosts = async () => {
   const markdownFiles = require
     .context('../../content/blogPosts', false, /\.md$/)
     .keys()
-    .map((relativePath) => relativePath.substring(2))
+    .map(relativePath => relativePath.substring(2))
 
   return Promise.all(
-    markdownFiles.map(async (path) => {
+    markdownFiles.map(async path => {
       const markdown = await import(`../../content/blogPosts/${path}`)
       return { ...markdown, slug: path.substring(0, path.length - 3) }
     })
@@ -18,7 +18,7 @@ const importBlogPosts = async () => {
 
 const Blog = ({ postsList }) => (
   <Layout>
-    {postsList.map((post) => (
+    {postsList.map(post => (
       <div key={post.slug} className="post">
         <Link href="/blog/post/[slug]" as={`/blog/post/${post.slug}`}>
           <a>

--- a/examples/with-netlify-cms/pages/blog/post/[slug].js
+++ b/examples/with-netlify-cms/pages/blog/post/[slug].js
@@ -1,9 +1,11 @@
+import fs from 'fs'
+import path from 'path'
 import Layout from '../../../components/layout'
 
 const Post = ({ blogpost }) => {
   if (!blogpost) return <div>not found</div>
 
-  const { html, attributes } = blogpost.default
+  const { html, attributes } = blogpost
 
   return (
     <Layout>
@@ -24,12 +26,34 @@ const Post = ({ blogpost }) => {
   )
 }
 
-Post.getInitialProps = async ({ query }) => {
-  const { slug } = query
+export async function getStaticPaths() {
+  const paths = fs
+    .readdirSync(path.join(process.cwd(), 'content/blogPosts'))
+    .map((blogName) => {
+      const trimmedName = blogName.substring(0, blogName.length - 3)
+      return {
+        params: { slug: trimmedName },
+      }
+    })
+
+  return {
+    paths,
+    fallback: false, // constrols wheter not predefined paths should be processed on demand, check for more info: https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const { slug } = params
+
   const blogpost = await import(`../../../content/blogPosts/${slug}.md`).catch(
     () => null
   )
-  return { blogpost }
+
+  return {
+    props: {
+      blogpost: blogpost.default,
+    },
+  }
 }
 
 export default Post

--- a/examples/with-netlify-cms/pages/blog/post/[slug].js
+++ b/examples/with-netlify-cms/pages/blog/post/[slug].js
@@ -29,7 +29,7 @@ const Post = ({ blogpost }) => {
 export async function getStaticPaths() {
   const paths = fs
     .readdirSync(path.join(process.cwd(), 'content/blogPosts'))
-    .map((blogName) => {
+    .map(blogName => {
       const trimmedName = blogName.substring(0, blogName.length - 3)
       return {
         params: { slug: trimmedName },


### PR DESCRIPTION
Adding getStaticPaths and getStaticProps to example, removing the need for using exported maps.