### PR TITLE
Use `core-js` for URL(SearchParams) Polyfill

### DIFF
--- a/packages/next-polyfill-nomodule/package.json
+++ b/packages/next-polyfill-nomodule/package.json
@@ -16,7 +16,6 @@
     "core-js": "3.6.5",
     "microbundle": "0.11.0",
     "object-assign": "4.1.1",
-    "url-polyfill": "1.1.9",
     "whatwg-fetch": "3.0.0"
   }
 }

--- a/packages/next-polyfill-nomodule/src/index.js
+++ b/packages/next-polyfill-nomodule/src/index.js
@@ -42,6 +42,9 @@ import 'core-js/features/string/repeat'
 import 'core-js/features/string/starts-with'
 import 'core-js/features/string/trim-left'
 import 'core-js/features/string/trim-right'
+import 'core-js/features/url'
+import 'core-js/features/url/to-json'
+import 'core-js/features/url-search-params'
 import 'core-js/features/weak-map'
 import 'core-js/features/weak-set'
 import 'core-js/features/promise'
@@ -50,6 +53,5 @@ import 'core-js/features/promise/finally'
 
 // Specialized Packages:
 import 'whatwg-fetch'
-import 'url-polyfill'
 import assign from 'object-assign'
 Object.assign = assign

--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -80,7 +80,7 @@ describe('Production response size', () => {
     )
 
     // These numbers are without gzip compression!
-    const delta = responseSizesBytes - 261 * 1024
+    const delta = responseSizesBytes - 273 * 1024
     expect(delta).toBeLessThanOrEqual(1024) // don't increase size more than 1kb
     expect(delta).toBeGreaterThanOrEqual(-1024) // don't decrease size more than 1kb without updating target
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15818,10 +15818,6 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-polyfill@1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.9.tgz#2c8d4224889a5c942800f708f5585368085603d9"
-
 url-template@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"


### PR DESCRIPTION
This replaces the `url-polyfill` package with the `core-js` version which handles more edge cases in legacy browsers.

Closes #11702
Fixes #15194