### PR TITLE
Update with-tailwindcss to use Tailwind CSS v1.4.0's new built-in purge option

### DIFF
--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -43,13 +43,8 @@ Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&ut
 
 ## Notes
 
-This setup is a basic starting point for using [Tailwind CSS](https://tailwindcss.com) with Next.js. This example also includes the following [PostCSS](https://github.com/postcss/postcss) plugins:
+This example is a basic starting point for using [Tailwind CSS](https://tailwindcss.com) with Next.js. It includes the following [PostCSS](https://github.com/postcss/postcss) plugins:
 
 - [postcss-preset-env](https://preset-env.cssdb.org/) - Adds stage 2+ features and autoprefixes
-- [purgecss](https://github.com/FullHuman/purgecss) - Removes unused CSS
 
-## Limitations
-
-### Dynamically generated class strings will be purged
-
-Purgecss takes a very straightforward approach to removing unused CSS. It simply searches an entire file for a string that matches a regular expression. As a result, class strings that are dynamically created in a template using string concatenation will be considered unused and removed from your stylesheet. Tailwind CSS addresses this problem in more detail in [their documentation](https://tailwindcss.com/docs/controlling-file-size#writing-purgeable-html).
+To control the generated stylesheet's filesize, this example uses Tailwind CSS' [`purge` option](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css) to removed unused CSS.

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -47,4 +47,4 @@ This example is a basic starting point for using [Tailwind CSS](https://tailwind
 
 - [postcss-preset-env](https://preset-env.cssdb.org/) - Adds stage 2+ features and autoprefixes
 
-To control the generated stylesheet's filesize, this example uses Tailwind CSS' [`purge` option](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css) to removed unused CSS.
+To control the generated stylesheet's filesize, this example uses Tailwind CSS' [`purge` option](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css) to remove unused CSS.

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -12,8 +12,7 @@
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^1.3.0",
     "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.1.4"
+    "tailwindcss": "^1.4.0"
   }
 }

--- a/examples/with-tailwindcss/postcss.config.js
+++ b/examples/with-tailwindcss/postcss.config.js
@@ -1,21 +1,3 @@
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    ...(process.env.NODE_ENV === 'production'
-      ? [
-          [
-            '@fullhuman/postcss-purgecss',
-            {
-              content: [
-                './pages/**/*.{js,jsx,ts,tsx}',
-                './components/**/*.{js,jsx,ts,tsx}',
-              ],
-              defaultExtractor: content =>
-                content.match(/[\w-/:]+(?<!:)/g) || [],
-            },
-          ],
-        ]
-      : []),
-    'postcss-preset-env',
-  ],
+  plugins: ['tailwindcss', 'postcss-preset-env'],
 }

--- a/examples/with-tailwindcss/styles/index.css
+++ b/examples/with-tailwindcss/styles/index.css
@@ -1,9 +1,7 @@
 @import './button.css';
 
-/* purgecss start ignore */
 @tailwind base;
 @tailwind components;
-/* purgecss end ignore */
 @tailwind utilities;
 
 .hero {

--- a/examples/with-tailwindcss/tailwind.config.js
+++ b/examples/with-tailwindcss/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  purge: ['./components/**/*.js', './pages/**/*.js'],
+  theme: {
+    extend: {},
+  },
+  variants: {},
+  plugins: [],
+}


### PR DESCRIPTION
As of [v1.4.0](https://github.com/tailwindcss/tailwindcss/releases/tag/v1.4.0), Tailwind CSS integrates PurgeCSS directly.

This PR:
- Removes `@fullhuman/postcss-purgecss` as a dependency and its usage
- Updates the `tailwindcss` version to `1.4.0`
- Removes unneeded `purgecss ignore` comments
- Add a `tailwind.config.js` file that utilizes the new `purge` option
- Updates the `README` to note that we're using the `purge` option