### PR TITLE
Add babel.config.js to Preact example

### DIFF
--- a/examples/using-preact/babel.config.js
+++ b/examples/using-preact/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env']
+};

--- a/examples/using-preact/babel.config.js
+++ b/examples/using-preact/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: ['@babel/preset-env']
+  presets: ['next/babel']
 };


### PR DESCRIPTION
I'm moving a project from Create React App to NextJS using the Preact example as the base. The first roadblock I ran into was the following error when trying to get my pre-existing Jest tests running:

`SyntaxError: Cannot use import statement outside a module`

This was fixed by adding a simple `babel.config.js`. It might be useful to include this with the examples so others can avoid it in the future. 