### PR TITLE
[Examples] with-expo: Stop tracking changes in .next folder

### DIFF
--- a/examples/with-expo/.gitignore
+++ b/examples/with-expo/.gitignore
@@ -10,6 +10,7 @@ npm-debug.*
 *.orig.*
 web-build/
 web-report/
+.next/*
 
 # debug
 yarn-debug.log*


### PR DESCRIPTION
The .next folder doesn't need to be tracked