### PR TITLE
[Experimental] Do not type check twice

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -988,6 +988,7 @@ export default async function getBaseWebpackConfig(
         !isServer &&
         !dev &&
         new NextEsmPlugin({
+          excludedPlugins: ['ForkTsCheckerWebpackPlugin'],
           filename: (getFileName: Function | string) => (...args: any[]) => {
             const name =
               typeof getFileName === 'function'

--- a/packages/next/build/webpack/plugins/next-esm-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-esm-plugin.ts
@@ -74,10 +74,7 @@ export default class NextEsmPlugin implements Plugin {
     additionalPlugins?: any
   }) {
     this.options = Object.assign(
-      {
-        excludedPlugins: [PLUGIN_NAME],
-        additionalPlugins: [],
-      },
+      { excludedPlugins: [], additionalPlugins: [] },
       options
     )
   }
@@ -284,7 +281,11 @@ export default class NextEsmPlugin implements Plugin {
     }
 
     let plugins = (compiler.options.plugins || []).filter(
-      (c) => !this.options.excludedPlugins.includes(c.constructor.name)
+      (c) =>
+        !(
+          this.options.excludedPlugins.includes(c.constructor.name) ||
+          c.constructor.name === PLUGIN_NAME
+        )
     )
 
     // Add the additionalPlugins

--- a/test/integration/typescript-ignore-errors/next.config.js
+++ b/test/integration/typescript-ignore-errors/next.config.js
@@ -1,1 +1,3 @@
-module.exports = {}
+module.exports = {
+  experimental: { modern: true },
+}

--- a/test/integration/typescript-ignore-errors/test/index.test.js
+++ b/test/integration/typescript-ignore-errors/test/index.test.js
@@ -23,9 +23,10 @@ describe('TypeScript with error handling options', () => {
       describe(`ignoreDevErrors: ${ignoreDevErrors}, ignoreBuildErrors: ${ignoreBuildErrors}`, () => {
         beforeAll(() => {
           const nextConfig = {
+            experimental: { modern: true },
             typescript: { ignoreDevErrors, ignoreBuildErrors },
           }
-          nextConfigFile.replace('{}', JSON.stringify(nextConfig))
+          nextConfigFile.write('module.exports = ' + JSON.stringify(nextConfig))
         })
         afterAll(() => {
           nextConfigFile.restore()


### PR DESCRIPTION
The experimental modern mode runs the type checking plugin twice, which **occasionally** suffers from a race condition that hangs the build.

This PR fixes type checking to only be run once.

While this test cannot 100% reproduce/capture the race condition, I don't feel strongly about the test case:

- We're planning on eliminating this type checking plugin ASAP (for a faster alternative)
- Modern mode implementation as-is will probably go away with webpack 5