### PR TITLE
Don't use assetprefix for getServerSideProps

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -9,7 +9,7 @@ import { RouterContext } from '../next-server/lib/router-context'
 import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
 import * as envConfig from '../next-server/lib/runtime-config'
 import { getURL, loadGetInitialProps, ST } from '../next-server/lib/utils'
-import { delBasePath } from '../next-server/lib/router/router'
+import { delBasePath, basePath } from '../next-server/lib/router/router'
 import initHeadManager from './head-manager'
 import PageLoader from './page-loader'
 import measureWebVitals from './performance-relayer'
@@ -63,7 +63,7 @@ if (
   asPath = delBasePath(asPath)
 }
 
-const pageLoader = new PageLoader(buildId, prefix, page)
+const pageLoader = new PageLoader(buildId, prefix, basePath, page)
 const register = ([r, f]) => pageLoader.registerPage(r, f)
 if (window.__NEXT_P) {
   // Defer page registration for another tick. This will increase the overall

--- a/packages/next/client/page-loader.js
+++ b/packages/next/client/page-loader.js
@@ -63,9 +63,10 @@ function appendLink(href, rel, as) {
 }
 
 export default class PageLoader {
-  constructor(buildId, assetPrefix, initialPage) {
+  constructor(buildId, assetPrefix, basePath, initialPage) {
     this.buildId = buildId
     this.assetPrefix = assetPrefix
+    this.basePath = basePath
 
     this.pageCache = {}
     this.pageRegisterEvents = mitt()
@@ -127,9 +128,9 @@ export default class PageLoader {
 
     const getHrefForSlug = (/** @type string */ path) => {
       const dataRoute = getAssetPathFromRoute(path, '.json')
-      return `${this.assetPrefix}/_next/data/${this.buildId}${dataRoute}${
-        ssg ? '' : search || ''
-      }`
+      return `${ssg ? this.assetPrefix : this.basePath}/_next/data/${
+        this.buildId
+      }${dataRoute}${ssg ? '' : search || ''}`
     }
 
     let isDynamic = isDynamicRoute(route),

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -22,7 +22,7 @@ import {
   normalizePathTrailingSlash,
 } from '../../../client/normalize-trailing-slash'
 
-const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+export const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
 function buildCancellationError() {
   return Object.assign(new Error('Route Cancelled'), {


### PR DESCRIPTION
IMO, one way to look at it is, If you want to treat serverside generated data as a static asset you should use `getStaticProps`. If you want to treat it as dynamically generated data you use `getServerSideProps`.