### PR TITLE
Export NextApiRequest type as interface

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -175,7 +175,7 @@ export type DocumentProps = DocumentInitialProps & {
 /**
  * Next `API` route request
  */
-export type NextApiRequest = IncomingMessage & {
+export interface NextApiRequest extends IncomingMessage {
   /**
    * Object of `query` values from url
    */


### PR DESCRIPTION
This allows the consumers of the lib to do [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) with the `NextApiRequest` type, adding their own properties without overriding the original ones.

Fixes #12175 