### PR TITLE
Allow custom tsconfig path in next.config.js

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -175,7 +175,16 @@ export default async function build(dir: string, conf = null): Promise<void> {
   eventNextPlugins(path.resolve(dir)).then((events) => telemetry.record(events))
 
   const ignoreTypeScriptErrors = Boolean(config.typescript?.ignoreBuildErrors)
-  await verifyTypeScriptSetup(dir, pagesDir, !ignoreTypeScriptErrors)
+
+  const tsConfigPath = config.typescript?.tsConfigPath
+    ? path.resolve(dir, config.typescript.tsConfigPath)
+    : path.join(dir, 'tsconfig.json')
+  await verifyTypeScriptSetup(
+    tsConfigPath,
+    dir,
+    pagesDir,
+    !ignoreTypeScriptErrors
+  )
 
   try {
     await promises.stat(publicDir)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -242,7 +242,9 @@ export default async function getBaseWebpackConfig(
   try {
     typeScriptPath = resolveRequest('typescript', `${dir}/`)
   } catch (_) {}
-  const tsConfigPath = path.join(dir, 'tsconfig.json')
+  const tsConfigPath = config.typescript?.tsConfigPath
+    ? path.resolve(dir, config.typescript.tsConfigPath)
+    : path.join(dir, 'tsconfig.json')
   const useTypeScript = Boolean(
     typeScriptPath && (await fileExists(tsConfigPath))
   )

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -1,5 +1,4 @@
 import chalk from 'next/dist/compiled/chalk'
-import path from 'path'
 import { FatalTypeScriptError } from './typescript/FatalTypeScriptError'
 import { getTypeScriptIntent } from './typescript/getTypeScriptIntent'
 import {
@@ -12,13 +11,13 @@ import { writeAppTypeDeclarations } from './typescript/writeAppTypeDeclarations'
 import { writeConfigurationDefaults } from './typescript/writeConfigurationDefaults'
 
 export async function verifyTypeScriptSetup(
+  tsConfigPath: string,
   dir: string,
   pagesDir: string,
   typeCheckPreflight: boolean
 ): Promise<TypeCheckResult | boolean> {
-  const tsConfigPath = path.join(dir, 'tsconfig.json')
-
   try {
+    console.log({ tsConfigPath })
     // Check if the project uses TypeScript:
     const intent = await getTypeScriptIntent(dir, pagesDir)
     if (!intent) {

--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -252,7 +252,10 @@ export default class DevServer extends Server {
   }
 
   async prepare(): Promise<void> {
-    await verifyTypeScriptSetup(this.dir, this.pagesDir!, false)
+    const tsConfigPath = this.nextConfig.typescript?.tsConfigPath
+      ? pathResolve(this.dir, this.nextConfig.typescript.tsConfigPath)
+      : pathJoin(this.dir, 'tsconfig.json')
+    await verifyTypeScriptSetup(tsConfigPath, this.dir, this.pagesDir!, false)
     await this.loadCustomRoutes()
 
     if (this.customRoutes) {

--- a/test/integration/custom-tsconfig-path/components/hello.module.css
+++ b/test/integration/custom-tsconfig-path/components/hello.module.css
@@ -1,0 +1,3 @@
+.hello {
+  content: 'hello';
+}

--- a/test/integration/custom-tsconfig-path/components/hello.module.sass
+++ b/test/integration/custom-tsconfig-path/components/hello.module.sass
@@ -1,0 +1,2 @@
+.hello
+  content: 'hello'

--- a/test/integration/custom-tsconfig-path/components/hello.module.scss
+++ b/test/integration/custom-tsconfig-path/components/hello.module.scss
@@ -1,0 +1,3 @@
+.hello {
+  content: 'hello';
+}

--- a/test/integration/custom-tsconfig-path/components/hello.ts
+++ b/test/integration/custom-tsconfig-path/components/hello.ts
@@ -1,0 +1,10 @@
+import helloStyles from './hello.module.css'
+import helloStyles2 from './hello.module.scss'
+import helloStyles3 from './hello.module.sass'
+
+export function hello(): string {
+  console.log(helloStyles.hello)
+  console.log(helloStyles2.hello)
+  console.log(helloStyles3.hello)
+  return 'Hello'
+}

--- a/test/integration/custom-tsconfig-path/components/link.tsx
+++ b/test/integration/custom-tsconfig-path/components/link.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import Link, { LinkProps } from 'next/link'
+
+export default () => {
+  const props: LinkProps = {
+    href: '/page',
+    as: '/as-page',
+  }
+
+  return (
+    <Link {...props}>
+      <a>Test</a>
+    </Link>
+  )
+}

--- a/test/integration/custom-tsconfig-path/components/router.tsx
+++ b/test/integration/custom-tsconfig-path/components/router.tsx
@@ -1,0 +1,20 @@
+/* eslint-disable no-unused-expressions, @typescript-eslint/no-unused-expressions */
+import React from 'react'
+import Router, { withRouter } from 'next/router'
+
+export default withRouter(({ router }) => {
+  React.useEffect(() => {
+    Router.events.on('event', () => {})
+    Router.prefetch('/page')
+    Router.push
+    Router.back
+    Router.reload
+
+    router.events.on('event', () => {})
+    router.prefetch('/page')
+    router.push
+    router.back
+    router.reload
+  })
+  return <>{router.pathname}</>
+})

--- a/test/integration/custom-tsconfig-path/components/world.tsx
+++ b/test/integration/custom-tsconfig-path/components/world.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function World(): JSX.Element {
+  return <>World</>
+}

--- a/test/integration/custom-tsconfig-path/extension-order/js-first.js
+++ b/test/integration/custom-tsconfig-path/extension-order/js-first.js
@@ -1,0 +1,1 @@
+export const value = 'OK'

--- a/test/integration/custom-tsconfig-path/extension-order/js-first.ts
+++ b/test/integration/custom-tsconfig-path/extension-order/js-first.ts
@@ -1,0 +1,1 @@
+export const value = 'WRONG FILE'

--- a/test/integration/custom-tsconfig-path/next.config.js
+++ b/test/integration/custom-tsconfig-path/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+}

--- a/test/integration/custom-tsconfig-path/pages/_error.tsx
+++ b/test/integration/custom-tsconfig-path/pages/_error.tsx
@@ -1,0 +1,11 @@
+import { NextPageContext } from 'next'
+import ErrorComponent from 'next/error'
+
+class CustomError extends ErrorComponent {
+  static getInitialProps({ res }: NextPageContext) {
+    const statusCode = 500
+    return { statusCode, title: 'CustomError' }
+  }
+}
+
+export default CustomError

--- a/test/integration/custom-tsconfig-path/pages/api/async.tsx
+++ b/test/integration/custom-tsconfig-path/pages/api/async.tsx
@@ -1,0 +1,7 @@
+import { NextApiHandler } from 'next'
+
+const AsyncApiEndpoint: NextApiHandler = async (req, res) => {
+  res.status(200).json({ code: 'ok' })
+}
+
+export default AsyncApiEndpoint

--- a/test/integration/custom-tsconfig-path/pages/api/sync.tsx
+++ b/test/integration/custom-tsconfig-path/pages/api/sync.tsx
@@ -1,0 +1,7 @@
+import { NextApiHandler } from 'next'
+
+const SyncApiEndpoint: NextApiHandler = (req, res) => {
+  res.status(200).json({ code: 'ok' })
+}
+
+export default SyncApiEndpoint

--- a/test/integration/custom-tsconfig-path/pages/hello.tsx
+++ b/test/integration/custom-tsconfig-path/pages/hello.tsx
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router'
+import React from 'react'
+import { hello } from '../components/hello'
+import Link from '../components/link'
+import Router from '../components/router'
+import { World } from '../components/world'
+import { value as resolveOrderValue } from '../extension-order/js-first'
+
+export enum SearchEntity {
+  SEARCH_ENTITY_NONE = 0,
+  SEARCH_ENTITY_POSITION = 1,
+  SEARCH_ENTITY_USER = 2,
+  SEARCH_ENTITY_QUESTION = 3,
+  SEARCH_ENTITY_TOPIC = 4,
+}
+
+export default function HelloPage(): JSX.Element {
+  const router = useRouter()
+  console.log(process.browser)
+  console.log(router.pathname)
+  return (
+    <div>
+      <p>One trillion dollars: {1_000_000_000_000}</p>
+      <p id="imported-value">{resolveOrderValue}</p>
+      {hello()} <World />
+      <Router />
+      <Link />
+    </div>
+  )
+}

--- a/test/integration/custom-tsconfig-path/pages/ssg/[slug].tsx
+++ b/test/integration/custom-tsconfig-path/pages/ssg/[slug].tsx
@@ -1,0 +1,29 @@
+import { GetStaticPaths, GetStaticProps } from 'next'
+
+type Params = {
+  slug: string
+}
+
+type Props = {
+  data: string
+}
+
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
+  return {
+    paths: [{ params: { slug: 'test' } }],
+    fallback: false,
+  }
+}
+
+export const getStaticProps: GetStaticProps<Props, Params> = async ({
+  params,
+}) => {
+  return {
+    props: { data: params!.slug },
+    unstable_revalidate: false,
+  }
+}
+
+export default function Page({ data }: Props) {
+  return <h1>{data}</h1>
+}

--- a/test/integration/custom-tsconfig-path/pages/ssg/blog/[post].tsx
+++ b/test/integration/custom-tsconfig-path/pages/ssg/blog/[post].tsx
@@ -1,0 +1,46 @@
+import {
+  InferGetStaticPropsType,
+  GetStaticPaths,
+  GetStaticPropsContext,
+} from 'next'
+
+type Post = {
+  author: string
+  content: string
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [{ params: { post: '1' } }],
+    fallback: false,
+  }
+}
+
+export const getStaticProps = async (
+  ctx: GetStaticPropsContext<{ post: string }>
+) => {
+  const posts: Post[] = [
+    {
+      author: 'Vercel',
+      content: 'hello wolrd',
+    },
+  ]
+
+  return {
+    props: {
+      posts,
+    },
+  }
+}
+
+function Blog({ posts }: InferGetStaticPropsType<typeof getStaticProps>) {
+  return (
+    <>
+      {posts.map((post) => (
+        <div key={post.author}>{post.author}</div>
+      ))}
+    </>
+  )
+}
+
+export default Blog

--- a/test/integration/custom-tsconfig-path/pages/ssg/blog/index.tsx
+++ b/test/integration/custom-tsconfig-path/pages/ssg/blog/index.tsx
@@ -1,0 +1,14 @@
+import { InferGetStaticPropsType } from 'next'
+
+export const getStaticProps = async () => {
+  return {
+    props: { data: ['hello', 'world'] },
+    unstable_revalidate: false,
+  }
+}
+
+export default function Page({
+  data,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return <h1>{data.join(' ')}</h1>
+}

--- a/test/integration/custom-tsconfig-path/pages/ssr/[slug].tsx
+++ b/test/integration/custom-tsconfig-path/pages/ssr/[slug].tsx
@@ -1,0 +1,21 @@
+import { GetServerSideProps } from 'next'
+
+type Params = {
+  slug: string
+}
+
+type Props = {
+  data: string
+}
+
+export const getServerSideProps: GetServerSideProps<Props, Params> = async ({
+  params,
+}) => {
+  return {
+    props: { data: params!.slug },
+  }
+}
+
+export default function Page({ data }: Props) {
+  return <h1>{data}</h1>
+}

--- a/test/integration/custom-tsconfig-path/pages/ssr/blog/[post].tsx
+++ b/test/integration/custom-tsconfig-path/pages/ssr/blog/[post].tsx
@@ -1,0 +1,32 @@
+import { InferGetServerSidePropsType, GetServerSidePropsContext } from 'next'
+
+type Post = {
+  author: string
+  content: string
+}
+
+export const getServerSideProps = async (
+  ctx: GetServerSidePropsContext<{ post: string }>
+) => {
+  const res = await fetch(`https://.../posts/`)
+  const posts: Post[] = await res.json()
+  return {
+    props: {
+      posts,
+    },
+  }
+}
+
+function Blog({
+  posts,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <>
+      {posts.map((post) => (
+        <div key={post.author}>{post.author}</div>
+      ))}
+    </>
+  )
+}
+
+export default Blog

--- a/test/integration/custom-tsconfig-path/test/index.test.js
+++ b/test/integration/custom-tsconfig-path/test/index.test.js
@@ -1,0 +1,110 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import cheerio from 'cheerio'
+import { writeFile, remove } from 'fs-extra'
+import {
+  renderViaHTTP,
+  nextBuild,
+  findPort,
+  launchApp,
+  killApp,
+  File,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '..')
+let appPort
+let app
+let output
+
+const handleOutput = (msg) => {
+  output += msg
+}
+
+async function get$(path, query) {
+  const html = await renderViaHTTP(appPort, path, query)
+  return cheerio.load(html)
+}
+
+describe('TypeScript Features', () => {
+  describe('default behavior', () => {
+    beforeAll(async () => {
+      output = ''
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {
+        onStdout: handleOutput,
+        onStderr: handleOutput,
+      })
+    })
+    afterAll(() => killApp(app))
+
+    it('should render the page', async () => {
+      const $ = await get$('/hello')
+      expect($('body').text()).toMatch(/Hello World/)
+      expect($('body').text()).toMatch(/1000000000000/)
+    })
+
+    it('should resolve files in correct order', async () => {
+      const $ = await get$('/hello')
+      expect($('#imported-value').text()).toBe('OK')
+    })
+
+    // old behavior:
+    it.skip('should report type checking to stdout', async () => {
+      expect(output).toContain('waiting for typecheck results...')
+    })
+
+    it('should respond to sync API route correctly', async () => {
+      const data = JSON.parse(await renderViaHTTP(appPort, '/api/sync'))
+      expect(data).toEqual({ code: 'ok' })
+    })
+
+    it('should respond to async API route correctly', async () => {
+      const data = JSON.parse(await renderViaHTTP(appPort, '/api/async'))
+      expect(data).toEqual({ code: 'ok' })
+    })
+
+    it('should not fail to render when an inactive page has an error', async () => {
+      await killApp(app)
+      let evilFile = join(appDir, 'pages', 'evil.tsx')
+      try {
+        await writeFile(
+          evilFile,
+          `import React from 'react'
+
+export default function EvilPage(): JSX.Element {
+  return <div notARealProp />
+}
+`
+        )
+        app = await launchApp(appDir, appPort)
+
+        const $ = await get$('/hello')
+        expect($('body').text()).toMatch(/Hello World/)
+      } finally {
+        await remove(evilFile)
+      }
+    })
+  })
+
+  it('should build the app', async () => {
+    const output = await nextBuild(appDir, [], { stdout: true })
+    expect(output.stdout).toMatch(/Compiled successfully/)
+    expect(output.code).toBe(0)
+  })
+
+  describe('should compile with different types', () => {
+    it('should compile async getInitialProps for _error', async () => {
+      const errorPage = new File(join(appDir, 'pages/_error.tsx'))
+      try {
+        errorPage.replace('static ', 'static async ')
+        const output = await nextBuild(appDir, [], { stdout: true })
+        expect(output.stdout).toMatch(/Compiled successfully/)
+      } finally {
+        errorPage.restore()
+      }
+    })
+  })
+})

--- a/test/integration/custom-tsconfig-path/tsconfig.json
+++ b/test/integration/custom-tsconfig-path/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "esnext",
+    "jsx": "preserve",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "components", "pages"]
+}

--- a/test/integration/custom-tsconfig-path/tsconfig.next.json
+++ b/test/integration/custom-tsconfig-path/tsconfig.next.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json"
+}


### PR DESCRIPTION
Next.js needs the following definitions in `tsconfig.json`:

* `jsx: preseve`
* `module: esnext`

This can be a problem when integrating Next.js with another service, like `ts-jest`, which won't be able to run tests that contain JSX in them. Also, if you rely on TypeScript with a "custom Next.js server", you will need to either use the `esm` module or have a different build process.

This commit brings the ability to provide a custom `tsconfig.json` path for Next.js, like `tsconfig.nextjs.json` — instead of configuring every other tool.

This is not controlled by an environment variable because it looks like Next.js prefers a file configuration (which makes sense because you can write `tsConfigPath: process.env.MY_TSCONFIG_PATH` yourself)