### PR TITLE
Allow React experimental version without warning

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -69,7 +69,7 @@ const nextDev: cliCommand = (argv) => {
     if (
       reactVersion &&
       semver.lt(reactVersion, '16.10.0') &&
-      semver.coerce(reactVersion).version !== '0.0.0'
+      semver.coerce(reactVersion)?.version !== '0.0.0'
     ) {
       Log.warn(
         'Fast Refresh is disabled in your application due to an outdated `react` version. Please upgrade 16.10 or newer!' +
@@ -83,7 +83,7 @@ const nextDev: cliCommand = (argv) => {
       if (
         reactDomVersion &&
         semver.lt(reactDomVersion, '16.10.0') &&
-        semver.coerce(reactDomVersion).version !== '0.0.0'
+        semver.coerce(reactDomVersion)?.version !== '0.0.0'
       ) {
         Log.warn(
           'Fast Refresh is disabled in your application due to an outdated `react-dom` version. Please upgrade 16.10 or newer!' +

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -66,7 +66,11 @@ const nextDev: cliCommand = (argv) => {
       cwd: dir,
       name: 'react',
     })
-    if (reactVersion && semver.lt(reactVersion, '16.10.0')) {
+    if (
+      reactVersion &&
+      semver.lt(reactVersion, '16.10.0') &&
+      semver.coerce(reactVersion).version !== '0.0.0'
+    ) {
       Log.warn(
         'Fast Refresh is disabled in your application due to an outdated `react` version. Please upgrade 16.10 or newer!' +
           ' Read more: https://err.sh/next.js/react-version'
@@ -76,7 +80,11 @@ const nextDev: cliCommand = (argv) => {
         cwd: dir,
         name: 'react-dom',
       })
-      if (reactDomVersion && semver.lt(reactDomVersion, '16.10.0')) {
+      if (
+        reactDomVersion &&
+        semver.lt(reactDomVersion, '16.10.0') &&
+        semver.coerce(reactDomVersion).version !== '0.0.0'
+      ) {
         Log.warn(
           'Fast Refresh is disabled in your application due to an outdated `react-dom` version. Please upgrade 16.10 or newer!' +
             ' Read more: https://err.sh/next.js/react-version'

--- a/test/integration/cli/experimental-react-dom/.gitignore
+++ b/test/integration/cli/experimental-react-dom/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/integration/cli/experimental-react-dom/node_modules/react-dom/index.js
+++ b/test/integration/cli/experimental-react-dom/node_modules/react-dom/index.js
@@ -1,0 +1,1 @@
+module.exports = { Suspense: true }

--- a/test/integration/cli/experimental-react-dom/node_modules/react-dom/package.json
+++ b/test/integration/cli/experimental-react-dom/node_modules/react-dom/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "react-dom",
+  "version": "0.0.0-experimental-94c0244ba"
+}

--- a/test/integration/cli/experimental-react-dom/package.json
+++ b/test/integration/cli/experimental-react-dom/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react": "*",
+    "react-dom": "*"
+  }
+}

--- a/test/integration/cli/experimental-react-dom/pages/index.js
+++ b/test/integration/cli/experimental-react-dom/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Hello</p>
+}

--- a/test/integration/cli/experimental-react/.gitignore
+++ b/test/integration/cli/experimental-react/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/integration/cli/experimental-react/node_modules/react/index.js
+++ b/test/integration/cli/experimental-react/node_modules/react/index.js
@@ -1,0 +1,1 @@
+module.exports = { Suspense: true }

--- a/test/integration/cli/experimental-react/node_modules/react/package.json
+++ b/test/integration/cli/experimental-react/node_modules/react/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "react",
+  "version": "0.0.0-experimental-94c0244ba"
+}

--- a/test/integration/cli/experimental-react/package.json
+++ b/test/integration/cli/experimental-react/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "react": "*",
+    "react-dom": "*"
+  }
+}

--- a/test/integration/cli/experimental-react/pages/index.js
+++ b/test/integration/cli/experimental-react/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Hello</p>
+}

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -16,6 +16,8 @@ jest.setTimeout(1000 * 60 * 5)
 const dir = join(__dirname, '..')
 const dirOldReact = join(__dirname, '../old-react')
 const dirOldReactDom = join(__dirname, '../old-react-dom')
+const dirExperimentalReact = join(__dirname, '../experimental-react')
+const dirExperimentalReactDom = join(__dirname, '../experimental-react-dom')
 
 describe('CLI Usage', () => {
   describe('no command', () => {
@@ -253,6 +255,42 @@ describe('CLI Usage', () => {
       expect(stderr).toMatch(
         'Fast Refresh is disabled in your application due to an outdated `react-dom` version'
       )
+      expect(stderr).not.toMatch('`react`')
+
+      await killApp(instance)
+    })
+
+    test('experimental react version', async () => {
+      const port = await findPort()
+
+      let stderr = ''
+      let instance = await launchApp(dirExperimentalReact, port, {
+        stderr: true,
+        onStderr(msg) {
+          stderr += msg
+        },
+      })
+
+      expect(stderr).not.toMatch('disabled')
+      expect(stderr).not.toMatch('outdated')
+      expect(stderr).not.toMatch(`react-dom`)
+
+      await killApp(instance)
+    })
+
+    test('experimental react-dom version', async () => {
+      const port = await findPort()
+
+      let stderr = ''
+      let instance = await launchApp(dirExperimentalReactDom, port, {
+        stderr: true,
+        onStderr(msg) {
+          stderr += msg
+        },
+      })
+
+      expect(stderr).not.toMatch('disabled')
+      expect(stderr).not.toMatch('outdated')
       expect(stderr).not.toMatch('`react`')
 
       await killApp(instance)


### PR DESCRIPTION
React uses `0.0.0-experimental-<sha>` (or `0.0.0-<sha>`) for their experimental builds. When using these experimental versions of React, Next would output a warning notifying the user that Fast Refresh will not work. This fix ensures the react and react-dom versions are not equal to `0.0.0` before showing the warning.

Fixes #16103

