### PR TITLE
fix: use latest experimental method names

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -371,8 +371,8 @@ function renderReactElement(reactEl, domEl) {
       const opts = { hydrate: true }
       reactRoot =
         process.env.__NEXT_REACT_MODE === 'concurrent'
-          ? ReactDOM.createRoot(domEl, opts)
-          : ReactDOM.createBlockingRoot(domEl, opts)
+          ? ReactDOM.unstable_createRoot(domEl, opts)
+          : ReactDOM.unstable_createBlockingRoot(domEl, opts)
     }
     reactRoot.render(reactEl)
   } else {


### PR DESCRIPTION
Experimental APIs are now always prefixed: https://github.com/facebook/react/pull/18825

Latest experimental build: https://unpkg.com/react-dom@experimental/cjs/react-dom.development.js

---

Fixes #12670