### PR TITLE
[Docs]: minor typo in `jsx` file extension

### DIFF
--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -6,7 +6,7 @@ description: Next.js pages are React Components exported in a file in the pages 
 
 > This document is for Next.js versions 9.3 and up. If you're using older versions of Next.js, refer to our [previous documentation](https://nextjs.org/docs/tag/v9.2.2/basic-features/pages).
 
-In Next.js, a **page** is a [React Component](https://reactjs.org/docs/components-and-props.html) exported from a `.js`, `jsx`, `.ts`, or `.tsx` file in the `pages` directory. Each page is associated with a route based on its file name.
+In Next.js, a **page** is a [React Component](https://reactjs.org/docs/components-and-props.html) exported from a `.js`, `.jsx`, `.ts`, or `.tsx` file in the `pages` directory. Each page is associated with a route based on its file name.
 
 **Example**: If you create `pages/about.js` that exports a React component like below, it will be accessible at `/about`.
 


### PR DESCRIPTION
There was no period before `jsx` in the list of file types for pages. I added the period for consistency.