### PR TITLE
Fix: Cannot read property 'indexOf' of undefined cuased by undefined u…

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -256,7 +256,7 @@ export default class Router implements BaseRouter {
   }
 
   onPopState = (e: PopStateEvent): void => {
-    if (!e.state) {
+    if (!e.state || !e.state.url) {
       // We get state as undefined for two reasons.
       //  1. With older safari (< 8) and older chrome (< 34)
       //  2. When the URL changed with #


### PR DESCRIPTION
…rl in router

Code is making an assumption that `PopStateEvent.state.url` is a string when `PopStateEvent` is truthy.  The assumption is wrong based on the type:

```
/** PopStateEvent is an event handler for the popstate event on the window. */
interface PopStateEvent extends Event {
    /**
     * Returns a copy of the information that was provided to pushState() or replaceState().
     */
    readonly state: any;
}
``` 

because the value can be anything.  In the case below (in the gif), the url is undefined.

![undefined error](https://user-images.githubusercontent.com/58744872/83296607-e57be800-a1a5-11ea-8be8-105e534ac9a7.gif)
