### PR TITLE
`sync` and `built` are identical commands

### DIFF
--- a/packages/next/client/dev/dev-build-watcher.js
+++ b/packages/next/client/dev/dev-build-watcher.js
@@ -63,6 +63,7 @@ export default function initializeBuildWatcher() {
         updateContainer()
         break
       case 'built':
+      case 'sync':
         isBuilding = false
         // Wait for the fade out transtion to complete
         timeoutId = setTimeout(() => {


### PR DESCRIPTION
This fixes a weird state where the build watcher wouldn't dismiss because sometimes it sends `sync` instead of `built` (after a timeout). This isn't really easy to test, though it may be "covered" as part of the occasional flakes we see in Windows tests regarding HMR.