### PR TITLE
Only retry tests on CI

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -136,6 +136,7 @@ const TIMINGS_API = `https://next-timings.jjsweb.site/api/timings`
         {
           stdio: 'inherit',
           env: {
+            JEST_RETRY_TIMES: 3,
             ...process.env,
             ...(isAzure
               ? {

--- a/test/jest-setup-after-env.js
+++ b/test/jest-setup-after-env.js
@@ -1,3 +1,7 @@
 /* eslint-env jest */
 
-jest.retryTimes(3)
+if (process.env.JEST_RETRY_TIMES) {
+  const retries = Number(process.env.JEST_RETRY_TIMES)
+  console.log(`Configuring jest retries: ${retries}`)
+  jest.retryTimes(retries)
+}


### PR DESCRIPTION
Avoid having to wait for 3 retries on failing tests when running tests locally. `jest.retryTimes` is only really useful on CI.