### PR TITLE
Handle encoding for data requests and fix fallback response

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -427,11 +427,16 @@ export default class Server {
           }
 
           // re-create page's pathname
-          const pathname = `/${params.path.join('/')}`
+          const pathname = `/${params.path
+            // we need to re-encode the params since they are decoded
+            // by path-match and we are re-building the URL
+            .map((param: string) => encodeURIComponent(param))
+            .join('/')}`
             .replace(/\.json$/, '')
             .replace(/\/index$/, '/')
 
           const parsedUrl = parseUrl(pathname, true)
+
           await this.render(
             req,
             res,
@@ -960,7 +965,7 @@ export default class Server {
     }
 
     // Toggle whether or not this is a Data request
-    const isDataReq = !!query._nextDataReq
+    const isDataReq = !!query._nextDataReq && (isSSG || isServerProps)
     delete query._nextDataReq
 
     let previewData: string | false | object | undefined
@@ -1128,6 +1133,7 @@ export default class Server {
       }
 
       sendPayload(res, html, 'html')
+      return null
     }
 
     const {

--- a/test/integration/prerender/pages/fallback-only/[slug].js
+++ b/test/integration/prerender/pages/fallback-only/[slug].js
@@ -1,0 +1,43 @@
+import React from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+
+  return {
+    props: {
+      params,
+      hello: 'world',
+      post: params.slug,
+      random: Math.random(),
+      time: (await import('perf_hooks')).performance.now(),
+    },
+    unstable_revalidate: 1,
+  }
+}
+
+export default ({ post, time, params }) => {
+  if (useRouter().isFallback) {
+    return <p>hi fallback</p>
+  }
+
+  return (
+    <>
+      <p>Post: {post}</p>
+      <span>time: {time}</span>
+      <div id="params">{JSON.stringify(params)}</div>
+      <div id="query">{JSON.stringify(useRouter().query)}</div>
+      <Link href="/">
+        <a id="home">to home</a>
+      </Link>
+    </>
+  )
+}


### PR DESCRIPTION
This addresses some errors for `/_next/data` requests where encoded `/` values in dynamic route param would cause invalid behavior, a headers already sent error would be shown when sending the fallback page in development, and when rendering the `_error` page for a data request the error response would still be treated as a data request. 

This also adds test cases for these errors to prevent regression