### PR TITLE
Fix: with-firebase-authentication event listener

### DIFF
--- a/examples/with-firebase-authentication/utils/auth/useUser.js
+++ b/examples/with-firebase-authentication/utils/auth/useUser.js
@@ -33,7 +33,7 @@ const useUser = () => {
     // Firebase updates the id token every hour, this
     // makes sure the react state and the cookie are
     // both kept up to date
-    firebase.auth().onIdTokenChanged((user) => {
+    const cancelAuthListener = firebase.auth().onIdTokenChanged((user) => {
       if (user) {
         const userData = mapUserData(user)
         setUserCookie(userData)
@@ -50,6 +50,10 @@ const useUser = () => {
       return
     }
     setUser(userFromCookie)
+
+    return () => {
+      cancelAuthListener()
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 


### PR DESCRIPTION
Reference to discussion https://github.com/vercel/next.js/discussions/16010
Bug fixes to `with-firebase-authentication` example that enter in a loop `maximum update depth exceeded errors` becase of the `onIdTokenChanged` Firebase auth method.
I added a clean up event listener.