### PR TITLE
Fix ncc'd version of terser not being used by terser webpack plugin

### DIFF
--- a/packages/next/compiled/terser-webpack-plugin/worker.js
+++ b/packages/next/compiled/terser-webpack-plugin/worker.js
@@ -1,8 +1,8 @@
-"use strict";
+
 
 const {
   minify: terserMinify
-} = require('terser');
+} = require("next/dist/compiled/terser");
 
 const buildTerserOptions = ({
   ecma,

--- a/packages/next/compiled/terser-webpack-plugin/worker.js
+++ b/packages/next/compiled/terser-webpack-plugin/worker.js
@@ -1,4 +1,4 @@
-
+"use strict";
 
 const {
   minify: terserMinify

--- a/packages/next/taskfile-ncc.js
+++ b/packages/next/taskfile-ncc.js
@@ -14,13 +14,26 @@ module.exports = function(task) {
       minify: true,
       ...options,
     }).then(({ code, assets }) => {
-      Object.keys(assets).forEach(key =>
+      Object.keys(assets).forEach(key => {
+        let data = assets[key].source
+
+        if (join(file.dir, key).endsWith('terser-webpack-plugin/worker.js')) {
+          data = Buffer.from(
+            data
+              .toString()
+              .replace(
+                `require('terser')`,
+                `require("${options.externals['terser']}")`
+              )
+          )
+        }
+
         this._.files.push({
-          dir: join(file.dir, dirname(key)),
+          data,
           base: basename(key),
-          data: assets[key].source,
+          dir: join(file.dir, dirname(key)),
         })
-      )
+      })
 
       if (options && options.packageName) {
         writePackageManifest.call(this, options.packageName, file.base)


### PR DESCRIPTION
This makes sure that the `terser` require in `terser-webpack-plugin`'s `worker.js` asset file gets updated to the correct `externals` output path so that our ncc'd version of `terser` is used and not the closest installed version

x-ref: https://github.com/zeit/next.js/pull/12178 