### PR TITLE
Update docs for basePath custom-routes interop

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -89,3 +89,37 @@ module.exports = {
   },
 }
 ```
+
+### Headers with basePath support
+
+When leveraging <a href="/docs/api-reference/next.config.js/basepath.md">basePath</a> support with headers each `source` is automatically prefixed with the `basePath` unless you add `basePath: false` to the header.
+
+```js
+module.exports = {
+  basePath: '/docs',
+
+  async headers() {
+    return [
+      {
+        source: '/with-basePath', // becomes /docs/with-basePath
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world'
+          }
+        ]
+      },
+      {
+        source: '/without-basePath', // is not modified since basePath: false is set
+        headers: [
+          {
+            key: 'x-hello',
+            value: 'world'
+          }
+        ]
+        basePath: false
+      },
+    ]
+  },
+}
+```

--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -92,7 +92,7 @@ module.exports = {
 
 ### Headers with basePath support
 
-When leveraging <a href="/docs/api-reference/next.config.js/basepath.md">basePath</a> support with headers each `source` is automatically prefixed with the `basePath` unless you add `basePath: false` to the header.
+When leveraging [`basePath`](/docs/api-reference/next.config.js/basepath.md) support with headers each `source` is automatically prefixed with the `basePath` unless you add `basePath: false` to the header:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -92,7 +92,7 @@ module.exports = {
 
 ### Headers with basePath support
 
-When leveraging [`basePath`](/docs/api-reference/next.config.js/basepath.md) support with headers each `source` is automatically prefixed with the `basePath` unless you add `basePath: false` to the header:
+When leveraging [`basePath` support](/docs/api-reference/next.config.js/basepath.md) with headers each `source` is automatically prefixed with the `basePath` unless you add `basePath: false` to the header:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -68,7 +68,7 @@ module.exports = {
 
 ### Redirects with basePath support
 
-When leveraging [`basePath`](/docs/api-reference/next.config.js/basepath.md) with redirects each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the redirect:
+When leveraging [`basePath` support](/docs/api-reference/next.config.js/basepath.md) with redirects each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the redirect:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -65,3 +65,30 @@ module.exports = {
   },
 }
 ```
+
+### Redirects with basePath support
+
+When leveraging <a href="/docs/api-reference/next.config.js/basepath.md">basePath support</a> with redirects each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the redirect.
+
+```js
+module.exports = {
+  basePath: '/docs',
+
+  async redirects() {
+    return [
+      {
+        source: '/with-basePath', // automatically becomes /docs/with-basePath
+        destination: '/another', // automatically becomes /docs/another
+        permanent: false,
+      },
+      {
+        // does not add /docs since basePath: false is set
+        source: '/without-basePath',
+        destination: '/another',
+        basePath: false,
+        permanent: false,
+      },
+    ]
+  },
+}
+```

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -68,7 +68,7 @@ module.exports = {
 
 ### Redirects with basePath support
 
-When leveraging <a href="/docs/api-reference/next.config.js/basepath.md">basePath support</a> with redirects each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the redirect.
+When leveraging [`basePath`](/docs/api-reference/next.config.js/basepath.md) with redirects each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the redirect:
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -110,3 +110,28 @@ module.exports = {
   },
 }
 ```
+
+### Rewrites with basePath support
+
+When leveraging <a href="/docs/api-reference/next.config.js/basepath.md">basePath support</a> with rewrites each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the rewrite.
+
+```js
+module.exports = {
+  basePath: '/docs',
+
+  async rewrites() {
+    return [
+      {
+        source: '/with-basePath', // automatically becomes /docs/with-basePath
+        destination: '/another', // automatically becomes /docs/another
+      },
+      {
+        // does not add /docs since basePath: false is set
+        source: '/without-basePath',
+        destination: '/another',
+        basePath: false,
+      },
+    ]
+  },
+}
+```

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -113,7 +113,7 @@ module.exports = {
 
 ### Rewrites with basePath support
 
-When leveraging <a href="/docs/api-reference/next.config.js/basepath.md">basePath support</a> with rewrites each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the rewrite.
+When leveraging [`basePath` support](/docs/api-reference/next.config.js/basepath.md) with rewrites each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the rewrite:
 
 ```js
 module.exports = {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/15041 this updates the documentation for custom-routes to mention `basePath` handling with them