### PR TITLE
Elements with `role=link` should open on [Enter]

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/Dialog/Dialog.tsx
+++ b/packages/react-dev-overlay/src/internal/components/Dialog/Dialog.tsx
@@ -20,6 +20,34 @@ const Dialog: React.FC<DialogProps> = function Dialog({
   }, [])
   useOnClickOutside(dialog, onClose)
 
+  // Make HTMLElements with `role=link` accessible to be triggered by the
+  // keyboard, i.e. [Enter].
+  React.useEffect(() => {
+    if (dialog == null) {
+      return
+    }
+
+    const root = dialog.getRootNode()
+    // Always true, but we do this for TypeScript:
+    if (!(root instanceof ShadowRoot)) {
+      return
+    }
+    const shadowRoot = root
+    function handler(e: KeyboardEvent) {
+      const el = shadowRoot.activeElement
+      if (
+        e.key === 'Enter' &&
+        el instanceof HTMLElement &&
+        el.getAttribute('role') === 'link'
+      ) {
+        el.click()
+      }
+    }
+
+    shadowRoot.addEventListener('keydown', handler)
+    return () => shadowRoot.removeEventListener('keydown', handler)
+  }, [dialog])
+
   return (
     <div
       ref={onDialog}

--- a/packages/react-dev-overlay/src/internal/components/Dialog/Dialog.tsx
+++ b/packages/react-dev-overlay/src/internal/components/Dialog/Dialog.tsx
@@ -40,6 +40,9 @@ const Dialog: React.FC<DialogProps> = function Dialog({
         el instanceof HTMLElement &&
         el.getAttribute('role') === 'link'
       ) {
+        e.preventDefault()
+        e.stopPropagation()
+
         el.click()
       }
     }


### PR DESCRIPTION
This pull request extends the behavior of the new overlay to make elements with `role=link` accessible via means of the `[Enter]` key.