### PR TITLE
Do not remove no-FOUC styles too early

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/loaders/client.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/client.ts
@@ -29,25 +29,6 @@ export function getClientStyleLoader({
             // anchor. By inserting before and not after, we do not
             // need to track the last inserted element.
             parentNode.insertBefore(element, anchorElement)
-
-            // Remember: this is development only code.
-            //
-            // After styles are injected, we need to remove the
-            // <style> tags that set `body { display: none; }`.
-            //
-            // We use `requestAnimationFrame` as a way to defer
-            // this operation since there may be multiple style
-            // tags.
-            ;(self.requestAnimationFrame || setTimeout)(function () {
-              for (
-                var x = document.querySelectorAll('[data-next-hide-fouc]'),
-                  i = x.length;
-                i--;
-
-              ) {
-                x[i].parentNode!.removeChild(x[i])
-              }
-            })
           },
         },
       }

--- a/packages/next/client/dev/fouc.js
+++ b/packages/next/client/dev/fouc.js
@@ -1,7 +1,7 @@
+// This function is used to remove Next.js' no-FOUC styles workaround for using
+// `style-loader` in development. It must be called before hydration, or else
+// rendering won't have the correct computed values in effects.
 export function displayContent(callback) {
-  // This is the fallback helper that removes Next.js' no-FOUC styles when
-  // CSS mode is enabled. This only really activates if you haven't created
-  // _any_ styles in your application yet.
   ;(window.requestAnimationFrame || setTimeout)(function () {
     for (
       var x = document.querySelectorAll('[data-next-hide-fouc]'), i = x.length;


### PR DESCRIPTION
We previously used to remove our FOUC helper inside of the style injection to ensure content was shown as fast as possible.

This behavior, however, was problematic for a few reasons:

1. Large JavaScript chunks would take longer than an animation frame to parse, causing FOUC
1. Rendering would sometimes complete before an animation frame, causing improper effects

To fix the latter, we started removing the no FOUC helper **before** rendering, however, we never fixed the former by removing the dead code.

There's not a great way to test this because the FOUC is so fast and flaky, however, this code really shouldn't exist and isn't likely to be re-added (regress).

Also, we already have FOUC tests that occasionally flake, probably due to this.


Fixes #12448
Fixes #13058
Fixes #11195
Fixes #10404