### PR TITLE
Avoid adding basePath when it's not needed

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -9,6 +9,7 @@ import { RouterContext } from '../next-server/lib/router-context'
 import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
 import * as envConfig from '../next-server/lib/runtime-config'
 import { getURL, loadGetInitialProps, ST } from '../next-server/lib/utils'
+import { delBasePath } from '../next-server/lib/router/router'
 import initHeadManager from './head-manager'
 import PageLoader from './page-loader'
 import measureWebVitals from './performance-relayer'
@@ -48,7 +49,7 @@ envConfig.setConfig({
   publicRuntimeConfig: runtimeConfig || {},
 })
 
-const asPath = getURL()
+const asPath = delBasePath(getURL())
 
 const pageLoader = new PageLoader(buildId, prefix, page)
 const register = ([r, f]) => pageLoader.registerPage(r, f)

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -263,7 +263,7 @@ export default class Router implements BaseRouter {
         this.changeState(
           'replaceState',
           formatWithValidation({ pathname: addBasePath(pathname), query }),
-          as
+          addBasePath(as)
         )
       }
 

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -21,7 +21,7 @@ import getAssetPathFromRoute from './utils/get-asset-path-from-route'
 const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
 export function addBasePath(path: string): string {
-  return path.startsWith(basePath) ? path : `${basePath}${path}`;
+  return path.startsWith(basePath) ? path : `${basePath}${path}`
 }
 
 export function delBasePath(path: string): string {

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -21,7 +21,7 @@ import getAssetPathFromRoute from './utils/get-asset-path-from-route'
 const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
 export function addBasePath(path: string): string {
-  return path.startsWith(basePath) ? path : `${basePath}${path}`
+  return `${basePath}${path}`
 }
 
 export function delBasePath(path: string): string {

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -21,7 +21,7 @@ import getAssetPathFromRoute from './utils/get-asset-path-from-route'
 const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
 export function addBasePath(path: string): string {
-  return `${basePath}${path}`
+  return path.startsWith(basePath) ? path : `${basePath}${path}`;
 }
 
 export function delBasePath(path: string): string {

--- a/test/integration/basepath/pages/[slug].js
+++ b/test/integration/basepath/pages/[slug].js
@@ -1,3 +1,3 @@
 import { useRouter } from 'next/router'
 
-export default () => <p>slug: {useRouter().query.slug}</p>
+export default () => <p id="slug">slug: {useRouter().query.slug}</p>

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -116,6 +116,12 @@ const runTests = (context, dev = false) => {
     })
   }
 
+  it('should update dynamic params after mount correctly', async () => {
+    const browser = await webdriver(context.appPort, '/docs/hello-dynamic')
+    const text = await browser.elementByCss('#slug').text()
+    expect(text).toContain('slug: hello-dynamic')
+  })
+
   it('should navigate to index page with getStaticProps', async () => {
     const browser = await webdriver(context.appPort, '/docs/hello')
     await browser.eval('window.beforeNavigate = "hi"')


### PR DESCRIPTION
### Bug description 

When using the `basePath` on pages with params it will fire a router change. This will pass the url pathname in the `as` param using the `getUrl()` function. When the app is mounted on a sub-path (which is the whole point of the `basePath`) the url will from `window.location.href` which will already include the base path.

What this means is that the `as` path will be sent through to the router already including the `basePath`, leading to `/basePath/basePath/path` which will cause the router to throw an error about mis-matched `as` and `href` params.

### Reproduction 
[Here's a reproduction](https://github.com/anthonyshort/next-basepath-param) that uses nginx to route `/sub/path` to the Next app. The `basePath` is also set to `/sub/path`. It's not trying to do anything special other than rendering and grabbing the param using the router hook. 

- Clone down the repo
- `yarn install` 
- `yarn docker:up`
- Navigate to http://localhost:12000/sub/path/anything