### PR TITLE
Improve query conversion logic

### DIFF
--- a/packages/next/next-server/lib/router/utils/search-params-to-url-query.ts
+++ b/packages/next/next-server/lib/router/utils/search-params-to-url-query.ts
@@ -4,7 +4,7 @@ export function searchParamsToUrlQuery(
   searchParams: URLSearchParams
 ): ParsedUrlQuery {
   const query: ParsedUrlQuery = {}
-  Array.from(searchParams.entries()).forEach(([key, value]) => {
+  searchParams.forEach((value, key) => {
     if (typeof query[key] === 'undefined') {
       query[key] = value
     } else if (Array.isArray(query[key])) {


### PR DESCRIPTION
`URLSearchParams` has a `forEach` method. this should simplify and shorten the logic. Perhaps it will even phix https://github.com/vercel/next.js/issues/15232