### PR TITLE
Add quotes to static paths in fallback section

### DIFF
--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -313,7 +313,7 @@ function Post({ post }) {
 export async function getStaticPaths() {
   return {
     // Only `/posts/1` and `/posts/2` are generated at build time
-    paths: [{ params: { id: 1 } }, { params: { id: 2 } }],
+    paths: [{ params: { id: '1' } }, { params: { id: '2' } }],
     // Enable statically generating additional pages
     // For example: `/posts/3`
     fallback: true,


### PR DESCRIPTION
getStaticPaths expects paths as strings.