### PR TITLE
Update documentation that refers to isomorphic fetch libs

### DIFF
--- a/docs/advanced-features/custom-error-page.md
+++ b/docs/advanced-features/custom-error-page.md
@@ -54,7 +54,6 @@ If you want to render the built-in error page you can by importing the `Error` c
 
 ```jsx
 import Error from 'next/error'
-import fetch from 'node-fetch'
 
 export async function getServerSideProps() {
   const res = await fetch('https://api.github.com/repos/zeit/next.js')

--- a/docs/api-reference/data-fetching/getInitialProps.md
+++ b/docs/api-reference/data-fetching/getInitialProps.md
@@ -25,8 +25,6 @@ description: Enable Server-Side Rendering in a page and do initial data populati
 `getInitialProps` is an [`async`](https://vercel.com/blog/async-and-await) function that can be added to any page as a [`static method`](https://javascript.info/static-properties-methods). Take a look at the following example:
 
 ```jsx
-import fetch from 'isomorphic-unfetch'
-
 function Page({ stars }) {
   return <div>Next stars: {stars}</div>
 }
@@ -44,7 +42,6 @@ Or using a class component:
 
 ```jsx
 import React from 'react'
-import fetch from 'isomorphic-unfetch'
 
 class Page extends React.Component {
   static async getInitialProps(ctx) {

--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -52,9 +52,6 @@ The `context` parameter is an object containing the following keys:
 Here’s an example which uses `getStaticProps` to fetch a list of blog posts from a CMS (content management system). This example is also in the [Pages documentation](/docs/basic-features/pages.md).
 
 ```jsx
-// You can use any data fetching library
-import fetch from 'node-fetch'
-
 // posts will be populated at build time by getStaticProps()
 function Blog({ posts }) {
   return (
@@ -71,6 +68,7 @@ function Blog({ posts }) {
 // direct database queries. See the "Technical details" section.
 export async function getStaticProps() {
   // Call an external API endpoint to get posts.
+  // You can use any data fetching library
   const res = await fetch('https://.../posts')
   const posts = await res.json()
 
@@ -250,7 +248,6 @@ Here’s an example which pre-renders one blog post per page called `pages/posts
 
 ```jsx
 // pages/posts/[id].js
-import fetch from 'node-fetch'
 
 function Post({ post }) {
   // Render post...
@@ -308,7 +305,6 @@ Here’s an example that uses `isFallback`:
 ```jsx
 // pages/posts/[id].js
 import { useRouter } from 'next/router'
-import fetch from 'node-fetch'
 
 function Post({ post }) {
   const router = useRouter()

--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -106,8 +106,6 @@ export default Blog
 To fetch this data on pre-render, Next.js allows you to `export` an `async` function called `getStaticProps` from the same file. This function gets called at build time and lets you pass fetched data to the page's `props` on pre-render.
 
 ```jsx
-// You can use any data fetching library
-
 function Blog({ posts }) {
   // Render posts...
 }

--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -107,7 +107,6 @@ To fetch this data on pre-render, Next.js allows you to `export` an `async` func
 
 ```jsx
 // You can use any data fetching library
-import fetch from 'node-fetch'
 
 function Blog({ posts }) {
   // Render posts...
@@ -148,8 +147,6 @@ Later, you might add the second post with `id: 2`. Then you'd want to pre-render
 So your page **paths** that are pre-rendered depend on external data**.** To handle this, Next.js lets you `export` an `async` function called `getStaticPaths` from a dynamic page (`pages/posts/[id].js` in this case). This function gets called at build time and lets you specify which paths you want to pre-render.
 
 ```jsx
-import fetch from 'node-fetch'
-
 // This function gets called at build time
 export async function getStaticPaths() {
   // Call an external API endpoint to get posts
@@ -168,8 +165,6 @@ export async function getStaticPaths() {
 Also in `pages/posts/[id].js`, you need to export `getStaticProps` so that you can fetch the data about the post with this `id` and use it to pre-render the page:
 
 ```jsx
-import fetch from 'node-fetch'
-
 function Post({ post }) {
   // Render post...
 }
@@ -225,8 +220,6 @@ To use Server-side Rendering for a page, you need to `export` an `async` functio
 For example, suppose that your page needs to pre-render frequently updated data (fetched from an external API). You can write `getServerSideProps` which fetches this data and passes it to `Page` like below:
 
 ```jsx
-import fetch from 'node-fetch'
-
 function Page({ data }) {
   // Render data...
 }


### PR DESCRIPTION
These extra imports are no longer needed because of built-in fetch support.