### PR TITLE
Add a clarification

### DIFF
--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -66,6 +66,8 @@ When linking to a route with [dynamic path segments](/docs/routing/dynamic-route
 - `href` - The name of the page in the `pages` directory. For example `/blog/[slug]`.
 - `as` - The url that will be shown in the browser. For example `/blog/hello-world`.
 
+You have to make sure `href` and `as` are compatible, as explained [here](https://github.com/vercel/next.js/blob/master/errors/incompatible-href-as.md). 
+
 ```jsx
 import Link from 'next/link'
 


### PR DESCRIPTION
I ran into a problem when trying to use `href` and `as`. Initially, due to the sentence **that will be shown in the browser**, I thought `as` could be anything (which would be great if it were the case, because then I would have the freedom to organize folders in `pages` in whatever way I like, and yet the visitors of my site would maybe be unaware of that organization, would that be possible?).