### PR TITLE
Fix data URL with root-catchall and basePath

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -726,7 +726,7 @@ export default class Router implements BaseRouter {
       if (__N_SSG || __N_SSP) {
         dataHref = this.pageLoader.getDataHref(
           formatWithValidation({ pathname, query }),
-          as,
+          delBasePath(as),
           __N_SSG
         )
       }

--- a/test/integration/basepath-root-catch-all/next.config.js
+++ b/test/integration/basepath-root-catch-all/next.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // target: 'experimental-serverless-trace',
+  basePath: '/docs',
+}

--- a/test/integration/basepath-root-catch-all/pages/[...parts].js
+++ b/test/integration/basepath-root-catch-all/pages/[...parts].js
@@ -1,0 +1,14 @@
+export default ({ url }) => (
+  <>
+    <h1>root catch-all</h1>
+    <p id="url">{url}</p>
+  </>
+)
+
+export const getServerSideProps = ({ req, res }) => {
+  return {
+    props: {
+      url: req.url,
+    },
+  }
+}

--- a/test/integration/basepath-root-catch-all/pages/hello.js
+++ b/test/integration/basepath-root-catch-all/pages/hello.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 export default () => (
-  <Link href="/[...poarts]" as="/root/catch-all">
+  <Link href="/[...parts]" as="/root/catch-all">
     <a id="root-catchall-link">root catch-all</a>
   </Link>
 )

--- a/test/integration/basepath-root-catch-all/pages/hello.js
+++ b/test/integration/basepath-root-catch-all/pages/hello.js
@@ -1,0 +1,7 @@
+import Link from 'next/link'
+
+export default () => (
+  <Link href="/[...poarts]" as="/root/catch-all">
+    <a id="root-catchall-link">root catch-all</a>
+  </Link>
+)

--- a/test/integration/basepath-root-catch-all/test/index.test.js
+++ b/test/integration/basepath-root-catch-all/test/index.test.js
@@ -1,0 +1,69 @@
+import {
+  nextBuild,
+  findPort,
+  killApp,
+  nextStart,
+  File,
+  launchApp,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { join } from 'path'
+import fs from 'fs-extra'
+import url from 'url'
+
+let app
+let appPort
+let buildId
+const appDir = join(__dirname, '..')
+const nextConfig = new File(join(appDir, 'next.config.js'))
+
+jest.setTimeout(1000 * 60 * 2)
+
+const runTests = () => {
+  it('should use correct data URL for root catch-all', async () => {
+    const browser = await webdriver(appPort, '/docs/hello')
+    await browser.elementByCss('#root-catchall-link').click()
+    await browser.waitForElementByCss('#url')
+
+    const dataUrl = await browser.elementByCss('#url').text()
+    const { pathname } = url.parse(dataUrl)
+    expect(pathname).toBe(`/_next/data/${buildId}/root/catch-all.json`)
+  })
+}
+
+describe('dev mode', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    buildId = 'development'
+    app = await launchApp(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+  runTests()
+})
+
+describe('production mode', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+  runTests()
+})
+
+describe('serverless mode', () => {
+  beforeAll(async () => {
+    nextConfig.replace('// target', 'target')
+    await nextBuild(appDir)
+    buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(async () => {
+    nextConfig.restore()
+    await killApp(app)
+  })
+  runTests()
+})


### PR DESCRIPTION
This fixes the incorrect `/_next/data` URL being generated on client transition due to the `as` value passed to `getRouteInfo` having the `basePath` which is used while interpolating the values for dynamic routes, specifically root catch-all routes. A regression test has also been added to ensure this is working

Closes: https://github.com/vercel/next.js/issues/15747