### PR TITLE
Disable cache warning on supported platforms

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -128,7 +128,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
     headers.push(..._headers)
   }
 
-  if (ciEnvironment.isCI) {
+  if (ciEnvironment.isCI && !ciEnvironment.hasNextSupport) {
     const cacheDir = path.join(distDir, 'cache')
     const hasCache = await promises
       .access(cacheDir)

--- a/packages/next/telemetry/ci-info.ts
+++ b/packages/next/telemetry/ci-info.ts
@@ -10,3 +10,8 @@ const isHeroku =
 
 export const isCI = isZeitNow || isHeroku || _isCI
 export const name = isZeitNow ? 'ZEIT Now' : isHeroku ? 'Heroku' : _name
+
+// This boolean indicates if the CI platform has first-class Next.js support,
+// which allows us to disable certain messages which do not require their
+// action.
+export const hasNextSupport = Boolean(isZeitNow)

--- a/test/integration/build-warnings/test/index.test.js
+++ b/test/integration/build-warnings/test/index.test.js
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 /* global jasmine */
-import { join } from 'path'
 import { remove } from 'fs-extra'
-import { nextBuild, File, waitFor } from 'next-test-utils'
+import { File, nextBuild, waitFor } from 'next-test-utils'
+import { join } from 'path'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 1
 const appDir = join(__dirname, '../')
@@ -57,6 +57,16 @@ describe('Build warnings', () => {
         GITHUB_ACTIONS: '',
         GITHUB_EVENT_NAME: '',
       },
+    })
+    expect(stdout).not.toContain('no-cache')
+  })
+
+  it('should not warn about missing cache on supported platforms', async () => {
+    await remove(join(appDir, '.next'))
+
+    const { stdout } = await nextBuild(appDir, undefined, {
+      stdout: true,
+      env: { CI: '1', NOW_BUILDER: '1' },
     })
     expect(stdout).not.toContain('no-cache')
   })


### PR DESCRIPTION
This disables the cache warning on supported platforms (namely Vercel), as it's automatically configured and action is not required on the user's part.

This prevents a confusing message that leaves the user thinking something is wrong.