### PR TITLE
Introduce react profiling production flag

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -263,6 +263,18 @@ export default async function getBaseWebpackConfig(
     resolvedBaseUrl = path.resolve(dir, jsConfig.compilerOptions.baseUrl)
   }
 
+  function getReactProfilingInProduction() {
+    if (config.reactProductionProfiling) {
+      return Object.assign(
+        {},
+        {
+          'react-dom$': 'react-dom/profiling',
+          'scheduler/tracing': 'scheduler/tracing-profiling',
+        }
+      )
+    }
+  }
+
   const resolveConfig = {
     // Disable .mjs for node_modules bundling
     extensions: isServer
@@ -297,6 +309,7 @@ export default async function getBaseWebpackConfig(
       [PAGES_DIR_ALIAS]: pagesDir,
       [DOT_NEXT_ALIAS]: distDir,
       ...getOptimizedAliases(isServer),
+      ...getReactProfilingInProduction(),
     },
     mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
     plugins: isWebpack5

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -48,6 +48,7 @@ const defaultConfig: { [key: string]: any } = {
     profiling: false,
     sprFlushToDisk: true,
     reactMode: 'legacy',
+    reactProductionProfiling: false,
     workerThreads: false,
     basePath: '',
     pageEnv: false,


### PR DESCRIPTION
Closes [13709](https://github.com/vercel/next.js/issues/13709).

The solution works, **(tested and confirmed with true and false flags with the latest next version)** though I am quite sure this is not the most elegant and proper way to implement it. I have spent the good part of yesterday and today's morning in order to make it more generic but since it's my first time working with anything related to webpack I have struggled miserably. Last, but not least I'm unsure if this is the most proper naming for the flag.

Please, let me know what you want me to change and I'll get it done asap.