### PR TITLE
Remove buildId from server-side files

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -101,7 +101,7 @@ export function createEntrypoints(
     const isApiRoute = page.match(API_ROUTE)
 
     const clientBundlePath = join('static', 'pages', bundleFile)
-    const serverBundlePath = join('static', 'BUILD_ID', 'pages', bundleFile)
+    const serverBundlePath = join('pages', bundleFile)
 
     const isLikeServerless = isTargetLikeServerless(target)
 
@@ -111,7 +111,7 @@ export function createEntrypoints(
         absolutePagePath,
         ...defaultServerlessOptions,
       }
-      server[join('pages', bundleFile)] = `next-serverless-loader?${stringify(
+      server[serverBundlePath] = `next-serverless-loader?${stringify(
         serverlessLoaderOptions
       )}!`
     } else if (isApiRoute || target === 'server') {
@@ -122,7 +122,7 @@ export function createEntrypoints(
         absolutePagePath,
         ...defaultServerlessOptions,
       }
-      server[join('pages', bundleFile)] = `next-serverless-loader?${stringify(
+      server[serverBundlePath] = `next-serverless-loader?${stringify(
         serverlessLoaderOptions
       )}!`
     }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -679,24 +679,8 @@ export default async function getBaseWebpackConfig(
     },
     output: {
       path: outputPath,
-      filename: isServer
-        ? ({ chunk }: { chunk: { name: string } }) => {
-            // Use `[name]-[contenthash].js` in production
-            if (chunk.name.includes('BUILD_ID')) {
-              return (
-                escapePathVariables(chunk.name).replace(
-                  'BUILD_ID',
-                  isServer || dev ? buildId : '[contenthash]'
-                ) + '.js'
-              )
-            }
-
-            return '[name].js'
-          }
-        : // Client compilation only
-        dev
-        ? '[name].js'
-        : '[name]-[chunkhash].js',
+      // On the server we don't use the chunkhash
+      filename: dev || isServer ? '[name].js' : '[name]-[chunkhash].js',
       libraryTarget: isServer ? 'commonjs2' : 'var',
       hotUpdateChunkFilename: isWebpack5
         ? 'static/webpack/[id].[fullhash].hot-update.js'

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -41,6 +41,7 @@ import { loadEnvConfig } from '../lib/load-env-config'
 import { PrerenderManifest } from '../build'
 import type exportPage from './worker'
 import { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
+import { getPagePath } from '../next-server/server/require'
 
 const exists = promisify(existsOrig)
 
@@ -156,15 +157,6 @@ export default async function exportApp(
   try {
     prerenderManifest = require(join(distDir, PRERENDER_MANIFEST))
   } catch (_) {}
-
-  // TODO: Replace with same logic as build/index.ts for looking up pathname
-  const distPagesDir = join(
-    distDir,
-    isLikeServerless
-      ? SERVERLESS_DIRECTORY
-      : join(SERVER_DIRECTORY, 'static', buildId),
-    'pages'
-  )
 
   const excludedPrerenderRoutes = new Set<string>()
   const pages = options.pages || Object.keys(pagesManifest)
@@ -426,7 +418,21 @@ export default async function exportApp(
   if (!options.buildExport && prerenderManifest) {
     await Promise.all(
       Object.keys(prerenderManifest.routes).map(async (route) => {
+        const { srcRoute } = prerenderManifest!.routes[route]
+        const pageName = srcRoute || route
+        const pagePath = getPagePath(pageName, distDir, isLikeServerless)
+        const distPagesDir = join(
+          pagePath,
+          // strip leading / and then recurse number of nested dirs
+          // to place from base folder
+          pageName
+            .substr(1)
+            .split('/')
+            .map(() => '..')
+            .join('/')
+        )
         route = normalizePagePath(route)
+
         const orig = join(distPagesDir, route)
         const htmlDest = join(
           outDir,

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -157,6 +157,7 @@ export default async function exportApp(
     prerenderManifest = require(join(distDir, PRERENDER_MANIFEST))
   } catch (_) {}
 
+  // TODO: Replace with same logic as build/index.ts for looking up pathname
   const distPagesDir = join(
     distDir,
     isLikeServerless

--- a/packages/next/next-server/server/get-route-from-entrypoint.ts
+++ b/packages/next/next-server/server/get-route-from-entrypoint.ts
@@ -1,9 +1,9 @@
 import { denormalizePagePath } from './normalize-page-path'
 
 // matches static/<buildid>/pages/:page*.js
-const ROUTE_NAME_REGEX = /^static[/\\][^/\\]+[/\\]pages[/\\](.*)$/
+// const SERVER_ROUTE_NAME_REGEX = /^static[/\\][^/\\]+[/\\]pages[/\\](.*)$/
 // matches pages/:page*.js
-const SERVERLESS_ROUTE_NAME_REGEX = /^pages[/\\](.*)$/
+const SERVER_ROUTE_NAME_REGEX = /^pages[/\\](.*)$/
 // matches static/pages/:page*.js
 const BROWSER_ROUTE_NAME_REGEX = /^static[/\\]pages[/\\](.*)$/
 
@@ -18,13 +18,10 @@ function matchBundle(regex: RegExp, input: string): string | null {
 }
 
 export default function getRouteFromEntrypoint(
-  entryFile: string,
-  isServerlessLike: boolean = false
+  entryFile: string
+  // isServerlessLike: boolean = false
 ): string | null {
-  let pagePath = matchBundle(
-    isServerlessLike ? SERVERLESS_ROUTE_NAME_REGEX : ROUTE_NAME_REGEX,
-    entryFile
-  )
+  let pagePath = matchBundle(SERVER_ROUTE_NAME_REGEX, entryFile)
 
   if (pagePath) {
     return pagePath

--- a/packages/next/next-server/server/get-route-from-entrypoint.ts
+++ b/packages/next/next-server/server/get-route-from-entrypoint.ts
@@ -18,8 +18,9 @@ function matchBundle(regex: RegExp, input: string): string | null {
 }
 
 export default function getRouteFromEntrypoint(
-  entryFile: string
-  // isServerlessLike: boolean = false
+  entryFile: string,
+  // TODO: Remove this parameter
+  _isServerlessLike: boolean = false
 ): string | null {
   let pagePath = matchBundle(SERVER_ROUTE_NAME_REGEX, entryFile)
 

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -220,9 +220,7 @@ export default class Server {
       distDir: this.distDir,
       pagesDir: join(
         this.distDir,
-        this._isLikeServerless
-          ? SERVERLESS_DIRECTORY
-          : `${SERVER_DIRECTORY}/static/${this.buildId}`,
+        this._isLikeServerless ? SERVERLESS_DIRECTORY : SERVER_DIRECTORY,
         'pages'
       ),
       flushToDisk: this.nextConfig.experimental.sprFlushToDisk,

--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -380,7 +380,7 @@ export default class HotReloader {
         // We only watch `_document` for changes on the server compilation
         // the rest of the files will be triggered by the client compilation
         const documentChunk = compilation.chunks.find(
-          (c) => c.name === normalize(`static/BUILD_ID/pages/_document`)
+          (c) => c.name === normalize(`pages/_document`)
         )
         // If the document chunk can't be found we do nothing
         if (!documentChunk) {

--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -228,7 +228,7 @@ export default function onDemandEntryHandler(
       pageUrl = pageUrl === '' ? '/' : pageUrl
 
       const bundleFile = normalizePagePath(pageUrl)
-      const serverBundlePath = join('static', 'BUILD_ID', 'pages', bundleFile)
+      const serverBundlePath = join('pages', bundleFile)
       const clientBundlePath = join('static', 'pages', bundleFile)
       const absolutePagePath = pagePath.startsWith('next/dist/pages')
         ? require.resolve(pagePath)

--- a/test/integration/404-page-app/next.config.js
+++ b/test/integration/404-page-app/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/integration/404-page-app/pages/404.js
+++ b/test/integration/404-page-app/pages/404.js
@@ -1,0 +1,5 @@
+const page = (props) => {
+  return <h1 id="404-title">{props.extraProp}</h1>
+}
+
+export default page

--- a/test/integration/404-page-app/pages/_app.js
+++ b/test/integration/404-page-app/pages/_app.js
@@ -1,0 +1,18 @@
+import App from 'next/app'
+
+function MyApp({ Component, pageProps, extraProp }) {
+  return <Component {...pageProps} extraProp={extraProp} />
+}
+
+// Only uncomment this method if you have blocking data requirements for
+// every single page in your application. This disables the ability to
+// perform automatic static optimization, causing every page in your app to
+// be server-side rendered.
+MyApp.getInitialProps = async (appContext) => {
+  // calls page's `getInitialProps` and fills `appProps.pageProps`
+  const appProps = await App.getInitialProps(appContext)
+
+  return { ...appProps, extraProp: 'Hi There' }
+}
+
+export default MyApp

--- a/test/integration/404-page-app/pages/err.js
+++ b/test/integration/404-page-app/pages/err.js
@@ -1,0 +1,5 @@
+const page = () => 'custom 404 page'
+page.getInitialProps = () => {
+  throw new Error('oops')
+}
+export default page

--- a/test/integration/404-page-app/pages/index.js
+++ b/test/integration/404-page-app/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'hello from index'

--- a/test/integration/404-page-app/test/index.test.js
+++ b/test/integration/404-page-app/test/index.test.js
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  killApp,
+  findPort,
+  launchApp,
+  nextStart,
+  nextBuild,
+  fetchViaHTTP,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import cheerio from 'cheerio'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../')
+const gip404Err = /`pages\/404` can not have getInitialProps\/getServerSideProps/
+
+let appPort
+let app
+
+describe('404 Page Support with _app', () => {
+  describe('production mode', () => {
+    afterAll(() => killApp(app))
+
+    it('should build successfully', async () => {
+      const { code, stderr, stdout } = await nextBuild(appDir, [], {
+        stderr: true,
+        stdout: true,
+      })
+
+      expect(code).toBe(0)
+      expect(stderr).not.toMatch(gip404Err)
+      expect(stdout).not.toMatch(gip404Err)
+
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+
+    it('should not output static 404 if _app has getInitialProps', async () => {
+      const browser = await webdriver(appPort, '/404')
+      const isAutoExported = await browser.eval('__NEXT_DATA__.autoExport')
+      expect(isAutoExported).toBe(null)
+    })
+
+    it('specify to use the 404 page still in the routes-manifest', async () => {
+      const manifest = await fs.readJSON(
+        join(appDir, '.next/routes-manifest.json')
+      )
+      expect(manifest.pages404).toBe(true)
+    })
+
+    it('should still use 404 page', async () => {
+      const res = await fetchViaHTTP(appPort, '/abc')
+      expect(res.status).toBe(404)
+      const $ = cheerio.load(await res.text())
+      expect($('#404-title').text()).toBe('Hi There')
+    })
+  })
+
+  describe('dev mode', () => {
+    let stderr = ''
+    let stdout = ''
+
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {
+        onStderr(msg) {
+          stderr += msg
+        },
+        onStdout(msg) {
+          stdout += msg
+        },
+      })
+    })
+    afterAll(() => killApp(app))
+
+    it('should not show pages/404 GIP error if _app has GIP', async () => {
+      const res = await fetchViaHTTP(appPort, '/abc')
+      expect(res.status).toBe(404)
+      const $ = cheerio.load(await res.text())
+      expect($('#404-title').text()).toBe('Hi There')
+      expect(stderr).not.toMatch(gip404Err)
+      expect(stdout).not.toMatch(gip404Err)
+    })
+  })
+})

--- a/test/integration/404-page-custom-error/test/index.test.js
+++ b/test/integration/404-page-custom-error/test/index.test.js
@@ -10,6 +10,7 @@ import {
   nextBuild,
   renderViaHTTP,
   fetchViaHTTP,
+  getPageFileFromPagesManifest,
 } from 'next-test-utils'
 
 jest.setTimeout(1000 * 60 * 2)
@@ -18,7 +19,6 @@ const appDir = join(__dirname, '../')
 const nextConfig = join(appDir, 'next.config.js')
 
 let appPort
-let buildId
 let app
 
 const runTests = (mode) => {
@@ -47,21 +47,8 @@ const runTests = (mode) => {
     })
 
     it('should have output 404.html', async () => {
-      expect(
-        await fs
-          .access(
-            join(
-              appDir,
-              '.next',
-              ...(mode === 'server'
-                ? ['server', 'static', buildId, 'pages']
-                : ['serverless', 'pages']),
-              '404.html'
-            )
-          )
-          .then(() => true)
-          .catch(() => false)
-      ).toBe(true)
+      const page = getPageFileFromPagesManifest(appDir, '/404')
+      expect(page.endsWith('.html')).toBe(true)
     })
   }
 }
@@ -81,7 +68,6 @@ describe('Default 404 Page with custom _error', () => {
       appPort = await findPort()
 
       app = await nextStart(appDir, appPort)
-      buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
     })
 
     runTests('server')
@@ -109,7 +95,6 @@ describe('Default 404 Page with custom _error', () => {
 
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
-      buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
     })
 
     runTests('serverless')

--- a/test/integration/404-page/test/index.test.js
+++ b/test/integration/404-page/test/index.test.js
@@ -11,6 +11,7 @@ import {
   renderViaHTTP,
   fetchViaHTTP,
   waitFor,
+  getPageFileFromPagesManifest,
 } from 'next-test-utils'
 
 jest.setTimeout(1000 * 60 * 2)
@@ -21,7 +22,6 @@ const nextConfig = join(appDir, 'next.config.js')
 const gip404Err = /`pages\/404` can not have getInitialProps\/getServerSideProps/
 
 let nextConfigContent
-let buildId
 let appPort
 let app
 
@@ -50,18 +50,8 @@ const runTests = (mode = 'server') => {
 
   if (mode !== 'dev') {
     it('should output 404.html during build', async () => {
-      expect(
-        await fs.exists(
-          join(
-            appDir,
-            '.next',
-            mode === 'serverless'
-              ? 'serverless/pages'
-              : `server/static/${buildId}/pages`,
-            '404.html'
-          )
-        )
-      ).toBe(true)
+      const page = getPageFileFromPagesManifest(appDir, '/404')
+      expect(page.endsWith('.html')).toBe(true)
     })
 
     it('should add /404 to pages-manifest correctly', async () => {
@@ -78,7 +68,6 @@ describe('404 Page Support', () => {
     beforeAll(async () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
-      buildId = 'development'
     })
     afterAll(() => killApp(app))
 
@@ -90,7 +79,6 @@ describe('404 Page Support', () => {
       await nextBuild(appDir)
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
-      buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
     })
     afterAll(() => killApp(app))
 
@@ -111,7 +99,6 @@ describe('404 Page Support', () => {
       await nextBuild(appDir)
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
-      buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
     })
     afterAll(async () => {
       await fs.writeFile(nextConfig, nextConfigContent)

--- a/test/integration/404-page/test/index.test.js
+++ b/test/integration/404-page/test/index.test.js
@@ -17,7 +17,6 @@ jest.setTimeout(1000 * 60 * 2)
 
 const appDir = join(__dirname, '../')
 const pages404 = join(appDir, 'pages/404.js')
-const appPage = join(appDir, 'pages/_app.js')
 const nextConfig = join(appDir, 'next.config.js')
 const gip404Err = /`pages\/404` can not have getInitialProps\/getServerSideProps/
 
@@ -274,86 +273,5 @@ describe('404 Page Support', () => {
     await fs.move(`${pages404}.bak`, pages404)
 
     expect(stderr).toMatch(gip404Err)
-  })
-
-  describe('_app with getInitialProps', () => {
-    beforeAll(() =>
-      fs.writeFile(
-        appPage,
-        `
-      import NextApp from 'next/app'
-      const App = ({ Component, pageProps }) => <Component {...pageProps} />
-      App.getInitialProps = NextApp.getInitialProps
-      export default App
-    `
-      )
-    )
-    afterAll(() => fs.remove(appPage))
-
-    describe('production mode', () => {
-      afterAll(() => killApp(app))
-
-      it('should build successfully', async () => {
-        const { code, stderr, stdout } = await nextBuild(appDir, [], {
-          stderr: true,
-          stdout: true,
-        })
-
-        expect(code).toBe(0)
-        expect(stderr).not.toMatch(gip404Err)
-        expect(stdout).not.toMatch(gip404Err)
-
-        appPort = await findPort()
-        app = await nextStart(appDir, appPort)
-        buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
-      })
-
-      it('should not output static 404 if _app has getInitialProps', async () => {
-        expect(
-          await fs.exists(
-            join(appDir, '.next/server/static', buildId, 'pages/404.html')
-          )
-        ).toBe(false)
-      })
-
-      it('specify to use the 404 page still in the routes-manifest', async () => {
-        const manifest = await fs.readJSON(
-          join(appDir, '.next/routes-manifest.json')
-        )
-        expect(manifest.pages404).toBe(true)
-      })
-
-      it('should still use 404 page', async () => {
-        const res = await fetchViaHTTP(appPort, '/abc')
-        expect(res.status).toBe(404)
-        expect(await res.text()).toContain('custom 404 page')
-      })
-    })
-
-    describe('dev mode', () => {
-      let stderr = ''
-      let stdout = ''
-
-      beforeAll(async () => {
-        appPort = await findPort()
-        app = await launchApp(appDir, appPort, {
-          onStderr(msg) {
-            stderr += msg
-          },
-          onStdout(msg) {
-            stdout += msg
-          },
-        })
-      })
-      afterAll(() => killApp(app))
-
-      it('should not show pages/404 GIP error if _app has GIP', async () => {
-        const res = await fetchViaHTTP(appPort, '/abc')
-        expect(res.status).toBe(404)
-        expect(await res.text()).toContain('custom 404 page')
-        expect(stderr).not.toMatch(gip404Err)
-        expect(stdout).not.toMatch(gip404Err)
-      })
-    })
   })
 })

--- a/test/integration/amphtml-ssg/test/index.test.js
+++ b/test/integration/amphtml-ssg/test/index.test.js
@@ -117,13 +117,8 @@ describe('AMP SSG Support', () => {
       await nextBuild(appDir)
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
-      const buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
-      builtServerPagesDir = join(
-        appDir,
-        '.next/server/static',
-        buildId,
-        'pages'
-      )
+      // TODO: use browser instead to do checks that now need filesystem access
+      builtServerPagesDir = join(appDir, '.next', 'server', 'pages')
     })
     afterAll(() => killApp(app))
     runTests()

--- a/test/integration/amphtml/pages/nav.js
+++ b/test/integration/amphtml/pages/nav.js
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+if (typeof window !== 'undefined') {
+  window.NAV_PAGE_LOADED = true
+}
+
+export default function Nav() {
+  return (
+    <ul>
+      <li>
+        <Link href="/only-amp">
+          <a id="only-amp-link">AMP First Page</a>
+        </Link>
+      </li>
+    </ul>
+  )
+}

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -2,13 +2,7 @@
 
 import { validateAMP } from 'amp-test-utils'
 import cheerio from 'cheerio'
-import {
-  accessSync,
-  readFile,
-  readFileSync,
-  writeFile,
-  writeFileSync,
-} from 'fs-extra'
+import { readFile, readFileSync, writeFile, writeFileSync } from 'fs-extra'
 import {
   check,
   findPort,
@@ -72,31 +66,12 @@ describe('AMP Usage', () => {
       })
 
       it('should not output client pages for AMP only', async () => {
-        const buildId = readFileSync(join(appDir, '.next/BUILD_ID'), 'utf8')
-        const ampOnly = ['only-amp', 'root-hmr', 'another-amp']
-        for (const pg of ampOnly) {
-          expect(() =>
-            accessSync(
-              join(appDir, '.next/static', buildId, 'pages', pg + '.js')
-            )
-          ).toThrow()
-          expect(() =>
-            accessSync(
-              join(
-                appDir,
-                '.next/server/static',
-                buildId,
-                'pages',
-                pg + '.html'
-              )
-            )
-          ).not.toThrow()
-          expect(() =>
-            accessSync(
-              join(appDir, '.next/server/static', buildId, 'pages', pg + '.js')
-            )
-          ).toThrow()
-        }
+        const browser = await webdriver(appPort, '/nav')
+        await browser.elementByCss('#only-amp-link').click()
+
+        const result = await browser.eval('window.NAV_PAGE_LOADED')
+
+        expect(result).toBe(null)
       })
 
       it('should add link preload for amp script', async () => {
@@ -285,51 +260,12 @@ describe('AMP Usage', () => {
     })
 
     it('should not output client pages for AMP only', async () => {
-      const buildId = readFileSync(join(appDir, '.next/BUILD_ID'), 'utf8')
-      const ampOnly = ['only-amp', 'root-hmr', 'another-amp']
-      for (const pg of ampOnly) {
-        expect(() =>
-          accessSync(join(appDir, '.next/static', buildId, 'pages', pg + '.js'))
-        ).toThrow()
-        expect(() =>
-          accessSync(
-            join(appDir, '.next/server/static', buildId, 'pages', pg + '.html')
-          )
-        ).not.toThrow()
-        expect(() =>
-          accessSync(
-            join(appDir, '.next/server/static', buildId, 'pages', pg + '.js')
-          )
-        ).toThrow()
-      }
-    })
+      const browser = await webdriver(appPort, '/nav')
+      await browser.elementByCss('#only-amp-link').click()
 
-    it('should not output modern client pages for AMP only', async () => {
-      const buildId = readFileSync(join(appDir, '.next/BUILD_ID'), 'utf8')
-      const ampOnly = ['only-amp', 'root-hmr', 'another-amp']
-      for (const pg of ampOnly) {
-        expect(() =>
-          accessSync(
-            join(appDir, '.next/static', buildId, 'pages', pg + '.module.js')
-          )
-        ).toThrow()
-        expect(() =>
-          accessSync(
-            join(appDir, '.next/server/static', buildId, 'pages', pg + '.html')
-          )
-        ).not.toThrow()
-        expect(() =>
-          accessSync(
-            join(
-              appDir,
-              '.next/server/static',
-              buildId,
-              'pages',
-              pg + '.module.js'
-            )
-          )
-        ).toThrow()
-      }
+      const result = await browser.eval('window.NAV_PAGE_LOADED')
+
+      expect(result).toBe(null)
     })
   })
 

--- a/test/integration/chunking/next.config.js
+++ b/test/integration/chunking/next.config.js
@@ -1,7 +1,6 @@
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin
 module.exports = {
-  assetPrefix: '/foo/',
   webpack(config) {
     config.plugins = config.plugins || []
     config.plugins.push(

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -4,9 +4,6 @@ import cheerio from 'cheerio'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
 import { join } from 'path'
 import url from 'url'
-import { getPageFileFromBuildManifest } from 'next-test-utils'
-
-const appDir = join(__dirname, '../')
 
 export default function (render, fetch) {
   async function get$(path, query) {
@@ -266,25 +263,6 @@ export default function (render, fetch) {
     test('should render page that has module.exports anywhere', async () => {
       const res = await fetch('/exports')
       expect(res.status).toBe(200)
-    })
-
-    test('should expose the compiled page file in development', async () => {
-      await fetch('/stateless') // make sure the stateless page is built
-      const statelessPageFile = getPageFileFromBuildManifest(
-        appDir,
-        '/stateless'
-      )
-      const clientSideJsRes = await fetch(join('/_next', statelessPageFile))
-      expect(clientSideJsRes.status).toBe(200)
-      const clientSideJsBody = await clientSideJsRes.text()
-      expect(clientSideJsBody).toMatch(/My component!/)
-
-      const serverSideJsRes = await fetch(
-        '/_next/development/server/static/development/pages/stateless.js'
-      )
-      expect(serverSideJsRes.status).toBe(200)
-      const serverSideJsBody = await serverSideJsRes.text()
-      expect(serverSideJsBody).toMatch(/My component!/)
     })
 
     test('allows to import .json files', async () => {

--- a/test/integration/externalize-next-server/test/index.test.js
+++ b/test/integration/externalize-next-server/test/index.test.js
@@ -1,26 +1,19 @@
 /* eslint-env jest */
-
-import fs from 'fs-extra'
 import path from 'path'
-import { nextBuild } from 'next-test-utils'
+import { nextBuild, readNextBuildServerPageFile } from 'next-test-utils'
 import escapeStringRegexp from 'escape-string-regexp'
 
 jest.setTimeout(1000 * 60 * 1)
 
 const appDir = path.join(__dirname, '../app')
-let buildId
 
 describe('externalize next/dist/next-server', () => {
   beforeAll(async () => {
     await nextBuild(appDir)
-    buildId = await fs.readFile(path.join(appDir, '.next/BUILD_ID'), 'utf8')
   })
 
   it('Does not bundle next/dist/next-server/lib/head.js in _error', async () => {
-    const content = await fs.readFile(
-      path.join(appDir, '.next/server/static', buildId, 'pages/_error.js'),
-      'utf8'
-    )
+    const content = readNextBuildServerPageFile(appDir, '/_error')
     expect(content).toMatch(
       new RegExp(
         '^' +

--- a/test/integration/non-next-dist-exclude/test/index.test.js
+++ b/test/integration/non-next-dist-exclude/test/index.test.js
@@ -1,25 +1,18 @@
 /* eslint-env jest */
-
-import fs from 'fs-extra'
 import path from 'path'
-import { nextBuild } from 'next-test-utils'
+import { nextBuild, readNextBuildServerPageFile } from 'next-test-utils'
 
 jest.setTimeout(1000 * 60 * 1)
 
 const appDir = path.join(__dirname, '../app')
-let buildId
 
 describe('Non-Next externalization', () => {
   beforeAll(async () => {
     await nextBuild(appDir)
-    buildId = await fs.readFile(path.join(appDir, '.next/BUILD_ID'), 'utf8')
   })
 
   it('Externalized non-Next dist-using package', async () => {
-    const content = await fs.readFile(
-      path.join(appDir, '.next/server/static', buildId, 'pages/index.js'),
-      'utf8'
-    )
+    const content = readNextBuildServerPageFile(appDir, '/')
     expect(content).not.toContain('BrokenExternalMarker')
   })
 })

--- a/test/integration/prerender-no-revalidate/test/index.test.js
+++ b/test/integration/prerender-no-revalidate/test/index.test.js
@@ -21,14 +21,13 @@ let buildId
 let stderr
 
 function runTests(route, routePath, serverless) {
-  const fileName = join(
-    appDir,
-    '.next',
-    serverless ? 'serverless' : 'server',
-    getPageFileFromPagesManifest(appDir, routePath)
-  )
-
   it(`[${route}] should not revalidate when set to false`, async () => {
+    const fileName = join(
+      appDir,
+      '.next',
+      serverless ? 'serverless' : 'server',
+      getPageFileFromPagesManifest(appDir, routePath)
+    )
     const initialHtml = await renderViaHTTP(appPort, route)
     const initialFileHtml = await fs.readFile(fileName, 'utf8')
 
@@ -52,6 +51,12 @@ function runTests(route, routePath, serverless) {
   })
 
   it(`[${route}] should not revalidate /_next/data when set to false`, async () => {
+    const fileName = join(
+      appDir,
+      '.next',
+      serverless ? 'serverless' : 'server',
+      getPageFileFromPagesManifest(appDir, routePath)
+    )
     const route = join(`/_next/data/${buildId}`, `${routePath}.json`)
 
     const initialData = JSON.parse(await renderViaHTTP(appPort, route))

--- a/test/integration/prerender-no-revalidate/test/index.test.js
+++ b/test/integration/prerender-no-revalidate/test/index.test.js
@@ -8,6 +8,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  getPageFileFromPagesManifest,
 } from 'next-test-utils'
 import { join } from 'path'
 
@@ -20,13 +21,14 @@ let buildId
 let stderr
 
 function runTests(route, routePath, serverless) {
+  const fileName = join(
+    appDir,
+    '.next',
+    serverless ? 'serverless' : 'server',
+    getPageFileFromPagesManifest(appDir, routePath)
+  )
+
   it(`[${route}] should not revalidate when set to false`, async () => {
-    const fileName = join(
-      appDir,
-      `.next`,
-      ...(serverless ? ['serverless'] : ['server', 'static', buildId]),
-      `pages/${routePath}.html`
-    )
     const initialHtml = await renderViaHTTP(appPort, route)
     const initialFileHtml = await fs.readFile(fileName, 'utf8')
 
@@ -51,12 +53,6 @@ function runTests(route, routePath, serverless) {
 
   it(`[${route}] should not revalidate /_next/data when set to false`, async () => {
     const route = join(`/_next/data/${buildId}`, `${routePath}.json`)
-    const fileName = join(
-      appDir,
-      `.next`,
-      ...(serverless ? ['serverless'] : ['server', 'static', buildId]),
-      `pages/${routePath}.json`
-    )
 
     const initialData = JSON.parse(await renderViaHTTP(appPort, route))
     const initialFileJson = await fs.readFile(fileName, 'utf8')
@@ -99,7 +95,7 @@ describe('SSG Prerender No Revalidate', () => {
     })
     afterAll(() => killApp(app))
 
-    runTests('/', '/index', true)
+    runTests('/', '/', true)
     runTests('/named', '/named', true)
     runTests('/nested', '/nested', true)
     runTests('/nested/named', '/nested/named', true)
@@ -121,7 +117,7 @@ describe('SSG Prerender No Revalidate', () => {
     })
     afterAll(() => killApp(app))
 
-    runTests('/', '/index')
+    runTests('/', '/')
     runTests('/named', '/named')
     runTests('/nested', '/nested')
     runTests('/nested/named', '/nested/named')

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -1482,7 +1482,8 @@ describe('SSG Prerender', () => {
         },
       })
       buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
-      distPagesDir = join(appDir, '.next/server/static', buildId, 'pages')
+      // TODO: Don't rely on this path
+      distPagesDir = join(appDir, '.next', 'server', 'pages')
     })
     afterAll(() => killApp(app))
 

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -25,7 +25,7 @@ async function checkInjected(browser) {
 }
 
 module.exports = (context) => {
-  describe('With Security Related Issues', () => {
+  describe.skip('With Security Related Issues', () => {
     it('should only access files inside .next directory', async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
 

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -25,7 +25,7 @@ async function checkInjected(browser) {
 }
 
 module.exports = (context) => {
-  describe.skip('With Security Related Issues', () => {
+  describe('With Security Related Issues', () => {
     it('should only access files inside .next directory', async () => {
       const buildId = readFileSync(join(__dirname, '../.next/BUILD_ID'), 'utf8')
 

--- a/test/integration/serverless-trace/test/index.test.js
+++ b/test/integration/serverless-trace/test/index.test.js
@@ -11,6 +11,7 @@ import {
   fetchViaHTTP,
   renderViaHTTP,
   readNextBuildClientPageFile,
+  getPageFileFromPagesManifest,
 } from 'next-test-utils'
 import fetch from 'node-fetch'
 
@@ -117,21 +118,23 @@ describe('Serverless Trace', () => {
   })
 
   it('should replace static pages with HTML files', async () => {
-    const staticFiles = ['abc', 'dynamic', 'dynamic-two', 'some-amp']
-    for (const file of staticFiles) {
-      expect(existsSync(join(serverlessDir, file + '.html'))).toBe(true)
-      expect(existsSync(join(serverlessDir, file + '.js'))).toBe(false)
+    const pages = ['/abc', '/dynamic', '/dynamic-two', '/some-amp']
+    for (const page of pages) {
+      const file = getPageFileFromPagesManifest(appDir, page)
+
+      expect(file.endsWith('.html')).toBe(true)
     }
   })
 
   it('should not replace non-static pages with HTML files', async () => {
-    const nonStaticFiles = ['fetch', '_error']
-    for (const file of nonStaticFiles) {
-      expect(existsSync(join(serverlessDir, file + '.js'))).toBe(true)
-      expect(existsSync(join(serverlessDir, file + '.html'))).toBe(false)
+    const pages = ['/fetch', '/_error']
+
+    for (const page of pages) {
+      const file = getPageFileFromPagesManifest(appDir, page)
+
+      expect(file.endsWith('.js')).toBe(true)
     }
   })
-
   it('should reply on API request successfully', async () => {
     const content = await renderViaHTTP(appPort, '/api/hello')
     expect(content).toMatch(/hello world/)

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -13,6 +13,7 @@ import {
   fetchViaHTTP,
   renderViaHTTP,
   getPageFileFromBuildManifest,
+  getPageFileFromPagesManifest,
 } from 'next-test-utils'
 import qs from 'querystring'
 import path from 'path'
@@ -186,18 +187,21 @@ describe('Serverless', () => {
   })
 
   it('should replace static pages with HTML files', async () => {
-    const staticFiles = ['abc', 'dynamic', 'dynamic-two', 'some-amp']
-    for (const file of staticFiles) {
-      expect(existsSync(join(serverlessDir, file + '.html'))).toBe(true)
-      expect(existsSync(join(serverlessDir, file + '.js'))).toBe(false)
+    const pages = ['/abc', '/dynamic', '/dynamic-two', '/some-amp']
+    for (const page of pages) {
+      const file = getPageFileFromPagesManifest(appDir, page)
+
+      expect(file.endsWith('.html')).toBe(true)
     }
   })
 
   it('should not replace non-static pages with HTML files', async () => {
-    const nonStaticFiles = ['fetch', '_error']
-    for (const file of nonStaticFiles) {
-      expect(existsSync(join(serverlessDir, file + '.js'))).toBe(true)
-      expect(existsSync(join(serverlessDir, file + '.html'))).toBe(false)
+    const pages = ['/fetch', '/_error']
+
+    for (const page of pages) {
+      const file = getPageFileFromPagesManifest(appDir, page)
+
+      expect(file.endsWith('.js')).toBe(true)
     }
   })
 

--- a/test/integration/static-404/test/index.test.js
+++ b/test/integration/static-404/test/index.test.js
@@ -13,10 +13,8 @@ import {
 jest.setTimeout(1000 * 60 * 2)
 const appDir = join(__dirname, '..')
 const nextConfig = join(appDir, 'next.config.js')
-const static404 = join(appDir, '.next/server/static/test-id/pages/404.html')
 const appPage = join(appDir, 'pages/_app.js')
 const errorPage = join(appDir, 'pages/_error.js')
-const buildId = `generateBuildId: () => 'test-id'`
 let app
 let appPort
 
@@ -29,10 +27,6 @@ describe('Static 404 page', () => {
   beforeEach(() => fs.remove(join(appDir, '.next/server')))
 
   describe('With config enabled', () => {
-    beforeEach(() =>
-      fs.writeFile(nextConfig, `module.exports = { ${buildId} }`)
-    )
-
     it('should export 404 page without custom _error', async () => {
       await nextBuild(appDir)
       appPort = await findPort()
@@ -40,7 +34,6 @@ describe('Static 404 page', () => {
       const html = await renderViaHTTP(appPort, '/non-existent')
       await killApp(app)
       expect(html).toContain('This page could not be found')
-      expect(await fs.exists(static404)).toBe(true)
     })
 
     it('should export 404 page without custom _error (serverless)', async () => {
@@ -76,7 +69,6 @@ describe('Static 404 page', () => {
       )
       await nextBuild(appDir)
       await fs.remove(errorPage)
-      expect(await fs.exists(static404)).toBe(false)
     })
 
     it('should not export 404 page with getInitialProps in _app', async () => {
@@ -92,7 +84,6 @@ describe('Static 404 page', () => {
       )
       await nextBuild(appDir)
       await fs.remove(appPage)
-      expect(await fs.exists(static404)).toBe(false)
     })
   })
 })

--- a/test/integration/static-404/test/index.test.js
+++ b/test/integration/static-404/test/index.test.js
@@ -58,9 +58,6 @@ describe('Static 404 page', () => {
       const html = await renderViaHTTP(appPort, '/non-existent')
       await killApp(app)
       expect(html).toContain('This page could not be found')
-      expect(
-        await fs.exists(join(appDir, '.next/serverless/pages/404.html'))
-      ).toBe(true)
     })
 
     it('should not export 404 page with custom _error GIP', async () => {

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -493,8 +493,12 @@ export function normalizeRegEx(src) {
   return new RegExp(src).source.replace(/\^\//g, '^\\/')
 }
 
+function readJson(path) {
+  return JSON.parse(readFileSync(path))
+}
+
 export function getBuildManifest(dir) {
-  return JSON.parse(readFileSync(path.join(dir, '.next/build-manifest.json')))
+  return readJson(path.join(dir, '.next/build-manifest.json'))
 }
 
 export function getPageFileFromBuildManifest(dir, page) {
@@ -522,7 +526,12 @@ export function readNextBuildClientPageFile(appDir, page) {
 }
 
 export function getPagesManifest(dir) {
-  return require(path.join(dir, '.next/server/pages-manifest.json'))
+  const serverFile = path.join(dir, '.next/server/pages-manifest.json')
+
+  if (existsSync(serverFile)) {
+    return readJson(serverFile)
+  }
+  return readJson(path.join(dir, '.next/serverless/pages-manifest.json'))
 }
 
 export function getPageFileFromPagesManifest(dir, page) {


### PR DESCRIPTION
Gets rid of the custom function for naming files by removing buildId from the file paths.