### PR TITLE
Clean up styles in with-tailwindcss example

### DIFF
--- a/examples/with-tailwindcss/components/nav.js
+++ b/examples/with-tailwindcss/components/nav.js
@@ -14,9 +14,9 @@ export default function Nav() {
             <a className="text-blue-500 no-underline">Home</a>
           </Link>
         </li>
-        <ul className="flex justify-between items-center">
+        <ul className="flex justify-between items-center space-x-4">
           {links.map(({ href, label }) => (
-            <li key={`${href}${label}`} className="ml-4">
+            <li key={`${href}${label}`}>
               <a href={href} className="btn-blue no-underline">
                 {label}
               </a>

--- a/examples/with-tailwindcss/styles/button.css
+++ b/examples/with-tailwindcss/styles/button.css
@@ -1,3 +1,0 @@
-.btn-blue {
-  @apply bg-blue-500 text-white font-bold py-2 px-4 rounded;
-}

--- a/examples/with-tailwindcss/styles/index.css
+++ b/examples/with-tailwindcss/styles/index.css
@@ -1,23 +1,18 @@
-@import './button.css';
-
 @tailwind base;
 @tailwind components;
-@tailwind utilities;
+
+.btn-blue {
+  @apply bg-blue-500 text-white font-bold py-2 px-4 rounded;
+}
 
 .hero {
-  width: 100%;
-  color: #333;
+  @apply py-20;
 }
 
 .title {
-  margin: 0;
-  width: 100%;
-  padding-top: 80px;
+  @apply text-5xl text-center;
+  color: #333;
   line-height: 1.15;
-  font-size: 48px;
 }
 
-.title,
-.description {
-  text-align: center;
-}
+@tailwind utilities;


### PR DESCRIPTION
As many PRs as I've done against the `with-tailwindcss` example, I've never actually looked at the styles. I took a look and noticed a few small things.

This PR:
- Updates the **Nav** component to use Tailwind's new [space-* utilities](https://tailwindcss.com/docs/space/#app)
- Cleans up the `.title` and `.hero` classes by removing unnecessary styles and replacing CSS properties with Tailwind utilities where possible
- Removes unused `.description` class
- Inlines `.btn-blue` class instead of breaking it out into `button.css`
- [As recommended in the Tailwind CSS docs](https://tailwindcss.com/docs/extracting-components/#extracting-css-components-with-apply), moves the custom styles _before_ `@tailwind utilities` 