### PR TITLE
Add note about statusCode config for redirects

### DIFF
--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -92,3 +92,5 @@ module.exports = {
   },
 }
 ```
+
+In some rare cases, you might need to assign a custom status code for older HTTP Clients to properly redirect. In these cases, you can use the `statusCode` property instead of the `permanent` property, but not both. Note: to ensure IE11 compatibility a `Refresh` header is automatically added for the 308 status code.


### PR DESCRIPTION
This adds a note to our documentation about the `statusCode` config to match the note from the redirects documentation for [`vercel.json`](https://vercel.com/docs/configuration#project/redirects)