### PR TITLE
Run all logbox tests

### DIFF
--- a/test/acceptance/ReactRefreshLogBox.test.js
+++ b/test/acceptance/ReactRefreshLogBox.test.js
@@ -606,7 +606,7 @@ test('unterminated JSX', async () => {
   await cleanup()
 })
 
-test.only('conversion to class component (1)', async () => {
+test('conversion to class component (1)', async () => {
   const [session, cleanup] = await sandbox()
 
   await session.write(


### PR DESCRIPTION
This re-enables all the logbox tests. They were mistakenly disabled via an erroneous `.only` inclusion.