### PR TITLE
Fix "Commitment to Open Source" link in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to Next.js
 
-Our Commitment to Open Source can be found [here](https://vercel.com/oss)
+Our Commitment to Open Source can be found [here](https://vercel.com/oss).
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 2. Create a new branch `git checkout -b MY_BRANCH_NAME`

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to Next.js
 
-Our Commitment to Open Source can be found [here](https://vercel.com/blog/oss)
+Our Commitment to Open Source can be found [here](https://vercel.com/oss)
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 2. Create a new branch `git checkout -b MY_BRANCH_NAME`


### PR DESCRIPTION
https://vercel.com/blog/oss redirects to https://vercel.com. Is https://vercel.com/oss the right URL?