### PR TITLE
Remove another broken demo link from with-graphql-faunadb

### DIFF
--- a/examples/with-graphql-faunadb/README.md
+++ b/examples/with-graphql-faunadb/README.md
@@ -1,6 +1,6 @@
 # FaunaDB Graphql Starter Example -- The FaunaDB Guestbook
 
-This simple Guestbook SPA example shows you how to use [FaunaDB's GraphQL endpoint](https://docs.fauna.com/fauna/current/api/graphql/) in your Next.js project. [[Live demo](https://with-graphql-faunadb.now.sh/)].
+This simple Guestbook SPA example shows you how to use [FaunaDB's GraphQL endpoint](https://docs.fauna.com/fauna/current/api/graphql/) in your Next.js project.
 
 ## Deploy your own
 


### PR DESCRIPTION
The link used to appear twice in the README, but it has only been removed once (#15267) to fix #15219. This commit removes the other link to the broken demo.