### PR TITLE
Add message when automatic dotenv loading is disabled

### DIFF
--- a/errors/env-loading-disabled.md
+++ b/errors/env-loading-disabled.md
@@ -1,0 +1,18 @@
+# Env Loading Disabled
+
+#### Why This Error Occurred
+
+In your project you have `dotenv` listed as a `dependency` or a `devDependency` which opts-out of Next.js' automatic loading to prevent creating a conflict with any existing `dotenv` behavior in your project.
+
+This is also disabled if a `package.json` isn't able to found in your project somehow.
+
+#### Possible Ways to Fix It
+
+Remove `dotenv` from your `devDependencies` or `dependencies` and allow Next.js to load your `dotenv` files for you
+
+### Useful Links
+
+- [dotenv](https://npmjs.com/package/dotenv)
+- [dotenv-expand](https://npmjs.com/package/dotenv-expand)
+- [Environment Variables](https://en.wikipedia.org/wiki/Environment_variable)
+- [Next.js Environment Variables Docs](https://nextjs.org/docs/basic-features/environment-variables)

--- a/test/integration/env-config-disable/test/index.test.js
+++ b/test/integration/env-config-disable/test/index.test.js
@@ -25,34 +25,14 @@ const runTests = () => {
   describe('dev mode', () => {
     it('should start dev server without errors', async () => {
       let stderr = ''
+      let stdout = ''
       appPort = await findPort()
       app = await launchApp(appDir, appPort, {
         onStderr(msg) {
           stderr += msg || ''
         },
-      })
-
-      const html = await renderViaHTTP(appPort, '/')
-      await killApp(app)
-
-      expect(html).toContain('hi')
-      expect(stderr).not.toContain('Failed to load env')
-    })
-  })
-
-  describe('production mode', () => {
-    it('should build app successfully', async () => {
-      const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
-      expect(code).toBe(0)
-      expect((stderr || '').length).toBe(0)
-    })
-
-    it('should start without error', async () => {
-      let stderr = ''
-      appPort = await findPort()
-      app = await nextStart(appDir, appPort, {
-        onStderr(msg) {
-          stderr += msg || ''
+        onStdout(msg) {
+          stdout += msg || ''
         },
       })
 
@@ -61,6 +41,46 @@ const runTests = () => {
 
       expect(html).toContain('hi')
       expect(stderr).not.toContain('Failed to load env')
+      expect(stdout).toContain(
+        'dotenv loading was disabled due to the `dotenv` package being installed in'
+      )
+    })
+  })
+
+  describe('production mode', () => {
+    it('should build app successfully', async () => {
+      const { stderr, stdout, code } = await nextBuild(appDir, [], {
+        stderr: true,
+        stdout: true,
+      })
+      expect(code).toBe(0)
+      expect((stderr || '').length).toBe(0)
+      expect(stdout).toContain(
+        'dotenv loading was disabled due to the `dotenv` package being installed in'
+      )
+    })
+
+    it('should start without error', async () => {
+      let stderr = ''
+      let stdout = ''
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort, {
+        onStderr(msg) {
+          stderr += msg || ''
+        },
+        onStdout(msg) {
+          stdout += msg || ''
+        },
+      })
+
+      const html = await renderViaHTTP(appPort, '/')
+      await killApp(app)
+
+      expect(html).toContain('hi')
+      expect(stderr).not.toContain('Failed to load env')
+      expect(stdout).toContain(
+        'dotenv loading was disabled due to the `dotenv` package being installed in'
+      )
     })
   })
 }


### PR DESCRIPTION
This adds a message when we opt-out of the automatic `dotenv` loading to explain to the user that this is occurring and why

Closes: https://github.com/zeit/next.js/issues/12728