### PR TITLE
Add note about HoC possibly adding GIP to _app

### DIFF
--- a/errors/opt-out-auto-static-optimization.md
+++ b/errors/opt-out-auto-static-optimization.md
@@ -11,6 +11,8 @@ This causes **all non-getStaticProps pages** to be executed on the server -- dis
 Be sure you meant to use `getInitialProps` in `pages/_app`!
 There are some valid use cases for this, but it is often better to handle `getInitialProps` on a _per-page_ basis.
 
+Check for any [higher-order components](https://reactjs.org/docs/higher-order-components.html) that may have added `getInitialProps` to your [Custom `<App>`](https://nextjs.org/docs#custom-app).
+
 If you previously copied the [Custom `<App>`](https://nextjs.org/docs#custom-app) example, you may be able to remove your `getInitialProps`.
 
 The following `getInitialProps` does nothing and may be removed:


### PR DESCRIPTION
This adds an additional note to our automatic static optimization opt-out err.sh to mention that a higher-order component might be the cause for the opt-out

x-ref: https://github.com/zeit/next.js/issues/12476