### PR TITLE
Make sure link can render without router

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -166,14 +166,15 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
   const [childElm, setChildElm] = React.useState<Element>()
 
   const router = useRouter()
+  const pathname = (router && router.pathname) || '/'
 
   const { href, as } = React.useMemo(() => {
-    const resolvedHref = resolveHref(router.pathname, props.href)
+    const resolvedHref = resolveHref(pathname, props.href)
     return {
       href: resolvedHref,
-      as: props.as ? resolveHref(router.pathname, props.as) : resolvedHref,
+      as: props.as ? resolveHref(pathname, props.as) : resolvedHref,
     }
-  }, [router.pathname, props.href, props.as])
+  }, [pathname, props.href, props.as])
 
   React.useEffect(() => {
     if (p && IntersectionObserver && childElm && childElm.tagName) {

--- a/test/unit/link-rendering.test.js
+++ b/test/unit/link-rendering.test.js
@@ -1,0 +1,20 @@
+/* eslint-env jest */
+import React from 'react'
+import ReactDOM from 'react-dom/server'
+import Link from 'next/link'
+
+describe('Link rendering', () => {
+  it('should render Link on its own', async () => {
+    const element = React.createElement(
+      Link,
+      {
+        href: '/my-path',
+      },
+      React.createElement('a', {}, 'to another page')
+    )
+    const html = ReactDOM.renderToString(element)
+    expect(html).toMatchInlineSnapshot(
+      `"<a href=\\"/my-path\\" data-reactroot=\\"\\">to another page</a>"`
+    )
+  })
+})


### PR DESCRIPTION
This ensures rendering `next/link` doesn't fail without being nested under the router context.

Closes: https://github.com/vercel/next.js/issues/15543