### PR TITLE
Package Entry Points for Node.js v13+

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -3,6 +3,15 @@
   "version": "9.3.7-canary.6",
   "description": "The React Framework",
   "main": "./dist/server/next.js",
+  "exports": {
+    ".": "./dist/server/next.js",
+    "./app": "./app.js",
+    "./document": "./document.js",
+    "./dynamic": "./dynamic.js",
+    "./head": "./head.js",
+    "./link": "./link.js",
+    "./router": "./router.js"
+  },
   "license": "MIT",
   "repository": "zeit/next.js",
   "bugs": "https://github.com/zeit/next.js/issues",


### PR DESCRIPTION
Node.js v13 and later (including the upcoming LTS v14), when running in ESM mode, is not able to load modules unless the path includes the file extension. That is a problem when trying to load "next/link", "next/router" etc.

The new Node.js version supports a new field in package.json, which is used to map these internal modules to real files. This PR as is should fix that issue.

The new field can also be used to point to different files depending on who requests the module, eg.

```
{
  "exports": {
    ".": {
      "import": "./dist/server/next.esm.js",
      "require": "./dist/server/next.js",
    },
    "./app": {
      "import": "./dist/app.esm.js",
      "require": "./dist/app.js",
    }
  }
}
```

I'm not aware of any bundler that uses it, but I'm sure webpack and rollup will add support for that soon.

The full documentation to Node.js v13+ ESM is here: https://nodejs.org/api/esm.html