### PR TITLE
Fix basePath not being applied for GS(S)P data routes

### DIFF
--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -3,6 +3,7 @@ import mitt from '../next-server/lib/mitt'
 import { isDynamicRoute } from './../next-server/lib/router/utils/is-dynamic'
 import { getRouteMatcher } from './../next-server/lib/router/utils/route-matcher'
 import { getRouteRegex } from './../next-server/lib/router/utils/route-regex'
+import { delBasePath } from './../next-server/lib/router/router'
 
 function hasRel(rel, link) {
   try {
@@ -96,10 +97,12 @@ export default class PageLoader {
    * @param {string} asPath the URL as shown in browser (virtual path); used for dynamic routes
    */
   getDataHref(href, asPath) {
-    const getHrefForSlug = (/** @type string */ path) =>
-      `${this.assetPrefix}/_next/data/${this.buildId}${
+    const getHrefForSlug = (/** @type string */ path) => {
+      path = delBasePath(path)
+      return `${this.assetPrefix}/_next/data/${this.buildId}${
         path === '/' ? '/index' : path
       }.json`
+    }
 
     const { pathname: hrefPathname, query } = parse(href, true)
     const { pathname: asPathname } = parse(asPath)

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -91,8 +91,8 @@ function fetchNextData(
   function getResponse(): Promise<any> {
     return fetch(
       formatWithValidation({
-        // @ts-ignore __NEXT_DATA__
         pathname: addBasePath(
+          // @ts-ignore __NEXT_DATA__
           `/_next/data/${__NEXT_DATA__.buildId}${delBasePath(pathname)}.json`
         ),
         query,

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -22,7 +22,7 @@ export function addBasePath(path: string): string {
   return path.indexOf(basePath) !== 0 ? basePath + path : path
 }
 
-function delBasePath(path: string): string {
+export function delBasePath(path: string): string {
   return path.indexOf(basePath) === 0
     ? path.substr(basePath.length) || '/'
     : path
@@ -758,7 +758,7 @@ export default class Router implements BaseRouter {
       }
       const route = delBasePath(toRoute(pathname))
       Promise.all([
-        this.pageLoader.prefetchData(route, delBasePath(asPath)),
+        this.pageLoader.prefetchData(url, delBasePath(asPath)),
         this.pageLoader[options.priority ? 'loadPage' : 'prefetch'](route),
       ]).then(() => resolve(), reject)
     })

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -92,7 +92,9 @@ function fetchNextData(
     return fetch(
       formatWithValidation({
         // @ts-ignore __NEXT_DATA__
-        pathname: `/_next/data/${__NEXT_DATA__.buildId}${pathname}.json`,
+        pathname: addBasePath(
+          `/_next/data/${__NEXT_DATA__.buildId}${delBasePath(pathname)}.json`
+        ),
         query,
       }),
       {
@@ -756,7 +758,7 @@ export default class Router implements BaseRouter {
       }
       const route = delBasePath(toRoute(pathname))
       Promise.all([
-        this.pageLoader.prefetchData(url, delBasePath(asPath)),
+        this.pageLoader.prefetchData(route, delBasePath(asPath)),
         this.pageLoader[options.priority ? 'loadPage' : 'prefetch'](route),
       ]).then(() => resolve(), reject)
     })

--- a/test/integration/basepath/pages/gsp.js
+++ b/test/integration/basepath/pages/gsp.js
@@ -1,0 +1,15 @@
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'world',
+      random: Math.random(),
+    },
+  }
+}
+
+export default props => (
+  <>
+    <h3 id="gsp">getStaticProps</h3>
+    <p id="props">{JSON.stringify(props)}</p>
+  </>
+)

--- a/test/integration/basepath/pages/gssp.js
+++ b/test/integration/basepath/pages/gssp.js
@@ -1,0 +1,15 @@
+export const getServerSideProps = () => {
+  return {
+    props: {
+      hello: 'world',
+      random: Math.random(),
+    },
+  }
+}
+
+export default props => (
+  <>
+    <h3 id="gssp">getServerSideProps</h3>
+    <p id="props">{JSON.stringify(props)}</p>
+  </>
+)

--- a/test/integration/basepath/pages/hello.js
+++ b/test/integration/basepath/pages/hello.js
@@ -8,6 +8,18 @@ export default () => (
         <h1>Hello World</h1>
       </a>
     </Link>
+    <br />
+    <Link href="/gsp">
+      <a id="gsp-link">
+        <h1>getStaticProps</h1>
+      </a>
+    </Link>
+    <br />
+    <Link href="/gssp">
+      <a id="gssp-link">
+        <h1>getServerSideProps</h1>
+      </a>
+    </Link>
     <div id="base-path">{useRouter().basePath}</div>
   </>
 )

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -50,6 +50,28 @@ const runTests = (context, dev = false) => {
     }
   })
 
+  it('should fetch data for getStaticProps without reloading', async () => {
+    const browser = await webdriver(context.appPort, '/docs/hello')
+    await browser.eval('window.beforeNavigate = true')
+    await browser.elementByCss('#gsp-link').click()
+    await browser.waitForElementByCss('#gsp')
+    expect(await browser.eval('window.beforeNavigate')).toBe(true)
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props.hello).toBe('world')
+  })
+
+  it('should fetch data for getServerSideProps without reloading', async () => {
+    const browser = await webdriver(context.appPort, '/docs/hello')
+    await browser.eval('window.beforeNavigate = true')
+    await browser.elementByCss('#gsp-link').click()
+    await browser.waitForElementByCss('#gsp')
+    expect(await browser.eval('window.beforeNavigate')).toBe(true)
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props.hello).toBe('world')
+  })
+
   it('should have correct href for a link', async () => {
     const browser = await webdriver(context.appPort, '/docs/hello')
     const href = await browser.elementByCss('a').getAttribute('href')


### PR DESCRIPTION
Per https://github.com/zeit/next.js/pull/9872#issuecomment-618931481 this updates `basePath` adding/removing for `getStaticProps` and `getServerSideProps` data routes. This also corrects the behavior during `next export` which was mentioned in the comment and adds additional tests to prevent regressing on this