### PR TITLE
Add CSS Modules examples to docs

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -4,7 +4,7 @@ description: Add rewrites to your Next.js app.
 
 # Rewrites
 
-<details>
+<details open>
   <summary><b>Examples</b></summary>
   <ul>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/rewrites">Rewrites</a></li>

--- a/docs/basic-features/built-in-css-support.md
+++ b/docs/basic-features/built-in-css-support.md
@@ -4,6 +4,14 @@ description: Next.js supports including CSS files as Global CSS or CSS Modules, 
 
 # Built-In CSS Support
 
+<details open>
+  <summary><b>Examples</b></summary>
+  <ul>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/basic-css">Basic CSS Example</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-tailwindcss">With Tailwind CSS</a></li>
+  </ul>
+</details>
+
 Next.js allows you to import CSS files from a JavaScript file.
 This is possible because Next.js extends the concept of [`import`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) beyond JavaScript.
 
@@ -143,8 +151,10 @@ Error: Cannot find module 'less'
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/basic-css">Styled JSX</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-styled-jsx">Styled JSX</a></li>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-styled-components">Styled Components</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-emotion">Emotion</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-tailwindcss-emotion">Tailwind CSS + Emotion</a></li>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-styletron">Styletron</a></li>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-glamor">Glamor</a></li>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-cxs">Cxs</a></li>

--- a/examples/basic-css/README.md
+++ b/examples/basic-css/README.md
@@ -1,6 +1,6 @@
 # Basic CSS example
 
-Next.js has built-in support for [CSS Modules](https://nextjs.org/docs/basic-features/built-in-css-support#adding-component-level-css) allowing you to write scope CSS by automatically creating a unique class name. CSS Module files can be imported anywhere in your application and you don't have to worry about collisions.
+Next.js has built-in support for [CSS Modules](https://nextjs.org/docs/basic-features/built-in-css-support#adding-component-level-css) allowing you to write scoped CSS by automatically creating a unique class name. CSS Module files can be imported anywhere in your application and you don't have to worry about collisions.
 
 ## Deploy your own
 

--- a/examples/basic-css/README.md
+++ b/examples/basic-css/README.md
@@ -1,6 +1,6 @@
 # Basic CSS example
 
-Next.js ships with [styled-jsx](https://github.com/zeit/styled-jsx) allowing you to write scope styled components with full css support. This is important for the modularity and code size of your bundles and also for the learning curve of the framework. If you know css you can write styled-jsx right away.
+Next.js has built-in support for [CSS Modules](https://nextjs.org/docs/basic-features/built-in-css-support#adding-component-level-css) allowing you to write scope CSS by automatically creating a unique class name. CSS Module files can be imported anywhere in your application and you don't have to worry about collisions.
 
 ## Deploy your own
 
@@ -10,35 +10,12 @@ Deploy the example using [Vercel](https://vercel.com):
 
 ## How to use
 
-[Try it on CodeSandbox](https://codesandbox.io/s/github/vercel/next.js/tree/canary/examples/basic-css)
-
-### Using `create-next-app`
-
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
 npx create-next-app --example basic-css basic-css-app
 # or
 yarn create next-app --example basic-css basic-css-app
-```
-
-### Download manually
-
-Download the example:
-
-```bash
-curl https://codeload.github.com/vercel/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/basic-css
-cd basic-css
-```
-
-Install it and run:
-
-```bash
-npm install
-npm run dev
-# or
-yarn
-yarn dev
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/basic-css/pages/index.js
+++ b/examples/basic-css/pages/index.js
@@ -1,19 +1,9 @@
+import styles from '../styles.module.css'
+
 export default function Home() {
   return (
-    <div className="hello">
+    <div className={styles.hello}>
       <p>Hello World</p>
-      <style jsx>{`
-        .hello {
-          font: 15px Helvetica, Arial, sans-serif;
-          background: #eee;
-          padding: 100px;
-          text-align: center;
-          transition: 100ms ease-in background;
-        }
-        .hello:hover {
-          background: #ccc;
-        }
-      `}</style>
     </div>
   )
 }

--- a/examples/basic-css/styles.module.css
+++ b/examples/basic-css/styles.module.css
@@ -1,0 +1,10 @@
+.hello {
+  font: 15px Helvetica, Arial, sans-serif;
+  background: #eee;
+  padding: 100px;
+  text-align: center;
+  transition: 100ms ease-in background;
+}
+.hello:hover {
+  background: #ccc;
+}

--- a/examples/with-styled-jsx/.gitignore
+++ b/examples/with-styled-jsx/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/with-styled-jsx/README.md
+++ b/examples/with-styled-jsx/README.md
@@ -1,6 +1,6 @@
 # styled-jsx example
 
-Next.js ships with [styled-jsx](https://github.com/vercel/styled-jsx) allowing you to write scope styled components with full css support. This is important for the modularity and code size of your bundles and also for the learning curve of the framework. If you know css you can write styled-jsx right away.
+Next.js ships with [styled-jsx](https://github.com/vercel/styled-jsx) allowing you to write scoped styled components with full CSS support. This is important for the modularity and code size of your bundles and also for the learning curve of the framework. If you know CSS you can write `styled-jsx` right away.
 
 ## Deploy your own
 

--- a/examples/with-styled-jsx/README.md
+++ b/examples/with-styled-jsx/README.md
@@ -1,0 +1,21 @@
+# styled-jsx example
+
+Next.js ships with [styled-jsx](https://github.com/vercel/styled-jsx) allowing you to write scope styled components with full css support. This is important for the modularity and code size of your bundles and also for the learning curve of the framework. If you know css you can write styled-jsx right away.
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/vercel/next.js/tree/canary/examples/with-styled-jsx)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-styled-jsx with-styled-jsx-app
+# or
+yarn create next-app --example with-styled-jsx with-styled-jsx-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-styled-jsx/package.json
+++ b/examples/with-styled-jsx/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "with-styled-jsx",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "license": "MIT"
+}

--- a/examples/with-styled-jsx/pages/index.js
+++ b/examples/with-styled-jsx/pages/index.js
@@ -1,0 +1,20 @@
+export default function Home() {
+  return (
+    <div className="hello">
+      <p>Hello World</p>
+
+      <style jsx>{`
+        .hello {
+          font: 15px Helvetica, Arial, sans-serif;
+          background: #eee;
+          padding: 100px;
+          text-align: center;
+          transition: 100ms ease-in background;
+        }
+        .hello:hover {
+          background: #ccc;
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/examples/with-tailwindcss-emotion/package.json
+++ b/examples/with-tailwindcss-emotion/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/ui": "^0.2.2",
     "@tailwindcssinjs/macro": "^0.3.1",
     "babel-plugin-macros": "2.8.0",
-    "tailwindcss": "1.3.5"
-  }
+    "tailwindcss": "^1.6.0"
+  },
+  "license": "MIT"
 }

--- a/examples/with-tailwindcss-emotion/styles/base.css
+++ b/examples/with-tailwindcss-emotion/styles/base.css
@@ -380,7 +380,6 @@ pre {
 button {
   background-color: transparent;
   background-image: none;
-  padding: 0;
 }
 
 /**
@@ -482,11 +481,6 @@ img {
 
 textarea {
   resize: vertical;
-}
-
-input::-webkit-input-placeholder,
-textarea::-webkit-input-placeholder {
-  color: #a0aec0;
 }
 
 input::-moz-placeholder,
@@ -602,4 +596,102 @@ img,
 video {
   max-width: 100%;
   height: auto;
+}
+
+@-webkit-keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes ping {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  75%,
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@keyframes ping {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  75%,
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@-webkit-keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+
+  50% {
+    transform: translateY(0);
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+
+  50% {
+    transform: translateY(0);
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
 }

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -7,12 +7,13 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^9.2.0",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "next": "latest",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
+    "postcss-flexbugs-fixes": "4.2.1",
     "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.4.0"
+    "tailwindcss": "^1.6.0"
   }
 }

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -15,5 +15,6 @@
     "postcss-flexbugs-fixes": "4.2.1",
     "postcss-preset-env": "^6.7.0",
     "tailwindcss": "^1.6.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/examples/with-tailwindcss/pages/index.js
+++ b/examples/with-tailwindcss/pages/index.js
@@ -4,8 +4,10 @@ export default function IndexPage() {
   return (
     <div>
       <Nav />
-      <div className="hero">
-        <h1 className="title">Next.js + Tailwind CSS</h1>
+      <div className="py-20">
+        <h1 className="text-5xl text-center text-accent-1">
+          Next.js + Tailwind CSS
+        </h1>
       </div>
     </div>
   )

--- a/examples/with-tailwindcss/postcss.config.js
+++ b/examples/with-tailwindcss/postcss.config.js
@@ -1,3 +1,18 @@
 module.exports = {
-  plugins: ['tailwindcss', 'postcss-preset-env'],
+  plugins: [
+    'tailwindcss',
+    'postcss-flexbugs-fixes',
+    [
+      'postcss-preset-env',
+      {
+        autoprefixer: {
+          flexbox: 'no-2009',
+        },
+        stage: 3,
+        features: {
+          'custom-properties': false,
+        },
+      },
+    ],
+  ],
 }

--- a/examples/with-tailwindcss/styles/index.css
+++ b/examples/with-tailwindcss/styles/index.css
@@ -1,18 +1,18 @@
 @tailwind base;
-@tailwind components;
 
+/* Write your own custom base styles here */
+
+/* Start purging... */
+@tailwind components;
+/* Stop purging. */
+
+/* Write you own custom component styles here */
 .btn-blue {
   @apply bg-blue-500 text-white font-bold py-2 px-4 rounded;
 }
 
-.hero {
-  @apply py-20;
-}
-
-.title {
-  @apply text-5xl text-center;
-  color: #333;
-  line-height: 1.15;
-}
-
+/* Start purging... */
 @tailwind utilities;
+/* Stop purging. */
+
+/* Your own custom utilities */

--- a/examples/with-tailwindcss/tailwind.config.js
+++ b/examples/with-tailwindcss/tailwind.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   purge: ['./components/**/*.{js,ts,jsx,tsx}', './pages/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'accent-1': '#333',
+      },
+    },
   },
   variants: {},
   plugins: [],


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/15595

- Updated the tailwindcss and tailwindcss-emotion examples to the latest version of tailwindcss
- Added a new `with-styled-jsx` example
- Updated the `basic-css` example to use CSS Modules instead of styled-jsx
- Added the examples to the documentation page for built-in css support