### PR TITLE
chore(examples): update next to latest on cms examples

### DIFF
--- a/examples/cms-contentful/package.json
+++ b/examples/cms-contentful/package.json
@@ -12,7 +12,7 @@
     "classnames": "2.2.6",
     "contentful": "7.14.4",
     "date-fns": "2.10.0",
-    "next": "9.3.6",
+    "next": "latest",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
   },

--- a/examples/cms-prismic/package.json
+++ b/examples/cms-prismic/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
-    "next": "9.2.3-canary.26",
+    "next": "latest",
     "prismic-javascript": "2.2.0",
     "prismic-reactjs": "1.2.0",
     "react": "^16.13.0",


### PR DESCRIPTION
Hey guys, thanks for the amazing job you are doing 💜 

This PR fixes a small error I faced when starting a project with Prismic + Next.js.

Since the version on the `cms-prismic` example was fixed to `9.2.3-canary.26` I was having the following error because the example uses the environment variables feature that is for Next.js 9.4+

<img width="1256" alt="Screen Shot 2020-06-16 at 12 13 38" src="https://user-images.githubusercontent.com/26466516/84793626-bc43c000-afcb-11ea-8823-b1dee30dbb00.png">

After updating to the latest version, I could run it successfully.

ps: I also realized that the `cms-contentful` example was also not using the `latest` version, so I decided to update it (I have not tested, but the error certainly will happen).

ps2: if you want to reproduce the error, just create a project using the example and add dummy data on the environment variables, then start the server and access `http://localhost:3000`.