### PR TITLE
examples/custom-server-typescript upgrade dependencies

### DIFF
--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -7,17 +7,17 @@
     "start": "cross-env NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "next": "latest",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
     "@types/node": "^12.0.12",
-    "@types/react": "^16.8.17",
-    "@types/react-dom": "16.8.4",
-    "nodemon": "^1.19.0",
-    "ts-node": "^8.1.0",
-    "typescript": "^3.4.5"
+    "@types/react": "^16.9.44",
+    "@types/react-dom": "^16.9.8",
+    "nodemon": "^2.0.4",
+    "ts-node": "^8.10.2",
+    "typescript": "3.8.3"
   }
 }


### PR DESCRIPTION
Upgrade dependencies for example `custom-server-typescript`.
This also fixes an issue with TypeScript #15769 (`TypeError: Cannot read property 'kind' of undefined`).

## Notes

- in `package.json` I specified exact TypeScript version `3.8.3` to hint users not to upgrade TypeScript, so they will see the TypeScript issue only when manually upgrade dependencies.

- I kept `@types/node` version as-is (Node.js current version is 14, Node.js LTS version is 12).
