### PR TITLE
Set environment variable for preview mode

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -521,11 +521,12 @@ export async function renderToHTML(
       previewData = tryGetPreviewData(req, res, previewProps)
     }
 
+    // Set environment variable flag for whether or not preview mode is active
+    if (!!previewData) setConfig()
+    process.env.__NEXT_PREVIEW_MODE = (!!previewData).toString()
+
     if (isSSG && !isFallback) {
       let data: UnwrapPromise<ReturnType<GetStaticProps>>
-
-      // Set environment variable flag for whether or not preview mode is active
-      process.env.__NEXT_PREVIEW_MODE = (!!previewData).toString()
 
       try {
         data = await getStaticProps!({

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -524,6 +524,9 @@ export async function renderToHTML(
     if (isSSG && !isFallback) {
       let data: UnwrapPromise<ReturnType<GetStaticProps>>
 
+      // Set environment variable flag for whether or not preview mode is active
+      process.env.__NEXT_PREVIEW_MODE = (!!previewData).toString()
+
       try {
         data = await getStaticProps!({
           ...(pageIsDynamic ? { params: query as ParsedUrlQuery } : undefined),


### PR DESCRIPTION
There are a couple hangups my team had with the current implementation of preview mode:

- Having to explicitly pass `preview` or `context` into our data fetching tool in every route seems a little repetitive, and if missed could easily break the site, so it must be a hard-required parameter that throws an error if not present.
- There's no way to tell if you're in preview mode or not in `_app.js` where we apply our layout. We'd love to be able to display a toolbar up top that calls out that you are in preview mode for extra clarity for viewers, but that becomes awkward when your layout can't tell if it's in preview mode or not.

Both of these are quickly and easily solved by having an environment variable reflect whether preview mode is active or not. I'm not sure if this is the most ideal spot to add it, but this feature immediately solves both problems and we would **love** to get it going if possible!

**EDIT:** Ok, I still have some work to do getting this to be present on the client side - right now it only works on server render.