### PR TITLE
Handle rendering next/head outside of Next.js

### DIFF
--- a/packages/next/next-server/lib/side-effect.tsx
+++ b/packages/next/next-server/lib/side-effect.tsx
@@ -15,31 +15,42 @@ type SideEffectProps = {
 }
 
 export default class extends Component<SideEffectProps> {
+  private _hasHeadManager: boolean
+
   emitChange = (): void => {
-    this.props.headManager.updateHead(
-      this.props.reduceComponentsToState(
-        [...this.props.headManager.mountedInstances],
-        this.props
+    if (this._hasHeadManager) {
+      this.props.headManager.updateHead(
+        this.props.reduceComponentsToState(
+          [...this.props.headManager.mountedInstances],
+          this.props
+        )
       )
-    )
+    }
   }
 
   constructor(props: any) {
     super(props)
-    if (isServer) {
+    this._hasHeadManager =
+      this.props.headManager && this.props.headManager.mountedInstances
+
+    if (isServer && this._hasHeadManager) {
       this.props.headManager.mountedInstances.add(this)
       this.emitChange()
     }
   }
   componentDidMount() {
-    this.props.headManager.mountedInstances.add(this)
+    if (this._hasHeadManager) {
+      this.props.headManager.mountedInstances.add(this)
+    }
     this.emitChange()
   }
   componentDidUpdate() {
     this.emitChange()
   }
   componentWillUnmount() {
-    this.props.headManager.mountedInstances.delete(this)
+    if (this._hasHeadManager) {
+      this.props.headManager.mountedInstances.delete(this)
+    }
     this.emitChange()
   }
 

--- a/test/unit/next-head-rendering.test.js
+++ b/test/unit/next-head-rendering.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+import Head from 'next/head'
+import React from 'react'
+import ReactDOM from 'react-dom/server'
+
+describe('Rendering next/head', () => {
+  it('should render outside of Next.js without error', () => {
+    const html = ReactDOM.renderToString(
+      React.createElement(
+        React.Fragment,
+        {},
+        React.createElement(Head, {}),
+        React.createElement('p', {}, 'hello world')
+      )
+    )
+    expect(html).toContain('hello world')
+  })
+})


### PR DESCRIPTION
This ensures `next/head` doesn't fail to render when being rendered during tests or outside of Next.js' tree

Closes: https://github.com/vercel/next.js/issues/14425