### PR TITLE
Ensure errors pass through react-dev-overlay

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -205,7 +205,7 @@ export default async ({ webpackHMR: passedWebpackHMR } = {}) => {
     }
   }
 
-  let initialErr = err
+  let initialErr = err ? new ServerSideError(err) : null
 
   try {
     ;({ page: Component } = await pageLoader.loadPage(page))
@@ -294,7 +294,7 @@ export function renderError(props) {
       const { getNodeError } = require('@next/react-dev-overlay/lib/client')
       // Server-side runtime errors need to be re-thrown on the client-side so
       // that the overlay is rendered.
-      if (isInitialRender) {
+      if (!(err instanceof ServerSideError)) {
         setTimeout(() => {
           let error
           try {
@@ -531,4 +531,12 @@ async function doRender({ App, Component, props, err }) {
   )
 
   emitter.emit('after-reactdom-render', { Component, ErrorComponent, appProps })
+}
+
+class ServerSideError /* implements Error */ {
+  constructor(error) {
+    this.name = error.name
+    this.message = error.message
+    this.stack = error.stack
+  }
 }

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -294,7 +294,7 @@ export function renderError(props) {
       const { getNodeError } = require('@next/react-dev-overlay/lib/client')
       // Server-side runtime errors need to be re-thrown on the client-side so
       // that the overlay is rendered.
-      if (!(err instanceof ServerSideError)) {
+      if (err instanceof ServerSideError) {
         setTimeout(() => {
           let error
           try {

--- a/packages/react-dev-overlay/src/client.ts
+++ b/packages/react-dev-overlay/src/client.ts
@@ -3,6 +3,7 @@ import * as Bus from './internal/bus'
 
 let isRegistered = false
 let stackTraceLimit: number | undefined = undefined
+let handledErrors = new WeakSet()
 
 function onUnhandledError(ev: ErrorEvent) {
   const error = ev?.error
@@ -12,6 +13,7 @@ function onUnhandledError(ev: ErrorEvent) {
   }
 
   const e = error
+  handledErrors.add(e)
   Bus.emit({
     type: Bus.TYPE_UNHANDLED_ERROR,
     reason: error,
@@ -31,6 +33,7 @@ function onUnhandledRejection(ev: PromiseRejectionEvent) {
   }
 
   const e = reason
+  handledErrors.add(e)
   Bus.emit({
     type: Bus.TYPE_UNHANDLED_REJECTION,
     reason: reason,
@@ -83,6 +86,17 @@ function onRefresh() {
   Bus.emit({ type: Bus.TYPE_REFFRESH })
 }
 
+function didHandleError(e: any) {
+  return handledErrors.has(e)
+}
+
 export { getNodeError } from './internal/helpers/nodeStackFrames'
 export { default as ReactDevOverlay } from './internal/ReactDevOverlay'
-export { onBuildOk, onBuildError, register, unregister, onRefresh }
+export {
+  onBuildOk,
+  onBuildError,
+  register,
+  unregister,
+  onRefresh,
+  didHandleError,
+}


### PR DESCRIPTION
Instead of relying on `isInitialRender` (which is state that I want to remove in a future PR), we make sure that all Fast Refresh errors at development time pass through the `react-dev-overlay` by rethrowing them if it hasn't already handled them.

An alternative approach might just be to expose a `handleError` method from `react-dev-overlay` and let it deal with conditionally throwing.