### PR TITLE
De-experimentalize custom-routes

### DIFF
--- a/errors/rewrite-auto-export-fallback.md
+++ b/errors/rewrite-auto-export-fallback.md
@@ -1,0 +1,18 @@
+# Rewriting to Auto Export or Fallback Dynamic Route
+
+#### Why This Error Occurred
+
+One of your rewrites in your `next.config.js` point to a [dynamic route](https://nextjs.org/docs/routing/dynamic-routes) that is automatically statically optimized or is a [fallback SSG page](https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required).
+
+Rewriting to these pages are not yet supported since rewrites are not available client-side and the dynamic route params are unable to be parsed. Support for this may be added in a future release.
+
+#### Possible Ways to Fix It
+
+For fallback SSG pages you can add the page to the list of [prerendered paths](https://nextjs.org/docs/basic-features/data-fetching#the-paths-key-required).
+
+For static dynamic routes, you will currently need to either rewrite to non-dynamic route or opt the page out of the static optimization with [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering)
+
+### Useful Links
+
+- [Dynamic Routes Documentation](https://nextjs.org/docs/routing/dynamic-routes)
+- [Fallback Documentation](https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required)

--- a/errors/routes-must-be-array.md
+++ b/errors/routes-must-be-array.md
@@ -13,13 +13,11 @@ Make sure to return an array that contains the routes.
 ```js
 // next.config.js
 module.exports = {
-  experimental: {
-    async rewrites() {
-      return {
-        source: '/feedback',
-        destination: '/feedback/general',
-      }
-    },
+  async rewrites() {
+    return {
+      source: '/feedback',
+      destination: '/feedback/general',
+    }
   },
 }
 ```
@@ -28,15 +26,13 @@ module.exports = {
 
 ```js
 module.exports = {
-  experimental: {
-    async rewrites() {
-      return [
-        {
-          source: '/feedback',
-          destination: '/feedback/general',
-        },
-      ]
-    },
+  async rewrites() {
+    return [
+      {
+        source: '/feedback',
+        destination: '/feedback/general',
+      },
+    ]
   },
 }
 ```

--- a/examples/custom-routes-proxying/next.config.js
+++ b/examples/custom-routes-proxying/next.config.js
@@ -1,18 +1,16 @@
 module.exports = {
-  experimental: {
-    async rewrites() {
-      return [
-        // we need to define a no-op rewrite to trigger checking
-        // all pages/static files before we attempt proxying
-        {
-          source: '/:path*',
-          destination: '/:path*',
-        },
-        {
-          source: '/:path*',
-          destination: `https://custom-routes-proxying-endpoint.vercel.app/:path*`,
-        },
-      ]
-    },
+  async rewrites() {
+    return [
+      // we need to define a no-op rewrite to trigger checking
+      // all pages/static files before we attempt proxying
+      {
+        source: '/:path*',
+        destination: '/:path*',
+      },
+      {
+        source: '/:path*',
+        destination: `https://custom-routes-proxying-endpoint.vercel.app/:path*`,
+      },
+    ]
   },
 }

--- a/examples/with-next-offline/next.config.js
+++ b/examples/with-next-offline/next.config.js
@@ -18,14 +18,12 @@ module.exports = withOffline({
       },
     ],
   },
-  experimental: {
-    async rewrites() {
-      return [
-        {
-          source: '/service-worker.js',
-          destination: '/_next/static/service-worker.js',
-        },
-      ]
-    },
+  async rewrites() {
+    return [
+      {
+        source: '/service-worker.js',
+        destination: '/_next/static/service-worker.js',
+      },
+    ]
   },
 })

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -310,28 +310,28 @@ export interface CustomRoutes {
 }
 
 async function loadRedirects(config: any) {
-  if (typeof config.experimental.redirects !== 'function') {
+  if (typeof config.redirects !== 'function') {
     return []
   }
-  const _redirects = await config.experimental.redirects()
+  const _redirects = await config.redirects()
   checkCustomRoutes(_redirects, 'redirect')
   return _redirects
 }
 
 async function loadRewrites(config: any) {
-  if (typeof config.experimental.rewrites !== 'function') {
+  if (typeof config.rewrites !== 'function') {
     return []
   }
-  const _rewrites = await config.experimental.rewrites()
+  const _rewrites = await config.rewrites()
   checkCustomRoutes(_rewrites, 'rewrite')
   return _rewrites
 }
 
 async function loadHeaders(config: any) {
-  if (typeof config.experimental.headers !== 'function') {
+  if (typeof config.headers !== 'function') {
     return []
   }
-  const _headers = await config.experimental.headers()
+  const _headers = await config.headers()
   checkCustomRoutes(_headers, 'header')
   return _headers
 }

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -341,15 +341,14 @@ export async function renderToHTML(
     pageIsDynamic &&
     didRewrite
   ) {
-    // TODO: add err.sh when rewrites go stable
-    // Behavior might change before then (prefer SSR in this case).
-    // If we decide to ship rewrites to the client we could solve this
-    // by running over the rewrites and getting the params.
+    // TODO: If we decide to ship rewrites to the client we could
+    // solve this by running over the rewrites and getting the params.
     throw new Error(
       `Rewrites don't support${
         isFallback ? ' ' : ' auto-exported '
-      }dynamic pages${isFallback ? ' with getStaticProps ' : ' '}yet. ` +
-        `Using this will cause the page to fail to parse the params on the client`
+      }dynamic pages${isFallback ? ' with getStaticProps ' : ' '}yet.\n` +
+        `Using this will cause the page to fail to parse the params on the client\n` +
+        `See more info: https://err.sh/next.js/rewrite-auto-export-fallback`
     )
   }
 

--- a/test/integration/custom-routes-catchall/next.config.js
+++ b/test/integration/custom-routes-catchall/next.config.js
@@ -1,12 +1,10 @@
 module.exports = {
-  experimental: {
-    rewrites() {
-      return [
-        {
-          source: '/docs/:path*',
-          destination: '/:path*',
-        },
-      ]
-    },
+  rewrites() {
+    return [
+      {
+        source: '/docs/:path*',
+        destination: '/:path*',
+      },
+    ]
   },
 }

--- a/test/integration/custom-routes-catchall/test/index.test.js
+++ b/test/integration/custom-routes-catchall/test/index.test.js
@@ -19,6 +19,11 @@ let appPort
 let app
 
 const runTests = () => {
+  it('should rewrite and render page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/docs/hello')
+    expect(html).toMatch(/hello world/)
+  })
+
   it('should rewrite to /_next/static correctly', async () => {
     const bundlePath = await join(
       '/docs/_next/static/',
@@ -27,11 +32,6 @@ const runTests = () => {
     )
     const data = await renderViaHTTP(appPort, bundlePath)
     expect(data).toContain('/hello')
-  })
-
-  it('should rewrite and render page correctly', async () => {
-    const html = await renderViaHTTP(appPort, '/docs/hello')
-    expect(html).toMatch(/hello world/)
   })
 
   it('should rewrite to public/static correctly', async () => {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -1,302 +1,300 @@
 module.exports = {
   // target: 'serverless',
-  experimental: {
-    async rewrites() {
-      return [
-        {
-          source: '/to-another',
-          destination: '/another/one',
-        },
-        {
-          source: '/nav',
-          destination: '/404',
-        },
-        {
-          source: '/hello-world',
-          destination: '/static/hello.txt',
-        },
-        {
-          source: '/',
-          destination: '/another',
-        },
-        {
-          source: '/another',
-          destination: '/multi-rewrites',
-        },
-        {
-          source: '/first',
-          destination: '/hello',
-        },
-        {
-          source: '/second',
-          destination: '/hello-again',
-        },
-        {
-          source: '/to-hello',
-          destination: '/hello',
-        },
-        {
-          source: '/blog/post-1',
-          destination: '/blog/post-2',
-        },
-        {
-          source: '/test/:path',
-          destination: '/:path',
-        },
-        {
-          source: '/test-overwrite/:something/:another',
-          destination: '/params/this-should-be-the-value',
-        },
-        {
-          source: '/params/:something',
-          destination: '/with-params',
-        },
-        {
-          source: '/query-rewrite/:section/:name',
-          destination: '/with-params?first=:section&second=:name',
-        },
-        {
-          source: '/hidden/_next/:path*',
-          destination: '/_next/:path*',
-        },
-        {
-          source: '/proxy-me/:path*',
-          destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
-        },
-        {
-          source: '/api-hello',
-          destination: '/api/hello',
-        },
-        {
-          source: '/api-hello-regex/:first(.*)',
-          destination: '/api/hello?name=:first*',
-        },
-        {
-          source: '/api-hello-param/:name',
-          destination: '/api/hello?hello=:name',
-        },
-        {
-          source: '/api-dynamic-param/:name',
-          destination: '/api/dynamic/:name?hello=:name',
-        },
-        {
-          source: '/:path/post-321',
-          destination: '/with-params',
-        },
-        {
-          source: '/unnamed-params/nested/(.*)/:test/(.*)',
-          destination: '/with-params',
-        },
-        {
-          source: '/catchall-rewrite/:path*',
-          destination: '/with-params',
-        },
-        {
-          source: '/catchall-query/:path*',
-          destination: '/with-params?another=:path*',
-        },
-      ]
-    },
-    async redirects() {
-      return [
-        {
-          source: '/redirect/me/to-about/:lang',
-          destination: '/:lang/about',
-          permanent: false,
-        },
-        {
-          source: '/docs/router-status/:code',
-          destination: '/docs/v2/network/status-codes#:code',
-          statusCode: 301,
-        },
-        {
-          source: '/docs/github',
-          destination: '/docs/v2/advanced/now-for-github',
-          statusCode: 301,
-        },
-        {
-          source: '/docs/v2/advanced/:all(.*)',
-          destination: '/docs/v2/more/:all',
-          statusCode: 301,
-        },
-        {
-          source: '/hello/:id/another',
-          destination: '/blog/:id',
-          permanent: false,
-        },
-        {
-          source: '/redirect1',
-          destination: '/',
-          permanent: false,
-        },
-        {
-          source: '/redirect2',
-          destination: '/',
-          statusCode: 301,
-        },
-        {
-          source: '/redirect3',
-          destination: '/another',
-          statusCode: 302,
-        },
-        {
-          source: '/redirect4',
-          destination: '/',
-          permanent: true,
-        },
-        {
-          source: '/redir-chain1',
-          destination: '/redir-chain2',
-          statusCode: 301,
-        },
-        {
-          source: '/redir-chain2',
-          destination: '/redir-chain3',
-          statusCode: 302,
-        },
-        {
-          source: '/redir-chain3',
-          destination: '/',
-          statusCode: 303,
-        },
-        {
-          source: '/to-external',
-          destination: 'https://google.com',
-          permanent: false,
-        },
-        {
-          source: '/query-redirect/:section/:name',
-          destination: '/with-params?first=:section&second=:name',
-          permanent: false,
-        },
-        {
-          source: '/unnamed/(first|second)/(.*)',
-          destination: '/got-unnamed',
-          permanent: false,
-        },
-        {
-          source: '/named-like-unnamed/:0',
-          destination: '/:0',
-          permanent: false,
-        },
-        {
-          source: '/redirect-override',
-          destination: '/thank-you-next',
-          permanent: false,
-        },
-        {
-          source: '/docs/:first(integrations|now-cli)/v2:second(.*)',
-          destination: '/:first/:second',
-          permanent: false,
-        },
-        {
-          source: '/catchall-redirect/:path*',
-          destination: '/somewhere',
-          permanent: false,
-        },
-      ]
-    },
+  async rewrites() {
+    return [
+      {
+        source: '/to-another',
+        destination: '/another/one',
+      },
+      {
+        source: '/nav',
+        destination: '/404',
+      },
+      {
+        source: '/hello-world',
+        destination: '/static/hello.txt',
+      },
+      {
+        source: '/',
+        destination: '/another',
+      },
+      {
+        source: '/another',
+        destination: '/multi-rewrites',
+      },
+      {
+        source: '/first',
+        destination: '/hello',
+      },
+      {
+        source: '/second',
+        destination: '/hello-again',
+      },
+      {
+        source: '/to-hello',
+        destination: '/hello',
+      },
+      {
+        source: '/blog/post-1',
+        destination: '/blog/post-2',
+      },
+      {
+        source: '/test/:path',
+        destination: '/:path',
+      },
+      {
+        source: '/test-overwrite/:something/:another',
+        destination: '/params/this-should-be-the-value',
+      },
+      {
+        source: '/params/:something',
+        destination: '/with-params',
+      },
+      {
+        source: '/query-rewrite/:section/:name',
+        destination: '/with-params?first=:section&second=:name',
+      },
+      {
+        source: '/hidden/_next/:path*',
+        destination: '/_next/:path*',
+      },
+      {
+        source: '/proxy-me/:path*',
+        destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
+      },
+      {
+        source: '/api-hello',
+        destination: '/api/hello',
+      },
+      {
+        source: '/api-hello-regex/:first(.*)',
+        destination: '/api/hello?name=:first*',
+      },
+      {
+        source: '/api-hello-param/:name',
+        destination: '/api/hello?hello=:name',
+      },
+      {
+        source: '/api-dynamic-param/:name',
+        destination: '/api/dynamic/:name?hello=:name',
+      },
+      {
+        source: '/:path/post-321',
+        destination: '/with-params',
+      },
+      {
+        source: '/unnamed-params/nested/(.*)/:test/(.*)',
+        destination: '/with-params',
+      },
+      {
+        source: '/catchall-rewrite/:path*',
+        destination: '/with-params',
+      },
+      {
+        source: '/catchall-query/:path*',
+        destination: '/with-params?another=:path*',
+      },
+    ]
+  },
+  async redirects() {
+    return [
+      {
+        source: '/redirect/me/to-about/:lang',
+        destination: '/:lang/about',
+        permanent: false,
+      },
+      {
+        source: '/docs/router-status/:code',
+        destination: '/docs/v2/network/status-codes#:code',
+        statusCode: 301,
+      },
+      {
+        source: '/docs/github',
+        destination: '/docs/v2/advanced/now-for-github',
+        statusCode: 301,
+      },
+      {
+        source: '/docs/v2/advanced/:all(.*)',
+        destination: '/docs/v2/more/:all',
+        statusCode: 301,
+      },
+      {
+        source: '/hello/:id/another',
+        destination: '/blog/:id',
+        permanent: false,
+      },
+      {
+        source: '/redirect1',
+        destination: '/',
+        permanent: false,
+      },
+      {
+        source: '/redirect2',
+        destination: '/',
+        statusCode: 301,
+      },
+      {
+        source: '/redirect3',
+        destination: '/another',
+        statusCode: 302,
+      },
+      {
+        source: '/redirect4',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/redir-chain1',
+        destination: '/redir-chain2',
+        statusCode: 301,
+      },
+      {
+        source: '/redir-chain2',
+        destination: '/redir-chain3',
+        statusCode: 302,
+      },
+      {
+        source: '/redir-chain3',
+        destination: '/',
+        statusCode: 303,
+      },
+      {
+        source: '/to-external',
+        destination: 'https://google.com',
+        permanent: false,
+      },
+      {
+        source: '/query-redirect/:section/:name',
+        destination: '/with-params?first=:section&second=:name',
+        permanent: false,
+      },
+      {
+        source: '/unnamed/(first|second)/(.*)',
+        destination: '/got-unnamed',
+        permanent: false,
+      },
+      {
+        source: '/named-like-unnamed/:0',
+        destination: '/:0',
+        permanent: false,
+      },
+      {
+        source: '/redirect-override',
+        destination: '/thank-you-next',
+        permanent: false,
+      },
+      {
+        source: '/docs/:first(integrations|now-cli)/v2:second(.*)',
+        destination: '/:first/:second',
+        permanent: false,
+      },
+      {
+        source: '/catchall-redirect/:path*',
+        destination: '/somewhere',
+        permanent: false,
+      },
+    ]
+  },
 
-    async headers() {
-      return [
-        {
-          source: '/add-header',
-          headers: [
-            {
-              key: 'x-custom-header',
-              value: 'hello world',
-            },
-            {
-              key: 'x-another-header',
-              value: 'hello again',
-            },
-          ],
-        },
-        {
-          source: '/my-headers/(.*)',
-          headers: [
-            {
-              key: 'x-first-header',
-              value: 'first',
-            },
-            {
-              key: 'x-second-header',
-              value: 'second',
-            },
-          ],
-        },
-        {
-          source: '/my-other-header/:path',
-          headers: [
-            {
-              key: 'x-path',
-              value: ':path',
-            },
-            {
-              key: 'some:path',
-              value: 'hi',
-            },
-          ],
-        },
-        {
-          source: '/without-params/url',
-          headers: [
-            {
-              key: 'x-origin',
-              value: 'https://example.com',
-            },
-          ],
-        },
-        {
-          source: '/with-params/url/:path*',
-          headers: [
-            {
-              key: 'x-url',
-              value: 'https://example.com/:path*',
-            },
-          ],
-        },
-        {
-          source: '/with-params/url2/:path*',
-          headers: [
-            {
-              key: 'x-url',
-              value: 'https://example.com:8080?hello=:path*',
-            },
-          ],
-        },
-        {
-          source: '/:path*',
-          headers: [
-            {
-              key: 'x-something',
-              value: 'applied-everywhere',
-            },
-          ],
-        },
-        {
-          source: '/named-pattern/:path(.*)',
-          headers: [
-            {
-              key: 'x-something',
-              value: 'value=:path',
-            },
-            {
-              key: 'path-:path',
-              value: 'end',
-            },
-          ],
-        },
-        {
-          source: '/catchall-header/:path*',
-          headers: [
-            {
-              key: 'x-value',
-              value: ':path*',
-            },
-          ],
-        },
-      ]
-    },
+  async headers() {
+    return [
+      {
+        source: '/add-header',
+        headers: [
+          {
+            key: 'x-custom-header',
+            value: 'hello world',
+          },
+          {
+            key: 'x-another-header',
+            value: 'hello again',
+          },
+        ],
+      },
+      {
+        source: '/my-headers/(.*)',
+        headers: [
+          {
+            key: 'x-first-header',
+            value: 'first',
+          },
+          {
+            key: 'x-second-header',
+            value: 'second',
+          },
+        ],
+      },
+      {
+        source: '/my-other-header/:path',
+        headers: [
+          {
+            key: 'x-path',
+            value: ':path',
+          },
+          {
+            key: 'some:path',
+            value: 'hi',
+          },
+        ],
+      },
+      {
+        source: '/without-params/url',
+        headers: [
+          {
+            key: 'x-origin',
+            value: 'https://example.com',
+          },
+        ],
+      },
+      {
+        source: '/with-params/url/:path*',
+        headers: [
+          {
+            key: 'x-url',
+            value: 'https://example.com/:path*',
+          },
+        ],
+      },
+      {
+        source: '/with-params/url2/:path*',
+        headers: [
+          {
+            key: 'x-url',
+            value: 'https://example.com:8080?hello=:path*',
+          },
+        ],
+      },
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'x-something',
+            value: 'applied-everywhere',
+          },
+        ],
+      },
+      {
+        source: '/named-pattern/:path(.*)',
+        headers: [
+          {
+            key: 'x-something',
+            value: 'value=:path',
+          },
+          {
+            key: 'path-:path',
+            value: 'end',
+          },
+        ],
+      },
+      {
+        source: '/catchall-header/:path*',
+        headers: [
+          {
+            key: 'x-value',
+            value: ':path*',
+          },
+        ],
+      },
+    ]
   },
 }

--- a/test/integration/env-config/app/next.config.js
+++ b/test/integration/env-config/app/next.config.js
@@ -1,14 +1,12 @@
 module.exports = {
   // update me
-  experimental: {
-    async redirects() {
-      return [
-        {
-          source: '/hello',
-          permanent: false,
-          destination: `/${process.env.NEXT_PUBLIC_TEST_DEST}`,
-        },
-      ]
-    },
+  async redirects() {
+    return [
+      {
+        source: '/hello',
+        permanent: false,
+        destination: `/${process.env.NEXT_PUBLIC_TEST_DEST}`,
+      },
+    ]
   },
 }

--- a/test/integration/invalid-custom-routes/test/index.test.js
+++ b/test/integration/invalid-custom-routes/test/index.test.js
@@ -14,10 +14,8 @@ const writeConfig = async (routes, type = 'redirects') => {
     nextConfigPath,
     `
     module.exports = {
-      experimental: {
-        async ${type}() {
-          return ${JSON.stringify(routes)}
-        }
+      async ${type}() {
+        return ${JSON.stringify(routes)}
       }
     }
   `

--- a/test/integration/invalid-multi-match/next.config.js
+++ b/test/integration/invalid-multi-match/next.config.js
@@ -1,12 +1,10 @@
 module.exports = {
-  experimental: {
-    rewrites() {
-      return [
-        {
-          source: '/:hello*',
-          destination: '/:hello',
-        },
-      ]
-    },
+  rewrites() {
+    return [
+      {
+        source: '/:hello*',
+        destination: '/:hello',
+      },
+    ]
   },
 }

--- a/test/integration/prerender/next.config.js
+++ b/test/integration/prerender/next.config.js
@@ -1,13 +1,13 @@
 module.exports = {
   experimental: {
     optionalCatchAll: true,
-    rewrites() {
-      return [
-        {
-          source: '/about',
-          destination: '/lang/en/about',
-        },
-      ]
-    },
+  },
+  rewrites() {
+    return [
+      {
+        source: '/about',
+        destination: '/lang/en/about',
+      },
+    ]
   },
 }

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -608,7 +608,7 @@ const runTests = (dev = false, isEmulatedServerless = false) => {
       const item = Math.round(Math.random() * 100)
       const html = await renderViaHTTP(appPort, `/some-rewrite/${item}`)
       expect(html).toContain(
-        `Rewrites don't support dynamic pages with getStaticProps yet. Using this will cause the page to fail to parse the params on the client`
+        `Rewrites don't support dynamic pages with getStaticProps yet`
       )
     })
 
@@ -1292,18 +1292,18 @@ describe('SSG Prerender', () => {
         module.exports = {
           experimental: {
             optionalCatchAll: true,
-            rewrites() {
-              return [
-                {
-                  source: "/some-rewrite/:item",
-                  destination: "/blog/post-:item"
-                },
-                {
-                  source: '/about',
-                  destination: '/lang/en/about'
-                }
-              ]
-            }
+          },
+          rewrites() {
+            return [
+              {
+                source: "/some-rewrite/:item",
+                destination: "/blog/post-:item"
+              },
+              {
+                source: '/about',
+                destination: '/lang/en/about'
+              }
+            ]
           }
         }
       `
@@ -1401,14 +1401,14 @@ describe('SSG Prerender', () => {
           target: 'serverless',
           experimental: {
             optionalCatchAll: true,
-            rewrites() {
-              return [
-                {
-                  source: '/about',
-                  destination: '/lang/en/about'
-                }
-              ]
-            }
+          },
+          rewrites() {
+            return [
+              {
+                source: '/about',
+                destination: '/lang/en/about'
+              }
+            ]
           }
         }`,
         'utf8'

--- a/test/integration/production/next.config.js
+++ b/test/integration/production/next.config.js
@@ -3,15 +3,13 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
   },
-  experimental: {
-    redirects() {
-      return [
-        {
-          source: '/redirect/me/to-about/:lang',
-          destination: '/:lang/about',
-          permanent: false,
-        },
-      ]
-    },
+  redirects() {
+    return [
+      {
+        source: '/redirect/me/to-about/:lang',
+        destination: '/:lang/about',
+        permanent: false,
+      },
+    ]
   },
 }


### PR DESCRIPTION
This moves the custom-routes configs outside of the experimental section to prepare them for being made stable

Fixes: https://github.com/vercel/next.js/issues/14184