### PR TITLE
Added modern terser options

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -351,6 +351,11 @@ export default async function getBaseWebpackConfig(
     },
   }
 
+  if (config.experimental.modern) {
+    terserOptions.module = true
+    terserOptions.ecma = terserOptions.compress.ecma = terserOptions.output.ecma = 8
+  }
+
   const isModuleCSS = (module: { type: string }): boolean => {
     return (
       // mini-css-extract-plugin


### PR DESCRIPTION
Added terser options when `experimental.modern = true`

Setting `terserOptions.ecma = 8` overwrites all other `ecma` options anyway, but it doesn't hurt to just override them all in 1 assignment. 

Closes #14707