### PR TITLE
fix crash when NODE_OPTIONS includes --inspect-port

### DIFF
--- a/packages/next/server/lib/utils.ts
+++ b/packages/next/server/lib/utils.ts
@@ -10,6 +10,6 @@ export function printAndExit(message: string, code = 1) {
 }
 
 export function getNodeOptionsWithoutInspect() {
-  const NODE_INSPECT_RE = /--inspect(-brk)?(=\S+)? ?/
+  const NODE_INSPECT_RE = /--inspect(-brk)?(=\S+)?( |$)/
   return (process.env.NODE_OPTIONS || '').replace(NODE_INSPECT_RE, '')
 }

--- a/test/unit/get-node-options-without-inspect.test.js
+++ b/test/unit/get-node-options-without-inspect.test.js
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+import { getNodeOptionsWithoutInspect } from 'next/dist/server/lib/utils'
+
+const originalNodeOptions = process.env.NODE_OPTIONS
+
+afterAll(() => {
+  process.env.NODE_OPTIONS = originalNodeOptions
+})
+
+describe('getNodeOptionsWithoutInspect', () => {
+  it('removes --inspect option', () => {
+    process.env.NODE_OPTIONS = '--other --inspect --additional'
+    const result = getNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--other --additional')
+  })
+
+  it('removes --inspect option at end of line', () => {
+    process.env.NODE_OPTIONS = '--other --inspect'
+    const result = getNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--other ')
+  })
+
+  it('removes --inspect option with parameters', () => {
+    process.env.NODE_OPTIONS = '--other --inspect=0.0.0.0:1234 --additional'
+    const result = getNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--other --additional')
+  })
+
+  it('removes --inspect-brk option', () => {
+    process.env.NODE_OPTIONS = '--other --inspect-brk --additional'
+    const result = getNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--other --additional')
+  })
+
+  it('removes --inspect-brk option with parameters', () => {
+    process.env.NODE_OPTIONS = '--other --inspect-brk=0.0.0.0:1234 --additional'
+    const result = getNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--other --additional')
+  })
+
+  it('ignores unrelated options starting with --inspect-', () => {
+    process.env.NODE_OPTIONS =
+      '--other --inspect-port=0.0.0.0:1234 --additional'
+    const result = getNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--other --inspect-port=0.0.0.0:1234 --additional')
+  })
+})


### PR DESCRIPTION
Next attempts to strip out `--inspect` and `--inspect-brk` parameters when launching a child process. The logic was previously transforming `--inspect-port` to `-port` resulting in a crash launching the child node process.

# Reproduction

```
$ NODE_OPTIONS=--inspect-port=0.0.0.0 next dev
[ wait ]  starting the development server ...
[ info ]  waiting on http://localhost:3000 ...
events.js:298
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at ChildProcess.target._send (internal/child_process.js:806:20)
    at ChildProcess.target.send (internal/child_process.js:677:19)
    at ChildProcessWorker.initialize (/home/mpareja/projects/alpha/web/node_modules/jest-worker/build/workers/ChildProcessWorker.js:181:11)
    at new ChildProcessWorker (/home/mpareja/projects/alpha/web/node_modules/jest-worker/build/workers/ChildProcessWorker.js:127:10)
    at WorkerPool.createWorker (/home/mpareja/projects/alpha/web/node_modules/jest-worker/build/WorkerPool.js:44:12)
    at new BaseWorkerPool (/home/mpareja/projects/alpha/web/node_modules/jest-worker/build/base/BaseWorkerPool.js:82:27)
    at new WorkerPool (/home/mpareja/projects/alpha/web/node_modules/jest-worker/build/WorkerPool.js:30:1)
    at new JestWorker (/home/mpareja/projects/alpha/web/node_modules/jest-worker/build/index.js:131:26)
    at new DevServer (/home/mpareja/projects/alpha/web/node_modules/next/dist/server/next-dev-server.js:1:4363)
    at createServer (/home/mpareja/projects/alpha/web/node_modules/next/dist/server/next.js:2:105)
Emitted 'error' event on ChildProcess instance at:
    at internal/child_process.js:810:39
    at processTicksAndRejections (internal/process/task_queues.js:79:11) {
  errno: 'EPIPE',
  code: 'EPIPE',
  syscall: 'write'
}
```