### PR TITLE
chore: Remove redundant imports in several examples

### DIFF
--- a/examples/auth0/pages/about.js
+++ b/examples/auth0/pages/about.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Layout from '../components/layout'
 import { useFetchUser } from '../lib/user'
 

--- a/examples/auth0/pages/index.js
+++ b/examples/auth0/pages/index.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Layout from '../components/layout'
 import { useFetchUser } from '../lib/user'
 

--- a/examples/auth0/pages/profile.js
+++ b/examples/auth0/pages/profile.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 // This import is only needed when checking authentication status directly from getInitialProps
 // import auth0 from '../lib/auth0'
 import { useFetchUser } from '../lib/user'

--- a/examples/with-apollo-and-redux/components/Clock.js
+++ b/examples/with-apollo-and-redux/components/Clock.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector, shallowEqual } from 'react-redux'
 
 const useClock = () => {

--- a/examples/with-apollo-and-redux/components/Counter.js
+++ b/examples/with-apollo-and-redux/components/Counter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
 const useCounter = () => {

--- a/examples/with-apollo-and-redux/components/ErrorMessage.js
+++ b/examples/with-apollo-and-redux/components/ErrorMessage.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 
 const ErrorMessage = ({ message }) => (

--- a/examples/with-apollo-and-redux/components/Layout.js
+++ b/examples/with-apollo-and-redux/components/Layout.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Nav from './Nav'
 import PropTypes from 'prop-types'
 

--- a/examples/with-apollo-and-redux/components/PostUpvoter.js
+++ b/examples/with-apollo-and-redux/components/PostUpvoter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useMutation } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import PropTypes from 'prop-types'

--- a/examples/with-apollo-and-redux/lib/apollo.js
+++ b/examples/with-apollo-and-redux/lib/apollo.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Head from 'next/head'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { ApolloClient } from 'apollo-client'

--- a/examples/with-apollo-and-redux/lib/redux.js
+++ b/examples/with-apollo-and-redux/lib/redux.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Provider } from 'react-redux'
 import { initializeStore } from '../store'
 import App from 'next/app'

--- a/examples/with-apollo-and-redux/pages/index.js
+++ b/examples/with-apollo-and-redux/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useDispatch } from 'react-redux'
 import { withRedux } from '../lib/redux'
 import { compose } from 'redux'

--- a/examples/with-apollo-and-redux/pages/redux.js
+++ b/examples/with-apollo-and-redux/pages/redux.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useDispatch } from 'react-redux'
 import { withRedux } from '../lib/redux'
 import useInterval from '../lib/useInterval'

--- a/examples/with-apollo/components/PostUpvoter.js
+++ b/examples/with-apollo/components/PostUpvoter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useMutation } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 

--- a/examples/with-apollo/lib/apollo.js
+++ b/examples/with-apollo/lib/apollo.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import App from 'next/app'
 import Head from 'next/head'
 import { ApolloProvider } from '@apollo/react-hooks'

--- a/examples/with-context-api/components/Counter.js
+++ b/examples/with-context-api/components/Counter.js
@@ -1,7 +1,7 @@
-import React, { useReducer, useContext } from 'react'
+import { useReducer, useContext, createContext } from 'react'
 
-const CounterStateContext = React.createContext()
-const CounterDispatchContext = React.createContext()
+const CounterStateContext = createContext()
+const CounterDispatchContext = createContext()
 
 const reducer = (state, action) => {
   switch (action.type) {

--- a/examples/with-context-api/pages/about.js
+++ b/examples/with-context-api/pages/about.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 import { useCount, useDispatchCount } from '../components/Counter'
 

--- a/examples/with-context-api/pages/index.js
+++ b/examples/with-context-api/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 import { useCount, useDispatchCount } from '../components/Counter'
 

--- a/examples/with-docker/pages/index.js
+++ b/examples/with-docker/pages/index.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default () => {
   return <h1>Hello World!</h1>
 }

--- a/examples/with-emotion/pages/_app.js
+++ b/examples/with-emotion/pages/_app.js
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import NextApp from 'next/app'
 import { CacheProvider } from '@emotion/core'
 

--- a/examples/with-redux-observable/components/CharacterInfo.js
+++ b/examples/with-redux-observable/components/CharacterInfo.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { connect } from 'react-redux'
 
 const CharacterInfo = ({

--- a/examples/with-redux-observable/pages/_app.js
+++ b/examples/with-redux-observable/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Provider } from 'react-redux'
 import App from 'next/app'
 import withRedux from 'next-redux-wrapper'

--- a/examples/with-redux-observable/pages/index.js
+++ b/examples/with-redux-observable/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Component } from 'react'
 import Link from 'next/link'
 import { of, Subject } from 'rxjs'
 import { StateObservable } from 'redux-observable'
@@ -7,7 +7,7 @@ import CharacterInfo from '../components/CharacterInfo'
 import { rootEpic } from '../redux/epics'
 import * as actions from '../redux/actions'
 
-class Counter extends React.Component {
+class Counter extends Component {
   static async getInitialProps({ store, isServer }) {
     const state$ = new StateObservable(new Subject(), store.getState())
     const resultAction = await rootEpic(

--- a/examples/with-redux-observable/pages/other.js
+++ b/examples/with-redux-observable/pages/other.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 
 const OtherPage = () => (

--- a/examples/with-redux-persist/components/counter.js
+++ b/examples/with-redux-persist/components/counter.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { incrementCount, decrementCount, resetCount } from '../store'

--- a/examples/with-redux-persist/components/data-list.js
+++ b/examples/with-redux-persist/components/data-list.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { loadExampleData, loadingExampleDataFailure } from '../store'

--- a/examples/with-redux-persist/lib/with-redux-store.js
+++ b/examples/with-redux-persist/lib/with-redux-store.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Component } from 'react'
 import { initializeStore } from '../store'
 
 const isServer = typeof window === 'undefined'
@@ -18,7 +18,7 @@ function getOrCreateStore(initialState) {
 }
 
 export default App => {
-  return class AppWithRedux extends React.Component {
+  return class AppWithRedux extends Component {
     static async getInitialProps(appContext) {
       // Get or Create the store with `undefined` as initialState
       // This allows you to set a custom default initialState

--- a/examples/with-redux-persist/pages/_app.js
+++ b/examples/with-redux-persist/pages/_app.js
@@ -1,5 +1,4 @@
 import App from 'next/app'
-import React from 'react'
 import withReduxStore from '../lib/with-redux-store'
 import { Provider } from 'react-redux'
 import { persistStore } from 'redux-persist'

--- a/examples/with-redux-persist/pages/index.js
+++ b/examples/with-redux-persist/pages/index.js
@@ -1,9 +1,9 @@
-import React from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 import { startClock, serverRenderClock } from '../store'
 import Examples from '../components/examples'
 
-class Index extends React.Component {
+class Index extends Component {
   static getInitialProps({ reduxStore, req }) {
     const isServer = !!req
     // DISPATCH ACTIONS HERE ONLY WITH `reduxStore.dispatch`

--- a/examples/with-redux-saga/components/clock.js
+++ b/examples/with-redux-saga/components/clock.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const pad = n => (n < 10 ? `0${n}` : n)
 
 const format = t => {

--- a/examples/with-redux-saga/components/counter.js
+++ b/examples/with-redux-saga/components/counter.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { increment, decrement, reset } from '../actions'

--- a/examples/with-redux-saga/pages/_app.js
+++ b/examples/with-redux-saga/pages/_app.js
@@ -1,5 +1,4 @@
 import App from 'next/app'
-import React from 'react'
 import { Provider } from 'react-redux'
 import withRedux from 'next-redux-wrapper'
 import withReduxSaga from 'next-redux-saga'

--- a/examples/with-redux-saga/pages/index.js
+++ b/examples/with-redux-saga/pages/index.js
@@ -1,10 +1,10 @@
-import React from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { loadData, startClock, tickClock } from '../actions'
 import Page from '../components/page'
 
-class Index extends React.Component {
+class Index extends Component {
   static async getInitialProps(props) {
     const { store, isServer } = props.ctx
     store.dispatch(tickClock(isServer))

--- a/examples/with-redux-saga/pages/other.js
+++ b/examples/with-redux-saga/pages/other.js
@@ -1,10 +1,10 @@
-import React from 'react'
+import { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { startClock, tickClock } from '../actions'
 import Page from '../components/page'
 
-class Other extends React.Component {
+class Other extends Component {
   static async getInitialProps(props) {
     const { store, isServer } = props.ctx
     store.dispatch(tickClock(isServer))

--- a/examples/with-redux-thunk/components/clock.js
+++ b/examples/with-redux-thunk/components/clock.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const pad = n => (n < 10 ? `0${n}` : n)
 
 const format = t =>

--- a/examples/with-redux-thunk/components/counter.js
+++ b/examples/with-redux-thunk/components/counter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { incrementCount, decrementCount, resetCount } from '../actions'
 

--- a/examples/with-redux-thunk/components/examples.js
+++ b/examples/with-redux-thunk/components/examples.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
 import Clock from './clock'
 import Counter from './counter'

--- a/examples/with-redux-thunk/lib/with-redux-store.js
+++ b/examples/with-redux-thunk/lib/with-redux-store.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Component } from 'react'
 import initializeStore from '../store'
 
 const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__'
@@ -17,7 +17,7 @@ function getOrCreateStore(initialState) {
 }
 
 export default App => {
-  return class AppWithRedux extends React.Component {
+  return class AppWithRedux extends Component {
     static async getInitialProps(appContext) {
       // Get or Create the store with `undefined` as initialState
       // This allows you to set a custom default initialState

--- a/examples/with-redux-thunk/pages/_app.js
+++ b/examples/with-redux-thunk/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Provider } from 'react-redux'
 import App from 'next/app'
 import withReduxStore from '../lib/with-redux-store'

--- a/examples/with-redux-thunk/pages/index.js
+++ b/examples/with-redux-thunk/pages/index.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import { PureComponent } from 'react'
 import { connect } from 'react-redux'
 import Link from 'next/link'
 import { startClock, serverRenderClock } from '../actions'

--- a/examples/with-redux-thunk/pages/show-redux-state.js
+++ b/examples/with-redux-thunk/pages/show-redux-state.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { connect } from 'react-redux'
 import Link from 'next/link'
 

--- a/examples/with-redux-toolkit/components/clock.js
+++ b/examples/with-redux-toolkit/components/clock.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector, shallowEqual } from 'react-redux'
 
 const useClock = () => {

--- a/examples/with-redux-toolkit/components/counter.js
+++ b/examples/with-redux-toolkit/components/counter.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createAction } from '@reduxjs/toolkit'
 import { useSelector, useDispatch } from 'react-redux'
 

--- a/examples/with-redux-toolkit/pages/_app.js
+++ b/examples/with-redux-toolkit/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Provider } from 'react-redux'
 import { store } from '../store'
 

--- a/examples/with-redux-toolkit/pages/index.js
+++ b/examples/with-redux-toolkit/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createAction } from '@reduxjs/toolkit'
 import { connect } from 'react-redux'
 import useInterval from '../lib/useInterval'

--- a/examples/with-styled-components/README.md
+++ b/examples/with-styled-components/README.md
@@ -58,7 +58,6 @@ When wrapping a [Link](https://nextjs.org/docs/api-reference/next/link) from `ne
 **components/StyledLink.js**
 
 ```javascript
-import React from 'react'
 import Link from 'next/link'
 import styled from 'styled-components'
 
@@ -88,7 +87,6 @@ export default styled(StyledLink)`
 **pages/index.js**
 
 ```javascript
-import React from 'react'
 import StyledLink from '../components/StyledLink'
 
 export default () => (

--- a/examples/with-styled-components/pages/_app.js
+++ b/examples/with-styled-components/pages/_app.js
@@ -1,5 +1,4 @@
 import App from 'next/app'
-import React from 'react'
 import { ThemeProvider } from 'styled-components'
 
 const theme = {

--- a/examples/with-styled-components/pages/index.js
+++ b/examples/with-styled-components/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 const Title = styled.h1`


### PR DESCRIPTION
This issue is related to [12694](https://github.com/zeit/next.js/issues/12964). I covered the following examples

- auth0
- with-apollo
- with-apollo-and-redux
- with-context-api
- with-docker
- with-emotion
- with-redux-observable
- with-redux-persist
- with-redux-saga
- with-redux-thunk
- with-redux-toolkit
- with-styled-components

If you have a suggestion or change I'd appreciate it