### PR TITLE
Update Code of Conduct email address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [abuse@vercel.com](mailto:abuse@vercel.com). All
+reported by contacting the project team at [coc@vercel.com](mailto:coc@vercel.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Fixes the Code of Conduct so complaints can be sent to the appropriate email address.