### PR TITLE
Ensure dev overlay uses basePath for requests

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
+++ b/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
@@ -46,12 +46,18 @@ export const CodeFrame: React.FC<CodeFrameProps> = function CodeFrame({
       params.append(key, (stackFrame[key] ?? '').toString())
     }
 
-    self.fetch(`/__nextjs_launch-editor?${params.toString()}`).then(
-      () => {},
-      () => {
-        // TODO: report error
-      }
-    )
+    self
+      .fetch(
+        `${
+          process.env.__NEXT_ROUTER_BASEPATH || ''
+        }/__nextjs_launch-editor?${params.toString()}`
+      )
+      .then(
+        () => {},
+        () => {
+          // TODO: report error
+        }
+      )
   }, [stackFrame])
 
   // TODO: make the caret absolute

--- a/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
+++ b/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
@@ -24,12 +24,18 @@ const CallStackFrame: React.FC<{
       params.append(key, (f[key] ?? '').toString())
     }
 
-    self.fetch(`/__nextjs_launch-editor?${params.toString()}`).then(
-      () => {},
-      () => {
-        // TODO: report error
-      }
-    )
+    self
+      .fetch(
+        `${
+          process.env.__NEXT_ROUTER_BASEPATH || ''
+        }/__nextjs_launch-editor?${params.toString()}`
+      )
+      .then(
+        () => {},
+        () => {
+          // TODO: report error
+        }
+      )
   }, [hasSource, f])
 
   return (

--- a/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
@@ -53,9 +53,14 @@ export function getOriginalStackFrame(
     const controller = new AbortController()
     const tm = setTimeout(() => controller.abort(), 3000)
     const res = await self
-      .fetch(`/__nextjs_original-stack-frame?${params.toString()}`, {
-        signal: controller.signal,
-      })
+      .fetch(
+        `${
+          process.env.__NEXT_ROUTER_BASEPATH || ''
+        }/__nextjs_original-stack-frame?${params.toString()}`,
+        {
+          signal: controller.signal,
+        }
+      )
       .finally(() => {
         clearTimeout(tm)
       })

--- a/test/integration/basepath/pages/hello.js
+++ b/test/integration/basepath/pages/hello.js
@@ -40,5 +40,13 @@ export default () => (
     </Link>
     <div id="base-path">{useRouter().basePath}</div>
     <div id="pathname">{useRouter().pathname}</div>
+    <div
+      id="trigger-error"
+      onClick={() => {
+        throw new Error('oops heres an error')
+      }}
+    >
+      click me for error
+    </div>
   </>
 )

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -41,7 +41,17 @@ const runTests = (context, dev = false) => {
       expect(await hasRedbox(browser)).toBe(true)
 
       const errorSource = await getRedboxSource(browser)
-      expect(errorSource).toContain('oops heres an error')
+      expect(errorSource).toMatchInlineSnapshot(`
+        "pages/hello.js (46:14) @ onClick
+
+          44 |   id=\\"trigger-error\\"
+          45 |   onClick={() => {
+        > 46 |     throw new Error('oops heres an error')
+             |          ^
+          47 |   }}
+          48 | >
+          49 |   click me for error"
+      `)
     })
   } else {
     it('should add basePath to routes-manifest', async () => {

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -42,15 +42,17 @@ const runTests = (context, dev = false) => {
 
       const errorSource = await getRedboxSource(browser)
       expect(errorSource).toMatchInlineSnapshot(`
-        "pages/hello.js (46:14) @ onClick
+        "pages${
+          process.platform === 'win32' ? '\\' : '/'
+        }hello.js (52:14) @ onClick
 
-          44 |   id=\\"trigger-error\\"
-          45 |   onClick={() => {
-        > 46 |     throw new Error('oops heres an error')
+          50 |   id=\\"trigger-error\\"
+          51 |   onClick={() => {
+        > 52 |     throw new Error('oops heres an error')
              |          ^
-          47 |   }}
-          48 | >
-          49 |   click me for error"
+          53 |   }}
+          54 | >
+          55 |   click me for error"
       `)
     })
   } else {

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -18,6 +18,8 @@ import {
   File,
   nextStart,
   initNextServerScript,
+  getRedboxSource,
+  hasRedbox,
 } from 'next-test-utils'
 import fs, {
   readFileSync,
@@ -32,7 +34,16 @@ jest.setTimeout(1000 * 60 * 2)
 const appDir = join(__dirname, '..')
 
 const runTests = (context, dev = false) => {
-  if (!dev) {
+  if (dev) {
+    it('should render error in dev overlay correctly', async () => {
+      const browser = await webdriver(context.appPort, '/docs/hello')
+      await browser.elementByCss('#trigger-error').click()
+      expect(await hasRedbox(browser)).toBe(true)
+
+      const errorSource = await getRedboxSource(browser)
+      expect(errorSource).toContain('oops heres an error')
+    })
+  } else {
     it('should add basePath to routes-manifest', async () => {
       const routesManifest = await fs.readJSON(
         join(appDir, '.next/routes-manifest.json')
@@ -317,7 +328,9 @@ describe('basePath development', () => {
 
   beforeAll(async () => {
     context.appPort = await findPort()
-    server = await launchApp(join(__dirname, '..'), context.appPort)
+    server = await launchApp(join(__dirname, '..'), context.appPort, {
+      env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
+    })
   })
   afterAll(async () => {
     await killApp(server)


### PR DESCRIPTION
This fixes the `basePath` not being used when making requests for the `react-dev-overlay`. We might want to pass down the `basePath` to the overlay instead of relying on the `process.env` injection although may be fine this way, will defer to @Timer for preferred way to pass this value to the dev-overlay

Closes: https://github.com/vercel/next.js/issues/14470