### PR TITLE
Fail build when importing with wrong casing

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -36,6 +36,7 @@ import BuildManifestPlugin from './webpack/plugins/build-manifest-plugin'
 import ChunkNamesPlugin from './webpack/plugins/chunk-names-plugin'
 import { CssMinimizerPlugin } from './webpack/plugins/css-minimizer-plugin'
 import { JsConfigPathsPlugin } from './webpack/plugins/jsconfig-paths-plugin'
+import CaseSensitivePathsPlugin from './webpack/plugins/case-sensitive-paths-plugin'
 import { DropClientPage } from './webpack/plugins/next-drop-client-page-plugin'
 import NextEsmPlugin from './webpack/plugins/next-esm-plugin'
 import NextJsSsrImportPlugin from './webpack/plugins/nextjs-ssr-import'
@@ -299,10 +300,13 @@ export default async function getBaseWebpackConfig(
       ...getOptimizedAliases(isServer),
     },
     mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
-    plugins: isWebpack5
-      ? // webpack 5+ has the PnP resolver built-in by default:
-        []
-      : [PnpWebpackPlugin],
+    plugins: [
+      new CaseSensitivePathsPlugin(),
+      ...(isWebpack5
+        ? // webpack 5+ has the PnP resolver built-in by default:
+          []
+        : [PnpWebpackPlugin]),
+    ],
   }
 
   const webpackMode = dev ? 'development' : 'production'

--- a/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
@@ -32,7 +32,8 @@ export default class CaseSensitivePathsPlugin implements ResolvePlugin {
         return true
       }
       if (!segmentExists && isFromCache) {
-        // revalidate when the cached value was used
+        // revalidate when the cached value was used, it might have updated since
+        // the cache was last written
         const freshParentDirEntries = await fs.readdir(segmentParentDir)
         this._cache.set(segmentParentDir, freshParentDirEntries)
         return freshParentDirEntries.includes(segment)

--- a/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
@@ -1,5 +1,5 @@
 import { ResolvePlugin } from 'webpack'
-import { join, sep as pathSeparator, normalize } from 'path'
+import { sep as pathSeparator, normalize } from 'path'
 import { promises as fs } from 'fs'
 
 // webpack resolver plugin to verify the casing of resolved files in case it's
@@ -12,11 +12,14 @@ export default class CaseSensitivePathsPlugin implements ResolvePlugin {
     this._lastPurge = Date.now()
   }
   async checkIsTrueCasePath(file: string) {
-    console.log(file)
-    const segments = normalize(file).split(pathSeparator).filter(Boolean)
+    const segments = normalize(file).split(pathSeparator)
 
     const segmentExistsPromises = segments.map(async (segment, i) => {
-      const segmentParentDir = join('/', ...segments.slice(0, i))
+      if (i <= 0) {
+        return true
+      }
+      const segmentParentDir =
+        segments.slice(0, i).join(pathSeparator) + pathSeparator
       const cachedEntries = this._cache.get(segmentParentDir)
       const isFromCache = !!cachedEntries
       const parentDirEntries =

--- a/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
@@ -1,6 +1,5 @@
 import { ResolvePlugin } from 'webpack'
 import { join, sep as pathSeparator, normalize } from 'path'
-import { promisify } from 'util'
 import { promises as fs } from 'fs'
 
 async function checkIsTrueCasePath(file: string, readdir: typeof fs.readdir) {
@@ -19,11 +18,6 @@ async function checkIsTrueCasePath(file: string, readdir: typeof fs.readdir) {
 // run on a case-insesnitive filesystem
 export default class CaseSensitivePathsPlugin implements ResolvePlugin {
   apply(resolver: any) {
-    // Make sure to use a cached file system to deduplicate readdir calls
-    // for the same folder
-    const readdir: typeof fs.readdir = promisify(
-      resolver.fileSystem.readdir.bind(resolver.fileSystem)
-    )
     resolver.getHook(`existing-file`).intercept({
       register: (tapInfo: any) => {
         if (tapInfo.name === 'NextPlugin') {
@@ -57,7 +51,7 @@ export default class CaseSensitivePathsPlugin implements ResolvePlugin {
               callback
             )
           }
-          checkIsTrueCasePath(file, readdir).then((isTrueCasePath) => {
+          checkIsTrueCasePath(file, fs.readdir).then((isTrueCasePath) => {
             if (!isTrueCasePath) {
               // Can't resolve these
               return callback()

--- a/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
@@ -1,0 +1,76 @@
+import { ResolvePlugin } from 'webpack'
+import { join, sep as pathSeparator, normalize } from 'path'
+import { promisify } from 'util'
+import { promises as fs } from 'fs'
+
+async function checkIsTrueCasePath(file: string, readdir: typeof fs.readdir) {
+  const segments = normalize(file).split(pathSeparator).filter(Boolean)
+
+  const segmentExistsPromises = segments.map(async (segment, i) => {
+    const segmentParentDir = join('/', ...segments.slice(0, i))
+    const parentDirEntries = await readdir(segmentParentDir)
+    return parentDirEntries.includes(segment)
+  })
+
+  return (await Promise.all(segmentExistsPromises)).every(Boolean)
+}
+
+// webpack resolver plugin to verify the casing of resolved files in case it's
+// run on a case-insesnitive filesystem
+export default class CaseSensitivePathsPlugin implements ResolvePlugin {
+  apply(resolver: any) {
+    // Make sure to use a cached file system to deduplicate readdir calls
+    // for the same folder
+    const readdir: typeof fs.readdir = promisify(
+      resolver.fileSystem.readdir.bind(resolver.fileSystem)
+    )
+    resolver.getHook(`existing-file`).intercept({
+      register: (tapInfo: any) => {
+        if (tapInfo.name === 'NextPlugin') {
+          // Prevent the NextPlugin from kicking in, we want to add another check
+          // in between existing-file and resolved
+          return {
+            ...tapInfo,
+            fn: (_req: any, _ctx: any, callback: any) => callback(),
+          }
+        }
+        return tapInfo
+      },
+    })
+    resolver
+      .getHook('existing-file')
+      .tapAsync(
+        'CaseSensitivePathsPlugin',
+        (request: any, resolveContext: any, callback: any) => {
+          // Don't check anything coming from node_modules, we assume these are
+          // published with the correct casing
+          const isIgnored =
+            request.context.issuer &&
+            /\/node_modules\//.test(request.context.issuer)
+          const file = request.path
+          if (!file || isIgnored) {
+            return resolver.doResolve(
+              resolver.hooks.resolved,
+              request,
+              `true case path ${file}`,
+              resolveContext,
+              callback
+            )
+          }
+          checkIsTrueCasePath(file, readdir).then((isTrueCasePath) => {
+            if (!isTrueCasePath) {
+              // Can't resolve these
+              return callback()
+            }
+            resolver.doResolve(
+              resolver.hooks.resolved,
+              request,
+              null,
+              resolveContext,
+              callback
+            )
+          }, callback)
+        }
+      )
+  }
+}

--- a/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
+++ b/packages/next/build/webpack/plugins/case-sensitive-paths-plugin.ts
@@ -12,6 +12,7 @@ export default class CaseSensitivePathsPlugin implements ResolvePlugin {
     this._lastPurge = Date.now()
   }
   async checkIsTrueCasePath(file: string) {
+    console.log(file)
     const segments = normalize(file).split(pathSeparator).filter(Boolean)
 
     const segmentExistsPromises = segments.map(async (segment, i) => {

--- a/test/integration/build-warnings/test/index.test.js
+++ b/test/integration/build-warnings/test/index.test.js
@@ -8,7 +8,7 @@ jest.setTimeout(1000 * 60 * 1)
 const appDir = join(__dirname, '../')
 
 describe('Build warnings', () => {
-  it('should not shown warning about minification withou any modification', async () => {
+  it('should not shown warning about minification without any modification', async () => {
     const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
     expect(stderr).not.toContain('optimization has been disabled')
   })

--- a/test/integration/case-sensitive-import/components/mycomponent.js
+++ b/test/integration/case-sensitive-import/components/mycomponent.js
@@ -1,0 +1,3 @@
+export default function MyComponent() {
+  return null
+}

--- a/test/integration/case-sensitive-import/pages/about.js
+++ b/test/integration/case-sensitive-import/pages/about.js
@@ -1,0 +1,14 @@
+import Head from 'next/head'
+import MyComponent from '../components/mycomponent'
+
+export default function () {
+  return (
+    <div>
+      <Head>
+        <title>about</title>
+      </Head>
+      about page
+      <MyComponent />
+    </div>
+  )
+}

--- a/test/integration/case-sensitive-import/test/index.test.js
+++ b/test/integration/case-sensitive-import/test/index.test.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+
+import { File, nextBuild } from 'next-test-utils'
+import { join } from 'path'
+
+jest.setTimeout(1000 * 60 * 1)
+const appDir = join(__dirname, '../')
+
+describe('Build warnings', () => {
+  it('should not shown error without modifications', async () => {
+    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    expect(stderr).not.toContain('optimization has been disabled')
+  })
+
+  it("should shown error when importing 'next/Head'", async () => {
+    const page = new File(join(appDir, 'pages/about.js'))
+    try {
+      page.replace('next/head', 'next/Head')
+      const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+      expect(stderr).toContain(
+        "Module not found: Error: Can't resolve 'next/Head' in "
+      )
+    } finally {
+      page.restore()
+    }
+  })
+
+  it('should shown error when importing wrong cased user file', async () => {
+    const page = new File(join(appDir, 'pages/about.js'))
+    try {
+      page.replace('../components/mycomponent', '../components/MyComponent')
+      const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+      expect(stderr).toContain(
+        "Module not found: Error: Can't resolve '../components/MyComponent' in "
+      )
+    } finally {
+      page.restore()
+    }
+  })
+})


### PR DESCRIPTION
Make sure the build fails when importing modules with the incorrect casing. e.g.
```js
import Head from 'next/Head'
```
This also works for user code modules.

This particluar approach patches the webpack resolver to reject modules if they're not correctly cased

Fixes https://github.com/vercel/next.js/issues/11742

Blocked on https://github.com/vercel/next.js/pull/14191

**Edit:** planning to revisit after webpack 5 support