### PR TITLE
Link to CLI doc from getting started doc / link to Telemetry doc from CLI doc

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -47,3 +47,10 @@ NODE_OPTIONS='--inspect' next
 - **First Load JS** – The number of assets downloaded when visiting the page from the server. The amount of JS shared by all is shown as a separate metric.
 
 The first load is colored green, yellow, or red. Aim for green for performant applications.
+
+## Telemetry
+
+Next.js collects **completely anonymous** telemetry data about general usage.
+Participation in this anonymous program is optional, and you may opt-out if you'd not like to share any information.
+
+To learn more about Telemetry, [please read this document](https://nextjs.org/telemetry/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,3 +97,10 @@ For more information on what to do next, we recommend the following sections:
     <small>Use the built-in CSS support to add custom styles to your app.</small>
   </a>
 </div>
+
+<div class="card">
+  <a href="/docs/api-reference/cli.md">
+    <b>Pages:</b>
+    <small>Learn more about the Next.js CLI.</small>
+  </a>
+</div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,7 +100,7 @@ For more information on what to do next, we recommend the following sections:
 
 <div class="card">
   <a href="/docs/api-reference/cli.md">
-    <b>Pages:</b>
+    <b>CLI:</b>
     <small>Learn more about the Next.js CLI.</small>
   </a>
 </div>


### PR DESCRIPTION
- Link to the [CLI doc](https://nextjs.org/docs/api-reference/cli) from the [getting started doc](https://nextjs.org/docs/getting-started)
- Link to the [telemetry doc](https://nextjs.org/telemetry/) from the [CLI doc](https://nextjs.org/docs/api-reference/cli)