### PR TITLE
Correct /_next/data link for GS(S)P with basePath

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -31,7 +31,7 @@ function toRoute(path: string): string {
 }
 
 const prepareRoute = (path: string) =>
-  toRoute(!path || path === '/' ? '/index' : path)
+  toRoute(!path || delBasePath(path) === '/' ? '/index' : path)
 
 type Url = UrlObject | string
 
@@ -106,7 +106,7 @@ function fetchNextData(
       formatWithValidation({
         pathname: addBasePath(
           // @ts-ignore __NEXT_DATA__
-          `/_next/data/${__NEXT_DATA__.buildId}${delBasePath(pathname)}.json`
+          `/_next/data/${__NEXT_DATA__.buildId}${pathname}.json`
         ),
         query,
       }),
@@ -446,13 +446,12 @@ export default class Router implements BaseRouter {
 
       const route = toRoute(pathname)
       const { shallow = false } = options
+      const cleanedAs = delBasePath(as)
 
       if (isDynamicRoute(route)) {
-        const { pathname: asPathname } = parse(as)
+        const { pathname: asPathname } = parse(cleanedAs)
         const routeRegex = getRouteRegex(route)
-        const routeMatch = getRouteMatcher(routeRegex)(
-          delBasePath(asPathname || '')
-        )
+        const routeMatch = getRouteMatcher(routeRegex)(asPathname)
         if (!routeMatch) {
           const missingParams = Object.keys(routeRegex.groups).filter(
             (param) => !query[param]
@@ -502,17 +501,15 @@ export default class Router implements BaseRouter {
               !(routeInfo.Component as any).getInitialProps
           }
 
-          this.set(route, pathname!, query, delBasePath(as), routeInfo).then(
-            () => {
-              if (error) {
-                Router.events.emit('routeChangeError', error, as)
-                throw error
-              }
-
-              Router.events.emit('routeChangeComplete', as)
-              return resolve(true)
+          this.set(route, pathname!, query, cleanedAs, routeInfo).then(() => {
+            if (error) {
+              Router.events.emit('routeChangeError', error, as)
+              throw error
             }
-          )
+
+            Router.events.emit('routeChangeComplete', as)
+            return resolve(true)
+          })
         },
         reject
       )

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -30,8 +30,10 @@ function toRoute(path: string): string {
   return path.replace(/\/$/, '') || '/'
 }
 
-const prepareRoute = (path: string) =>
-  toRoute(!path || delBasePath(path) === '/' ? '/index' : path)
+function prepareRoute(path: string) {
+  path = delBasePath(path || '')
+  return toRoute(!path || path === '/' ? '/index' : path)
+}
 
 type Url = UrlObject | string
 

--- a/test/integration/basepath/pages/hello.js
+++ b/test/integration/basepath/pages/hello.js
@@ -32,6 +32,12 @@ export default () => (
         <h1>catchall page</h1>
       </a>
     </Link>
+    <br />
+    <Link href="/">
+      <a id="index-gsp">
+        <h1>index getStaticProps</h1>
+      </a>
+    </Link>
     <div id="base-path">{useRouter().basePath}</div>
     <div id="pathname">{useRouter().pathname}</div>
   </>

--- a/test/integration/basepath/pages/index.js
+++ b/test/integration/basepath/pages/index.js
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router'
+
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'hello',
+    },
+  }
+}
+
+export default function Index({ hello }) {
+  const { query, pathname } = useRouter()
+  return (
+    <>
+      <p id="prop">{hello} world</p>
+      <p id="query">{JSON.stringify(query)}</p>
+      <p id="pathname">{pathname}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This corrects the `/_next/data` path generated when using `basePath` with `getStaticProps` in a `pages/index.js` file which was previously stripping the `basePath` without checking if `/index` needed to be appended after stripping. This also adds additional checks to the `basePath` test suite to prevent regressing   

x-ref: https://github.com/vercel/next.js/pull/9872#issuecomment-646841260