### PR TITLE
Add `<link>` attributes in proper order

### DIFF
--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -61,13 +61,15 @@ export function createLink(
   return [
     link,
     new Promise((res, rej) => {
-      link!.crossOrigin = process.env.__NEXT_CROSS_ORIGIN!
-      link!.href = href
-      link!.rel = rel
+      // The order of property assignment here is intentional:
       if (as) link!.as = as
-
+      link!.rel = rel
+      link!.crossOrigin = process.env.__NEXT_CROSS_ORIGIN!
       link!.onload = res
       link!.onerror = rej
+
+      // `href` should always be last:
+      link!.href = href
     }),
   ]
 }


### PR DESCRIPTION
1. `as` should be set before `rel` in case of `preload` or `prefetch`
2. `href` should be after `onload` and `onerror`