### PR TITLE
Modify low priority files in manifest

### DIFF
--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -17,6 +17,8 @@ import { getSortedRoutes } from '../../../next-server/lib/router/utils'
 
 const isWebpack5 = parseInt(webpack.version!) === 5
 
+type DeepMutable<T> = { -readonly [P in keyof T]: DeepMutable<T[P]> }
+
 export type ClientBuildManifest = Record<string, string[]>
 
 // This function takes the asset map generated in BuildManifestPlugin and creates a
@@ -102,7 +104,7 @@ export default class BuildManifestPlugin {
   createAssets(compilation: any, assets: any) {
     const namedChunks: Map<string, CompilationType.Chunk> =
       compilation.namedChunks
-    const assetMap: BuildManifest = {
+    const assetMap: DeepMutable<BuildManifest> = {
       polyfillFiles: [],
       devFiles: [],
       ampDevFiles: [],

--- a/packages/next/next-server/server/get-page-files.ts
+++ b/packages/next/next-server/server/get-page-files.ts
@@ -1,21 +1,21 @@
 import { normalizePagePath, denormalizePagePath } from './normalize-page-path'
 
 export type BuildManifest = {
-  devFiles: string[]
-  ampDevFiles: string[]
-  polyfillFiles: string[]
-  lowPriorityFiles: string[]
+  devFiles: readonly string[]
+  ampDevFiles: readonly string[]
+  polyfillFiles: readonly string[]
+  lowPriorityFiles: readonly string[]
   pages: {
-    '/_app': string[]
-    [page: string]: string[]
+    '/_app': readonly string[]
+    [page: string]: readonly string[]
   }
-  ampFirstPages: string[]
+  ampFirstPages: readonly string[]
 }
 
 export function getPageFiles(
   buildManifest: BuildManifest,
   page: string
-): string[] {
+): readonly string[] {
   const normalizedPage = denormalizePagePath(normalizePagePath(page))
   let files = buildManifest.pages[normalizedPage]
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -27,6 +27,7 @@ import { HeadManagerContext } from '../lib/head-manager-context'
 import Loadable from '../lib/loadable'
 import { LoadableContext } from '../lib/loadable-context'
 import mitt, { MittEmitter } from '../lib/mitt'
+import postProcess from '../lib/post-process'
 import { RouterContext } from '../lib/router-context'
 import { NextRouter } from '../lib/router/router'
 import { isDynamicRoute } from '../lib/router/utils/is-dynamic'
@@ -42,11 +43,12 @@ import {
   RenderPage,
 } from '../lib/utils'
 import { tryGetPreviewData, __ApiPreviewProps } from './api-utils'
+import { denormalizePagePath } from './denormalize-page-path'
+import { FontManifest, getFontDefinitionFromManifest } from './font-utils'
 import { getPageFiles } from './get-page-files'
 import { LoadComponentsReturnType, ManifestItem } from './load-components'
+import { normalizePagePath } from './normalize-page-path'
 import optimizeAmp from './optimize-amp'
-import postProcess from '../lib/post-process'
-import { FontManifest, getFontDefinitionFromManifest } from './font-utils'
 
 function noRouter() {
   const message =
@@ -675,21 +677,27 @@ export async function renderToHTML(
   // we preload the buildManifest for auto-export dynamic pages
   // to speed up hydrating query values
   let filteredBuildManifest = buildManifest
-  const additionalFiles: string[] = []
-
   if (isAutoExport && pageIsDynamic) {
-    filteredBuildManifest = {
-      ...buildManifest,
-      lowPriorityFiles: buildManifest.lowPriorityFiles.filter((file) => {
-        if (
-          file.endsWith('_buildManifest.js') ||
-          file.endsWith('_buildManifest.module.js')
-        ) {
-          additionalFiles.push(file)
-          return false
-        }
-        return true
-      }),
+    const page = denormalizePagePath(normalizePagePath(pathname))
+    // This code would be much cleaner using `immer` and directly pushing into
+    // the result from `getPageFiles`, we could maybe consider that in the
+    // future.
+    if (page in filteredBuildManifest.pages) {
+      filteredBuildManifest = {
+        ...filteredBuildManifest,
+        pages: {
+          ...filteredBuildManifest.pages,
+          [page]: [
+            ...filteredBuildManifest.pages[page],
+            ...filteredBuildManifest.lowPriorityFiles.filter((f) =>
+              f.includes('_buildManifest')
+            ),
+          ],
+        },
+        lowPriorityFiles: filteredBuildManifest.lowPriorityFiles.filter(
+          (f) => !f.includes('_buildManifest')
+        ),
+      }
     }
   }
 
@@ -703,7 +711,6 @@ export async function renderToHTML(
             ? getPageFiles(buildManifest, pathname)
             : []),
         ]),
-        ...additionalFiles,
       ]
 
   const renderPage: RenderPage = (

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -706,9 +706,9 @@ export async function renderToHTML(
     ? []
     : [
         ...new Set([
-          ...getPageFiles(buildManifest, '/_app'),
+          ...getPageFiles(filteredBuildManifest, '/_app'),
           ...(pathname !== '/_error'
-            ? getPageFiles(buildManifest, pathname)
+            ? getPageFiles(filteredBuildManifest, pathname)
             : []),
         ]),
       ]


### PR DESCRIPTION
This pull request edits the `BuildManifest` that is sent to `/_document` instead of modifying a single input array to decouple its implementation details.

Optimally, we'd eliminate the `files` key all together.

---

Related to #16182