### PR TITLE
with-mux-video update

### DIFF
--- a/examples/with-mux-video/components/upload-form.js
+++ b/examples/with-mux-video/components/upload-form.js
@@ -66,7 +66,7 @@ const UploadForm = () => {
     })
 
     upload.on('progress', (progress) => {
-      setProgress(progress.detail)
+      setProgress(Math.floor(progress.detail))
     })
 
     upload.on('success', () => {

--- a/examples/with-mux-video/package.json
+++ b/examples/with-mux-video/package.json
@@ -8,12 +8,12 @@
     "start": "next start"
   },
   "dependencies": {
-    "@mux/mux-node": "2.8.0",
-    "@mux/upchunk": "2.0.0",
-    "hls.js": "0.13.2",
+    "@mux/mux-node": "^2.8.0",
+    "@mux/upchunk": "^2.0.0",
+    "hls.js": "^0.13.2",
     "next": "latest",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "swr": "0.2.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "swr": "^0.2.0"
   }
 }

--- a/examples/with-mux-video/package.json
+++ b/examples/with-mux-video/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@mux/mux-node": "2.8.0",
-    "@mux/upchunk": "1.0.8",
+    "@mux/upchunk": "2.0.0",
     "hls.js": "0.13.2",
     "next": "latest",
     "react": "16.13.1",

--- a/examples/with-mux-video/pages/api/asset/[id].js
+++ b/examples/with-mux-video/pages/api/asset/[id].js
@@ -1,7 +1,7 @@
 import Mux from '@mux/mux-node'
 const { Video } = new Mux()
 
-export default async function uploadHandler(req, res) {
+export default async function assetHandler(req, res) {
   const { method } = req
 
   switch (method) {


### PR DESCRIPTION
* function rename
* update package.json dependencies to use `^` for semver. I noticed the package-lock.json is not committed in these examples, which seems to be intentional. Is it advisable to use semver for dependencies? This could actually break if someone clones, installs and a newer version of something has a breakage, but in general it might be nice to have folks installing the latest patch releases for deps.
* use Upchunk 2.0.0. with 1000x [better progress reporting on uploads](https://github.com/muxinc/upchunk/releases/tag/v2.0.0)

**Notice the progress %**

Upchunk pre 2.0:

![before-loading](https://user-images.githubusercontent.com/764988/84232581-70fa5080-aaa5-11ea-8db8-2cfe50339b43.gif)

Upchunk 2.0:

![after-loading](https://user-images.githubusercontent.com/764988/84232620-85d6e400-aaa5-11ea-82cc-b348ead1f5de.gif)

