### PR TITLE
Throw error for falsey env config values

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -133,6 +133,12 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       })
     }
 
+    if (key === 'env' && !userConfig[key]) {
+      throw new Error(
+        `> Specified env is not an object, found "${userConfig[key]}". Please update this config or remove it.`
+      )
+    }
+
     const maybeObject = userConfig[key]
     if (!!maybeObject && maybeObject.constructor === Object) {
       userConfig[key] = {


### PR DESCRIPTION
If a user passes in a falsey `env` config option in their `next.config.js`, this will throw an error. Otherwise if a user has `env: null` [this line in `webpack-config.ts`](https://github.com/zeit/next.js/blob/00c64d08f9dcdca065ce59c0cc08c9be9db6d1dd/packages/next/build/webpack-config.ts#L796) will throw an error and cause the build to fail with the error mentioned in #9754.

Closes #9754