### PR TITLE
Test macOS on canary with separate workflow

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -77,24 +77,6 @@ jobs:
     steps:
       - run: exit 0
 
-  testMacOS:
-    name: macOS (Basic, Production, Acceptance)
-    if: github.ref == 'canary'
-    runs-on: macos-latest
-    env:
-      NEXT_TELEMETRY_DISABLED: 1
-      NEXT_TEST_JOB: 1
-      HEADLESS: true
-
-    steps:
-      - uses: actions/checkout@v2
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      # Installing dependencies again since OS changed
-      - run: yarn install --frozen-lockfile --check-files || yarn install --frozen-lockfile --check-files
-      - run: node run-tests.js test/integration/production/test/index.test.js
-      - run: node run-tests.js test/integration/basic/test/index.test.js
-      - run: node run-tests.js test/acceptance/*
-
   testWebpack5:
     name: webpack 5 (Basic, Production, Acceptance)
     runs-on: ubuntu-latest

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches: [canary]
+
+name: Test macOS
+
+jobs:
+  testMacOS:
+    name: macOS (Basic, Production, Acceptance)
+    runs-on: macos-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      NEXT_TEST_JOB: 1
+      HEADLESS: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - run: yarn install --frozen-lockfile --check-files || yarn install --frozen-lockfile --check-files
+      - run: node run-tests.js test/integration/production/test/index.test.js
+      - run: node run-tests.js test/integration/basic/test/index.test.js
+      - run: node run-tests.js test/acceptance/*


### PR DESCRIPTION
Follow up to #15899 since it didn't solve the [concurrency limit](https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits) issue.

It seems that the job is queued prior to the `if` statement being evaluated so we must use a separate workflow to listen for push events and filter prior to the job being queued. 