### PR TITLE
Remove unnecessary export to make usage clearer.

### DIFF
--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -38,7 +38,7 @@ class Store {
   }
 }
 
-export function initializeStore(initialData = null) {
+function initializeStore(initialData = null) {
   const _store = store ?? new Store()
 
   // If your page has Next.js data fetching methods that use a Mobx store, it will


### PR DESCRIPTION
The method initializeStore is only being used locally by useStore.
By having this exported I initially thought the consumer would have to call this as setup globally and then call useStore as well for each consuming component.

Downloading the sample I saw it's only useStore that is being used by the consuming app and this could be made clear by not exporting initializeStore.