### PR TITLE
Fix forEach error in CSS commit in ie11

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -641,7 +641,9 @@ async function doRender({
   }
 
   function onAbort() {
-    document.querySelectorAll('link[data-n-staging]').forEach((el) => {
+    ;([].slice.call(
+      document.querySelectorAll('link[data-n-staging]')
+    ) as HTMLLinkElement[]).forEach((el) => {
       el.remove()
     })
   }
@@ -660,7 +662,9 @@ async function doRender({
       process.env.NODE_ENV === 'production'
     ) {
       // Remove old stylesheets:
-      document.querySelectorAll('link[data-n-p]').forEach((el) => el.remove())
+      ;([].slice.call(
+        document.querySelectorAll('link[data-n-p]')
+      ) as HTMLLinkElement[]).forEach((el) => el.remove())
 
       // Activate new stylesheets:
       ;[].slice


### PR DESCRIPTION
This fixes an error that was occurring in ie11 due to `forEach` being called on `querySelectorAll` before it was massaged to an array.

x-ref: https://github.com/vercel/next.js/pull/16126
Fixes #16283