### PR TITLE
fix(packages/next-polyfill-nomodule): url-polyfill is replaced by cor…

### DIFF
--- a/packages/next-polyfill-nomodule/src/index.js
+++ b/packages/next-polyfill-nomodule/src/index.js
@@ -44,9 +44,9 @@ import 'core-js/features/weak-set'
 import 'core-js/features/promise'
 import 'core-js/features/promise/all-settled'
 import 'core-js/features/promise/finally'
+import 'core-js/features/url'
 
 // Specialized Packages:
 import 'whatwg-fetch'
-import 'url-polyfill'
 import assign from 'object-assign'
 Object.assign = assign


### PR DESCRIPTION
fix(packages/next-polyfill-nomodule): url-polyfill is replaced by core-js/features/url

url-polyfill does not throw on invalid URLs. Although the issue is resolved by [pull request 54](https://github.com/lifaon74/url-polyfill/pull/54), but url-polyfill have not release new version. In addition, core-js polyfill is more reliable than url-polyfill, although core-js url polyfill make polyfill bundle bigger the 10KB.

fix: [9851](https://github.com/zeit/next.js/issues/9851)