### PR TITLE
Webpack 5 build compat

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -771,7 +771,7 @@ export default async function getBaseWebpackConfig(
     plugins: [
       hasReactRefresh && new ReactRefreshWebpackPlugin(),
       // This plugin makes sure `output.filename` is used for entry chunks
-      new ChunkNamesPlugin(),
+      !isWebpack5 && new ChunkNamesPlugin(),
       new webpack.DefinePlugin({
         ...Object.keys(process.env).reduce(
           (prev: { [key: string]: string }, key: string) => {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -358,7 +358,7 @@ export default async function getBaseWebpackConfig(
         defaultVendors: false,
         framework: {
           chunks: 'all',
-          name: 'framework',
+          name: isWebpack5 ? 'static/chunks/framework' : 'framework',
           // This regex ignores nested copies of framework libraries so they're
           // bundled with their issuer.
           // https://github.com/vercel/next.js/pull/9012
@@ -393,32 +393,36 @@ export default async function getBaseWebpackConfig(
               hash.update(module.libIdent({ context: dir }))
             }
 
-            return hash.digest('hex').substring(0, 8)
+            return isWebpack5
+              ? 'static/chunks/'
+              : '' + hash.digest('hex').substring(0, 8)
           },
           priority: 30,
           minChunks: 1,
           reuseExistingChunk: true,
         },
         commons: {
-          name: 'commons',
+          name: (isWebpack5 ? 'static/chunks/' : '') + 'commons',
           minChunks: totalPages,
           priority: 20,
         },
         shared: {
           name(module, chunks) {
-            return (
-              crypto
-                .createHash('sha1')
-                .update(
-                  chunks.reduce(
-                    (acc: string, chunk: webpack.compilation.Chunk) => {
-                      return acc + chunk.name
-                    },
-                    ''
-                  )
-                )
-                .digest('hex') + (isModuleCSS(module) ? '_CSS' : '')
-            )
+            return isWebpack5
+              ? 'static/chunks/'
+              : '' +
+                  (crypto
+                    .createHash('sha1')
+                    .update(
+                      chunks.reduce(
+                        (acc: string, chunk: webpack.compilation.Chunk) => {
+                          return acc + chunk.name
+                        },
+                        ''
+                      )
+                    )
+                    .digest('hex') +
+                    (isModuleCSS(module) ? '_CSS' : ''))
           },
           priority: 10,
           minChunks: 2,

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -393,9 +393,10 @@ export default async function getBaseWebpackConfig(
               hash.update(module.libIdent({ context: dir }))
             }
 
-            return isWebpack5
-              ? 'static/chunks/'
-              : '' + hash.digest('hex').substring(0, 8)
+            return (
+              (isWebpack5 ? 'static/chunks/' : '') +
+              hash.digest('hex').substring(0, 8)
+            )
           },
           priority: 30,
           minChunks: 1,
@@ -408,21 +409,21 @@ export default async function getBaseWebpackConfig(
         },
         shared: {
           name(module, chunks) {
-            return isWebpack5
-              ? 'static/chunks/'
-              : '' +
-                  (crypto
-                    .createHash('sha1')
-                    .update(
-                      chunks.reduce(
-                        (acc: string, chunk: webpack.compilation.Chunk) => {
-                          return acc + chunk.name
-                        },
-                        ''
-                      )
-                    )
-                    .digest('hex') +
-                    (isModuleCSS(module) ? '_CSS' : ''))
+            return (
+              (isWebpack5 ? 'static/chunks/' : '') +
+              (crypto
+                .createHash('sha1')
+                .update(
+                  chunks.reduce(
+                    (acc: string, chunk: webpack.compilation.Chunk) => {
+                      return acc + chunk.name
+                    },
+                    ''
+                  )
+                )
+                .digest('hex') +
+                (isModuleCSS(module) ? '_CSS' : ''))
+            )
           },
           priority: 10,
           minChunks: 2,

--- a/packages/next/client/dev/error-overlay/format-webpack-messages.js
+++ b/packages/next/client/dev/error-overlay/format-webpack-messages.js
@@ -32,6 +32,10 @@ function isLikelyASyntaxError(message) {
 
 // Cleans up webpack error messages.
 function formatMessage(message) {
+  // TODO: Replace this once webpack 5 is stable
+  if (typeof message === 'object' && message.message) {
+    message = message.message
+  }
   let lines = message.split('\n')
 
   // Strip Webpack-added headers off errors/warnings


### PR DESCRIPTION
Initial PR to make `next build` work with webpack 5, still needs more work to make sure runtimeChunk and such are shared between pages.

- No longer needs the custom ChunkNamesPlugin as the default behavior was changed
- Dropping AMP First client page bundles is now compatible