### PR TITLE
Update api-middlewares.md

### DIFF
--- a/docs/api-routes/api-middlewares.md
+++ b/docs/api-routes/api-middlewares.md
@@ -96,10 +96,10 @@ function runMiddleware(req, res, fn) {
   return new Promise((resolve, reject) => {
     fn(req, res, (result) => {
       if (result instanceof Error) {
-        return reject(result)
+        reject(result)
       }
 
-      return resolve(result)
+      resolve(result)
     })
   })
 }


### PR DESCRIPTION
`reject` and `resolve` do not require a return statement.