### PR TITLE
Fix: UnhandledPromiseRejectionWarning when unknown flag provided for cli commands 

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -8,21 +8,26 @@ import { startedDevelopmentServer } from '../build/output'
 import { cliCommand } from '../bin/next'
 
 const nextDev: cliCommand = (argv) => {
-  const args = arg(
-    {
-      // Types
-      '--help': Boolean,
-      '--port': Number,
-      '--hostname': String,
+  const validArgs: arg.Spec = {
+    // Types
+    '--help': Boolean,
+    '--port': Number,
+    '--hostname': String,
 
-      // Aliases
-      '-h': '--help',
-      '-p': '--port',
-      '-H': '--hostname',
-    },
-    { argv }
-  )
-
+    // Aliases
+    '-h': '--help',
+    '-p': '--port',
+    '-H': '--hostname',
+  }
+  let args: arg.Result<arg.Spec>
+  try {
+    args = arg(validArgs, { argv })
+  } catch (error) {
+    if (error.code === 'ARG_UNKNOWN_OPTION') {
+      return printAndExit(error.message, 1)
+    }
+    throw error
+  }
   if (args['--help']) {
     // tslint:disable-next-line
     console.log(`

--- a/packages/next/cli/next-export.ts
+++ b/packages/next/cli/next-export.ts
@@ -7,22 +7,27 @@ import { printAndExit } from '../server/lib/utils'
 import { cliCommand } from '../bin/next'
 
 const nextExport: cliCommand = (argv) => {
-  const args = arg(
-    {
-      // Types
-      '--help': Boolean,
-      '--silent': Boolean,
-      '--outdir': String,
-      '--threads': Number,
+  const validArgs: arg.Spec = {
+    // Types
+    '--help': Boolean,
+    '--silent': Boolean,
+    '--outdir': String,
+    '--threads': Number,
 
-      // Aliases
-      '-h': '--help',
-      '-s': '--silent',
-      '-o': '--outdir',
-    },
-    { argv }
-  )
-
+    // Aliases
+    '-h': '--help',
+    '-s': '--silent',
+    '-o': '--outdir',
+  }
+  let args: arg.Result<arg.Spec>
+  try {
+    args = arg(validArgs, { argv })
+  } catch (error) {
+    if (error.code === 'ARG_UNKNOWN_OPTION') {
+      return printAndExit(error.message, 1)
+    }
+    throw error
+  }
   if (args['--help']) {
     // tslint:disable-next-line
     console.log(`

--- a/packages/next/cli/next-start.ts
+++ b/packages/next/cli/next-start.ts
@@ -3,25 +3,31 @@
 import { resolve } from 'path'
 import arg from 'next/dist/compiled/arg/index.js'
 import startServer from '../server/lib/start-server'
+import { printAndExit } from '../server/lib/utils'
 import { cliCommand } from '../bin/next'
 import * as Log from '../build/output/log'
 
 const nextStart: cliCommand = (argv) => {
-  const args = arg(
-    {
-      // Types
-      '--help': Boolean,
-      '--port': Number,
-      '--hostname': String,
+  const validArgs: arg.Spec = {
+    // Types
+    '--help': Boolean,
+    '--port': Number,
+    '--hostname': String,
 
-      // Aliases
-      '-h': '--help',
-      '-p': '--port',
-      '-H': '--hostname',
-    },
-    { argv }
-  )
-
+    // Aliases
+    '-h': '--help',
+    '-p': '--port',
+    '-H': '--hostname',
+  }
+  let args: arg.Result<arg.Spec>
+  try {
+    args = arg(validArgs, { argv })
+  } catch (error) {
+    if (error.code === 'ARG_UNKNOWN_OPTION') {
+      return printAndExit(error.message, 1)
+    }
+    throw error
+  }
   if (args['--help']) {
     // tslint:disable-next-line
     console.log(`

--- a/packages/next/cli/next-telemetry.ts
+++ b/packages/next/cli/next-telemetry.ts
@@ -1,22 +1,28 @@
 #!/usr/bin/env node
 import chalk from 'next/dist/compiled/chalk'
 import arg from 'next/dist/compiled/arg/index.js'
-
+import { printAndExit } from '../server/lib/utils'
 import { cliCommand } from '../bin/next'
 import { Telemetry } from '../telemetry/storage'
 
 const nextTelemetry: cliCommand = (argv) => {
-  const args = arg(
-    {
-      // Types
-      '--help': Boolean,
-      '--enable': Boolean,
-      '--disable': Boolean,
-      // Aliases
-      '-h': '--help',
-    },
-    { argv }
-  )
+  const validArgs: arg.Spec = {
+    // Types
+    '--help': Boolean,
+    '--enable': Boolean,
+    '--disable': Boolean,
+    // Aliases
+    '-h': '--help',
+  }
+  let args: arg.Result<arg.Spec>
+  try {
+    args = arg(validArgs, { argv })
+  } catch (error) {
+    if (error.code === 'ARG_UNKNOWN_OPTION') {
+      return printAndExit(error.message, 1)
+    }
+    throw error
+  }
 
   if (args['--help']) {
     console.log(

--- a/test/integration/build-warnings/test/index.test.js
+++ b/test/integration/build-warnings/test/index.test.js
@@ -87,13 +87,4 @@ describe('Build warnings', () => {
     }))
     expect(stdout).not.toContain('no-cache')
   })
-
-  it('should warn when unknown argument provided', async () => {
-    const { stderr } = await nextBuild(appDir, ['--random'], { stderr: true })
-    expect(stderr).toEqual('Unknown or unexpected option: --random\n')
-  })
-  it('should not throw UnhandledPromiseRejectionWarning', async () => {
-    const { stderr } = await nextBuild(appDir, ['--random'], { stderr: true })
-    expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
-  })
 })

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -59,6 +59,19 @@ describe('CLI Usage', () => {
         /Compiles the application for production deployment/
       )
     })
+
+    test('should warn when unknown argument provided', async () => {
+      const { stderr } = await runNextCommand(['build', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).toEqual('Unknown or unexpected option: --random\n')
+    })
+    test('should not throw UnhandledPromiseRejectionWarning', async () => {
+      const { stderr } = await runNextCommand(['build', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+    })
   })
 
   describe('dev', () => {

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -206,4 +206,37 @@ describe('CLI Usage', () => {
       expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
     })
   })
+
+  describe('telemetry', () => {
+    test('--help', async () => {
+      const help = await runNextCommand(['telemetry', '--help'], {
+        stdout: true,
+      })
+      expect(help.stdout).toMatch(
+        /Allows you to control Next\.js' telemetry collection/
+      )
+    })
+
+    test('-h', async () => {
+      const help = await runNextCommand(['telemetry', '-h'], {
+        stdout: true,
+      })
+      expect(help.stdout).toMatch(
+        /Allows you to control Next\.js' telemetry collection/
+      )
+    })
+
+    test('should warn when unknown argument provided', async () => {
+      const { stderr } = await runNextCommand(['telemetry', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).toEqual('Unknown or unexpected option: --random\n')
+    })
+    test('should not throw UnhandledPromiseRejectionWarning', async () => {
+      const { stderr } = await runNextCommand(['telemetry', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+    })
+  })
 })

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -134,6 +134,19 @@ describe('CLI Usage', () => {
       )
       expect(output).toMatch(new RegExp(`http://0.0.0.0:${port}`))
     })
+
+    test('should warn when unknown argument provided', async () => {
+      const { stderr } = await runNextCommand(['dev', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).toEqual('Unknown or unexpected option: --random\n')
+    })
+    test('should not throw UnhandledPromiseRejectionWarning', async () => {
+      const { stderr } = await runNextCommand(['dev', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+    })
   })
 
   describe('start', () => {

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -163,6 +163,19 @@ describe('CLI Usage', () => {
       })
       expect(help.stdout).toMatch(/Starts the application in production mode/)
     })
+
+    test('should warn when unknown argument provided', async () => {
+      const { stderr } = await runNextCommand(['start', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).toEqual('Unknown or unexpected option: --random\n')
+    })
+    test('should not throw UnhandledPromiseRejectionWarning', async () => {
+      const { stderr } = await runNextCommand(['start', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+    })
   })
 
   describe('export', () => {

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -192,5 +192,18 @@ describe('CLI Usage', () => {
       })
       expect(help.stdout).toMatch(/Exports the application/)
     })
+
+    test('should warn when unknown argument provided', async () => {
+      const { stderr } = await runNextCommand(['export', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).toEqual('Unknown or unexpected option: --random\n')
+    })
+    test('should not throw UnhandledPromiseRejectionWarning', async () => {
+      const { stderr } = await runNextCommand(['export', '--random'], {
+        stderr: true,
+      })
+      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+    })
   })
 })


### PR DESCRIPTION
Similar to https://github.com/vercel/next.js/pull/15049 , 
Properly handling unknown flags provided for `dev, start, export, telemetry` commands
<img width="702" alt="Screenshot 2020-07-23 at 10 55 25 AM" src="https://user-images.githubusercontent.com/11258286/88254457-0575e680-ccd3-11ea-8908-c357f8f987fc.png">
 also added missing tests for `next telemetry`
Fixes: #15388