### PR TITLE
Add download time stat to build output

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -45,6 +45,7 @@ NODE_OPTIONS='--inspect' next
 
 - **Size** – The number of assets downloaded when navigating to the page client-side. The size for each route only includes its dependencies.
 - **First Load JS** – The number of assets downloaded when visiting the page from the server. The amount of JS shared by all is shown as a separate metric.
+- **Download Time** – The time it’ll take to download your page on a 3G connection.
 
 The first load is colored green, yellow, or red. Aim for green for performant applications.
 


### PR DESCRIPTION
This adds another column to the build output, displaying the download time of each page, as an extra stat for getting an overview of potential performance.

![carbon](https://user-images.githubusercontent.com/24858006/81472802-1d6cbc80-91f2-11ea-8323-a41f730bb311.png)
 