### PR TITLE
Fix cancellation control flow

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -25,7 +25,7 @@ import {
 const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
 function buildCancellationError() {
-  return Object.assign(new Error('Routing cancelled'), {
+  return Object.assign(new Error('Route Cancelled'), {
     cancelled: true,
   })
 }

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -495,6 +495,7 @@ export default class Router implements BaseRouter {
     }
 
     const route = removePathTrailingSlash(pathname)
+    const { shallow = false } = options
 
     if (isDynamicRoute(route)) {
       const { pathname: asPathname } = parseRelativeUrl(cleanedAs)
@@ -529,7 +530,13 @@ export default class Router implements BaseRouter {
     Router.events.emit('routeChangeStart', as)
 
     try {
-      const routeInfo = await this.getRouteInfo(route, pathname, query, as)
+      const routeInfo = await this.getRouteInfo(
+        route,
+        pathname,
+        query,
+        as,
+        shallow
+      )
       const { error } = routeInfo
 
       Router.events.emit('beforeHistoryChange', as)
@@ -652,10 +659,15 @@ export default class Router implements BaseRouter {
     route: string,
     pathname: string,
     query: any,
-    as: string
+    as: string,
+    shallow: boolean = false
   ): Promise<RouteInfo> {
     try {
       const cachedRouteInfo = this.components[route]
+
+      if (shallow && cachedRouteInfo && this.route === route) {
+        return cachedRouteInfo
+      }
 
       const routeInfo = cachedRouteInfo
         ? cachedRouteInfo

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -104,7 +104,7 @@ describe('Build Output', () => {
       expect(parseFloat(err404FirstLoad) - 63).toBeLessThanOrEqual(0)
       expect(err404FirstLoad.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(sharedByAll) - 59).toBeLessThanOrEqual(0)
+      expect(parseFloat(sharedByAll) - 59.2).toBeLessThanOrEqual(0)
       expect(sharedByAll.endsWith('kB')).toBe(true)
 
       if (_appSize.endsWith('kB')) {

--- a/test/integration/size-limit/test/index.test.js
+++ b/test/integration/size-limit/test/index.test.js
@@ -80,7 +80,7 @@ describe('Production response size', () => {
     )
 
     // These numbers are without gzip compression!
-    const delta = responseSizesBytes - 273 * 1024
+    const delta = responseSizesBytes - 274 * 1024
     expect(delta).toBeLessThanOrEqual(1024) // don't increase size more than 1kb
     expect(delta).toBeGreaterThanOrEqual(-1024) // don't decrease size more than 1kb without updating target
   })


### PR DESCRIPTION
Following up on https://github.com/vercel/next.js/pull/14848
- extract `handleError` into its own class method instead of nesting it in the `getRouteInfo` method.
- change the logic to async/await to visualize the flow better
- Remove the `ABORTED` symbol and unify cancellation logic by moving the `routeChangeError` upstream
- Remove `// @ts-ignore` by keeping cancellation in the error flow. This is sort of using try/catch for control flow, but it's also the same mechanism as being used for `AbortController` so I wouldn't consider it a problem.