### PR TITLE
Support both experimental method names 

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -393,10 +393,11 @@ function renderReactElement(reactEl, domEl) {
   if (process.env.__NEXT_REACT_MODE !== 'legacy') {
     if (!reactRoot) {
       const opts = { hydrate: true }
+
       reactRoot =
         process.env.__NEXT_REACT_MODE === 'concurrent'
-          ? ReactDOM.unstable_createRoot(domEl, opts)
-          : ReactDOM.unstable_createBlockingRoot(domEl, opts)
+          ? ReactDOM.createRoot(domEl, opts)
+          : ReactDOM.createBlockingRoot(domEl, opts)
     }
     reactRoot.render(reactEl)
   } else {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -393,12 +393,9 @@ function renderReactElement(reactEl, domEl) {
   if (process.env.__NEXT_REACT_MODE !== 'legacy') {
     if (!reactRoot) {
       const opts = { hydrate: true }
-      const createRoot = ReactDOM.unstable_createRoot
-        ? ReactDOM.unstable_createRoot
-        : ReactDOM.createRoot
-      const createBlockingRoot = ReactDOM.unstable_createBlockingRoot
-        ? ReactDOM.unstable_createBlockingRoot
-        : ReactDOM.createBlockingRoot
+      const createRoot = ReactDOM.unstable_createRoot || ReactDOM.createRoot
+      const createBlockingRoot =
+        ReactDOM.unstable_createBlockingRoot || ReactDOM.createBlockingRoot
 
       reactRoot =
         process.env.__NEXT_REACT_MODE === 'concurrent'

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -393,11 +393,17 @@ function renderReactElement(reactEl, domEl) {
   if (process.env.__NEXT_REACT_MODE !== 'legacy') {
     if (!reactRoot) {
       const opts = { hydrate: true }
+      const createRoot = ReactDOM.unstable_createRoot
+        ? ReactDOM.unstable_createRoot
+        : ReactDOM.createRoot
+      const createBlockingRoot = ReactDOM.unstable_createBlockingRoot
+        ? ReactDOM.unstable_createBlockingRoot
+        : ReactDOM.createBlockingRoot
 
       reactRoot =
         process.env.__NEXT_REACT_MODE === 'concurrent'
-          ? ReactDOM.createRoot(domEl, opts)
-          : ReactDOM.createBlockingRoot(domEl, opts)
+          ? createRoot(domEl, opts)
+          : createBlockingRoot(domEl, opts)
     }
     reactRoot.render(reactEl)
   } else {


### PR DESCRIPTION
Not all dependencies have updated to the latest react experimental build. There is an open issue in `react-native-web` preventing me from updating to the latest experimental build in react, but I can use previous experimental versions

#12669 has more context