### PR TITLE
Exclude node_modules in watchOptions

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -711,7 +711,7 @@ export default async function getBaseWebpackConfig(
       }
     },
     watchOptions: {
-      ignored: ['.git/**', 'node_modules/**', '.git/**'],
+      ignored: ['**/.git', '**/node_modules'],
     },
     output: {
       path: outputPath,


### PR DESCRIPTION
This only relates to when node_modules is not in the root directory and the change was only release on canary so far so it didn't affect production usage.