### PR TITLE
Updated with-firebase-authentication to fix errors

### DIFF
--- a/examples/with-firebase-authentication/pages/index.js
+++ b/examples/with-firebase-authentication/pages/index.js
@@ -6,10 +6,14 @@ import 'isomorphic-unfetch'
 import clientCredentials from '../credentials/client'
 
 export async function getServerSideProps({ req, query }) {
-  const user = req && req.session ? req.session.decodedToken : null
+  const user =
+    req.session && req.session.decodedToken ? req.session.decodedToken : null
   // don't fetch anything from firebase if the user is not found
-  // const snap = user && await req.firebaseServer.database().ref('messages').once('value')
-  // const messages = snap && snap.val()
+  // const snapshot = user && (await req.firebaseServer.firestore().collection('messages').get())
+  // let messages = []
+  // snapshot.forEach(function(doc) {
+  //   messages.push(doc.data())
+  // });
   const messages = null
   return {
     props: {

--- a/examples/with-firebase-authentication/server.js
+++ b/examples/with-firebase-authentication/server.js
@@ -13,6 +13,7 @@ const handle = app.getRequestHandler()
 const firebase = admin.initializeApp(
   {
     credential: admin.credential.cert(require('./credentials/server')),
+    // databaseURL: "https://<YOUR_PROJECT>.firebaseio.com",
   },
   'server'
 )


### PR DESCRIPTION
Related to #12139 

In this PR
- Fixed error where serializing `.user` is causing an `undefined` error.
- Updated to use `firestore` collection methods instead of `realtime database` methods.