### PR TITLE
Remove remaining granular chunks references

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -141,7 +141,7 @@ export function createEntrypoints(
         pageLoaderOpts
       )}!`
 
-      // Make sure next/router is a dependency of _app or else granularChunks
+      // Make sure next/router is a dependency of _app or else chunk splitting
       // might cause the router to not be able to load causing hydration
       // to fail
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -827,7 +827,6 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_MODERN_BUILD': JSON.stringify(
           config.experimental.modern && !dev
         ),
-        'process.env.__NEXT_GRANULAR_CHUNKS': JSON.stringify(!dev),
         'process.env.__NEXT_BUILD_INDICATOR': JSON.stringify(
           config.devIndicators.buildActivity
         ),

--- a/packages/next/build/webpack/plugins/webpack-conformance-plugin/checks/granular-chunks-conformance.ts
+++ b/packages/next/build/webpack/plugins/webpack-conformance-plugin/checks/granular-chunks-conformance.ts
@@ -17,8 +17,8 @@ export interface GranularChunksConformanceCheck
 
 function getWarningMessage(modifiedProp: string) {
   return (
-    `${CONFORMANCE_WARNING_PREFIX}: The splitChunks config as part of the granularChunks flag has ` +
-    `been carefully crafted to optimize build size and build times. Modifying - ${chalk.bold(
+    `${CONFORMANCE_WARNING_PREFIX}: The splitChunks config has been carefully ` +
+    `crafted to optimize build size and build times. Modifying - ${chalk.bold(
       modifiedProp
     )} could result in slower builds and increased code duplication`
   )
@@ -26,8 +26,8 @@ function getWarningMessage(modifiedProp: string) {
 
 function getErrorMessage(message: string) {
   return (
-    `${CONFORMANCE_ERROR_PREFIX}: The splitChunks config as part of the granularChunks flag has ` +
-    `been carefully crafted to optimize build size and build times. Please avoid changes to ${chalk.bold(
+    `${CONFORMANCE_ERROR_PREFIX}: The splitChunks config has been carefully ` +
+    `crafted to optimize build size and build times. Please avoid changes to ${chalk.bold(
       message
     )}`
   )

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -57,7 +57,7 @@ export default class PageLoader {
     this.pageCache = {}
     this.pageRegisterEvents = mitt()
     this.loadingRoutes = {}
-    if (process.env.__NEXT_GRANULAR_CHUNKS) {
+    if (process.env.NODE_ENV === 'production') {
       this.promisedBuildManifest = new Promise((resolve) => {
         if (window.__BUILD_MANIFEST) {
           resolve(window.__BUILD_MANIFEST)
@@ -215,7 +215,7 @@ export default class PageLoader {
 
       if (!this.loadingRoutes[route]) {
         this.loadingRoutes[route] = true
-        if (process.env.__NEXT_GRANULAR_CHUNKS) {
+        if (process.env.NODE_ENV === 'production') {
           this.getDependencies(route).then((deps) => {
             deps.forEach((d) => {
               if (
@@ -348,7 +348,7 @@ export default class PageLoader {
               relPrefetch,
               url.match(/\.css$/) ? 'style' : 'script'
             ),
-            process.env.__NEXT_GRANULAR_CHUNKS &&
+            process.env.NODE_ENV === 'production' &&
               !isDependency &&
               this.getDependencies(route).then((urls) =>
                 Promise.all(

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -112,8 +112,7 @@ module.exports = {
                 return config
               },
               experimental: {
-                modern: true,
-                granularChunks: true
+                modern: true
               }
             }
           `,
@@ -128,8 +127,7 @@ module.exports = {
             module.exports = {
               generateBuildId: () => 'BUILD_ID',
               experimental: {
-                modern: true,
-                granularChunks: true
+                modern: true
               }
             }
           `,
@@ -164,8 +162,7 @@ module.exports = {
               generateBuildId: () => 'BUILD_ID',
               target: 'serverless',
               experimental: {
-                modern: true,
-                granularChunks: true
+                modern: true
               }
             }
           `,

--- a/test/integration/chunking/test/index.test.js
+++ b/test/integration/chunking/test/index.test.js
@@ -139,7 +139,7 @@ describe('Chunking', () => {
 
     afterAll(() => stopApp(server))
 
-    it('should hydrate with granularChunks config', async () => {
+    it('should hydrate with aggressive chunking', async () => {
       const browser = await webdriver(appPort, '/page2')
       const text = await browser.elementByCss('#padded-str').text()
 

--- a/test/integration/conformance/test/index.test.js
+++ b/test/integration/conformance/test/index.test.js
@@ -30,11 +30,11 @@ describe('Conformance system', () => {
     )
   })
 
-  it('Should warn about changes to granularChunks config', async () => {
+  it('Should warn about changes to splitChunks config', async () => {
     const { stderr } = build
     expect(stderr).toContain(
-      '[BUILD CONFORMANCE ERROR]: The splitChunks config as part of the granularChunks flag has ' +
-        `been carefully crafted to optimize build size and build times. Please avoid changes to ${chalk.bold(
+      '[BUILD CONFORMANCE ERROR]: The splitChunks config has been carefully ' +
+        `crafted to optimize build size and build times. Please avoid changes to ${chalk.bold(
           'splitChunks.cacheGroups.vendors'
         )}`
     )


### PR DESCRIPTION
This removes remaining references to `granularChunks` in configs, error messages, and comments.

Also removed the `process.env.__NEXT_GRANULAR_CHUNKS` value.

---

Follow up to: https://github.com/vercel/next.js/pull/13663