### PR TITLE
Update to run tests in headless mode on Azure

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -137,6 +137,11 @@ const TIMINGS_API = `https://next-timings.jjsweb.site/api/timings`
           stdio: 'inherit',
           env: {
             ...process.env,
+            ...(isAzure
+              ? {
+                  HEADLESS: 'true',
+                }
+              : {}),
             ...(usePolling
               ? {
                   // Events can be finicky in CI. This switches to a more

--- a/test/acceptance/helpers.js
+++ b/test/acceptance/helpers.js
@@ -42,7 +42,7 @@ export async function sandbox(id = nanoid()) {
 
           var timeout = setTimeout(() => {
             window.__HMR_STATE = 'timeout'
-          }, 10000)
+          }, 30 * 1000)
           window.__NEXT_HMR_CB = function() {
             clearTimeout(timeout)
             window.__HMR_STATE = 'success'
@@ -62,7 +62,7 @@ export async function sandbox(id = nanoid()) {
               if (window.__NEXT_HYDRATED) {
                 callback()
               } else {
-                var timeout = setTimeout(callback, 10 * 1000)
+                var timeout = setTimeout(callback, 30 * 1000)
                 window.__NEXT_HYDRATED_CB = function() {
                   clearTimeout(timeout)
                   callback()


### PR DESCRIPTION
Follow-up to https://github.com/zeit/next.js/pull/12565 this adds the timeout and also updates to run our tests in headless mode since it appears that if a tab is moved to the background it can cause the test to flake on Windows

