### PR TITLE
[Fast Refresh] Add Titles for Click to Open Action

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
+++ b/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
@@ -57,7 +57,12 @@ export const CodeFrame: React.FC<CodeFrameProps> = function CodeFrame({
   // TODO: make the caret absolute
   return (
     <div data-nextjs-codeframe>
-      <p role="link" onClick={open} tabIndex={0}>
+      <p
+        role="link"
+        onClick={open}
+        tabIndex={0}
+        title="Click to open in your editor"
+      >
         <span>
           {getFrameSource(stackFrame)} @ {stackFrame.methodName}
         </span>

--- a/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
+++ b/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
@@ -40,6 +40,7 @@ const CallStackFrame: React.FC<{
         tabIndex={hasSource ? 0 : undefined}
         role={hasSource ? 'link' : undefined}
         onClick={open}
+        title={hasSource ? 'Click to open in your editor' : undefined}
       >
         <span>{getFrameSource(f)}</span>
         <svg


### PR DESCRIPTION
This adds the `title` property to elements with the click-to-open action, telling the user what will happen if they click it!