### PR TITLE
[Docs] Replace hot reloading with fast refresh

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,7 +27,7 @@ Congratulations! You’ve just deployed your Next.js app! If you have questions,
 
 Let’s talk about the workflow we recommend using. [Vercel](https://vercel.com) supports what we call the **DPS** workflow: **D**evelop, **P**review, and **S**hip:
 
-- **Develop:** Write code in Next.js. Keep the development server running and take advantage of its hot code reloading feature.
+- **Develop:** Write code in Next.js. Keep the development server running and take advantage of [React Fast Refresh](https://nextjs.org/blog/next-9-4#fast-refresh).
 - **Preview:** Every time you push changes to a branch on GitHub / GitLab / BitBucket, Vercel automatically creates a new deployment with a unique URL. You can view them on GitHub when you open a pull request, or under “Preview Deployments” on your project page on Vercel. [Learn more about it here](https://vercel.com/features/deployment-previews).
 - **Ship:** When you’re ready to ship, merge the pull request to your default branch (e.g. `master`). Vercel will automatically create a production deployment.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,3 +104,10 @@ For more information on what to do next, we recommend the following sections:
     <small>Learn more about the Next.js CLI.</small>
   </a>
 </div>
+
+<div class="card">
+  <a href="/docs/deployment.md">
+    <b>Deployment:</b>
+    <small>Deploy your Next.js app to production.</small>
+  </a>
+</div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ If you have questions about anything related to Next.js, you're always welcome t
 We recommend creating a new Next.js app using `create-next-app`, which sets up everything automatically for you. To create a project, run:
 
 ```bash
-npm init next-app
+npx create-next-app
 # or
 yarn create next-app
 ```
@@ -76,9 +76,11 @@ Visit `http://localhost:3000` to view your application.
 So far, we get:
 
 - Automatic compilation and bundling (with webpack and babel)
-- Hot code reloading
-- Static generation and server-side rendering of [`./pages/`](/docs/basic-features/pages.md)
+- [React Fast Refresh](https://nextjs.org/blog/next-9-4#fast-refresh)
+- [Static generation and server-side rendering](/docs/basic-features/data-fetching.md) of [`./pages/`](/docs/basic-features/pages.md)
 - [Static file serving](/docs/basic-features/static-file-serving.md). `./public/` is mapped to `/`
+
+In addition, any Next.js application is ready for production from the start, read more in our [Deployment documentation](/docs/deployment.md).
 
 ## Related
 
@@ -102,12 +104,5 @@ For more information on what to do next, we recommend the following sections:
   <a href="/docs/api-reference/cli.md">
     <b>CLI:</b>
     <small>Learn more about the Next.js CLI.</small>
-  </a>
-</div>
-
-<div class="card">
-  <a href="/docs/deployment.md">
-    <b>Deployment:</b>
-    <small>Deploy your Next.js app to production.</small>
   </a>
 </div>


### PR DESCRIPTION
- Mention React Fast Refresh instead of hot reloading in docs
- Added a mention of our deployment docs in the main documentation page
- replaced `npm init` with `npx`