### PR TITLE
Re-enabled create-next-app tests on windows

### DIFF
--- a/test/integration/create-next-app/index.test.js
+++ b/test/integration/create-next-app/index.test.js
@@ -43,7 +43,7 @@ async function usingTempDir(fn) {
 }
 
 describe('create next app', () => {
-  it.only('non-empty directory', async () => {
+  it('non-empty directory', async () => {
     await usingTempDir(async cwd => {
       const projectName = 'non-empty-directory'
       await fs.mkdirp(path.join(cwd, projectName))

--- a/test/integration/create-next-app/index.test.js
+++ b/test/integration/create-next-app/index.test.js
@@ -193,30 +193,34 @@ describe('create next app', () => {
       const runExample = (...args) => {
         const res = run(cwd, ...args)
 
+        const rl = readline.createInterface({
+          input: res.stdout,
+        })
+
         function pickExample(data) {
           if (/hello-world/.test(data.toString())) {
-            res.stdout.removeListener('data', pickExample)
+            rl.removeListener('line', pickExample)
             res.stdin.write('\n')
           }
         }
 
         function searchExample(data) {
           if (/Pick an example/.test(data.toString())) {
-            res.stdout.removeListener('data', searchExample)
+            rl.removeListener('line', searchExample)
             res.stdin.write('hello-world')
-            res.stdout.on('data', pickExample)
+            rl.on('line', pickExample)
           }
         }
 
         function selectExample(data) {
           if (/Pick a template/.test(data.toString())) {
-            res.stdout.removeListener('data', selectExample)
+            rl.removeListener('line', selectExample)
             res.stdin.write('\u001b[B\n') // Down key and enter
-            res.stdout.on('data', searchExample)
+            rl.on('line', searchExample)
           }
         }
 
-        res.stdout.on('data', selectExample)
+        rl.on('line', selectExample)
 
         return res
       }

--- a/test/integration/create-next-app/index.test.js
+++ b/test/integration/create-next-app/index.test.js
@@ -15,12 +15,10 @@ const runStarter = (cwd, ...args) => {
 
   const rl = readline.createInterface({
     input: res.stdout,
-    output: res.stdin,
   })
   rl.on('line', line => {
-    rl.prompt()
     if (/Pick a template/.test(line)) {
-      rl.write('\n')
+      res.stdin.write('\n')
     }
   })
 


### PR DESCRIPTION
_Created as a draft PR to see if the theory holds._

Follow up of https://github.com/zeit/next.js/pull/12974

Some tests were disabled on windows. Based on the comment next to them they seem to stall on windows. I reviewed the code and found an issue that is similar to one [I spotted before](https://github.com/gilamran/tsc-watch/issues/78#issuecomment-590956615). I converted the code to use the `readline` interface. This should guarantee we always receive whole lines.

I also changed some unnecessary sync methods to async