### PR TITLE
Remove unnecessary catch

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -91,24 +91,10 @@ export async function downloadAndExtractExample(
     throw new Error('This is an internal example for testing the CLI.')
   }
 
-  try {
-    return await pipeline(
-      got.stream('https://codeload.github.com/vercel/next.js/tar.gz/canary'),
-      tar.extract({ cwd: root, strip: 3 }, [`next.js-canary/examples/${name}`])
-    )
-  } catch (err) {
-    // TODO: remove after this change has been landed
-    if (err?.response?.statusCode === 404) {
-      return pipeline(
-        got.stream('https://codeload.github.com/vercel/next.js/tar.gz/canary'),
-        tar.extract({ cwd: root, strip: 3 }, [
-          `next.js-canary/examples/${name}`,
-        ])
-      )
-    } else {
-      throw err
-    }
-  }
+  return await pipeline(
+    got.stream('https://codeload.github.com/vercel/next.js/tar.gz/canary'),
+    tar.extract({ cwd: root, strip: 3 }, [`next.js-canary/examples/${name}`])
+  )
 }
 
 export async function listExamples(): Promise<any> {

--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -83,7 +83,7 @@ export function downloadAndExtractRepo(
   )
 }
 
-export async function downloadAndExtractExample(
+export function downloadAndExtractExample(
   root: string,
   name: string
 ): Promise<void> {
@@ -91,7 +91,7 @@ export async function downloadAndExtractExample(
     throw new Error('This is an internal example for testing the CLI.')
   }
 
-  return await pipeline(
+  return pipeline(
     got.stream('https://codeload.github.com/vercel/next.js/tar.gz/canary'),
     tar.extract({ cwd: root, strip: 3 }, [`next.js-canary/examples/${name}`])
   )


### PR DESCRIPTION
This undoes https://github.com/vercel/next.js/pull/13138 as the rename is done.