### PR TITLE
Add experimental webpack 5 cache option

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -237,7 +237,8 @@ export default async function getBaseWebpackConfig(
         distDir,
         pagesDir,
         cwd: dir,
-        cache: true,
+        // Webpack 5 has a built-in loader cache
+        cache: !config.experimental.unstable_webpack5cache,
         babelPresetPlugins,
         hasModern: !!config.experimental.modern,
         development: dev,
@@ -1116,6 +1117,14 @@ export default async function getBaseWebpackConfig(
         webpackConfig.optimization = {}
       }
       webpackConfig.optimization.usedExports = false
+    }
+
+    // Enable webpack 5 caching
+    if (config.experimental.unstable_webpack5cache) {
+      webpackConfig.cache = {
+        type: 'filesystem',
+        cacheDirectory: path.join(dir, '.next', 'cache', 'webpack'),
+      }
     }
   }
 

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -54,6 +54,7 @@ const defaultConfig: { [key: string]: any } = {
     optimizeFonts: false,
     optimizeImages: false,
     scrollRestoration: false,
+    unstable_webpack5cache: false,
   },
   future: {
     excludeDefaultMomentLocales: false,


### PR DESCRIPTION
Don't use this yet as it's still being developed. This is a first iteration that enables the webpack cache. There's still more to do here, for example if css modules are used there's currently a bug where webpack does not save the cache for browser compilation (impacting build performance). @sokra is going to look into that issue.