### PR TITLE
Removing system files/directories from GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,6 @@ coverage
 # test output
 test/**/out*
 test/**/next-env.d.ts
-.DS_Store
-
-# Editors
-**/.idea
 
 # examples
 examples/**/out

--- a/examples/cms-wordpress/.gitignore
+++ b/examples/cms-wordpress/.gitignore
@@ -16,7 +16,6 @@
 /build
 
 # misc
-.DS_Store
 *.pem
 
 # debug

--- a/examples/with-expo-typescript/.gitignore
+++ b/examples/with-expo-typescript/.gitignore
@@ -10,9 +10,6 @@ npm-debug.*
 web-build/
 web-report/
 
-# macOS
-.DS_Store
-
 # @generated: @expo/next-adapter@2.1.9
 /.expo/*
 # Expo Web

--- a/examples/with-expo/.gitignore
+++ b/examples/with-expo/.gitignore
@@ -16,9 +16,5 @@ web-report/
 yarn-debug.log*
 yarn-error.log*
 
-# macOS
-.DS_Store
-
 # misc
-.DS_Store
 .env*

--- a/examples/with-mongodb-mongoose/.gitignore
+++ b/examples/with-mongodb-mongoose/.gitignore
@@ -12,6 +12,3 @@ coverage
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# misc
-.DS_Store

--- a/examples/with-typescript-eslint-jest/.gitignore
+++ b/examples/with-typescript-eslint-jest/.gitignore
@@ -12,6 +12,3 @@ coverage
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# misc
-.DS_Store

--- a/examples/with-typescript-graphql/.gitignore
+++ b/examples/with-typescript-graphql/.gitignore
@@ -16,7 +16,6 @@
 /build
 
 # misc
-.DS_Store
 *.pem
 
 # debug

--- a/packages/create-next-app/templates/default/gitignore
+++ b/packages/create-next-app/templates/default/gitignore
@@ -16,7 +16,6 @@
 /build
 
 # misc
-.DS_Store
 *.pem
 
 # debug


### PR DESCRIPTION
.idea and .DS-Store are system specific files/directories and should be part of the system's global gitignore.
Only project related files and directories should be in a project's own gitignore.