### PR TITLE
Dynamic imports failing in Jest tests

### DIFF
--- a/packages/next/next-server/lib/loadable.js
+++ b/packages/next/next-server/lib/loadable.js
@@ -146,7 +146,8 @@ function createLoadableComponent(loadFn, options) {
   if (
     !initialized &&
     typeof window !== 'undefined' &&
-    typeof opts.webpack === 'function'
+    typeof opts.webpack === 'function' &&
+    typeof require.resolveWeak === 'function'
   ) {
     const moduleIds = opts.webpack()
     READY_INITIALIZERS.push((ids) => {


### PR DESCRIPTION
Jest tests in nextJs are failing with the following error on dynamic imports

`TypeError: require.resolveWeak is not a function`. 

I have been migrating my code to nextJs and it has become a blocker. This issue has been reported and fixed multiple times: 

First fixed here: https://github.com/vercel/next.js/pull/3414
Then again fixed in: https://github.com/vercel/next.js/pull/4208

There is an ongoing discussion here: https://github.com/vercel/next.js/issues/5416 which was closed as apparently this should have been fixed. I have added `typeof require.resolveWeak === 'function'` condition. Tested with my own repo and an example repo here: https://github.com/ellsclytn/next-with-jest and the issue was fixed with this. 