### PR TITLE
Update examples/custom-server-typescript

### DIFF
--- a/examples/custom-server-typescript/.vscode/launch.json
+++ b/examples/custom-server-typescript/.vscode/launch.json
@@ -1,0 +1,61 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Next: Edge",
+            "request": "launch",
+            "type": "pwa-msedge",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "name": "Next: Chrome",
+            "request": "launch",
+            "type": "chrome",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "name": "Next: Node",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": [
+                "--no-lazy",
+                "-r",
+                "ts-node/register"
+            ],
+            "args": [
+                "server/index.ts"
+            ],
+            "env": {
+                "NODE_OPTIONS": "--inspect=0.0.0.0:9229",
+                "TS_NODE_PROJECT": "tsconfig.server.json"
+            },
+            "sourceMaps": true,
+            "cwd": "${workspaceRoot}",
+            "skipFiles": [
+                "<node_internals>/**",
+                "node_modules/**"
+            ],
+            "port": 9229,
+            "internalConsoleOptions": "openOnSessionStart",
+            "console": "integratedTerminal"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Next: Full (Edge)",
+            "configurations": [
+                "Next: Node",
+                "Next: Edge"
+            ]
+        },
+        {
+            "name": "Next: Full (Chrome)",
+            "configurations": [
+                "Next: Node",
+                "Next: Chrome"
+            ]
+        }
+    ]
+}

--- a/examples/custom-server-typescript/README.md
+++ b/examples/custom-server-typescript/README.md
@@ -1,6 +1,6 @@
-# Custom server with TypeScript + Nodemon example
+# Custom server with TypeScript example
 
-The example shows how you can use [TypeScript](https://typescriptlang.com) on both the server and the client while using [Nodemon](https://nodemon.io/) to live reload the server code without affecting the Next.js universal code.
+The example shows how you can use [TypeScript](https://typescriptlang.com) on both the server and the client.
 
 Server entry point is `server/index.ts` in development and `dist/index.js` in production.
 The second directory should be added to `.gitignore`.

--- a/examples/custom-server-typescript/nodemon.json
+++ b/examples/custom-server-typescript/nodemon.json
@@ -1,5 +1,0 @@
-{
-  "watch": ["server"],
-  "exec": "ts-node --project tsconfig.server.json server/index.ts",
-  "ext": "js ts"
-}

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -16,7 +16,6 @@
     "@types/node": "^12.0.12",
     "@types/react": "^16.8.17",
     "@types/react-dom": "16.8.4",
-    "nodemon": "^1.19.0",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   }

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "custom-server-typescript",
   "version": "1.0.0",
   "scripts": {
-    "dev": "nodemon",
+    "dev": "ts-node --project tsconfig.server.json server/index.ts",
     "build": "next build && tsc --project tsconfig.server.json",
     "start": "cross-env NODE_ENV=production node dist/index.js"
   },


### PR DESCRIPTION
This commit removes nodemon in favor of [Fast Refresh](https://nextjs.org/blog/next-9-4#fast-refresh).

As this example is somewhat more complex with both client and server typescript, I have included a VS Code launch.json that simultaneously launches debuggers for both.