### PR TITLE
Fix `with-sentry-simple` example

### DIFF
--- a/examples/with-sentry-simple/pages/_error.js
+++ b/examples/with-sentry-simple/pages/_error.js
@@ -13,7 +13,10 @@ const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
 }
 
 MyError.getInitialProps = async ({ res, err, asPath }) => {
-  const errorInitialProps = await Error.getInitialProps({ res, err })
+  const errorInitialProps = await NextErrorComponent.getInitialProps({
+    res,
+    err,
+  })
 
   // Workaround for https://github.com/zeit/next.js/issues/8592, mark when
   // getInitialProps has run


### PR DESCRIPTION
Previous referencing the incorrect `Error` global.