### PR TITLE
Test: serverless target should set correct revalidation (`cache-control`) header

### DIFF
--- a/test/integration/serverless-trace-revalidate/next.config.js
+++ b/test/integration/serverless-trace-revalidate/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  target: 'experimental-serverless-trace',
+  // make sure error isn't thrown from empty publicRuntimeConfig
+  publicRuntimeConfig: {},
+}

--- a/test/integration/serverless-trace-revalidate/pages/revalidate.js
+++ b/test/integration/serverless-trace-revalidate/pages/revalidate.js
@@ -1,0 +1,16 @@
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'hello world',
+      random: Math.random(),
+    },
+    revalidate: 10,
+  }
+}
+
+export default ({ hello, random }) => (
+  <>
+    <p id="hello">{hello}</p>
+    <p id="random">{random}</p>
+  </>
+)

--- a/test/integration/serverless-trace-revalidate/server.js
+++ b/test/integration/serverless-trace-revalidate/server.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const http = require('http')
+
+const server = http.createServer((req, res) => {
+  const pagePath = (page) => path.join('.next/serverless/pages/', page)
+  const render = (page) => {
+    require(`./${pagePath(page)}`).render(req, res)
+  }
+
+  switch (req.url) {
+    case '/revalidate': {
+      return render('/revalidate')
+    }
+    default: {
+      return res.end('404')
+    }
+  }
+})
+server.listen(process.env.PORT, () => {
+  console.log('ready on', process.env.PORT)
+})

--- a/test/integration/serverless-trace-revalidate/test/index.test.js
+++ b/test/integration/serverless-trace-revalidate/test/index.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  nextBuild,
+  findPort,
+  killApp,
+  initNextServerScript,
+} from 'next-test-utils'
+
+const appDir = join(__dirname, '../')
+jest.setTimeout(1000 * 60 * 2)
+
+let appPort
+let app
+let buildId
+
+const nextStart = async (appDir, appPort) => {
+  const scriptPath = join(appDir, 'server.js')
+  const env = Object.assign({ ...process.env }, { PORT: `${appPort}` })
+
+  return initNextServerScript(
+    scriptPath,
+    /ready on/i,
+    env,
+    /ReferenceError: options is not defined/
+  )
+}
+
+describe('Serverless Trace', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+    buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
+  })
+  afterAll(() => killApp(app))
+
+  it('should have revalidate page in prerender-manifest with correct interval', async () => {
+    const data = await fs.readJSON(
+      join(appDir, '.next/prerender-manifest.json')
+    )
+    expect(data.routes['/revalidate']).toEqual({
+      initialRevalidateSeconds: 10,
+      dataRoute: `/_next/data/${buildId}/revalidate.json`,
+      srcRoute: null,
+    })
+  })
+
+  it('should set correct Cache-Control header', async () => {
+    const url = `http://localhost:${appPort}/revalidate`
+    const res = await fetch(url)
+    expect(res.headers.get('Cache-Control')).toMatch(
+      's-maxage=10, stale-while-revalidate'
+    )
+  })
+})


### PR DESCRIPTION
Added a test containing `getStaticProps` with `revalidate`, used `experimental-serverless-trace` without the `next start` emulator, and checked for has the correct headers.

Resolves: #14710
