### PR TITLE
Update Monaco Editor Example

### DIFF
--- a/examples/with-monaco-editor/pages/index.js
+++ b/examples/with-monaco-editor/pages/index.js
@@ -15,12 +15,12 @@ function IndexPage() {
       onChange={console.log}
       editorDidMount={() => {
         window.MonacoEnvironment.getWorkerUrl = (moduleId, label) => {
-          if (label === 'json') return '_next/static/json.worker.js'
-          if (label === 'css') return '_next/static/css.worker.js'
-          if (label === 'html') return '_next/static/html.worker.js'
+          if (label === 'json') return '/_next/static/json.worker.js'
+          if (label === 'css') return '/_next/static/css.worker.js'
+          if (label === 'html') return '/_next/static/html.worker.js'
           if (label === 'typescript' || label === 'javascript')
-            return '_next/static/ts.worker.js'
-          return '_next/static/editor.worker.js'
+            return '/_next/static/ts.worker.js'
+          return '/_next/static/editor.worker.js'
         }
       }}
     />


### PR DESCRIPTION
Changed the URLs inside the Monaco Editor Example: https://github.com/zeit/next.js/tree/canary/examples/with-monaco-editor

Converted the worker URL to start with the base URL.

The reason is if you use the Monaco example anywhere but in the main `pages` folder, it won't work since it uses a relative URL instead.

For example if we'll move the code to `pages/room/index.js` it won't work since it will try to search for the files inside `room/_next/_static/` instead of `_next/_static/`.

The base URL I added fixes the problem.