### PR TITLE
ci: add pnp test

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -70,10 +70,32 @@ jobs:
 
       - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3
 
+  testPnp:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      NODE_OPTIONS: '--unhandled-rejections=strict'
+    steps:
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+      - run: |
+          mkdir -p ./e2e-tests/next-pnp
+          cp -r ./examples/with-typescript/. ./e2e-tests/next-pnp
+          cd ./e2e-tests/next-pnp
+          touch yarn.lock
+          yarn set version berry
+          yarn config set pnpFallbackMode none
+          yarn link --all --private ../..
+          yarn
+          yarn build
+
   testsPass:
     name: thank you, next
     runs-on: ubuntu-latest
-    needs: [lint, checkPrecompiled, testAll]
+    needs: [lint, checkPrecompiled, testAll, testPnp]
     steps:
       - run: exit 0
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -80,7 +80,6 @@ jobs:
       - run: yarn install --frozen-lockfile --check-files
 
       - run: |
-          git ls-remote --refs https://github.com/watson/ci-info.git
           mkdir -p ./e2e-tests/next-pnp
           cp -r ./examples/with-typescript/. ./e2e-tests/next-pnp
           cd ./e2e-tests/next-pnp

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -87,7 +87,6 @@ jobs:
           yarn set version berry
           yarn config set pnpFallbackMode none
           yarn link --all --private ../..
-          yarn
           yarn build
 
   testsPass:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -92,7 +92,7 @@ jobs:
   testsPass:
     name: thank you, next
     runs-on: ubuntu-latest
-    needs: [lint, checkPrecompiled, testAll, testPnp]
+    needs: [lint, checkPrecompiled, testAll, testYarnPnP]
     steps:
       - run: exit 0
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
       - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3
 
-  testPnp:
+  testYarnPnP:
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--unhandled-rejections=strict'

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -72,16 +72,15 @@ jobs:
 
   testPnp:
     runs-on: ubuntu-latest
-    needs: build
     env:
       NODE_OPTIONS: '--unhandled-rejections=strict'
     steps:
-      - uses: actions/cache@v2
-        id: restore-build
-        with:
-          path: ./*
-          key: ${{ github.sha }}
+      - uses: actions/checkout@v2
+
+      - run: yarn install --frozen-lockfile --check-files
+
       - run: |
+          git ls-remote --refs https://github.com/watson/ci-info.git
           mkdir -p ./e2e-tests/next-pnp
           cp -r ./examples/with-typescript/. ./e2e-tests/next-pnp
           cd ./e2e-tests/next-pnp

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage
 test/**/out*
 test/**/next-env.d.ts
 .DS_Store
+/e2e-tests
 
 # Editors
 **/.idea

--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^12.12.21",
     "@types/react": "^16.9.16",
     "@types/react-dom": "^16.9.4",
-    "typescript": "3.7.3"
+    "typescript": "3.9.7"
   },
   "license": "ISC"
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -86,6 +86,7 @@
     "browserslist": "4.13.0",
     "buffer": "5.6.0",
     "cacache": "13.0.1",
+    "caniuse-lite": "^1.0.30001113",
     "chokidar": "2.1.8",
     "crypto-browserify": "3.12.0",
     "css-loader": "3.5.3",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -86,7 +86,6 @@
     "browserslist": "4.13.0",
     "buffer": "5.6.0",
     "cacache": "13.0.1",
-    "caniuse-lite": "^1.0.30001113",
     "chokidar": "2.1.8",
     "crypto-browserify": "3.12.0",
     "css-loader": "3.5.3",


### PR DESCRIPTION
**What's the problem this PR addresses?**

Next currently doesn't have a PnP test so it's up to the [e2e test in the berry repo](https://github.com/yarnpkg/berry/blob/8428baef8fa44696a173d22a63f2c8d0bcd57dd3/.github/workflows/e2e-next-workflow.yml) to catch issues, but at that point it's already too late.

Output when a dependency is missing https://github.com/vercel/next.js/runs/994230443#step:4:98
```
Error: next tried to access caniuse-lite, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: caniuse-lite (via "caniuse-lite")
Required by: next@virtual:f4078270accb7ecc153a7ffdc1e9528a68b3696b289d7508391771dacb534631a4090dee022ba626bfbfd43ccd2343d55fb1fbe4a802bcf93c14713aaf332c06#portal:/home/runner/work/next.js/next.js/packages/next::locator=with-typescript%40workspace%3A. (via /home/runner/work/next.js/next.js/e2e-tests/next-pnp/.yarn/$$virtual/next-virtual-bad7a6a53b/3/packages/next/dist/compiled/postcss-preset-env/)

Require stack:
- /home/runner/work/next.js/next.js/e2e-tests/next-pnp/.yarn/$$virtual/next-virtual-bad7a6a53b/3/packages/next/dist/compiled/postcss-preset-env/index.js
- /home/runner/work/next.js/next.js/e2e-tests/next-pnp/.yarn/$$virtual/next-virtual-bad7a6a53b/3/packages/next/dist/build/webpack/config/blocks/css/plugins.js
- /home/runner/work/next.js/next.js/e2e-tests/next-pnp/.yarn/$$virtual/next-virtual-bad7a6a53b/3/packages/next/dist/build/webpack/config/blocks/css/index.js
[...]
```

**How did you fix it?**

Added a PnP e2e test