### PR TITLE
[Examples] Revert styled-components to v4

### DIFF
--- a/examples/with-styled-components/README.md
+++ b/examples/with-styled-components/README.md
@@ -4,6 +4,8 @@ This example features how you use a different styling solution than [styled-jsx]
 
 For this purpose we are extending the `<Document />` and injecting the server side rendered styles into the `<head>`, and also adding the `babel-plugin-styled-components` (which is required for server side rendering). Additionally we set up a global [theme](https://www.styled-components.com/docs/advanced#theming) for styled-components using NextJS custom [`<App>`](https://nextjs.org/docs/advanced-features/custom-app) component.
 
+> **Note:** The example uses `styled-components v4` and not the latest `v5` version due to an [issue with production builds in `styled-components`](https://github.com/styled-components/styled-components/issues/3026). More about this in [`pages/v5-test.js`](pages/v5-test.js).
+
 ## Deploy your own
 
 Deploy the example using [Vercel](https://vercel.com):

--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -10,10 +10,10 @@
     "next": "latest",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "styled-components": "^5.0.0"
+    "styled-components": "4.4.1"
   },
   "devDependencies": {
-    "babel-plugin-styled-components": "^1.8.0"
+    "babel-plugin-styled-components": "1.10.7"
   },
   "license": "ISC"
 }

--- a/examples/with-styled-components/pages/v5-test.js
+++ b/examples/with-styled-components/pages/v5-test.js
@@ -1,0 +1,64 @@
+/**
+ * styled-components v5 currently has unexpected style outputs for production builds.
+ * More on that here: https://github.com/styled-components/styled-components/issues/3026
+ *
+ * Before updating styled-components to v5, make sure that this page outputs the same
+ * results for both `npm run dev` and `npm run build && npm run start`. Otherwise you
+ * may risk getting broken styles to the production app.
+ */
+
+import styled, { css } from 'styled-components'
+
+const Base = styled.div`
+  cursor: pointer;
+  touch-action: none;
+`
+
+function composeButton(css) {
+  const Root = styled(Base)`
+    ${css};
+  `
+
+  return function ComposeButton(props) {
+    return <Root {...props}>Compose</Root>
+  }
+}
+
+const ComposeButton1 = composeButton(
+  css`
+    user-select: none;
+    transform: translateX(-3px);
+    display: inline-block;
+    padding: 12px 20px;
+    border: 1px solid #dcdcdc;
+    background-color: #fff;
+    border-radius: 40px;
+    color: #222;
+    font-size: 16px;
+    line-height: 1.75;
+    letter-spacing: 0.2px;
+  `
+)
+
+const ComposeButton2 = composeButton(
+  css`
+    display: block;
+    height: 36px;
+    padding: 10px 16px;
+    font-size: 14px;
+    font-weight: bold;
+    height: 31px;
+    width: 36px;
+    position: relative;
+    color: #025aa5;
+  `
+)
+
+export default function Page() {
+  return (
+    <div>
+      <ComposeButton1 />
+      <ComposeButton2 />
+    </div>
+  )
+}


### PR DESCRIPTION
Related to https://github.com/vercel/next.js/pull/11765#issuecomment-653315488

The bug can affect production apps without having a good way of tracking why, so I'm making sure that doesn't happen for anyone that uses our example.