### PR TITLE
enables transpilation for packages below `baseUrl`

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -761,7 +761,9 @@ export default async function getBaseWebpackConfig(
       rules: [
         {
           test: /\.(tsx|ts|js|mjs|jsx)$/,
-          include: [dir, ...babelIncludeRegexes],
+          include: resolvedBaseUrl
+            ? [resolvedBaseUrl, dir, ...babelIncludeRegexes]
+            : [dir, ...babelIncludeRegexes],
           exclude: (excludePath: string) => {
             if (babelIncludeRegexes.some((r) => r.test(excludePath))) {
               return false

--- a/test/integration/typescript-workspaces-paths/packages/www/next.config.js
+++ b/test/integration/typescript-workspaces-paths/packages/www/next.config.js
@@ -1,21 +1,4 @@
-const path = require('path')
 module.exports = {
-  webpack: function (config, { defaultLoaders }) {
-    const resolvedBaseUrl = path.resolve(config.context, '../../')
-    config.module.rules = [
-      ...config.module.rules,
-      {
-        test: /\.(tsx|ts|js|mjs|jsx)$/,
-        include: [resolvedBaseUrl],
-        use: defaultLoaders.babel,
-        exclude: (excludePath) => {
-          return /node_modules/.test(excludePath)
-        },
-      },
-    ]
-    return config
-  },
-
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,


### PR DESCRIPTION
This enables automatic configuration of transpilation for modules resolved outside of nextjs app trough path aliases.

Since I'm not entirely sure what the process should be, and #13542  has been merged, I'm putting this here. The RFC is being discussed at https://github.com/vercel/next.js/discussions/15327 I don't expect this to be merged before the RFC is resolved.