### PR TITLE
Use @/ to show module alias instead of @ prefixed

### DIFF
--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -58,7 +58,7 @@ An example of this configuration:
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "_components/*": ["components/*"]
+      "@/components/*": ["components/*"]
     }
   }
 }

--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -73,7 +73,7 @@ export default function Button() {
 
 ```jsx
 // pages/index.js
-import Button from '_components/button'
+import Button from '@/components/button'
 
 export default function HomePage() {
   return (

--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -58,7 +58,7 @@ An example of this configuration:
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@components/*": ["components/*"]
+      "_components/*": ["components/*"]
     }
   }
 }
@@ -73,7 +73,7 @@ export default function Button() {
 
 ```jsx
 // pages/index.js
-import Button from '@components/button'
+import Button from '_components/button'
 
 export default function HomePage() {
   return (


### PR DESCRIPTION
Even being a common practice, the use of reserved '@' for prefixing module aliases should not be promoted in doc.

Why ?

Will hurt when an org publishes a '@core/xxx" package. 

Just changed the prefix by '_' in the example, but curious to know what are the practices here. 

NexJs rock ! Thanks for making it truly awesome.

