### PR TITLE
Examples: enhanced typescript-styled-components

### DIFF
--- a/examples/with-typescript-styled-components/pages/_document.tsx
+++ b/examples/with-typescript-styled-components/pages/_document.tsx
@@ -1,19 +1,25 @@
-import Document, { DocumentContext } from 'next/document'
-import { ServerStyleSheet } from 'styled-components'
+import React from 'react';
+import Document, { DocumentContext, DocumentInitialProps } from 'next/document';
+import { RenderPageResult } from 'next/dist/next-server/lib/utils';
 
-export default class MyDocument extends Document {
-  static async getInitialProps(ctx: DocumentContext) {
-    const sheet = new ServerStyleSheet()
-    const originalRenderPage = ctx.renderPage
+import { ServerStyleSheet } from 'styled-components';
+
+export default class MyDocument extends Document<DocumentInitialProps> {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
 
     try {
-      ctx.renderPage = () =>
-        originalRenderPage({
-          enhanceApp: (App) => (props) =>
-            sheet.collectStyles(<App {...props} />),
-        })
+      ctx.renderPage = (): RenderPageResult | Promise<RenderPageResult> => originalRenderPage({
+        enhanceApp: (App) => (
+          props,
+        ): React.ReactElement<{ sheet: ServerStyleSheet }> => sheet.collectStyles(
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <App {...props} />,
+        ),
+      });
 
-      const initialProps = await Document.getInitialProps(ctx)
+      const initialProps = await Document.getInitialProps(ctx);
       return {
         ...initialProps,
         styles: (
@@ -22,9 +28,9 @@ export default class MyDocument extends Document {
             {sheet.getStyleElement()}
           </>
         ),
-      }
+      };
     } finally {
-      sheet.seal()
+      sheet.seal();
     }
   }
 }


### PR DESCRIPTION
1. Added React import. (Can't have JSX without importing React)
2. Using DocumentInitialProps instead of implicit `any`
3. Using RenderPageResult instead of implicit `any`
4. Suppressed Eslint error (react/jsx-props-no-spreading)