### PR TITLE
Convert performance relayer to TypeScript

### DIFF
--- a/packages/next/client/performance-relayer.js
+++ b/packages/next/client/performance-relayer.js
@@ -1,9 +1,0 @@
-import { getCLS, getFID, getFCP, getLCP, getTTFB } from 'web-vitals'
-
-export default (onPerfEntry) => {
-  getCLS(onPerfEntry)
-  getFID(onPerfEntry)
-  getFCP(onPerfEntry)
-  getLCP(onPerfEntry)
-  getTTFB(onPerfEntry)
-}

--- a/packages/next/client/performance-relayer.ts
+++ b/packages/next/client/performance-relayer.ts
@@ -1,0 +1,16 @@
+import {
+  getCLS,
+  getFCP,
+  getFID,
+  getLCP,
+  getTTFB,
+  ReportHandler,
+} from 'web-vitals'
+
+export default (onPerfEntry: ReportHandler) => {
+  getCLS(onPerfEntry)
+  getFID(onPerfEntry)
+  getFCP(onPerfEntry)
+  getLCP(onPerfEntry)
+  getTTFB(onPerfEntry)
+}


### PR DESCRIPTION
Really basic one! Needed for `next/client`.