### PR TITLE
fix(create-server): Improve the message error for bad user input with next instantiation

### DIFF
--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -12,6 +12,11 @@ type NextServerConstructor = Omit<ServerConstructor, 'staticMarkup'> & {
 // This file is used for when users run `require('next')`
 function createServer(options: NextServerConstructor): Server {
   const standardEnv = ['production', 'development', 'test']
+  if (typeof options == 'undefined') {
+    throw new Error(
+      `It seems the next instance is being instantiated incorrectly. Please be sure you're passing a valid object.`
+    )
+  }
 
   if (
     !(options as any).isNextDevCommand &&


### PR DESCRIPTION
@Timer as discussed in [13466](https://github.com/vercel/next.js/issues/13466), this pull request adds a better error message when `next` is incorrectly instantiated.