### PR TITLE
Set target as ES5

### DIFF
--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "esnext",
-    "target": "ES2017",
+    "target": "ES5",
     "esModuleInterop": true,
     "moduleResolution": "node",
     "jsx": "react"


### PR DESCRIPTION
The function `loadGetInitialProps` uses async await in the file `packages/next/next-server/lib/utils.ts`.
This function is being used at the client code.
Since the target is set as ES2017, the polyfill for async await is not included by typescript and hence the final code is breaking in old Browsers used by the users accessing website build with nextjs.

Changing the target to ES5 will add support for old Browsers.