### PR TITLE
with-overmind Server Error due to invalid getStaticProps return statement

### DIFF
--- a/examples/with-overmind/pages/about.js
+++ b/examples/with-overmind/pages/about.js
@@ -13,7 +13,7 @@ export async function getStaticProps() {
   overmind.state.page = 'About'
 
   return {
-    mutations: overmind.hydrate(),
+    props: { mutations: overmind.hydrate() },
   }
 }
 

--- a/examples/with-overmind/pages/index.js
+++ b/examples/with-overmind/pages/index.js
@@ -24,7 +24,7 @@ export async function getStaticProps() {
   ]
 
   return {
-    mutations: overmind.hydrate(),
+    props: { mutations: overmind.hydrate() },
   }
 }
 


### PR DESCRIPTION
The pages/index.js & pages/index.js files have a return statement in **getStaticProps** without having a props key causing the app to fail.

Error:
![with-overmind-error](https://user-images.githubusercontent.com/12380586/82867079-d3deda00-9f32-11ea-91a0-04c04f2a088a.PNG)

Adding a props key removes the error and the app seems to behave as intended. Note that I've never used overmind previously.