### PR TITLE
[refactor] Remove denormalizePagePath

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -9,6 +9,7 @@ import { warn } from './output/log'
 import { ClientPagesLoaderOptions } from './webpack/loaders/next-client-pages-loader'
 import { ServerlessLoaderQuery } from './webpack/loaders/next-serverless-loader'
 import { LoadedEnvFiles } from '../lib/load-env-config'
+import { getAssetPath } from '../next-server/server/get-asset-path'
 
 type PagesMapping = {
   [page: string]: string
@@ -97,7 +98,7 @@ export function createEntrypoints(
 
   Object.keys(pages).forEach((page) => {
     const absolutePagePath = pages[page]
-    const bundleFile = `${normalizePagePath(page)}.js`
+    const bundleFile = `${getAssetPath(normalizePagePath(page))}.js`
     const isApiRoute = page.match(API_ROUTE)
 
     const bundlePath = join('static', buildId, 'pages', bundleFile)

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -75,6 +75,7 @@ import {
 import getBaseWebpackConfig from './webpack-config'
 import { PagesManifest } from './webpack/plugins/pages-manifest-plugin'
 import { writeBuildId } from './write-build-id'
+import { getAssetPath } from '../next-server/server/get-asset-path'
 
 const staticCheckWorker = require.resolve('./utils')
 
@@ -524,7 +525,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   const analysisBegin = process.hrtime()
   await Promise.all(
     pageKeys.map(async (page) => {
-      const actualPage = normalizePagePath(page)
+      const actualPage = getAssetPath(normalizePagePath(page))
       const [selfSize, allSize] = await getJsPageSizeInKb(
         actualPage,
         distDir,
@@ -685,7 +686,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       ...serverPropsPages,
       ...ssgPages,
     ]).map((page) => {
-      const pagePath = normalizePagePath(page)
+      const pagePath = getAssetPath(normalizePagePath(page))
       const dataRoute = path.posix.join(
         '/_next/data',
         buildId,
@@ -873,7 +874,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
       const isSsgFallback = ssgFallbackPages.has(page)
       const isDynamic = isDynamicRoute(page)
       const hasAmp = hybridAmpPages.has(page)
-      let file = normalizePagePath(page)
+      let file = getAssetPath(normalizePagePath(page))
 
       // The dynamic version of SSG pages are only prerendered if the fallback
       // is enabled. Below, we handle the specific prerenders of these.
@@ -932,7 +933,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
               dataRoute: path.posix.join(
                 '/_next/data',
                 buildId,
-                `${normalizePagePath(route)}.json`
+                `${getAssetPath(normalizePagePath(route))}.json`
               ),
             }
           }
@@ -971,7 +972,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   if (ssgPages.size > 0) {
     const finalDynamicRoutes: PrerenderManifest['dynamicRoutes'] = {}
     tbdPrerenderRoutes.forEach((tbdRoute) => {
-      const normalizedRoute = normalizePagePath(tbdRoute)
+      const normalizedRoute = getAssetPath(normalizePagePath(tbdRoute))
       const dataRoute = path.posix.join(
         '/_next/data',
         buildId,

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -4,6 +4,7 @@ import { isDynamicRoute } from './../next-server/lib/router/utils/is-dynamic'
 import { getRouteMatcher } from './../next-server/lib/router/utils/route-matcher'
 import { getRouteRegex } from './../next-server/lib/router/utils/route-regex'
 import { delBasePath } from './../next-server/lib/router/router'
+import { getAssetPath } from './../next-server/server/get-asset-path'
 
 function hasRel(rel, link) {
   try {
@@ -31,14 +32,6 @@ function normalizeRoute(route) {
 
   if (route === '/') return route
   return route.replace(/\/$/, '')
-}
-
-export function getAssetPath(route) {
-  return route === '/'
-    ? '/index'
-    : /^\/index(\/|$)/.test(route)
-    ? `/index${route}`
-    : `${route}`
 }
 
 function appendLink(href, rel, as) {

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -33,14 +33,12 @@ import loadConfig, {
 } from '../next-server/server/config'
 import { eventCliSession } from '../telemetry/events'
 import { Telemetry } from '../telemetry/storage'
-import {
-  normalizePagePath,
-  denormalizePagePath,
-} from '../next-server/server/normalize-page-path'
+import { normalizePagePath } from '../next-server/server/normalize-page-path'
 import { loadEnvConfig } from '../lib/load-env-config'
 import { PrerenderManifest } from '../build'
 import type exportPage from './worker'
 import { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
+import { getAssetPath } from '../next-server/server/get-asset-path'
 
 const exists = promisify(existsOrig)
 
@@ -290,9 +288,7 @@ export default async function exportApp(
   // make sure to prevent duplicates
   const exportPaths = [
     ...new Set(
-      Object.keys(exportPathMap).map((path) =>
-        denormalizePagePath(normalizePagePath(path))
-      )
+      Object.keys(exportPathMap).map((path) => normalizePagePath(path))
     ),
   ]
 
@@ -427,7 +423,7 @@ export default async function exportApp(
   if (!options.buildExport && prerenderManifest) {
     await Promise.all(
       Object.keys(prerenderManifest.routes).map(async (route) => {
-        route = normalizePagePath(route)
+        route = getAssetPath(normalizePagePath(route))
         const orig = join(distPagesDir, route)
         const htmlDest = join(
           outDir,

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -13,6 +13,7 @@ import 'next/dist/next-server/server/node-polyfill-fetch'
 import { IncomingMessage, ServerResponse } from 'http'
 import { ComponentType } from 'react'
 import { GetStaticProps } from '../types'
+import { getAssetPath } from '../next-server/server/get-asset-path'
 
 const envConfig = require('../next-server/lib/runtime-config')
 
@@ -88,7 +89,7 @@ export default async function exportPage({
   try {
     const { query: originalQuery = {} } = pathMap
     const { page } = pathMap
-    const filePath = normalizePagePath(path)
+    const filePath = getAssetPath(normalizePagePath(path))
     const ampPath = `${filePath}.amp`
     let query = { ...originalQuery }
     let params: { [key: string]: string | string[] } | undefined

--- a/packages/next/next-server/server/get-asset-path.ts
+++ b/packages/next/next-server/server/get-asset-path.ts
@@ -1,0 +1,9 @@
+export function getAssetPath(route: string) {
+  // If the page is `/` we use `/index`, otherwise the returned directory root will be bundles instead of pages
+  // this overwrites the asset of page `/index` so we prepend all route under `/index` with `/index`
+  return route === '/'
+    ? '/index'
+    : /^\/index(\/|$)/.test(route)
+    ? `/index${route}`
+    : `${route}`
+}

--- a/packages/next/next-server/server/get-page-files.ts
+++ b/packages/next/next-server/server/get-page-files.ts
@@ -1,4 +1,5 @@
 import { normalizePagePath } from './normalize-page-path'
+import { getAssetPath } from './get-asset-path'
 
 export type BuildManifest = {
   devFiles: string[]
@@ -14,7 +15,11 @@ export function getPageFiles(
   page: string
 ): string[] {
   const normalizedPage = normalizePagePath(page)
-  const files = buildManifest.pages[normalizedPage]
+  let files = buildManifest.pages[getAssetPath(normalizedPage)]
+
+  if (!files) {
+    files = buildManifest.pages[normalizedPage]
+  }
 
   if (!files) {
     // tslint:disable-next-line

--- a/packages/next/next-server/server/get-page-files.ts
+++ b/packages/next/next-server/server/get-page-files.ts
@@ -1,5 +1,4 @@
 import { normalizePagePath } from './normalize-page-path'
-import { getAssetPath } from './get-asset-path'
 
 export type BuildManifest = {
   devFiles: string[]
@@ -15,11 +14,7 @@ export function getPageFiles(
   page: string
 ): string[] {
   const normalizedPage = normalizePagePath(page)
-  let files = buildManifest.pages[getAssetPath(normalizedPage)]
-
-  if (!files) {
-    files = buildManifest.pages[normalizedPage]
-  }
+  const files = buildManifest.pages[normalizedPage]
 
   if (!files) {
     // tslint:disable-next-line

--- a/packages/next/next-server/server/get-page-files.ts
+++ b/packages/next/next-server/server/get-page-files.ts
@@ -1,4 +1,5 @@
-import { normalizePagePath, denormalizePagePath } from './normalize-page-path'
+import { normalizePagePath } from './normalize-page-path'
+import { getAssetPath } from './get-asset-path'
 
 export type BuildManifest = {
   devFiles: string[]
@@ -14,10 +15,10 @@ export function getPageFiles(
   page: string
 ): string[] {
   const normalizedPage = normalizePagePath(page)
-  let files = buildManifest.pages[normalizedPage]
+  let files = buildManifest.pages[getAssetPath(normalizedPage)]
 
   if (!files) {
-    files = buildManifest.pages[denormalizePagePath(normalizedPage)]
+    files = buildManifest.pages[normalizedPage]
   }
 
   if (!files) {

--- a/packages/next/next-server/server/get-route-from-entrypoint.ts
+++ b/packages/next/next-server/server/get-route-from-entrypoint.ts
@@ -1,8 +1,9 @@
-import { denormalizePagePath } from './normalize-page-path'
+import { normalizePathSep } from './normalize-page-path'
 
 // matches static/<buildid>/pages/:page*.js
-const ROUTE_NAME_REGEX = /^static[/\\][^/\\]+[/\\]pages[/\\](.*)\.js$/
-const SERVERLESS_ROUTE_NAME_REGEX = /^pages[/\\](.*)\.js$/
+const ROUTE_NAME_REGEX = /^static\/[^/]+\/pages\/(.*)\.js$/
+// matches pages/:page*.js
+const SERVERLESS_ROUTE_NAME_REGEX = /^pages\/(.*)\.js$/
 
 export default function getRouteFromEntrypoint(
   entryFile: string,
@@ -11,17 +12,23 @@ export default function getRouteFromEntrypoint(
   const result = (isServerlessLike
     ? SERVERLESS_ROUTE_NAME_REGEX
     : ROUTE_NAME_REGEX
-  ).exec(entryFile)
+  ).exec(normalizePathSep(entryFile))
 
   if (!result) {
     return null
   }
 
-  const pagePath = result[1]
+  let pagePath = `/${result[1]}`
 
   if (!pagePath) {
     return null
   }
 
-  return denormalizePagePath(`/${pagePath}`)
+  if (pagePath.startsWith('/index/')) {
+    pagePath = pagePath.slice(6)
+  } else if (pagePath === '/index') {
+    pagePath = '/'
+  }
+
+  return pagePath
 }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -66,6 +66,7 @@ import { compile as compilePathToRegex } from 'next/dist/compiled/path-to-regexp
 import { loadEnvConfig } from '../../lib/load-env-config'
 import './node-polyfill-fetch'
 import { PagesManifest } from '../../build/webpack/plugins/pages-manifest-plugin'
+import { getAssetPath } from './get-asset-path'
 
 const getCustomRouteMatcher = pathMatch(true)
 
@@ -878,7 +879,7 @@ export default class Server {
   ): Promise<FindComponentsResult | null> {
     const paths = [
       // try serving a static AMP version first
-      query.amp ? normalizePagePath(pathname) + '.amp' : null,
+      query.amp ? getAssetPath(normalizePagePath(pathname)) + '.amp' : null,
       pathname,
     ].filter(Boolean)
     for (const pagePath of paths) {

--- a/packages/next/next-server/server/normalize-page-path.ts
+++ b/packages/next/next-server/server/normalize-page-path.ts
@@ -5,12 +5,6 @@ export function normalizePathSep(path: string): string {
 }
 
 export function normalizePagePath(page: string): string {
-  // If the page is `/` we need to append `/index`, otherwise the returned directory root will be bundles instead of pages
-  if (page === '/') {
-    page = '/index'
-  } else if (/^\/index(\/|$)/.test(page)) {
-    page = `/index${page}`
-  }
   // Resolve on anything that doesn't start with `/`
   if (!page.startsWith('/')) {
     page = `/${page}`
@@ -21,16 +15,6 @@ export function normalizePagePath(page: string): string {
     throw new Error(
       `Requested and resolved page mismatch: ${page} ${resolvedPage}`
     )
-  }
-  return page
-}
-
-export function denormalizePagePath(page: string) {
-  page = normalizePathSep(page)
-  if (page.startsWith('/index/')) {
-    page = page.slice(6)
-  } else if (page === '/index') {
-    page = '/'
   }
   return page
 }

--- a/packages/next/next-server/server/require.ts
+++ b/packages/next/next-server/server/require.ts
@@ -5,7 +5,7 @@ import {
   SERVER_DIRECTORY,
   SERVERLESS_DIRECTORY,
 } from '../lib/constants'
-import { normalizePagePath, denormalizePagePath } from './normalize-page-path'
+import { normalizePagePath } from './normalize-page-path'
 import { PagesManifest } from '../../build/webpack/plugins/pages-manifest-plugin'
 
 export function pageNotFoundError(page: string): Error {
@@ -30,7 +30,7 @@ export function getPagePath(
   )) as PagesManifest
 
   try {
-    page = denormalizePagePath(normalizePagePath(page))
+    page = normalizePagePath(page)
   } catch (err) {
     // tslint:disable-next-line
     console.error(err)

--- a/packages/next/next-server/server/spr-cache.ts
+++ b/packages/next/next-server/server/spr-cache.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { PrerenderManifest } from '../../build'
 import { PRERENDER_MANIFEST } from '../lib/constants'
 import { normalizePagePath } from './normalize-page-path'
+import { getAssetPath } from './get-asset-path'
 
 function toRoute(pathname: string): string {
   return pathname.replace(/\/$/, '').replace(/\/index$/, '') || '/'
@@ -96,7 +97,7 @@ export function initializeSprCache({
 }
 
 export async function getFallback(page: string): Promise<string> {
-  page = normalizePagePath(page)
+  page = getAssetPath(normalizePagePath(page))
   return promises.readFile(getSeedPath(page, 'html'), 'utf8')
 }
 
@@ -105,7 +106,7 @@ export async function getSprCache(
   pathname: string
 ): Promise<SprCacheValue | undefined> {
   if (sprOptions.dev) return
-  pathname = normalizePagePath(pathname)
+  pathname = getAssetPath(normalizePagePath(pathname))
 
   let data: SprCacheValue | undefined = cache.get(pathname)
 
@@ -162,14 +163,14 @@ export async function setSprCache(
     prerenderManifest.routes[pathname] = {
       dataRoute: path.posix.join(
         '/_next/data',
-        `${normalizePagePath(pathname)}.json`
+        `${getAssetPath(normalizePagePath(pathname))}.json`
       ),
       srcRoute: null, // FIXME: provide actual source route, however, when dynamically appending it doesn't really matter
       initialRevalidateSeconds: revalidateSeconds,
     }
   }
 
-  pathname = normalizePagePath(pathname)
+  pathname = getAssetPath(normalizePagePath(pathname))
   cache.set(pathname, {
     ...data,
     revalidateAfter: calculateRevalidate(pathname),

--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -22,10 +22,7 @@ import { route } from '../next-server/server/router'
 import errorOverlayMiddleware from './lib/error-overlay-middleware'
 import { findPageFile } from './lib/find-page-file'
 import onDemandEntryHandler from './on-demand-entry-handler'
-import {
-  denormalizePagePath,
-  normalizePathSep,
-} from '../next-server/server/normalize-page-path'
+import { normalizePathSep } from '../next-server/server/normalize-page-path'
 import getRouteFromEntrypoint from '../next-server/server/get-route-from-entrypoint'
 
 export async function renderScriptError(res: ServerResponse, error: Error) {
@@ -80,7 +77,7 @@ function addCorsSupport(req: IncomingMessage, res: ServerResponse) {
 }
 
 const matchNextPageBundleRequest = route(
-  '/_next/static/:buildId/pages/:path*.js(\\.map|)'
+  '/_next/static/:buildId/:entrypoint(.*)'
 )
 
 // Recursively look up the issuer till it ends up at the root
@@ -204,7 +201,12 @@ export default class HotReloader {
         return {}
       }
 
-      const page = denormalizePagePath(`/${params.path.join('/')}`)
+      const page = getRouteFromEntrypoint(`/${params.entrypoint}`, true)
+
+      if (!page) {
+        return {}
+      }
+
       if (page === '/_error' || BLOCKED_PAGES.indexOf(page) === -1) {
         try {
           await this.ensurePage(page)

--- a/packages/next/server/lib/find-page-file.ts
+++ b/packages/next/server/lib/find-page-file.ts
@@ -4,7 +4,6 @@ import { isWriteable } from '../../build/is-writeable'
 import { warn } from '../../build/output/log'
 import fs from 'fs'
 import { promisify } from 'util'
-import { denormalizePagePath } from '../../next-server/server/normalize-page-path'
 
 const readdir = promisify(fs.readdir)
 
@@ -27,11 +26,9 @@ export async function findPageFile(
 ): Promise<string | null> {
   const foundPagePaths: string[] = []
 
-  const page = denormalizePagePath(normalizedPagePath)
-
   for (const extension of pageExtensions) {
     if (!normalizedPagePath.endsWith('/index')) {
-      const relativePagePath = `${page}.${extension}`
+      const relativePagePath = `${normalizedPagePath}.${extension}`
       const pagePath = join(rootDir, relativePagePath)
 
       if (await isWriteable(pagePath)) {
@@ -39,7 +36,10 @@ export async function findPageFile(
       }
     }
 
-    const relativePagePathWithIndex = join(page, `index.${extension}`)
+    const relativePagePathWithIndex = join(
+      normalizedPagePath,
+      `index.${extension}`
+    )
     const pagePathWithIndex = join(rootDir, relativePagePathWithIndex)
     if (await isWriteable(pagePathWithIndex)) {
       foundPagePaths.push(relativePagePathWithIndex)

--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -17,6 +17,7 @@ import {
 import { pageNotFoundError } from '../next-server/server/require'
 import { findPageFile } from './lib/find-page-file'
 import getRouteFromEntrypoint from '../next-server/server/get-route-from-entrypoint'
+import { getAssetPath } from '../next-server/server/get-asset-path'
 
 const ADDED = Symbol('added')
 const BUILDING = Symbol('building')
@@ -211,7 +212,7 @@ export default function onDemandEntryHandler(
 
       pageUrl = pageUrl === '' ? '/' : pageUrl
 
-      const bundleFile = `${normalizePagePath(pageUrl)}.js`
+      const bundleFile = `${getAssetPath(normalizePagePath(pageUrl))}.js`
       const name = join('static', buildId, 'pages', bundleFile)
       const absolutePagePath = pagePath.startsWith('next/dist/pages')
         ? require.resolve(pagePath)


### PR DESCRIPTION
Follow up on https://github.com/vercel/next.js/pull/13699

This removes the `denormalizePagePath` and removes the path rewriting from `normalizePagePath`. The latter was a source of bugs in fixing https://github.com/vercel/next.js/pull/13699. This PR separates that functionality off in a function that translates a page path into an entrypoint path, which is the inverse of `get-route-from-entrypoint`. The result of this is that `normalizePagePath` is now stable (`normalizePagePath(normalizePagePath(path)) === normalizePagePath(path)`) which seems to be more the original intent of the function.