### PR TITLE
Fix GraphQL Hooks Example Safari bug

### DIFF
--- a/examples/with-graphql-hooks/package.json
+++ b/examples/with-graphql-hooks/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "dependencies": {
     "graphql-hooks": "^4.4.4",
-    "graphql-hooks-memcache": "^1.3.2",
+    "graphql-hooks-memcache": "1.3.1 || ^1.3.3",
     "next": "latest",
     "prop-types": "^15.7.2",
     "react": "^16.8.2",


### PR DESCRIPTION
Fixes #14187, where the [GraphQL Hooks Example](https://github.com/vercel/next.js/tree/canary/examples/with-graphql-hooks), when opened in Safari, doesn't respond to events in production and doesn't load at all in the dev server.

This is caused by [a bug in graphql-hooks-memcache@1.3.2](https://github.com/nearform/graphql-hooks/issues/496), which they've fixed but haven't released the fix yet. So this example fix just temporarily downgrades graphql-hooks-memcache by changing its version range to `1.3.1 || ^1.3.3`.