### PR TITLE
Shave a few bytes off the bootstrap code

### DIFF
--- a/packages/next/client/next.js
+++ b/packages/next/client/next.js
@@ -2,6 +2,4 @@ import initNext, * as next from './'
 
 window.next = next
 
-initNext().catch((err) => {
-  console.error(`${err.message}\n${err.stack}`)
-})
+initNext().catch(console.error)


### PR DESCRIPTION
Saw in the client bootstrap script that the error message was printed alongside the stacktrace. This is unnecessary since the stacktrace already includes the error message. In fact, it seems like browsers already do a good job of printing an error with its stacktrace when you just print them using `console.error`. It's a bit minor, but this should shave off a few bytes of the bundle.