### PR TITLE
Do not duplicate compilation errors

### DIFF
--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -32,7 +32,11 @@ import { isWriteable } from '../build/is-writeable'
 import { ClientPagesLoaderOptions } from '../build/webpack/loaders/next-client-pages-loader'
 import { stringify } from 'querystring'
 
-export async function renderScriptError(res: ServerResponse, error: Error) {
+export async function renderScriptError(
+  res: ServerResponse,
+  error: Error,
+  { verbose = true } = {}
+) {
   // Asks CDNs and others to not to cache the errored page
   res.setHeader(
     'Cache-Control',
@@ -48,7 +52,9 @@ export async function renderScriptError(res: ServerResponse, error: Error) {
     return
   }
 
-  console.error(error.stack)
+  if (verbose) {
+    console.error(error.stack)
+  }
   res.statusCode = 500
   res.end('500 - Internal Error')
 }
@@ -213,7 +219,7 @@ export default class HotReloader {
 
         const errors = await this.getCompilationErrors(page)
         if (errors.length > 0) {
-          await renderScriptError(pageBundleRes, errors[0])
+          await renderScriptError(pageBundleRes, errors[0], { verbose: false })
           return { finished: true }
         }
       }

--- a/test/integration/no-duplicate-compile-error/next.config.js
+++ b/test/integration/no-duplicate-compile-error/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  onDemandEntries: {
+    // Make sure entries are not getting disposed.
+    maxInactiveAge: 1000 * 60 * 60,
+  },
+}

--- a/test/integration/no-duplicate-compile-error/pages/index.js
+++ b/test/integration/no-duplicate-compile-error/pages/index.js
@@ -1,0 +1,3 @@
+export default function Abc() {
+  return <div id="a">hello</div>
+}

--- a/test/integration/no-duplicate-compile-error/test/index.test.js
+++ b/test/integration/no-duplicate-compile-error/test/index.test.js
@@ -56,7 +56,18 @@ describe('no duplicate compile error output', () => {
     )
     await browser.waitForElementByCss('#a')
 
-    expect((stdout.match(/Unexpected token/g) || []).length).toBe(1)
+    function getRegexCount(str, regex) {
+      return (str.match(regex) || []).length
+    }
+
+    const correctMessagesRegex = /error - [^\r\n]+\r?\n[^\r\n]+Unexpected token/g
+    const totalMessagesRegex = /Unexpected token/g
+
+    const correctMessages = getRegexCount(stdout, correctMessagesRegex)
+    const totalMessages = getRegexCount(stdout, totalMessagesRegex)
+
+    expect(correctMessages).toBeGreaterThanOrEqual(1)
+    expect(correctMessages).toBe(totalMessages)
     expect(stderr).toBe('')
 
     await killApp(app)

--- a/test/integration/no-duplicate-compile-error/test/index.test.js
+++ b/test/integration/no-duplicate-compile-error/test/index.test.js
@@ -50,7 +50,10 @@ describe('no duplicate compile error output', () => {
     }
 
     // Wait for compile error to disappear:
-    await check(() => hasRedbox(browser).then((r) => (r ? 'yes' : 'no')), /no/)
+    await check(
+      () => hasRedbox(browser, false).then((r) => (r ? 'yes' : 'no')),
+      /no/
+    )
     await browser.waitForElementByCss('#a')
 
     expect((stdout.match(/Unexpected token/g) || []).length).toBe(1)

--- a/test/integration/no-duplicate-compile-error/test/index.test.js
+++ b/test/integration/no-duplicate-compile-error/test/index.test.js
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+import {
+  check,
+  File,
+  findPort,
+  hasRedbox,
+  killApp,
+  launchApp,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { join } from 'path'
+
+jest.setTimeout(1000 * 60 * 3)
+
+const appDir = join(__dirname, '../')
+
+describe('no duplicate compile error output', () => {
+  it('show not show compile error on page refresh', async () => {
+    let stdout = ''
+    let stderr = ''
+
+    const appPort = await findPort()
+    const app = await launchApp(appDir, appPort, {
+      env: { __NEXT_TEST_WITH_DEVTOOL: true },
+      onStdout(msg) {
+        stdout += msg || ''
+      },
+      onStderr(msg) {
+        stderr += msg || ''
+      },
+    })
+
+    const browser = await webdriver(appPort, '/')
+
+    await browser.waitForElementByCss('#a')
+
+    const f = new File(join(appDir, 'pages', 'index.js'))
+    f.replace('<div id="a">hello</div>', '<div id="a"!>hello</div>')
+
+    try {
+      // Wait for compile error:
+      expect(await hasRedbox(browser, true)).toBe(true)
+
+      await browser.refresh()
+
+      // Wait for compile error to re-appear:
+      expect(await hasRedbox(browser, true)).toBe(true)
+    } finally {
+      f.restore()
+    }
+
+    // Wait for compile error to disappear:
+    await check(() => hasRedbox(browser).then((r) => (r ? 'yes' : 'no')), /no/)
+    await browser.waitForElementByCss('#a')
+
+    expect((stdout.match(/Unexpected token/g) || []).length).toBe(1)
+    expect(stderr).toBe('')
+
+    await killApp(app)
+  })
+})


### PR DESCRIPTION
This pull request removes the duplication of compile errors.

Next.js meticulously controls the console output during a compilation error to give the user a very clear indication of the issue and where to fix it.

This code path would add console noise and obscure the real issue by not running the error through our appropriate human-friendly output.

Meaning, the user would see this error, **without the source file**:

```
Error: Syntax error: Unexpected token, expected ";"

  3 | 
  4 | export default function App({ Component, pageProps }) {
> 5 |   return <Component {...pageProps} />!;
    |                                      ^
  6 | }
  7 | 
    at getBabelError (/Users/joe/Documents/Blog/www/node_modules/next/dist/build/webpack/plugins/wellknown-errors-plugin/parseBabel.js:4:91)
    at getModuleBuildError (/Users/joe/Documents/Blog/www/node_modules/next/dist/build/webpack/plugins/wellknown-errors-plugin/webpackModuleError.js:1:2469)
    at /Users/joe/Documents/Blog/www/node_modules/next/dist/build/webpack/plugins/wellknown-errors-plugin/index.js:1:549
    at Array.map (<anonymous>)
    at /Users/joe/Documents/Blog/www/node_modules/next/dist/build/webpack/plugins/wellknown-errors-plugin/index.js:1:478
    at SyncHook.eval [as call] (eval at create (/Users/joe/Documents/Blog/www/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:1)
    at SyncHook.lazyCompileHook (/Users/joe/Documents/Blog/www/node_modules/tapable/lib/Hook.js:154:20)
    at Compilation.seal (/Users/joe/Documents/Blog/www/node_modules/webpack/lib/Compilation.js:1284:19)
    at /Users/joe/Documents/Blog/www/node_modules/webpack/lib/Compiler.js:675:18
    at /Users/joe/Documents/Blog/www/node_modules/webpack/lib/Compilation.js:1261:4
```

This pull request ensures the last thing logged in the console is the following code:

```js
error - ./pages/_app.js:5:37
Syntax error: Unexpected token, expected ";"

  3 | 
  4 | export default function App({ Component, pageProps }) {
> 5 |   return <Component {...pageProps} />!;
    |                                      ^
  6 | }
  7 | 
```

---

Fixes #15071