### PR TITLE
Fixing the bug that cause React to be imported as a global import

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -114,6 +114,7 @@ module.exports = (
           // @babel/plugin-transform-react-jsx-self automatically in development
           development: isDevelopment || isTest,
           pragma: '__jsx',
+          runtime: 'automatic',
           ...options['preset-react'],
         },
       ],


### PR DESCRIPTION
This is to fix issue #14703

Reference: https://babeljs.io/docs/en/babel-plugin-transform-react-jsx/#usebuiltins

