### PR TITLE
Add contentful as a related example link to each CMS example

### DIFF
--- a/examples/blog-starter/README.md
+++ b/examples/blog-starter/README.md
@@ -16,6 +16,7 @@ To create the blog posts we use [`remark`](https://github.com/remarkjs/remark) a
 - [Sanity](/examples/cms-sanity)
 - [TakeShape](/examples/cms-takeshape)
 - [Prismic](/examples/cms-prismic)
+- [Contentful](/examples/cms-contentful)
 
 ## How to use
 

--- a/examples/cms-contentful/README.md
+++ b/examples/cms-contentful/README.md
@@ -10,6 +10,7 @@ This example showcases Next.js's [Static Generation](/docs/basic-features/pages.
 
 - [Blog Starter](/examples/blog-starter)
 - [DatoCMS](/examples/cms-datocms)
+- [Prismic](/examples/cms-prismic)
 - [TakeShape](/examples/cms-takeshape)
 - [Sanity](/examples/cms-sanity)
 

--- a/examples/cms-prismic/README.md
+++ b/examples/cms-prismic/README.md
@@ -12,6 +12,7 @@ This example showcases Next.js's [Static Generation](/docs/basic-features/pages.
 - [DatoCMS](/examples/cms-datocms)
 - [TakeShape](/examples/cms-takeshape)
 - [Sanity](/examples/cms-sanity)
+- [Contentful](/examples/cms-contentful)
 
 ## How to use
 

--- a/examples/cms-sanity/README.md
+++ b/examples/cms-sanity/README.md
@@ -12,6 +12,7 @@ This example showcases Next.js's [Static Generation](https://nextjs.org/docs/bas
 - [DatoCMS](/examples/cms-datocms)
 - [TakeShape](/examples/cms-takeshape)
 - [Prismic](/examples/cms-prismic)
+- [Contentful](/examples/cms-contentful)
 
 ## How to use
 

--- a/examples/cms-takeshape/README.md
+++ b/examples/cms-takeshape/README.md
@@ -12,6 +12,7 @@ This example showcases Next.js's [Static Generation](https://nextjs.org/docs/bas
 - [DatoCMS](/examples/cms-datocms)
 - [Sanity](/examples/cms-sanity)
 - [Prismic](/examples/cms-prismic)
+- [Contentful](/examples/cms-contentful)
 
 ## How to use
 


### PR DESCRIPTION
This pull request adds a few links to the example readme files, just for consistency!