### PR TITLE
Support eliminating memoized functions

### DIFF
--- a/test/unit/babel-plugin-next-ssg-transform.test.js
+++ b/test/unit/babel-plugin-next-ssg-transform.test.js
@@ -439,5 +439,22 @@ describe('babel plugin (next-ssg-transform)', () => {
         `"export var __N_SSG=true;export{default}from'a';"`
       )
     })
+
+    it('should support babel-style memoized function', () => {
+      const output = babel(trim`
+        function fn() {
+          fn = function () {};
+          return fn.apply(this, arguments);
+        }
+        export function getStaticProps() {
+          fn;
+        }
+        export default function Home() { return <div />; }
+      `)
+
+      expect(output).toMatchInlineSnapshot(
+        `"export var __N_SSG=true;export default function Home(){return __jsx(\\"div\\",null);}"`
+      )
+    })
   })
 })


### PR DESCRIPTION
Newer versions of babel now memoize functions using a new pattern:

```js
function _getGreeting() {
  _getGreeting = _asyncToGenerator(
    /*#__PURE__*/ _regeneratorRuntime.mark(function _callee() {
      var result;
      return _regeneratorRuntime.wrap(function _callee$(_context) {
        while (1) {
          switch ((_context.prev = _context.next)) {
            case 0:
              _context.next = 2;
              return queryGraphql(gql(_templateObject()));
            case 2:
              result = _context.sent;
              return _context.abrupt("return", result.data.greeting);
            case 4:
            case "end":
              return _context.stop();
          }
        }
      }, _callee);
    })
  );
  return _getGreeting.apply(this, arguments);
}
```

This implements a unit test to ensure we can eliminate this style of code.

Credits @developit for the genius babel work.