### PR TITLE
Add check for if next.config.js exports a function

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -218,7 +218,10 @@ export default function loadConfig(
       userConfigModule.default || userConfigModule
     )
 
-    if (Object.keys(userConfig).length === 0 || typeof userConfig !== 'function') {
+    if (
+      Object.keys(userConfig).length === 0 &&
+      typeof userConfig !== 'function'
+    ) {
       console.warn(
         chalk.yellow.bold('Warning: ') +
           'Detected next.config.js, no exported configuration found. https://err.sh/zeit/next.js/empty-configuration'

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -218,7 +218,7 @@ export default function loadConfig(
       userConfigModule.default || userConfigModule
     )
 
-    if (Object.keys(userConfig).length === 0) {
+    if (Object.keys(userConfig).length === 0 || typeof userConfig !== 'function') {
       console.warn(
         chalk.yellow.bold('Warning: ') +
           'Detected next.config.js, no exported configuration found. https://err.sh/zeit/next.js/empty-configuration'

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -219,8 +219,8 @@ export default function loadConfig(
     )
 
     if (
-      Object.keys(userConfig).length === 0 &&
-      typeof userConfig !== 'function'
+      typeof userConfig !== 'function' &&
+      Object.keys(userConfig).length === 0
     ) {
       console.warn(
         chalk.yellow.bold('Warning: ') +


### PR DESCRIPTION
Currently there is a check to determine if the `next.config.js` file exports an object, but the config also supports exporting a function. This PR add a check to determine if a function is exported from the `next.config.js`

This was discovered inadvertently via a Discussion https://github.com/zeit/next.js/discussions/12749#discussioncomment-13326