### PR TITLE
Add test case for loading 404 on invalid bundle

### DIFF
--- a/test/integration/client-404/pages/invalid-link.js
+++ b/test/integration/client-404/pages/invalid-link.js
@@ -1,0 +1,7 @@
+import Link from 'next/link'
+
+export default () => (
+  <Link href="/[id]/non-existent" as="/another/non-existent">
+    <a id="to-nonexistent">to 404</a>
+  </Link>
+)

--- a/test/integration/client-404/test/client-navigation.js
+++ b/test/integration/client-404/test/client-navigation.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
+import { check } from 'next-test-utils'
 
 export default (context) => {
   describe('Client Navigation 404', () => {
@@ -21,6 +22,14 @@ export default (context) => {
         })
         await browser.close()
       })
+    })
+
+    it('should hard navigate to URL on failing to load bundle', async () => {
+      const browser = await webdriver(context.appPort, '/invalid-link')
+      await browser.eval(() => (window.beforeNav = 'hi'))
+      await browser.elementByCss('#to-nonexistent').click()
+      await check(() => browser.elementByCss('#errorStatusCode').text(), /404/)
+      expect(await browser.eval(() => window.beforeNav)).not.toBe('hi')
     })
   })
 }

--- a/test/integration/client-404/test/index.test.js
+++ b/test/integration/client-404/test/index.test.js
@@ -1,23 +1,48 @@
 /* eslint-env jest */
 
 import { join } from 'path'
-import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+import {
+  renderViaHTTP,
+  findPort,
+  launchApp,
+  killApp,
+  nextBuild,
+  nextStart,
+} from 'next-test-utils'
 
 // test suite
 import clientNavigation from './client-navigation'
 
 const context = {}
+const appDir = join(__dirname, '../')
 jest.setTimeout(1000 * 60 * 5)
 
-describe('Client 404', () => {
-  beforeAll(async () => {
-    context.appPort = await findPort()
-    context.server = await launchApp(join(__dirname, '../'), context.appPort)
-
-    // pre-build page at the start
-    await renderViaHTTP(context.appPort, '/')
-  })
-  afterAll(() => killApp(context.server))
-
+const runTests = () => {
   clientNavigation(context, (p, q) => renderViaHTTP(context.appPort, p, q))
+}
+
+describe('Client 404', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      context.appPort = await findPort()
+      context.server = await launchApp(appDir, context.appPort)
+
+      // pre-build page at the start
+      await renderViaHTTP(context.appPort, '/')
+    })
+    afterAll(() => killApp(context.server))
+
+    runTests()
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      context.appPort = await findPort()
+      context.server = await nextStart(appDir, context.appPort)
+    })
+    afterAll(() => killApp(context.server))
+
+    runTests()
+  })
 })


### PR DESCRIPTION
This adds a test case to ensure hard navigating when a client bundle fails to load is occurring correctly

x-ref: https://github.com/vercel/next.js/issues/13516