### PR TITLE
[example] Removing horizontal scroll blog-starter example

### DIFF
--- a/examples/blog-starter-typescript/components/post-header.tsx
+++ b/examples/blog-starter-typescript/components/post-header.tsx
@@ -18,7 +18,7 @@ const PostHeader = ({ title, coverImage, date, author }: Props) => {
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} src={coverImage} />
       </div>
       <div className="max-w-2xl mx-auto">


### PR DESCRIPTION
Horizontal scrolling occurs when the width is less than 640px.

This phenomenon occurs in all examples related to blog-starter.

Send a PR to fix this.

---

## 640px


![640px](https://user-images.githubusercontent.com/5674610/88182883-b8125e80-cc6b-11ea-989b-0bff3289c643.png)


---


## 639px


![639px](https://user-images.githubusercontent.com/5674610/88182865-b2b51400-cc6b-11ea-8258-16f06e6493b7.png)