### PR TITLE
Remove unused package in with-apollo-and-redux example

### DIFF
--- a/examples/with-apollo-and-redux/package.json
+++ b/examples/with-apollo-and-redux/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "3.1.3",
-    "@apollo/react-ssr": "3.1.3",
     "apollo-cache-inmemory": "1.6.3",
     "apollo-client": "2.6.4",
     "apollo-link-http": "1.5.16",


### PR DESCRIPTION
Usage of `apollo/react-ssr` was removed when the example moved to SSG. 