### PR TITLE
x-powered-by is added to response, not request

### DIFF
--- a/docs/api-reference/next.config.js/disabling-x-powered-by.md
+++ b/docs/api-reference/next.config.js/disabling-x-powered-by.md
@@ -1,5 +1,5 @@
 ---
-description: Next.js will add `x-powered-by` header by default. Learn to opt-out of it here.
+description: Next.js will add the `x-powered-by` header by default. Learn to opt-out of it here.
 ---
 
 # Disabling x-powered-by

--- a/docs/api-reference/next.config.js/disabling-x-powered-by.md
+++ b/docs/api-reference/next.config.js/disabling-x-powered-by.md
@@ -1,10 +1,10 @@
 ---
-description: Next.js will add `x-powered-by` to the response headers by default. Learn to opt-out of it here.
+description: Next.js will add `x-powered-by` header by default. Learn to opt-out of it here.
 ---
 
 # Disabling x-powered-by
 
-By default Next.js will add `x-powered-by` to the response headers. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
+By default Next.js will add the `x-powered-by` header. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/disabling-x-powered-by.md
+++ b/docs/api-reference/next.config.js/disabling-x-powered-by.md
@@ -1,10 +1,10 @@
 ---
-description: Next.js will add the `x-powered-by` header by default. Learn to opt-out of it here.
+description: Next.js will add `x-powered-by` to the response headers by default. Learn to opt-out of it here.
 ---
 
 # Disabling x-powered-by
 
-By default Next.js will add the `x-powered-by` header. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
+By default Next.js will add `x-powered-by` to the response headers. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/disabling-x-powered-by.md
+++ b/docs/api-reference/next.config.js/disabling-x-powered-by.md
@@ -1,10 +1,10 @@
 ---
-description: Next.js will add `x-powered-by` to the request headers by default. Learn to opt-out of it here.
+description: Next.js will add `x-powered-by` to the response headers by default. Learn to opt-out of it here.
 ---
 
 # Disabling x-powered-by
 
-By default Next.js will add `x-powered-by` to the request headers. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
+By default Next.js will add `x-powered-by` to the response headers. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/disabling-x-powered-by.md
+++ b/docs/api-reference/next.config.js/disabling-x-powered-by.md
@@ -1,10 +1,10 @@
 ---
-description: Next.js will add `x-powered-by` to the response headers by default. Learn to opt-out of it here.
+description: Next.js will add the `x-powered-by` header by default. Learn to opt-out of it here.
 ---
 
 # Disabling x-powered-by
 
-By default Next.js will add `x-powered-by` to the response headers. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
+By default Next.js will add the `x-powered-by` header. To opt-out of it, open `next.config.js` and disable the `poweredByHeader` config:
 
 ```js
 module.exports = {


### PR DESCRIPTION
Fix documentation for the x-powered-by header, i.e. that header is
added to the response, not the request.