### PR TITLE
Use fs.promises in test files

### DIFF
--- a/test/integration/amp-export-validation/test/index.test.js
+++ b/test/integration/amp-export-validation/test/index.test.js
@@ -1,14 +1,11 @@
 /* eslint-env jest */
 /* global jasmine */
-import fs from 'fs'
+import { promises } from 'fs'
 import { join } from 'path'
-import { promisify } from 'util'
 import { validateAMP } from 'amp-test-utils'
 import { File, nextBuild, nextExport, runNextCommand } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
-const access = promisify(fs.access)
-const readFile = promisify(fs.readFile)
 const appDir = join(__dirname, '../')
 const outDir = join(appDir, 'out')
 const nextConfig = new File(join(appDir, 'next.config.js'))
@@ -38,7 +35,7 @@ describe('AMP Validation on Export', () => {
     const toCheck = ['first', 'second', 'third.amp']
     await Promise.all(
       toCheck.map(async page => {
-        const content = await readFile(join(outDir, `${page}.html`))
+        const content = await promises.readFile(join(outDir, `${page}.html`))
         await validateAMP(content.toString())
       })
     )
@@ -62,7 +59,9 @@ describe('AMP Validation on Export', () => {
       expect(stdout).toMatch(
         /error.*The mandatory attribute 'height' is missing in tag 'amp-video'\./
       )
-      await expect(access(join(outDir, 'cat.html'))).resolves.toBe(undefined)
+      await expect(promises.access(join(outDir, 'cat.html'))).resolves.toBe(
+        undefined
+      )
       await expect(stderr).not.toMatch(
         /Found conflicting amp tag "meta" with conflicting prop name="viewport"/
       )
@@ -89,7 +88,9 @@ describe('AMP Validation on Export', () => {
       expect(stdout).toMatch(
         /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'/
       )
-      await expect(access(join(outDir, 'dog.html'))).resolves.toBe(undefined)
+      await expect(promises.access(join(outDir, 'dog.html'))).resolves.toBe(
+        undefined
+      )
       await expect(stderr).not.toMatch(
         /Found conflicting amp tag "meta" with conflicting prop name="viewport"/
       )
@@ -119,7 +120,7 @@ describe('AMP Validation on Export', () => {
       expect(stdout).toMatch(
         /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'/
       )
-      await expect(access(join(outDir, 'dog-cat.html'))).resolves.toBe(
+      await expect(promises.access(join(outDir, 'dog-cat.html'))).resolves.toBe(
         undefined
       )
       await expect(stderr).not.toMatch(

--- a/test/integration/amp-export-validation/test/index.test.js
+++ b/test/integration/amp-export-validation/test/index.test.js
@@ -6,6 +6,7 @@ import { validateAMP } from 'amp-test-utils'
 import { File, nextBuild, nextExport, runNextCommand } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const { access, readFile } = promises
 const appDir = join(__dirname, '../')
 const outDir = join(appDir, 'out')
 const nextConfig = new File(join(appDir, 'next.config.js'))
@@ -35,7 +36,7 @@ describe('AMP Validation on Export', () => {
     const toCheck = ['first', 'second', 'third.amp']
     await Promise.all(
       toCheck.map(async page => {
-        const content = await promises.readFile(join(outDir, `${page}.html`))
+        const content = await readFile(join(outDir, `${page}.html`))
         await validateAMP(content.toString())
       })
     )
@@ -59,9 +60,7 @@ describe('AMP Validation on Export', () => {
       expect(stdout).toMatch(
         /error.*The mandatory attribute 'height' is missing in tag 'amp-video'\./
       )
-      await expect(promises.access(join(outDir, 'cat.html'))).resolves.toBe(
-        undefined
-      )
+      await expect(access(join(outDir, 'cat.html'))).resolves.toBe(undefined)
       await expect(stderr).not.toMatch(
         /Found conflicting amp tag "meta" with conflicting prop name="viewport"/
       )
@@ -88,9 +87,7 @@ describe('AMP Validation on Export', () => {
       expect(stdout).toMatch(
         /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'/
       )
-      await expect(promises.access(join(outDir, 'dog.html'))).resolves.toBe(
-        undefined
-      )
+      await expect(access(join(outDir, 'dog.html'))).resolves.toBe(undefined)
       await expect(stderr).not.toMatch(
         /Found conflicting amp tag "meta" with conflicting prop name="viewport"/
       )
@@ -120,7 +117,7 @@ describe('AMP Validation on Export', () => {
       expect(stdout).toMatch(
         /error.*The parent tag of tag 'IMG-I-AMPHTML-INTRINSIC-SIZER' is 'div', but it can only be 'i-amphtml-sizer-intrinsic'/
       )
-      await expect(promises.access(join(outDir, 'dog-cat.html'))).resolves.toBe(
+      await expect(access(join(outDir, 'dog-cat.html'))).resolves.toBe(
         undefined
       )
       await expect(stderr).not.toMatch(

--- a/test/integration/export-default-map-serverless/test/index.test.js
+++ b/test/integration/export-default-map-serverless/test/index.test.js
@@ -1,14 +1,11 @@
 /* eslint-env jest */
 /* global jasmine */
-import fs from 'fs'
+import { promises } from 'fs'
 import { join } from 'path'
 import cheerio from 'cheerio'
-import { promisify } from 'util'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
-const readFile = promisify(fs.readFile)
-const access = promisify(fs.access)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -20,48 +17,66 @@ describe('Export with default map', () => {
 
   it('should export with folder that has dot in name', async () => {
     expect.assertions(1)
-    await expect(access(join(outdir, 'v1.12.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'v1.12.html'))).resolves.toBe(
+      undefined
+    )
   })
 
   it('should export an amp only page to clean path', async () => {
     expect.assertions(1)
-    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
+      undefined
+    )
   })
 
   it('should export hybrid amp page correctly', async () => {
     expect.assertions(2)
-    await expect(access(join(outdir, 'some.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'some.amp.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'some.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'some.amp.html'))).resolves.toBe(
+      undefined
+    )
   })
 
   it('should export nested hybrid amp page correctly', async () => {
     expect.assertions(3)
-    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'docs.amp.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'docs.amp.html'))).resolves.toBe(
+      undefined
+    )
 
-    const html = await readFile(join(outdir, 'docs.html'))
+    const html = await promises.readFile(join(outdir, 'docs.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/docs.amp')
   })
 
   it('should export nested hybrid amp page correctly with folder', async () => {
     expect.assertions(3)
-    await expect(access(join(outdir, 'info.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'info.amp.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'info.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'info.amp.html'))).resolves.toBe(
+      undefined
+    )
 
-    const html = await readFile(join(outdir, 'info.html'))
+    const html = await promises.readFile(join(outdir, 'info.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/info.amp')
   })
 
   it('should export hybrid index amp page correctly', async () => {
     expect.assertions(3)
-    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'index.amp.html'))).resolves.toBe(
+    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'index.amp.html'))).resolves.toBe(
       undefined
     )
 
-    const html = await readFile(join(outdir, 'index.html'))
+    const html = await promises.readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/index.amp')
   })

--- a/test/integration/export-default-map-serverless/test/index.test.js
+++ b/test/integration/export-default-map-serverless/test/index.test.js
@@ -6,6 +6,7 @@ import cheerio from 'cheerio'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const { access, readFile } = promises
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -17,66 +18,48 @@ describe('Export with default map', () => {
 
   it('should export with folder that has dot in name', async () => {
     expect.assertions(1)
-    await expect(promises.access(join(outdir, 'v1.12.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'v1.12.html'))).resolves.toBe(undefined)
   })
 
   it('should export an amp only page to clean path', async () => {
     expect.assertions(1)
-    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
   })
 
   it('should export hybrid amp page correctly', async () => {
     expect.assertions(2)
-    await expect(promises.access(join(outdir, 'some.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'some.amp.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'some.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'some.amp.html'))).resolves.toBe(undefined)
   })
 
   it('should export nested hybrid amp page correctly', async () => {
     expect.assertions(3)
-    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'docs.amp.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'docs.amp.html'))).resolves.toBe(undefined)
 
-    const html = await promises.readFile(join(outdir, 'docs.html'))
+    const html = await readFile(join(outdir, 'docs.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/docs.amp')
   })
 
   it('should export nested hybrid amp page correctly with folder', async () => {
     expect.assertions(3)
-    await expect(promises.access(join(outdir, 'info.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'info.amp.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'info.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'info.amp.html'))).resolves.toBe(undefined)
 
-    const html = await promises.readFile(join(outdir, 'info.html'))
+    const html = await readFile(join(outdir, 'info.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/info.amp')
   })
 
   it('should export hybrid index amp page correctly', async () => {
     expect.assertions(3)
-    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'index.amp.html'))).resolves.toBe(
+    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'index.amp.html'))).resolves.toBe(
       undefined
     )
 
-    const html = await promises.readFile(join(outdir, 'index.html'))
+    const html = await readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/index.amp')
   })

--- a/test/integration/export-default-map/test/index.test.js
+++ b/test/integration/export-default-map/test/index.test.js
@@ -1,14 +1,11 @@
 /* eslint-env jest */
 /* global jasmine */
-import fs from 'fs'
+import { promises } from 'fs'
 import { join } from 'path'
 import cheerio from 'cheerio'
-import { promisify } from 'util'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
-const readFile = promisify(fs.readFile)
-const access = promisify(fs.access)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -20,48 +17,66 @@ describe('Export with default map', () => {
 
   it('should export with folder that has dot in name', async () => {
     expect.assertions(1)
-    await expect(access(join(outdir, 'v1.12.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'v1.12.html'))).resolves.toBe(
+      undefined
+    )
   })
 
   it('should export an amp only page to clean path', async () => {
     expect.assertions(1)
-    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
+      undefined
+    )
   })
 
   it('should export hybrid amp page correctly', async () => {
     expect.assertions(2)
-    await expect(access(join(outdir, 'some.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'some.amp.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'some.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'some.amp.html'))).resolves.toBe(
+      undefined
+    )
   })
 
   it('should export nested hybrid amp page correctly', async () => {
     expect.assertions(3)
-    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'docs.amp.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'docs.amp.html'))).resolves.toBe(
+      undefined
+    )
 
-    const html = await readFile(join(outdir, 'docs.html'))
+    const html = await promises.readFile(join(outdir, 'docs.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/docs.amp')
   })
 
   it('should export nested hybrid amp page correctly with folder', async () => {
     expect.assertions(3)
-    await expect(access(join(outdir, 'info.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'info.amp.html'))).resolves.toBe(undefined)
+    await expect(promises.access(join(outdir, 'info.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'info.amp.html'))).resolves.toBe(
+      undefined
+    )
 
-    const html = await readFile(join(outdir, 'info.html'))
+    const html = await promises.readFile(join(outdir, 'info.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/info.amp')
   })
 
   it('should export hybrid index amp page correctly', async () => {
     expect.assertions(3)
-    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'index.amp.html'))).resolves.toBe(
+    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'index.amp.html'))).resolves.toBe(
       undefined
     )
 
-    const html = await readFile(join(outdir, 'index.html'))
+    const html = await promises.readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/index.amp')
   })

--- a/test/integration/export-default-map/test/index.test.js
+++ b/test/integration/export-default-map/test/index.test.js
@@ -6,6 +6,7 @@ import cheerio from 'cheerio'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const { access, readFile } = promises
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -17,66 +18,48 @@ describe('Export with default map', () => {
 
   it('should export with folder that has dot in name', async () => {
     expect.assertions(1)
-    await expect(promises.access(join(outdir, 'v1.12.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'v1.12.html'))).resolves.toBe(undefined)
   })
 
   it('should export an amp only page to clean path', async () => {
     expect.assertions(1)
-    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
   })
 
   it('should export hybrid amp page correctly', async () => {
     expect.assertions(2)
-    await expect(promises.access(join(outdir, 'some.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'some.amp.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'some.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'some.amp.html'))).resolves.toBe(undefined)
   })
 
   it('should export nested hybrid amp page correctly', async () => {
     expect.assertions(3)
-    await expect(promises.access(join(outdir, 'docs.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'docs.amp.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'docs.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'docs.amp.html'))).resolves.toBe(undefined)
 
-    const html = await promises.readFile(join(outdir, 'docs.html'))
+    const html = await readFile(join(outdir, 'docs.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/docs.amp')
   })
 
   it('should export nested hybrid amp page correctly with folder', async () => {
     expect.assertions(3)
-    await expect(promises.access(join(outdir, 'info.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'info.amp.html'))).resolves.toBe(
-      undefined
-    )
+    await expect(access(join(outdir, 'info.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'info.amp.html'))).resolves.toBe(undefined)
 
-    const html = await promises.readFile(join(outdir, 'info.html'))
+    const html = await readFile(join(outdir, 'info.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/info.amp')
   })
 
   it('should export hybrid index amp page correctly', async () => {
     expect.assertions(3)
-    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'index.amp.html'))).resolves.toBe(
+    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'index.amp.html'))).resolves.toBe(
       undefined
     )
 
-    const html = await promises.readFile(join(outdir, 'index.html'))
+    const html = await readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('link[rel=amphtml]').attr('href')).toBe('/index.amp')
   })

--- a/test/integration/export-override-404/test/index.test.js
+++ b/test/integration/export-override-404/test/index.test.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const { readFile } = promises
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -15,7 +16,7 @@ describe('Export with a page named 404.js', () => {
   })
 
   it('should export a custom 404.html instead of default 404.html', async () => {
-    const html = await promises.readFile(join(outdir, '404.html'), 'utf8')
+    const html = await readFile(join(outdir, '404.html'), 'utf8')
     expect(html).toMatch(/this is a 404 page override the default 404\.html/)
   })
 })

--- a/test/integration/export-override-404/test/index.test.js
+++ b/test/integration/export-override-404/test/index.test.js
@@ -1,12 +1,10 @@
 /* eslint-env jest */
 /* global jasmine */
-import fs from 'fs'
+import { promises } from 'fs'
 import { join } from 'path'
-import { promisify } from 'util'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
-const readFile = promisify(fs.readFile)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -17,7 +15,7 @@ describe('Export with a page named 404.js', () => {
   })
 
   it('should export a custom 404.html instead of default 404.html', async () => {
-    const html = await readFile(join(outdir, '404.html'), 'utf8')
+    const html = await promises.readFile(join(outdir, '404.html'), 'utf8')
     expect(html).toMatch(/this is a 404 page override the default 404\.html/)
   })
 })

--- a/test/integration/export-serverless/test/index.test.js
+++ b/test/integration/export-serverless/test/index.test.js
@@ -22,6 +22,7 @@ import apiRoutes from './api-routes'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 
+const { access, mkdir, writeFile } = promises
 const appDir = join(__dirname, '../')
 const context = {}
 context.appDir = appDir
@@ -33,16 +34,16 @@ describe('Static Export', () => {
     const outdir = join(appDir, 'out')
     const tempfile = join(outdir, 'temp.txt')
 
-    await promises.mkdir(outdir).catch(e => {
+    await mkdir(outdir).catch(e => {
       if (e.code !== 'EEXIST') throw e
     })
-    await promises.writeFile(tempfile, 'Hello there')
+    await writeFile(tempfile, 'Hello there')
 
     await nextBuild(appDir)
     await nextExport(appDir, { outdir })
 
     let doesNotExist = false
-    await promises.access(tempfile).catch(e => {
+    await access(tempfile).catch(e => {
       if (e.code === 'ENOENT') doesNotExist = true
     })
     expect(doesNotExist).toBe(true)

--- a/test/integration/export-serverless/test/index.test.js
+++ b/test/integration/export-serverless/test/index.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 /* global jasmine */
 import { join } from 'path'
+import { promises } from 'fs'
 import {
   nextBuild,
   nextExport,
@@ -16,16 +17,11 @@ import {
 import ssr from './ssr'
 import browser from './browser'
 import dev from './dev'
-import { promisify } from 'util'
-import fs from 'fs'
 import dynamic from './dynamic'
 import apiRoutes from './api-routes'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 
-const writeFile = promisify(fs.writeFile)
-const mkdir = promisify(fs.mkdir)
-const access = promisify(fs.access)
 const appDir = join(__dirname, '../')
 const context = {}
 context.appDir = appDir
@@ -37,16 +33,16 @@ describe('Static Export', () => {
     const outdir = join(appDir, 'out')
     const tempfile = join(outdir, 'temp.txt')
 
-    await mkdir(outdir).catch(e => {
+    await promises.mkdir(outdir).catch(e => {
       if (e.code !== 'EEXIST') throw e
     })
-    await writeFile(tempfile, 'Hello there')
+    await promises.writeFile(tempfile, 'Hello there')
 
     await nextBuild(appDir)
     await nextExport(appDir, { outdir })
 
     let doesNotExist = false
-    await access(tempfile).catch(e => {
+    await promises.access(tempfile).catch(e => {
       if (e.code === 'ENOENT') doesNotExist = true
     })
     expect(doesNotExist).toBe(true)

--- a/test/integration/export-subfolders-serverless/test/index.test.js
+++ b/test/integration/export-subfolders-serverless/test/index.test.js
@@ -1,14 +1,11 @@
 /* eslint-env jest */
 /* global jasmine */
-import fs from 'fs'
+import { promises } from 'fs'
 import { join } from 'path'
 import cheerio from 'cheerio'
-import { promisify } from 'util'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
-const readFile = promisify(fs.readFile)
-const access = promisify(fs.access)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -21,18 +18,26 @@ describe('Export config#exportTrailingSlash set to false', () => {
   it('should export pages as [filename].html instead of [filename]/index.html', async () => {
     expect.assertions(6)
 
-    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'about.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'posts.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'posts', 'single.html'))).resolves.toBe(
+    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
       undefined
     )
+    await expect(promises.access(join(outdir, 'about.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'posts.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(
+      promises.access(join(outdir, 'posts', 'single.html'))
+    ).resolves.toBe(undefined)
 
-    const html = await readFile(join(outdir, 'index.html'))
+    const html = await promises.readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('p').text()).toBe('I am a home page')
 
-    const htmlSingle = await readFile(join(outdir, 'posts', 'single.html'))
+    const htmlSingle = await promises.readFile(
+      join(outdir, 'posts', 'single.html')
+    )
     const $single = cheerio.load(htmlSingle)
     expect($single('p').text()).toBe('I am a single post')
   })

--- a/test/integration/export-subfolders-serverless/test/index.test.js
+++ b/test/integration/export-subfolders-serverless/test/index.test.js
@@ -6,6 +6,7 @@ import cheerio from 'cheerio'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const { access, readFile } = promises
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -18,26 +19,18 @@ describe('Export config#exportTrailingSlash set to false', () => {
   it('should export pages as [filename].html instead of [filename]/index.html', async () => {
     expect.assertions(6)
 
-    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
+    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'about.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'posts.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'posts', 'single.html'))).resolves.toBe(
       undefined
     )
-    await expect(promises.access(join(outdir, 'about.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'posts.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(
-      promises.access(join(outdir, 'posts', 'single.html'))
-    ).resolves.toBe(undefined)
 
-    const html = await promises.readFile(join(outdir, 'index.html'))
+    const html = await readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('p').text()).toBe('I am a home page')
 
-    const htmlSingle = await promises.readFile(
-      join(outdir, 'posts', 'single.html')
-    )
+    const htmlSingle = await readFile(join(outdir, 'posts', 'single.html'))
     const $single = cheerio.load(htmlSingle)
     expect($single('p').text()).toBe('I am a single post')
   })

--- a/test/integration/export-subfolders/test/index.test.js
+++ b/test/integration/export-subfolders/test/index.test.js
@@ -1,14 +1,11 @@
 /* eslint-env jest */
 /* global jasmine */
-import fs from 'fs'
+import { promises } from 'fs'
 import { join } from 'path'
 import cheerio from 'cheerio'
-import { promisify } from 'util'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
-const readFile = promisify(fs.readFile)
-const access = promisify(fs.access)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -21,18 +18,26 @@ describe('Export config#exportTrailingSlash set to false', () => {
   it('should export pages as [filename].html instead of [filename]/index.html', async () => {
     expect.assertions(6)
 
-    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'about.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'posts.html'))).resolves.toBe(undefined)
-    await expect(access(join(outdir, 'posts', 'single.html'))).resolves.toBe(
+    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
       undefined
     )
+    await expect(promises.access(join(outdir, 'about.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(promises.access(join(outdir, 'posts.html'))).resolves.toBe(
+      undefined
+    )
+    await expect(
+      promises.access(join(outdir, 'posts', 'single.html'))
+    ).resolves.toBe(undefined)
 
-    const html = await readFile(join(outdir, 'index.html'))
+    const html = await promises.readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('p').text()).toBe('I am a home page')
 
-    const htmlSingle = await readFile(join(outdir, 'posts', 'single.html'))
+    const htmlSingle = await promises.readFile(
+      join(outdir, 'posts', 'single.html')
+    )
     const $single = cheerio.load(htmlSingle)
     expect($single('p').text()).toBe('I am a single post')
   })

--- a/test/integration/export-subfolders/test/index.test.js
+++ b/test/integration/export-subfolders/test/index.test.js
@@ -6,6 +6,7 @@ import cheerio from 'cheerio'
 import { nextBuild, nextExport } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
+const { access, readFile } = promises
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 
@@ -18,26 +19,18 @@ describe('Export config#exportTrailingSlash set to false', () => {
   it('should export pages as [filename].html instead of [filename]/index.html', async () => {
     expect.assertions(6)
 
-    await expect(promises.access(join(outdir, 'index.html'))).resolves.toBe(
+    await expect(access(join(outdir, 'index.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'about.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'posts.html'))).resolves.toBe(undefined)
+    await expect(access(join(outdir, 'posts', 'single.html'))).resolves.toBe(
       undefined
     )
-    await expect(promises.access(join(outdir, 'about.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(promises.access(join(outdir, 'posts.html'))).resolves.toBe(
-      undefined
-    )
-    await expect(
-      promises.access(join(outdir, 'posts', 'single.html'))
-    ).resolves.toBe(undefined)
 
-    const html = await promises.readFile(join(outdir, 'index.html'))
+    const html = await readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
     expect($('p').text()).toBe('I am a home page')
 
-    const htmlSingle = await promises.readFile(
-      join(outdir, 'posts', 'single.html')
-    )
+    const htmlSingle = await readFile(join(outdir, 'posts', 'single.html'))
     const $single = cheerio.load(htmlSingle)
     expect($single('p').text()).toBe('I am a single post')
   })

--- a/test/integration/export/test/index.test.js
+++ b/test/integration/export/test/index.test.js
@@ -22,6 +22,7 @@ import apiRoutes from './api-routes'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 
+const { access, mkdir, writeFile } = promises
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 const outNoTrailSlash = join(appDir, 'outNoTrailSlash')
@@ -34,16 +35,16 @@ describe('Static Export', () => {
   it('should delete existing exported files', async () => {
     const tempfile = join(outdir, 'temp.txt')
 
-    await promises.mkdir(outdir).catch(e => {
+    await mkdir(outdir).catch(e => {
       if (e.code !== 'EEXIST') throw e
     })
-    await promises.writeFile(tempfile, 'Hello there')
+    await writeFile(tempfile, 'Hello there')
 
     await nextBuild(appDir)
     await nextExport(appDir, { outdir })
 
     let doesNotExist = false
-    await promises.access(tempfile).catch(e => {
+    await access(tempfile).catch(e => {
       if (e.code === 'ENOENT') doesNotExist = true
     })
     expect(doesNotExist).toBe(true)

--- a/test/integration/export/test/index.test.js
+++ b/test/integration/export/test/index.test.js
@@ -90,16 +90,14 @@ describe('Static Export', () => {
 
   it('should honor exportTrailingSlash for 404 page', async () => {
     expect(
-      await promises
-        .access(join(outdir, '404/index.html'))
+      await access(join(outdir, '404/index.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(true)
 
     // we still output 404.html for backwards compat
     expect(
-      await promises
-        .access(join(outdir, '404.html'))
+      await access(join(outdir, '404.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(true)
@@ -107,15 +105,13 @@ describe('Static Export', () => {
 
   it('should only output 404.html without exportTrailingSlash', async () => {
     expect(
-      await promises
-        .access(join(outNoTrailSlash, '404/index.html'))
+      await access(join(outNoTrailSlash, '404/index.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(false)
 
     expect(
-      await promises
-        .access(join(outNoTrailSlash, '404.html'))
+      await access(join(outNoTrailSlash, '404.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(true)

--- a/test/integration/export/test/index.test.js
+++ b/test/integration/export/test/index.test.js
@@ -16,16 +16,12 @@ import {
 import ssr from './ssr'
 import browser from './browser'
 import dev from './dev'
-import { promisify } from 'util'
-import fs from 'fs'
+import { promises } from 'fs'
 import dynamic from './dynamic'
 import apiRoutes from './api-routes'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 5
 
-const writeFile = promisify(fs.writeFile)
-const mkdir = promisify(fs.mkdir)
-const access = promisify(fs.access)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 const outNoTrailSlash = join(appDir, 'outNoTrailSlash')
@@ -38,16 +34,16 @@ describe('Static Export', () => {
   it('should delete existing exported files', async () => {
     const tempfile = join(outdir, 'temp.txt')
 
-    await mkdir(outdir).catch(e => {
+    await promises.mkdir(outdir).catch(e => {
       if (e.code !== 'EEXIST') throw e
     })
-    await writeFile(tempfile, 'Hello there')
+    await promises.writeFile(tempfile, 'Hello there')
 
     await nextBuild(appDir)
     await nextExport(appDir, { outdir })
 
     let doesNotExist = false
-    await access(tempfile).catch(e => {
+    await promises.access(tempfile).catch(e => {
       if (e.code === 'ENOENT') doesNotExist = true
     })
     expect(doesNotExist).toBe(true)
@@ -93,14 +89,16 @@ describe('Static Export', () => {
 
   it('should honor exportTrailingSlash for 404 page', async () => {
     expect(
-      await access(join(outdir, '404/index.html'))
+      await promises
+        .access(join(outdir, '404/index.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(true)
 
     // we still output 404.html for backwards compat
     expect(
-      await access(join(outdir, '404.html'))
+      await promises
+        .access(join(outdir, '404.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(true)
@@ -108,13 +106,15 @@ describe('Static Export', () => {
 
   it('should only output 404.html without exportTrailingSlash', async () => {
     expect(
-      await access(join(outNoTrailSlash, '404/index.html'))
+      await promises
+        .access(join(outNoTrailSlash, '404/index.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(false)
 
     expect(
-      await access(join(outNoTrailSlash, '404.html'))
+      await promises
+        .access(join(outNoTrailSlash, '404.html'))
         .then(() => true)
         .catch(() => false)
     ).toBe(true)

--- a/test/integration/production/test/process-env.js
+++ b/test/integration/production/test/process-env.js
@@ -1,12 +1,10 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
-import { readFile } from 'fs'
-import { promisify } from 'util'
+import { promises } from 'fs'
 import { join } from 'path'
 
-const readFileAsync = promisify(readFile)
 const readNextBuildFile = relativePath =>
-  readFileAsync(join(__dirname, '../.next', relativePath), 'utf8')
+  promises.readFile(join(__dirname, '../.next', relativePath), 'utf8')
 
 export default context => {
   describe('process.env', () => {


### PR DESCRIPTION
ref: #12026

After drop support **< Node v14.0.0** ,  We will use `fs/promises` alias.
`import { access, readFile } from 'fs/promises';`