### PR TITLE
Refactor <Document> files

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -171,7 +171,6 @@ export type DocumentProps = DocumentInitialProps & {
   inAmpMode: boolean
   hybridAmp: boolean
   isDevelopment: boolean
-  files: string[]
   dynamicImports: ManifestItem[]
   assetPrefix?: string
   canonicalBase: string

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -45,7 +45,6 @@ import {
 import { tryGetPreviewData, __ApiPreviewProps } from './api-utils'
 import { denormalizePagePath } from './denormalize-page-path'
 import { FontManifest, getFontDefinitionFromManifest } from './font-utils'
-import { getPageFiles } from './get-page-files'
 import { LoadComponentsReturnType, ManifestItem } from './load-components'
 import { normalizePagePath } from './normalize-page-path'
 import optimizeAmp from './optimize-amp'
@@ -178,7 +177,6 @@ function renderDocument(
     ampState,
     inAmpMode,
     hybridAmp,
-    files,
     dynamicImports,
     headTags,
     gsp,
@@ -200,7 +198,6 @@ function renderDocument(
     hybridAmp: boolean
     dynamicImportsIds: string[]
     dynamicImports: ManifestItem[]
-    files: string[]
     headTags: any
     isFallback?: boolean
     gsp?: boolean
@@ -242,7 +239,6 @@ function renderDocument(
           inAmpMode,
           isDevelopment: !!dev,
           hybridAmp,
-          files,
           dynamicImports,
           assetPrefix,
           headTags,
@@ -701,18 +697,6 @@ export async function renderToHTML(
     }
   }
 
-  // AMP First pages do not have client-side JavaScript files
-  const files = ampState.ampFirst
-    ? []
-    : [
-        ...new Set([
-          ...getPageFiles(filteredBuildManifest, '/_app'),
-          ...(pathname !== '/_error'
-            ? getPageFiles(filteredBuildManifest, pathname)
-            : []),
-        ]),
-      ]
-
   const renderPage: RenderPage = (
     options: ComponentsEnhancer = {}
   ): { html: string; head: any } => {
@@ -796,7 +780,6 @@ export async function renderToHTML(
     hybridAmp,
     dynamicImportsIds,
     dynamicImports,
-    files,
     gsp: !!getStaticProps ? true : undefined,
     gssp: !!getServerSideProps ? true : undefined,
     gip: hasPageGetInitialProps ? true : undefined,

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -61,7 +61,7 @@ function getDocumentFiles(
   return {
     sharedFiles,
     pageFiles,
-    allFiles: dedupe([...sharedFiles, ...pageFiles]),
+    allFiles: [...new Set([...sharedFiles, ...pageFiles])],
   }
 }
 
@@ -390,6 +390,7 @@ export class Head extends Component<
       this.context.buildManifest,
       this.context.__NEXT_DATA__.page
     )
+    console.log(files)
     return (
       <head {...this.props}>
         {this.context.isDevelopment && (
@@ -693,6 +694,7 @@ export class NextScript extends Component<OriginProps> {
       this.context.buildManifest,
       this.context.__NEXT_DATA__.page
     )
+    console.log('ff', files)
     return (
       <>
         {!disableRuntimeJS && buildManifest.devFiles

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -390,7 +390,6 @@ export class Head extends Component<
       this.context.buildManifest,
       this.context.__NEXT_DATA__.page
     )
-    console.log(files)
     return (
       <head {...this.props}>
         {this.context.isDevelopment && (
@@ -694,7 +693,6 @@ export class NextScript extends Component<OriginProps> {
       this.context.buildManifest,
       this.context.__NEXT_DATA__.page
     )
-    console.log('ff', files)
     return (
       <>
         {!disableRuntimeJS && buildManifest.devFiles

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useContext, Component, ReactNode } from 'react'
+import React, { Component, ReactNode, useContext } from 'react'
 import flush from 'styled-jsx/server'
 import {
   AMP_RENDER_TARGET,
@@ -11,6 +11,10 @@ import {
   DocumentInitialProps,
   DocumentProps,
 } from '../next-server/lib/utils'
+import {
+  BuildManifest,
+  getPageFiles,
+} from '../next-server/server/get-page-files'
 import { cleanAmpPath } from '../next-server/server/utils'
 import { htmlEscapeJsonString } from '../server/htmlescape'
 
@@ -38,6 +42,27 @@ function getOptionalModernScriptVariant(path: string): string {
     return path.replace(/\.js$/, '.module.js')
   }
   return path
+}
+
+type DocumentFiles = {
+  sharedFiles: readonly string[]
+  pageFiles: readonly string[]
+  allFiles: readonly string[]
+}
+
+function getDocumentFiles(
+  buildManifest: BuildManifest,
+  pathname: string
+): DocumentFiles {
+  const sharedFiles: readonly string[] = getPageFiles(buildManifest, '/_app')
+  const pageFiles: readonly string[] =
+    pathname !== '/_error' ? getPageFiles(buildManifest, pathname) : []
+
+  return {
+    sharedFiles,
+    pageFiles,
+    allFiles: dedupe([...sharedFiles, ...pageFiles]),
+  }
 }
 
 /**
@@ -126,10 +151,9 @@ export class Head extends Component<
 
   context!: React.ContextType<typeof DocumentComponentContext>
 
-  getCssLinks(): JSX.Element[] | null {
-    const { assetPrefix, files, devOnlyCacheBusterQueryString } = this.context
-    const cssFiles =
-      files && files.length ? files.filter((f) => f.endsWith('.css')) : []
+  getCssLinks(files: DocumentFiles): JSX.Element[] | null {
+    const { assetPrefix, devOnlyCacheBusterQueryString } = this.context
+    const cssFiles = files.allFiles.filter((f) => f.endsWith('.css'))
 
     const cssLinkElements: JSX.Element[] = []
     cssFiles.forEach((file) => {
@@ -200,18 +224,14 @@ export class Head extends Component<
     )
   }
 
-  getPreloadMainLinks(): JSX.Element[] | null {
-    const { assetPrefix, files, devOnlyCacheBusterQueryString } = this.context
-
-    const preloadFiles =
-      files && files.length
-        ? files.filter((file: string) => {
-            // `dynamicImports` will contain both `.js` and `.module.js` when
-            // the feature is enabled. This clause will filter down to the
-            // modern variants only.
-            return file.endsWith(getOptionalModernScriptVariant('.js'))
-          })
-        : []
+  getPreloadMainLinks(files: DocumentFiles): JSX.Element[] | null {
+    const { assetPrefix, devOnlyCacheBusterQueryString } = this.context
+    const preloadFiles = files.allFiles.filter((file: string) => {
+      // `dynamicImports` will contain both `.js` and `.module.js` when
+      // the feature is enabled. This clause will filter down to the
+      // modern variants only.
+      return file.endsWith(getOptionalModernScriptVariant('.js'))
+    })
 
     return !preloadFiles.length
       ? null
@@ -366,6 +386,10 @@ export class Head extends Component<
       })
     }
 
+    const files: DocumentFiles = getDocumentFiles(
+      this.context.buildManifest,
+      this.context.__NEXT_DATA__.page
+    )
     return (
       <head {...this.props}>
         {this.context.isDevelopment && (
@@ -452,10 +476,10 @@ export class Head extends Component<
               />
             )}
             {process.env.__NEXT_OPTIMIZE_FONTS
-              ? this.makeStylesheetInert(this.getCssLinks())
-              : this.getCssLinks()}
+              ? this.makeStylesheetInert(this.getCssLinks(files))
+              : this.getCssLinks(files)}
             {!disableRuntimeJS && this.getPreloadDynamicChunks()}
-            {!disableRuntimeJS && this.getPreloadMainLinks()}
+            {!disableRuntimeJS && this.getPreloadMainLinks(files)}
             {this.context.isDevelopment && (
               // this element is used to mount development styles so the
               // ordering matches production
@@ -491,11 +515,10 @@ export class NextScript extends Component<OriginProps> {
   static safariNomoduleFix =
     '!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();'
 
-  getDynamicChunks() {
+  getDynamicChunks(files: DocumentFiles) {
     const {
       dynamicImports,
       assetPrefix,
-      files,
       isDevelopment,
       devOnlyCacheBusterQueryString,
     } = this.context
@@ -508,7 +531,7 @@ export class NextScript extends Component<OriginProps> {
           : { noModule: true }
       }
 
-      if (!bundle.file.endsWith('.js') || files.includes(bundle.file))
+      if (!bundle.file.endsWith('.js') || files.allFiles.includes(bundle.file))
         return null
 
       return (
@@ -528,16 +551,15 @@ export class NextScript extends Component<OriginProps> {
     })
   }
 
-  getScripts() {
+  getScripts(files: DocumentFiles) {
     const {
       assetPrefix,
-      files,
       buildManifest,
       isDevelopment,
       devOnlyCacheBusterQueryString,
     } = this.context
 
-    const normalScripts = files?.filter((file) => file.endsWith('.js'))
+    const normalScripts = files.allFiles.filter((file) => file.endsWith('.js'))
     const lowPriorityScripts = buildManifest.lowPriorityFiles?.filter((file) =>
       file.endsWith('.js')
     )
@@ -667,6 +689,10 @@ export class NextScript extends Component<OriginProps> {
         )
     }
 
+    const files: DocumentFiles = getDocumentFiles(
+      this.context.buildManifest,
+      this.context.__NEXT_DATA__.page
+    )
     return (
       <>
         {!disableRuntimeJS && buildManifest.devFiles
@@ -709,8 +735,8 @@ export class NextScript extends Component<OriginProps> {
           />
         ) : null}
         {!disableRuntimeJS && this.getPolyfillScripts()}
-        {disableRuntimeJS ? null : this.getDynamicChunks()}
-        {disableRuntimeJS ? null : this.getScripts()}
+        {disableRuntimeJS ? null : this.getDynamicChunks(files)}
+        {disableRuntimeJS ? null : this.getScripts(files)}
       </>
     )
   }


### PR DESCRIPTION
Instead of reading the `BuildManifest` and passing it to `/_document`, it should be able to read it for itself.

---

Fixes #16182