### PR TITLE
Add cross-env package

### DIFF
--- a/examples/with-firebase-authentication-serverless/README.md
+++ b/examples/with-firebase-authentication-serverless/README.md
@@ -45,7 +45,3 @@ After deploying, copy the deployment URL and navigate to your Firebase project's
 ## The idea behind the example
 
 This example includes Firebase authentication and serverless [API routes](https://nextjs.org/docs/api-routes/introduction). On login, the app calls `/api/login`, which stores the user's info (their decoded Firebase token) in a cookie so that it's available server-side in `getInitialProps`. On logout, the app calls `/api/logout` to destroy the cookie.
-
-## Notes
-
-- **(Optional)** if you use windows os, install `npm install -g win-node-env` to avoid having future problems with `NODE_ENV = development` in `package.json`.

--- a/examples/with-firebase-authentication-serverless/README.md
+++ b/examples/with-firebase-authentication-serverless/README.md
@@ -45,3 +45,7 @@ After deploying, copy the deployment URL and navigate to your Firebase project's
 ## The idea behind the example
 
 This example includes Firebase authentication and serverless [API routes](https://nextjs.org/docs/api-routes/introduction). On login, the app calls `/api/login`, which stores the user's info (their decoded Firebase token) in a cookie so that it's available server-side in `getInitialProps`. On logout, the app calls `/api/logout` to destroy the cookie.
+
+## Notes
+
+- **(Optional)** if you use windows os, install `npm install -g win-node-env` to avoid having future problems with `NODE_ENV = development` in `package.json`.

--- a/examples/with-firebase-authentication-serverless/package.json
+++ b/examples/with-firebase-authentication-serverless/package.json
@@ -2,12 +2,13 @@
   "name": "with-firebase-auth-serverless",
   "version": "1.0.0",
   "scripts": {
-    "dev": "NODE_ENV=development next dev",
-    "build": "NODE_ENV=production next build",
-    "start": "NODE_ENV=production next start"
+    "dev": "cross-env NODE_ENV=development next dev",
+    "build": "cross-env NODE_ENV=production next build",
+    "start": "cross-env NODE_ENV=production next start"
   },
   "dependencies": {
     "cookie-session": "1.4.0",
+    "cross-env": "^7.0.2",
     "dotenv": "8.2.0",
     "firebase": "^7.6.1",
     "firebase-admin": "^8.9.0",

--- a/examples/with-firebase-authentication-serverless/package.json
+++ b/examples/with-firebase-authentication-serverless/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "cookie-session": "1.4.0",
-    "cross-env": "^7.0.2",
     "dotenv": "8.2.0",
     "firebase": "^7.6.1",
     "firebase-admin": "^8.9.0",
@@ -20,5 +19,7 @@
     "react-dom": "^16.12.0",
     "react-firebaseui": "4.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "cross-env": "^7.0.2"
+  }
 }


### PR DESCRIPTION
Most Windows command prompts will choke when you set environment variables with `NODE_ENV=development`
![image](https://user-images.githubusercontent.com/40905751/81238223-17df5e80-8fc7-11ea-9feb-321945a18da3.png)

So, I have added the cross-env package for a multiplatform solution
