### PR TITLE
Increase timeout for React refresh tests on windows

### DIFF
--- a/test/acceptance/helpers.js
+++ b/test/acceptance/helpers.js
@@ -62,7 +62,7 @@ export async function sandbox(id = nanoid()) {
               if (window.__NEXT_HYDRATED) {
                 callback()
               } else {
-                var timeout = setTimeout(callback, 10 * 1000)
+                var timeout = setTimeout(callback, 30 * 1000)
                 window.__NEXT_HYDRATED_CB = function() {
                   clearTimeout(timeout)
                   callback()

--- a/test/acceptance/helpers.js
+++ b/test/acceptance/helpers.js
@@ -42,7 +42,7 @@ export async function sandbox(id = nanoid()) {
 
           var timeout = setTimeout(() => {
             window.__HMR_STATE = 'timeout'
-          }, 10000)
+          }, 30 * 1000)
           window.__NEXT_HMR_CB = function() {
             clearTimeout(timeout)
             window.__HMR_STATE = 'success'


### PR DESCRIPTION
After investigating the tests failing on windows intermittently a bit it seems that it fails from timing out on windows so this increases it to 30 seconds before timing out