### PR TITLE
Update Create Next App to handle rename of org

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -82,14 +82,26 @@ export function downloadAndExtractRepo(
   )
 }
 
-export function downloadAndExtractExample(
+export async function downloadAndExtractExample(
   root: string,
   name: string
 ): Promise<void> {
-  return pipeline(
-    got.stream('https://codeload.github.com/zeit/next.js/tar.gz/canary'),
-    tar.extract({ cwd: root, strip: 3 }, [`next.js-canary/examples/${name}`])
-  )
+  try {
+    return await pipeline(
+      got.stream('https://codeload.github.com/zeit/next.js/tar.gz/canary'),
+      tar.extract({ cwd: root, strip: 3 }, [`next.js-canary/examples/${name}`])
+    )
+  } catch (err) {
+    // TODO: remove after this change has been landed
+    if (err?.response?.statusCode === 404) {
+      return pipeline(
+        got.stream('https://codeload.github.com/vercel/next.js/tar.gz/canary'),
+        tar.extract({ cwd: root, strip: 3 }, [
+          `next.js-canary/examples/${name}`,
+        ])
+      )
+    }
+  }
 }
 
 export async function listExamples(): Promise<any> {

--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -100,6 +100,8 @@ export async function downloadAndExtractExample(
           `next.js-canary/examples/${name}`,
         ])
       )
+    } else {
+      throw err
     }
   }
 }


### PR DESCRIPTION
As discussed this prepares for renaming by falling back to the new name after the current one 404s which should allow transitioning over without breaking.

The https://api.github.com/repositories/70107786/contents/examples URL used in CNA should not need updating since it seems to stay the same after renaming a project which I tested against one of my test repos [here](https://api.github.com/repositories/260536415) changing it from `next-update-loader` to `next-test-loader` and ensuring the URL is still valid 