### PR TITLE
Docs: Add req.body to custom express server example

### DIFF
--- a/examples/custom-server-express/README.md
+++ b/examples/custom-server-express/README.md
@@ -36,3 +36,22 @@ npm run dev
 yarn
 yarn dev
 ```
+
+### Populate body property
+Without the use of the body-parser package `req.body` will return undefined. To get express to populate `req.body` you need to install the body parser package and call the package within server.js.
+
+Install the package:
+```bash
+npm install body-parser
+```
+
+Use the package within server.js:
+```bash
+const bodyParser = require('body-parser');
+
+app.prepare().then(() => {
+  const server = express();
+  server.use(bodyParser.urlencoded({ extended: true }))
+  server.use(bodyParser.json())
+})
+```

--- a/examples/custom-server-express/README.md
+++ b/examples/custom-server-express/README.md
@@ -38,14 +38,17 @@ yarn dev
 ```
 
 ### Populate body property
+
 Without the use of the body-parser package `req.body` will return undefined. To get express to populate `req.body` you need to install the body parser package and call the package within server.js.
 
 Install the package:
+
 ```bash
 npm install body-parser
 ```
 
 Use the package within server.js:
+
 ```bash
 const bodyParser = require('body-parser');
 


### PR DESCRIPTION
On my personal project I use the custom express server.js and I noticed that by default `req.body` returns undefined unless you use bodyParser. This was not mentioned anywhere in the docs or in the custom-express-server example file.

I decided it would be better to add to the readme rather than to the server.js file as not all users may want to use it.