### PR TITLE
docs(env variables): small wording change (can => have to)

### DIFF
--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -43,7 +43,7 @@ export async function getStaticProps() {
 
 By default all environment variables loaded through `.env.local` are only available in the Node.js environment, meaning they won't be exposed to the browser.
 
-In order to expose a variable to the browser you can prefix the variable with `NEXT_PUBLIC_`. For example:
+In order to expose a variable to the browser you have to prefix the variable with `NEXT_PUBLIC_`. For example:
 
 ```bash
 NEXT_PUBLIC_ANALYTICS_ID=abcdefghijk


### PR DESCRIPTION
When reading
"In order to expose a variable to the browser you can prefix the variable with NEXT_PUBLIC_. For example:"

I thought that I could maybe use something else than NEXT_PUBLIC_. I guess "have to" or similar would be better here, let me know