### PR TITLE
chore(deps): upgrade url-polyfill

### DIFF
--- a/packages/next-polyfill-nomodule/package.json
+++ b/packages/next-polyfill-nomodule/package.json
@@ -16,7 +16,7 @@
     "core-js": "3.6.5",
     "microbundle": "0.11.0",
     "object-assign": "4.1.1",
-    "url-polyfill": "1.1.8",
+    "url-polyfill": "1.1.9",
     "whatwg-fetch": "3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17053,10 +17053,10 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-polyfill@1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.8.tgz#21eb58ad61192f52b77dcac8ab5293ae7bc67060"
-  integrity sha512-Ey61F4FEqhcu1vHSOMmjl0Vd/RPRLEjMj402qszD/dhMBrVfoUsnIj8KSZo2yj+eIlxJGKFdnm6ES+7UzMgZ3Q==
+url-polyfill@1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.9.tgz#2c8d4224889a5c942800f708f5585368085603d9"
+  integrity sha512-q/R5sowGuRfKHm497swkV+s9cPYtZRkHxzpDjRhqLO58FwdWTIkt6Y/fJlznUD/exaKx/XnDzCYXz0V16ND7ow==
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
Upgrades the url-polyfill version, which brings in the fix (https://github.com/lifaon74/url-polyfill/pull/54) for https://github.com/zeit/next.js/issues/11702.
This is an alternative to https://github.com/zeit/next.js/pull/12764, which replaces the dependency entirely

This should also help with https://github.com/zeit/next.js/issues/9851