### PR TITLE
Warn users about migrating to 9.4 environment variables if they were previously using dotenv

### DIFF
--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -47,6 +47,7 @@ npx cross-env NEXT_PUBLIC_EXAMPLE_KEY=my-value next dev
 
 - Trying to destructure `process.env` variables won't work due to the limitations of webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/).
 - To avoid exposing secrets, do not use the `NEXT_PUBLIC_` prefix for them. Instead, [expose the variables using `.env`](#exposing-environment-variables).
+- If you are migrating from the `dotenv` npm package, remove this package first, otherwise you'll be debugging why your variables are showing up as `undefined`.
 
 ## Exposing Environment Variables
 

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -47,7 +47,7 @@ npx cross-env NEXT_PUBLIC_EXAMPLE_KEY=my-value next dev
 
 - Trying to destructure `process.env` variables won't work due to the limitations of webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/).
 - To avoid exposing secrets, do not use the `NEXT_PUBLIC_` prefix for them. Instead, [expose the variables using `.env`](#exposing-environment-variables).
-- If you are migrating from the `dotenv` npm package, remove this package first, otherwise you'll be debugging why your variables are showing up as `undefined`.
+- You cannot have `dotenv` installed in your project, as this will cause Next.js to disable the auto-loading of the environment variables. Look for and uninstall this package if your variables are showing up as `undefined`.
 
 ## Exposing Environment Variables
 


### PR DESCRIPTION
The `dotenv` package prevents the new 9.4 env var feature from working.
Developers will just see `undefined` when using `process.env.my_env_var`.
Even if you comment out the `require('dotenv').config();` line to try things out
it won't work. This caveat is here to help others migrating from `dotenv`.

I removed `dotenv` from `package.json`, ran `rm -rf node_modules` then `npm install` and 9.4 environment variable feature worked fine.