### PR TITLE
Fetch Data on Runtime (with-MongoDB-mongoose example)

### DIFF
--- a/examples/with-mongodb-mongoose/pages/[id]/index.js
+++ b/examples/with-mongodb-mongoose/pages/[id]/index.js
@@ -63,16 +63,7 @@ const PetPage = ({ pet }) => {
   )
 }
 
-export async function getStaticPaths() {
-  await dbConnect()
-
-  const result = await Pet.find({})
-  const paths = result.map((doc) => ({ params: { id: doc._id.toString() } }))
-
-  return { paths, fallback: false }
-}
-
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
   await dbConnect()
 
   const pet = await Pet.findById(params.id).lean()

--- a/examples/with-mongodb-mongoose/pages/index.js
+++ b/examples/with-mongodb-mongoose/pages/index.js
@@ -48,7 +48,7 @@ const Index = ({ pets }) => (
 )
 
 /* Retrieves pet(s) data from mongodb database */
-export async function getStaticProps() {
+export async function getServerSideProps() {
   await dbConnect()
 
   /* find all the data in our database */


### PR DESCRIPTION
closes #14610 

Change Data Fetching Method in Example with-MongoDB-mongoose
Fetch Data on Runtime (getServerSideProps) rather than Build Time (getStaticProps)