### PR TITLE
[Fast Refresh] Reorder Loaders

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -765,15 +765,15 @@ export default async function getBaseWebpackConfig(
                     workerParallelJobs: Infinity,
                   },
                 },
-                defaultLoaders.babel,
                 hasReactRefresh
                   ? require.resolve('@next/react-refresh-utils/loader')
                   : '',
+                defaultLoaders.babel,
               ].filter(Boolean)
             : hasReactRefresh
             ? [
-                defaultLoaders.babel,
                 require.resolve('@next/react-refresh-utils/loader'),
+                defaultLoaders.babel,
               ]
             : defaultLoaders.babel,
         },

--- a/test/acceptance/helpers.js
+++ b/test/acceptance/helpers.js
@@ -134,8 +134,20 @@ export async function sandbox(id = nanoid(), initialFiles = new Map()) {
         } while (expected)
         return false
       },
-      async getRedboxSource() {
-        return this.evaluate(() => {
+      async getRedboxSource(includeHeader = false) {
+        const header = includeHeader
+          ? await this.evaluate(() => {
+              const portal = [].slice
+                .call(document.querySelectorAll('nextjs-portal'))
+                .find(p =>
+                  p.shadowRoot.querySelector('[data-nextjs-dialog-header')
+                )
+              const root = portal.shadowRoot
+              return root.querySelector('[data-nextjs-dialog-header]').innerText
+            })
+          : ''
+
+        const source = await this.evaluate(() => {
           const portal = [].slice
             .call(document.querySelectorAll('nextjs-portal'))
             .find(p =>
@@ -148,6 +160,11 @@ export async function sandbox(id = nanoid(), initialFiles = new Map()) {
             '[data-nextjs-codeframe], [data-nextjs-terminal]'
           ).innerText
         })
+
+        if (includeHeader) {
+          return `${header}\n\n${source}`
+        }
+        return source
       },
     },
     function cleanup() {


### PR DESCRIPTION
This reorders the fast refresh loader so that it does not influence Babel syntax errors, obscuring the real problem.

Without this, the user sees something like:
```hs
    SyntaxError: /Users/joe/Documents/Development/Work/zeit/next.js-extra/test/acceptance/__tmp__/fiuG3UK5eJ3kqLTI4GNv5/index.js: Unexpected token (17:8)

      15 |     // browser context before continuing.
      16 |     if (typeof self !== 'undefined') {
    > 17 |         var currentExports_1 = module.__proto__.exports;
         |         ^
      18 |         var prevExports = (_b = (_a = module.hot.data) === null || _a === void 0 ? void 0 : _a.prevExports) !== null && _b !== void 0 ? _b : null;
      19 |         // This cannot happen in MainTemplate because the exports mismatch between
      20 |         // templating and execution.
```