### PR TITLE
Fix download instructions in with-next-auth example

### DIFF
--- a/examples/with-next-auth/README.md
+++ b/examples/with-next-auth/README.md
@@ -31,8 +31,8 @@ yarn create next-app --example with-next-auth with-next-auth-app
 Download the example:
 
 ```bash
-curl https://codeload.github.com/vercel/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/next-auth
-cd next-auth
+curl https://codeload.github.com/vercel/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-next-auth
+cd with-next-auth
 ```
 
 Install it and run:


### PR DESCRIPTION
Download instructions in examples/with-next-auth/README.md currently fail because they refer to next-auth instead of with-next-auth.