### PR TITLE
Remove redundant React imports from with-redux-thunk example

### DIFF
--- a/examples/with-redux-thunk/components/clock.js
+++ b/examples/with-redux-thunk/components/clock.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const pad = n => (n < 10 ? `0${n}` : n)
 
 const format = t =>

--- a/examples/with-redux-thunk/components/counter.js
+++ b/examples/with-redux-thunk/components/counter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { incrementCount, decrementCount, resetCount } from '../actions'
 

--- a/examples/with-redux-thunk/components/examples.js
+++ b/examples/with-redux-thunk/components/examples.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
 import Clock from './clock'
 import Counter from './counter'

--- a/examples/with-redux-thunk/lib/with-redux-store.js
+++ b/examples/with-redux-thunk/lib/with-redux-store.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Component } from 'react'
 import initializeStore from '../store'
 
 const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
@@ -17,7 +17,7 @@ function getOrCreateStore(initialState) {
 }
 
 export default App => {
-  return class AppWithRedux extends React.Component {
+  return class AppWithRedux extends Component {
     static async getInitialProps(appContext) {
       // Get or Create the store with `undefined` as initialState
       // This allows you to set a custom default initialState

--- a/examples/with-redux-thunk/pages/_app.js
+++ b/examples/with-redux-thunk/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Provider } from 'react-redux'
 import App from 'next/app'
 import withReduxStore from '../lib/with-redux-store'

--- a/examples/with-redux-thunk/pages/index.js
+++ b/examples/with-redux-thunk/pages/index.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import { PureComponent } from 'react'
 import { connect } from 'react-redux'
 import Link from 'next/link'
 import { startClock, serverRenderClock } from '../actions'

--- a/examples/with-redux-thunk/pages/show-redux-state.js
+++ b/examples/with-redux-thunk/pages/show-redux-state.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { connect } from 'react-redux'
 import Link from 'next/link'
 


### PR DESCRIPTION
Removes any redundant `import React from "react"` imports from the `with-redux-thunk` example as mentioned in #12964. 

That said, I'm not sure if you guys want to remove all redundant React imports from all examples, as this would require some additional documentation about `React` being partially poly-filled (or imported for JSX files) within next.