### PR TITLE
feat: include ctx in getStaticProps when available

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -510,6 +510,7 @@ export async function renderToHTML(
           ...(previewData !== false
             ? { preview: true, previewData: previewData }
             : undefined),
+          ctx,
         })
       } catch (staticPropsError) {
         // remove not found error code to prevent triggering legacy

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -76,6 +76,11 @@ export type GetStaticPropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
   params?: Q
   preview?: boolean
   previewData?: any
+  ctx?: {
+    req: IncomingMessage
+    res: ServerResponse
+    query: ParsedUrlQuery
+  }
 }
 
 export type GetStaticPropsResult<P> = {


### PR DESCRIPTION
I have a use-case where I need to access the http request on SSG Previews.

It wouldn't hurt to pass the ctx as a prop on getStaticProps, so that's is my proposal.

You may need to get some query params, cookies, headers etc. that are too dynamic for the `setPreviewData` api.