### PR TITLE
Remove dead event code

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -514,12 +514,6 @@ async function doRender({ App, Component, props, err }) {
   // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error.
   lastAppProps = appProps
 
-  emitter.emit('before-reactdom-render', {
-    Component,
-    ErrorComponent,
-    appProps,
-  })
-
   const elem = (
     <AppContainer>
       <App {...appProps} />
@@ -535,6 +529,4 @@ async function doRender({ App, Component, props, err }) {
     ),
     appElement
   )
-
-  emitter.emit('after-reactdom-render', { Component, ErrorComponent, appProps })
 }

--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -43,28 +43,6 @@ initNext({ webpackHMR })
     displayContent(() => {
       render(renderCtx)
     })
-
-    let lastScroll
-
-    emitter.on('before-reactdom-render', ({ Component, ErrorComponent }) => {
-      // Remember scroll when ErrorComponent is being rendered to later restore it
-      if (!lastScroll && Component === ErrorComponent) {
-        const { pageXOffset, pageYOffset } = window
-        lastScroll = {
-          x: pageXOffset,
-          y: pageYOffset,
-        }
-      }
-    })
-
-    emitter.on('after-reactdom-render', ({ Component, ErrorComponent }) => {
-      if (lastScroll && Component !== ErrorComponent) {
-        // Restore scroll after ErrorComponent was replaced with a page component by HMR
-        const { x, y } = lastScroll
-        window.scroll(x, y)
-        lastScroll = null
-      }
-    })
   })
   .catch((err) => {
     console.error('Error was not caught', err)


### PR DESCRIPTION
`before-reactdom-render` and `after-reactdom-render` were only used in dev when rendering `ErrorComponent`, which never actually happens anymore.