### PR TITLE
fixed prettier --write args in package.json

### DIFF
--- a/examples/with-typescript-eslint-jest/package.json
+++ b/examples/with-typescript-eslint-jest/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "type-check": "tsc --pretty --noEmit",
-    "format": "prettier --write **/*.{js,ts,tsx}",
+    "format": "prettier --write \"**/*.{js,ts,tsx}\"",
     "lint": "eslint . --ext ts --ext tsx --ext js",
     "test": "jest",
     "test-all": "yarn lint && yarn type-check && yarn test"


### PR DESCRIPTION
prettier --write **/*.{js,ts,tsx} does not work as intended, it never does traverse all files with js,ts,tsx extension. For it to work as intended, extension args should be wrapped in quotes like this "**/*.{js,ts,tsx}"