### PR TITLE
Fix cms-wordpress preview mode for post revisions

### DIFF
--- a/examples/cms-wordpress/lib/api.js
+++ b/examples/cms-wordpress/lib/api.js
@@ -149,7 +149,7 @@ export async function getPostAndMorePosts(slug, preview, previewData) {
           // Only some of the fields of a revision are considered as there are some inconsistencies
           isRevision
             ? `
-        revisions(first: 1, where: { orderby: { field: MODIFIED, order: ASC } }) {
+        revisions(first: 1, where: { orderby: { field: MODIFIED, order: DESC } }) {
           edges {
             node {
               title


### PR DESCRIPTION
Preview of existing posts should always return the latest revision so DESC sorting was required. Otherwise, it would always return the oldest revision.

Tested against latest Wordpress and GraphQL plugins on drafts, published, and edited but unpublished changes. The example works great!