### PR TITLE
make NextApiRequest interface generic

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -183,7 +183,7 @@ export type DocumentProps = DocumentInitialProps & {
 /**
  * Next `API` route request
  */
-export interface NextApiRequest extends IncomingMessage {
+export interface NextApiRequest<T = any> extends IncomingMessage {
   /**
    * Object of `query` values from url
    */
@@ -197,7 +197,7 @@ export interface NextApiRequest extends IncomingMessage {
     [key: string]: string
   }
 
-  body: any
+  body: T
 
   env: Env
 


### PR DESCRIPTION
Makes the `NextApiRequest` interface generic so that the request body can be typed. This is pretty much the same as with `NextApiResponse` where you can generically type the response body.

See https://github.com/vercel/next.js/discussions/15612#discussioncomment-43910 for some context.