### PR TITLE
Fix style edit loss on browser refresh when using Emotion.

### DIFF
--- a/examples/with-emotion/pages/_document.js
+++ b/examples/with-emotion/pages/_document.js
@@ -1,28 +1,24 @@
 import Document, { Head, Main, NextScript } from 'next/document'
+import { renderToString } from 'react-dom/server'
 import { extractCritical } from 'emotion-server'
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx)
-    const styles = extractCritical(initialProps.html)
-    return {
-      ...initialProps,
-      styles: (
-        <>
-          {initialProps.styles}
-          <style
-            data-emotion-css={styles.ids.join(' ')}
-            dangerouslySetInnerHTML={{ __html: styles.css }}
-          />
-        </>
-      ),
-    }
+    const styles = extractCritical(renderToString(initialProps.html))
+
+    return { ...initialProps, ...styles }
   }
 
   render() {
     return (
       <html>
-        <Head />
+        <Head>
+          <style
+            data-emotion-css={this.props.ids.join(' ')}
+            dangerouslySetInnerHTML={{ __html: this.props.css }}
+          />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
This fixes style changes being lost on browser refresh when using styles defined in external packages.

I use [Theme UI](https://theme-ui.com/) to define a shared theme in a package (built with webpack) and I pull in this package and merge the shared theme with my site-specific theme as described [here](https://theme-ui.com/guides/merging-themes/#using-a-preset). This works great, and when I make changes to the shared theme, live reload / fast refresh shows the changes. However, upon browser refresh, my changes disappear until I restart my app.

After a lot of digging, I found that the [with-emotion example](https://github.com/zeit/next.js/tree/canary/examples/with-emotion) example is missing the use of `renderToString()` as shown in the [Emotion SSR docs](https://emotion.sh/docs/ssr#advanced-approach). This change adds this and fixes the problem described above.

Also note that the `<style>` element was moved from `getInitialProps()` into `render()`. Without this additional change, the issue described remains. This is how it is in [master](https://github.com/zeit/next.js/blob/master/examples/with-emotion/pages/_document.js#L15), and I see that the `<style>` element was moved to `getInitialProps()` for canary -- I recognize this undoes that change, but doing so may be necessary.

This change may also be needed in the with-emotion-11 example, but I have not tested that, so I have not touched that.