### PR TITLE
Added generic type for body in NextApiRequest

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -183,7 +183,7 @@ export type DocumentProps = DocumentInitialProps & {
 /**
  * Next `API` route request
  */
-export interface NextApiRequest extends IncomingMessage {
+export interface NextApiRequest<T = any> extends IncomingMessage {
   /**
    * Object of `query` values from url
    */
@@ -197,7 +197,7 @@ export interface NextApiRequest extends IncomingMessage {
     [key: string]: string
   }
 
-  body: any
+  body: T
 
   env: Env
 


### PR DESCRIPTION
Generic Type for the body in NextApiRequests to implement your custom interfaces to handle better the data.

