### PR TITLE
Fix wrong README of blog-starter-typescript example

### DIFF
--- a/examples/blog-starter-typescript/README.md
+++ b/examples/blog-starter-typescript/README.md
@@ -1,6 +1,6 @@
 # A statically generated blog example using Next.js and Markdown and TypeScript
 
-This is the existing [blog-starter](https://github.com/zeit/next.js/tree/canary/examples/blog-starter) plus TypeScript.
+This is the existing [blog-starter-typescript](https://github.com/zeit/next.js/tree/canary/examples/blog-starter-typescript) plus TypeScript.
 
 This example showcases Next.js's [Static Generation](https://nextjs.org/docs/basic-features/pages) feature using markdown files as the data source.
 
@@ -15,9 +15,9 @@ To create the blog posts we use [`remark`](https://github.com/remarkjs/remark) a
 Execute [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npm init next-app --example blog-starter blog-starter-app
+npm init next-app --example blog-starter-typescript blog-starter-typescript-app
 # or
-yarn create next-app --example blog-starter blog-starter-app
+yarn create next-app --example blog-starter-typescript blog-starter-typescript-app
 ```
 
 ### Download manually
@@ -25,8 +25,8 @@ yarn create next-app --example blog-starter blog-starter-app
 Download the example:
 
 ```bash
-curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/blog-starter
-cd blog-starter
+curl https://codeload.github.com/zeit/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/blog-starter-typescript
+cd blog-starter-typescript
 ```
 
 Install dependencies and run the example:
@@ -47,4 +47,4 @@ Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&ut
 
 # Notes
 
-This blog-starter uses [Tailwind CSS](https://tailwindcss.com). To control the generated stylesheet's filesize, this example uses Tailwind CSS' v1.4 [`purge` option](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css) to remove unused CSS.
+This blog-starter-typescript uses [Tailwind CSS](https://tailwindcss.com). To control the generated stylesheet's filesize, this example uses Tailwind CSS' v1.4 [`purge` option](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css) to remove unused CSS.

--- a/examples/blog-starter-typescript/README.md
+++ b/examples/blog-starter-typescript/README.md
@@ -1,6 +1,6 @@
 # A statically generated blog example using Next.js and Markdown and TypeScript
 
-This is the existing [blog-starter-typescript](https://github.com/zeit/next.js/tree/canary/examples/blog-starter-typescript) plus TypeScript.
+This is the existing [blog-starter](https://github.com/zeit/next.js/tree/canary/examples/blog-starter) plus TypeScript.
 
 This example showcases Next.js's [Static Generation](https://nextjs.org/docs/basic-features/pages) feature using markdown files as the data source.
 


### PR DESCRIPTION
I fixed wrong README of blog-starter-typescript example.