### PR TITLE
Update PR stats action branch check

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -39,7 +39,7 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
     // load stats config from allowed locations
     const { statsConfig, relativeStatsAppDir } = loadStatsConfig()
 
-    if (actionInfo.prRef === statsConfig.mainBranch) {
+    if (actionInfo.isLocal && actionInfo.prRef === statsConfig.mainBranch) {
       throw new Error(
         `'GITHUB_REF' can not be the same as mainBranch in 'stats-config.js'.\n` +
           `This will result in comparing against the same branch`

--- a/.github/actions/next-stats-action/src/prepare/action-info.js
+++ b/.github/actions/next-stats-action/src/prepare/action-info.js
@@ -53,6 +53,7 @@ module.exports = function actionInfo() {
     gitRoot: GIT_ROOT_DIR || 'https://github.com/',
     prRepo: GITHUB_REPOSITORY,
     prRef: GITHUB_REF,
+    isLocal: LOCAL_STATS,
     commitId: null,
     issueId: ISSUE_ID,
     isRelease: releaseTypes.has(GITHUB_ACTION),


### PR DESCRIPTION
This makes sure to handle a PR using the `canary` branch name

x-ref: https://github.com/zeit/next.js/pull/13384/checks?check_run_id=709365637