### PR TITLE
Update Fast Refresh full reload warning

### DIFF
--- a/packages/next/client/dev/error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev/error-overlay/hot-dev-client.js
@@ -269,11 +269,11 @@ function tryApplyUpdates(onHotUpdateSuccess) {
       if (err) {
         console.warn(
           '[Fast Refresh] performing full reload\n\n' +
-            "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React tree.\n" +
-            'You might have a file which renders a React component but also exports a value that is imported by a non-React component.\n' +
+            "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React rendering tree.\n" +
+            'You might have a file which exports a React component but also exports a value that is imported by a non-React component file.\n' +
             'Consider migrating the non-React component export to a separate file and importing it into both files.\n\n' +
-            'It is also possible you are using class components at the top-level of your application, which disables Fast Refresh.\n' +
-            'Fast Refresh requires at least one function component in your React tree.'
+            'It is also possible the parent component of the component you edited is a class component, which disables Fast Refresh.\n' +
+            'Fast Refresh requires at least one parent function component in your React tree.'
         )
       } else if (hadRuntimeError) {
         console.warn(


### PR DESCRIPTION
We've added a Babel warning for unnamed default exports, and this PR addresses the remaining points in #13024.

Fixes #13024