### PR TITLE
Add handling for custom-routes with basePath

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -259,11 +259,22 @@ export default async function build(
   const buildCustomRoute = (
     r: {
       source: string
+      basePath?: false
       statusCode?: number
+      destination?: string
     },
     type: RouteType
   ) => {
     const keys: any[] = []
+
+    if (r.basePath !== false) {
+      r.source = `${config.basePath}${r.source}`
+
+      if (r.destination && r.destination.startsWith('/')) {
+        r.destination = `${config.basePath}${r.destination}`
+      }
+    }
+
     const routeRegex = pathToRegexp(r.source, keys, {
       strict: true,
       sensitive: false,

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -137,7 +137,9 @@ const nextServerlessLoader: loader.Loader = function () {
           const { parsedDestination } = prepareDestination(
             rewrite.destination,
             params,
-            parsedUrl.query
+            parsedUrl.query,
+            true,
+            "${basePath}"
           )
 
           Object.assign(parsedUrl.query, parsedDestination.query, params)
@@ -173,6 +175,7 @@ const nextServerlessLoader: loader.Loader = function () {
     ? `
     // always strip the basePath if configured since it is required
     req.url = req.url.replace(new RegExp('^${basePath}'), '') || '/'
+    parsedUrl.pathname = parsedUrl.pathname.replace(new RegExp('^${basePath}'), '') || '/'
   `
     : ''
 
@@ -204,12 +207,12 @@ const nextServerlessLoader: loader.Loader = function () {
         try {
           await initServer()
 
-          ${handleBasePath}
-
           // We need to trust the dynamic route params from the proxy
           // to ensure we are using the correct values
           const trustQuery = req.headers['${vercelHeader}']
           const parsedUrl = handleRewrites(parse(req.url, true))
+
+          ${handleBasePath}
 
           const params = ${
             pageIsDynamicRoute
@@ -296,8 +299,6 @@ const nextServerlessLoader: loader.Loader = function () {
     export async function renderReqToHTML(req, res, renderMode, _renderOpts, _params) {
       const fromExport = renderMode === 'export' || renderMode === true;
 
-      ${handleBasePath}
-
       const options = {
         App,
         Document,
@@ -323,6 +324,8 @@ const nextServerlessLoader: loader.Loader = function () {
         // to ensure we are using the correct values
         const trustQuery = !getStaticProps && req.headers['${vercelHeader}']
         const parsedUrl = handleRewrites(parse(req.url, true))
+
+        ${handleBasePath}
 
         if (parsedUrl.pathname.match(/_next\\/data/)) {
           _nextData = true

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -321,7 +321,7 @@ export interface CustomRoutes {
   redirects: Redirect[]
 }
 
-async function loadRedirects(config: any): Promise<Redirect[]> {
+async function loadRedirects(config: any) {
   if (typeof config.redirects !== 'function') {
     return []
   }
@@ -330,7 +330,7 @@ async function loadRedirects(config: any): Promise<Redirect[]> {
   return _redirects
 }
 
-async function loadRewrites(config: any): Promise<Rewrite[]> {
+async function loadRewrites(config: any) {
   if (typeof config.rewrites !== 'function') {
     return []
   }
@@ -339,7 +339,7 @@ async function loadRewrites(config: any): Promise<Rewrite[]> {
   return _rewrites
 }
 
-async function loadHeaders(config: any): Promise<Header[]> {
+async function loadHeaders(config: any) {
   if (typeof config.headers !== 'function') {
     return []
   }

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -8,6 +8,7 @@ import {
 export type Rewrite = {
   source: string
   destination: string
+  basePath?: false
 }
 
 export type Redirect = Rewrite & {
@@ -17,6 +18,7 @@ export type Redirect = Rewrite & {
 
 export type Header = {
   source: string
+  basePath?: false
   headers: Array<{ key: string; value: string }>
 }
 
@@ -148,10 +150,11 @@ function checkCustomRoutes(
     allowedKeys = new Set([
       'source',
       'destination',
+      'basePath',
       ...(isRedirect ? ['statusCode', 'permanent'] : []),
     ])
   } else {
-    allowedKeys = new Set(['source', 'headers'])
+    allowedKeys = new Set(['source', 'headers', 'basePath'])
   }
 
   for (const route of routes) {
@@ -170,6 +173,10 @@ function checkCustomRoutes(
     const keys = Object.keys(route)
     const invalidKeys = keys.filter((key) => !allowedKeys.has(key))
     const invalidParts: string[] = []
+
+    if (typeof route.basePath !== 'undefined' && route.basePath !== false) {
+      invalidParts.push('`basePath` must be undefined or false')
+    }
 
     if (!route.source) {
       invalidParts.push('`source` is missing')
@@ -314,7 +321,7 @@ export interface CustomRoutes {
   redirects: Redirect[]
 }
 
-async function loadRedirects(config: any) {
+async function loadRedirects(config: any): Promise<Redirect[]> {
   if (typeof config.redirects !== 'function') {
     return []
   }
@@ -323,7 +330,7 @@ async function loadRedirects(config: any) {
   return _redirects
 }
 
-async function loadRewrites(config: any) {
+async function loadRewrites(config: any): Promise<Rewrite[]> {
   if (typeof config.rewrites !== 'function') {
     return []
   }
@@ -332,7 +339,7 @@ async function loadRewrites(config: any) {
   return _rewrites
 }
 
-async function loadHeaders(config: any) {
+async function loadHeaders(config: any): Promise<Header[]> {
   if (typeof config.headers !== 'function') {
     return []
   }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -253,13 +253,11 @@ export default class Server {
 
     const { basePath } = this.nextConfig
 
-    // if basePath is set require it be present
-    if (basePath && !req.url!.startsWith(basePath)) {
-      return this.render404(req, res, parsedUrl)
-    } else {
-      // If replace ends up replacing the full url it'll be `undefined`, meaning we have to default it to `/`
-      parsedUrl.pathname = parsedUrl.pathname!.replace(basePath, '') || '/'
-      req.url = req.url!.replace(basePath, '')
+    if (basePath && req.url?.startsWith(basePath)) {
+      // store original URL to allow checking if basePath was
+      // provided or not
+      ;(req as any)._nextHadBasePath = true
+      req.url = req.url!.replace(basePath, '') || '/'
     }
 
     res.statusCode = 200
@@ -308,6 +306,7 @@ export default class Server {
   }
 
   protected generateRoutes(): {
+    basePath: string
     headers: Route[]
     rewrites: Route[]
     fsRoutes: Route[]
@@ -445,11 +444,18 @@ export default class Server {
       ...staticFilesRoute,
     ]
 
+    const getCustomRouteBasePath = (r: { basePath?: false }) => {
+      return r.basePath !== false && this.renderOpts.dev
+        ? this.nextConfig.basePath
+        : ''
+    }
+
     const getCustomRoute = (r: Rewrite | Redirect | Header, type: RouteType) =>
       ({
         ...r,
         type,
-        match: getCustomRouteMatcher(r.source),
+        matchSrc: `${getCustomRouteBasePath(r)}${r.source}`,
+        match: getCustomRouteMatcher(`${getCustomRouteBasePath(r)}${r.source}`),
         name: type,
         fn: async (_req, _res, _params, _parsedUrl) => ({ finished: false }),
       } as Route & Rewrite & Header)
@@ -458,7 +464,13 @@ export default class Server {
       if (!value.includes(':')) {
         return value
       }
-      const { parsedDestination } = prepareDestination(value, params, {})
+      const { parsedDestination } = prepareDestination(
+        value,
+        params,
+        {},
+        false,
+        ''
+      )
 
       if (
         !parsedDestination.pathname ||
@@ -507,7 +519,9 @@ export default class Server {
           const { parsedDestination } = prepareDestination(
             redirectRoute.destination,
             params,
-            parsedUrl.query
+            parsedUrl.query,
+            false,
+            getCustomRouteBasePath(redirectRoute)
           )
           const updatedDestination = formatUrl(parsedDestination)
 
@@ -531,6 +545,7 @@ export default class Server {
     const rewrites = this.customRoutes.rewrites.map((rewrite) => {
       const rewriteRoute = getCustomRoute(rewrite, 'rewrite')
       return {
+        ...rewriteRoute,
         check: true,
         type: rewriteRoute.type,
         name: `Rewrite route`,
@@ -540,7 +555,8 @@ export default class Server {
             rewriteRoute.destination,
             params,
             parsedUrl.query,
-            true
+            true,
+            getCustomRouteBasePath(rewriteRoute)
           )
 
           // external rewrite, proxy it
@@ -560,8 +576,9 @@ export default class Server {
               finished: true,
             }
           }
-          ;(req as any)._nextDidRewrite = true
           ;(req as any)._nextRewroteUrl = newUrl
+          ;(req as any)._nextDidRewrite =
+            (req as any)._nextRewroteUrl !== req.url
 
           return {
             finished: false,
@@ -618,6 +635,7 @@ export default class Server {
       catchAllRoute,
       useFileSystemPublicRoutes,
       dynamicRoutes: this.dynamicRoutes,
+      basePath: this.nextConfig.basePath,
       pageChecker: this.hasPage.bind(this),
     }
   }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -454,7 +454,6 @@ export default class Server {
       ({
         ...r,
         type,
-        matchSrc: `${getCustomRouteBasePath(r)}${r.source}`,
         match: getCustomRouteMatcher(`${getCustomRouteBasePath(r)}${r.source}`),
         name: type,
         fn: async (_req, _res, _params, _parsedUrl) => ({ finished: false }),

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -304,8 +304,7 @@ export async function renderToHTML(
 
   const headTags = (...args: any) => callMiddleware('headTags', args)
 
-  const didRewrite =
-    (req as any)._nextDidRewrite && (req as any)._nextRewroteUrl !== req.url
+  const didRewrite = (req as any)._nextDidRewrite
   const isFallback = !!query.__nextFallback
   delete query.__nextFallback
 

--- a/test/integration/basepath/next.config.js
+++ b/test/integration/basepath/next.config.js
@@ -4,4 +4,66 @@ module.exports = {
     maxInactiveAge: 1000 * 60 * 60,
   },
   basePath: '/docs',
+  // replace me
+  async rewrites() {
+    return [
+      {
+        source: '/rewrite-1',
+        destination: '/gssp',
+      },
+      {
+        source: '/rewrite-no-basepath',
+        destination: '/gssp',
+        basePath: false,
+      },
+      {
+        source: '/rewrite/chain-1',
+        destination: '/rewrite/chain-2',
+      },
+      {
+        source: '/rewrite/chain-2',
+        destination: '/gssp',
+      },
+    ]
+  },
+
+  async redirects() {
+    return [
+      {
+        source: '/redirect-1',
+        destination: '/somewhere-else',
+        permanent: false,
+      },
+      {
+        source: '/redirect-no-basepath',
+        destination: '/another-destination',
+        permanent: false,
+        basePath: false,
+      },
+    ]
+  },
+
+  async headers() {
+    return [
+      {
+        source: '/add-header',
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+      },
+      {
+        source: '/add-header-no-basepath',
+        basePath: false,
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world',
+          },
+        ],
+      },
+    ]
+  },
 }

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -20,6 +20,7 @@ import {
   initNextServerScript,
   getRedboxSource,
   hasRedbox,
+  fetchViaHTTP,
 } from 'next-test-utils'
 import fs, {
   readFileSync,
@@ -115,6 +116,98 @@ const runTests = (context, dev = false) => {
       )
     })
   }
+
+  it('should rewrite with basePath by default', async () => {
+    const html = await renderViaHTTP(context.appPort, '/docs/rewrite-1')
+    expect(html).toContain('getServerSideProps')
+  })
+
+  it('should not rewrite without basePath without disabling', async () => {
+    const res = await fetchViaHTTP(context.appPort, '/rewrite-1')
+    expect(res.status).toBe(404)
+  })
+
+  it('should not rewrite with basePath when set to false', async () => {
+    // won't 404 as it matches the dynamic [slug] route
+    const html = await renderViaHTTP(
+      context.appPort,
+      '/docs/rewrite-no-basePath'
+    )
+    expect(html).toContain('slug')
+  })
+
+  it('should rewrite without basePath when set to false', async () => {
+    const html = await renderViaHTTP(context.appPort, '/rewrite-no-basePath')
+    expect(html).toContain('getServerSideProps')
+  })
+
+  it('should redirect with basePath by default', async () => {
+    const res = await fetchViaHTTP(
+      context.appPort,
+      '/docs/redirect-1',
+      undefined,
+      {
+        redirect: 'manual',
+      }
+    )
+    const { pathname } = url.parse(res.headers.get('location') || '')
+    expect(pathname).toBe('/docs/somewhere-else')
+    expect(res.status).toBe(307)
+  })
+
+  it('should not redirect without basePath without disabling', async () => {
+    const res = await fetchViaHTTP(context.appPort, '/redirect-1', undefined, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('should not redirect with basePath when set to false', async () => {
+    // won't 404 as it matches the dynamic [slug] route
+    const html = await renderViaHTTP(
+      context.appPort,
+      '/docs/rewrite-no-basePath'
+    )
+    expect(html).toContain('slug')
+  })
+
+  it('should redirect without basePath when set to false', async () => {
+    const res = await fetchViaHTTP(
+      context.appPort,
+      '/redirect-no-basepath',
+      undefined,
+      {
+        redirect: 'manual',
+      }
+    )
+    const { pathname } = url.parse(res.headers.get('location') || '')
+    expect(pathname).toBe('/another-destination')
+    expect(res.status).toBe(307)
+  })
+
+  //
+  it('should add header with basePath by default', async () => {
+    const res = await fetchViaHTTP(context.appPort, '/docs/add-header')
+    expect(res.headers.get('x-hello')).toBe('world')
+  })
+
+  it('should not add header without basePath without disabling', async () => {
+    const res = await fetchViaHTTP(context.appPort, '/add-header')
+    expect(res.headers.get('x-hello')).toBe(null)
+  })
+
+  it('should not add header with basePath when set to false', async () => {
+    const res = await fetchViaHTTP(
+      context.appPort,
+      '/docs/add-header-no-basepath'
+    )
+    expect(res.headers.get('x-hello')).toBe(null)
+  })
+
+  it('should add header without basePath when set to false', async () => {
+    const res = await fetchViaHTTP(context.appPort, '/add-header-no-basepath')
+    expect(res.headers.get('x-hello')).toBe('world')
+  })
 
   it('should not update URL for a 404', async () => {
     const browser = await webdriver(context.appPort, '/missing')
@@ -759,8 +852,9 @@ describe('basePath serverless', () => {
   const nextConfig = new File(join(appDir, 'next.config.js'))
 
   beforeAll(async () => {
-    await nextConfig.write(
-      `module.exports = { target: 'experimental-serverless-trace', basePath: '/docs' } `
+    await nextConfig.replace(
+      '// replace me',
+      `target: 'experimental-serverless-trace',`
     )
     await nextBuild(appDir)
     context.appPort = await findPort()


### PR DESCRIPTION
This adds handling for custom-routes with `basePath` to automatically add the `basePath` for custom-routes `source` and `destination` unless `basePath: false` is set for the route. 

Closes: https://github.com/vercel/next.js/issues/14782