### PR TITLE
[Examples] Update data-fetch example

### DIFF
--- a/examples/data-fetch/pages/index.js
+++ b/examples/data-fetch/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 import fetch from 'node-fetch'
 
@@ -6,7 +5,7 @@ function Index({ stars }) {
   return (
     <div>
       <p>Next.js has {stars} ⭐️</p>
-      <Link href="/preact">
+      <Link href="/preact-stars">
         <a>How about preact?</a>
       </Link>
     </div>
@@ -15,7 +14,8 @@ function Index({ stars }) {
 
 export async function getStaticProps() {
   const res = await fetch('https://api.github.com/repos/zeit/next.js')
-  const json = await res.json() // better use it inside try .. catch
+  const json = await res.json()
+
   return {
     props: {
       stars: json.stargazers_count,

--- a/examples/data-fetch/pages/preact-stars.js
+++ b/examples/data-fetch/pages/preact-stars.js
@@ -1,8 +1,7 @@
-import React from 'react'
 import Link from 'next/link'
 import fetch from 'node-fetch'
 
-function Preact({ stars }) {
+function PreactStars({ stars }) {
   return (
     <div>
       <p>Preact has {stars} ⭐</p>
@@ -15,7 +14,8 @@ function Preact({ stars }) {
 
 export async function getStaticProps() {
   const res = await fetch('https://api.github.com/repos/developit/preact')
-  const json = await res.json() // better use it inside try .. catch
+  const json = await res.json()
+
   return {
     props: {
       stars: json.stargazers_count,
@@ -23,4 +23,4 @@ export async function getStaticProps() {
   }
 }
 
-export default Preact
+export default PreactStars


### PR DESCRIPTION
- Moved `pages/preact.js` to `pages/preact-stars` to better clarify what the page does, currently it may seem that the example is using preact
- Removed the comment for `// better use it inside try .. catch` - It's not necessary to handle the error as the build will never work if the API is down and you'll never ship a broken app in this case.