### PR TITLE
Update to 3.0 in api-routes-apollo-server-and-client example

### DIFF
--- a/examples/api-routes-apollo-server-and-client/apollo/client.js
+++ b/examples/api-routes-apollo-server-and-client/apollo/client.js
@@ -1,16 +1,15 @@
 import { useMemo } from 'react'
-import { ApolloClient } from 'apollo-client'
-import { InMemoryCache } from 'apollo-cache-inmemory'
+import { ApolloClient, InMemoryCache } from '@apollo/client'
 
 let apolloClient
 
 function createIsomorphLink() {
   if (typeof window === 'undefined') {
-    const { SchemaLink } = require('apollo-link-schema')
+    const { SchemaLink } = require('@apollo/client/link/schema')
     const { schema } = require('./schema')
     return new SchemaLink({ schema })
   } else {
-    const { HttpLink } = require('apollo-link-http')
+    const { HttpLink } = require('@apollo/client/link/http')
     return new HttpLink({
       uri: '/api/graphql',
       credentials: 'same-origin',

--- a/examples/api-routes-apollo-server-and-client/apollo/type-defs.js
+++ b/examples/api-routes-apollo-server-and-client/apollo/type-defs.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export const typeDefs = gql`
   type User {

--- a/examples/api-routes-apollo-server-and-client/package.json
+++ b/examples/api-routes-apollo-server-and-client/package.json
@@ -7,16 +7,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@apollo/react-common": "^3.1.4",
-    "@apollo/react-hooks": "^3.1.5",
-    "apollo-cache-inmemory": "^1.6.6",
-    "apollo-client": "^2.6.10",
-    "apollo-link-http": "^1.5.17",
-    "apollo-link-schema": "^1.2.5",
+    "@apollo/client": "^3.0.2",
     "apollo-server-micro": "^2.14.2",
-    "apollo-utilities": "^1.3.2",
     "graphql": "^14.0.2",
-    "graphql-tag": "2.10.3",
     "next": "latest",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",

--- a/examples/api-routes-apollo-server-and-client/pages/_app.js
+++ b/examples/api-routes-apollo-server-and-client/pages/_app.js
@@ -1,4 +1,4 @@
-import { ApolloProvider } from '@apollo/react-hooks'
+import { ApolloProvider } from '@apollo/client'
 import { useApollo } from '../apollo/client'
 
 export default function App({ Component, pageProps }) {

--- a/examples/api-routes-apollo-server-and-client/pages/index.js
+++ b/examples/api-routes-apollo-server-and-client/pages/index.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 import Link from 'next/link'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery } from '@apollo/client'
 import { initializeApollo } from '../apollo/client'
 
 const ViewerQuery = gql`


### PR DESCRIPTION
This PR upgrades [Apollo Client](https://www.apollographql.com/docs/react/) in the `api-routes-apollo-server-and-client` example to the latest major version (3.0) following the [migration guide](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/). As recommended in the aforementioned guide, the `graphql-tag` dependency was dropped in favour of importing from `@apollo/client`.