### PR TITLE
Allow passing HTML Div props to Main component

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -479,12 +479,19 @@ export class Head extends Component<
   }
 }
 
-export function Main() {
+export function Main(
+  props: React.DetailedHTMLProps<
+    React.HtmlHTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  >
+) {
   const { inAmpMode, html } = useContext(
     DocumentComponentContext
   )._documentProps
   if (inAmpMode) return <>{AMP_RENDER_TARGET}</>
-  return <div id="__next" dangerouslySetInnerHTML={{ __html: html }} />
+  return (
+    <div {...props} id="__next" dangerouslySetInnerHTML={{ __html: html }} />
+  )
 }
 
 export class NextScript extends Component<OriginProps> {


### PR DESCRIPTION
As Next.js `<Html>` `<Head>` document components which allow us to pass properties to specific HTML element, there should be the same way how to define properties to `<Main>` component. Because `<Main>` component is necessary for properly rendering, there is no other way how to pass props into specific DIV wrapper. That component should be also used as "wrapper/container" for complex designs. It reduces the need to have another "wrapper" as a child of `<Main>` component.

This should be considered also as micro-optimization which reduces 1 level in DOM tree depth.