### PR TITLE
Test macOS on canary

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -79,6 +79,7 @@ jobs:
 
   testMacOS:
     name: macOS (Basic, Production, Acceptance)
+    if: github.ref == 'canary'
     runs-on: macos-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
Only run macOS tests on canary to avoid queued jobs due to [concurrency limit](https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits).

Follow up to #15366 