### PR TITLE
[Docs] Update heading

### DIFF
--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -2,7 +2,7 @@
 description: Configure module path aliases that allow you to remap certain import paths.
 ---
 
-## Absolute Imports and Module path aliases
+# Absolute Imports and Module path aliases
 
 Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options.
 


### PR DESCRIPTION
This is causing issues with the Algolia indexing of this page. Currently every documentation page has to have a top level 1 heading.