### PR TITLE
Update analytics examples to not use provided url

### DIFF
--- a/examples/with-google-analytics-amp/lib/gtag.js
+++ b/examples/with-google-analytics-amp/lib/gtag.js
@@ -3,7 +3,7 @@ export const GA_TRACKING_ID = '<YOUR_GA_TRACKING_ID>'
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = () => {
   window.gtag('config', GA_TRACKING_ID, {
-    page_path: window.location.pathname,
+    page_path: window.location.pathname + window.location.search,
   })
 }
 

--- a/examples/with-google-analytics-amp/lib/gtag.js
+++ b/examples/with-google-analytics-amp/lib/gtag.js
@@ -1,9 +1,9 @@
 export const GA_TRACKING_ID = '<YOUR_GA_TRACKING_ID>'
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url) => {
+export const pageview = () => {
   window.gtag('config', GA_TRACKING_ID, {
-    page_path: url,
+    page_path: window.location.pathname,
   })
 }
 

--- a/examples/with-google-analytics-amp/pages/_app.js
+++ b/examples/with-google-analytics-amp/pages/_app.js
@@ -3,6 +3,6 @@ import Router from 'next/router'
 
 import * as gtag from '../lib/gtag'
 
-Router.events.on('routeChangeComplete', (url) => gtag.pageview(url))
+Router.events.on('routeChangeComplete', () => gtag.pageview())
 
 export default App

--- a/examples/with-google-analytics/lib/gtag.js
+++ b/examples/with-google-analytics/lib/gtag.js
@@ -3,7 +3,7 @@ export const GA_TRACKING_ID = '<YOUR_GA_TRACKING_ID>'
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = () => {
   window.gtag('config', GA_TRACKING_ID, {
-    page_path: window.location.pathname,
+    page_path: window.location.pathname + window.location.search,
   })
 }
 

--- a/examples/with-google-analytics/lib/gtag.js
+++ b/examples/with-google-analytics/lib/gtag.js
@@ -1,9 +1,9 @@
 export const GA_TRACKING_ID = '<YOUR_GA_TRACKING_ID>'
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url) => {
+export const pageview = () => {
   window.gtag('config', GA_TRACKING_ID, {
-    page_path: url,
+    page_path: window.location.pathname,
   })
 }
 

--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -4,8 +4,8 @@ import * as gtag from '../lib/gtag'
 
 const App = ({ Component, pageProps }) => {
   useEffect(() => {
-    const handleRouteChange = (url) => {
-      gtag.pageview(url)
+    const handleRouteChange = () => {
+      gtag.pageview()
     }
     Router.events.on('routeChangeComplete', handleRouteChange)
     return () => {

--- a/examples/with-segment-analytics/components/Page.js
+++ b/examples/with-segment-analytics/components/Page.js
@@ -3,8 +3,8 @@ import Router from 'next/router'
 import Header from './Header'
 
 // Track client-side page views with Segment
-Router.events.on('routeChangeComplete', (url) => {
-  window.analytics.page(url)
+Router.events.on('routeChangeComplete', () => {
+  window.analytics.page(window.location.pathname)
 })
 
 const Page = ({ children }) => (

--- a/examples/with-segment-analytics/components/Page.js
+++ b/examples/with-segment-analytics/components/Page.js
@@ -4,7 +4,7 @@ import Header from './Header'
 
 // Track client-side page views with Segment
 Router.events.on('routeChangeComplete', () => {
-  window.analytics.page(window.location.pathname)
+  window.analytics.page(window.location.pathname + window.location.search)
 })
 
 const Page = ({ children }) => (


### PR DESCRIPTION
Use actual value, independent from `basePath`