### PR TITLE
Improve page loader types

### DIFF
--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -68,7 +68,8 @@ function appendLink(
   })
 }
 
-type PageCacheEntry = { error?: any; page?: any; mod?: any }
+export type GoodPageCache = { page: any; mod: any }
+export type PageCacheEntry = { error: any } | GoodPageCache
 
 export default class PageLoader {
   private buildId: string
@@ -225,26 +226,29 @@ export default class PageLoader {
     )
   }
 
-  loadPage(route: string) {
+  loadPage(route: string): Promise<GoodPageCache> {
     route = normalizeRoute(route)
 
-    return new Promise((resolve, reject) => {
+    return new Promise<GoodPageCache>((resolve, reject) => {
       // If there's a cached version of the page, let's use it.
       const cachedPage = this.pageCache[route]
       if (cachedPage) {
-        const { error, page, mod } = cachedPage
-        error ? reject(error) : resolve({ page, mod })
+        if ('error' in cachedPage) {
+          reject(cachedPage.error)
+        } else {
+          resolve(cachedPage)
+        }
         return
       }
 
-      const fire = ({ error, page, mod }: PageCacheEntry) => {
+      const fire = (pageToCache: PageCacheEntry) => {
         this.pageRegisterEvents.off(route, fire)
         delete this.loadingRoutes[route]
 
-        if (error) {
-          reject(error)
+        if ('error' in pageToCache) {
+          reject(pageToCache.error)
         } else {
-          resolve({ page, mod })
+          resolve(pageToCache)
         }
       }
 


### PR DESCRIPTION
This is a minor improvement to the page loader types. It separates the "good page cache" so that it can be used for the `loadPage` result without the `error` prop, which causes rejection.