### PR TITLE
Add release argument to SentryWebpackPlugin

### DIFF
--- a/examples/with-sentry-simple/next.config.js
+++ b/examples/with-sentry-simple/next.config.js
@@ -51,6 +51,7 @@ module.exports = withSourceMaps({
           include: '.next',
           ignore: ['node_modules'],
           urlPrefix: '~/_next',
+          release: options.buildId,
         })
       )
     }


### PR DESCRIPTION
This PR adds the `release` argument to `SentryWebpackPlugin`. Without this change, the build is failing with the following error:
```
Sentry CLI Plugin: Unable to determine version. Make sure to include `release` option or use the environment that supports auto-detection https://docs.sentry.io/cli/releases/#creating-releases
```

I have taken the fix from an existing open issue with the Sentry webpack plugin: https://github.com/getsentry/sentry-webpack-plugin/issues/185#issuecomment-625592584