### PR TITLE
Stabilize error-is-clickable test

### DIFF
--- a/test/integration/error-is-clickable/test/index.test.js
+++ b/test/integration/error-is-clickable/test/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { findPort, killApp, launchApp } from 'next-test-utils'
+import { findPort, killApp, launchApp, hasRedbox } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -21,14 +21,16 @@ describe('Clickable error link', () => {
   it('Shows error which is clickable and redirects', async () => {
     const browser = await webdriver(appPort, '/first')
 
-    await browser.eval(`(function () {
-          document.querySelector("nextjs-portal")
-          .shadowRoot
-          .querySelector("#nextjs__container_errors_desc > a").click()
-          })()
-        `)
-    const url = await browser.url()
+    await hasRedbox(browser)
 
+    await browser.eval(`(function () {
+      document.querySelector("nextjs-portal")
+      .shadowRoot
+      .querySelector("#nextjs__container_errors_desc > a").click()
+      })()
+    `)
+
+    const url = await browser.url()
     expect(url).toBe('https://nextjs.org/')
   })
 })


### PR DESCRIPTION
This attempts to stabilize the `error-is-clickable` test since it has been flaking recently

Closes: https://github.com/vercel/next.js/issues/15585