### PR TITLE
(fix) Missing props key from getServerSideProps

### DIFF
--- a/examples/with-cookie-auth-fauna/pages/profile.js
+++ b/examples/with-cookie-auth-fauna/pages/profile.js
@@ -35,7 +35,7 @@ export async function getServerSideProps(ctx) {
 
     const profileInfo = await profileApi(faunaSecret)
 
-    return { props: { userId: data.userId } }
+    return { props: { userId: profileInfo } }
   }
 
   const response = await fetch('/api/profile')

--- a/examples/with-cookie-auth-fauna/pages/profile.js
+++ b/examples/with-cookie-auth-fauna/pages/profile.js
@@ -35,7 +35,7 @@ export async function getServerSideProps(ctx) {
 
     const profileInfo = await profileApi(faunaSecret)
 
-    return { userId: profileInfo }
+    return { props: { userId: data.userId } }
   }
 
   const response = await fetch('/api/profile')
@@ -50,7 +50,7 @@ export async function getServerSideProps(ctx) {
 
   const data = await response.json()
 
-  return { userId: data.userId }
+  return { props: { userId: data.userId } }
 }
 
 export default withAuthSync(Profile)


### PR DESCRIPTION
Crashes the site
This change fixes the example
examples/with-cookie-auth-fauna/pages/profile.js