### PR TITLE
Fixing Redundant React imports on next.js/examples

### DIFF
--- a/examples/with-ant-design/pages/_app.js
+++ b/examples/with-ant-design/pages/_app.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import 'antd/dist/antd.css'
 import '../styles/vars.css'
 import '../styles/global.css'

--- a/examples/with-dynamic-import/pages/index.js
+++ b/examples/with-dynamic-import/pages/index.js
@@ -6,17 +6,12 @@ const DynamicComponent1 = dynamic(() => import('../components/hello1'))
 
 const DynamicComponent2WithCustomLoading = dynamic(
   () => import('../components/hello2'),
-  {
-    loading: () => <p>Loading caused by client page transition ...</p>,
-  }
+  { loading: () => <p>Loading caused by client page transition ...</p> }
 )
 
 const DynamicComponent3WithNoSSR = dynamic(
   () => import('../components/hello3'),
-  {
-    loading: () => <p>Loading ...</p>,
-    ssr: false,
-  }
+  { loading: () => <p>Loading ...</p>, ssr: false }
 )
 
 const DynamicComponent4 = dynamic(() => import('../components/hello4'))
@@ -25,6 +20,7 @@ const DynamicComponent5 = dynamic(() => import('../components/hello5'))
 
 const IndexPage = () => {
   const [showMore, setShowMore] = useState(false)
+  const [falsyField] = useState(false)
 
   return (
     <div>
@@ -40,7 +36,7 @@ const IndexPage = () => {
       <DynamicComponent3WithNoSSR />
 
       {/* This component will never be loaded */}
-      {React.noSuchField && <DynamicComponent4 />}
+      {falsyField && <DynamicComponent4 />}
 
       {/* Load on demand */}
       {showMore && <DynamicComponent5 />}

--- a/examples/with-dynamic-import/pages/index.js
+++ b/examples/with-dynamic-import/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import Header from '../components/Header'
 import dynamic from 'next/dynamic'
 

--- a/examples/with-iron-session/pages/index.js
+++ b/examples/with-iron-session/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Layout from '../components/Layout'
 
 const Home = () => (

--- a/examples/with-iron-session/pages/login.js
+++ b/examples/with-iron-session/pages/login.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useState } from 'react'
 import useUser from '../lib/useUser'
 import Layout from '../components/Layout'

--- a/examples/with-iron-session/pages/profile-sg.js
+++ b/examples/with-iron-session/pages/profile-sg.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import useUser from '../lib/useUser'
 import Layout from '../components/Layout'
 

--- a/examples/with-iron-session/pages/profile-ssr.js
+++ b/examples/with-iron-session/pages/profile-ssr.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Layout from '../components/Layout'
 import withSession from '../lib/session'
 import PropTypes from 'prop-types'

--- a/examples/with-monaco-editor/pages/index.js
+++ b/examples/with-monaco-editor/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import dynamic from 'next/dynamic'
 
 import sample from '../code-sample'

--- a/examples/with-next-page-transitions/pages/_app.js
+++ b/examples/with-next-page-transitions/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { PageTransition } from 'next-page-transitions'
 
 import Loader from '../components/Loader'

--- a/examples/with-next-page-transitions/pages/_document.js
+++ b/examples/with-next-page-transitions/pages/_document.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Document, { Head, Main, NextScript } from 'next/document'
 
 export default class MyDocument extends Document {

--- a/examples/with-next-page-transitions/pages/index.js
+++ b/examples/with-next-page-transitions/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 
 const Index = () => (

--- a/examples/with-react-with-styles/pages/_app.js
+++ b/examples/with-react-with-styles/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { DIRECTIONS } from 'react-with-direction'
 import AphroditeInterface from 'react-with-styles-interface-aphrodite'
 import WithStylesContext from 'react-with-styles/lib/WithStylesContext'

--- a/examples/with-react-with-styles/pages/index.js
+++ b/examples/with-react-with-styles/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { css, withStyles } from 'react-with-styles'
 
 function Home({ styles }) {

--- a/examples/with-style-sheet/pages/index.js
+++ b/examples/with-style-sheet/pages/index.js
@@ -1,10 +1,10 @@
-import React from 'react'
+import { useEffect } from 'react'
 import { StyleSheet, StyleResolver } from 'style-sheet'
 const cls = StyleResolver.resolve
 
 export default function Home() {
   const [color, setColor] = React.useState('#111')
-  React.useEffect(() => {
+  useEffect(() => {
     setTimeout(() => {
       setColor('#00f')
     }, 2000)

--- a/examples/with-style-sheet/pages/index.js
+++ b/examples/with-style-sheet/pages/index.js
@@ -1,9 +1,9 @@
-import { useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { StyleSheet, StyleResolver } from 'style-sheet'
 const cls = StyleResolver.resolve
 
 export default function Home() {
-  const [color, setColor] = React.useState('#111')
+  const [color, setColor] = useState('#111')
   useEffect(() => {
     setTimeout(() => {
       setColor('#00f')

--- a/examples/with-why-did-you-render/pages/_app.js
+++ b/examples/with-why-did-you-render/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import whyDidYouRender from '@welldone-software/why-did-you-render'
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {

--- a/examples/with-why-did-you-render/pages/_app.js
+++ b/examples/with-why-did-you-render/pages/_app.js
@@ -1,3 +1,4 @@
+import React from 'react'	
 import whyDidYouRender from '@welldone-software/why-did-you-render'
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {

--- a/examples/with-why-did-you-render/pages/_app.js
+++ b/examples/with-why-did-you-render/pages/_app.js
@@ -1,4 +1,4 @@
-import React from 'react'	
+import React from 'react'
 import whyDidYouRender from '@welldone-software/why-did-you-render'
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Per https://github.com/zeit/next.js/issues/12964

* with-ant-design
* with-dynamic-import
* with-iron-session
* with-monaco-editor
* with-next-page-transitions
* with-react-with-styles
* with-style-sheet
* with-why-did-you-render

Tested each example, working as intended, no additional issues presented