### PR TITLE
add payment description for with-stripe-typescript

### DIFF
--- a/examples/with-stripe-typescript/.env.local.example
+++ b/examples/with-stripe-typescript/.env.local.example
@@ -2,5 +2,6 @@
 # https://dashboard.stripe.com/apikeys
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_12345
 STRIPE_SECRET_KEY=sk_12345
+STRIPE_PAYMENT_DESCRIPTION='Software development services'
 # https://stripe.com/docs/webhooks/signatures
 STRIPE_WEBHOOK_SECRET=whsec_1234

--- a/examples/with-stripe-typescript/pages/api/payment_intents/index.ts
+++ b/examples/with-stripe-typescript/pages/api/payment_intents/index.ts
@@ -25,6 +25,7 @@ export default async function handler(
         payment_method_types: ['card'],
         amount: formatAmountForStripe(amount, CURRENCY),
         currency: CURRENCY,
+        description: process.env.STRIPE_PAYMENT_DESCRIPTION ?? '',
       }
       const payment_intent: Stripe.PaymentIntent = await stripe.paymentIntents.create(
         params


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/15813

Adds an environment variable to set payment description since stripe throws this error ` As per Indian regulations, export transactions require a description. More info here: https://stripe.com/docs/india-exports` while attempting to make payment in india