### PR TITLE
Update TypeScript API routes tests

### DIFF
--- a/test/integration/typescript/test/index.test.js
+++ b/test/integration/typescript/test/index.test.js
@@ -55,6 +55,16 @@ describe('TypeScript Features', () => {
       expect(output).toContain('waiting for typecheck results...')
     })
 
+    it('should respond to sync API route correctly', async () => {
+      const data = JSON.parse(await renderViaHTTP(appPort, '/api/sync'))
+      expect(data).toEqual({ code: 'ok' })
+    })
+
+    it('should respond to async API route correctly', async () => {
+      const data = JSON.parse(await renderViaHTTP(appPort, '/api/async'))
+      expect(data).toEqual({ code: 'ok' })
+    })
+
     it('should not fail to render when an inactive page has an error', async () => {
       await killApp(app)
       let evilFile = join(appDir, 'pages', 'evil.tsx')
@@ -78,7 +88,7 @@ export default function EvilPage(): JSX.Element {
     })
   })
 
-  it('should compile the app', async () => {
+  it('should build the app', async () => {
     const output = await nextBuild(appDir, [], { stdout: true })
     expect(output.stdout).toMatch(/Compiled successfully/)
   })


### PR DESCRIPTION
This adds a couple additional tests from the below PR to ensure we handle TypeScript API routes correctly

x-ref: https://github.com/zeit/next.js/pull/11988