### PR TITLE
fix modal overlay in RTL layouts

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/Dialog/styles.ts
+++ b/packages/react-dev-overlay/src/internal/components/Dialog/styles.ts
@@ -14,6 +14,7 @@ const styles = css`
       rgba(0, 0, 0, 0.25);
     max-height: calc(100% - 3.5rem);
     overflow-y: hidden;
+    direction: ltr;
   }
 
   @media (min-width: 576px) {

--- a/packages/react-dev-overlay/src/internal/components/Dialog/styles.ts
+++ b/packages/react-dev-overlay/src/internal/components/Dialog/styles.ts
@@ -14,7 +14,6 @@ const styles = css`
       rgba(0, 0, 0, 0.25);
     max-height: calc(100% - 3.5rem);
     overflow-y: hidden;
-    direction: ltr;
   }
 
   @media (min-width: 576px) {

--- a/packages/react-dev-overlay/src/internal/styles/CssReset.tsx
+++ b/packages/react-dev-overlay/src/internal/styles/CssReset.tsx
@@ -8,6 +8,9 @@ export function CssReset() {
         __html: css`
           :host {
             all: initial;
+
+            /* the direction property is not reset by 'all' */
+            direction: ltr;
           }
 
           /*!


### PR DESCRIPTION
This PR enforces `direction: ltr` on the overlay modal, fixes #12999