### PR TITLE
De-experimentalize basePath config

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -84,7 +84,7 @@ export function createEntrypoints(
     assetPrefix: config.assetPrefix,
     generateEtags: config.generateEtags,
     canonicalBase: config.canonicalBase,
-    basePath: config.experimental.basePath,
+    basePath: config.basePath,
     runtimeConfig: hasRuntimeConfig
       ? JSON.stringify({
           publicRuntimeConfig: config.publicRuntimeConfig,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -291,7 +291,7 @@ export default async function build(dir: string, conf = null): Promise<void> {
   const routesManifest: any = {
     version: 3,
     pages404: true,
-    basePath: config.experimental.basePath,
+    basePath: config.basePath,
     redirects: redirects.map((r) => buildCustomRoute(r, 'redirect')),
     rewrites: rewrites.map((r) => buildCustomRoute(r, 'rewrite')),
     headers: headers.map((r) => buildCustomRoute(r, 'header')),

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -845,9 +845,7 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_REACT_MODE': JSON.stringify(
           config.experimental.reactMode
         ),
-        'process.env.__NEXT_ROUTER_BASEPATH': JSON.stringify(
-          config.experimental.basePath
-        ),
+        'process.env.__NEXT_ROUTER_BASEPATH': JSON.stringify(config.basePath),
         ...(isServer
           ? {
               // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -252,7 +252,7 @@ export default async function exportApp(
     distDir,
     dev: false,
     hotReloader: null,
-    basePath: nextConfig.experimental.basePath,
+    basePath: nextConfig.basePath,
     canonicalBase: nextConfig.amp?.canonicalBase || '',
     isModern: nextConfig.experimental.modern,
     ampValidatorPath: nextConfig.experimental.amp?.validator || undefined,

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -35,6 +35,7 @@ const defaultConfig: { [key: string]: any } = {
   amp: {
     canonicalBase: '',
   },
+  basePath: '',
   exportTrailingSlash: false,
   sassOptions: {},
   experimental: {
@@ -49,7 +50,6 @@ const defaultConfig: { [key: string]: any } = {
     sprFlushToDisk: true,
     reactMode: 'legacy',
     workerThreads: false,
-    basePath: '',
     pageEnv: false,
     productionBrowserSourceMaps: false,
     optionalCatchAll: false,
@@ -158,35 +158,34 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     )
   }
   if (result.experimental) {
-    if (typeof result.experimental.basePath !== 'string') {
+    if (typeof result.basePath !== 'string') {
       throw new Error(
-        `Specified basePath is not a string, found type "${typeof result
-          .experimental.basePath}"`
+        `Specified basePath is not a string, found type "${typeof result.basePath}"`
       )
     }
 
-    if (result.experimental.basePath !== '') {
-      if (result.experimental.basePath === '/') {
+    if (result.basePath !== '') {
+      if (result.basePath === '/') {
         throw new Error(
           `Specified basePath /. basePath has to be either an empty string or a path prefix"`
         )
       }
 
-      if (!result.experimental.basePath.startsWith('/')) {
+      if (!result.basePath.startsWith('/')) {
         throw new Error(
-          `Specified basePath has to start with a /, found "${result.experimental.basePath}"`
+          `Specified basePath has to start with a /, found "${result.basePath}"`
         )
       }
 
-      if (result.experimental.basePath !== '/') {
-        if (result.experimental.basePath.endsWith('/')) {
+      if (result.basePath !== '/') {
+        if (result.basePath.endsWith('/')) {
           throw new Error(
-            `Specified basePath should not end with /, found "${result.experimental.basePath}"`
+            `Specified basePath should not end with /, found "${result.basePath}"`
           )
         }
 
         if (result.assetPrefix === '') {
-          result.assetPrefix = result.experimental.basePath
+          result.assetPrefix = result.basePath
         }
       }
     }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -170,7 +170,7 @@ export default class Server {
       previewProps: this.getPreviewProps(),
       customServer: customServer === true ? true : undefined,
       ampOptimizerConfig: this.nextConfig.experimental.amp?.optimizer,
-      basePath: this.nextConfig.experimental.basePath,
+      basePath: this.nextConfig.basePath,
     }
 
     // Only the `publicRuntimeConfig` key is exposed to the client side
@@ -258,7 +258,7 @@ export default class Server {
       parsedUrl.query = parseQs(parsedUrl.query)
     }
 
-    const { basePath } = this.nextConfig.experimental
+    const { basePath } = this.nextConfig
 
     // if basePath is set require it be present
     if (basePath && !req.url!.startsWith(basePath)) {

--- a/test/integration/basepath/next.config.js
+++ b/test/integration/basepath/next.config.js
@@ -3,7 +3,5 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
   },
-  experimental: {
-    basePath: '/docs',
-  },
+  basePath: '/docs',
 }

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -625,7 +625,7 @@ describe('basePath serverless', () => {
 
   beforeAll(async () => {
     await nextConfig.write(
-      `module.exports = { target: 'serverless', experimental: { basePath: '/docs' } }`
+      `module.exports = { target: 'experimental-serverless-trace', basePath: '/docs' } `
     )
     await nextBuild(appDir)
     context.appPort = await findPort()


### PR DESCRIPTION
This moves the experimental `basePath` config out of the `experimental` section to prepare it for being stable