### PR TITLE
Context types for getStaticProps and getServerSideProps

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -72,14 +72,16 @@ export {
   NextApiHandler,
 }
 
-export type GetStaticProps<
-  P extends { [key: string]: any } = { [key: string]: any },
-  Q extends ParsedUrlQuery = ParsedUrlQuery
-> = (ctx: {
+export type GetStaticPropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
   params?: Q
   preview?: boolean
   previewData?: any
-}) => Promise<{
+};
+
+export type GetStaticProps<
+  P extends { [key: string]: any } = { [key: string]: any },
+  Q extends ParsedUrlQuery = ParsedUrlQuery
+> = (ctx: GetStaticPropsContext<Q>) => Promise<{
   props: P
   unstable_revalidate?: number | boolean
 }>
@@ -91,16 +93,18 @@ export type GetStaticPaths<
   fallback: boolean
 }>
 
-export type GetServerSideProps<
-  P extends { [key: string]: any } = { [key: string]: any },
-  Q extends ParsedUrlQuery = ParsedUrlQuery
-> = (context: {
+export type GetServerSidePropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
   req: IncomingMessage
   res: ServerResponse
   params?: Q
   query: ParsedUrlQuery
   preview?: boolean
   previewData?: any
-}) => Promise<{ props: P }>
+};
+
+export type GetServerSideProps<
+  P extends { [key: string]: any } = { [key: string]: any },
+  Q extends ParsedUrlQuery = ParsedUrlQuery
+> = (context: GetServerSidePropsContext<Q>) => Promise<{ props: P }>
 
 export default next

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -76,12 +76,14 @@ export type GetStaticPropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
   params?: Q
   preview?: boolean
   previewData?: any
-};
+}
 
 export type GetStaticProps<
   P extends { [key: string]: any } = { [key: string]: any },
   Q extends ParsedUrlQuery = ParsedUrlQuery
-> = (ctx: GetStaticPropsContext<Q>) => Promise<{
+> = (
+  ctx: GetStaticPropsContext<Q>
+) => Promise<{
   props: P
   unstable_revalidate?: number | boolean
 }>
@@ -93,14 +95,16 @@ export type GetStaticPaths<
   fallback: boolean
 }>
 
-export type GetServerSidePropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
+export type GetServerSidePropsContext<
+  Q extends ParsedUrlQuery = ParsedUrlQuery
+> = {
   req: IncomingMessage
   res: ServerResponse
   params?: Q
   query: ParsedUrlQuery
   preview?: boolean
   previewData?: any
-};
+}
 
 export type GetServerSideProps<
   P extends { [key: string]: any } = { [key: string]: any },


### PR DESCRIPTION
I'm proposing adding `GetStaticPropsContext` and `GetServerSidePropsContext` types. This makes it easier for those types to be reused.