### PR TITLE
[Fast Refresh] Skip Environment Check

### DIFF
--- a/packages/next/build/webpack/loaders/next-babel-loader.js
+++ b/packages/next/build/webpack/loaders/next-babel-loader.js
@@ -141,7 +141,7 @@ module.exports = babelLoader.custom(babel => {
 
       if (hasReactRefresh) {
         const reactRefreshPlugin = babel.createConfigItem(
-          [require('react-refresh/babel')],
+          [require('react-refresh/babel'), { skipEnvCheck: true }],
           { type: 'plugin' }
         )
         options.plugins.unshift(reactRefreshPlugin)


### PR DESCRIPTION
Projects that have a misconfigured `NODE_ENV` will fail to run in development when using the Fast Refresh experiment.

Next.js already handles ensuring this plugin is only enabled in development, so it's safe to disable the check.

While the proper behavior here **is to fail**, we can't for backwards compatibility.
We're going to add a console warning to tell users that they shouldn't be configuring `NODE_ENV` in their applications.