### PR TITLE
Fix trailing slash handling in exporting pages with getStaticPaths

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -24,6 +24,7 @@ import { findPageFile } from '../server/lib/find-page-file'
 import { GetStaticPaths } from 'next/types'
 import { denormalizePagePath } from '../next-server/server/normalize-page-path'
 import { BuildManifest } from '../next-server/server/get-page-files'
+import { normalizeTrailingSlash } from '../next-server/lib/router/normalize-trailing-slash'
 
 const fileGzipStats: { [k: string]: Promise<number> } = {}
 const fsStatGzip = (file: string) => {
@@ -573,6 +574,7 @@ export async function buildStaticPaths(
     // For a string-provided path, we must make sure it matches the dynamic
     // route.
     if (typeof entry === 'string') {
+      entry = normalizeTrailingSlash(entry)
       const result = _routeMatcher(entry)
       if (!result) {
         throw new Error(

--- a/test/integration/export/pages/gssp/[slug].js
+++ b/test/integration/export/pages/gssp/[slug].js
@@ -1,0 +1,14 @@
+export async function getStaticPaths() {
+  return {
+    paths: ['/gssp/foo/'],
+    fallback: false,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  return { props: params }
+}
+
+export default function Page({ slug }) {
+  return `Hello ${slug}`
+}

--- a/test/integration/export/test/index.test.js
+++ b/test/integration/export/test/index.test.js
@@ -103,6 +103,20 @@ describe('Static Export', () => {
     ).toBe(true)
   })
 
+  it('should handle trailing slash in getStaticPaths', async () => {
+    expect(
+      await access(join(outdir, 'gssp/foo/index.html'))
+        .then(() => true)
+        .catch(() => false)
+    ).toBe(true)
+
+    expect(
+      await access(join(outNoTrailSlash, 'gssp/foo.html'))
+        .then(() => true)
+        .catch(() => false)
+    ).toBe(true)
+  })
+
   it('should only output 404.html without exportTrailingSlash', async () => {
     expect(
       await access(join(outNoTrailSlash, '404/index.html'))


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/14573