### PR TITLE
Fix auto export opting out from _error edge case

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -497,7 +497,8 @@ export default async function build(dir: string, conf = null): Promise<void> {
           : ['server', 'static', buildId, 'pages']),
         '_error.js'
       ),
-      runtimeEnvConfig
+      runtimeEnvConfig,
+      false
     ))
 
   const analysisBegin = process.hrtime()
@@ -540,7 +541,8 @@ export default async function build(dir: string, conf = null): Promise<void> {
                 SERVER_DIRECTORY,
                 `/static/${buildId}/pages/_app.js`
               ),
-          runtimeEnvConfig
+          runtimeEnvConfig,
+          true
         )
 
         namedExports = getNamedExports(

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -776,16 +776,16 @@ export async function isPageStatic(
 
 export function hasCustomGetInitialProps(
   bundle: string,
-  runtimeEnvConfig: any
+  runtimeEnvConfig: any,
+  checkingApp: boolean
 ): boolean {
   require('../next-server/lib/runtime-config').setConfig(runtimeEnvConfig)
   let mod = require(bundle)
 
-  if (bundle.endsWith('_app.js') || bundle.endsWith('_error.js')) {
-    mod = mod.default || mod
+  if (checkingApp) {
+    mod = mod._app || mod.default || mod
   } else {
-    // since we don't output _app in serverless mode get it from a page
-    mod = mod._app
+    mod = mod.default || mod
   }
   return mod.getInitialProps !== mod.origGetInitialProps
 }

--- a/test/integration/auto-export-error-bail/pages/app/_error.js
+++ b/test/integration/auto-export-error-bail/pages/app/_error.js
@@ -1,0 +1,11 @@
+import Error from 'next/Error'
+
+function MyError(props) {
+  return <Error {...props} />
+}
+
+MyError.getInitialProps = async (ctx) => {
+  return Error.getInitialProps(ctx)
+}
+
+export default MyError

--- a/test/integration/auto-export-error-bail/pages/app/_error.js
+++ b/test/integration/auto-export-error-bail/pages/app/_error.js
@@ -1,4 +1,4 @@
-import Error from 'next/Error'
+import Error from 'next/error'
 
 function MyError(props) {
   return <Error {...props} />

--- a/test/integration/auto-export-error-bail/test/index.test.js
+++ b/test/integration/auto-export-error-bail/test/index.test.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+
+import path from 'path'
+import fs from 'fs-extra'
+import { nextBuild } from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 1)
+const appDir = path.join(__dirname, '..')
+const nextConfig = path.join(appDir, 'next.config.js')
+
+const runTests = () => {
+  it('should not opt-out of auto static optimization from invalid _error', async () => {
+    const output = await nextBuild(appDir, undefined, {
+      stdout: true,
+      stderr: true,
+    })
+
+    expect(output.code).toBe(0)
+    expect(output.stderr + output.stdout).not.toContain(
+      'You have opted-out of Automatic Static Optimization due to'
+    )
+  })
+}
+
+describe('Auto Export _error bail', () => {
+  describe('server mode', () => {
+    runTests()
+  })
+
+  describe('serverless mode', () => {
+    beforeAll(() =>
+      fs.writeFile(
+        nextConfig,
+        `
+      module.exports = {
+        target: 'experimental-serverless-trace'
+      }
+    `
+      )
+    )
+    afterAll(() => fs.remove(nextConfig))
+
+    runTests()
+  })
+})

--- a/test/integration/auto-export-error-bail/test/index.test.js
+++ b/test/integration/auto-export-error-bail/test/index.test.js
@@ -15,6 +15,10 @@ const runTests = () => {
       stderr: true,
     })
 
+    if (output.code) {
+      console.log(output)
+    }
+
     expect(output.code).toBe(0)
     expect(output.stderr + output.stdout).not.toContain(
       'You have opted-out of Automatic Static Optimization due to'


### PR DESCRIPTION
This fixes an edge case where an application can seemingly randomly be opted out of the automatic static optimization from having an `_error` file that isn't directly nested under the `pages` folder e.g. `pages/hello/_error.js`. 

Since in serverless mode we use the `_app` export from the first serverless page, if this `_error.js` file is used to check for custom `getIniitalProps` in `_app` and the `_error.js` page had a custom `getInitialProps` itself it would cause the check to fail opting the application out of the static optimization. 

This fixes it by having the check be explicit instead of relying on the bundle name and it also adds regression tests for this. It might be good to also add a warning when `_error` or `_app` are not directly nested under the pages folder in a follow up PR