### PR TITLE
Add names to components in amp example

### DIFF
--- a/examples/amp/components/Byline.js
+++ b/examples/amp/components/Byline.js
@@ -1,11 +1,13 @@
-export default ({ author }) => (
-  <>
-    <div className="byline">By {author}</div>
-    <style jsx>{`
-      .byline {
-        color: green;
-        font-weight: bolder;
-      }
-    `}</style>
-  </>
-)
+export default function Byline({ author }) {
+  return (
+    <>
+      <div className="byline">By {author}</div>
+      <style jsx>{`
+        .byline {
+          color: green;
+          font-weight: bolder;
+        }
+      `}</style>
+    </>
+  )
+}

--- a/examples/amp/pages/dog.js
+++ b/examples/amp/pages/dog.js
@@ -6,7 +6,7 @@ export const config = {
   amp: 'hybrid',
 }
 
-export default () => {
+export default function DogPage() {
   const isAmp = useAmp()
 
   return (

--- a/examples/amp/pages/index.js
+++ b/examples/amp/pages/index.js
@@ -7,7 +7,7 @@ export const config = {
   amp: true,
 }
 
-export default () => {
+export default function IndexPage() {
   const isAmp = useAmp()
 
   return (

--- a/examples/amp/pages/normal.js
+++ b/examples/amp/pages/normal.js
@@ -1,1 +1,3 @@
-export default () => <p>I'm just a normal old page, no AMP for me</p>
+export default function NormalPage() {
+  return <p>I'm just a normal old page, no AMP for me</p>
+}


### PR DESCRIPTION
This PR adds names to the components in the `amp` example.

This was sparked by @gaearon's [post on Twitter](https://twitter.com/dan_abramov/status/1255229440860262400).