### PR TITLE
docs(ssr-caching): remove link to react-esi example

### DIFF
--- a/examples/ssr-caching/README.md
+++ b/examples/ssr-caching/README.md
@@ -5,8 +5,6 @@ That's what this example demonstrate.
 
 This app uses Next's [custom server and routing](https://github.com/zeit/next.js#custom-server-and-routing) mode. It also uses [express](https://expressjs.com/) to handle routing and page serving.
 
-Alternatively, see [the example using React ESI](../with-react-esi/).
-
 ## How to use
 
 ### Using `create-next-app`


### PR DESCRIPTION
As the React-ESI example was designed incorrectly and deleted (#8262), I removed the broken link pointing to it on the `ssr-caching` example!