### PR TITLE
Updated with-passport example to fix syntax errors

### DIFF
--- a/examples/with-passport/package.json
+++ b/examples/with-passport/package.json
@@ -7,14 +7,14 @@
   },
   "dependencies": {
     "@hapi/iron": "6.0.0",
-    "cookie": "0.4.0",
+    "cookie": "0.4.1",
     "next": "latest",
-    "next-connect": "0.6.1",
+    "next-connect": "0.8.1",
     "passport": "0.4.1",
     "passport-local": "1.0.0",
     "react": "latest",
     "react-dom": "latest",
-    "swr": "0.1.16"
+    "swr": "0.3.0"
   },
   "license": "ISC"
 }

--- a/examples/with-passport/pages/login.js
+++ b/examples/with-passport/pages/login.js
@@ -9,8 +9,8 @@ const Login = () => {
 
   const [errorMsg, setErrorMsg] = useState('')
 
-  async function handleSubmit(e) {
-    event.preventDefault()
+  async function handleSubmit (e) {
+    e.preventDefault()
 
     if (errorMsg) setErrorMsg('')
 

--- a/examples/with-passport/pages/login.js
+++ b/examples/with-passport/pages/login.js
@@ -9,7 +9,7 @@ const Login = () => {
 
   const [errorMsg, setErrorMsg] = useState('')
 
-  async function handleSubmit (e) {
+  async function handleSubmit(e) {
     e.preventDefault()
 
     if (errorMsg) setErrorMsg('')

--- a/examples/with-passport/pages/signup.js
+++ b/examples/with-passport/pages/signup.js
@@ -9,7 +9,7 @@ const Signup = () => {
 
   const [errorMsg, setErrorMsg] = useState('')
 
-  async function handleSubmit (e) {
+  async function handleSubmit(e) {
     e.preventDefault()
 
     if (errorMsg) setErrorMsg('')

--- a/examples/with-passport/pages/signup.js
+++ b/examples/with-passport/pages/signup.js
@@ -9,8 +9,8 @@ const Signup = () => {
 
   const [errorMsg, setErrorMsg] = useState('')
 
-  async function handleSubmit(e) {
-    event.preventDefault()
+  async function handleSubmit (e) {
+    e.preventDefault()
 
     if (errorMsg) setErrorMsg('')
 


### PR DESCRIPTION
I was referencing the with-passport example and found a minor syntax error:\
The login and signup page both used `event.preventDefault()` on the submit handlers, whereby the correct reference to the event is `e` as defined within the `handleSubmit` functions.

Additionally used the chance to bump npm packages, the largest bump being swr to the latest version: 0.3.0

### Summary of all Changes made:
* Fixed syntax error on login page
* Fixed syntax error on signup page
* Bumped cookie to 0.4.1
* Bumped next-connect to 0.8.1
* Bumped swr to 0.3.0