### PR TITLE
Typescript option `enableDevErrorsCheck`

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -968,8 +968,7 @@ export default async function getBaseWebpackConfig(
         new ProfilingPlugin({
           tracer,
         }),
-      !dev &&
-        !isServer &&
+      !isServer &&
         useTypeScript &&
         !ignoreTypeScriptErrors &&
         new ForkTsCheckerWebpackPlugin(

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -248,7 +248,8 @@ export default async function getBaseWebpackConfig(
     typeScriptPath && (await fileExists(tsConfigPath))
   )
   const ignoreTypeScriptErrors =
-    dev || Boolean(config.typescript?.ignoreBuildErrors)
+    (dev && !Boolean(config.typescript?.enableDevErrorsCheck)) ||
+    Boolean(config.typescript?.ignoreBuildErrors)
 
   let jsConfig
   // jsconfig is a subset of tsconfig


### PR DESCRIPTION
Since NextJS,  by default, removed Typescript errors check in dev mode,
this PR add new Typescript option that allows you to enable error checking in development mode if needed

```js
// next.config.js
module.exports = {
  typescript: {
    enableDevErrorsCheck: true,
  },
}
```