### PR TITLE
Update route regex for optional catch-all parameters in named regexes

### DIFF
--- a/packages/next/next-server/lib/router/utils/route-regex.ts
+++ b/packages/next/next-server/lib/router/utils/route-regex.ts
@@ -1,3 +1,9 @@
+interface Group {
+  pos: number
+  repeat: boolean
+  optional: boolean
+}
+
 // this isn't importing the escape-string-regex module
 // to reduce bytes
 function escapeRegex(str: string) {
@@ -23,54 +29,52 @@ export function getRouteRegex(
   re: RegExp
   namedRegex?: string
   routeKeys?: { [named: string]: string }
-  groups: {
-    [groupName: string]: { pos: number; repeat: boolean; optional: boolean }
-  }
+  groups: { [groupName: string]: Group }
 } {
   const segments = (normalizedRoute.replace(/\/$/, '') || '/')
-    .split('/')
     .slice(1)
+    .split('/')
 
-  const groups: {
-    [groupName: string]: { pos: number; repeat: boolean; optional: boolean }
-  } = {}
+  const groups: { [groupName: string]: Group } = {}
   let groupIndex = 1
+  let parameterizedRoute = ''
 
-  const parameterizedRoute = segments
-    .map((seg) => {
-      if (seg.startsWith('[') && seg.endsWith(']')) {
-        const { key, optional, repeat } = parseParameter(seg.slice(1, -1))
-        groups[key] = { pos: groupIndex++, repeat, optional }
-        return repeat ? (optional ? '(?:/(.+?))?' : '/(.+?)') : '/([^/]+?)'
-      } else {
-        return `/${escapeRegex(seg)}`
-      }
-    })
-    .join('')
+  for (const segment of segments) {
+    if (segment.startsWith('[') && segment.endsWith(']')) {
+      const { key, optional, repeat } = parseParameter(segment.slice(1, -1))
+      groups[key] = { pos: groupIndex++, repeat, optional }
+      parameterizedRoute += repeat
+        ? optional
+          ? '(?:/(.+?))?'
+          : '/(.+?)'
+        : '/([^/]+?)'
+    } else {
+      parameterizedRoute += `/${escapeRegex(segment)}`
+    }
+  }
 
   // dead code eliminate for browser since it's only needed
   // while generating routes-manifest
   if (typeof window === 'undefined') {
     const routeKeys: { [named: string]: string } = {}
 
-    const namedParameterizedRoute = segments
-      .map((seg) => {
-        if (seg.startsWith('[') && seg.endsWith(']')) {
-          const { key, optional, repeat } = parseParameter(seg.slice(1, -1))
-          // replace any non-word characters since they can break
-          // the named regex
-          const cleanedKey = key.replace(/\W/g, '')
-          routeKeys[cleanedKey] = key
-          return repeat
-            ? optional
-              ? `(?:/(?<${cleanedKey}>.+?))?`
-              : `/(?<${cleanedKey}>.+?)`
-            : `/(?<${cleanedKey}>[^/]+?)`
-        } else {
-          return `/${escapeRegex(seg)}`
-        }
-      })
-      .join('')
+    let namedParameterizedRoute = ''
+    for (const segment of segments) {
+      if (segment.startsWith('[') && segment.endsWith(']')) {
+        const { key, optional, repeat } = parseParameter(segment.slice(1, -1))
+        // replace any non-word characters since they can break
+        // the named regex
+        const cleanedKey = key.replace(/\W/g, '')
+        routeKeys[cleanedKey] = key
+        namedParameterizedRoute += repeat
+          ? optional
+            ? `(?:/(?<${cleanedKey}>.+?))?`
+            : `/(?<${cleanedKey}>.+?)`
+          : `/(?<${cleanedKey}>[^/]+?)`
+      } else {
+        namedParameterizedRoute += `/${escapeRegex(segment)}`
+      }
+    }
 
     return {
       re: new RegExp(`^${parameterizedRoute}(?:/)?$`, 'i'),

--- a/packages/next/next-server/lib/router/utils/route-regex.ts
+++ b/packages/next/next-server/lib/router/utils/route-regex.ts
@@ -4,12 +4,8 @@ function escapeRegex(str: string) {
   return str.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&')
 }
 
-function unescapeRegex(str: string) {
-  return str.replace(/\\([|\\{}()[\]^$+*?.-])/g, '$1')
-}
-
 function parseParameter(param: string) {
-  let key = unescapeRegex(param)
+  let key = param
   const optional = key.startsWith('[') && key.endsWith(']')
   if (optional) {
     key = key.slice(1, -1)
@@ -31,42 +27,53 @@ export function getRouteRegex(
     [groupName: string]: { pos: number; repeat: boolean; optional: boolean }
   }
 } {
-  // Escape all characters that could be considered RegEx
-  const escapedRoute = escapeRegex(normalizedRoute.replace(/\/$/, '') || '/')
+  const segments = (normalizedRoute.replace(/\/$/, '') || '/')
+    .split('/')
+    .slice(1)
 
   const groups: {
     [groupName: string]: { pos: number; repeat: boolean; optional: boolean }
   } = {}
   let groupIndex = 1
 
-  const parameterizedRoute = escapedRoute.replace(
-    /\/\\\[([^/]+?)\\\](?=\/|$)/g,
-    (_, $1) => {
-      const { key, optional, repeat } = parseParameter($1)
-      groups[key] = { pos: groupIndex++, repeat, optional }
-      return repeat ? (optional ? '(?:/(.+?))?' : '/(.+?)') : '/([^/]+?)'
-    }
-  )
+  const parameterizedRoute = segments
+    .map((seg) => {
+      if (seg.startsWith('[') && seg.endsWith(']')) {
+        const { key, optional, repeat } = parseParameter(seg.slice(1, -1))
+        groups[key] = { pos: groupIndex++, repeat, optional }
+        return repeat ? (optional ? '(?:/(.+?))?' : '/(.+?)') : '/([^/]+?)'
+      } else {
+        return `/${escapeRegex(seg)}`
+      }
+    })
+    .join('')
 
   // dead code eliminate for browser since it's only needed
   // while generating routes-manifest
   if (typeof window === 'undefined') {
     const routeKeys: { [named: string]: string } = {}
 
-    const namedParameterizedRoute = escapedRoute.replace(
-      /\/\\\[([^/]+?)\\\](?=\/|$)/g,
-      (_, $1) => {
-        const { key, repeat } = parseParameter($1)
-        // replace any non-word characters since they can break
-        // the named regex
-        const cleanedKey = key.replace(/\W/g, '')
-        routeKeys[cleanedKey] = key
-        return repeat ? `/(?<${cleanedKey}>.+?)` : `/(?<${cleanedKey}>[^/]+?)`
-      }
-    )
+    const namedParameterizedRoute = segments
+      .map((seg) => {
+        if (seg.startsWith('[') && seg.endsWith(']')) {
+          const { key, optional, repeat } = parseParameter(seg.slice(1, -1))
+          // replace any non-word characters since they can break
+          // the named regex
+          const cleanedKey = key.replace(/\W/g, '')
+          routeKeys[cleanedKey] = key
+          return repeat
+            ? optional
+              ? `(?:/(?<${cleanedKey}>.+?))?`
+              : `/(?<${cleanedKey}>.+?)`
+            : `/(?<${cleanedKey}>[^/]+?)`
+        } else {
+          return `/${escapeRegex(seg)}`
+        }
+      })
+      .join('')
 
     return {
-      re: new RegExp('^' + parameterizedRoute + '(?:/)?$', 'i'),
+      re: new RegExp(`^${parameterizedRoute}(?:/)?$`, 'i'),
       groups,
       routeKeys,
       namedRegex: `^${namedParameterizedRoute}(?:/)?$`,
@@ -74,7 +81,7 @@ export function getRouteRegex(
   }
 
   return {
-    re: new RegExp('^' + parameterizedRoute + '(?:/)?$', 'i'),
+    re: new RegExp(`^${parameterizedRoute}(?:/)?$`, 'i'),
     groups,
   }
 }

--- a/packages/next/next-server/lib/router/utils/route-regex.ts
+++ b/packages/next/next-server/lib/router/utils/route-regex.ts
@@ -11,16 +11,15 @@ function escapeRegex(str: string) {
 }
 
 function parseParameter(param: string) {
-  let key = param
-  const optional = key.startsWith('[') && key.endsWith(']')
+  const optional = param.startsWith('[') && param.endsWith(']')
   if (optional) {
-    key = key.slice(1, -1)
+    param = param.slice(1, -1)
   }
-  const repeat = key.startsWith('...')
+  const repeat = param.startsWith('...')
   if (repeat) {
-    key = key.slice(3)
+    param = param.slice(3)
   }
-  return { key, repeat, optional }
+  return { key: param, repeat, optional }
 }
 
 export function getRouteRegex(

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -942,7 +942,7 @@ const runTests = (dev = false, isEmulatedServerless = false) => {
         {
           namedDataRouteRegex: `^/_next/data/${escapeRegex(
             buildId
-          )}/catchall\\-optional/(?<slug>.+?)\\.json$`,
+          )}/catchall\\-optional(?:/(?<slug>.+?))?\\.json$`,
           dataRouteRegex: normalizeRegEx(
             `^\\/_next\\/data\\/${escapeRegex(
               buildId


### PR DESCRIPTION
Noticed while working on https://github.com/vercel/next.js/pull/14400 that the optional catch-all handling was missing in `namedRegex`.

This whole file also seemed quite regex heavy so I took a look at the overall logic and changed a few things. It worked by regex escaping the whole route then unescape the dynamic parts. I changed it to only regex escape the static parts, this eliminates unnecessary back and forth escaping. It also makes the dynamic parts handling more readable. The whole logic is less reliant on regexes and just uses simple string manipulation to translate the route into a regex, I didn't measure anything but as an effect this should make it more performant.