### PR TITLE
Warn about full reload after page reloads

### DIFF
--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -19,6 +19,11 @@ if (!window.EventSource) {
   window.EventSource = EventSourcePolyfill
 }
 
+if (sessionStorage && sessionStorage.getItem('consoleWarnAfterReload')) {
+  console.warn(sessionStorage.getItem('consoleWarnAfterReload'))
+  sessionStorage.removeItem('consoleWarnAfterReload')
+}
+
 const {
   __NEXT_DATA__: { assetPrefix },
 } = window


### PR DESCRIPTION
Fixes #13070, where it was pointed out that the hot dev client's [full reload console warning](https://github.com/vercel/next.js/blob/2a473ab42ca538337ad2ccb1e418d61e9a731c31/packages/next/client/dev/error-overlay/hot-dev-client.js#L270-L277) isn't terribly helpful because as soon as it shows up, the page reloads, and in Chrome, the console clears between page loads by default. There is a "Preserve log" option you can enable, but a lot of users may not know about it, and the current warning flashes on the screen so briefly they may not even notice it.

This fix saves the text content of the warning to the window's [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) in a key called `'consoleWarnAfterReload'`, and now on page load [`next-dev.js`](https://github.com/vercel/next.js/blob/canary/packages/next/client/next-dev.js) checks <code>sessionStorage.getItem&#8203;('consoleWarnAfterReload')</code> near the top and `console.warn`s it if it exists and removes the item from `sessionStorage` afterward.

![The new console warning showing up after the page reloads](https://user-images.githubusercontent.com/5317080/83334176-acf61000-a272-11ea-9eff-0068e55bba30.gif)

Two questions:

1. Is `next-dev.js` the best place to check <code>sessionStorage.getItem&#8203;('consoleWarnAfterReload')</code>? Should I put that in [`client/index.js`](https://github.com/vercel/next.js/blob/canary/packages/next/client/index.js) instead?

2. A good 38 lines of my changes are just feature-detecting `sessionStorage`, but [MDN says](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage) that the Storage API is available in current versions of all major browsers, so testing for availability is only necessary in weird cases like Internet Explorer 7 or Private Browsing in Safari. Should I get rid of those lines and just use `sessionStorage` regardless?