### PR TITLE
Fix typo in fast-refresh.md

### DIFF
--- a/docs/basic-features/fast-refresh.md
+++ b/docs/basic-features/fast-refresh.md
@@ -107,6 +107,6 @@ Sometimes, this can lead to unexpected results. For example, even a `useEffect`
 with an empty array of dependencies would still re-run once during Fast Refresh.
 
 However, writing code resilient to occasional re-running of `useEffect` is a good practice even
-without Fash Refresh. It will make it easier for you to introduce new dependencies to it later on
+without Fast Refresh. It will make it easier for you to introduce new dependencies to it later on
 and it's enforced by [React Strict Mode](/docs/api-reference/next.config.js/react-strict-mode),
 which we highly recommend enabling.


### PR DESCRIPTION
Just correcting a simple typo `fash` to `fast`