### PR TITLE
Fix bug in profiling test

### DIFF
--- a/test/integration/profiling/test/index.test.js
+++ b/test/integration/profiling/test/index.test.js
@@ -4,18 +4,23 @@ import { join } from 'path'
 import { nextBuild } from 'next-test-utils'
 import fs from 'fs'
 const appDir = join(__dirname, '../')
+const profileEventsPath = join(appDir, '.next', 'profile-events.json')
 jest.setTimeout(1000 * 60 * 5)
 
 describe('Profiling Usage', () => {
   beforeAll(async () => {
+    // Delete file if it already exists
+    if (await fs.existsSync(profileEventsPath))
+      await fs.unlink(profileEventsPath, () => {
+        console.log('Deleted Existing profile-events.json file')
+      })
+
     await nextBuild(appDir)
   })
 
   describe('Profiling the build', () => {
     it('should emit files', async () => {
-      expect(fs.existsSync(join(appDir, '.next', 'profile-events.json'))).toBe(
-        true
-      )
+      expect(fs.existsSync(profileEventsPath)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
The profiling test checked if profile-events.json exists after the build, but does not remove the existing file, which means if the test ran successfully on a developers machine once, it will pass all the subsequent times. 

I understand this won't be an issue in CI systems, but thought it might save someone time if they are relying on this test to test their code changes 