### PR TITLE
Update stats-config for new polyfills location

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -3,19 +3,19 @@ const clientGlobs = [
     name: 'Client Bundles (main, webpack, commons)',
     globs: [
       '.next/static/runtime/+(main|webpack)-!(*.module.js)',
-      '.next/static/chunks/!(*.module.js)',
+      '.next/static/chunks/!(polyfills-*|*.module.js)',
     ],
   },
   {
     name: 'Client Bundles (main, webpack, commons) Modern',
     globs: [
       '.next/static/runtime/+(main|webpack)-*.module.js',
-      '.next/static/chunks/*.module.js',
+      '.next/static/chunks/!(polyfills-*)*.module.js',
     ],
   },
   {
     name: 'Legacy Client Bundles (polyfills)',
-    globs: ['.next/static/runtime/+(polyfills)-!(*.module.js)'],
+    globs: ['.next/static/chunks/+(polyfills)-!(*.module.js)'],
   },
   {
     name: 'Client Pages',


### PR DESCRIPTION
This makes sure to not group the polyfills chunk in with the client bundles group now that it is output under chunks instead of runtime