### PR TITLE
Make sure to watch all next-server files in taskr

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -708,7 +708,7 @@ export default async function (task) {
   await task.watch('lib/**/*.+(js|ts|tsx)', 'lib')
   await task.watch('cli/**/*.+(js|ts|tsx)', 'cli')
   await task.watch('telemetry/**/*.+(js|ts|tsx)', 'telemetry')
-  await task.watch('next-server/server/**/*.+(js|ts|tsx)', 'nextserver')
+  await task.watch('next-server/**/*.+(js|ts|tsx)', 'nextserver')
 }
 
 export async function nextserver(task, opts) {


### PR DESCRIPTION
This updates the watch glob to make sure to watch all the `next-server` files

x-ref: https://github.com/vercel/next.js/pull/13842