### PR TITLE
Delay server start message until it's listening

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -59,14 +59,13 @@ const nextDev: cliCommand = (argv) => {
   const port = args['--port'] || 3000
   const appUrl = `http://${args['--hostname'] || 'localhost'}:${port}`
 
-  startedDevelopmentServer(appUrl)
-
   startServer(
     { dir, dev: true, isNextDevCommand: true },
     port,
     args['--hostname']
   )
     .then(async (app) => {
+      startedDevelopmentServer(appUrl)
       await app.prepare()
     })
     .catch((err) => {


### PR DESCRIPTION
Fixes #15928

---

This would cause us to print the message too early and open the browser to a server that wasn't started yet. This waits until we're listening, but before the app is ready fully.