### PR TITLE
Docs: Add postcss-preset-env to the warning when customising the PostCSS configuration

### DIFF
--- a/docs/advanced-features/customizing-postcss-config.md
+++ b/docs/advanced-features/customizing-postcss-config.md
@@ -57,7 +57,7 @@ You can learn more about [Next.js' CSS Module support here](/docs/basic-features
 
 > **Warning**: When you define a custom PostCSS configuration file, Next.js **completely disables** the [default behavior](#default-behavior).
 > Be sure to manually configure all the features you need compiled, including [Autoprefixer](https://github.com/postcss/autoprefixer).
-> You also need to install any plugins included in your custom configuration manually, i.e. `npm install postcss-flexbugs-fixes`.
+> You also need to install any plugins included in your custom configuration manually, i.e. `npm install postcss-flexbugs-fixes postcss-preset-env`.
 
 To customize the PostCSS configuration, create a `postcss.config.json` file in the root of your project.
 


### PR DESCRIPTION
The [docs for customising the PostCSS config](https://nextjs.org/docs/advanced-features/customizing-postcss-config) warn the user they will need to manually install any dependencies that Next.JS will implicitly use if the config is not overridden. `postcss-preset-env` is missing from the install command.