### PR TITLE
Make `loadPage` track success of script loading

### DIFF
--- a/test/integration/client-404/pages/missing.js
+++ b/test/integration/client-404/pages/missing.js
@@ -1,0 +1,3 @@
+export default function Missing() {
+  return <p id="missing">poof</p>
+}

--- a/test/integration/client-404/pages/to-missing-link.js
+++ b/test/integration/client-404/pages/to-missing-link.js
@@ -1,0 +1,7 @@
+import Link from 'next/link'
+
+export default () => (
+  <Link href="/missing">
+    <a id="to-missing">to 404</a>
+  </Link>
+)

--- a/test/integration/client-404/test/index.test.js
+++ b/test/integration/client-404/test/index.test.js
@@ -8,7 +8,9 @@ import {
   killApp,
   nextBuild,
   nextStart,
+  getBuildManifest,
 } from 'next-test-utils'
+import fs from 'fs-extra'
 
 // test suite
 import clientNavigation from './client-navigation'
@@ -17,8 +19,8 @@ const context = {}
 const appDir = join(__dirname, '../')
 jest.setTimeout(1000 * 60 * 5)
 
-const runTests = () => {
-  clientNavigation(context, (p, q) => renderViaHTTP(context.appPort, p, q))
+const runTests = (isProd = false) => {
+  clientNavigation(context, isProd)
 }
 
 describe('Client 404', () => {
@@ -40,9 +42,18 @@ describe('Client 404', () => {
       await nextBuild(appDir)
       context.appPort = await findPort()
       context.server = await nextStart(appDir, context.appPort)
+
+      const manifest = await getBuildManifest(appDir)
+      const files = manifest.pages['/missing'].filter((d) =>
+        /static[\\/]chunks[\\/]pages/.test(d)
+      )
+      if (files.length < 1) {
+        throw new Error('oops!')
+      }
+      await Promise.all(files.map((f) => fs.remove(join(appDir, '.next', f))))
     })
     afterAll(() => killApp(context.server))
 
-    runTests()
+    runTests(true)
   })
 })


### PR DESCRIPTION
Prior to this PR, `loadPage` would call `loadScript` which would then report if the script failed to load.

This was problematic because `loadScript` notified a failure to load via `pageRegisterEvents`, which would not set the `pageCache` value for future requests.
This means a one-off promise rejection would happen, [in lieu of being] typically consumed within the client-side router, causing a server-side reload.

However, when `loadPage` was used independently (i.e. to preload pages), this promise rejection would be ignored as a preload failure.
When the real routing request comes in, the `loadPage` function skips its attempt to load the `<script>` because it was already in the DOM, and the router would stop functioning.

---

To fix this behavior, I've removed erroneous emits on `pageRegisterEvents` to only happen during the page registration lifecycle (its intended use).

The new behavior is that `loadScript` returns a `Promise` that `loadPage` can track, and if any of the page(s) scripts fail to load, we mark the entire page as errored in `pageCache`. This ensures future requests to `loadPage` will always immediately reject with a `PAGE_LOAD_ERROR`, which causes the server-side redirect at the appropriate point.

---

Fixes #16333