### PR TITLE
Fix windows tests: snapshot backslash needs to be escaped

### DIFF
--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -43,7 +43,7 @@ const runTests = (context, dev = false) => {
       const errorSource = await getRedboxSource(browser)
       expect(errorSource).toMatchInlineSnapshot(`
         "pages${
-          process.platform === 'win32' ? '\\' : '/'
+          process.platform === 'win32' ? '\\\\' : '/'
         }hello.js (52:14) @ onClick
 
           50 |   id=\\"trigger-error\\"


### PR DESCRIPTION
Noticed while trying to get https://github.com/vercel/next.js/pull/14442 tests to pass. The backslash needs to be double escaped in snapshots. Forward slashes aren't escaped, maybe that was the assumption when this test was written?
