### PR TITLE
Update the with-graphql-react example

### DIFF
--- a/examples/with-graphql-react/README.md
+++ b/examples/with-graphql-react/README.md
@@ -1,6 +1,6 @@
 # Next.js example with [`graphql-react`](https://github.com/jaydenseric/graphql-react)
 
-[`graphql-react`](https://github.com/jaydenseric/graphql-react) is a [GraphQL](https://graphql.org) client for [React](https://reactjs.org) using modern [context](https://reactjs.org/docs/context) and [hooks](https://reactjs.org/docs/hooks-intro) APIs that is lightweight (&lt; 2.5 KB [size limited](https://github.com/ai/size-limit)) but powerful; the first [Relay](https://facebook.github.io/relay) and [Apollo](https://apollographql.com/docs/react) alternative with server side rendering.
+[`graphql-react`](https://github.com/jaydenseric/graphql-react) is a [GraphQL](https://graphql.org) client for [React](https://reactjs.org) using modern [context](https://reactjs.org/docs/context) and [hooks](https://reactjs.org/docs/hooks-intro) APIs that is lightweight (&lt; 3 KB [size limited](https://github.com/ai/size-limit)) but powerful; the first [Relay](https://facebook.github.io/relay) and [Apollo](https://apollographql.com/docs/react) alternative with server side rendering.
 
 ## Deploy your own
 
@@ -43,6 +43,5 @@ Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&ut
 
 ## Notes
 
-- In `next.config.js` Next.js config is decorated using [`withGraphQLConfig`](https://github.com/jaydenseric/next-graphql-react#function-withgraphqlconfig) from [`next-graphql-react`](https://github.com/jaydenseric/next-graphql-react), to exclude specific [`graphql-react`](https://github.com/jaydenseric/graphql-react) and [`next-graphql-react`](https://github.com/jaydenseric/next-graphql-react) server only imports from the client bundle.
 - In `pages/_app.js` a [custom `App` component](https://github.com/vercel/next.js#custom-app) is decorated with the [`withGraphQLApp`](https://github.com/jaydenseric/next-graphql-react/#function-withgraphqlapp) [higher-order component](https://reactjs.org/docs/higher-order-components) from [`next-graphql-react`](https://github.com/jaydenseric/next-graphql-react), generating a `graphql` prop that populates the [`GraphQLProvider`](https://github.com/jaydenseric/graphql-react#function-graphqlprovider) component from [`graphql-react`](https://github.com/jaydenseric/graphql-react).
 - In `pages/index.js` the [`useGraphQL`](https://github.com/jaydenseric/graphql-react#function-usegraphql) React hook from [`graphql-react`](https://github.com/jaydenseric/graphql-react) is used to query the [GraphQL Pokémon API](https://github.com/lucasbento/graphql-pokemon) and show a picture of Pikachu.

--- a/examples/with-graphql-react/next.config.js
+++ b/examples/with-graphql-react/next.config.js
@@ -1,3 +1,0 @@
-const { withGraphQLConfig } = require('next-graphql-react/server')
-
-module.exports = withGraphQLConfig()

--- a/examples/with-graphql-react/package.json
+++ b/examples/with-graphql-react/package.json
@@ -3,12 +3,11 @@
   "private": true,
   "license": "ISC",
   "dependencies": {
-    "cross-fetch": "^3.0.4",
-    "graphql-react": "^9.0.0",
+    "graphql-react": "^11.0.1",
     "next": "latest",
-    "next-graphql-react": "^5.0.0",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "next-graphql-react": "^8.0.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "scripts": {
     "dev": "next",

--- a/examples/with-graphql-react/pages/_app.js
+++ b/examples/with-graphql-react/pages/_app.js
@@ -1,4 +1,3 @@
-import 'cross-fetch/polyfill'
 import { GraphQLProvider } from 'graphql-react'
 import { withGraphQLApp } from 'next-graphql-react'
 

--- a/examples/with-graphql-react/pages/index.js
+++ b/examples/with-graphql-react/pages/index.js
@@ -1,6 +1,6 @@
 import { useGraphQL } from 'graphql-react'
 
-export default function Home() {
+export default function IndexPage() {
   const { loading, cacheValue: { data } = {} } = useGraphQL({
     fetchOptionsOverride(options) {
       options.url = 'https://graphql-pokemon.now.sh'


### PR DESCRIPTION
- Removed the manual `fetch` polyfill as that is handled automatically by Next.js now.
- Updated dependencies, including [`graphql-react`](https://github.com/jaydenseric/graphql-react) and [`next-graphql-react`](https://github.com/jaydenseric/next-graphql-react).
- Removed `next.config.js` as it’s no longer required for [`next-graphql-react`](https://github.com/jaydenseric/next-graphql-react).
- Renamed the index page component from `Home` to `IndexPage`.
- Tweaked the [`graphql-react`](https://github.com/jaydenseric/graphql-react) bundle size mentioned in the readme.