### PR TITLE
Update Apollo example for 9.5

### DIFF
--- a/examples/with-apollo/pages/index.js
+++ b/examples/with-apollo/pages/index.js
@@ -29,7 +29,7 @@ export async function getStaticProps() {
     props: {
       initialApolloState: apolloClient.cache.extract(),
     },
-    unstable_revalidate: 1,
+    revalidate: 1,
   }
 }
 


### PR DESCRIPTION
…se use `revalidate` instead.