### PR TITLE
Fix with-emotion examples

### DIFF
--- a/examples/with-emotion-11/pages/_document.js
+++ b/examples/with-emotion-11/pages/_document.js
@@ -2,21 +2,27 @@ import Document, { Head, Main, NextScript } from 'next/document'
 import { extractCritical } from '@emotion/server'
 
 export default class MyDocument extends Document {
-  static getInitialProps({ renderPage }) {
-    const page = renderPage()
-    const styles = extractCritical(page.html)
-    return { ...page, ...styles }
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    const styles = extractCritical(initialProps.html)
+    return {
+      ...initialProps,
+      styles: (
+        <>
+          {initialProps.styles}
+          <style
+            data-emotion-css={styles.ids.join(' ')}
+            dangerouslySetInnerHTML={{ __html: styles.css }}
+          />
+        </>
+      ),
+    }
   }
 
   render() {
     return (
       <html>
-        <Head>
-          <style
-            data-emotion-css={this.props.ids.join(' ')}
-            dangerouslySetInnerHTML={{ __html: this.props.css }}
-          />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />

--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -2,21 +2,27 @@ import Document, { Head, Main, NextScript } from 'next/document'
 import { extractCritical } from 'emotion-server'
 
 export default class MyDocument extends Document {
-  static getInitialProps({ renderPage }) {
-    const page = renderPage()
-    const styles = extractCritical(page.html)
-    return { ...page, ...styles }
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    const styles = extractCritical(initialProps.html)
+    return {
+      ...initialProps,
+      styles: (
+        <>
+          {initialProps.styles}
+          <style
+            data-emotion-css={styles.ids.join(' ')}
+            dangerouslySetInnerHTML={{ __html: styles.css }}
+          />
+        </>
+      ),
+    }
   }
 
   render() {
     return (
       <html>
-        <Head>
-          <style
-            data-emotion-css={this.props.ids.join(' ')}
-            dangerouslySetInnerHTML={{ __html: this.props.css }}
-          />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
This fixes the issues I describe in #12384 

(Copy and paste for convenience)

I've played around with the with-emotion example and ran into a couple of issues with next/head:

1. The default `<meta charSet="..." />` is placed after the inlined styles (possibly after the first 1024 bytes).
2. I tried to be clever and put my own `<meta charSet="..." />` above the style tag in _document.js which somehow made me end up with 2 `<meta charSet="..." />` elements.
3. I would have expected the global stylesheets to be placed at the beginning of `<head>`, allowing me to override them.