### PR TITLE
Simplify CSS Errors

### DIFF
--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseCss.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseCss.ts
@@ -1,0 +1,38 @@
+import Chalk from 'next/dist/compiled/chalk'
+import { SimpleWebpackError } from './simpleWebpackError'
+
+const chalk = new Chalk.constructor({ enabled: true })
+const regexCssError = /^(?:CssSyntaxError|SyntaxError)\n\n\((\d+):(\d*)\) (.*)$/s
+
+export function getCssError(
+  fileName: string,
+  err: Error
+): SimpleWebpackError | false {
+  if (
+    !(
+      (err.name === 'CssSyntaxError' || err.name === 'SyntaxError') &&
+      (err as any).stack === false &&
+      !(err instanceof SyntaxError)
+    )
+  ) {
+    return false
+  }
+
+  // https://github.com/postcss/postcss-loader/blob/d6931da177ac79707bd758436e476036a55e4f59/src/Error.js
+
+  const res = regexCssError.exec(err.message)
+  if (res) {
+    const [, _lineNumer, _column, reason] = res
+    const lineNumber = Math.max(1, parseInt(_lineNumer, 10))
+    const column = Math.max(1, parseInt(_column, 10))
+
+    return new SimpleWebpackError(
+      `${chalk.cyan(fileName)}:${chalk.yellow(
+        lineNumber.toString()
+      )}:${chalk.yellow(column.toString())}`,
+      chalk.red.bold('Syntax error').concat(`: ${reason}`)
+    )
+  }
+
+  return false
+}

--- a/test/integration/css-features/test/index.test.js
+++ b/test/integration/css-features/test/index.test.js
@@ -150,7 +150,7 @@ describe('Custom Properties: Fail for :root {} in CSS Modules', () => {
     expect(code).not.toBe(0)
     expect(stderr).toContain('Failed to compile')
     expect(stderr).toContain('pages/styles.module.css')
-    expect(stderr).toContain('CssSyntax error: Selector ":root" is not pure')
+    expect(stderr).toContain('Selector ":root" is not pure')
   })
 })
 
@@ -168,7 +168,7 @@ describe('Custom Properties: Fail for global element in CSS Modules', () => {
     expect(code).not.toBe(0)
     expect(stderr).toContain('Failed to compile')
     expect(stderr).toContain('pages/styles.module.css')
-    expect(stderr).toContain('CssSyntax error: Selector "h1" is not pure')
+    expect(stderr).toContain('Selector "h1" is not pure')
   })
 })
 
@@ -218,6 +218,6 @@ describe('CSS Modules: Importing Invalid Global CSS', () => {
     expect(code).not.toBe(0)
     expect(stderr).toContain('Failed to compile')
     expect(stderr).toContain('pages/styles.module.css')
-    expect(stderr).toContain('CssSyntax error: Selector "a" is not pure')
+    expect(stderr).toContain('Selector "a" is not pure')
   })
 })


### PR DESCRIPTION
This implements custom formatting that massages errors returned by `postcss` or `css-loader`.

The default (old) error format had a bunch of loader cruft, full file paths, and poorly placed column information.

**New**

![image](https://user-images.githubusercontent.com/616428/81861672-9ba0ca00-9536-11ea-8a97-1971fa18c376.png)

**Old**

![image](https://user-images.githubusercontent.com/616428/81861713-ad826d00-9536-11ea-9816-fd897782bf60.png)
