### PR TITLE
Enable NEXT_PUBLIC_ env var support

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -50,7 +50,7 @@ const defaultConfig: { [key: string]: any } = {
     workerThreads: false,
     basePath: '',
     sassOptions: {},
-    pageEnv: false,
+    pageEnv: true,
     measureFid: false,
     reactRefresh: false,
   },

--- a/test/integration/process-env-stub/next.config.js
+++ b/test/integration/process-env-stub/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    pageEnv: true,
-  },
-}
+module.exports = {}


### PR DESCRIPTION
Last part needed for https://github.com/zeit/next.js/discussions/11106. This enables inlining of `NEXT_PUBLIC_` prefixed environment variables at build time.