### PR TITLE
Added production, basic, and Fast Refresh test suites on macOS

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -93,10 +93,9 @@ jobs:
           path: '.'
           key: ${{ github.sha }}
 
-      - run: |
-          node run-tests.js test/integration/production/test/index.test.js
-          node run-tests.js test/integration/basic/test/index.test.js
-          node run-tests.js test/acceptance/*
+      - run: node run-tests.js test/integration/production/test/index.test.js
+      - run: node run-tests.js test/integration/basic/test/index.test.js
+      - run: node run-tests.js test/acceptance/*
 
   testFirefox:
     name: Test Firefox (production)

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -77,6 +77,27 @@ jobs:
     steps:
       - run: exit 0
 
+  testMacOS:
+    name: macOS ( Basic, Production, Acceptance )
+    runs-on: macos-latest
+    needs: build
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      NEXT_TEST_JOB: 1
+      HEADLESS: true
+
+    steps:
+      - uses: actions/cache@v1
+        id: restore-build
+        with:
+          path: '.'
+          key: ${{ github.sha }}
+
+      - run: |
+          node run-tests.js test/integration/production/test/index.test.js
+          node run-tests.js test/integration/basic/test/index.test.js
+          node run-tests.js test/acceptance/*
+
   testFirefox:
     name: Test Firefox (production)
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -87,6 +87,8 @@ jobs:
       HEADLESS: true
 
     steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       # Installing dependencies again since OS changed
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js test/integration/production/test/index.test.js

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -87,12 +87,8 @@ jobs:
       HEADLESS: true
 
     steps:
-      - uses: actions/cache@v1
-        id: restore-build
-        with:
-          path: '.'
-          key: ${{ github.sha }}
-
+      # Installing dependencies again since OS changed
+      - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js test/integration/production/test/index.test.js
       - run: node run-tests.js test/integration/basic/test/index.test.js
       - run: node run-tests.js test/acceptance/*


### PR DESCRIPTION
Added GitHub action to run Basic, Production, and Acceptance test suites. 
Let me know if I should add matrix tests for Ubuntu, macOS, and windows for all the tests albeit increasing the runtime a lot

Edit: Screenshot 
![Screenshot 2020-07-21 at 5 02 13 PM](https://user-images.githubusercontent.com/11258286/88050176-faf10b00-cb73-11ea-820a-112b8ad776f8.png)


Resolves: #15301 