### PR TITLE
Remove some leftovers after index page updates

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -380,16 +380,12 @@ async function computeFromManifest(
   let expected = 0
   const files = new Map<string, number>()
   Object.keys(manifest.pages).forEach((key) => {
-    // prevent duplicate '/' and '/index'
-    if (key === '/index') return
-
     if (key === '/_polyfills') {
       return
     }
 
     if (pageInfos) {
-      const cleanKey = key.replace(/\/index$/, '') || '/'
-      const pageInfo = pageInfos.get(cleanKey)
+      const pageInfo = pageInfos.get(key)
       // don't include AMP pages since they don't rely on shared bundles
       if (pageInfo?.isHybridAmp || pageInfo?.isAmp) {
         return

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -111,10 +111,6 @@ export default class BuildManifestPlugin {
           assetMap.pages[pagePath] = [...filesForEntry, ...mainJsFiles]
         }
 
-        if (typeof assetMap.pages['/index'] !== 'undefined') {
-          assetMap.pages['/'] = assetMap.pages['/index']
-        }
-
         // Create a separate entry  for polyfills
         assetMap.polyfillFiles = polyfillFiles
 

--- a/packages/next/next-server/server/get-page-files.ts
+++ b/packages/next/next-server/server/get-page-files.ts
@@ -14,12 +14,8 @@ export function getPageFiles(
   buildManifest: BuildManifest,
   page: string
 ): string[] {
-  const normalizedPage = normalizePagePath(page)
+  const normalizedPage = denormalizePagePath(normalizePagePath(page))
   let files = buildManifest.pages[normalizedPage]
-
-  if (!files) {
-    files = buildManifest.pages[denormalizePagePath(normalizedPage)]
-  }
 
   if (!files) {
     // tslint:disable-next-line


### PR DESCRIPTION
buildmanifest and pagesmanifest keys are now strictly (not `normalizePagePath` style) page paths. Duplicates and `/index`,`/` workarounds were removed in https://github.com/vercel/next.js/pull/13699, so these shouldn't be necessary anymore.