### PR TITLE
Upgrade `source-map` package

### DIFF
--- a/packages/react-dev-overlay/package.json
+++ b/packages/react-dev-overlay/package.json
@@ -19,7 +19,7 @@
     "@babel/code-frame": "7.8.3",
     "anser": "1.4.9",
     "classnames": "2.2.6",
-    "source-map": "0.7.3",
+    "source-map": "0.8.0-beta.0",
     "stacktrace-parser": "0.1.9",
     "strip-ansi": "6.0.0"
   },

--- a/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
@@ -44,7 +44,10 @@ export function getOriginalStackFrame(
     }
 
     const controller = new AbortController()
-    const tm = setTimeout(() => controller.abort(), 3000)
+    const tm = setTimeout(
+      () => controller.abort(),
+      process.env.__NEXT_TEST_MODE ? 10000 : 3000
+    )
     const res = await self
       .fetch(`/__nextjs_original-stack-frame?${params.toString()}`, {
         signal: controller.signal,

--- a/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
@@ -44,10 +44,7 @@ export function getOriginalStackFrame(
     }
 
     const controller = new AbortController()
-    const tm = setTimeout(
-      () => controller.abort(),
-      process.env.__NEXT_TEST_MODE ? 10000 : 3000
-    )
+    const tm = setTimeout(() => controller.abort(), 3000)
     const res = await self
       .fetch(`/__nextjs_original-stack-frame?${params.toString()}`, {
         signal: controller.signal,

--- a/packages/react-dev-overlay/src/middleware.ts
+++ b/packages/react-dev-overlay/src/middleware.ts
@@ -74,6 +74,7 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
           })
           consumer.destroy()
         } catch (err) {
+          console.log('Failed to parse source map:', err)
           res.statusCode = 500
           res.write('Internal Server Error')
           return res.end()

--- a/packages/react-refresh-utils/internal/helpers.ts
+++ b/packages/react-refresh-utils/internal/helpers.ts
@@ -135,7 +135,15 @@ function scheduleUpdate() {
 
     // Only trigger refresh if the webpack HMR state is idle
     if (canApplyUpdate()) {
-      return RefreshRuntime.performReactRefresh()
+      try {
+        RefreshRuntime.performReactRefresh()
+      } catch (err) {
+        console.warn(
+          'Warning: Failed to re-render. We will retry on the next Fast Refresh event.\n' +
+            err
+        )
+      }
+      return
     }
 
     return scheduleUpdate()

--- a/test/acceptance/ReactRefresh.test.js
+++ b/test/acceptance/ReactRefresh.test.js
@@ -272,7 +272,7 @@ test('cyclic dependencies', async () => {
   await cleanup()
 })
 
-test('logbox: can recover from a event handler error', async () => {
+test.skip('logbox: can recover from a event handler error', async () => {
   const [session, cleanup] = await sandbox()
 
   await session.patch(
@@ -350,7 +350,7 @@ test('logbox: can recover from a event handler error', async () => {
   await cleanup()
 })
 
-test('logbox: can recover from a component error', async () => {
+test.skip('logbox: can recover from a component error', async () => {
   const [session, cleanup] = await sandbox()
 
   await session.write(

--- a/test/acceptance/ReactRefresh.test.js
+++ b/test/acceptance/ReactRefresh.test.js
@@ -272,7 +272,7 @@ test('cyclic dependencies', async () => {
   await cleanup()
 })
 
-test.skip('logbox: can recover from a event handler error', async () => {
+test('logbox: can recover from a event handler error', async () => {
   const [session, cleanup] = await sandbox()
 
   await session.patch(
@@ -350,7 +350,7 @@ test.skip('logbox: can recover from a event handler error', async () => {
   await cleanup()
 })
 
-test.skip('logbox: can recover from a component error', async () => {
+test('logbox: can recover from a component error', async () => {
   const [session, cleanup] = await sandbox()
 
   await session.write(

--- a/yarn.lock
+++ b/yarn.lock
@@ -15244,6 +15244,13 @@ source-map@0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
+source-map@0.8.0-beta.0:
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
+  integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
+  dependencies:
+    whatwg-url "^7.0.0"
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"


### PR DESCRIPTION
`source-map` breaks in Node.js when `global.fetch` is defined. This was fixed in the beta.