### PR TITLE
Make css-minimizer compatible with webpack 5

### DIFF
--- a/packages/next/build/webpack/plugins/css-minimizer-plugin.ts
+++ b/packages/next/build/webpack/plugins/css-minimizer-plugin.ts
@@ -11,6 +11,8 @@ type CssMinimizerPluginOptions = {
   }
 }
 
+const isWebpack5 = parseInt(webpack.version!) === 5
+
 export class CssMinimizerPlugin {
   __next_css_remove = true
 
@@ -20,8 +22,55 @@ export class CssMinimizerPlugin {
     this.options = options
   }
 
+  optimizeAsset(file, asset: any) {
+    const postcssOptions = {
+      ...this.options.postcssOptions,
+      to: file,
+      from: file,
+    }
+
+    let input: string
+    if (postcssOptions.map && asset.sourceAndMap) {
+      const { source, map } = asset.sourceAndMap()
+      input = source
+      postcssOptions.map.prev = map ? map : false
+    } else {
+      input = asset.source()
+    }
+
+    return minify(input, postcssOptions).then((res) => {
+      if (res.map) {
+        return new SourceMapSource(res.css, file, res.map.toJSON())
+      } else {
+        return new RawSource(res.css)
+      }
+    })
+  }
+
   apply(compiler: webpack.Compiler) {
     compiler.hooks.compilation.tap('CssMinimizerPlugin', (compilation: any) => {
+      if (isWebpack5) {
+        compilation.hooks.processAssets.tapPromise(
+          {
+            name: 'CssMinimizerPlugin',
+            // @ts-ignore TODO: Remove ignore when webpack 5 is stable
+            stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
+          },
+          async (assets: any) => {
+            const files = Object.keys(assets)
+            await Promise.all(
+              files
+                .filter((file) => CSS_REGEX.test(file))
+                .map(async (file) => {
+                  const asset = compilation.assets[file]
+
+                  assets[file] = await this.optimizeAsset(file, asset)
+                })
+            )
+          }
+        )
+        return
+      }
       compilation.hooks.optimizeChunkAssets.tapPromise(
         'CssMinimizerPlugin',
         (chunks: webpack.compilation.Chunk[]) =>
@@ -32,35 +81,10 @@ export class CssMinimizerPlugin {
                 [] as string[]
               )
               .filter((entry) => CSS_REGEX.test(entry))
-              .map((file) => {
-                const postcssOptions = {
-                  ...this.options.postcssOptions,
-                  to: file,
-                  from: file,
-                }
-
+              .map(async (file) => {
                 const asset = compilation.assets[file]
 
-                let input: string
-                if (postcssOptions.map && asset.sourceAndMap) {
-                  const { source, map } = asset.sourceAndMap()
-                  input = source
-                  postcssOptions.map.prev = map ? map : false
-                } else {
-                  input = asset.source()
-                }
-
-                return minify(input, postcssOptions).then((res) => {
-                  if (res.map) {
-                    compilation.assets[file] = new SourceMapSource(
-                      res.css,
-                      file,
-                      res.map.toJSON()
-                    )
-                  } else {
-                    compilation.assets[file] = new RawSource(res.css)
-                  }
-                })
+                compilation.assets[file] = await this.optimizeAsset(file, asset)
               })
           )
       )

--- a/packages/next/build/webpack/plugins/css-minimizer-plugin.ts
+++ b/packages/next/build/webpack/plugins/css-minimizer-plugin.ts
@@ -22,7 +22,7 @@ export class CssMinimizerPlugin {
     this.options = options
   }
 
-  optimizeAsset(file, asset: any) {
+  optimizeAsset(file: string, asset: any) {
     const postcssOptions = {
       ...this.options.postcssOptions,
       to: file,


### PR DESCRIPTION
Fixes some deprecation warnings during `next build`