### PR TITLE
Mark `preact` as externals for server bundle

### DIFF
--- a/examples/using-preact/next.config.js
+++ b/examples/using-preact/next.config.js
@@ -16,7 +16,9 @@ module.exports = withPrefresh({
 
     if (isServer) {
       // mark `preact` stuffs as external for server bundle to prevent duplicate copies of preact
-      config.externals.push(/^(preact|preact-render-to-string|preact-context-provider)([\\/]|$)/);
+      config.externals.push(
+        /^(preact|preact-render-to-string|preact-context-provider)([\\/]|$)/
+      )
     }
 
     // Install webpack aliases:

--- a/examples/using-preact/next.config.js
+++ b/examples/using-preact/next.config.js
@@ -14,6 +14,11 @@ module.exports = withPrefresh({
       }
     }
 
+    if (isServer) {
+      // mark `preact` stuffs as external for server bundle to prevent duplicate copies of preact
+      config.externals.push(/^preact/);
+    }
+
     // Install webpack aliases:
     const aliases = config.resolve.alias || (config.resolve.alias = {})
     aliases.react = aliases['react-dom'] = 'preact/compat'

--- a/examples/using-preact/next.config.js
+++ b/examples/using-preact/next.config.js
@@ -16,7 +16,7 @@ module.exports = withPrefresh({
 
     if (isServer) {
       // mark `preact` stuffs as external for server bundle to prevent duplicate copies of preact
-      config.externals.push(/^preact/);
+      config.externals.push(/^(preact|preact-render-to-string|preact-context-provider)([\\/]|$)/);
     }
 
     // Install webpack aliases:


### PR DESCRIPTION
3rd party packages usually imports `react` or `preact` during the runtime. The server bundle shouldn't keep its own copy of `preact` to avoid issues with more than one instance of `preact` existing in the same runtime.

Example issue caused by duplicate `preact`: https://github.com/preactjs/preact/issues/1959#issuecomment-541087225