### PR TITLE
Update to match log style for new env loading

### DIFF
--- a/packages/next/lib/load-env-config.ts
+++ b/packages/next/lib/load-env-config.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import chalk from 'next/dist/compiled/chalk'
+import * as log from '../build/output/log'
 import findUp from 'next/dist/compiled/find-up'
 import dotenvExpand from 'next/dist/compiled/dotenv-expand'
 import dotenv, { DotenvConfigOutput } from 'next/dist/compiled/dotenv'
@@ -84,16 +84,13 @@ export function loadEnvConfig(dir: string, dev?: boolean): Env | false {
       result = dotenvExpand(result)
 
       if (result.parsed) {
-        console.log(`> ${chalk.cyan.bold('Info:')} Loaded env from ${envFile}`)
+        log.info(`Loaded env from ${envFile}`)
       }
 
       Object.assign(combinedEnv, result.parsed)
     } catch (err) {
       if (err.code !== 'ENOENT') {
-        console.error(
-          `> ${chalk.cyan.bold('Error: ')} Failed to load env from ${envFile}`,
-          err
-        )
+        log.error(`Failed to load env from ${envFile}`, err)
       }
     }
   }


### PR DESCRIPTION
This updates to match the log style we use elsewhere when logging when an env file is loaded with the new env support

<img width="927" alt="Screen Shot 2020-04-23 at 10 07 05" src="https://user-images.githubusercontent.com/22380829/80115456-619d6300-854a-11ea-9509-5d8f4ee26052.png">
