### PR TITLE
feat: expose webpack compiler

### DIFF
--- a/packages/next/build/compiler.ts
+++ b/packages/next/build/compiler.ts
@@ -19,10 +19,12 @@ function generateStats(result: CompilerResult, stat: Stats): CompilerResult {
 }
 
 export function runCompiler(
-  config: Configuration | Configuration[]
+  config: Configuration | Configuration[],
+  exposeCompiler: (compiler: webpack.Compiler) => void
 ): Promise<CompilerResult> {
   return new Promise(async (resolve, reject) => {
     const compiler = webpack(config)
+    exposeCompiler(compiler)
     compiler.run(
       (err: Error, statsOrMultiStats: { stats: Stats[] } | Stats) => {
         if (err) {


### PR DESCRIPTION
# Problem

- `next.js` does _not_ expose a mechanism to get at webpack `stats` or webpack compiler hooks, required by our application for post-processing

# Solution

- Provide the user a mechanism to get a handle on the webpack compiler.

# Discussion

- Motivator--I need a clean way to bundle my next.js Server application for docker. I do _not_ want to bundle my full `node_modules`, as I have a monorepo and my dependency stack has all sorts of _other_ stuff in it. One way to keep my size down would be to _know_ what top level application dependencies my application is using, and use that to reduce my node_modules footprint. Such an effort would require webpack stats exposed
  - Ideally, there could be some customization to the server bundling process [see help request #13916](https://github.com/vercel/next.js/discussions/13916) to simply _not externalize_ things in `node_modules`.
  - Next uses a moderately _complex_ server bundling/externalizing algorithm, (see `packages/next/build/webpack-config.ts`), so adding support _here_ would be strongly preferred :)

This PR in the current state is more-or-less a proposal, not targeted at acceptance. We're this feature accepted, clearly documentation and tests would need to accompany :)