### PR TITLE
Refactor with rematch example

### DIFF
--- a/examples/with-rematch/package.json
+++ b/examples/with-rematch/package.json
@@ -7,12 +7,12 @@
     "start": "next start"
   },
   "dependencies": {
-    "@rematch/core": "^1.1.0",
+    "@rematch/core": "1.4.0",
     "next": "latest",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
-    "react-redux": "^6.0.1",
-    "redux": "^4.0.1"
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "react-redux": "7.2.0",
+    "redux": "4.0.5"
   },
   "license": "ISC"
 }

--- a/examples/with-rematch/pages/_app.js
+++ b/examples/with-rematch/pages/_app.js
@@ -1,8 +1,7 @@
 import App from 'next/app'
-import React from 'react'
+import { Provider } from 'react-redux'
 
 import withRematch from '../shared/withRematch'
-import { Provider } from 'react-redux'
 
 class MyApp extends App {
   render() {

--- a/examples/with-rematch/pages/github-users.js
+++ b/examples/with-rematch/pages/github-users.js
@@ -5,12 +5,14 @@ import { initializeStore } from '../shared/store'
 import CounterDisplay from '../shared/components/counter-display'
 import Header from '../shared/components/header'
 
-const Github = () => {
+const Github = (props) => {
   const github = useSelector((state) => state.github)
   const { users, isLoading } = github
   const { fetchUsers } = useRematchDispatch((dispatch) => ({
     fetchUsers: dispatch.github.fetchUsers,
   }))
+
+  const { usersList } = props
   return (
     <div>
       <Header />
@@ -19,10 +21,21 @@ const Github = () => {
         Server rendered github user list. You can also reload the users from the
         api by clicking the <b>Get users</b> button below.
       </p>
+      <h1> Users passed as property from getStaticProps</h1>
+      {usersList.map((user) => (
+        <div key={user.login}>
+          <a href={user.html_url}>
+            <img height="45" width="45" src={user.avatar_url} />
+            <span> Username - {user.login}</span>
+          </a>
+          <br />
+        </div>
+      ))}
       {isLoading ? <p>Loading ...</p> : null}
       <p>
         <button onClick={fetchUsers}>Get users</button>
       </p>
+      {users.length === 0 ? null : <h1> Users fetched from async function</h1>}
       {users.map((user) => (
         <div key={user.login}>
           <a href={user.html_url}>
@@ -33,10 +46,21 @@ const Github = () => {
         </div>
       ))}
       <br />
-
       <CounterDisplay />
     </div>
   )
+}
+
+export async function getStaticProps() {
+  const store = initializeStore()
+  const usersList = await store.dispatch.github.fetchUsers()
+  console.log(usersList)
+
+  return {
+    props: {
+      usersList,
+    },
+  }
 }
 
 export default Github

--- a/examples/with-rematch/pages/github-users.js
+++ b/examples/with-rematch/pages/github-users.js
@@ -34,12 +34,10 @@ class Github extends Component {
         </p>
         {userList.map((user) => (
           <div key={user.login}>
-            <Link href={user.html_url} passHref>
-              <a>
-                <img height="45" width="45" src={user.avatar_url} />
-                <span> Username - {user.login}</span>
-              </a>
-            </Link>
+            <a href={user.html_url}>
+              <img height="45" width="45" src={user.avatar_url} />
+              <span> Username - {user.login}</span>
+            </a>
             <br />
           </div>
         ))}

--- a/examples/with-rematch/pages/github-users.js
+++ b/examples/with-rematch/pages/github-users.js
@@ -53,7 +53,6 @@ const Github = (props) => {
 export async function getStaticProps() {
   const store = initializeStore()
   const usersList = await store.dispatch.github.fetchUsers()
-  console.log(usersList)
 
   return {
     props: {

--- a/examples/with-rematch/pages/github-users.js
+++ b/examples/with-rematch/pages/github-users.js
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux'
 import { useRematchDispatch } from '../shared/utils'
-
 import { initializeStore } from '../shared/store'
 import CounterDisplay from '../shared/components/counter-display'
 import Header from '../shared/components/header'

--- a/examples/with-rematch/pages/github-users.js
+++ b/examples/with-rematch/pages/github-users.js
@@ -1,61 +1,42 @@
-import { Component } from 'react'
-import Link from 'next/link'
-import { connect } from 'react-redux'
+import { useSelector } from 'react-redux'
+import { useRematchDispatch } from '../shared/utils'
 
-import { checkServer } from '../shared/utils'
+import { initializeStore } from '../shared/store'
 import CounterDisplay from '../shared/components/counter-display'
 import Header from '../shared/components/header'
 
-class Github extends Component {
-  static async getInitialProps(ctx) {
-    const store = ctx.reduxStore
+const Github = () => {
+  const github = useSelector((state) => state.github)
+  const { users, isLoading } = github
+  const { fetchUsers } = useRematchDispatch((dispatch) => ({
+    fetchUsers: dispatch.github.fetchUsers,
+  }))
+  return (
+    <div>
+      <Header />
+      <h1> Github users </h1>
+      <p>
+        Server rendered github user list. You can also reload the users from the
+        api by clicking the <b>Get users</b> button below.
+      </p>
+      {isLoading ? <p>Loading ...</p> : null}
+      <p>
+        <button onClick={fetchUsers}>Get users</button>
+      </p>
+      {users.map((user) => (
+        <div key={user.login}>
+          <a href={user.html_url}>
+            <img height="45" width="45" src={user.avatar_url} />
+            <span> Username - {user.login}</span>
+          </a>
+          <br />
+        </div>
+      ))}
+      <br />
 
-    // Pre-populate users only on the server-side
-    if (checkServer()) {
-      await store.dispatch.github.fetchUsers()
-    }
-    return {}
-  }
-
-  render() {
-    const { isLoading, fetchUsers, userList } = this.props
-
-    return (
-      <div>
-        <Header />
-        <h1> Github users </h1>
-        <p>
-          Server rendered github user list. You can also reload the users from
-          the api by clicking the <b>Get users</b> button below.
-        </p>
-        {isLoading ? <p>Loading ...</p> : null}
-        <p>
-          <button onClick={fetchUsers}>Get users</button>
-        </p>
-        {userList.map((user) => (
-          <div key={user.login}>
-            <a href={user.html_url}>
-              <img height="45" width="45" src={user.avatar_url} />
-              <span> Username - {user.login}</span>
-            </a>
-            <br />
-          </div>
-        ))}
-        <br />
-
-        <CounterDisplay />
-      </div>
-    )
-  }
+      <CounterDisplay />
+    </div>
+  )
 }
 
-const mapState = (state) => ({
-  userList: state.github.users,
-  isLoading: state.github.isLoading,
-})
-
-const mapDispatch = ({ github: { fetchUsers } }) => ({
-  fetchUsers: () => fetchUsers(),
-})
-
-export default connect(mapState, mapDispatch)(Github)
+export default Github

--- a/examples/with-rematch/pages/index.js
+++ b/examples/with-rematch/pages/index.js
@@ -1,39 +1,33 @@
-import { Component } from 'react'
-import { connect } from 'react-redux'
-
+import React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
 import Header from '../shared/components/header'
+import { useRematchDispatch } from '../shared/utils'
 
-class Home extends Component {
-  render() {
-    const { counter, increment, incrementBy, incrementAsync } = this.props
+const Home = () => {
+  const counter = useSelector((state) => state.counter)
+  const dispatch = useDispatch()
+  const { increment } = useRematchDispatch((dispatch) => ({
+    increment: dispatch.counter.increment,
+  }))
 
-    return (
-      <div>
-        <Header />
-        <h1> Counter </h1>
-        <h3>The count is {counter}</h3>
-        <p>
-          <button onClick={increment}>increment</button>
-          <button onClick={() => increment(1)}>
-            increment (using dispatch function)
-          </button>
-          <button onClick={incrementBy(5)}>increment by 5</button>
-          <button onClick={incrementAsync}>incrementAsync</button>
-        </p>
-        <br />
-      </div>
-    )
-  }
+  return (
+    <div>
+      <Header />
+      <h1> Counter </h1>
+      <h3>The count is {counter}</h3>
+      <p>
+        <button onClick={dispatch.counter.increment}>increment</button>
+        <button onClick={() => increment(1)}>
+          increment (using dispatch function)
+        </button>
+        <button onClick={() => increment(5)}>increment by 5</button>
+        <button onClick={dispatch.counter.incrementAsync}>
+          incrementAsync
+        </button>
+      </p>
+      <br />
+    </div>
+  )
 }
 
-const mapState = (state) => ({
-  counter: state.counter,
-})
-
-const mapDispatch = ({ counter: { increment, incrementAsync } }) => ({
-  increment: () => increment(1),
-  incrementBy: (amount) => () => increment(amount),
-  incrementAsync: () => incrementAsync(1),
-})
-
-export default connect(mapState, mapDispatch)(Home)
+export default Home

--- a/examples/with-rematch/pages/index.js
+++ b/examples/with-rematch/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import Header from '../shared/components/header'
 import { useRematchDispatch } from '../shared/utils'

--- a/examples/with-rematch/shared/components/counter-display.js
+++ b/examples/with-rematch/shared/components/counter-display.js
@@ -15,7 +15,7 @@ const CounterDisplay = () => {
         which are not pages can be connected using the useSelector hook just
         like redux components.
       </p>
-      <p>Current value {counter} gosho</p>
+      <p>Current value {counter}</p>
       <p>
         <button onClick={() => increment(3)}>Increment by 3</button>
       </p>

--- a/examples/with-rematch/shared/components/counter-display.js
+++ b/examples/with-rematch/shared/components/counter-display.js
@@ -1,33 +1,26 @@
-import React, { Component } from 'react'
-import { connect } from 'react-redux'
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { useRematchDispatch } from '../utils'
 
-class CounterDisplay extends Component {
-  render() {
-    const { counter, incrementBy3 } = this.props
-
-    return (
-      <div>
-        <h3> Counter </h3>
-        <p>
-          This counter is connected via the <b>connect</b> function. Components
-          which are not pages can be connected using the connect function just
-          like redux components.
-        </p>
-        <p>Current value {counter} </p>
-        <p>
-          <button onClick={incrementBy3}>Increment by 3</button>
-        </p>
-      </div>
-    )
-  }
+const CounterDisplay = () => {
+  const counter = useSelector((state) => state.counter)
+  const { increment } = useRematchDispatch((dispatch) => ({
+    increment: dispatch.counter.increment,
+  }))
+  return (
+    <>
+      <h3> Counter </h3>
+      <p>
+        This counter is connected via the <b>useSelector</b> hook. Components
+        which are not pages can be connected using the useSelector hook just
+        like redux components.
+      </p>
+      <p>Current value {counter} gosho</p>
+      <p>
+        <button onClick={() => increment(3)}>Increment by 3</button>
+      </p>
+    </>
+  )
 }
 
-const mapState = (state) => ({
-  counter: state.counter,
-})
-
-const mapDispatch = ({ counter: { increment, incrementAsync } }) => ({
-  incrementBy3: () => increment(3),
-})
-
-export default connect(mapState, mapDispatch)(CounterDisplay)
+export default CounterDisplay

--- a/examples/with-rematch/shared/components/header.js
+++ b/examples/with-rematch/shared/components/header.js
@@ -1,27 +1,20 @@
-import React, { Component } from 'react'
-import Link from 'next/link'
+import React from 'react'
 
-class Header extends Component {
-  render() {
-    return (
-      <div>
-        <nav>
-          <ul>
-            <li>
-              <Link href="/" passHref>
-                <a>Home</a>
-              </Link>
-            </li>
-            <li>
-              <Link href="/github-users" passHref>
-                <a>Async Example </a>
-              </Link>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    )
-  }
+const Header = () => {
+  return (
+    <div>
+      <nav>
+        <ul>
+          <li>
+            <a href="/">Home</a>
+          </li>
+          <li>
+            <a href="/github-users">Async Example </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  )
 }
 
 export default Header

--- a/examples/with-rematch/shared/models/counter.js
+++ b/examples/with-rematch/shared/models/counter.js
@@ -1,8 +1,11 @@
-const counter = {
+import { createModel } from '@rematch/core'
+
+const counter = createModel({
   state: 0, // initial state
   reducers: {
     // handle state changes with pure functions
-    increment(state, payload) {
+    increment: (state, payload) => {
+      if (typeof payload === 'object') return state + 1
       return state + payload
     },
   },
@@ -14,6 +17,6 @@ const counter = {
       this.increment(payload)
     },
   },
-}
+})
 
 export default counter

--- a/examples/with-rematch/shared/models/github.js
+++ b/examples/with-rematch/shared/models/github.js
@@ -26,6 +26,7 @@ const github = {
         const response = await fetch('https://api.github.com/users')
         const users = await response.json()
         this.receiveUsers(users)
+        return users
       } catch (err) {
         console.log(err)
         this.receiveUsers([])

--- a/examples/with-rematch/shared/utils.js
+++ b/examples/with-rematch/shared/utils.js
@@ -1,4 +1,10 @@
 // Robust way to check if it's Node or browser
+import { useDispatch } from 'react-redux'
 export const checkServer = () => {
   return typeof window === 'undefined'
+}
+
+export const useRematchDispatch = (selector) => {
+  const dispatch = useDispatch()
+  return selector(dispatch)
 }


### PR DESCRIPTION
Related [11014](https://github.com/zeit/next.js/issues/11014)

1. Updated all the packages.
2. Created utility useRematchDispatch method which will help us wrap rematch "dispatches" and return them accordingly.
3. Refactored the CounterDisplay component from class to functional and also implemented the features with the new redux hooks API.
4. Refactored the home component from class to functional, also using the new redux hooks API.
5. Refactored the models with the new rematch createModel function.
6. Refactored the GitHub component from class to functional, also using the new redux hooks API. Moved from getInitialProps to getStaticProps
7. Fixed issue with non-internal href being passed to the links
![Screenshot 2020-05-26 at 11 12 13](https://user-images.githubusercontent.com/51530311/82895274-a1e26d80-9f5c-11ea-8859-7a2b9b527c9f.png)

If you don't like anything or you want me to change something, please let me know.