### PR TITLE
Add name to component in with-tailwindcss example

### DIFF
--- a/examples/with-tailwindcss/pages/index.js
+++ b/examples/with-tailwindcss/pages/index.js
@@ -1,10 +1,12 @@
 import Nav from '../components/nav'
 
-export default () => (
-  <div>
-    <Nav />
-    <div className="hero">
-      <h1 className="title">Next.js + Tailwind CSS</h1>
+export default function IndexPage() {
+  return (
+    <div>
+      <Nav />
+      <div className="hero">
+        <h1 className="title">Next.js + Tailwind CSS</h1>
+      </div>
     </div>
-  </div>
-)
+  )
+}


### PR DESCRIPTION
This PR adds a name to the index page component in the `with-tailwindcss` example.

Sparked by https://twitter.com/dan_abramov/status/1255229440860262400