### PR TITLE
(chore) Add with-goober as an example

### DIFF
--- a/examples/with-goober/README.md
+++ b/examples/with-goober/README.md
@@ -1,0 +1,42 @@
+# Example with goober
+
+This is an example of how [goober](https://github.com/cristianbote/goober) can be used with `Next.js` to fully render a SSR website or app. `goober's` proposal is it's size, at around 1Kb and offering the same functionality one would need. If you are running into any issues with this example, feel free to open-up an issue at https://github.com/cristianbote/goober/issues.
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com/now):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/vercel/next.js/tree/canary/examples/with-goober)
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-goober with-goober-app
+# or
+yarn create next-app --example with-goober with-goober-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/vercel/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/with-goober
+cd with-goober
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-goober/README.md
+++ b/examples/with-goober/README.md
@@ -1,6 +1,12 @@
 # Example with goober
 
-This is an example of how [goober](https://github.com/cristianbote/goober) can be used with `Next.js` to fully render a SSR website or app. `goober's` proposal is it's size, at around 1Kb and offering the same functionality one would need. If you are running into any issues with this example, feel free to open-up an issue at https://github.com/cristianbote/goober/issues.
+This is an example of how [🥜 goober](https://github.com/cristianbote/goober) can be used with `Next.js` to fully render a SSR website or app. [🥜 goober](https://github.com/cristianbote/goober) proposal is: "a less than 1KB css-in-js alternative with a familiar API" and offering the same functionality one would need.
+
+If you are running into any issues with this example, feel free to open-up an issue at https://github.com/cristianbote/goober/issues.
+
+Why is there a peanut emoji?
+
+Goober initially started with a slogan as "a less than 1KB css-in-js library at the cost of _peanuts_". Goober also means a kind of peanut so, it fits!
 
 ## Deploy your own
 

--- a/examples/with-goober/package.json
+++ b/examples/with-goober/package.json
@@ -1,7 +1,6 @@
 {
   "name": "with-goober",
   "version": "1.0.0",
-  "main": "index.js",
   "license": "MIT",
   "scripts": {
     "dev": "next",
@@ -10,8 +9,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "goober": "^2.0.2",
     "goober-autoprefixer": "^1.2.0"
   }

--- a/examples/with-goober/package.json
+++ b/examples/with-goober/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "with-goober",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "goober": "^2.0.2",
+    "goober-autoprefixer": "^1.2.0"
+  }
+}

--- a/examples/with-goober/pages/_app.js
+++ b/examples/with-goober/pages/_app.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { prefix } from 'goober-autoprefixer'
+import { setup } from 'goober'
+
+// goober's needs to know how to render the `styled` nodes.
+// So to let it know, we run the `setup` function with the
+// `createElement` function and prefixer function.
+setup(React.createElement, prefix)
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/examples/with-goober/pages/_document.js
+++ b/examples/with-goober/pages/_document.js
@@ -1,0 +1,30 @@
+import Document, { Head, Main, NextScript } from 'next/document'
+import { extractCss } from 'goober'
+
+export default class MyDocument extends Document {
+  static getInitialProps({ renderPage }) {
+    const page = renderPage()
+
+    // Extrach the css for each page render
+    const css = extractCss()
+    return { ...page, css }
+  }
+
+  render() {
+    return (
+      <html>
+        <Head>
+          <style
+            id={'_goober'}
+            // And defined it in here
+            dangerouslySetInnerHTML={{ __html: ' ' + this.props.css }}
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}

--- a/examples/with-goober/pages/index.js
+++ b/examples/with-goober/pages/index.js
@@ -1,0 +1,28 @@
+import { styled } from 'goober'
+
+const Title = styled('h1')`
+  padding: 0;
+  margin: 0;
+  color: tomato;
+`
+
+const SmallTitle = styled('p')`
+  font-size: 1em;
+  color: dodgerblue;
+  transition: padding 200ms ease-in-out;
+  padding: 1em;
+
+  &:hover {
+    padding-left: 2em;
+    color: darkseagreen;
+  }
+`
+
+export default function Home() {
+  return (
+    <>
+      <Title>You are using goober! Yay!</Title>
+      <SmallTitle>Go on, try it!</SmallTitle>
+    </>
+  )
+}

--- a/examples/with-goober/pages/index.js
+++ b/examples/with-goober/pages/index.js
@@ -21,7 +21,7 @@ const SmallTitle = styled('p')`
 export default function Home() {
   return (
     <>
-      <Title>You are using goober! Yay!</Title>
+      <Title>You are using 🥜 goober! Yay!</Title>
       <SmallTitle>Go on, try it!</SmallTitle>
     </>
   )


### PR DESCRIPTION
This PR creates an example for [🥜 goober](https://github.com/cristianbote/goober). Let me know if there's something else I need to create. Locally I can run it and everything is as it should be.