### PR TITLE
Added .next folder to gitignore for examples/blog-starter

### DIFF
--- a/examples/blog-starter/.gitignore
+++ b/examples/blog-starter/.gitignore
@@ -1,2 +1,3 @@
 .env
 .now
+.next


### PR DESCRIPTION
```.next``` folder wasn't in the gitignore file causing .next folder to be tracked by git