### PR TITLE
Update ignored patterns for webpack 4

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -711,7 +711,7 @@ export default async function getBaseWebpackConfig(
       }
     },
     watchOptions: {
-      ignored: ['**/.git', '**/node_modules'],
+      ignored: ['**/.git/**', '**/node_modules/**', '**/.next/**'],
     },
     output: {
       path: outputPath,


### PR DESCRIPTION
Found while working on figuring out this bug: https://twitter.com/timneutkens/status/1282129714627448832

 I noticed that the node_modules got passed by the ignore still because when chokidar identifies a ignore pattern is a glob it treats the glob as-is instead of appending `/**` to the glob