### PR TITLE
Remove launched experimental options

### DIFF
--- a/examples/with-carbon-components/next.config.js
+++ b/examples/with-carbon-components/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  experimental: {
-    scss: true,
-  },
-}

--- a/packages/next/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/build/webpack/config/blocks/css/index.ts
@@ -232,10 +232,7 @@ export const css = curry(async function css(
     loader({
       oneOf: [
         {
-          test: [
-            regexCssGlobal,
-            (scssEnabled && regexSassGlobal) as RegExp,
-          ].filter(Boolean),
+          test: [regexCssGlobal, regexSassGlobal].filter(Boolean),
           use: {
             loader: 'error-loader',
             options: {

--- a/packages/next/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/build/webpack/config/blocks/css/index.ts
@@ -25,15 +25,9 @@ const regexSassGlobal = /(?<!\.module)\.(scss|sass)$/
 const regexSassModules = /\.module\.(scss|sass)$/
 
 export const css = curry(async function css(
-  enabled: boolean,
-  scssEnabled: boolean,
   ctx: ConfigurationContext,
   config: Configuration
 ) {
-  if (!enabled) {
-    return config
-  }
-
   const sassPreprocessors: webpack.RuleSetUseItem[] = [
     // First, process files with `sass-loader`: this inlines content, and
     // compiles away the proprietary syntax.
@@ -128,41 +122,36 @@ export const css = curry(async function css(
       ],
     })
   )
-  if (scssEnabled) {
-    fns.push(
-      loader({
-        oneOf: [
-          // Opt-in support for Sass (using .scss or .sass extensions).
-          {
-            // Sass Modules should never have side effects. This setting will
-            // allow unused Sass to be removed from the production build.
-            // We ensure this by disallowing `:global()` Sass at the top-level
-            // via the `pure` mode in `css-loader`.
-            sideEffects: false,
-            // Sass Modules are activated via this specific extension.
-            test: regexSassModules,
-            // Sass Modules are only supported in the user's application. We're
-            // not yet allowing Sass imports _within_ `node_modules`.
-            issuer: {
-              include: [ctx.rootDirectory],
-              exclude: /node_modules/,
-            },
-            use: getCssModuleLoader(ctx, postCssPlugins, sassPreprocessors),
+  fns.push(
+    loader({
+      oneOf: [
+        // Opt-in support for Sass (using .scss or .sass extensions).
+        {
+          // Sass Modules should never have side effects. This setting will
+          // allow unused Sass to be removed from the production build.
+          // We ensure this by disallowing `:global()` Sass at the top-level
+          // via the `pure` mode in `css-loader`.
+          sideEffects: false,
+          // Sass Modules are activated via this specific extension.
+          test: regexSassModules,
+          // Sass Modules are only supported in the user's application. We're
+          // not yet allowing Sass imports _within_ `node_modules`.
+          issuer: {
+            include: [ctx.rootDirectory],
+            exclude: /node_modules/,
           },
-        ],
-      })
-    )
-  }
+          use: getCssModuleLoader(ctx, postCssPlugins, sassPreprocessors),
+        },
+      ],
+    })
+  )
 
   // Throw an error for CSS Modules used outside their supported scope
   fns.push(
     loader({
       oneOf: [
         {
-          test: [
-            regexCssModules,
-            (scssEnabled && regexSassModules) as RegExp,
-          ].filter(Boolean),
+          test: [regexCssModules, regexSassModules].filter(Boolean),
           use: {
             loader: 'error-loader',
             options: {
@@ -179,10 +168,7 @@ export const css = curry(async function css(
       loader({
         oneOf: [
           {
-            test: [
-              regexCssGlobal,
-              (scssEnabled && regexSassGlobal) as RegExp,
-            ].filter(Boolean),
+            test: [regexCssGlobal, regexSassGlobal].filter(Boolean),
             use: require.resolve('next/dist/compiled/ignore-loader'),
           },
         ],
@@ -205,24 +191,22 @@ export const css = curry(async function css(
         ],
       })
     )
-    if (scssEnabled) {
-      fns.push(
-        loader({
-          oneOf: [
-            {
-              // A global Sass import always has side effects. Webpack will tree
-              // shake the Sass without this option if the issuer claims to have
-              // no side-effects.
-              // See https://github.com/webpack/webpack/issues/6571
-              sideEffects: true,
-              test: regexSassGlobal,
-              issuer: { include: ctx.customAppFile },
-              use: getGlobalCssLoader(ctx, postCssPlugins, sassPreprocessors),
-            },
-          ],
-        })
-      )
-    }
+    fns.push(
+      loader({
+        oneOf: [
+          {
+            // A global Sass import always has side effects. Webpack will tree
+            // shake the Sass without this option if the issuer claims to have
+            // no side-effects.
+            // See https://github.com/webpack/webpack/issues/6571
+            sideEffects: true,
+            test: regexSassGlobal,
+            issuer: { include: ctx.customAppFile },
+            use: getGlobalCssLoader(ctx, postCssPlugins, sassPreprocessors),
+          },
+        ],
+      })
+    )
   }
 
   // Throw an error for Global CSS used inside of `node_modules`
@@ -230,10 +214,7 @@ export const css = curry(async function css(
     loader({
       oneOf: [
         {
-          test: [
-            regexCssGlobal,
-            (scssEnabled && regexSassGlobal) as RegExp,
-          ].filter(Boolean),
+          test: [regexCssGlobal, regexSassGlobal].filter(Boolean),
           issuer: { include: [/node_modules/] },
           use: {
             loader: 'error-loader',

--- a/packages/next/build/webpack/config/index.ts
+++ b/packages/next/build/webpack/config/index.ts
@@ -10,8 +10,6 @@ export async function build(
     customAppFile,
     isDevelopment,
     isServer,
-    hasSupportCss,
-    hasSupportScss,
     assetPrefix,
     sassOptions,
   }: {
@@ -19,8 +17,6 @@ export async function build(
     customAppFile: string | null
     isDevelopment: boolean
     isServer: boolean
-    hasSupportCss: boolean
-    hasSupportScss: boolean
     assetPrefix: string
     sassOptions: any
   }
@@ -40,6 +36,6 @@ export async function build(
     sassOptions,
   }
 
-  const fn = pipe(base(ctx), css(hasSupportCss, hasSupportScss, ctx))
+  const fn = pipe(base(ctx), css(ctx))
   return fn(config)
 }

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -158,7 +158,6 @@ export type DocumentProps = DocumentInitialProps & {
   hybridAmp: boolean
   staticMarkup: boolean
   isDevelopment: boolean
-  hasCssMode: boolean
   devFiles: string[]
   files: string[]
   lowPriorityFiles: string[]

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -41,8 +41,6 @@ const defaultConfig: { [key: string]: any } = {
       (Number(process.env.CIRCLE_NODE_TOTAL) ||
         (os.cpus() || { length: 1 }).length) - 1
     ),
-    css: true,
-    scss: true,
     documentMiddleware: false,
     granularChunks: true,
     modern: false,
@@ -155,15 +153,6 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     )
   }
   if (result.experimental) {
-    if (result.experimental.css) {
-      // The new CSS support requires granular chunks be enabled.
-      if (result.experimental.granularChunks !== true) {
-        throw new Error(
-          `The new CSS support requires granular chunks be enabled.`
-        )
-      }
-    }
-
     if (typeof result.experimental.basePath !== 'string') {
       throw new Error(
         `Specified basePath is not a string, found type "${typeof result

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -119,7 +119,6 @@ export default class Server {
     assetPrefix?: string
     canonicalBase: string
     documentMiddlewareEnabled: boolean
-    hasCssMode: boolean
     dev?: boolean
     previewProps: __ApiPreviewProps
     customServer?: boolean
@@ -174,7 +173,6 @@ export default class Server {
       canonicalBase: this.nextConfig.amp.canonicalBase,
       documentMiddlewareEnabled: this.nextConfig.experimental
         .documentMiddleware,
-      hasCssMode: this.nextConfig.experimental.css,
       staticMarkup,
       buildId: this.buildId,
       generateEtags,

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -141,7 +141,6 @@ export type RenderOptsPartial = {
   canonicalBase: string
   runtimeConfig?: { [key: string]: any }
   assetPrefix?: string
-  hasCssMode: boolean
   err?: Error | null
   autoExport?: boolean
   nextExport?: boolean
@@ -180,7 +179,6 @@ function renderDocument(
     isFallback,
     dynamicImportsIds,
     dangerousAsPath,
-    hasCssMode,
     err,
     dev,
     ampPath,
@@ -258,7 +256,6 @@ function renderDocument(
           ampPath,
           inAmpMode,
           isDevelopment: !!dev,
-          hasCssMode,
           hybridAmp,
           staticMarkup,
           devFiles,

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -407,28 +407,27 @@ export class Head extends Component<
 
     return (
       <head {...this.props}>
-        {this.context._documentProps.isDevelopment &&
-          this.context._documentProps.hasCssMode && (
-            <>
+        {this.context._documentProps.isDevelopment && (
+          <>
+            <style
+              data-next-hide-fouc
+              data-ampdevmode={inAmpMode ? 'true' : undefined}
+              dangerouslySetInnerHTML={{
+                __html: `body{display:none}`,
+              }}
+            />
+            <noscript
+              data-next-hide-fouc
+              data-ampdevmode={inAmpMode ? 'true' : undefined}
+            >
               <style
-                data-next-hide-fouc
-                data-ampdevmode={inAmpMode ? 'true' : undefined}
                 dangerouslySetInnerHTML={{
-                  __html: `body{display:none}`,
+                  __html: `body{display:block}`,
                 }}
               />
-              <noscript
-                data-next-hide-fouc
-                data-ampdevmode={inAmpMode ? 'true' : undefined}
-              >
-                <style
-                  dangerouslySetInnerHTML={{
-                    __html: `body{display:block}`,
-                  }}
-                />
-              </noscript>
-            </>
-          )}
+            </noscript>
+          </>
+        )}
         {children}
         {head}
         <meta
@@ -526,13 +525,12 @@ export class Head extends Component<
             )}
             {!disableRuntimeJS && this.getPreloadDynamicChunks()}
             {!disableRuntimeJS && this.getPreloadMainLinks()}
-            {this.context._documentProps.isDevelopment &&
-              this.context._documentProps.hasCssMode && (
-                // this element is used to mount development styles so the
-                // ordering matches production
-                // (by default, style-loader injects at the bottom of <head />)
-                <noscript id="__next_css__DO_NOT_USE__" />
-              )}
+            {this.context._documentProps.isDevelopment && (
+              // this element is used to mount development styles so the
+              // ordering matches production
+              // (by default, style-loader injects at the bottom of <head />)
+              <noscript id="__next_css__DO_NOT_USE__" />
+            )}
             {styles || null}
           </>
         )}


### PR DESCRIPTION
These options have been launched and they're backwards compatible with the previous css/sass plugins (new behavior is disabled). So these options can be cleaned up.