### PR TITLE
Add documentation for TypeScript baseUrl and paths option

### DIFF
--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -2,7 +2,7 @@
 description: Configure module path aliases that allow you to remap certain import paths.
 ---
 
-## Module path aliases and baseUrl
+## Absolute Imports and Module path aliases
 
 Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options.
 

--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -1,0 +1,86 @@
+---
+description: Configure module path aliases that allow you to remap certain import paths.
+---
+
+## Module path aliases and baseUrl
+
+Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options.
+
+> Note: `jsconfig.json` can be used when you don't use TypeScript
+
+These option allow you to configure module aliases, for example a common pattern is aliasing certain directories to use absolute paths.
+
+One useful feature of these options is that they integrate automatically into certain editors, for example vscode.
+
+The `baseUrl` configuration option allows you to import directly from the root of the project.
+
+An example of this configuration:
+
+```json
+// tsconfig.json or jsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}
+```
+
+```jsx
+// components/button.js
+export default function Button() {
+  return <button>Click me</button>
+}
+```
+
+```jsx
+// pages/index.js
+import Button from 'components/button'
+
+export default function HomePage() {
+  return (
+    <>
+      <h1>Hello World</h1>
+      <Button />
+    </>
+  )
+}
+```
+
+While `baseUrl` is useful you might want to add other aliases that don't match 1 on 1. For this TypeScript has the `"paths"` option.
+
+Using `"paths"` allows you to configure module aliases. For example `@components/*` to `components/*`.
+
+An example of this configuration:
+
+```json
+// tsconfig.json or jsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["components/*"]
+    }
+  }
+}
+```
+
+```jsx
+// components/button.js
+export default function Button() {
+  return <button>Click me</button>
+}
+```
+
+```jsx
+// pages/index.js
+import Button from '@components/button'
+
+export default function HomePage() {
+  return (
+    <>
+      <h1>Hello World</h1>
+      <Button />
+    </>
+  )
+}
+```

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -108,3 +108,9 @@ function MyApp({ Component, pageProps }: AppProps) {
 
 export default MyApp
 ```
+
+## Path aliases and baseUrl
+
+Next.js automatically supports the `tsconfig.json` `"paths"` and `"baseUrl"` options.
+
+You can learn more about this feature on the [Module Path aliases documentation](/docs/advanced-features/module-path-aliases.md).

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -97,6 +97,10 @@
               "path": "/docs/advanced-features/static-html-export.md"
             },
             {
+              "title": "Module Path Aliases",
+              "path": "/docs/advanced-features/module-path-aliases.md"
+            },
+            {
               "title": "AMP Support",
               "routes": [
                 {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -97,7 +97,7 @@
               "path": "/docs/advanced-features/static-html-export.md"
             },
             {
-              "title": "Module Path Aliases",
+              "title": "Absolute Imports and Module Path Aliases",
               "path": "/docs/advanced-features/module-path-aliases.md"
             },
             {


### PR DESCRIPTION
Adds the documentation for `"paths"` and `"baseUrl"` in `tsconfig.json`/`jsconfig.json` which has landed in the latest stable version of Next.js.