### PR TITLE
Update dependencies for `with-iron-session` example

### DIFF
--- a/examples/with-iron-session/package.json
+++ b/examples/with-iron-session/package.json
@@ -8,11 +8,11 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "9.3.6",
-    "next-iron-session": "4.0.0",
+    "next": "9.4.4",
+    "next-iron-session": "4.1.7",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "swr": "0.2.0"
+    "swr": "0.2.3"
   }
 }

--- a/examples/with-iron-session/package.json
+++ b/examples/with-iron-session/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "9.4.4",
+    "next": "^9.4.4",
     "next-iron-session": "4.1.7",
     "prop-types": "15.7.2",
     "react": "16.13.1",


### PR DESCRIPTION
This PR updates the dependencies of the `with-iron-session` example. This includes bumping the version of `next` to `9.4.4` which fixes #15033. This is because Next polyfills `fetch` on the browser side since `9.1.7` but the Node.js `fetch` polyfill wasn't included until `9.4`