### PR TITLE
[Fast Refresh] Better Tabbing Order

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
+++ b/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
@@ -60,7 +60,7 @@ export const CodeFrame: React.FC<CodeFrameProps> = function CodeFrame({
       <p
         role="link"
         onClick={open}
-        tabIndex={0}
+        tabIndex={1}
         title="Click to open in your editor"
       >
         <span>

--- a/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
+++ b/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
@@ -37,7 +37,7 @@ const CallStackFrame: React.FC<{
       <h6>{f.methodName}</h6>
       <div
         data-has-source={hasSource ? 'true' : undefined}
-        tabIndex={hasSource ? 0 : undefined}
+        tabIndex={hasSource ? 10 : undefined}
         role={hasSource ? 'link' : undefined}
         onClick={open}
         title={hasSource ? 'Click to open in your editor' : undefined}


### PR DESCRIPTION
This improves the order that the Fast Refresh overlay is tabbed through:

1. Source error (tab+enter = open source in editor)
2. Stack frames
3. Left / Right (accessible via arrow keys)
4. Close action (accessible via escape key)