### PR TITLE
Add client bootstrap

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -92,6 +92,7 @@ export function createEntrypoints(
         })
       : '',
     previewProps: JSON.stringify(previewMode),
+    reactMode: config.experimental.reactMode,
   }
 
   Object.keys(pages).forEach(page => {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -17,7 +17,6 @@ import { fileExists } from '../lib/file-exists'
 import { resolveRequest } from '../lib/resolve-request'
 import {
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
-  CLIENT_STATIC_FILES_RUNTIME_BOOTSTRAP,
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS,
   CLIENT_STATIC_FILES_RUNTIME_WEBPACK,
   REACT_LOADABLE_MANIFEST,
@@ -215,10 +214,6 @@ export default async function getBaseWebpackConfig(
               dev ? `next-dev.js` : 'next.js'
             )
           ),
-        [CLIENT_STATIC_FILES_RUNTIME_BOOTSTRAP]: path.join(
-          NEXT_PROJECT_ROOT_DIST_CLIENT,
-          'bootstrap.js'
-        ),
         [CLIENT_STATIC_FILES_RUNTIME_POLYFILLS]: path.join(
           NEXT_PROJECT_ROOT_DIST_CLIENT,
           'polyfills.js'
@@ -331,18 +326,6 @@ export default async function getBaseWebpackConfig(
       module.type === `css/extract-css-chunks`
     )
   }
-  // TODO: This is a stub used instead of webpack.compilation.Module. There is currently
-  // an issue where the DefinitelyTyped type definition for compilation Modules
-  // doesn't quite match the module API that we rely on throughout this section. Once
-  // that type definition is corrected, we can use it instead of the partial one below.
-  interface webpackModule {
-    _chunks: { values(): Array<{ name: string }> }
-  }
-
-  const isRequiredBy = (module: webpackModule, requiredBy: string) =>
-    !!Array.from(module._chunks.values()).find(
-      chunk => chunk.name === requiredBy
-    )
 
   // Contains various versions of the Webpack SplitChunksPlugin used in different build types
   const splitChunksConfigs: {
@@ -376,21 +359,13 @@ export default async function getBaseWebpackConfig(
       cacheGroups: {
         default: false,
         vendors: false,
-        bootstrap: {
-          chunks: 'all',
-          name: 'bootstrap',
-          test: (module: webpackModule) =>
-            isRequiredBy(module, 'static/runtime/bootstrap.js'),
-          priority: 50,
-          // Don't let webpack eliminate this chunk (prevents this chunk from
-          // becoming a part of the commons chunk)
-          enforce: true,
-        },
         framework: {
           chunks: 'all',
           name: 'framework',
-          test: (module: webpackModule) =>
-            isRequiredBy(module, 'static/runtime/main.js'),
+          // This regex ignores nested copies of framework libraries so they're
+          // bundled with their issuer.
+          // https://github.com/zeit/next.js/pull/9012
+          test: /(?<!node_modules.*)[\\/]node_modules[\\/](react|react-dom|scheduler|prop-types|use-subscription)[\\/]/,
           priority: 40,
           // Don't let webpack eliminate this chunk (prevents this chunk from
           // becoming a part of the commons chunk)
@@ -711,7 +686,6 @@ export default async function getBaseWebpackConfig(
         if (
           !dev &&
           (chunk.name === CLIENT_STATIC_FILES_RUNTIME_MAIN ||
-            chunk.name === CLIENT_STATIC_FILES_RUNTIME_BOOTSTRAP ||
             chunk.name === CLIENT_STATIC_FILES_RUNTIME_WEBPACK ||
             chunk.name === CLIENT_STATIC_FILES_RUNTIME_POLYFILLS)
         ) {

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -26,6 +26,7 @@ export type ServerlessLoaderQuery = {
   basePath: string
   runtimeConfig: string
   previewProps: string
+  reactMode: string
 }
 
 const nextServerlessLoader: loader.Loader = function() {
@@ -43,6 +44,7 @@ const nextServerlessLoader: loader.Loader = function() {
     basePath,
     runtimeConfig,
     previewProps,
+    reactMode,
   }: ServerlessLoaderQuery =
     typeof this.query === 'string' ? parse(this.query.substr(1)) : this.query
 
@@ -271,6 +273,7 @@ const nextServerlessLoader: loader.Loader = function() {
         previewProps: ${encodedPreviewProps},
         env: process.env,
         basePath: "${basePath}",
+        reactMode: "${reactMode}",
         ..._renderOpts
       }
       let _nextData = false

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -136,6 +136,7 @@ export default class BuildManifestPlugin {
           assetMap.pages[`/${pagePath.replace(/\\/g, '/')}`] = [
             ...filesForEntry,
             ...mainJsFiles,
+            ...bootstrapFiles,
           ]
         }
 
@@ -143,9 +144,8 @@ export default class BuildManifestPlugin {
           assetMap.pages['/'] = assetMap.pages['/index']
         }
 
-        // Create separate entries for polyfills and bootstrap
+        // Create a separate entry for polyfills
         assetMap.pages['/_polyfills'] = polyfillFiles
-        assetMap.pages['/_bootstrap'] = bootstrapFiles
 
         // Add the runtime build manifest file (generated later in this file)
         // as a dependency for the app. If the flag is false, the file won't be

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -7,6 +7,7 @@ import {
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS,
   CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH,
+  CLIENT_STATIC_FILES_RUNTIME_BOOTSTRAP,
   IS_BUNDLED_PAGE_REGEX,
   ROUTE_NAME_REGEX,
 } from '../../../next-server/lib/constants'
@@ -84,6 +85,12 @@ export default class BuildManifestPlugin {
           c => c.name === CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH
         )
         assetMap.devFiles.push(...(reactRefreshChunk?.files ?? []))
+        const bootstrapChunk = chunks.find(
+          c => c.name === CLIENT_STATIC_FILES_RUNTIME_BOOTSTRAP
+        )
+        const bootstrapFiles: string[] = bootstrapChunk
+          ? bootstrapChunk.files
+          : []
 
         for (const filePath of Object.keys(compilation.assets)) {
           const path = filePath.replace(/\\/g, '/')
@@ -136,8 +143,9 @@ export default class BuildManifestPlugin {
           assetMap.pages['/'] = assetMap.pages['/index']
         }
 
-        // Create a separate entry  for polyfills
+        // Create separate entries for polyfills and bootstrap
         assetMap.pages['/_polyfills'] = polyfillFiles
+        assetMap.pages['/_bootstrap'] = bootstrapFiles
 
         // Add the runtime build manifest file (generated later in this file)
         // as a dependency for the app. If the flag is false, the file won't be

--- a/packages/next/client/bootstrap.tsx
+++ b/packages/next/client/bootstrap.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+export interface Bootstrapper {
+  render(fn: RenderGenerator): void
+}
+
+export type RenderOpts = {
+  element: React.ReactElement
+  callback: () => void
+}
+export type RenderGenerator = (isInitialRender: boolean) => RenderOpts
+type RenderToDOM = (
+  isInitialRender: boolean,
+  children: React.ReactElement
+) => void
+
+function bootstrap(): Bootstrapper {
+  let renderToDOM: RenderToDOM | null
+  const render = (fn: RenderGenerator) => {
+    const container = document.getElementById('__next')
+    if (container == null) {
+      throw new Error('Could not find __next element')
+    }
+    let isInitialRender = false
+    if (!renderToDOM) {
+      if (process.env.__NEXT_REACT_MODE !== 'legacy') {
+        const opts = { hydrate: true }
+        performance.mark('bootstrap_createRoot_start')
+        const reactRoot =
+          process.env.__NEXT_REACT_MODE === 'concurrent'
+            ? ReactDOM.unstable_createRoot(container, opts)
+            : ReactDOM.unstable_createBlockingRoot(container, opts)
+        performance.mark('bootstrap_createRoot_end')
+        renderToDOM = (_, children) => {
+          performance.mark('bootstrap_render_start')
+          reactRoot.render(children)
+          performance.mark('bootstrap_render_end')
+        }
+        isInitialRender = true
+      } else {
+        isInitialRender = typeof ReactDOM.hydrate === 'function'
+        renderToDOM = (isInitialRender, children) => {
+          if (isInitialRender) {
+            ReactDOM.hydrate(children, container)
+          } else {
+            ReactDOM.render(children, container)
+          }
+        }
+      }
+    }
+    const content = <NextRoot useContent={() => fn(isInitialRender)} />
+    renderToDOM(
+      isInitialRender,
+      process.env.__NEXT_REACT_MODE !== 'legacy' ? (
+        <React.Suspense fallback={null}>{content}</React.Suspense>
+      ) : (
+        content
+      )
+    )
+  }
+  let renderImpl = render
+
+  if (process.env.__NEXT_REACT_MODE !== 'legacy') {
+    let generatorFn: RenderGenerator | null = null
+    const promise = new Promise(resolve => {
+      renderImpl = newGeneratorFn => {
+        if (newGeneratorFn != null) {
+          generatorFn = newGeneratorFn
+          renderImpl = render
+          resolve()
+        }
+      }
+    })
+    render(isInitalRender => {
+      if (generatorFn == null) {
+        throw promise
+      }
+      return generatorFn(isInitalRender)
+    })
+  }
+  return {
+    render: fn => renderImpl(fn),
+  }
+}
+
+function NextRoot({ useContent }: { useContent: () => RenderOpts }) {
+  const { element, callback } = useContent()
+  React.useLayoutEffect(() => callback(), [callback])
+  return element
+}
+
+export default bootstrap()

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -205,7 +205,7 @@ export default async ({ webpackHMR: passedWebpackHMR } = {}) => {
     }
   }
 
-  let initialErr = err
+  let initialErr = err ? new ServerSideError(err) : null
 
   try {
     ;({ page: Component } = await pageLoader.loadPage(page))
@@ -548,4 +548,12 @@ async function doRender({ App, Component, props, err }) {
   )
 
   emitter.emit('after-reactdom-render', { Component, ErrorComponent, appProps })
+}
+
+class ServerSideError /* implements Error */ {
+  constructor(error) {
+    this.name = error.name
+    this.message = error.message
+    this.stack = error.stack
+  }
 }

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -388,7 +388,9 @@ function renderReactElement(reactEl) {
       if (ST) {
         performance.mark('beforeRender')
       }
-      const innerCallback = isInitialRender ? markHydrateComplete : markRenderComplete
+      const innerCallback = isInitialRender
+        ? markHydrateComplete
+        : markRenderComplete
       callback = () => {
         if (isInitialRender && onPerfEntry && ST) {
           measureWebVitals(onPerfEntry)

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -392,10 +392,10 @@ function renderReactElement(reactEl) {
         ? markHydrateComplete
         : markRenderComplete
       callback = () => {
+        innerCallback()
         if (isInitialRender && onPerfEntry && ST) {
           measureWebVitals(onPerfEntry)
         }
-        innerCallback()
       }
     }
     return {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -205,7 +205,7 @@ export default async ({ webpackHMR: passedWebpackHMR } = {}) => {
     }
   }
 
-  let initialErr = err ? new ServerSideError(err) : null
+  let initialErr = err
 
   try {
     ;({ page: Component } = await pageLoader.loadPage(page))
@@ -548,12 +548,4 @@ async function doRender({ App, Component, props, err }) {
   )
 
   emitter.emit('after-reactdom-render', { Component, ErrorComponent, appProps })
-}
-
-class ServerSideError /* implements Error */ {
-  constructor(error) {
-    this.name = error.name
-    this.message = error.message
-    this.stack = error.stack
-  }
 }

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -241,6 +241,7 @@ export default async function(
     ampValidatorPath: nextConfig.experimental.amp?.validator || undefined,
     ampSkipValidation: nextConfig.experimental.amp?.skipValidation || false,
     ampOptimizerConfig: nextConfig.experimental.amp?.optimizer || undefined,
+    reactMode: nextConfig.experimental.reactMode,
   }
 
   const { serverRuntimeConfig, publicRuntimeConfig } = nextConfig

--- a/packages/next/next-server/lib/constants.ts
+++ b/packages/next/next-server/lib/constants.ts
@@ -23,6 +23,8 @@ export const CLIENT_STATIC_FILES_RUNTIME_PATH = `${CLIENT_STATIC_FILES_PATH}/${C
 export const CLIENT_STATIC_FILES_RUNTIME_MAIN = `${CLIENT_STATIC_FILES_RUNTIME_PATH}/main.js`
 // static/runtime/react-refresh.js
 export const CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH = `${CLIENT_STATIC_FILES_RUNTIME_PATH}/react-refresh.js`
+// static/runtime/bootstrap.js
+export const CLIENT_STATIC_FILES_RUNTIME_BOOTSTRAP = `${CLIENT_STATIC_FILES_RUNTIME_PATH}/bootstrap.js`
 // static/runtime/amp.js
 export const CLIENT_STATIC_FILES_RUNTIME_AMP = `${CLIENT_STATIC_FILES_RUNTIME_PATH}/amp.js`
 // static/runtime/webpack.js

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -123,6 +123,7 @@ export default class Server {
     customServer?: boolean
     ampOptimizerConfig?: { [key: string]: any }
     basePath: string
+    reactMode: string
   }
   private compression?: Middleware
   private onErrorMiddleware?: ({ err }: { err: Error }) => Promise<void>
@@ -177,6 +178,7 @@ export default class Server {
       customServer: customServer === true ? true : undefined,
       ampOptimizerConfig: this.nextConfig.experimental.amp?.optimizer,
       basePath: this.nextConfig.experimental.basePath,
+      reactMode: this.nextConfig.experimental.reactMode,
     }
 
     // Only the `publicRuntimeConfig` key is exposed to the client side

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -142,7 +142,7 @@
     "@types/node-fetch": "2.3.4",
     "@types/path-to-regexp": "1.7.0",
     "@types/react": "16.9.17",
-    "@types/react-dom": "16.9.4",
+    "@types/react-dom": "16.9.8",
     "@types/react-is": "16.7.1",
     "@types/resolve": "0.0.8",
     "@types/send": "0.14.4",

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -5,7 +5,8 @@
     "target": "ES2017",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "types": ["react-dom/experimental"]
   },
   "exclude": ["dist", "./*.d.ts"]
 }

--- a/packages/react-dev-overlay/src/client.ts
+++ b/packages/react-dev-overlay/src/client.ts
@@ -3,6 +3,7 @@ import * as Bus from './internal/bus'
 
 let isRegistered = false
 let stackTraceLimit: number | undefined = undefined
+let handledErrors = new WeakSet()
 
 function onUnhandledError(ev: ErrorEvent) {
   const error = ev?.error
@@ -12,6 +13,7 @@ function onUnhandledError(ev: ErrorEvent) {
   }
 
   const e = error
+  handledErrors.add(e)
   Bus.emit({
     type: Bus.TYPE_UNHANDLED_ERROR,
     reason: error,
@@ -31,6 +33,7 @@ function onUnhandledRejection(ev: PromiseRejectionEvent) {
   }
 
   const e = reason
+  handledErrors.add(e)
   Bus.emit({
     type: Bus.TYPE_UNHANDLED_REJECTION,
     reason: reason,
@@ -83,6 +86,17 @@ function onRefresh() {
   Bus.emit({ type: Bus.TYPE_REFFRESH })
 }
 
+function didHandleError(e: any) {
+  return handledErrors.has(e)
+}
+
 export { getNodeError } from './internal/helpers/nodeStackFrames'
 export { default as ReactDevOverlay } from './internal/ReactDevOverlay'
-export { onBuildOk, onBuildError, register, unregister, onRefresh }
+export {
+  onBuildOk,
+  onBuildError,
+  register,
+  unregister,
+  onRefresh,
+  didHandleError,
+}

--- a/test/integration/chunking/test/index.test.js
+++ b/test/integration/chunking/test/index.test.js
@@ -105,8 +105,8 @@ describe('Chunking', () => {
 
   it('should not include more than one instance of react-dom', async () => {
     const misplacedReactDom = stats.chunks.some(chunk => {
-      if (chunk.names.includes('framework')) {
-        // disregard react-dom in framework--it's supposed to be there
+      if (chunk.names.includes('bootstrap')) {
+        // disregard react-dom in bootstrap--it's supposed to be there
         return false
       }
       return chunk.modules.some(module => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,10 +2906,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@16.9.4":
-  version "16.9.4"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
-  integrity sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==
+"@types/react-dom@16.9.8":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Today, the Next.js initialization on the client looks _sort of_ like this:

```
const [App, Page] = await Promise.all([
    import(app),
    import(page),
])
ReactDOM.render(<App props={Page} />)
```

In Concurrent Mode, we want React to drive initialization, including waiting for dynamically loaded components. There's more work to be done, but this PR gets us started by turning Concurrent Mode initialization into something like:

```
ReactDOM.unstable_createRoot(root).render(<NextRoot />)
```

`NextRoot` will suspend (in Concurrent Mode) until the dependencies are loaded. For now, this just waits until the existing Next.js initialization finishes. In the future, it may make sense to actually render `<App>` and `<Page>` as `React.lazy` components instead.

This all gets broken out into a `static/bootstrap.js` chunk that only contains React dependencies. By separating it, we can ensure that React can mount before any other Next or user code, which enables Selective Hydration in React.