### PR TITLE
gitignore graphql-let generated .d.ts files

### DIFF
--- a/examples/with-typescript-graphql/.gitignore
+++ b/examples/with-typescript-graphql/.gitignore
@@ -1,3 +1,5 @@
 .next
 node_modules
 __generated__
+*.graphql.d.ts
+*.graphqls.d.ts


### PR DESCRIPTION
Gitignore graphql-let generated files, which are in the same folder of .graphql files as the documentation says: https://github.com/piglovesyou/graphql-let#gitignore