### PR TITLE
Fix asPath normalizing for non-dynamic pages

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -439,14 +439,20 @@ const nextServerlessLoader: loader.Loader = function () {
 
         // make sure to normalize req.url on Vercel to strip dynamic params
         // from the query which are added during routing
-        if (trustQuery) {
-          const _parsedUrl = parseUrl(req.url, true)
-          delete _parsedUrl.search
+        ${
+          pageIsDynamicRoute
+            ? `
+          if (trustQuery) {
+            const _parsedUrl = parseUrl(req.url, true)
+            delete _parsedUrl.search
 
-          for (const param of Object.keys(defaultRouteRegex.groups)) {
-            delete _parsedUrl.query[param]
+            for (const param of Object.keys(defaultRouteRegex.groups)) {
+              delete _parsedUrl.query[param]
+            }
+            req.url = formatUrl(_parsedUrl)
           }
-          req.url = formatUrl(_parsedUrl)
+        `
+            : ''
         }
 
         const isFallback = parsedUrl.query.__nextFallback

--- a/test/integration/dynamic-optional-routing/pages/about.js
+++ b/test/integration/dynamic-optional-routing/pages/about.js
@@ -1,3 +1,9 @@
 export default function Page(props) {
-  return <div>about</div>
+  return <div id="content">about</div>
+}
+
+export const getServerSideProps = () => {
+  return {
+    props: {},
+  }
 }

--- a/test/integration/dynamic-optional-routing/server.js
+++ b/test/integration/dynamic-optional-routing/server.js
@@ -16,6 +16,8 @@ const server = http.createServer((req, res) => {
   const { pathname } = url.parse(req.url)
 
   switch (pathname) {
+    case '/about':
+      return render('/about.js')
     case '/api/post':
     case '/api/post/hello':
     case '/api/post/hello/world': {

--- a/test/integration/dynamic-optional-routing/test/index.test.js
+++ b/test/integration/dynamic-optional-routing/test/index.test.js
@@ -370,6 +370,12 @@ describe('Dynamic Optional Routing', () => {
       }).then((res) => res.text())
     }
 
+    it('should render normal (non-dynamic) page', async () => {
+      const html = await render('/about')
+      const $ = cheerio.load(html)
+      expect($('#content').text()).toBe('about')
+    })
+
     it('should render top level optional catch-all root', async () => {
       const html = await render('/', { optionalName: '' })
       const $ = cheerio.load(html)


### PR DESCRIPTION
Corrects `asPath` normalizing being run for non-dynamic pages, and adds an additional test case to prevent regression

Closes: https://github.com/vercel/next.js/issues/15940