### PR TITLE
Do not syntax highlight collapsed frames [ch1899]

### DIFF
--- a/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
@@ -68,9 +68,10 @@ export function getOriginalStackFrame(
       error: false,
       reason: null,
       external: false,
-      expanded:
-        body.originalStackFrame?.file &&
-        !body.originalStackFrame.file.includes('node_modules'),
+      expanded: !Boolean(
+        /* collapsed */
+        body.originalStackFrame?.file?.includes('node_modules') ?? true
+      ),
       sourceStackFrame: source,
       originalStackFrame: body.originalStackFrame,
       originalCodeFrame: body.originalCodeFrame || null,

--- a/packages/react-dev-overlay/src/middleware.ts
+++ b/packages/react-dev-overlay/src/middleware.ts
@@ -178,7 +178,9 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
       }
 
       const originalCodeFrame: string | null =
-        posSourceContent && pos.line
+        !(originalFrame.file?.includes('node_modules') ?? true) &&
+        posSourceContent &&
+        pos.line
           ? (codeFrameColumns(
               posSourceContent,
               { start: { line: pos.line, column: pos.column } },


### PR DESCRIPTION
No tests need updated as it's already covered:

- Tests fail if the overlay takes too long to open
- Tests fail if we don't get the code frame when we should

These speed optimizations should allow #13669 to land without being too slow.