### PR TITLE
Remove `isomorphic-unfetch` from examples

### DIFF
--- a/examples/auth0/lib/user.js
+++ b/examples/auth0/lib/user.js
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react'
-import fetch from 'isomorphic-unfetch'
 
 export async function fetchUser(cookie = '') {
   if (typeof window !== 'undefined' && window.__user) {

--- a/examples/auth0/package.json
+++ b/examples/auth0/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^0.6.0",
     "dotenv": "^8.2.0",
-    "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/examples/blog-starter/package.json
+++ b/examples/blog-starter/package.json
@@ -10,7 +10,6 @@
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
     "gray-matter": "4.0.2",
-    "isomorphic-unfetch": "3.0.0",
     "next": "latest",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/examples/cms-datocms/lib/api.js
+++ b/examples/cms-datocms/lib/api.js
@@ -1,5 +1,3 @@
-import 'isomorphic-unfetch'
-
 const API_URL = 'https://graphql.datocms.com'
 const API_TOKEN = process.env.NEXT_EXAMPLE_CMS_DATOCMS_API_TOKEN
 

--- a/examples/cms-datocms/package.json
+++ b/examples/cms-datocms/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
-    "isomorphic-unfetch": "3.0.0",
     "next": "latest",
     "react": "^16.13.0",
     "react-datocms": "1.1.0",

--- a/examples/cms-prismic/lib/api.js
+++ b/examples/cms-prismic/lib/api.js
@@ -1,4 +1,3 @@
-import 'isomorphic-unfetch'
 import Prismic from 'prismic-javascript'
 
 const REPOSITORY = process.env.NEXT_EXAMPLE_CMS_PRISMIC_REPOSITORY_NAME

--- a/examples/cms-prismic/package.json
+++ b/examples/cms-prismic/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
-    "isomorphic-unfetch": "3.0.0",
     "next": "9.2.3-canary.26",
     "prismic-javascript": "2.2.0",
     "prismic-reactjs": "1.2.0",

--- a/examples/cms-takeshape/lib/api.js
+++ b/examples/cms-takeshape/lib/api.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const API_URL = `https://api.takeshape.io/project/${process.env.NEXT_EXAMPLE_CMS_TAKESHAPE_PROJECT_ID}/graphql`
 const API_KEY = process.env.NEXT_EXAMPLE_CMS_TAKESHAPE_API_KEY
 

--- a/examples/cms-takeshape/package.json
+++ b/examples/cms-takeshape/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
-    "isomorphic-unfetch": "3.0.0",
     "next": "latest",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/examples/custom-server-actionhero/package.json
+++ b/examples/custom-server-actionhero/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "actionhero": "^18.1.2",
     "ioredis": "^3.2.2",
-    "isomorphic-fetch": "^2.2.1",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/examples/with-apollo-and-redux/lib/apollo.js
+++ b/examples/with-apollo-and-redux/lib/apollo.js
@@ -4,7 +4,6 @@ import { ApolloProvider } from '@apollo/react-hooks'
 import { ApolloClient } from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { HttpLink } from 'apollo-link-http'
-import fetch from 'isomorphic-unfetch'
 
 let globalApolloClient = null
 
@@ -130,7 +129,6 @@ function createApolloClient(initialState = {}) {
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
       credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
-      fetch,
     }),
     cache: new InMemoryCache().restore(initialState),
   })

--- a/examples/with-apollo-and-redux/package.json
+++ b/examples/with-apollo-and-redux/package.json
@@ -14,7 +14,6 @@
     "apollo-link-http": "1.5.16",
     "graphql": "14.5.8",
     "graphql-tag": "2.10.1",
-    "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "prop-types": "^15.6.0",
     "react": "^16.11.0",

--- a/examples/with-apollo/apolloClient.js
+++ b/examples/with-apollo/apolloClient.js
@@ -1,7 +1,6 @@
 import { ApolloClient } from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { HttpLink } from 'apollo-link-http'
-import fetch from 'isomorphic-unfetch'
 
 export default function createApolloClient(initialState, ctx) {
   // The `ctx` (NextPageContext) will only be present on the server.
@@ -11,7 +10,6 @@ export default function createApolloClient(initialState, ctx) {
     link: new HttpLink({
       uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
       credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
-      fetch,
     }),
     cache: new InMemoryCache().restore(initialState),
   })

--- a/examples/with-apollo/package.json
+++ b/examples/with-apollo/package.json
@@ -14,7 +14,6 @@
     "apollo-link-http": "1.5.16",
     "graphql": "^14.0.2",
     "graphql-tag": "2.10.3",
-    "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",

--- a/examples/with-docker/package.json
+++ b/examples/with-docker/package.json
@@ -14,8 +14,5 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   },
-  "devDependencies": {
-    "isomorphic-unfetch": "^3.0.0"
-  },
   "license": "ISC"
 }

--- a/examples/with-firebase-authentication/package.json
+++ b/examples/with-firebase-authentication/package.json
@@ -10,7 +10,6 @@
     "cookie-session": "1.4.0",
     "firebase": "^7.6.1",
     "firebase-admin": "^8.9.0",
-    "isomorphic-unfetch": "^3.0.0",
     "lodash": "4.17.15",
     "next": "latest",
     "prop-types": "15.7.2",

--- a/examples/with-firebase-authentication/utils/auth/firebaseSessionHandler.js
+++ b/examples/with-firebase-authentication/utils/auth/firebaseSessionHandler.js
@@ -1,8 +1,6 @@
 // From:
 // https://github.com/zeit/next.js/blob/canary/examples/with-firebase-authentication/pages/index.js
 
-import fetch from 'isomorphic-unfetch'
-
 export const setSession = user => {
   // Log in.
   if (user) {

--- a/examples/with-graphql-hooks/lib/init-graphql.js
+++ b/examples/with-graphql-hooks/lib/init-graphql.js
@@ -1,6 +1,5 @@
 import { GraphQLClient } from 'graphql-hooks'
 import memCache from 'graphql-hooks-memcache'
-import unfetch from 'isomorphic-unfetch'
 
 let graphQLClient = null
 
@@ -9,7 +8,6 @@ function create(initialState = {}) {
     ssrMode: typeof window === 'undefined',
     url: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn',
     cache: memCache({ initialState }),
-    fetch: typeof window !== 'undefined' ? fetch.bind() : unfetch, // eslint-disable-line
   })
 }
 

--- a/examples/with-graphql-hooks/package.json
+++ b/examples/with-graphql-hooks/package.json
@@ -14,7 +14,6 @@
     "graphql-hooks": "^3.2.1",
     "graphql-hooks-memcache": "^1.0.4",
     "graphql-hooks-ssr": "^1.0.1",
-    "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "prop-types": "^15.7.2",
     "react": "^16.8.2",

--- a/examples/with-react-relay-network-modern/lib/createEnvironment/index.js
+++ b/examples/with-react-relay-network-modern/lib/createEnvironment/index.js
@@ -1,5 +1,3 @@
-import 'isomorphic-fetch'
-
 export const { initEnvironment, createEnvironment } = (typeof window ===
 'undefined'
   ? require('./server')

--- a/examples/with-react-relay-network-modern/package.json
+++ b/examples/with-react-relay-network-modern/package.json
@@ -16,7 +16,6 @@
     "dotenv": "^8.0.0",
     "dotenv-webpack": "^1.5.4",
     "graphql": "^14.6.0",
-    "isomorphic-fetch": "^2.2.1",
     "next": "latest",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/examples/with-redux-saga/package.json
+++ b/examples/with-redux-saga/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "es6-promise": "4.1.1",
-    "isomorphic-unfetch": "2.0.0",
     "next": "latest",
     "next-redux-saga": "4.0.0",
     "next-redux-wrapper": "2.0.0",

--- a/examples/with-redux-saga/saga.js
+++ b/examples/with-redux-saga/saga.js
@@ -1,8 +1,5 @@
-/* global fetch */
-
 import { all, call, delay, put, take, takeLatest } from 'redux-saga/effects'
 import es6promise from 'es6-promise'
-import 'isomorphic-unfetch'
 
 import { actionTypes, failure, loadDataSuccess, tickClock } from './actions'
 

--- a/examples/with-relay-modern/lib/createRelayEnvironment.js
+++ b/examples/with-relay-modern/lib/createRelayEnvironment.js
@@ -1,5 +1,4 @@
 import { Environment, Network, RecordSource, Store } from 'relay-runtime'
-import fetch from 'isomorphic-unfetch'
 
 let relayEnvironment = null
 

--- a/examples/with-relay-modern/package.json
+++ b/examples/with-relay-modern/package.json
@@ -16,7 +16,6 @@
     "dotenv": "^8.2.0",
     "dotenv-webpack": "^1.7.0",
     "graphql": "^14.6.0",
-    "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",

--- a/examples/with-rematch/package.json
+++ b/examples/with-rematch/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@rematch/core": "^1.1.0",
-    "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/examples/with-rematch/shared/models/github.js
+++ b/examples/with-rematch/shared/models/github.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const github = {
   state: {
     users: [],

--- a/examples/with-static-export/package.json
+++ b/examples/with-static-export/package.json
@@ -1,7 +1,6 @@
 {
   "name": "with-static-export",
   "dependencies": {
-    "isomorphic-unfetch": "^3.0.0",
     "next": "latest",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",

--- a/examples/with-static-export/pages/index.js
+++ b/examples/with-static-export/pages/index.js
@@ -1,5 +1,4 @@
 import Head from 'next/head'
-import fetch from 'isomorphic-unfetch'
 
 import Post from '../components/post'
 

--- a/examples/with-static-export/pages/post/[id].js
+++ b/examples/with-static-export/pages/post/[id].js
@@ -1,7 +1,6 @@
 import { Component } from 'react'
 import Link from 'next/link'
 import Head from 'next/head'
-import fetch from 'isomorphic-unfetch'
 
 export async function getStaticPaths() {
   const response = await fetch(

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -8,7 +8,6 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "isomorphic-unfetch": "3.0.0",
     "next": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"


### PR DESCRIPTION
Since 9.4 release, we have [Improved Built-in Fetch Support](https://nextjs.org/blog/next-9-4#improved-built-in-fetch-support) that was done in #12353 , so the import is not needed anymore.