### PR TITLE
Disable trusting query values from proxy

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -208,7 +208,7 @@ const nextServerlessLoader: loader.Loader = function () {
 
           // We need to trust the dynamic route params from the proxy
           // to ensure we are using the correct values
-          const trustQuery = req.headers['${vercelHeader}']
+          const trustQuery = false // req.headers['${vercelHeader}']
           const parsedUrl = handleRewrites(parse(req.url, true))
 
           const params = ${
@@ -321,7 +321,7 @@ const nextServerlessLoader: loader.Loader = function () {
       try {
         // We need to trust the dynamic route params from the proxy
         // to ensure we are using the correct values
-        const trustQuery = !getStaticProps && req.headers['${vercelHeader}']
+        const trustQuery = false // !getStaticProps && req.headers['${vercelHeader}']
         const parsedUrl = handleRewrites(parse(req.url, true))
 
         if (parsedUrl.pathname.match(/_next\\/data/)) {


### PR DESCRIPTION
This disables trusting query values from the proxy which was introduced on canary to handle edge cases with custom routes although seems to need updating before can be relied on

Note: this PR can be closed/reverted if https://github.com/vercel/vercel/pull/4778 is landed

x-ref: https://github.com/vercel/vercel/pull/4778
x-ref: https://github.com/vercel/next.js/pull/12608
closes: https://github.com/vercel/next.js/issues/14828