### PR TITLE
Make helpers.ts compatible with ie11

### DIFF
--- a/packages/react-refresh-utils/internal/helpers.ts
+++ b/packages/react-refresh-utils/internal/helpers.ts
@@ -163,10 +163,11 @@ function scheduleUpdate() {
   }, 30)
 }
 
+// Needs to be compatible with IE11
 export default {
-  registerExportsForReactRefresh,
-  isReactRefreshBoundary,
-  shouldInvalidateReactRefreshBoundary,
-  getRefreshBoundarySignature,
-  scheduleUpdate,
+  registerExportsForReactRefresh: registerExportsForReactRefresh,
+  isReactRefreshBoundary: isReactRefreshBoundary,
+  shouldInvalidateReactRefreshBoundary: shouldInvalidateReactRefreshBoundary,
+  getRefreshBoundarySignature: getRefreshBoundarySignature,
+  scheduleUpdate: scheduleUpdate,
 }


### PR DESCRIPTION
Fixes #15680

This does not solve the issue that an error triggered will fail on shadowroots being created, however it does fix the general failure

Closes https://github.com/vercel/next.js/pull/15825