### PR TITLE
Update Algolia's Instant Search Example

### DIFF
--- a/examples/with-algolia-react-instantsearch/components/app.js
+++ b/examples/with-algolia-react-instantsearch/components/app.js
@@ -7,8 +7,9 @@ import {
   Configure,
   Highlight,
   Pagination,
-} from 'react-instantsearch/dom'
-import { InstantSearch } from './instantsearch'
+  InstantSearch,
+} from 'react-instantsearch-dom'
+import { indexName, searchClient } from './instantsearch'
 
 const HitComponent = ({ hit }) => (
   <div className="hit">
@@ -19,15 +20,15 @@ const HitComponent = ({ hit }) => (
     </div>
     <div className="hit-content">
       <div>
-        <Highlight attributeName="name" hit={hit} />
+        <Highlight attribute="name" hit={hit} />
         <span> - ${hit.price}</span>
         <span> - {hit.rating} stars</span>
       </div>
       <div className="hit-type">
-        <Highlight attributeName="type" hit={hit} />
+        <Highlight attribute="type" hit={hit} />
       </div>
       <div className="hit-description">
-        <Highlight attributeName="description" hit={hit} />
+        <Highlight attribute="description" hit={hit} />
       </div>
     </div>
   </div>
@@ -47,9 +48,8 @@ export default class App extends React.Component {
   render() {
     return (
       <InstantSearch
-        appId="appId" // change this
-        apiKey="apiKey" // change this
-        indexName="indexName" // change this
+        indexName={indexName}
+        searchClient={searchClient}
         resultsState={this.props.resultsState}
         onSearchStateChange={this.props.onSearchStateChange}
         searchState={this.props.searchState}
@@ -61,7 +61,7 @@ export default class App extends React.Component {
         </header>
         <content>
           <menu>
-            <RefinementList attributeName="category" />
+            <RefinementList attribute="category" />
           </menu>
           <results>
             <Hits hitComponent={HitComponent} />

--- a/examples/with-algolia-react-instantsearch/components/app.js
+++ b/examples/with-algolia-react-instantsearch/components/app.js
@@ -63,9 +63,7 @@ export default class App extends React.Component {
           <menu>
             <RefinementList attribute="category" />
           </menu>
-          <results>
-            <Hits hitComponent={HitComponent} />
-          </results>
+          <Hits hitComponent={HitComponent} />
         </content>
         <footer>
           <Pagination />

--- a/examples/with-algolia-react-instantsearch/components/instantsearch.js
+++ b/examples/with-algolia-react-instantsearch/components/instantsearch.js
@@ -1,5 +1,13 @@
-import { createInstantSearch } from 'react-instantsearch/server'
+import { findResultsState } from 'react-instantsearch-dom/server'
+import algoliasearch from 'algoliasearch/lite'
 
-const { InstantSearch, findResultsState } = createInstantSearch()
+const indexName = 'instant_search'
 
-export { InstantSearch, findResultsState }
+// Keys are supplied from Algolio's instant search example
+// https://github.com/algolia/react-instantsearch
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+)
+
+export { findResultsState, indexName, searchClient }

--- a/examples/with-algolia-react-instantsearch/package.json
+++ b/examples/with-algolia-react-instantsearch/package.json
@@ -6,14 +6,14 @@
     "start": "next start"
   },
   "dependencies": {
+    "algoliasearch": "4.3.0",
     "css-loader": "1.0.0",
+    "next": "latest",
     "prop-types": "^15.5.10",
     "qs": "^6.4.0",
-    "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "react-instantsearch": "beta",
-    "react-instantsearch-theme-algolia": "beta",
+    "react-instantsearch-dom": "6.6.0",
     "style-loader": "^0.17.0"
   }
 }

--- a/examples/with-algolia-react-instantsearch/pages/index.js
+++ b/examples/with-algolia-react-instantsearch/pages/index.js
@@ -5,7 +5,6 @@ import {
   searchClient,
 } from '../components/instantsearch'
 import { Component } from 'react'
-import PropTypes from 'prop-types'
 import Router from 'next/router'
 import qs from 'qs'
 
@@ -14,22 +13,7 @@ const updateAfter = 700
 const searchStateToUrl = (searchState) =>
   searchState ? `${window.location.pathname}?${qs.stringify(searchState)}` : ''
 
-export async function getServerSideProps({ req }) {
-  const path = req.url
-  const searchState = qs.parse(path.substring(path.indexOf('?') + 1))
-  let resultsState = await findResultsState(App, { indexName, searchClient })
-  resultsState.state = JSON.stringify(resultsState.state)
-  return {
-    props: { resultsState, searchState },
-  }
-}
-
 export default class Home extends Component {
-  static propTypes = {
-    resultsState: PropTypes.object,
-    searchState: PropTypes.object,
-  }
-
   constructor(props) {
     super(props)
     this.onSearchStateChange = this.onSearchStateChange.bind(this)
@@ -46,8 +30,11 @@ export default class Home extends Component {
     this.setState({ searchState })
   }
 
-  componentDidMount() {
-    this.setState({ searchState: qs.parse(window.location.search.slice(1)) })
+  async componentDidMount() {
+    this.setState({
+      searchState: qs.parse(window.location.search.slice(1)),
+      resultsState: await findResultsState(App, { indexName, searchClient }),
+    })
   }
 
   UNSAFE_componentWillReceiveProps() {
@@ -59,15 +46,13 @@ export default class Home extends Component {
       <div>
         <Head title="Home" />
         <div>
-          <App
-            resultsState={this.props.resultsState}
-            onSearchStateChange={this.onSearchStateChange}
-            searchState={
-              this.state && this.state.searchState
-                ? this.state.searchState
-                : this.props.searchState
-            }
-          />
+          {this.state && this.state.resultsState && this.state.searchState && (
+            <App
+              resultsState={this.state.resultsState}
+              onSearchStateChange={this.onSearchStateChange}
+              searchState={this.state.searchState}
+            />
+          )}
         </div>
       </div>
     )

--- a/examples/with-algolia-react-instantsearch/pages/index.js
+++ b/examples/with-algolia-react-instantsearch/pages/index.js
@@ -1,4 +1,9 @@
-import { Head, App, findResultsState } from '../components'
+import { Head, App } from '../components'
+import {
+  findResultsState,
+  indexName,
+  searchClient,
+} from '../components/instantsearch'
 import { Component } from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
@@ -9,6 +14,16 @@ const updateAfter = 700
 const searchStateToUrl = (searchState) =>
   searchState ? `${window.location.pathname}?${qs.stringify(searchState)}` : ''
 
+export async function getServerSideProps({ req }) {
+  const path = req.url
+  const searchState = qs.parse(path.substring(path.indexOf('?') + 1))
+  let resultsState = await findResultsState(App, { indexName, searchClient })
+  resultsState.state = JSON.stringify(resultsState.state)
+  return {
+    props: { resultsState, searchState },
+  }
+}
+
 export default class Home extends Component {
   static propTypes = {
     resultsState: PropTypes.object,
@@ -18,19 +33,6 @@ export default class Home extends Component {
   constructor(props) {
     super(props)
     this.onSearchStateChange = this.onSearchStateChange.bind(this)
-  }
-
-  /*
-     nextjs params.query doesn't handle nested objects
-     once it does, params.query could be used directly here, but also inside the constructor
-     to initialize the searchState.
-  */
-  static async getInitialProps(params) {
-    const searchState = qs.parse(
-      params.asPath.substring(params.asPath.indexOf('?') + 1)
-    )
-    const resultsState = await findResultsState(App, { searchState })
-    return { resultsState, searchState }
   }
 
   onSearchStateChange = (searchState) => {


### PR DESCRIPTION
- Moved from `getInitialProps` to `getServerSideProps`
- Update Algolia libraries

Co-authored-by: Arsalan Khattak <akkhattak65@gmail.com>