### PR TITLE
Fix broken example link in docs for catch all routes

### DIFF
--- a/docs/routing/dynamic-routes.md
+++ b/docs/routing/dynamic-routes.md
@@ -83,8 +83,6 @@ And in the case of `/post/a/b`, and any other matching path, new parameters will
 { "slug": ["a", "b"] }
 ```
 
-> A good example of catch all routes is the Next.js docs, a single page called [pages/docs/[...slug].js](https://github.com/zeit/next-site/blob/master/pages/docs/%5B...slug%5D.js) takes care of all the docs you're currently looking at.
-
 ### Optional catch all routes
 
 Catch all routes can be made optional by including the parameter in double brackets (`[[...slug]]`).
@@ -98,6 +96,8 @@ The `query` objects are as follows:
 { "slug": ["a"] } // `GET /post/a` (single-element array)
 { "slug": ["a", "b"] } // `GET /post/a/b` (multi-element array)
 ```
+
+> A good example of optional catch all routes is the Next.js docs, a single page called [pages/docs/[[...slug]].js](https://github.com/zeit/next-site/blob/master/pages/docs/%5B%5B...slug%5D%5D.js) takes care of all the docs you're currently looking at.
 
 ## Caveats
 


### PR DESCRIPTION
Fixes a broken link on https://nextjs.org/docs/routing/dynamic-routes

This path was updated from `pages/docs/[...slug].js` to `pages/docs/[[...slug]].js`, so I've updated the link and moved that example down to the "Optional catch all routes" section.