### PR TITLE
removed renderToHTML definition from with-flow example

### DIFF
--- a/examples/with-flow/flow-typed/next.js.flow
+++ b/examples/with-flow/flow-typed/next.js.flow
@@ -5,8 +5,6 @@ declare module "next" {
     prepare(): Promise<void>;
     getRequestHandler(): any;
     render(req: any, res: any, pathname: string, query: any): any;
-    renderError(err: Error, req: any, res: any, pathname: any, query: any): any;
-    renderErrorToHTML(err: Error, req: any, res: any, pathname: string, query: any): string;
   };
   declare module.exports: (...opts: any) => NextApp
 }

--- a/examples/with-flow/flow-typed/next.js.flow
+++ b/examples/with-flow/flow-typed/next.js.flow
@@ -5,7 +5,6 @@ declare module "next" {
     prepare(): Promise<void>;
     getRequestHandler(): any;
     render(req: any, res: any, pathname: string, query: any): any;
-    renderToHTML(req: any, res: any, pathname: string, query: string): string;
     renderError(err: Error, req: any, res: any, pathname: any, query: any): any;
     renderErrorToHTML(err: Error, req: any, res: any, pathname: string, query: any): string;
   };


### PR DESCRIPTION
This is my very first PR, I'm hoping to contribute more. Should I also remove `renderErrorToHTML` and `renderError`?

#14737 