### PR TITLE
Fix wrong asPath on 404

### DIFF
--- a/packages/next/client/index.js
+++ b/packages/next/client/index.js
@@ -58,7 +58,7 @@ if (
     page === '/_error' &&
     hydrateProps &&
     hydrateProps.pageProps &&
-    hydrateProps.pageProps.statusCode === '404'
+    hydrateProps.pageProps.statusCode === 404
   )
 ) {
   asPath = delBasePath(asPath)

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -212,6 +212,7 @@ const runTests = (context, dev = false) => {
   it('should not update URL for a 404', async () => {
     const browser = await webdriver(context.appPort, '/missing')
     const pathname = await browser.eval(() => window.location.pathname)
+    expect(await browser.eval(() => window.next.router.asPath)).toBe('/missing')
     expect(pathname).toBe('/missing')
   })
 


### PR DESCRIPTION
Caught this while reviewing router code for https://github.com/vercel/next.js/pull/15710