### PR TITLE
feat: Remove redundant imports in XState example

### DIFF
--- a/examples/with-xstate/components/Toggle.js
+++ b/examples/with-xstate/components/Toggle.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const Toggle = ({ onToggle, active }) => {
   return (
     <div>

--- a/examples/with-xstate/pages/index.js
+++ b/examples/with-xstate/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useMachine } from '@xstate/react'
 import { Counter, Toggle } from '../components'
 import { toggleMachine } from '../machines/toggleMachine'


### PR DESCRIPTION
This issue is related with [https://github.com/zeit/next.js/issues/12964](12964)
As @timneutkens said Next provide React when JSX is used behind the scenes. Therefore is redundant to import again React. In this opportunity, I'm deleting the import in the XState example