### PR TITLE
Remove unnecessary loadGetInitialProps

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -488,25 +488,6 @@ const wrapApp = (App) => (props) => {
 }
 
 async function doRender({ App, Component, props, err }) {
-  // Usual getInitialProps fetching is handled in next/router
-  // this is for when ErrorComponent gets replaced by Component by HMR
-  if (
-    !props &&
-    Component &&
-    Component !== ErrorComponent &&
-    lastAppProps.Component === ErrorComponent
-  ) {
-    const { pathname, query, asPath } = router
-    const AppTree = wrapApp(App)
-    const appCtx = {
-      router,
-      AppTree,
-      Component: ErrorComponent,
-      ctx: { err, pathname, query, asPath, AppTree },
-    }
-    props = await loadGetInitialProps(App, appCtx)
-  }
-
   Component = Component || lastAppProps.Component
   props = props || lastAppProps.props
 


### PR DESCRIPTION
An `ErrorComponent` will never be replaced by HMR, since the former is never rendered in development mode. That means we don't need this branch.