### PR TITLE
Add PR labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,1 @@
+'Type: Example': examples/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+name: Pull Request Labeler
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
This uses the https://github.com/actions/labeler action to automatically add the `Type: Example` label to PRs that change the examples folder