### PR TITLE
fix(deps): add 'sass-loader' peer dependencies

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -116,7 +116,21 @@
   },
   "peerDependencies": {
     "react": "^16.6.0",
-    "react-dom": "^16.6.0"
+    "react-dom": "^16.6.0",
+    "sass": "^1.3.0",
+    "node-sass": "^4.0.0",
+    "fibers": ">= 3.1.0"
+  },
+  "peerDependenciesMeta": {
+    "node-sass": {
+      "optional": true
+    },
+    "sass": {
+      "optional": true
+    },
+    "fibers": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@next/polyfill-nomodule": "9.5.2-canary.0",


### PR DESCRIPTION
Fixes #14157 by adding sass-loader's peer dependencies as optional peer
dependencies to Next.js (this same fix can also be applied to any other
packages that Next.js requires that also have peer dependencies).