### PR TITLE
examples: Update with-electron .gitignore

### DIFF
--- a/examples/with-electron/.gitignore
+++ b/examples/with-electron/.gitignore
@@ -9,11 +9,11 @@
 /coverage
 
 # next.js
-/.next/
-/out/
+/renderer/.next/
+/renderer/out/
 
 # production
-/build
+/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
Thank you for the excellent examples.

This PR updates the `.gitignore` for [with-electron](https://github.com/vercel/next.js/tree/canary/examples/with-electron) example to ignore the output folders.