### PR TITLE
Add failing test: exportTrailingSlash conflict with dynamic routes

### DIFF
--- a/test/integration/export/pages/gssp/[slug].js
+++ b/test/integration/export/pages/gssp/[slug].js
@@ -1,6 +1,6 @@
 export async function getStaticPaths() {
   return {
-    paths: ['/gssp/foo/'],
+    paths: ['/gssp/foo.bar', '/gssp/foo/'],
     fallback: false,
   }
 }

--- a/test/integration/export/pages/index.js
+++ b/test/integration/export/pages/index.js
@@ -30,6 +30,9 @@ export default () => (
       <Link href="/dynamic?text=Vercel+is+awesome#cool">
         <a id="with-hash">With Hash</a>
       </Link>
+      <Link href="/gssp/[slug]" as="/gssp/foo.bar">
+        <a id="path-with-dot">Path with dot</a>
+      </Link>
       <Link href="/dynamic?text=this+file+has+an+extension" as="/file-name.md">
         <a id="path-with-extension">Path with extension</a>
       </Link>

--- a/test/integration/export/test/ssr.js
+++ b/test/integration/export/test/ssr.js
@@ -19,8 +19,10 @@ export default function (context) {
       const $ = cheerio.load(html)
       const dynamicLink = $('#dynamic-1').prop('href')
       const filePathLink = $('#path-with-extension').prop('href')
+      const dotPathLink = $('#path-with-dot').prop('href')
       expect(dynamicLink).toEqual('/dynamic/one/')
       expect(filePathLink).toEqual('/file-name.md')
+      expect(dotPathLink).toEqual('/gssp/foo.bar/')
     })
 
     it('should render a page with getInitialProps', async () => {


### PR DESCRIPTION
Looking into whether it's possible to consolidate `trailingSlash` and `exportTrailingSlash` features. Running into this edge-case with file extensions. How do we want this to behave?

related: https://github.com/vercel/next.js/pull/2973