### PR TITLE
Fixed with-iron-session to work on Windows systems

### DIFF
--- a/examples/with-iron-session/package.json
+++ b/examples/with-iron-session/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "SECRET_COOKIE_PASSWORD=2gyZ3GDw3LHZQKDhPmPDL3sjREVRXPr8 next dev",
+    "dev": "cross-env SECRET_COOKIE_PASSWORD=2gyZ3GDw3LHZQKDhPmPDL3sjREVRXPr8 next dev",
     "start": "next start"
   },
   "dependencies": {
@@ -15,5 +15,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "swr": "0.2.0"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.2"
   }
 }


### PR DESCRIPTION
#### Issue

Currently `$ npm run dev` fails on Windows systems for the [with-iron-session](https://github.com/zeit/next.js/tree/canary/examples/with-iron-session) example. That is due to setting a variable on an npm script. To make it work for Windows you would have to alter the script which would probably fail on other operating systems.

#### Reproducing

Run `$ npm run dev` on a Windows machine

#### Fix

There's many solutions to this, but since this is an example I went with the most simple one, which is using the **cross-env** package.