### PR TITLE
[Examples] Add .next to .gitignore

### DIFF
--- a/examples/blog-starter-typescript/.gitignore
+++ b/examples/blog-starter-typescript/.gitignore
@@ -1,2 +1,3 @@
 .env
 .now
+.next

--- a/examples/blog-starter-typescript/.gitignore
+++ b/examples/blog-starter-typescript/.gitignore
@@ -1,3 +1,31 @@
-.env
-.now
-.next
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Vercel
+.vercel


### PR DESCRIPTION
The TypeScript blog starter didn't have `.next` in the `.gitignore` file.