### PR TITLE
Rename import to solve conflicting usage of Error constructor

### DIFF
--- a/examples/with-sentry-simple/pages/_error.js
+++ b/examples/with-sentry-simple/pages/_error.js
@@ -1,4 +1,4 @@
-import Error from 'next/error'
+import NextErrorComponent from 'next/error'
 import * as Sentry from '@sentry/node'
 
 const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
@@ -9,7 +9,7 @@ const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
     Sentry.captureException(err)
   }
 
-  return <Error statusCode={statusCode} />
+  return <NextErrorComponent statusCode={statusCode} />
 }
 
 MyError.getInitialProps = async ({ res, err, asPath }) => {


### PR DESCRIPTION
In the `sentry-simple-test` example, next's error component is imported like this:

`import Error from 'next/error'`


In another, unrelated line a generic javascript `Error` is supposed to be thrown.

I've renamed the error component import to avoid a conflict in case the Error constructor branch is hit.