### PR TITLE
updated active-class-name example to also demo a `[slug]` path

### DIFF
--- a/examples/active-class-name/components/ActiveLink.js
+++ b/examples/active-class-name/components/ActiveLink.js
@@ -8,8 +8,11 @@ const ActiveLink = ({ children, activeClassName, ...props }) => {
   const child = Children.only(children)
   const childClassName = child.props.className || ''
 
+  // pages/index.js will be matched via props.href
+  // pages/about.js will be matched via props.href
+  // pages/[slug].js will be matched via props.as
   const className =
-    asPath === props.href
+    asPath === props.href || asPath === props.as
       ? `${childClassName} ${activeClassName}`.trim()
       : childClassName
 

--- a/examples/active-class-name/components/Nav.js
+++ b/examples/active-class-name/components/Nav.js
@@ -22,6 +22,11 @@ const Nav = () => (
           <a className="nav-link">About</a>
         </ActiveLink>
       </li>
+      <li>
+        <ActiveLink activeClassName="active" href="/[slug]" as="/slug">
+          <a className="nav-link">Slug</a>
+        </ActiveLink>
+      </li>
     </ul>
   </nav>
 )

--- a/examples/active-class-name/components/Nav.js
+++ b/examples/active-class-name/components/Nav.js
@@ -23,8 +23,8 @@ const Nav = () => (
         </ActiveLink>
       </li>
       <li>
-        <ActiveLink activeClassName="active" href="/[slug]" as="/slug">
-          <a className="nav-link">Slug</a>
+        <ActiveLink activeClassName="active" href="/[slug]" as="/dynamic-route">
+          <a className="nav-link">Dynamic Route</a>
         </ActiveLink>
       </li>
     </ul>

--- a/examples/active-class-name/pages/[slug].js
+++ b/examples/active-class-name/pages/[slug].js
@@ -1,0 +1,14 @@
+import { useRouter } from 'next/router'
+import Nav from '../components/Nav'
+
+const SlugPage = () => {
+  const { asPath } = useRouter()
+  return (
+    <>
+      <Nav />
+      <p>Hello, I'm the {asPath} page</p>
+    </>
+  )
+}
+
+export default SlugPage


### PR DESCRIPTION
updated example for [active-class-name](https://github.com/vercel/next.js/tree/f00ad581a16a3023f4be88940d3330550544509b/examples/active-class-name) to also support a `[slug].js` page that matches on `as` instead of `href` (as `href` would be `/[slug]`)

> This does not demo `[..slug].js` as this requires possible custom code for determining the slug path part for the active classname. i.e. page tree active nodes. A possible other example or another PR on this example.

Has possible information for:
 * https://github.com/vercel/next.js/issues/7410
