### PR TITLE
Explicit header for SSR error

### DIFF
--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -14,6 +14,7 @@ import {
 import { LeftRightDialogHeader } from '../components/LeftRightDialogHeader'
 import { Overlay } from '../components/Overlay'
 import { Toast } from '../components/Toast'
+import { isNodeError } from '../helpers/nodeStackFrames'
 import { noop as css } from '../helpers/noop-template'
 import {
   getOriginalStackFrames,
@@ -210,6 +211,7 @@ export const Errors: React.FC<ErrorsProps> = function Errors({ errors }) {
     )
   }
 
+  const isServerError = isNodeError(activeError.error)
   return (
     <Overlay>
       <Dialog
@@ -231,10 +233,22 @@ export const Errors: React.FC<ErrorsProps> = function Errors({ errors }) {
                 {readyErrors.length < 2 ? '' : 's'}
               </small>
             </LeftRightDialogHeader>
-            <h1 id="nextjs__container_errors_label">Unhandled Runtime Error</h1>
+            <h1 id="nextjs__container_errors_label">
+              {isServerError ? 'Server Error' : 'Unhandled Runtime Error'}
+            </h1>
             <p id="nextjs__container_errors_desc">
               {activeError.error.name}: {activeError.error.message}
             </p>
+            {isServerError ? (
+              <div>
+                <small>
+                  This error happened while generating the page. Any console
+                  logs will be displayed in the terminal window.
+                </small>
+              </div>
+            ) : (
+              undefined
+            )}
           </DialogHeader>
           <DialogBody className="nextjs-container-errors-body">
             <RuntimeError key={activeError.id.toString()} error={activeError} />
@@ -270,6 +284,10 @@ export const styles = css`
     margin-top: var(--size-gap-half);
     color: var(--color-ansi-red);
     white-space: pre-wrap;
+  }
+  .nextjs-container-errors-header > div > small {
+    margin: 0;
+    margin-top: var(--size-gap-half);
   }
 
   .nextjs-container-errors-body > h5:not(:first-child) {

--- a/packages/react-dev-overlay/src/internal/helpers/nodeStackFrames.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/nodeStackFrames.ts
@@ -19,6 +19,12 @@ export function getFilesystemFrame(frame: StackFrame): StackFrame {
   return f
 }
 
+const symbolNodeError = Symbol('NextjsNodeError')
+
+export function isNodeError(error: Error): boolean {
+  return symbolNodeError in error
+}
+
 export function getNodeError(error: Error): Error {
   let n: Error
   try {
@@ -50,5 +56,10 @@ export function getNodeError(error: Error): Error {
     n.stack = error.stack
   }
 
+  Object.defineProperty(n, symbolNodeError, {
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  })
   return n
 }

--- a/test/integration/basic/test/error-recovery.js
+++ b/test/integration/basic/test/error-recovery.js
@@ -201,10 +201,15 @@ export default (context, renderViaHTTP) => {
           'export default {};\nexport const fn ='
         )
 
-        await check(
-          () => getRedboxHeader(browser),
-          /The default export is not a React Component/
-        )
+        expect(await hasRedbox(browser)).toBe(true)
+        expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
+          " 1 of 1 unhandled error
+          Server Error
+
+          Error: The default export is not a React Component in page: \\"/hmr/about5\\"
+
+          This error happened while generating the page. Any console logs will be displayed in the terminal window."
+        `)
 
         aboutPage.restore()
 
@@ -241,10 +246,22 @@ export default (context, renderViaHTTP) => {
           'export default () => /search/;\nexport const fn ='
         )
 
-        await check(
-          () => getRedboxHeader(browser),
-          /Objects are not valid as a React child/
-        )
+        expect(await hasRedbox(browser)).toBe(true)
+        expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
+          " 1 of 1 unhandled error
+          Server Error
+
+          Error: Objects are not valid as a React child (found: /search/). If you meant to render a collection of children, use an array instead.
+              in Unknown
+              in App
+              in Unknown
+              in Context.Provider
+              in Context.Provider
+              in Context.Provider
+              in AppContainer
+
+          This error happened while generating the page. Any console logs will be displayed in the terminal window."
+        `)
 
         aboutPage.restore()
 
@@ -281,14 +298,20 @@ export default (context, renderViaHTTP) => {
           'export default undefined;\nexport const fn ='
         )
 
-        await check(async () => {
-          const txt = await getRedboxHeader(browser)
-          return txt
-        }, /The default export is not a React Component/)
+        expect(await hasRedbox(browser)).toBe(true)
+        expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
+          " 1 of 1 unhandled error
+          Server Error
+
+          Error: The default export is not a React Component in page: \\"/hmr/about7\\"
+
+          This error happened while generating the page. Any console logs will be displayed in the terminal window."
+        `)
 
         aboutPage.restore()
 
         await check(() => getBrowserBodyText(browser), /This is the about page/)
+        expect(await hasRedbox(browser, false)).toBe(false)
       } catch (err) {
         aboutPage.restore()
 
@@ -317,9 +340,12 @@ export default (context, renderViaHTTP) => {
         await browser.elementByCss('#error-in-gip-link').click()
 
         expect(await hasRedbox(browser)).toBe(true)
-        expect(await getRedboxSource(browser)).toMatch(
-          /an-expected-error-in-gip/
-        )
+        expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
+          " 1 of 1 unhandled error
+          Unhandled Runtime Error
+
+          Error: an-expected-error-in-gip"
+        `)
 
         erroredPage.replace('throw error', 'return {}')
 
@@ -356,9 +382,14 @@ export default (context, renderViaHTTP) => {
         browser = await webdriver(context.appPort, '/hmr/error-in-gip')
 
         expect(await hasRedbox(browser)).toBe(true)
-        expect(await getRedboxSource(browser)).toMatch(
-          /an-expected-error-in-gip/
-        )
+        expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
+          " 1 of 1 unhandled error
+          Server Error
+
+          Error: an-expected-error-in-gip
+
+          This error happened while generating the page. Any console logs will be displayed in the terminal window."
+        `)
 
         const erroredPage = new File(
           join(__dirname, '../', 'pages', 'hmr', 'error-in-gip.js')


### PR DESCRIPTION
This adds a special title for server errors so you don't try to debug them in the browser.