### PR TITLE
Add better typing for redirect

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -226,7 +226,8 @@ export type NextApiResponse<T = any> = ServerResponse & {
    */
   json: Send<T>
   status: (statusCode: number) => NextApiResponse<T>
-  redirect: (statusOrUrl: string | number, url?: string) => NextApiResponse<T>
+  redirect(url: string): NextApiResponse<T>
+  redirect(status: number, url: string): NextApiResponse<T>
 
   /**
    * Set preview data for Next.js' prerender mode

--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -68,7 +68,8 @@ export async function apiResolver(
     apiRes.status = (statusCode) => sendStatusCode(apiRes, statusCode)
     apiRes.send = (data) => sendData(apiReq, apiRes, data)
     apiRes.json = (data) => sendJson(apiRes, data)
-    apiRes.redirect = (statusOrUrl, url) => redirect(apiRes, statusOrUrl, url)
+    apiRes.redirect = (statusOrUrl: number | string, url?: string) =>
+      redirect(apiRes, statusOrUrl, url)
     apiRes.setPreviewData = (data, options = {}) =>
       setPreviewData(apiRes, data, Object.assign({}, apiContext, options))
     apiRes.clearPreviewData = () => clearPreviewData(apiRes)


### PR DESCRIPTION
Related: #15594.

This pull request adds a better typing for the `redirect` method on the `NextApiResponse` type.

Redirect was introduced in #14705 but the typing for the params was `statusOrUrl: string | number, url?: string)` which is too broad and allows for an invalid combination. I have added an overload to allow two possible combinations: `url: string` or `status: number, url: string`.