### PR TITLE
[WIP] Conditional polyfills

### DIFF
--- a/packages/next-polyfill-nomodule/package.json
+++ b/packages/next-polyfill-nomodule/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "core-js": "3.6.5",
+    "intersection-observer": "0.11.0",
     "microbundle": "0.11.0",
     "object-assign": "4.1.1",
     "whatwg-fetch": "3.0.0"

--- a/packages/next-polyfill-nomodule/src/index.js
+++ b/packages/next-polyfill-nomodule/src/index.js
@@ -54,4 +54,5 @@ import 'core-js/features/promise/finally'
 // Specialized Packages:
 import 'whatwg-fetch'
 import assign from 'object-assign'
+import 'intersection-observer'
 Object.assign = assign

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -309,6 +309,10 @@ export async function render(renderingProps) {
   }
 
   try {
+    if (!('IntersectionObserver' in window)) {
+      // This is practically just Safari 11 and 12.0
+      await import('next/dist/build/polyfills/intersection-observer')
+    }
     await doRender(renderingProps)
   } catch (renderErr) {
     if (process.env.NODE_ENV === 'development') {

--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -311,6 +311,10 @@ export async function render(renderingProps) {
   try {
     if (!('IntersectionObserver' in window)) {
       // This is practically just Safari 11 and 12.0
+      /**
+       * If we find any more such discrepencies between script type=module browsers
+       * then this can be extended as a separate bundle to address them.
+       */
       await import('next/dist/build/polyfills/intersection-observer')
     }
     await doRender(renderingProps)

--- a/packages/next/compiled/intersection-observer/package.json
+++ b/packages/next/compiled/intersection-observer/package.json
@@ -1,0 +1,1 @@
+{"name":"intersection-observer","main":"intersection-observer.js","author":{"name":"Philip Walton","email":"philip@philipwalton.com","url":"http://philipwalton.com"},"license":"W3C-20150513"}

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -87,6 +87,7 @@
     "css-loader": "3.5.3",
     "cssnano-simple": "1.0.4",
     "find-cache-dir": "3.3.1",
+    "intersection-observer": "0.11.0",
     "jest-worker": "24.9.0",
     "loader-utils": "2.0.0",
     "mini-css-extract-plugin": "0.8.0",

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -25,11 +25,21 @@ export async function unfetch(task, opts) {
     .target('dist/build/polyfills')
 }
 
+export async function intersectionObserver(task, opts) {
+  await task
+    .source(
+      opts.src || relative(__dirname, require.resolve('intersection-observer'))
+    )
+    .ncc({ packageName: 'intersection-observer' })
+    .target('dist/build/polyfills')
+}
+
 export async function browser_polyfills(task) {
   await task.parallel([
     'next__polyfill_nomodule',
     'finally_polyfill',
     'unfetch',
+    'intersectionObserver',
   ])
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8153,6 +8153,11 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+intersection-observer@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.11.0.tgz#f4ea067070326f68393ee161cc0a2ca4c0040c6f"
+  integrity sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ==
+
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
This PR makes Intersection observer available to all the browser that NextJS works on
- For browsers supporting `nomodule` the polyfill is loaded via `next-polyfill-nomodule` bundle.
- For browsers supporting `script type=module` but not IntersectionObserver(`Only Safari 11/12.0`) a conditional webpack chunk is loaded before rendering starts.