### PR TITLE
Adds type for NextApiRequest.body

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -174,7 +174,7 @@ export type DocumentProps = DocumentInitialProps & {
 /**
  * Next `API` route request
  */
-export interface NextApiRequest extends IncomingMessage {
+export interface NextApiRequest<T = any> extends IncomingMessage {
   /**
    * Object of `query` values from url
    */
@@ -188,7 +188,7 @@ export interface NextApiRequest extends IncomingMessage {
     [key: string]: string
   }
 
-  body: any
+  body: T
 
   env: Env
 }


### PR DESCRIPTION
Adding a generic to NextApiRequest would let typescript users pass in their expected request body type. This also types the generic as an `any` by default to keep this from being a breaking change and let users make the choice themselves.

![image](https://user-images.githubusercontent.com/32269552/83330474-cc7e4000-a254-11ea-98fa-c66e072cffbc.png)
