### PR TITLE
Add test for title and routeChangeComplete

### DIFF
--- a/test/integration/production/pages/with-title.js
+++ b/test/integration/production/pages/with-title.js
@@ -1,0 +1,10 @@
+import Head from 'next/head'
+
+export default () => (
+  <>
+    <Head>
+      <title>hello from title</title>
+    </Head>
+    <p id="with-title">hi</p>
+  </>
+)

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -324,8 +324,10 @@ describe('Production Usage', () => {
 
     it('should set title by routeChangeComplete event', async () => {
       const browser = await webdriver(appPort, '/')
-      await browser.eval(() => {
-        window.next.router.events.on('routeChangeComplete', (url) => {
+      await browser.eval(function setup() {
+        window.next.router.events.on('routeChangeComplete', function handler(
+          url
+        ) {
           window.routeChangeTitle = document.title
           window.routeChangeUrl = url
         })
@@ -333,8 +335,8 @@ describe('Production Usage', () => {
       })
       await browser.waitForElementByCss('#with-title')
 
-      const title = await browser.eval(() => window.routeChangeTitle)
-      const url = await browser.eval(() => window.routeChangeUrl)
+      const title = await browser.eval(`window.routeChangeTitle`)
+      const url = await browser.eval(`window.routeChangeUrl`)
       expect(title).toBe('hello from title')
       expect(url).toBe('/with-title')
     })

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -321,6 +321,23 @@ describe('Production Usage', () => {
       expect(text).toBe('Hello World')
       await browser.close()
     })
+
+    it('should set title by routeChangeComplete event', async () => {
+      const browser = await webdriver(appPort, '/')
+      await browser.eval(() => {
+        window.next.router.events.on('routeChangeComplete', (url) => {
+          window.routeChangeTitle = document.title
+          window.routeChangeUrl = url
+        })
+        window.next.router.push('/with-title')
+      })
+      await browser.waitForElementByCss('#with-title')
+
+      const title = await browser.eval(() => window.routeChangeTitle)
+      const url = await browser.eval(() => window.routeChangeUrl)
+      expect(title).toBe('hello from title')
+      expect(url).toBe('/with-title')
+    })
   })
 
   it('should navigate to external site and back', async () => {


### PR DESCRIPTION
This adds a test case for the `document.title` not being updated by the time `routeChangeComplete` is fired. This should have been made consistent with https://github.com/vercel/next.js/pull/13287 so should be able to be closed now

Closes: https://github.com/vercel/next.js/issues/6025