### PR TITLE
Add docs for next dev and next start

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -48,6 +48,26 @@ NODE_OPTIONS='--inspect' next
 
 The first load is colored green, yellow, or red. Aim for green for performant applications.
 
+## Development
+
+`next dev` starts the application in development mode with hot-code reloading, error reporting, and more:
+
+The application will start at `http://localhost:3000` by default. The default port can be changed with `-p`, like so:
+
+```bash
+npx next dev -p 4000
+```
+
+## Production
+
+`next start` starts the application in production mode. The application should be compiled with [`next build`](#build) first.
+
+The application will start at `http://localhost:3000` by default. The default port can be changed with `-p`, like so:
+
+```bash
+npx next start -p 4000
+```
+
 ## Telemetry
 
 Next.js collects **completely anonymous** telemetry data about general usage.


### PR DESCRIPTION
As requested by @Timer, the main focus is to add more info about the usage of a custom port