### PR TITLE
Syntax error from @next/react-refresh-utils in IE11

### DIFF
--- a/packages/react-refresh-utils/tsconfig.json
+++ b/packages/react-refresh-utils/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "sourceMap": true,
     "esModuleInterop": true,
-    "target": "es2015",
+    "target": "ES5",
     "lib": ["dom"],
     "downlevelIteration": true,
     "preserveWatchOutput": true


### PR DESCRIPTION
Change `react-refresh-utils`  Typescript configuration to be compiled to ES5.

This has fixed the console issue on IE 11 but please verify the other issue maintainers experienced before switching to `ES2015`
C.C: @Timer @timneutkens 

close #15680 