### PR TITLE
fix(example): needs TypeScript support

### DIFF
--- a/examples/with-ant-design-pro-layout-less/package.json
+++ b/examples/with-ant-design-pro-layout-less/package.json
@@ -24,6 +24,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "13.13.4",
+    "@types/react": "^16.9.36",
     "typescript": "3.8.3"
   }
 }


### PR DESCRIPTION
Example:  with-ant-design-pro-layout-less needs TypeScript support.

![image](https://user-images.githubusercontent.com/1228449/84468957-ee4ade80-acba-11ea-9438-e1a0e40493f2.png)
