### PR TITLE
Adjust overlay modal padding on mobile

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/Dialog/styles.ts
+++ b/packages/react-dev-overlay/src/internal/components/Dialog/styles.ts
@@ -16,6 +16,12 @@ const styles = css`
     overflow-y: hidden;
   }
 
+  @media (max-height: 812px) {
+    [data-nextjs-dialog-overlay] {
+      max-height: calc(100% - 15px);
+    }
+  }
+
   @media (min-width: 576px) {
     [data-nextjs-dialog] {
       max-width: 540px;

--- a/packages/react-dev-overlay/src/internal/components/Overlay/styles.tsx
+++ b/packages/react-dev-overlay/src/internal/components/Overlay/styles.tsx
@@ -17,6 +17,12 @@ const styles = css`
     padding: 10vh 15px 0;
   }
 
+  @media (max-height: 812px) {
+    [data-nextjs-dialog-overlay] {
+      padding: 15px 15px 0;
+    }
+  }
+
   [data-nextjs-dialog-backdrop] {
     position: fixed;
     top: 0;


### PR DESCRIPTION
This PR reduces padding on all [iPhone models](https://developer.apple.com/library/archive/documentation/DeviceInformation/Reference/iOSDeviceCompatibility/Displays/Displays.html) to make the error easier to see when you have the debugger open.

Before
![image](https://user-images.githubusercontent.com/616428/89454188-5a334b80-d72e-11ea-8e0b-ce392615d814.png)


After
![image](https://user-images.githubusercontent.com/616428/89454129-40920400-d72e-11ea-903d-8a8178da2966.png)

---

Fixes #14702
Closes #14767
