### PR TITLE
Update tests to poll for output instead of wait for it

### DIFF
--- a/test/integration/jsconfig-baseurl/test/index.test.js
+++ b/test/integration/jsconfig-baseurl/test/index.test.js
@@ -8,7 +8,7 @@ import {
   findPort,
   launchApp,
   killApp,
-  waitFor,
+  check,
 } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
@@ -54,11 +54,13 @@ describe('TypeScript Features', () => {
       )
       await renderViaHTTP(appPort, '/hello')
 
-      await waitFor(2 * 1000)
-      await fs.writeFile(basicPage, contents)
-      expect(output).toContain(
-        `Module not found: Can't resolve 'components/worldd' in`
+      const found = await check(
+        () => output,
+        /Module not found: Can't resolve 'components\/worldd' in/,
+        false
       )
+      await fs.writeFile(basicPage, contents)
+      expect(found).toBe(true)
     })
   })
 })

--- a/test/integration/jsconfig-paths/test/index.test.js
+++ b/test/integration/jsconfig-paths/test/index.test.js
@@ -8,7 +8,7 @@ import {
   findPort,
   launchApp,
   killApp,
-  waitFor,
+  check,
 } from 'next-test-utils'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
@@ -71,9 +71,13 @@ describe('TypeScript Features', () => {
       await fs.writeFile(basicPage, contents.replace('@c/world', '@c/worldd'))
       await renderViaHTTP(appPort, '/basic-alias')
 
-      await waitFor(2 * 1000)
+      const found = await check(
+        () => output,
+        /Module not found: Can't resolve '@c\/worldd' in/,
+        false
+      )
       await fs.writeFile(basicPage, contents)
-      expect(output).toContain(`Module not found: Can't resolve '@c/worldd' in`)
+      expect(found).toBe(true)
     })
   })
 })


### PR DESCRIPTION
As discussed this updates to poll instead of wait for an arbitrary amount of time for the output we're checking for in these tests to make them more stable. 

This also reworks the `check` test util to allow handling the content not being found gracefully instead of throwing an error inside of the timeout which can't be caught gracefully to allow clean-up but still maintains the previous behavior for existing tests 