### PR TITLE
Remove beta label from Netlify Plugins

### DIFF
--- a/errors/no-cache.md
+++ b/errors/no-cache.md
@@ -60,7 +60,7 @@ cache:
 
 #### Netlify CI
 
-Use [Netlify Plugins (beta)](https://www.netlify.com/build/plugins-beta/) with [`netlify-plugin-cache-nextjs`](https://www.npmjs.com/package/netlify-plugin-cache-nextjs).
+Use [Netlify Plugins](https://www.netlify.com/products/build/plugins/) with [`netlify-plugin-cache-nextjs`](https://www.npmjs.com/package/netlify-plugin-cache-nextjs).
 
 #### AWS CodeBuild
 


### PR DESCRIPTION
Netlify Plugins are out of beta!

https://www.netlify.com/blog/2020/05/27/netlify-build-plugins-are-here/