### PR TITLE
Fix up CMS examples

### DIFF
--- a/examples/cms-contentful/pages/posts/[slug].js
+++ b/examples/cms-contentful/pages/posts/[slug].js
@@ -59,8 +59,8 @@ export async function getStaticProps({ params, preview = false }) {
   return {
     props: {
       preview,
-      post: data?.post,
-      morePosts: data?.morePosts,
+      post: data?.post ?? null,
+      morePosts: data?.morePosts ?? null,
     },
   }
 }
@@ -68,7 +68,7 @@ export async function getStaticProps({ params, preview = false }) {
 export async function getStaticPaths() {
   const allPosts = await getAllPostsWithSlug()
   return {
-    paths: allPosts?.map(({ slug }) => `/posts/${slug}`) || [],
+    paths: allPosts?.map(({ slug }) => `/posts/${slug}`) ?? [],
     fallback: true,
   }
 }

--- a/examples/cms-datocms/pages/index.js
+++ b/examples/cms-datocms/pages/index.js
@@ -35,7 +35,7 @@ export default function Index({ allPosts }) {
   )
 }
 
-export async function getStaticProps({ preview }) {
+export async function getStaticProps({ preview = false }) {
   const allPosts = (await getAllPostsForHome(preview)) || []
   return {
     props: { allPosts },

--- a/examples/cms-datocms/pages/posts/[slug].js
+++ b/examples/cms-datocms/pages/posts/[slug].js
@@ -50,7 +50,7 @@ export default function Post({ post, morePosts, preview }) {
   )
 }
 
-export async function getStaticProps({ params, preview = null }) {
+export async function getStaticProps({ params, preview = false }) {
   const data = await getPostAndMorePosts(params.slug, preview)
   const content = await markdownToHtml(data?.post?.content || '')
 
@@ -61,7 +61,7 @@ export async function getStaticProps({ params, preview = null }) {
         ...data?.post,
         content,
       },
-      morePosts: data?.morePosts,
+      morePosts: data?.morePosts ?? [],
     },
   }
 }

--- a/examples/cms-prismic/pages/index.js
+++ b/examples/cms-prismic/pages/index.js
@@ -35,7 +35,7 @@ export default function Index({ preview, allPosts }) {
   )
 }
 
-export async function getStaticProps({ preview, previewData }) {
+export async function getStaticProps({ preview = false, previewData }) {
   const allPosts = await getAllPostsForHome(previewData)
   return {
     props: { preview, allPosts },

--- a/examples/cms-prismic/pages/posts/[slug].js
+++ b/examples/cms-prismic/pages/posts/[slug].js
@@ -52,14 +52,14 @@ export default function Post({ post, morePosts, preview }) {
   )
 }
 
-export async function getStaticProps({ params, preview, previewData }) {
+export async function getStaticProps({ params, preview = false, previewData }) {
   const data = await getPostAndMorePosts(params.slug, previewData)
 
   return {
     props: {
       preview,
-      post: data?.post,
-      morePosts: data?.morePosts,
+      post: data?.post ?? null,
+      morePosts: data?.morePosts ?? [],
     },
   }
 }

--- a/examples/cms-sanity/pages/posts/[slug].js
+++ b/examples/cms-sanity/pages/posts/[slug].js
@@ -54,8 +54,8 @@ export async function getStaticProps({ params, preview = false }) {
   return {
     props: {
       preview,
-      post: data.post || null,
-      morePosts: data.morePosts || null,
+      post: data?.post || null,
+      morePosts: data?.morePosts || null,
     },
   }
 }

--- a/examples/cms-takeshape/pages/index.js
+++ b/examples/cms-takeshape/pages/index.js
@@ -35,7 +35,7 @@ export default function Index({ allPosts, preview }) {
   )
 }
 
-export async function getStaticProps({ preview = null }) {
+export async function getStaticProps({ preview = false }) {
   const allPosts = await getAllPostsForHome(preview)
   return {
     props: { allPosts, preview },

--- a/examples/cms-takeshape/pages/posts/[slug].js
+++ b/examples/cms-takeshape/pages/posts/[slug].js
@@ -59,7 +59,7 @@ export default function Post({ post, morePosts, preview }) {
   )
 }
 
-export async function getStaticProps({ params, preview = null }) {
+export async function getStaticProps({ params, preview = false }) {
   const data = await getPostAndMorePosts(params.slug, preview)
   const content = await markdownToHtml(
     (data?.post?.items || [])[0]?.content || ''
@@ -72,7 +72,7 @@ export async function getStaticProps({ params, preview = null }) {
         ...(data?.post?.items || [])[0],
         content,
       },
-      morePosts: data?.morePosts.items,
+      morePosts: data?.morePosts.items ?? [],
     },
   }
 }


### PR DESCRIPTION
This change ensures we do not pass `undefined` values into the `getStaticProps` return object.

---

Fixes #12806
Fixes #12798