### PR TITLE
Make ReactDevOverlay reducer more resilient to bad events

### DIFF
--- a/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
+++ b/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
@@ -15,7 +15,7 @@ type OverlayState = {
 }
 
 function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
-  switch (ev.type) {
+  switch (ev?.type) {
     case Bus.TYPE_BUILD_OK: {
       return { ...state, buildError: null }
     }


### PR DESCRIPTION
I got the following stack and thought the error presenter should not throw so easily 

<details>

```
[example-server] TypeError: Cannot read property 'type' of undefined
[example-server]     at reducer (/Users/mohsen_azimi/Code/nice-commander/node_modules/@next/react-dev-overlay/lib/internal/ReactDevOverlay.js:51:16)
[example-server]     at Object.useReducer (/Users/mohsen_azimi/Code/nice-commander/node_modules/react-dom/cjs/react-dom-server.node.development.js:1170:22)
[example-server]     at Object.useReducer (/Users/mohsen_azimi/Code/nice-commander/node_modules/react/cjs/react.development.js:1501:21)
[example-server]     at ReactDevOverlay (/Users/mohsen_azimi/Code/nice-commander/node_modules/@next/react-dev-overlay/lib/internal/ReactDevOverlay.js:74:27)
[example-server]     at finishHooks (/Users/mohsen_azimi/Code/nice-commander/node_modules/react-dom/cjs/react-dom-server.node.development.js:1075:16)
[example-server]     at processChild (/Users/mohsen_azimi/Code/nice-commander/node_modules/react-dom/cjs/react-dom-server.node.development.js:3044:14)
[example-server]     at resolve (/Users/mohsen_azimi/Code/nice-commander/node_modules/react-dom/cjs/react-dom-server.node.development.js:2960:5)
[example-server]     at ReactDOMServerRenderer.render (/Users/mohsen_azimi/Code/nice-commander/node_modules/react-dom/cjs/react-dom-server.node.development.js:3435:22)
[example-server]     at ReactDOMServerRenderer.read (/Users/mohsen_azimi/Code/nice-commander/node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
[example-server]     at renderToString (/Users/mohsen_azimi/Code/nice-commander/node_modules/react-dom/cjs/react-dom-server.node.development.js:3988:27)
[example-server]     at render (/Users/mohsen_azimi/Code/nice-commander/node_modules/next/dist/next-server/server/render.js:3:298)
[example-server]     at renderPageError (/Users/mohsen_azimi/Code/nice-commander/node_modules/next/dist/next-server/server/render.js:46:516)
[example-server]     at Object.renderPage (/Users/mohsen_azimi/Code/nice-commander/node_modules/next/dist/next-server/server/render.js:46:869)
[example-server]     at Function.getInitialProps (webpack-internal:///../../node_modules/next/dist/pages/_document.js:133:19)
[example-server]     at loadGetInitialProps (/Users/mohsen_azimi/Code/nice-commander/node_modules/next/dist/next-server/lib/utils.js:5:101)
[example-server]     at renderToHTML (/Users/mohsen_azimi/Code/nice-commander/node_modules/next/dist/next-server/server/render.js:46:1330)
```


</details>

if you are wondering how this can happen, this issue is reproducible here:

https://github.com/mohsen1/nice-commander/tree/1995cce6b858204c4a7ebcd76d9cacb2f4c1ae6b