### PR TITLE
[Fast Refresh] Fix overlay display on Safari

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/Overlay/styles.tsx
+++ b/packages/react-dev-overlay/src/internal/components/Overlay/styles.tsx
@@ -3,7 +3,7 @@ import { noop as css } from '../../helpers/noop-template'
 const styles = css`
   [data-nextjs-dialog-overlay] {
     position: fixed;
-    top: 10vh;
+    top: 0;
     right: 0;
     bottom: 0;
     left: 0;
@@ -14,7 +14,7 @@ const styles = css`
     align-content: center;
     align-items: center;
     flex-direction: column;
-    padding: 0 15px;
+    padding: 10vh 15px 0;
   }
 
   [data-nextjs-dialog-backdrop] {


### PR DESCRIPTION
This fixes the overlay display in Safari, which does not allow elements to reach out side of their parent's boundaries.

The old behavior worked in Chrome and Firefox, but this new behavior works in all 3 (Chrome, Firefox, Safari).

**Before**

![image](https://user-images.githubusercontent.com/616428/81084012-54299680-8ec3-11ea-912e-6e844623d83a.png)

**After**

![image](https://user-images.githubusercontent.com/616428/81084308-b08cb600-8ec3-11ea-808e-57732bd9e44a.png)
