### PR TITLE
Added a link to the next.config.js docs for the with-env-next-config-js example

### DIFF
--- a/examples/with-env-from-next-config-js/README.md
+++ b/examples/with-env-from-next-config-js/README.md
@@ -10,6 +10,8 @@ As the build process (`next build`) is proceeding, `next.config.js` is processed
 in your react app, whatever is returned by `next.config.js` as the variable `env`, (or `env.RESTURL_SPEAKERS`) will be accessible in your
 app as `process.env.RESTURL_SPEAKERS`.
 
+View the docs on [`next.config.js`](https://nextjs.org/docs/api-reference/next.config.js/introduction) for more information.
+
 ## Deploy your own
 
 Deploy the example using [Vercel](https://vercel.com):


### PR DESCRIPTION
Added a link to the official [next.config.js](https://nextjs.org/docs/api-reference/next.config.js/introduction) docs to the `with-env-from-next-config-js` example README. :sparkles: 

I found both the docs and the example to be helpful! :hibiscus: 