### PR TITLE
Run tsconfig paths resolver before PnP

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1014,7 +1014,7 @@ export default async function getBaseWebpackConfig(
   }
 
   if (jsConfig?.compilerOptions?.paths && resolvedBaseUrl) {
-    webpackConfig.resolve?.plugins?.push(
+    webpackConfig.resolve?.plugins?.unshift(
       new JsConfigPathsPlugin(jsConfig.compilerOptions.paths, resolvedBaseUrl)
     )
   }


### PR DESCRIPTION
Based on https://github.com/zeit/next.js/pull/11293#issuecomment-617745204

Not sure how to test PnP and couldn't figure out how to debug packages installed through PnP. We'll have to update this either way as PnP is going to be built into webpack 5 and that would change the order to be like this too.