### PR TITLE
Polyfill fetch by default

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -139,6 +139,11 @@ const nextServerlessLoader: loader.Loader = function() {
     return `
       import initServer from 'next-plugin-loader?middleware=on-init-server!'
       import onError from 'next-plugin-loader?middleware=on-error-server!'
+      import fetch from 'next/dist/compiled/node-fetch'
+    
+      if(!global.fetch) {
+        global.fetch = fetch
+      }
       ${runtimeConfigImports}
       ${
         /*
@@ -203,6 +208,11 @@ const nextServerlessLoader: loader.Loader = function() {
     return `
     import initServer from 'next-plugin-loader?middleware=on-init-server!'
     import onError from 'next-plugin-loader?middleware=on-error-server!'
+    import fetch from 'next/dist/compiled/node-fetch'
+    
+    if(!global.fetch) {
+      global.fetch = fetch
+    }
     ${runtimeConfigImports}
     ${
       // this needs to be called first so its available for any other imports

--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -10,6 +10,14 @@ import { getRouteMatcher } from '../next-server/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../next-server/lib/router/utils/route-regex'
 import { normalizePagePath } from '../next-server/server/normalize-page-path'
 import { SERVER_PROPS_EXPORT_ERROR } from '../lib/constants'
+import fetch from 'next/dist/compiled/node-fetch'
+
+// @ts-ignore fetch exists globally
+if (!global.fetch) {
+  // Polyfill fetch() in the Node.js environment
+  // @ts-ignore fetch exists globally
+  global.fetch = fetch
+}
 
 const envConfig = require('../next-server/lib/runtime-config')
 const writeFileP = promisify(writeFile)

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -65,6 +65,14 @@ import { execOnce } from '../lib/utils'
 import { isBlockedPage } from './utils'
 import { compile as compilePathToRegex } from 'next/dist/compiled/path-to-regexp'
 import { loadEnvConfig } from '../../lib/load-env-config'
+import fetch from 'next/dist/compiled/node-fetch'
+
+// @ts-ignore fetch exists globally
+if (!global.fetch) {
+  // Polyfill fetch() in the Node.js environment
+  // @ts-ignore fetch exists globally
+  global.fetch = fetch
+}
 
 const getCustomRouteMatcher = pathMatch(true)
 

--- a/packages/next/server/static-paths-worker.ts
+++ b/packages/next/server/static-paths-worker.ts
@@ -1,5 +1,13 @@
 import { buildStaticPaths } from '../build/utils'
 import { loadComponents } from '../next-server/server/load-components'
+import fetch from 'next/dist/compiled/node-fetch'
+
+// @ts-ignore fetch exists globally
+if (!global.fetch) {
+  // Polyfill fetch() in the Node.js environment
+  // @ts-ignore fetch exists globally
+  global.fetch = fetch
+}
 
 let workerWasUsed = false
 

--- a/test/integration/fetch-polyfill/api-server.js
+++ b/test/integration/fetch-polyfill/api-server.js
@@ -1,0 +1,14 @@
+const http = require('http')
+const port = process.env.PORT || 3000
+
+const server = new http.Server(async (req, res) => {
+  res.end(JSON.stringify({ foo: 'bar' }))
+})
+
+server.listen(port, err => {
+  if (err) {
+    throw err
+  }
+
+  console.log(`> Ready on http://localhost:${port}`)
+})

--- a/test/integration/fetch-polyfill/pages/getinitialprops.js
+++ b/test/integration/fetch-polyfill/pages/getinitialprops.js
@@ -1,0 +1,12 @@
+export default function SSRPageWithGetInitialProps({ data }) {
+  return <div>{data.foo}</div>
+}
+
+SSRPageWithGetInitialProps.getInitialProps = async () => {
+  const port = process.env.NEXT_PUBLIC_API_PORT
+  const res = await fetch(`http://localhost:${port}/`)
+  const json = await res.json()
+  return {
+    data: json,
+  }
+}

--- a/test/integration/fetch-polyfill/pages/ssr.js
+++ b/test/integration/fetch-polyfill/pages/ssr.js
@@ -1,0 +1,14 @@
+export default function SSRPage({ data }) {
+  return <div>{data.foo}</div>
+}
+
+export async function getServerSideProps() {
+  const port = process.env.NEXT_PUBLIC_API_PORT
+  const res = await fetch(`http://localhost:${port}/`)
+  const json = await res.json()
+  return {
+    props: {
+      data: json,
+    },
+  }
+}

--- a/test/integration/fetch-polyfill/pages/static.js
+++ b/test/integration/fetch-polyfill/pages/static.js
@@ -1,0 +1,14 @@
+export default function StaticPage({ data }) {
+  return <div>{data.foo}</div>
+}
+
+export async function getStaticProps() {
+  const port = process.env.NEXT_PUBLIC_API_PORT
+  const res = await fetch(`http://localhost:${port}/`)
+  const json = await res.json()
+  return {
+    props: {
+      data: json,
+    },
+  }
+}

--- a/test/integration/fetch-polyfill/serverless-server.js
+++ b/test/integration/fetch-polyfill/serverless-server.js
@@ -1,0 +1,34 @@
+const path = require('path')
+const http = require('http')
+const send = require('send')
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/ssr') {
+    return require('./.next/serverless/pages/ssr.js').render(req, res)
+  }
+
+  if (req.url === '/getinitialprops') {
+    return require('./.next/serverless/pages/getinitialprops.js').render(
+      req,
+      res
+    )
+  }
+
+  if (req.url === '/static') {
+    return send(
+      req,
+      path.join(__dirname, '.next/serverless/pages/static.html')
+    ).pipe(res)
+  }
+
+  if (req.url.startsWith('/_next')) {
+    send(
+      req,
+      path.join(__dirname, '.next', req.url.split('/_next').pop())
+    ).pipe(res)
+  }
+})
+
+server.listen(process.env.PORT, () => {
+  console.log('ready on', process.env.PORT)
+})

--- a/test/integration/fetch-polyfill/test/index.test.js
+++ b/test/integration/fetch-polyfill/test/index.test.js
@@ -1,0 +1,138 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  killApp,
+  findPort,
+  launchApp,
+  initNextServerScript,
+  renderViaHTTP,
+  nextBuild,
+  nextStart,
+} from 'next-test-utils'
+import clone from 'clone'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '../')
+const nextConfig = join(appDir, 'next.config.js')
+let appPort
+let app
+let apiServerPort
+let apiServer
+
+const startApiServer = async (optEnv = {}, opts) => {
+  const scriptPath = join(appDir, 'api-server.js')
+  apiServerPort = await findPort()
+  const env = Object.assign(
+    {},
+    clone(process.env),
+    { PORT: `${apiServerPort}` },
+    optEnv
+  )
+
+  apiServer = await initNextServerScript(
+    scriptPath,
+    /ready on/i,
+    env,
+    /ReferenceError: options is not defined/,
+    opts
+  )
+}
+
+const startServerlessServer = async (optEnv = {}, opts) => {
+  const scriptPath = join(appDir, 'serverless-server.js')
+  appPort = await findPort()
+  const env = Object.assign(
+    {},
+    clone(process.env),
+    { PORT: `${appPort}` },
+    optEnv
+  )
+
+  return await initNextServerScript(
+    scriptPath,
+    /ready on/i,
+    env,
+    /ReferenceError: options is not defined/,
+    opts
+  )
+}
+
+function runTests() {
+  it('includes polyfilled fetch when using getStaticProps', async () => {
+    const html = await renderViaHTTP(appPort, '/static')
+    expect(html).toMatch(/bar/)
+  })
+  it('includes polyfilled fetch when using getServerSideProps', async () => {
+    const html = await renderViaHTTP(appPort, '/ssr')
+    expect(html).toMatch(/bar/)
+  })
+  it('includes polyfilled fetch when using getInitialProps', async () => {
+    const html = await renderViaHTTP(appPort, '/getinitialprops')
+    expect(html).toMatch(/bar/)
+  })
+}
+
+describe('API routes', () => {
+  describe('dev support', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      await startApiServer()
+      app = await launchApp(appDir, appPort, {
+        env: {
+          NEXT_PUBLIC_API_PORT: apiServerPort,
+        },
+      })
+    })
+    afterAll(async () => {
+      await killApp(app)
+      await killApp(apiServer)
+    })
+
+    runTests()
+  })
+
+  describe('Server support', () => {
+    beforeAll(async () => {
+      await startApiServer()
+      await nextBuild(appDir, [], {
+        env: {
+          NEXT_PUBLIC_API_PORT: apiServerPort,
+        },
+      })
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(async () => {
+      await killApp(app)
+      await killApp(apiServer)
+    })
+
+    runTests()
+  })
+
+  describe('Serverless support', () => {
+    beforeAll(async () => {
+      await fs.writeFile(
+        nextConfig,
+        `module.exports = { target: 'serverless' }`
+      )
+      await startApiServer()
+      await nextBuild(appDir, [], {
+        env: {
+          NEXT_PUBLIC_API_PORT: apiServerPort,
+        },
+      })
+      appPort = await findPort()
+      app = await startServerlessServer()
+    })
+    afterAll(async () => {
+      await killApp(app)
+      await fs.remove(nextConfig)
+      await killApp(apiServer)
+    })
+
+    runTests()
+  })
+})


### PR DESCRIPTION
We already polyfilled fetch client-side in older browsers. This adds a similar polyfilling behavior to the Node.js side of things to ensure `fetch` can be used without any imports needed.

Previously users would need to import `isomorphic-fetch` or `isomorphic-unfetch`, this won't be needed once this has landed.