### PR TITLE
[Fast Refresh] Support client-side code being ran in Node

### DIFF
--- a/packages/react-refresh-utils/ReactRefreshWebpackPlugin.ts
+++ b/packages/react-refresh-utils/ReactRefreshWebpackPlugin.ts
@@ -27,10 +27,13 @@ function webpack4(compiler: Compiler) {
         return source
       }
 
+      // Legacy CSS implementations will `eval` browser code in a Node.js
+      // context to extract CSS. For backwards compatibility, we need to check
+      // we're in a browser context before continuing.
       return Template.asString([
         ...lines.slice(0, evalIndex),
         `
-        var hasRefresh = !!self.$RefreshInterceptModuleExecution$;
+        var hasRefresh = typeof self !== "undefined" && !!self.$RefreshInterceptModuleExecution$;
         var cleanup = hasRefresh
           ? self.$RefreshInterceptModuleExecution$(moduleId)
           : function() {};

--- a/packages/react-refresh-utils/internal/ReactRefreshModule.runtime.ts
+++ b/packages/react-refresh-utils/internal/ReactRefreshModule.runtime.ts
@@ -14,59 +14,66 @@ declare const module: {
   }
 }
 
+// This function gets unwrapped into global scope, which is why we don't invert
+// if-blocks. Also, you cannot use `return`.
 export default function() {
-  const currentExports = module.__proto__.exports
-  const prevExports = module.hot.data?.prevExports ?? null
+  // Legacy CSS implementations will `eval` browser code in a Node.js context
+  // to extract CSS. For backwards compatibility, we need to check we're in a
+  // browser context before continuing.
+  if (typeof self !== 'undefined') {
+    const currentExports = module.__proto__.exports
+    const prevExports = module.hot.data?.prevExports ?? null
 
-  // This cannot happen in MainTemplate because the exports mismatch between
-  // templating and execution.
-  self.$RefreshHelpers$.registerExportsForReactRefresh(
-    currentExports,
-    module.id
-  )
+    // This cannot happen in MainTemplate because the exports mismatch between
+    // templating and execution.
+    self.$RefreshHelpers$.registerExportsForReactRefresh(
+      currentExports,
+      module.id
+    )
 
-  // A module can be accepted automatically based on its exports, e.g. when it
-  // is a Refresh Boundary.
-  if (self.$RefreshHelpers$.isReactRefreshBoundary(currentExports)) {
-    // Save the previous exports on update so we can compare the boundary
-    // signatures.
-    module.hot.dispose(data => {
-      data.prevExports = currentExports
-    })
-    // Unconditionally accept an update to this module, we'll check if it's
-    // still a Refresh Boundary later.
-    module.hot.accept()
+    // A module can be accepted automatically based on its exports, e.g. when it
+    // is a Refresh Boundary.
+    if (self.$RefreshHelpers$.isReactRefreshBoundary(currentExports)) {
+      // Save the previous exports on update so we can compare the boundary
+      // signatures.
+      module.hot.dispose(data => {
+        data.prevExports = currentExports
+      })
+      // Unconditionally accept an update to this module, we'll check if it's
+      // still a Refresh Boundary later.
+      module.hot.accept()
 
-    // This field is set when the previous version of this module was a Refresh
-    // Boundary, letting us know we need to check for invalidation or enqueue
-    // an update.
-    if (prevExports !== null) {
-      // A boundary can become ineligible if its exports are incompatible with
-      // the previous exports.
-      //
-      // For example, if you add/remove/change exports, we'll want to
-      // re-execute the importing modules, and force those components to
-      // re-render. Similarly, if you convert a class component to a function,
-      // we want to invalidate the boundary.
-      if (
-        self.$RefreshHelpers$.shouldInvalidateReactRefreshBoundary(
-          prevExports,
-          currentExports
-        )
-      ) {
-        module.hot.invalidate()
-      } else {
-        self.$RefreshHelpers$.scheduleUpdate()
+      // This field is set when the previous version of this module was a Refresh
+      // Boundary, letting us know we need to check for invalidation or enqueue
+      // an update.
+      if (prevExports !== null) {
+        // A boundary can become ineligible if its exports are incompatible with
+        // the previous exports.
+        //
+        // For example, if you add/remove/change exports, we'll want to
+        // re-execute the importing modules, and force those components to
+        // re-render. Similarly, if you convert a class component to a function,
+        // we want to invalidate the boundary.
+        if (
+          self.$RefreshHelpers$.shouldInvalidateReactRefreshBoundary(
+            prevExports,
+            currentExports
+          )
+        ) {
+          module.hot.invalidate()
+        } else {
+          self.$RefreshHelpers$.scheduleUpdate()
+        }
       }
-    }
-  } else {
-    // Since we just executed the code for the module, it's possible that the
-    // new exports made it ineligible for being a boundary.
-    // We only care about the case when we were _previously_ a boundary,
-    // because we already accepted this update (accidental side effect).
-    const isNoLongerABoundary = prevExports !== null
-    if (isNoLongerABoundary) {
-      module.hot.invalidate()
+    } else {
+      // Since we just executed the code for the module, it's possible that the
+      // new exports made it ineligible for being a boundary.
+      // We only care about the case when we were _previously_ a boundary,
+      // because we already accepted this update (accidental side effect).
+      const isNoLongerABoundary = prevExports !== null
+      if (isNoLongerABoundary) {
+        module.hot.invalidate()
+      }
     }
   }
 }

--- a/packages/react-refresh-utils/internal/ReactRefreshModule.runtime.ts
+++ b/packages/react-refresh-utils/internal/ReactRefreshModule.runtime.ts
@@ -31,8 +31,8 @@ export default function() {
       module.id
     )
 
-    // A module can be accepted automatically based on its exports, e.g. when it
-    // is a Refresh Boundary.
+    // A module can be accepted automatically based on its exports, e.g. when
+    // it is a Refresh Boundary.
     if (self.$RefreshHelpers$.isReactRefreshBoundary(currentExports)) {
       // Save the previous exports on update so we can compare the boundary
       // signatures.
@@ -43,17 +43,17 @@ export default function() {
       // still a Refresh Boundary later.
       module.hot.accept()
 
-      // This field is set when the previous version of this module was a Refresh
-      // Boundary, letting us know we need to check for invalidation or enqueue
-      // an update.
+      // This field is set when the previous version of this module was a
+      // Refresh Boundary, letting us know we need to check for invalidation or
+      // enqueue an update.
       if (prevExports !== null) {
-        // A boundary can become ineligible if its exports are incompatible with
-        // the previous exports.
+        // A boundary can become ineligible if its exports are incompatible
+        // with the previous exports.
         //
         // For example, if you add/remove/change exports, we'll want to
         // re-execute the importing modules, and force those components to
-        // re-render. Similarly, if you convert a class component to a function,
-        // we want to invalidate the boundary.
+        // re-render. Similarly, if you convert a class component to a
+        // function, we want to invalidate the boundary.
         if (
           self.$RefreshHelpers$.shouldInvalidateReactRefreshBoundary(
             prevExports,

--- a/test/integration/legacy-sass/next.config.js
+++ b/test/integration/legacy-sass/next.config.js
@@ -1,2 +1,2 @@
 const withSass = require('@zeit/next-sass')
-module.exports = withSass({})
+module.exports = withSass({ experimental: { reactRefresh: true } })

--- a/test/integration/legacy-sass/test/index.test.js
+++ b/test/integration/legacy-sass/test/index.test.js
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 /* global jasmine */
 import { remove } from 'fs-extra'
-import { nextBuild } from 'next-test-utils'
+import { findPort, killApp, launchApp, nextBuild } from 'next-test-utils'
+import webdriver from 'next-webdriver'
 import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
 import { join } from 'path'
 
@@ -22,5 +23,34 @@ describe('Legacy Sass Support Should Disable New CSS', () => {
     )
 
     expect(cssFiles.length).toBe(1)
+  })
+})
+
+describe('Legacy Sass Support should work in development', () => {
+  beforeAll(async () => {
+    await remove(join(appDir, '.next'))
+  })
+
+  let appPort
+  let app
+  beforeAll(async () => {
+    appPort = await findPort()
+    app = await launchApp(appDir, appPort)
+  })
+  afterAll(async () => {
+    await killApp(app)
+  })
+
+  it('should render the page', async () => {
+    let browser
+    try {
+      browser = await webdriver(appPort, '/')
+      const exampleElText = await browser.elementByCss('.example').text()
+      expect(exampleElText).toBe('Hello World!')
+    } finally {
+      if (browser) {
+        await browser.close()
+      }
+    }
   })
 })


### PR DESCRIPTION
Legacy webpack plugins (e.g. `mini-css-extract-plugin`, used by `@zeit/next-sass`) will run client-side only code in a Node.js context.

To support this, we need the Fast Refresh runtime to verify its in a client-side environment before executing.

---

Fixes #12304