### PR TITLE
Update proxy example to http-proxy-middleware ^1

### DIFF
--- a/examples/with-custom-reverse-proxy/package.json
+++ b/examples/with-custom-reverse-proxy/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "cross-env": "^5.0.1",
-    "http-proxy-middleware": "^0.17.4"
+    "http-proxy-middleware": "^1.0.4"
   },
   "scripts": {
     "dev": "cross-env NODE_ENV=development PORT=3000 node server.js",

--- a/examples/with-custom-reverse-proxy/server.js
+++ b/examples/with-custom-reverse-proxy/server.js
@@ -28,9 +28,9 @@ app
 
     // Set up the proxy.
     if (dev && devProxy) {
-      const proxyMiddleware = require('http-proxy-middleware')
+      const { createProxyMiddleware } = require('http-proxy-middleware')
       Object.keys(devProxy).forEach(function (context) {
-        server.use(proxyMiddleware(context, devProxy[context]))
+        server.use(context, createProxyMiddleware(devProxy[context]))
       })
     }
 


### PR DESCRIPTION
The current example doesn't work if one try to reproduce it with a recent version of http-proxy-middleware.