### PR TITLE
Removed React import from pages/index.js

### DIFF
--- a/examples/with-linaria/pages/index.js
+++ b/examples/with-linaria/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Head from 'next/head'
 import { styled } from 'linaria/react'
 
@@ -23,11 +22,11 @@ const Box = styled.div`
 
 export default function Home() {
   return (
-    <React.Fragment>
+    <>
       <Head>
         <title>With Linaria</title>
       </Head>
       <Box>Zero runtime CSS in JS</Box>
-    </React.Fragment>
+    </>
   )
 }


### PR DESCRIPTION
This should close https://github.com/vercel/next.js/issues/12964 but I'm leaving it up to one of the Tims (or if there are other maintainers) to close the issue as they see fit.

