### PR TITLE
switch to function component with-react-intl example 

### DIFF
--- a/examples/with-react-intl/pages/_app.js
+++ b/examples/with-react-intl/pages/_app.js
@@ -4,7 +4,7 @@ import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl'
 // since it prevents memory leak
 const cache = createIntlCache()
 
-function MyApp({ Component, pageProps, locale = '', messages = {} }) {
+function MyApp({ Component, pageProps, locale, messages }) {
   const intl = createIntl(
     {
       locale,

--- a/examples/with-react-intl/pages/_app.js
+++ b/examples/with-react-intl/pages/_app.js
@@ -1,41 +1,36 @@
-import App from 'next/app'
 import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl'
 
 // This is optional but highly recommended
 // since it prevents memory leak
 const cache = createIntlCache()
 
-export default class MyApp extends App {
-  static async getInitialProps({ Component, ctx }) {
-    let pageProps = {}
-
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx)
-    }
-
-    // Get the `locale` and `messages` from the request object on the server.
-    // In the browser, use the same values that the server serialized.
-    const { req } = ctx
-    const { locale, messages } = req
-
-    return { pageProps, locale, messages }
-  }
-
-  render() {
-    const { Component, pageProps, locale, messages } = this.props
-
-    const intl = createIntl(
-      {
-        locale,
-        messages,
-      },
-      cache
-    )
-
-    return (
-      <RawIntlProvider value={intl}>
-        <Component {...pageProps} />
-      </RawIntlProvider>
-    )
-  }
+function MyApp({ Component, pageProps, locale = '', messages = {} }) {
+  const intl = createIntl(
+    {
+      locale,
+      messages,
+    },
+    cache
+  )
+  return (
+    <RawIntlProvider value={intl}>
+      <Component {...pageProps} />
+    </RawIntlProvider>
+  )
 }
+
+MyApp.getInitialProps = async ({ Component, ctx }) => {
+  let pageProps = {}
+
+  const { req } = ctx
+  const locale = req?.locale ?? ''
+  const messages = req?.messages ?? {}
+
+  if (Component.getInitialProps) {
+    Object.assign(pageProps, await Component.getInitialProps(ctx))
+  }
+
+  return { pageProps, locale, messages }
+}
+
+export default MyApp


### PR DESCRIPTION
The example was using class-based component for custom _app, switched to function component.


**Sidenote:** The existing code gave an error when navigated to a new page using the navbar
![Screenshot 2020-06-16 at 2 47 52 PM](https://user-images.githubusercontent.com/11258286/84760988-6cbebd80-afe6-11ea-9b7f-98aca7404895.png)
