### PR TITLE
Fix no-anon-default-export for webpack 5

### DIFF
--- a/packages/next/client/dev/error-overlay/format-webpack-messages.js
+++ b/packages/next/client/dev/error-overlay/format-webpack-messages.js
@@ -34,7 +34,10 @@ function isLikelyASyntaxError(message) {
 function formatMessage(message) {
   // TODO: Replace this once webpack 5 is stable
   if (typeof message === 'object' && message.message) {
-    message = (message.file ? message.file + '\n' : '') + message.message
+    message =
+      (message.moduleName ? message.moduleName + '\n' : '') +
+      (message.file ? message.file + '\n' : '') +
+      message.message
   }
   let lines = message.split('\n')
 


### PR DESCRIPTION
Fixes one of the cases of https://github.com/vercel/next.js/pull/15185#issuecomment-660128647