### PR TITLE
[Examples] Remove horizontal scroll in CMS examples

### DIFF
--- a/examples/cms-agilitycms/components/post-header.js
+++ b/examples/cms-agilitycms/components/post-header.js
@@ -10,7 +10,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage
           title={title}
           responsiveImage={coverImage.responsiveImage}

--- a/examples/cms-buttercms/components/post-header.js
+++ b/examples/cms-buttercms/components/post-header.js
@@ -13,7 +13,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
           picture={author.profile_image}
         />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} url={coverImage} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-contentful/components/post-header.js
+++ b/examples/cms-contentful/components/post-header.js
@@ -10,7 +10,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         {author && <Avatar name={author.name} picture={author.picture} />}
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} url={coverImage.url} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-cosmic/components/post-header.js
+++ b/examples/cms-cosmic/components/post-header.js
@@ -13,7 +13,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
           picture={author.metadata.picture.imgix_url}
         />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} url={coverImage.imgix_url} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-datocms/components/post-header.js
+++ b/examples/cms-datocms/components/post-header.js
@@ -10,7 +10,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage
           title={title}
           responsiveImage={coverImage.responsiveImage}

--- a/examples/cms-prismic/components/post-header.js
+++ b/examples/cms-prismic/components/post-header.js
@@ -11,7 +11,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         {author && <Avatar name={author.name} picture={author.picture} />}
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={RichText.asText(title)} url={coverImage.url} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-sanity/components/post-header.js
+++ b/examples/cms-sanity/components/post-header.js
@@ -10,7 +10,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} url={coverImage} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-storyblok/components/post-header.js
+++ b/examples/cms-storyblok/components/post-header.js
@@ -10,7 +10,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.content.picture} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} url={coverImage} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-strapi/components/post-header.js
+++ b/examples/cms-strapi/components/post-header.js
@@ -10,7 +10,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} url={coverImage.url} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-takeshape/components/post-header.js
+++ b/examples/cms-takeshape/components/post-header.js
@@ -10,7 +10,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
       <div className="hidden md:block md:mb-12">
         <Avatar name={author.name} picture={author.picture} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} coverImage={coverImage} />
       </div>
       <div className="max-w-2xl mx-auto">

--- a/examples/cms-wordpress/components/post-header.js
+++ b/examples/cms-wordpress/components/post-header.js
@@ -17,7 +17,7 @@ export default function PostHeader({
       <div className="hidden md:block md:mb-12">
         <Avatar author={author} />
       </div>
-      <div className="mb-8 md:mb-16 -mx-5 sm:mx-0">
+      <div className="mb-8 md:mb-16 sm:mx-0">
         <CoverImage title={title} coverImage={coverImage} />
       </div>
       <div className="max-w-2xl mx-auto">


### PR DESCRIPTION
This is the same fix from https://github.com/vercel/next.js/pull/15729 - Adding it in a new PR as I can't update the current one.

Closes #15729
Fixes #15676