### PR TITLE
Disable Comment Extraction

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -640,6 +640,7 @@ export default async function getBaseWebpackConfig(
       minimizer: [
         // Minify JavaScript
         new TerserPlugin({
+          extractComments: false,
           cache: path.join(distDir, 'cache', 'next-minifier'),
           parallel: config.experimental.cpus || true,
           terserOptions,

--- a/test/integration/build-output/fixtures/basic-app/pages/index.js
+++ b/test/integration/build-output/fixtures/basic-app/pages/index.js
@@ -1,3 +1,4 @@
+/*! DO NOT EXTRACT ME */
 export default function() {
   return <div />
 }

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -4,6 +4,7 @@ import 'flat-map-polyfill'
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
+import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
 
@@ -33,6 +34,14 @@ describe('Build Output', () => {
       expect(stdout).not.toContain('<buildId>')
 
       expect(stdout).toContain('○ /')
+    })
+
+    it('should not emit extracted comments', async () => {
+      const files = await recursiveReadDir(
+        join(appDir, '.next'),
+        /\.txt|\.LICENSE\./
+      )
+      expect(files).toEqual([])
     })
   })
 


### PR DESCRIPTION
This disables Terser's default comment extraction. These files are not accessible through the Next.js server, so there's no reason to write them.

Users who are concerned about retaining these comments should implement their own workflow and disclosure/acknowledgements in their application.