### PR TITLE
Eliminate 404s from internal requests

### DIFF
--- a/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
@@ -52,7 +52,7 @@ export function getOriginalStackFrame(
       .finally(() => {
         clearTimeout(tm)
       })
-    if (!res.ok) {
+    if (!res.ok || res.status === 204) {
       return Promise.reject(new Error(await res.text()))
     }
 

--- a/packages/react-dev-overlay/src/middleware.ts
+++ b/packages/react-dev-overlay/src/middleware.ts
@@ -100,8 +100,8 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
       }
 
       if (source == null) {
-        res.statusCode = 404
-        res.write('Not Found')
+        res.statusCode = 204
+        res.write('No Content')
         return res.end()
       }
 
@@ -130,8 +130,8 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
       }
 
       if (pos.source == null) {
-        res.statusCode = 404
-        res.write('Not Found')
+        res.statusCode = 204
+        res.write('No Content')
         return res.end()
       }
 
@@ -188,8 +188,8 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
         () => false
       )
       if (!fileExists) {
-        res.statusCode = 404
-        res.write('Not Found')
+        res.statusCode = 204
+        res.write('No Content')
         return res.end()
       }
 


### PR DESCRIPTION
This prevent flooding the user's console with this noise that obscures their app logs:
![image](https://user-images.githubusercontent.com/616428/81937219-570e4080-95c1-11ea-993c-9b5ab5fe9d4e.png)
