### PR TITLE
Fix gh-pages deploy script

### DIFF
--- a/examples/gh-pages/.gitignore
+++ b/examples/gh-pages/.gitignore
@@ -10,7 +10,6 @@
 
 # next.js
 /.next/
-/out/
 
 # production
 /build


### PR DESCRIPTION
## What

The current `gh-pages` example has issue when deploying. 

This is how the error looks like:
![image](https://user-images.githubusercontent.com/1008093/88996697-827f0c80-d320-11ea-93bd-48141c321a65.png)

```
...
Export successful
The following paths are ignored by one of your .gitignore files:
out
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! next@1.0.0 deploy: `rm -rf node_modules/.cache && next build && next export && touch out/.nojekyll && git add out/`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the next@1.0.0 deploy script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
...
```

It's because `out` folder is added on `.gitignore` and the deploy script runs `git add out/`.
The fix is to remove `out` folder from `.gitignore`.

## How was it tested
run `npm run deploy`, it should be completed successfully.
