### PR TITLE
[Examples] Chakra UI - Move CSSReset inside ColorModeProvider

### DIFF
--- a/examples/with-chakra-ui/src/pages/_app.js
+++ b/examples/with-chakra-ui/src/pages/_app.js
@@ -9,8 +9,8 @@ class App extends NextApp {
     const { Component } = this.props
     return (
       <ThemeProvider theme={theme}>
-        <CSSReset />
         <ColorModeProvider>
+          <CSSReset />
           <Component />
         </ColorModeProvider>
       </ThemeProvider>


### PR DESCRIPTION
CSSReset doesn't style `<html>` according to color mode changes (light/dark) if it's outside `<ColorModeProvider>`