### PR TITLE
[Experimental] Add support for production browser source maps

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -136,6 +136,8 @@ export default async function getBaseWebpackConfig(
     entrypoints: WebpackEntrypoints
   }
 ): Promise<webpack.Configuration> {
+  const productionBrowserSourceMaps =
+    config.experimental.productionBrowserSourceMaps && !isServer
   let plugins: PluginMetaData[] = []
   let babelPresetPlugins: { dir: string; config: any }[] = []
 
@@ -643,6 +645,7 @@ export default async function getBaseWebpackConfig(
           cache: path.join(distDir, 'cache', 'next-minifier'),
           parallel: config.experimental.cpus || true,
           terserOptions,
+          sourceMap: productionBrowserSourceMaps,
         }),
         // Minify CSS
         new CssMinimizerPlugin({
@@ -1032,6 +1035,7 @@ export default async function getBaseWebpackConfig(
     isServer,
     assetPrefix: config.assetPrefix || '',
     sassOptions: config.sassOptions,
+    productionBrowserSourceMaps,
   })
 
   if (typeof config.webpack === 'function') {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -645,7 +645,6 @@ export default async function getBaseWebpackConfig(
           cache: path.join(distDir, 'cache', 'next-minifier'),
           parallel: config.experimental.cpus || true,
           terserOptions,
-          sourceMap: productionBrowserSourceMaps,
         }),
         // Minify CSS
         new CssMinimizerPlugin({

--- a/packages/next/build/webpack/config/blocks/base.ts
+++ b/packages/next/build/webpack/config/blocks/base.ts
@@ -25,7 +25,12 @@ export const base = curry(function base(
       config.devtool = 'eval-source-map'
     }
   } else {
-    config.devtool = false
+    // Enable browser sourcemaps
+    if (ctx.productionBrowserSourceMaps) {
+      config.devtool = 'cheap-module-source-map'
+    } else {
+      config.devtool = false
+    }
   }
 
   if (!config.module) {

--- a/packages/next/build/webpack/config/blocks/base.ts
+++ b/packages/next/build/webpack/config/blocks/base.ts
@@ -27,7 +27,7 @@ export const base = curry(function base(
   } else {
     // Enable browser sourcemaps
     if (ctx.productionBrowserSourceMaps) {
-      config.devtool = 'cheap-module-source-map'
+      config.devtool = 'source-map'
     } else {
       config.devtool = false
     }

--- a/packages/next/build/webpack/config/index.ts
+++ b/packages/next/build/webpack/config/index.ts
@@ -12,6 +12,7 @@ export async function build(
     isServer,
     assetPrefix,
     sassOptions,
+    productionBrowserSourceMaps,
   }: {
     rootDirectory: string
     customAppFile: string | null
@@ -19,6 +20,7 @@ export async function build(
     isServer: boolean
     assetPrefix: string
     sassOptions: any
+    productionBrowserSourceMaps: boolean
   }
 ): Promise<webpack.Configuration> {
   const ctx: ConfigurationContext = {
@@ -34,6 +36,7 @@ export async function build(
         : assetPrefix
       : '',
     sassOptions,
+    productionBrowserSourceMaps,
   }
 
   const fn = pipe(base(ctx), css(ctx))

--- a/packages/next/build/webpack/config/utils.ts
+++ b/packages/next/build/webpack/config/utils.ts
@@ -13,6 +13,7 @@ export type ConfigurationContext = {
   assetPrefix: string
 
   sassOptions: any
+  productionBrowserSourceMaps: boolean
 }
 
 export type ConfigurationFn = (

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -52,6 +52,7 @@ const defaultConfig: { [key: string]: any } = {
     workerThreads: false,
     basePath: '',
     pageEnv: false,
+    productionBrowserSourceMaps: false,
   },
   future: {
     excludeDefaultMomentLocales: false,

--- a/test/integration/production-browser-sourcemaps/next.config.js
+++ b/test/integration/production-browser-sourcemaps/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    productionBrowserSourceMaps: true,
+  },
+}

--- a/test/integration/production-browser-sourcemaps/pages/ssr.js
+++ b/test/integration/production-browser-sourcemaps/pages/ssr.js
@@ -1,0 +1,13 @@
+export default function SSRPage({ data }) {
+  return <div>{data.foo}</div>
+}
+
+export async function getServerSideProps() {
+  return {
+    props: {
+      data: {
+        foo: 'bar',
+      },
+    },
+  }
+}

--- a/test/integration/production-browser-sourcemaps/pages/static.js
+++ b/test/integration/production-browser-sourcemaps/pages/static.js
@@ -1,0 +1,13 @@
+export default function StaticPage({ data }) {
+  return <div>{data.foo}</div>
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      data: {
+        foo: 'bar',
+      },
+    },
+  }
+}

--- a/test/integration/production-browser-sourcemaps/serverless-server.js
+++ b/test/integration/production-browser-sourcemaps/serverless-server.js
@@ -1,0 +1,58 @@
+// This is not the correct way to implement the Next.js serverless target for production traffic
+// It is only used for testing cases of rendering specific pages in the integration test suite
+
+const path = require('path')
+const http = require('http')
+const send = require('send')
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/ssr') {
+    return require('./.next/serverless/pages/ssr.js').render(req, res)
+  }
+
+  if (req.url === '/getinitialprops') {
+    return require('./.next/serverless/pages/getinitialprops.js').render(
+      req,
+      res
+    )
+  }
+
+  if (req.url === '/api/api-route') {
+    return require('./.next/serverless/pages/api/api-route.js').default(
+      req,
+      res
+    )
+  }
+
+  if (req.url === '/user/a') {
+    return send(
+      req,
+      path.join(__dirname, '.next/serverless/pages/user/a.html')
+    ).pipe(res)
+  }
+
+  if (req.url === '/user/b') {
+    return send(
+      req,
+      path.join(__dirname, '.next/serverless/pages/user/b.html')
+    ).pipe(res)
+  }
+
+  if (req.url === '/static') {
+    return send(
+      req,
+      path.join(__dirname, '.next/serverless/pages/static.html')
+    ).pipe(res)
+  }
+
+  if (req.url.startsWith('/_next')) {
+    send(
+      req,
+      path.join(__dirname, '.next', req.url.split('/_next').pop())
+    ).pipe(res)
+  }
+})
+
+server.listen(process.env.PORT, () => {
+  console.log('ready on', process.env.PORT)
+})

--- a/test/integration/production-browser-sourcemaps/test/index.test.js
+++ b/test/integration/production-browser-sourcemaps/test/index.test.js
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+/* global jasmine */
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+const appDir = join(__dirname, '../')
+const nextConfig = join(appDir, 'next.config.js')
+let nextConfigContent
+
+function runTests() {
+  it('includes sourcemaps for all browser files', async () => {
+    const browserFiles = await recursiveReadDir(
+      join(appDir, '.next', 'static'),
+      /.*/
+    )
+    const jsFiles = browserFiles.filter(
+      file => file.endsWith('.js') && file.includes('/pages/')
+    )
+
+    jsFiles.forEach(file => {
+      expect(browserFiles.includes(`${file}.map`)).toBe(true)
+    })
+  })
+}
+
+describe('Production browser sourcemaps', () => {
+  describe('Server support', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir, [], {})
+    })
+
+    runTests()
+  })
+
+  describe('Serverless support', () => {
+    beforeAll(async () => {
+      nextConfigContent = await fs.readFile(nextConfig, 'utf8')
+      await fs.writeFile(
+        nextConfig,
+        `
+        module.exports = {
+          target: 'serverless',
+          experimental: {
+            productionBrowserSourceMaps: true
+          }
+        }
+      `
+      )
+      await nextBuild(appDir, [], {})
+    })
+    afterAll(async () => {
+      await fs.writeFile(nextConfig, nextConfigContent)
+    })
+
+    runTests()
+  })
+})

--- a/test/integration/production-browser-sourcemaps/test/index.test.js
+++ b/test/integration/production-browser-sourcemaps/test/index.test.js
@@ -1,11 +1,11 @@
 /* eslint-env jest */
-/* global jasmine */
 import fs from 'fs-extra'
 import { join } from 'path'
 import { nextBuild } from 'next-test-utils'
 import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 60 * 2
+jest.setTimeout(1000 * 60 * 2)
+
 const appDir = join(__dirname, '../')
 const nextConfig = join(appDir, 'next.config.js')
 let nextConfigContent


### PR DESCRIPTION
Adds support for enabling sourcemaps for the browser in production (development already has sourcemaps).

```js
module.exports = {
  experimental: {
    productionBrowserSourceMaps: true
  }
}
```

Initial implementation for #7579