### PR TITLE
Disable experimental pageEnv stub by default

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -51,7 +51,7 @@ const defaultConfig: { [key: string]: any } = {
     workerThreads: false,
     basePath: '',
     sassOptions: {},
-    pageEnv: true,
+    pageEnv: false,
     measureFid: false,
     reactRefresh: false,
   },

--- a/test/integration/process-env-stub/next.config.js
+++ b/test/integration/process-env-stub/next.config.js
@@ -1,1 +1,5 @@
-module.exports = {}
+module.exports = {
+  experimental: {
+    pageEnv: true,
+  },
+}


### PR DESCRIPTION
As discussed this re-disables the experimental `pageEnv` stub by default while it is iterated on