### PR TITLE
[Fast Refresh] Correctly Trap Focus in Overlay

### DIFF
--- a/packages/react-dev-overlay/package.json
+++ b/packages/react-dev-overlay/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@babel/code-frame": "7.8.3",
+    "ally.js": "1.4.1",
     "anser": "1.4.9",
     "chalk": "4.0.0",
     "classnames": "2.2.6",

--- a/packages/react-dev-overlay/src/internal/components/LeftRightDialogHeader/LeftRightDialogHeader.tsx
+++ b/packages/react-dev-overlay/src/internal/components/LeftRightDialogHeader/LeftRightDialogHeader.tsx
@@ -48,12 +48,8 @@ const LeftRightDialogHeader: React.FC<LeftRightDialogHeaderProps> = function Lef
         e.stopPropagation()
         if (root instanceof ShadowRoot) {
           const a = root.activeElement
-          if (a !== buttonClose.current && a instanceof HTMLElement) {
-            if (buttonClose.current) {
-              buttonClose.current.focus()
-            } else {
-              a.blur()
-            }
+          if (a && a !== buttonClose.current && a instanceof HTMLElement) {
+            a.blur()
             return
           }
         }

--- a/packages/react-dev-overlay/src/internal/components/Overlay/Overlay.tsx
+++ b/packages/react-dev-overlay/src/internal/components/Overlay/Overlay.tsx
@@ -1,3 +1,5 @@
+import allyDisable from 'ally.js/maintain/disabled'
+import allyTrap from 'ally.js/maintain/tab-focus'
 import * as React from 'react'
 import { lock, unlock } from './body-locker'
 
@@ -14,8 +16,26 @@ const Overlay: React.FC<OverlayProps> = function Overlay({
     }
   }, [])
 
+  const [overlay, setOverlay] = React.useState<HTMLElement | null>(null)
+  const onOverlay = React.useCallback((el: HTMLElement) => {
+    setOverlay(el)
+  }, [])
+
+  React.useEffect(() => {
+    if (overlay == null) {
+      return
+    }
+
+    const handle1 = allyDisable({ filter: overlay })
+    const handle2 = allyTrap({ context: overlay })
+    return () => {
+      handle1.disengage()
+      handle2.disengage()
+    }
+  }, [overlay])
+
   return (
-    <div data-nextjs-dialog-overlay className={className}>
+    <div data-nextjs-dialog-overlay className={className} ref={onOverlay}>
       <div data-nextjs-dialog-backdrop />
       {children}
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,6 +3225,14 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ally.js@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ally.js/-/ally.js-1.4.1.tgz#9fb7e6ba58efac4ee9131cb29aa9ee3b540bcf1e"
+  integrity sha1-n7fmuljvrE7pExyymqnuO1QLzx4=
+  dependencies:
+    css.escape "^1.5.0"
+    platform "1.3.3"
+
 alphanum-sort@^1.0.0, alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -5546,6 +5554,11 @@ css-what@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.2.1.tgz#f4a8f12421064621b456755e34a03a2c22df5da1"
   integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
+
+css.escape@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
 css@^2.0.0:
   version "2.2.4"
@@ -12283,6 +12296,11 @@ pkg-up@^3.0.1:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+platform@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
+  integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
As required for accessibility, we need to trap focus within the overlay.

This makes it easy to tab through everything that is focusable, without it going into the address bar or your application.