### PR TITLE
Add warning when reserved pages are nested

### DIFF
--- a/errors/nested-reserved-page.md
+++ b/errors/nested-reserved-page.md
@@ -1,0 +1,15 @@
+# Nested Reserved Page
+
+#### Why This Error Occurred
+
+In your pages folder you nested a reserved page e.g. `_app`, `_error`, or `_document` which causes the page to not be used since they must be located directly under the pages folder.
+
+#### Possible Ways to Fix It
+
+Move the reserved pages directly under your pages folder so that they are picked up and used correctly.
+
+### Useful Links
+
+- [Custom `_app` Documentation](https://nextjs.org/docs/advanced-features/custom-app)
+- [Custom `_error` Documentation](https://nextjs.org/docs/advanced-features/custom-error-page)
+- [Custom `_document` Documentation](https://nextjs.org/docs/advanced-features/custom-document)

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -260,6 +260,26 @@ export default async function build(dir: string, conf = null): Promise<void> {
     )
   }
 
+  const nestedReservedPages = pageKeys.filter((page) => {
+    return (
+      page.match(/\/(_app|_document|_error)$/) && path.dirname(page) !== '/'
+    )
+  })
+
+  if (nestedReservedPages.length) {
+    console.warn(
+      '\n' +
+        chalk.bold.yellow(`Warning: `) +
+        chalk.bold(
+          `The following reserved Next.js pages were detected not directly under the pages directory:\n`
+        ) +
+        nestedReservedPages.join('\n') +
+        chalk.bold(
+          `\nSee more info here: https://err.sh/next.js/nested-reserved-page\n`
+        )
+    )
+  }
+
   const buildCustomRoute = (
     r: {
       source: string

--- a/test/integration/auto-export-error-bail/test/index.test.js
+++ b/test/integration/auto-export-error-bail/test/index.test.js
@@ -19,10 +19,16 @@ const runTests = () => {
       console.log(output)
     }
 
+    const combinedOutput = output.stderr + output.stdout
+
     expect(output.code).toBe(0)
-    expect(output.stderr + output.stdout).not.toContain(
+    expect(combinedOutput).not.toContain(
       'You have opted-out of Automatic Static Optimization due to'
     )
+    expect(combinedOutput).toContain(
+      'The following reserved Next.js pages were detected not directly under the pages directory'
+    )
+    expect(combinedOutput).toContain('/app/_error')
   })
 }
 


### PR DESCRIPTION
This adds a warning when a user has nested a reserved page `_error`, `_app`, or `_document` in their pages directory since it causes it to not be picked up and used by Next.js in the expected way

x-ref: https://github.com/zeit/next.js/pull/13425

<details>
<summary>Example of warning</summary>

<img width="927" alt="Screen Shot 2020-05-27 at 10 39 09" src="https://user-images.githubusercontent.com/22380829/83042315-24276c00-a007-11ea-9dc4-cabcc93571d2.png">
</details>