### PR TITLE
Fix ssg in with-ant-design example

### DIFF
--- a/examples/with-ant-design/.babelrc
+++ b/examples/with-ant-design/.babelrc
@@ -5,7 +5,7 @@
       "import",
       {
         "libraryName": "antd",
-        "libraryDirectory": "es",
+        "libraryDirectory": "lib",
         "style": "index.css"
       }
     ],
@@ -13,7 +13,7 @@
       "import",
       {
         "libraryName": "@ant-design/icons",
-        "libraryDirectory": "es/icons",
+        "libraryDirectory": "lib/icons",
         "camel2DashComponentName": false
       },
       "@ant-design/icons"

--- a/examples/with-ant-design/package.json
+++ b/examples/with-ant-design/package.json
@@ -10,12 +10,12 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@next/bundle-analyzer": "^9.1.4",
-    "antd": "4.1.2",
+    "antd": "4.3.0",
     "babel-plugin-import": "1.13.0",
     "cross-env": "^7.0.2",
-    "dayjs": "1.8.24",
+    "dayjs": "1.8.28",
     "esm": "^3.2.25",
-    "next": "9.3.4",
+    "next": "9.4.4",
     "postcss-preset-env": "^6.7.0",
     "react": "16.13.1",
     "react-dom": "16.13.1"


### PR DESCRIPTION
This will switch the `libraryDirectory` for Ant Design packages from `es` to `lib` and fixes https://github.com/vercel/next.js/issues/12664.

The dependencies were also updated.