### PR TITLE
improves baseUrl resolution in typescript monorepos

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -15,6 +15,7 @@ import {
 } from '../lib/constants'
 import { fileExists } from '../lib/file-exists'
 import { resolveRequest } from '../lib/resolve-request'
+import { getTypeScriptConfiguration } from '../lib/typescript/getTypeScriptConfiguration'
 import {
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS,
@@ -261,7 +262,9 @@ export default async function getBaseWebpackConfig(
   let jsConfig
   // jsconfig is a subset of tsconfig
   if (useTypeScript) {
-    jsConfig = parseJsonFile(tsConfigPath)
+    const ts = (await import(typeScriptPath)) as typeof import('typescript')
+    const tsConfig = await getTypeScriptConfiguration(ts, tsConfigPath)
+    jsConfig = { compilerOptions: tsConfig.options }
   }
 
   const jsConfigPath = path.join(dir, 'jsconfig.json')

--- a/test/integration/typescript-workspaces-paths/packages/lib/a/api.ts
+++ b/test/integration/typescript-workspaces-paths/packages/lib/a/api.ts
@@ -1,0 +1,5 @@
+//this line uses typescript specific syntax
+//to demonstrate that transpilation occurs
+export type API = () => string
+const api: API = () => 'Hello from a'
+export default api

--- a/test/integration/typescript-workspaces-paths/packages/lib/b/api.ts
+++ b/test/integration/typescript-workspaces-paths/packages/lib/b/api.ts
@@ -1,0 +1,4 @@
+import { API } from '@lib/api'
+
+const b: API = () => 'Hello from b'
+export default b

--- a/test/integration/typescript-workspaces-paths/packages/lib/b/b-only.ts
+++ b/test/integration/typescript-workspaces-paths/packages/lib/b/b-only.ts
@@ -1,0 +1,4 @@
+import { API } from '@lib/api'
+
+const b: API = () => 'Hello from only b'
+export default b

--- a/test/integration/typescript-workspaces-paths/packages/www/components/alias-to-d-ts.d.ts
+++ b/test/integration/typescript-workspaces-paths/packages/www/components/alias-to-d-ts.d.ts
@@ -1,0 +1,1 @@
+export default () => any

--- a/test/integration/typescript-workspaces-paths/packages/www/components/alias-to-d-ts.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/components/alias-to-d-ts.tsx
@@ -1,0 +1,4 @@
+const Named = () => {
+  return <>Not aliased to d.ts file</>
+}
+export default Named

--- a/test/integration/typescript-workspaces-paths/packages/www/components/hello.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/components/hello.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Hello() {
+  return <>Hello</>
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/components/world.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/components/world.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function World(): JSX.Element {
+  return <>World</>
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/next.config.js
+++ b/test/integration/typescript-workspaces-paths/packages/www/next.config.js
@@ -1,0 +1,23 @@
+const path = require('path')
+module.exports = {
+  webpack: function (config, { defaultLoaders }) {
+    const resolvedBaseUrl = path.resolve(config.context, '../../')
+    config.module.rules = [
+      ...config.module.rules,
+      {
+        test: /\.(tsx|ts|js|mjs|jsx)$/,
+        include: [resolvedBaseUrl],
+        use: defaultLoaders.babel,
+        exclude: (excludePath) => {
+          return /node_modules/.test(excludePath)
+        },
+      },
+    ]
+    return config
+  },
+
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/pages/alias-to-d-ts.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/pages/alias-to-d-ts.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import NotAliasedToDTS from 'd-ts-alias'
+
+export default function HelloPage(): JSX.Element {
+  return (
+    <div>
+      <NotAliasedToDTS />
+    </div>
+  )
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/pages/basic-alias.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/pages/basic-alias.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { World } from '@c/world'
+export default function HelloPage(): JSX.Element {
+  return (
+    <div>
+      <World />
+    </div>
+  )
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/pages/resolve-fallback.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/pages/resolve-fallback.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+import api from '@lib/b-only'
+export default function ResolveOrder(): JSX.Element {
+  return <div>{api()}</div>
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/pages/resolve-order.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/pages/resolve-order.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+import api from '@lib/api'
+export default function ResolveOrder(): JSX.Element {
+  return <div>{api()}</div>
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/pages/single-alias.tsx
+++ b/test/integration/typescript-workspaces-paths/packages/www/pages/single-alias.tsx
@@ -1,0 +1,9 @@
+import { Hello } from '@mycomponent'
+
+export default function SingleAlias() {
+  return (
+    <div>
+      <Hello />
+    </div>
+  )
+}

--- a/test/integration/typescript-workspaces-paths/packages/www/test/index.test.js
+++ b/test/integration/typescript-workspaces-paths/packages/www/test/index.test.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import cheerio from 'cheerio'
+import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '..')
+let appPort
+let app
+
+async function get$(path, query) {
+  const html = await renderViaHTTP(appPort, path, query)
+  return cheerio.load(html)
+}
+
+describe('TypeScript Features', () => {
+  describe('default behavior', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {})
+    })
+    afterAll(() => killApp(app))
+
+    it('should alias components', async () => {
+      const $ = await get$('/basic-alias')
+      expect($('body').text()).toMatch(/World/)
+    })
+
+    it('should resolve the first item in the array first', async () => {
+      const $ = await get$('/resolve-order')
+      expect($('body').text()).toMatch(/Hello from a/)
+    })
+
+    it('should resolve the second item in as a fallback', async () => {
+      const $ = await get$('/resolve-fallback')
+      expect($('body').text()).toMatch(/Hello from only b/)
+    })
+
+    it('should resolve a single matching alias', async () => {
+      const $ = await get$('/single-alias')
+      expect($('body').text()).toMatch(/Hello/)
+    })
+
+    it('should not resolve to .d.ts files', async () => {
+      const $ = await get$('/alias-to-d-ts')
+      expect($('body').text()).toMatch(/Not aliased to d\.ts file/)
+    })
+  })
+})

--- a/test/integration/typescript-workspaces-paths/packages/www/tsconfig.json
+++ b/test/integration/typescript-workspaces-paths/packages/www/tsconfig.json
@@ -1,0 +1,6 @@
+/* This is a single line comment to check if that works */
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "components", "pages"]
+}

--- a/test/integration/typescript-workspaces-paths/tsconfig.json
+++ b/test/integration/typescript-workspaces-paths/tsconfig.json
@@ -1,0 +1,30 @@
+/* This is a single line comment to check if that works */
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "isomorphic-unfetch": ["packages/www/types/unfetch.d.ts"],
+      "@c/*": ["packages/www/components/*"],
+      "@lib/*": ["packages/lib/a/*", "packages/lib/b/*"],
+      "@mycomponent": ["packages/www/components/hello.tsx"],
+      "d-ts-alias": [
+        "packages/www/components/alias-to-d-ts.d.ts",
+        "packages/www/components/alias-to-d-ts.tsx"
+      ]
+      // This is a single line comment to check if that works
+    },
+    "esModuleInterop": true,
+    "module": "esnext",
+    "jsx": "preserve",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
Typescript configuration can inherit from files above cwd in the
filesystem. If a baseUrl was declared in such a file, it would not be
picked up by the webpack config. This would force users to use the
next-transpile-module and duplicate configuration with unintuitive path
relations (see #13197 for a detailed analysis)

If baseUrl is resolved it should be used instead of dir as the root
include for babel-resolve-loader.

An even nicer DX would auto detect the presence of a `paths` section in
the typescript config and automatically include
`tsconfig-paths-webpack-plugin`

fixes #13197 
fixes #13616
fixes partially #9474