### PR TITLE
Allow for disabling source maps in dev

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1142,7 +1142,7 @@ export default async function getBaseWebpackConfig(
       webpack,
     })
 
-    if (dev && originalDevtool !== webpackConfig.devtool) {
+    if (dev && originalDevtool !== webpackConfig.devtool && webpackConfig.devtool !== false) {
       webpackConfig.devtool = originalDevtool
       devtoolRevertWarning(originalDevtool)
     }


### PR DESCRIPTION
Disabling source maps for debugging purposes is sometimes highly useful. Disabling them on purpose should not revert to the original devtools. It also should not result in any perf problems - after all, not generating source maps is less work and not more.