### PR TITLE
Remove async around Functional React component

### DIFF
--- a/examples/with-sentry/pages/_error.js
+++ b/examples/with-sentry/pages/_error.js
@@ -1,14 +1,14 @@
 import NextErrorComponent from 'next/error'
 import * as Sentry from '@sentry/node'
 
-const MyError = async ({ statusCode, hasGetInitialPropsRun, err }) => {
+const MyError =  ({ statusCode, hasGetInitialPropsRun, err }) => {
   if (!hasGetInitialPropsRun && err) {
     // getInitialProps is not called in case of
     // https://github.com/vercel/next.js/issues/8592. As a workaround, we pass
     // err via _app.js so it can be captured
     Sentry.captureException(err)
     // flush is needed after calling captureException to send server side errors to Sentry, otherwise the serverless function will exit before it's sent
-    await Sentry.flush(2000)
+    Sentry.flush(2000).catch(e => console.error(e));
   }
 
   return <NextErrorComponent statusCode={statusCode} />

--- a/examples/with-sentry/pages/_error.js
+++ b/examples/with-sentry/pages/_error.js
@@ -1,7 +1,7 @@
 import NextErrorComponent from 'next/error'
 import * as Sentry from '@sentry/node'
 
-const MyError =  ({ statusCode, hasGetInitialPropsRun, err }) => {
+const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
   if (!hasGetInitialPropsRun && err) {
     // getInitialProps is not called in case of
     // https://github.com/vercel/next.js/issues/8592. As a workaround, we pass


### PR DESCRIPTION
Adding async to the component MyError turns the function into a Promise instead of a pure function. This causes a React error code to be thrown:

https://reactjs.org/docs/error-decoder.html/?invariant=31&args%5B%5D=%5Bobject%20Promise%5D&args%5B%5D=

There's no need to await for Sentry to flush the output at this point. Added the catch so that if Sentry's flush throws an exception we dont spiral out of control.