### PR TITLE
Remove __NEXT_DATA__ from production builds when runtime JS is disabled

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -681,7 +681,6 @@ export class NextScript extends Component<OriginProps> {
         CLIENT_STATIC_FILES_RUNTIME_WEBPACK,
       ]
 
-      console.log('disabled:', disableRuntimeJS)
       return (
         <>
           {staticMarkup || disableRuntimeJS ? null : (

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -681,9 +681,10 @@ export class NextScript extends Component<OriginProps> {
         CLIENT_STATIC_FILES_RUNTIME_WEBPACK,
       ]
 
+      console.log('disabled:', disableRuntimeJS)
       return (
         <>
-          {staticMarkup ? null : (
+          {staticMarkup || disableRuntimeJS ? null : (
             <script
               id="__NEXT_DATA__"
               type="application/json"
@@ -803,7 +804,7 @@ export class NextScript extends Component<OriginProps> {
                 )
             )
           : null}
-        {staticMarkup ? null : (
+        {staticMarkup || disableRuntimeJS ? null : (
           <script
             id="__NEXT_DATA__"
             type="application/json"

--- a/test/integration/disable-js/test/index.test.js
+++ b/test/integration/disable-js/test/index.test.js
@@ -1,0 +1,101 @@
+/* eslint-env jest */
+/* global jasmine */
+import { join } from 'path'
+import cheerio from 'cheerio'
+import {
+  nextServer,
+  nextBuild,
+  startApp,
+  stopApp,
+  renderViaHTTP,
+  findPort,
+  launchApp,
+  killApp,
+} from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+let appPort
+let server
+let app
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+
+const context = {}
+
+describe('disabled runtime JS', () => {
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      app = nextServer({
+        dir: join(__dirname, '../'),
+        dev: false,
+        quiet: true,
+      })
+
+      server = await startApp(app)
+      context.appPort = appPort = server.address().port
+    })
+    afterAll(() => stopApp(server))
+
+    it('should render the page', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      expect(html).toMatch(/Hello World/)
+    })
+
+    it('should not have __NEXT_DATA__ script', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+
+      const $ = cheerio.load(html)
+      expect($('script#__NEXT_DATA__').length).toBe(0)
+    })
+
+    it('should not have scripts', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      const $ = cheerio.load(html)
+      expect($('script[src]').length).toBe(0)
+    })
+
+    it('should not have preload links', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      const $ = cheerio.load(html)
+      expect($('link[rel=preload]').length).toBe(0)
+    })
+  })
+
+  describe('dev mode', () => {
+    let appPort
+    let app
+
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(join(__dirname, '../'), appPort)
+    })
+
+    afterAll(() => killApp(app))
+
+    it('should render the page', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      expect(html).toMatch(/Hello World/)
+    })
+
+    it('should not have __NEXT_DATA__ script', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+
+      const $ = cheerio.load(html)
+      expect($('script#__NEXT_DATA__').length).toBe(1)
+    })
+    it('should have preload links', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      const $ = cheerio.load(html)
+      expect($('link[rel=preload]').length).toBeGreaterThan(0)
+    })
+    it('should have a script for each preload link', async () => {
+      const html = await renderViaHTTP(appPort, '/')
+      const $ = cheerio.load(html)
+      const preloadLinks = $('link[rel=preload]')
+      preloadLinks.each((idx, element) => {
+        const url = $(element).attr('href')
+        expect($(`script[src="${url}"]`).length).toBe(1)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR removes the `__NEXT_DATA__` script tag on production builds on pages that explicitly opt out of including the JS bundle in the generated html, as discussed in [#11949 (comment)](https://github.com/zeit/next.js/pull/11949#issuecomment-621205877).

Additionally, it implements initial tests for excluding the runtime bundle