### PR TITLE
[Examples] Fix active-class-name 

### DIFF
--- a/examples/active-class-name/components/ActiveLink.js
+++ b/examples/active-class-name/components/ActiveLink.js
@@ -4,12 +4,12 @@ import Link from 'next/link'
 import React, { Children } from 'react'
 
 const ActiveLink = ({ children, activeClassName, ...props }) => {
-  const { pathname } = useRouter()
+  const { asPath } = useRouter()
   const child = Children.only(children)
   const childClassName = child.props.className || ''
 
   const className =
-    pathname === props.href
+    asPath === props.href
       ? `${childClassName} ${activeClassName}`.trim()
       : childClassName
 


### PR DESCRIPTION
The example was using the wrong router property.
When a user wants to use dynamic routes the example will break since the active route will test against the file system `pathname` instead of the url path (`asPath`).