### PR TITLE
[Fast Refresh] Overlay hash must consider stack

### DIFF
--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -41,7 +41,7 @@ function getErrorSignature(ev: SupportedErrorEvent): string {
   switch (event.type) {
     case TYPE_UNHANDLED_ERROR:
     case TYPE_UNHANDLED_REJECTION: {
-      return `${event.reason.name}::${event.reason.message}`
+      return `${event.reason.name}::${event.reason.message}::${event.reason.stack}`
     }
     default: {
     }


### PR DESCRIPTION
This prevents us from hiding two separate errors that contain the same message.