### PR TITLE
Add docs for Internationalization (i18n).

### DIFF
--- a/docs/advanced-features/i18n.md
+++ b/docs/advanced-features/i18n.md
@@ -13,12 +13,10 @@ description: Internationalization (i18n) is the process of adapting your website
   </ul>
 </details>
 
-Internationalization (i18n) is the process of adapting your website based on a user's location. If you're developing global applications with Next.js, you likely need to support multiple languages. Supporting
+Internationalization (i18n) is the process of adapting your website based on a user's location. If you're developing global applications with Next.js, you likely need to support multiple languages. Currently, i18n support is not built directly into Next.js. There are a few options each with their own tradeoffs.
 
-Currently, i18n is not built directly into Next.js. There are a few options for adding i18n support, each with their own tradeoffs.
-
-1. [next-i18next](https://github.com/isaachinman/next-i18next), which uses [react-i18next](https://github.com/i18next/react-i18next) under the hood, is an excellent library. It requires a higher-order component (HoC) with `getInitialProps` on `_app.js`. The tradeoff with this approach is that you've opted out of static rendering on a per-page basis. If you're okay with server-side rendering (SSR) every page, then this approach could work for you. next-i18nnext does not support serverless and requires a custom server.
+1. `getStaticProps`/`getStaticPaths` in combination with dynamic routing will allow you to generate localized versions of pages without any external libraries. This works for simple applications but lacks some of the advanced features libraries like [react-i18next](https://github.com/i18next/react-i18next) support. **Note:** You have to add `getStaticProps`/`getStaticPaths` to all routes that have dynamic parameters.
 1. [next-translate](https://github.com/vinissimus/next-translate) allows for static rendering. It uses a separate folder `pages_`, which builds the _actual_ pages folder with the required subpaths.
-1. `getStaticProps`/`getStaticPaths` in combination with dynamic routing will allow you to generate localized versions of pages with any external libraries. This works for simple applications but lacks some of the advanced features libraries like [react-i18next](https://github.com/i18next/react-i18next) support. **Note:** You have to add `getStaticProps`/`getStaticPaths` to all routes that have dynamic parameters.
+1. [next-i18next](https://github.com/isaachinman/next-i18next), which uses [react-i18next](https://github.com/i18next/react-i18next) under the hood. It requires a higher-order component (HoC) with `getInitialProps` on `_app.js`. The tradeoff with this approach is that you've opted out of static rendering on a per-page basis. If you're okay with server-side rendering (SSR) every page, this approach could work for you. It does not support serverless and requires a custom server.
 
-All of these solutions have tradeoffs, which is why we're working on building i18n support directly into Next.js. Stay tuned!
+All of these solutions have tradeoffs, which is why we're working on building i18n support directly into Next.js.

--- a/docs/advanced-features/i18n.md
+++ b/docs/advanced-features/i18n.md
@@ -1,0 +1,24 @@
+---
+description: Internationalization (i18n) is the process of adapting your website based on a user's location.
+---
+
+# Internationalization and Localization (i18n)
+
+<details>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-i18n-rosetta">with-i18n-rosetta</a></li>
+<li><a href="https://github.com/zeit/next.js/tree/canary/examples/with-next-i18next">with-next-i18next</a></li>
+<li><a href="https://github.com/vinissimus/next-translate/tree/master/examples/with-dynamic-routes">with-dynamic-routes</a></li>
+  </ul>
+</details>
+
+Internationalization (i18n) is the process of adapting your website based on a user's location. If you're developing global applications with Next.js, you likely need to support multiple languages. Supporting
+
+Currently, i18n is not built directly into Next.js. There are a few options for adding i18n support, each with their own tradeoffs.
+
+1. [next-i18next](https://github.com/isaachinman/next-i18next), which uses [react-i18next](https://github.com/i18next/react-i18next) under the hood, is an excellent library. It requires a higher-order component (HoC) with `getInitialProps` on `_app.js`. The tradeoff with this approach is that you've opted out of static rendering on a per-page basis. If you're okay with server-side rendering (SSR) every page, then this approach could work for you. next-i18nnext does not support serverless and requires a custom server.
+1. [next-translate](https://github.com/vinissimus/next-translate) allows for static rendering. It uses a separate folder `pages_`, which builds the _actual_ pages folder with the required subpaths.
+1. `getStaticProps`/`getStaticPaths` in combination with dynamic routing will allow you to generate localized versions of pages with any external libraries. This works for simple applications but lacks some of the advanced features libraries like [react-i18next](https://github.com/i18next/react-i18next) support. **Note:** You have to add `getStaticProps`/`getStaticPaths` to all routes that have dynamic parameters.
+
+All of these solutions have tradeoffs, which is why we're working on building i18n support directly into Next.js. Stay tuned!

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -152,6 +152,10 @@
             {
               "title": "Multi Zones",
               "path": "/docs/advanced-features/multi-zones.md"
+            },
+            {
+              "title": "Internationalization (i18n)",
+              "path": "/docs/advanced-features/i18n.md"
             }
           ]
         },


### PR DESCRIPTION
There have been a few questions in the Discussions about i18n. Hopefully, this will help clear up the options available before i18n is built directly into Next.js. 