### PR TITLE
refactor(with-sentry): example

### DIFF
--- a/examples/with-sentry-simple/package.json
+++ b/examples/with-sentry-simple/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "scripts": {
-    "dev": "next node server.js",
+    "dev": "next",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/with-sentry-simple/package.json
+++ b/examples/with-sentry-simple/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "ISC",
   "scripts": {
-    "dev": "next",
+    "dev": "next node server.js",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/with-sentry/package.json
+++ b/examples/with-sentry/package.json
@@ -2,21 +2,21 @@
   "name": "with-sentry",
   "version": "1.1.0",
   "scripts": {
-    "dev": "SENTRY_DSN=abc123 node server.js",
+    "dev": "SENTRY_DSN=abc123",
     "build": "SENTRY_DSN=abc123 next build",
     "start": "SENTRY_DSN=abc123 NODE_ENV=production node server.js"
   },
   "dependencies": {
     "@sentry/browser": "^5.0.3",
-    "@sentry/node": "^5.0.3",
     "@sentry/integrations": "^5.0.3",
+    "@sentry/node": "^5.0.3",
     "@zeit/next-source-maps": "0.0.4-canary.1",
     "cookie-parser": "1.4.4",
     "express": "^4.16.4",
     "js-cookie": "2.2.0",
     "next": "latest",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "sentry-testkit": "^2.1.0",
     "uuid": "^3.3.2"
   },

--- a/examples/with-sentry/package.json
+++ b/examples/with-sentry/package.json
@@ -2,7 +2,7 @@
   "name": "with-sentry",
   "version": "1.1.0",
   "scripts": {
-    "dev": "SENTRY_DSN=abc123",
+    "dev": "SENTRY_DSN=abc123 node server.js",
     "build": "SENTRY_DSN=abc123 next build",
     "start": "SENTRY_DSN=abc123 NODE_ENV=production node server.js"
   },

--- a/examples/with-sentry/pages/index.js
+++ b/examples/with-sentry/pages/index.js
@@ -1,58 +1,51 @@
-import { Component } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 
-class Index extends Component {
-  static getInitialProps({ query, req }) {
-    if (query.raiseError) {
-      throw new Error('Error in getInitialProps')
+const Index = () => {
+  const [state, setState] = useState({
+    raiseErrorInUseEffectHook: null,
+  })
+
+  useEffect(() => {
+    if (state.raiseErrorInUseEffectHook) {
+      throw new Error('Error in useEffect Hook')
     }
+  }, [state.raiseErrorInUseEffectHook])
+
+  return (
+    <div>
+      <h2>Index page</h2>
+      <ul>
+        <li>
+          <a
+            href="#"
+            onClick={() =>
+              setState((current) => ({
+                ...current,
+                raiseErrorInUseEffectHook: '1',
+              }))
+            }
+          >
+            Raise the error in render or update
+          </a>
+        </li>
+        <li>
+          <Link href={{ pathname: '/', query: { raiseError: '1' } }}>
+            <a>Raise error in getServerSideProps</a>
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}
+
+export async function getServerSideProps({ query }) {
+  if (query.raiseError) {
+    throw new Error('Error in getServerSideProps')
   }
 
-  state = {
-    raiseError: false,
-  }
-
-  componentDidUpdate() {
-    if (this.state.raiseErrorInUpdate) {
-      throw new Error('Error in componentDidUpdate')
-    }
-  }
-
-  raiseErrorInUpdate = () => this.setState({ raiseErrorInUpdate: '1' })
-  raiseErrorInRender = () => this.setState({ raiseErrorInRender: '1' })
-
-  render() {
-    if (this.state.raiseErrorInRender) {
-      throw new Error('Error in render')
-    }
-
-    return (
-      <div>
-        <h2>Index page</h2>
-        <ul>
-          <li>
-            <a href="#" onClick={this.raiseErrorInRender}>
-              Raise the error in render
-            </a>
-          </li>
-          <li>
-            <a href="#" onClick={this.raiseErrorInUpdate}>
-              Raise the error in componentDidUpdate
-            </a>
-          </li>
-          <li>
-            <Link href={{ pathname: '/', query: { raiseError: '1' } }}>
-              <a>Raise error in getInitialProps of client-loaded page</a>
-            </Link>
-          </li>
-          <li>
-            <a href="/?raiseError=1">
-              Raise error in getInitialProps of server-loaded page
-            </a>
-          </li>
-        </ul>
-      </div>
-    )
+  return {
+    props: {},
   }
 }
 


### PR DESCRIPTION
1. I updated all the packages.
2. Refactored the home component from class to functional
3. Example now uses getServerSideProps instead of getInitialProps