### PR TITLE
Prefer docs site for documentation links in CMS examples

### DIFF
--- a/examples/cms-contentful/README.md
+++ b/examples/cms-contentful/README.md
@@ -1,6 +1,6 @@
 # A statically generated blog example using Next.js and Contentful
 
-This example showcases Next.js's [Static Generation](/docs/basic-features/pages.md) feature using [Contentful](https://www.contentful.com/) as the data source.
+This example showcases Next.js's [Static Generation](https://nextjs.org/docs/basic-features/pages) feature using [Contentful](https://www.contentful.com/) as the data source.
 
 ## Demo
 

--- a/examples/cms-prismic/README.md
+++ b/examples/cms-prismic/README.md
@@ -1,6 +1,6 @@
 # A statically generated blog example using Next.js and Prismic
 
-This example showcases Next.js's [Static Generation](/docs/basic-features/pages.md) feature using [Prismic](https://prismic.io/) as the data source.
+This example showcases Next.js's [Static Generation](https://nextjs.org/docs/basic-features/pages) feature using [Prismic](https://prismic.io/) as the data source.
 
 ## Demo
 

--- a/examples/cms-sanity/README.md
+++ b/examples/cms-sanity/README.md
@@ -143,7 +143,7 @@ On Sanity, go to one of the posts you've created and:
 - **Update the title**. For example, you can add `[Draft]` in front of the title.
 - As you edit the document it will be saved as a draft, but **DO NOT** click **Publish**. By doing this, the post will be in the draft state.
 
-Now, if you go to the post page on localhost, you won't see the updated title. However, if you use the **Preview Mode**, you'll be able to see the change ([Documentation](/docs/advanced-features/preview-mode.md)).
+Now, if you go to the post page on localhost, you won't see the updated title. However, if you use the **Preview Mode**, you'll be able to see the change ([Documentation](https://nextjs.org/docs/advanced-features/preview-mode)).
 
 To view the preview, go to the post edit page on Sanity, click the three dots above the document and select **Open preview** ([see the instruction here](https://www.sanity.io/docs/preview-content-on-site))
 

--- a/examples/cms-takeshape/README.md
+++ b/examples/cms-takeshape/README.md
@@ -142,7 +142,7 @@ Your blog should be up and running on [http://localhost:3000](http://localhost:3
 
 On TakeShape, create a new post like before. But **DO NOT** click **Enabled** under **Workflow Status**.
 
-Now, if you go to `http://localhost:3000/posts/<slug>` (replace `<slug>`), you won’t see the post. However, if you use the **Preview Mode**, you'll be able to see the change ([Documentation](/docs/advanced-features/preview-mode.md)).
+Now, if you go to `http://localhost:3000/posts/<slug>` (replace `<slug>`), you won’t see the post. However, if you use the **Preview Mode**, you'll be able to see the change ([Documentation](https://nextjs.org/docs/advanced-features/preview-mode)).
 
 To enable the Preview Mode, go to this URL:
 

--- a/examples/cms-wordpress/README.md
+++ b/examples/cms-wordpress/README.md
@@ -82,7 +82,7 @@ Inside your WordPress admin, go to **Posts** and start adding new posts:
 
 When you’re done, make sure to **Publish** the posts.
 
-> **Note:** Only **published** posts and public fields will be rendered by the app unless [Preview Mode](/docs/advanced-features/preview-mode.md) is enabled.
+> **Note:** Only **published** posts and public fields will be rendered by the app unless [Preview Mode](https://nextjs.org/docs/advanced-features/preview-mode) is enabled.
 
 ### Step 3. Set up environment variables
 
@@ -176,7 +176,7 @@ NEXT_EXAMPLE_CMS_WORDPRESS_PREVIEW_SECRET=...
 
 On your WordPress admin, create a new post like before, but **do not publish** it.
 
-Now, if you go to `http://localhost:3000`, you won’t see the post. However, if you enable **Preview Mode**, you'll be able to see the change ([Documentation](/docs/advanced-features/preview-mode.md)).
+Now, if you go to `http://localhost:3000`, you won’t see the post. However, if you enable **Preview Mode**, you'll be able to see the change ([Documentation](https://nextjs.org/docs/advanced-features/preview-mode)).
 
 To enable Preview Mode, go to this URL:
 


### PR DESCRIPTION
[ch579]

Some README files in `examples/cms-*` were linking to a documentation markdown file inside the repo (e.g. `/docs/basic-features/pages.md`) instead of the documentation website. We should always link to the documentation website from an example README file because (1) the website has better UX and (2) as we’re creating the examples pages on `next-site` (https://github.com/vercel/next-site/pull/672), we’d like to avoid extra processing of markdown content.