### PR TITLE
Using cross-spawn for cross platform use in with-react-intl

### DIFF
--- a/examples/with-react-intl/package.json
+++ b/examples/with-react-intl/package.json
@@ -23,6 +23,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "cross-spawn": "7.0.3",
     "next-transpile-modules": "^3.2.0"
   }
 }

--- a/examples/with-react-intl/scripts/extract.js
+++ b/examples/with-react-intl/scripts/extract.js
@@ -1,12 +1,12 @@
 const { readFileSync, writeFileSync } = require('fs')
 const { resolve } = require('path')
 const glob = require('glob')
-const { execFileSync } = require('child_process')
+const spawn = require('cross-spawn')
 
 // formatjs cli doesn't currently support globbing, so we perform it ourselves
 // as a workaround. see https://github.com/formatjs/formatjs/issues/383
 const sourceFiles = glob.sync(process.argv[2])
-execFileSync('npx', [
+spawn.sync('npx', [
   'formatjs',
   'extract',
   '--messages-dir',


### PR DESCRIPTION
[In this Discussion](https://github.com/vercel/next.js/discussions/14220) it appears that trying to build the `with-react-intl` example with a Windows machine throws an error. So instead of using `execFileSync` to execute the command, I used [`cross-spawn` ](https://www.npmjs.com/package/cross-spawn) for better cross platform compatibility. 

