### PR TITLE
Find pages/_document.js chunk in development

### DIFF
--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -2,7 +2,7 @@ import { getOverlayMiddleware } from '@next/react-dev-overlay/lib/middleware'
 import { NextHandleFunction } from 'connect'
 import { IncomingMessage, ServerResponse } from 'http'
 import { WebpackHotMiddleware } from './hot-middleware'
-import { join, normalize, relative as relativePath } from 'path'
+import { join, relative as relativePath } from 'path'
 import { UrlObject } from 'url'
 import webpack from 'webpack'
 import { createEntrypoints, createPagesMapping } from '../build/entries'
@@ -353,7 +353,7 @@ export default class HotReloader {
         // We only watch `_document` for changes on the server compilation
         // the rest of the files will be triggered by the client compilation
         const documentChunk = compilation.chunks.find(
-          (c) => c.name === normalize(`pages/_document`)
+          (c) => c.name === `pages/_document`
         )
         // If the document chunk can't be found we do nothing
         if (!documentChunk) {


### PR DESCRIPTION
Chunks already have a normalized path.

Not sure if there are other chunks that require this change, I did a global search and didn't find similar cases.