### PR TITLE
[example-with-fela] CSS imports compatibility

### DIFF
--- a/examples/with-fela/package.json
+++ b/examples/with-fela/package.json
@@ -7,12 +7,12 @@
     "start": "next start"
   },
   "dependencies": {
-    "fela": "^10.2.4",
-    "fela-dom": "^10.2.4",
-    "fela-preset-web": "^10.2.4",
+    "fela": "latest",
+    "fela-dom": "latest",
+    "fela-preset-web": "latest",
     "next": "latest",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-fela": "^10.2.4"
+    "react": "latest",
+    "react-dom": "latest",
+    "react-fela": "latest"
   }
 }

--- a/examples/with-fela/pages/_document.js
+++ b/examples/with-fela/pages/_document.js
@@ -17,7 +17,10 @@ export default class MyDocument extends Document {
     const styles = renderToNodeList(renderer)
     return {
       ...initialProps,
-      styles,
+      styles: [
+        ...initialProps.styles,
+        styles
+      ]
     }
   }
 

--- a/examples/with-fela/pages/_document.js
+++ b/examples/with-fela/pages/_document.js
@@ -1,5 +1,6 @@
-import Document, { Head, Main, NextScript } from 'next/document'
-import { renderToSheetList } from 'fela-dom'
+import Document, { Main, NextScript } from 'next/document'
+import { renderToNodeList } from 'react-fela'
+
 import getFelaRenderer from '../getFelaRenderer'
 
 export default class MyDocument extends Document {
@@ -13,31 +14,16 @@ export default class MyDocument extends Document {
       })
 
     const initialProps = await Document.getInitialProps(ctx)
-    const sheetList = renderToSheetList(renderer)
+    const styles = renderToNodeList(renderer)
     return {
       ...initialProps,
-      sheetList,
+      styles,
     }
   }
 
   render() {
-    const styleNodes = this.props.sheetList.map(
-      ({ type, rehydration, support, media, css }) => (
-        <style
-          dangerouslySetInnerHTML={{ __html: css }}
-          data-fela-id=""
-          data-fela-rehydration={rehydration}
-          data-fela-support={support}
-          data-fela-type={type}
-          key={`${type}-${media}`}
-          media={media}
-        />
-      )
-    )
-
     return (
       <html>
-        <Head>{styleNodes}</Head>
         <body>
           <Main />
           <NextScript />

--- a/examples/with-fela/pages/_document.js
+++ b/examples/with-fela/pages/_document.js
@@ -19,7 +19,7 @@ export default class MyDocument extends Document {
       ...initialProps,
       styles: [
         ...initialProps.styles,
-        styles
+        ...styles
       ]
     }
   }

--- a/examples/with-fela/pages/_document.js
+++ b/examples/with-fela/pages/_document.js
@@ -17,10 +17,7 @@ export default class MyDocument extends Document {
     const styles = renderToNodeList(renderer)
     return {
       ...initialProps,
-      styles: [
-        ...initialProps.styles,
-        ...styles
-      ]
+      styles: [...initialProps.styles, ...styles],
     }
   }
 


### PR DESCRIPTION
This PR updates the Fela example adding CSS imports compatibility (style nodes order etc.)
It also bumps all fela versions to `latest` making sure we always get the newest versions.