### PR TITLE
Move stylesheet link tag above js preload tags to the bottom of js preload tags.

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -459,11 +459,11 @@ export class Head extends Component<
                 href={canonicalBase + getAmpPath(ampPath, dangerousAsPath)}
               />
             )}
+            {!disableRuntimeJS && this.getPreloadDynamicChunks()}
+            {!disableRuntimeJS && this.getPreloadMainLinks()}
             {process.env.__NEXT_OPTIMIZE_FONTS
               ? this.makeStylesheetInert(this.getCssLinks())
               : this.getCssLinks()}
-            {!disableRuntimeJS && this.getPreloadDynamicChunks()}
-            {!disableRuntimeJS && this.getPreloadMainLinks()}
             {this.context._documentProps.isDevelopment && (
               // this element is used to mount development styles so the
               // ordering matches production

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -141,9 +141,10 @@ export class Head extends Component<
     const cssFiles =
       files && files.length ? files.filter((f) => f.endsWith('.css')) : []
 
-    const cssLinkElements: JSX.Element[] = []
+    const cssPreloadLinkElements: JSX.Element[] = []
+    const cssStylesheetLinkElements: JSX.Element[] = []
     cssFiles.forEach((file) => {
-      cssLinkElements.push(
+      cssPreloadLinkElements.push(
         <link
           key={`${file}-preload`}
           nonce={this.props.nonce}
@@ -155,7 +156,9 @@ export class Head extends Component<
           crossOrigin={
             this.props.crossOrigin || process.env.__NEXT_CROSS_ORIGIN
           }
-        />,
+        />
+      )
+      cssStylesheetLinkElements.push(
         <link
           key={file}
           nonce={this.props.nonce}
@@ -169,6 +172,9 @@ export class Head extends Component<
         />
       )
     })
+    const cssLinkElements = cssPreloadLinkElements.concat(
+      cssStylesheetLinkElements
+    )
 
     return cssLinkElements.length === 0 ? null : cssLinkElements
   }

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -531,7 +531,9 @@ describe('CSS Support', () => {
       expect(cssSheet.attr('href')).toMatch(/^\/_next\/static\/css\/.*\.css$/)
 
       /* ensure CSS preloaded first */
-      const allPreloads = [].slice.call($('link[rel="preload"]'))
+      const allPreloads = [].slice.call(
+        $('link[rel="preload"][as="style"], link[rel="stylesheet"]')
+      )
       const styleIndexes = allPreloads.flatMap((p, i) =>
         p.attribs.as === 'style' ? i : []
       )

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -531,10 +531,10 @@ describe('CSS Support', () => {
       expect(cssSheet.attr('href')).toMatch(/^\/_next\/static\/css\/.*\.css$/)
 
       /* ensure CSS preloaded first */
-      const allPreloads = [].slice.call(
+      const styleLinks = [].slice.call(
         $('link[rel="preload"][as="style"], link[rel="stylesheet"]')
       )
-      const styleIndexes = allPreloads.flatMap((p, i) =>
+      const styleIndexes = styleLinks.flatMap((p, i) =>
         p.attribs.as === 'style' ? i : []
       )
       expect(styleIndexes).toEqual([0])

--- a/test/integration/scss/test/index.test.js
+++ b/test/integration/scss/test/index.test.js
@@ -607,10 +607,10 @@ describe('SCSS Support', () => {
       expect(cssSheet.attr('href')).toMatch(/^\/_next\/static\/css\/.*\.css$/)
 
       /* ensure CSS preloaded first */
-      const allPreloads = [].slice.call(
+      const styleLinks = [].slice.call(
         $('link[rel="preload"][as="style"], link[rel="stylesheet"]')
       )
-      const styleIndexes = allPreloads.flatMap((p, i) =>
+      const styleIndexes = styleLinks.flatMap((p, i) =>
         p.attribs.as === 'style' ? i : []
       )
       expect(styleIndexes).toEqual([0])

--- a/test/integration/scss/test/index.test.js
+++ b/test/integration/scss/test/index.test.js
@@ -607,7 +607,9 @@ describe('SCSS Support', () => {
       expect(cssSheet.attr('href')).toMatch(/^\/_next\/static\/css\/.*\.css$/)
 
       /* ensure CSS preloaded first */
-      const allPreloads = [].slice.call($('link[rel="preload"]'))
+      const allPreloads = [].slice.call(
+        $('link[rel="preload"][as="style"], link[rel="stylesheet"]')
+      )
       const styleIndexes = allPreloads.flatMap((p, i) =>
         p.attribs.as === 'style' ? i : []
       )


### PR DESCRIPTION
Currently stylesheet link tag is above js preload link tags which would block preloading scripts until stylesheet is received.
eg)
![image](https://user-images.githubusercontent.com/55690750/89025399-be869180-d361-11ea-95c7-244e2c1a050b.png)


This PR moves the stylesheet link tag to the bottom of js preload tags, which unblocks js preloading and still keeps the loading order of resources as is.
