### PR TITLE
[WIP]Rmove the dotenv dependency from all Next.js examples

### DIFF
--- a/examples/auth0/package.json
+++ b/examples/auth0/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "dependencies": {
     "@auth0/nextjs-auth0": "^0.6.0",
-    "dotenv": "^8.2.0",
     "next": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/examples/with-firebase/package.json
+++ b/examples/with-firebase/package.json
@@ -11,8 +11,5 @@
     "next": "latest",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
-  },
-  "devDependencies": {
-    "dotenv": "8.2.0"
   }
 }

--- a/examples/with-reason-relay/package.json
+++ b/examples/with-reason-relay/package.json
@@ -17,7 +17,6 @@
     "@zeit/next-css": "1.0.1",
     "bs-fetch": "0.5.2",
     "bs-platform": "7.2.2",
-    "dotenv": "^8.2.0",
     "dotenv-webpack": "^1.7.0",
     "graphql": "15.0.0",
     "isomorphic-unfetch": "^3.0.0",

--- a/examples/with-stripe-typescript/package.json
+++ b/examples/with-stripe-typescript/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@stripe/react-stripe-js": "1.1.2",
     "@stripe/stripe-js": "1.5.0",
-    "dotenv": "latest",
     "micro": "^9.3.4",
     "micro-cors": "^0.1.1",
     "next": "latest",

--- a/examples/with-universal-configuration-build-time/package.json
+++ b/examples/with-universal-configuration-build-time/package.json
@@ -11,8 +11,5 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   },
-  "devDependencies": {
-    "dotenv": "^6.2.0"
-  },
   "license": "ISC"
 }


### PR DESCRIPTION
#15225
- [ ] examples/auth0
- [ ]   examples/with-firebase/package.json
 - [ ] examples/with-reason-relay/package.json
- [ ]  examples/with-stripe-typescript/package.json
- [ ]  examples/with-universal-configuration-build-time/package.json