### PR TITLE
docs: redirect error to the correct url

### DIFF
--- a/packages/next/export/worker.js
+++ b/packages/next/export/worker.js
@@ -276,7 +276,7 @@ export default async function({
     return results
   } catch (error) {
     console.error(
-      `\nError occurred prerendering page "${path}". Read more: https://err.sh/next.js/prerender-error:\n` +
+      `\nError occurred prerendering page "${path}". Read more: https://err.sh/next.js/prerender-error\n` +
         error
     )
     return { ...results, error: true }


### PR DESCRIPTION
Potential(?) small fix

I encountered this error on `next export` and could not access the error documentation URL at 

`https://err.sh/next.js/prerender-error:`

upon realizing it was

`https://err.sh/next.js/prerender-error`