### PR TITLE
Update multi-zone example link from relative to absolute

### DIFF
--- a/docs/advanced-features/multi-zones.md
+++ b/docs/advanced-features/multi-zones.md
@@ -3,7 +3,7 @@
 <details>
   <summary><b>Examples</b></summary>
   <ul>
-    <li><a href="/examples/with-zones">With Zones</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-zones">With Zones</a></li>
   </ul>
 </details>
 


### PR DESCRIPTION
## Why
**1. Because cloning this repository would make the link in the multi-zone example an invalid link**
We're currently working on an unofficial [Japanese translation of Next.js documentation](https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs) project.  The other pages are linked correctly as the links are absolute paths, but only the multi-zone page got invalid link(404). I sent this PR since you need to update link when you clone it in the same way.
(c.f: https://github.com/Nextjs-ja-translation/Nextjs-ja-translation-docs/issues/145)

**2. Consistency Perspective**
On other pages, the example link is an absolute path, so I think it's better to match it for the sake of uniformity.
(e.g: https://raw.githubusercontent.com/vercel/next.js/canary/docs/advanced-features/dynamic-import.md, https://raw.githubusercontent.com/vercel/next.js/canary/docs/advanced-features/customizing-postcss-config.md)

