### PR TITLE
Update stats action for running locally

### DIFF
--- a/.github/actions/next-stats-action/src/constants.js
+++ b/.github/actions/next-stats-action/src/constants.js
@@ -8,6 +8,9 @@ const mainRepoDir = path.join(workDir, mainRepoName)
 const diffRepoDir = path.join(workDir, diffRepoName)
 const statsAppDir = path.join(workDir, 'stats-app')
 const diffingDir = path.join(workDir, 'diff')
+const yarnEnvValues = {
+  YARN_CACHE_FOLDER: path.join(workDir, 'yarn-cache'),
+}
 const allowedConfigLocations = [
   './',
   '.stats-app',
@@ -24,5 +27,6 @@ module.exports = {
   mainRepoDir,
   diffRepoDir,
   statsAppDir,
+  yarnEnvValues,
   allowedConfigLocations,
 }

--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -46,6 +46,12 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       )
     }
 
+    if (actionInfo.isLocal) {
+      // make sure to use local repo location instead of the
+      // one provided in statsConfig
+      statsConfig.mainRepo = actionInfo.prRepo
+    }
+
     // clone main repository/ref
     if (!actionInfo.skipClone) {
       await cloneRepo(statsConfig.mainRepo, mainRepoDir)

--- a/.github/actions/next-stats-action/src/util/exec.js
+++ b/.github/actions/next-stats-action/src/util/exec.js
@@ -9,9 +9,13 @@ const env = {
   PR_STATS_COMMENT_TOKEN: '',
 }
 
-function exec(command, noLog = false) {
+function exec(command, noLog = false, opts = {}) {
   if (!noLog) logger(`exec: ${command}`)
-  return execP(command, { env, timeout: 180 * 1000 })
+  return execP(command, {
+    timeout: 180 * 1000,
+    ...opts,
+    env: { ...env, ...opts.env },
+  })
 }
 
 exec.spawn = function spawn(command = '', opts = {}) {


### PR DESCRIPTION
Noticed a few things that could be updated to make running the stats locally better e.g. if the folder name didn't match the name of the repo in the `stats-config.js` file it would fail to run and the `yarn` cache could break diffing from a cached package being used instead