### PR TITLE
Fix: space issue in error overlay and add tests

### DIFF
--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -53,7 +53,7 @@ function getErrorSignature(ev: SupportedErrorEvent): string {
   return ''
 }
 
-function makeClickable(text) {
+function makeClickable(text: string): JSX.Element[] | string {
   // Regex Checks for http:// or https://
   const linkRegex = /https?:\/\/[^\s/$.?#].[^\s]*/gi
   if (!linkRegex.test(text)) return text

--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -53,7 +53,7 @@ function getErrorSignature(ev: SupportedErrorEvent): string {
   return ''
 }
 
-function makeClickable(text: string): JSX.Element[] | string {
+function makeClickable(text) {
   // Regex Checks for http:// or https://
   const linkRegex = /https?:\/\/[^\s/$.?#].[^\s]*/gi
   if (!linkRegex.test(text)) return text
@@ -61,8 +61,8 @@ function makeClickable(text: string): JSX.Element[] | string {
     if (linkRegex.test(word)) {
       return (
         <>
-          <a href={word}>{word} </a>
-          {index === array.length - 1 ? ' ' : ''}
+          <a href={word}>{word}</a>
+          {index === array.length - 1 ? '' : ' '}
         </>
       )
     }

--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -61,7 +61,7 @@ function makeClickable(text: string): JSX.Element[] | string {
     if (linkRegex.test(word)) {
       return (
         <>
-          <a href={word}>{word}</a>
+          <a href={word}>{word} </a>
           {index === array.length - 1 ? ' ' : ''}
         </>
       )

--- a/test/integration/error-is-clickable/pages/first.js
+++ b/test/integration/error-is-clickable/pages/first.js
@@ -1,5 +1,5 @@
 export default function Index() {
   throw new Error(
-    'This error should be clickable. https://nextjs.org is the best. Visit https://nextjs.org/docs for documentation'
+    'This error should be clickable. https://nextjs.org is the homepage. Visit https://nextjs.org/docs for documentation'
   )
 }

--- a/test/integration/error-is-clickable/pages/first.js
+++ b/test/integration/error-is-clickable/pages/first.js
@@ -1,3 +1,5 @@
 export default function Index() {
-  throw new Error('This error should be clickable. https://nextjs.org')
+  throw new Error(
+    'This error should be clickable. https://nextjs.org is the best'
+  )
 }

--- a/test/integration/error-is-clickable/pages/first.js
+++ b/test/integration/error-is-clickable/pages/first.js
@@ -1,5 +1,5 @@
 export default function Index() {
   throw new Error(
-    'This error should be clickable. https://nextjs.org is the best'
+    'This error should be clickable. https://nextjs.org is the best. Visit https://nextjs.org/docs for documentation'
   )
 }

--- a/test/integration/error-is-clickable/test/index.test.js
+++ b/test/integration/error-is-clickable/test/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { findPort, killApp, launchApp } from 'next-test-utils'
+import { findPort, killApp, launchApp, hasRedbox } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -21,14 +21,16 @@ describe('Clickable error link', () => {
   it('Shows error which is clickable and redirects', async () => {
     const browser = await webdriver(appPort, '/first')
 
-    await browser.eval(`(function () {
-          document.querySelector("nextjs-portal")
-          .shadowRoot
-          .querySelector("#nextjs__container_errors_desc > a").click()
-          })()
-        `)
-    const url = await browser.url()
+    await hasRedbox(browser)
 
+    await browser.eval(`(function () {
+      document.querySelector("nextjs-portal")
+      .shadowRoot
+      .querySelector("#nextjs__container_errors_desc > a").click()
+      })()
+    `)
+
+    const url = await browser.url()
     expect(url).toBe('https://nextjs.org/')
   })
 })

--- a/test/integration/error-is-clickable/test/index.test.js
+++ b/test/integration/error-is-clickable/test/index.test.js
@@ -91,7 +91,7 @@ describe('Clickable error link', () => {
     await hasRedbox(browser)
     const headerText = await getRedboxHeader(browser)
     expect(headerText).toMatch(
-      /Error: This error should be clickable\. https:\/\/nextjs\.org is the best\. Visit https:\/\/nextjs\.org\/docs for documentation/
+      /Error: This error should be clickable\. https:\/\/nextjs\.org is the homepage\. Visit https:\/\/nextjs\.org\/docs for documentation/
     )
   })
 })

--- a/test/integration/error-is-clickable/test/index.test.js
+++ b/test/integration/error-is-clickable/test/index.test.js
@@ -1,6 +1,12 @@
 /* eslint-env jest */
 
-import { findPort, killApp, launchApp, hasRedbox } from 'next-test-utils'
+import {
+  findPort,
+  killApp,
+  launchApp,
+  hasRedbox,
+  getRedboxHeader,
+} from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -32,5 +38,14 @@ describe('Clickable error link', () => {
 
     const url = await browser.url()
     expect(url).toBe('https://nextjs.org/')
+  })
+
+  it('Shows error message correctly', async () => {
+    const browser = await webdriver(appPort, '/first')
+    await hasRedbox(browser)
+    const headerText = await getRedboxHeader(browser)
+    expect(headerText).toMatch(
+      /Error: This error should be clickable\. https:\/\/nextjs\.org is the best/
+    )
   })
 })

--- a/test/integration/error-is-clickable/test/index.test.js
+++ b/test/integration/error-is-clickable/test/index.test.js
@@ -6,6 +6,8 @@ import {
   launchApp,
   hasRedbox,
   getRedboxHeader,
+  evaluate,
+  waitFor,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -29,15 +31,59 @@ describe('Clickable error link', () => {
 
     await hasRedbox(browser)
 
-    await browser.eval(`(function () {
-      document.querySelector("nextjs-portal")
-      .shadowRoot
-      .querySelector("#nextjs__container_errors_desc > a").click()
-      })()
-    `)
+    await evaluate(browser, () => {
+      document
+        .querySelector('body > nextjs-portal')
+        .shadowRoot.querySelector(
+          '#nextjs__container_errors_desc > a:nth-child(1)'
+        )
+        .click()
+    })
 
+    await waitFor(1000)
     const url = await browser.url()
+
     expect(url).toBe('https://nextjs.org/')
+  })
+
+  it('Handles multiple links in error', async () => {
+    const browser = await webdriver(appPort, '/first')
+
+    // Open the first link from error
+    await hasRedbox(browser)
+
+    await evaluate(browser, () => {
+      document
+        .querySelector('body > nextjs-portal')
+        .shadowRoot.querySelector(
+          '#nextjs__container_errors_desc > a:nth-child(1)'
+        )
+        .click()
+    })
+    await waitFor(1000)
+    const url1 = await browser.url()
+
+    // Go back to error page
+    await browser.back()
+
+    // Open the second link from error
+    await hasRedbox(browser)
+
+    await evaluate(browser, () => {
+      document
+        .querySelector('body > nextjs-portal')
+        .shadowRoot.querySelector(
+          '#nextjs__container_errors_desc > a:nth-child(2)'
+        )
+        .click()
+    })
+    await waitFor(1000)
+    const url2 = await browser.url()
+
+    expect({ url1, url2 }).toEqual({
+      url1: 'https://nextjs.org/',
+      url2: 'https://nextjs.org/docs',
+    })
   })
 
   it('Shows error message correctly', async () => {
@@ -45,7 +91,7 @@ describe('Clickable error link', () => {
     await hasRedbox(browser)
     const headerText = await getRedboxHeader(browser)
     expect(headerText).toMatch(
-      /Error: This error should be clickable\. https:\/\/nextjs\.org is the best/
+      /Error: This error should be clickable\. https:\/\/nextjs\.org is the best\. Visit https:\/\/nextjs\.org\/docs for documentation/
     )
   })
 })


### PR DESCRIPTION
Fixes #15599
The ternary operator condition was swapped, was not caught since previously the error link was towards the end of the message and there was no test for the error message

- @ijjk's fixes to the test from #15606 
- Use `evaluate` from `next-test-utils`
- Test for the error message to be the same as the one thrown
- Test to check if multiple links in the error are handled properly

