### PR TITLE
[Example] Unsubscribe Router.on.events

### DIFF
--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -1,8 +1,19 @@
-import App from 'next/app'
+import {useEffect} from 'react'
 import Router from 'next/router'
-
 import * as gtag from '../lib/gtag'
 
-Router.events.on('routeChangeComplete', (url) => gtag.pageview(url))
+const App = ({ Component, pageProps }) => {
+  useEffect(() => {
+    const handleRouteChange = url => {
+      gtag.pageview(url);
+    }
+    Router.events.on('routeChangeComplete', handleRouteChange)
+    return () => {
+      Router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [])
+  
+  return <Component {...pageProps} />
+}
 
 export default App

--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -1,18 +1,18 @@
-import {useEffect} from 'react'
+import { useEffect } from 'react'
 import Router from 'next/router'
 import * as gtag from '../lib/gtag'
 
 const App = ({ Component, pageProps }) => {
   useEffect(() => {
-    const handleRouteChange = url => {
-      gtag.pageview(url);
+    const handleRouteChange = (url) => {
+      gtag.pageview(url)
     }
     Router.events.on('routeChangeComplete', handleRouteChange)
     return () => {
       Router.events.off('routeChangeComplete', handleRouteChange)
     }
   }, [])
-  
+
   return <Component {...pageProps} />
 }
 


### PR DESCRIPTION
In `with-google-analytics` example. According to next/router [documentation](https://nextjs.org/docs/api-reference/next/router#routerevents), the listener should be unsubscribed when the component is unmounted.

fixes #13097