### PR TITLE
Fix page checking failing with trailingSlash

### DIFF
--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -2,6 +2,7 @@ import { IncomingMessage, ServerResponse } from 'http'
 import { UrlWithParsedQuery } from 'url'
 
 import pathMatch from './lib/path-match'
+import { removePathTrailingSlash } from '../../client/normalize-trailing-slash'
 
 export const route = pathMatch()
 
@@ -133,7 +134,7 @@ export default class Router {
               match: route('/:path*'),
               fn: async (checkerReq, checkerRes, params, parsedCheckerUrl) => {
                 let { pathname } = parsedCheckerUrl
-                pathname = pathname?.replace(/\/$/, '') || '/'
+                pathname = removePathTrailingSlash(pathname || '/')
 
                 if (!pathname) {
                   return { finished: false }

--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -132,11 +132,13 @@ export default class Router {
               requireBasePath: false,
               match: route('/:path*'),
               fn: async (checkerReq, checkerRes, params, parsedCheckerUrl) => {
-                const { pathname } = parsedCheckerUrl
+                let { pathname } = parsedCheckerUrl
+                pathname = pathname?.replace(/\/$/, '') || '/'
 
                 if (!pathname) {
                   return { finished: false }
                 }
+
                 if (await memoizedPageChecker(pathname)) {
                   return this.catchAllRoute.fn(
                     checkerReq,

--- a/test/integration/trailing-slashes-rewrite/next.config.js
+++ b/test/integration/trailing-slashes-rewrite/next.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  trailingSlash: true,
+
+  async rewrites() {
+    return [
+      {
+        source: '/:path*/',
+        destination: '/:path*/',
+      },
+      {
+        source: '/:path*/',
+        destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
+      },
+    ]
+  },
+}

--- a/test/integration/trailing-slashes-rewrite/pages/catch-all/[...slug].js
+++ b/test/integration/trailing-slashes-rewrite/pages/catch-all/[...slug].js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>catch-all</p>
+}

--- a/test/integration/trailing-slashes-rewrite/pages/index.js
+++ b/test/integration/trailing-slashes-rewrite/pages/index.js
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <p>index page</p>
+}

--- a/test/integration/trailing-slashes-rewrite/pages/products/[product].js
+++ b/test/integration/trailing-slashes-rewrite/pages/products/[product].js
@@ -1,0 +1,3 @@
+export default function Products() {
+  return <p>a product</p>
+}

--- a/test/integration/trailing-slashes-rewrite/pages/products/index.js
+++ b/test/integration/trailing-slashes-rewrite/pages/products/index.js
@@ -1,0 +1,3 @@
+export default function Products() {
+  return <p>some products</p>
+}

--- a/test/integration/trailing-slashes-rewrite/server.js
+++ b/test/integration/trailing-slashes-rewrite/server.js
@@ -1,0 +1,10 @@
+const http = require('http')
+const server = http.createServer((req, res) => {
+  console.log('got request', req.url)
+  res.end(req.url)
+})
+const port = process.env.PORT || 3000
+
+server.listen(port, () => {
+  console.log('Ready on http://localhost:' + port)
+})

--- a/test/integration/trailing-slashes-rewrite/test/index.test.js
+++ b/test/integration/trailing-slashes-rewrite/test/index.test.js
@@ -1,0 +1,103 @@
+/* eslint-env jest */
+import { join } from 'path'
+import {
+  findPort,
+  killApp,
+  nextBuild,
+  nextStart,
+  File,
+  initNextServerScript,
+  renderViaHTTP,
+  launchApp,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+let app
+let appPort
+let proxyPort
+let proxyServer
+const appDir = join(__dirname, '../')
+const nextConfig = new File(join(appDir, 'next.config.js'))
+
+const runTests = () => {
+  it('should resolve index page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    expect(html).toContain('index page')
+  })
+
+  it('should resolve products page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/products')
+    expect(html).toContain('some products')
+  })
+
+  it('should resolve a dynamic page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/products/first')
+    expect(html).toContain('a product')
+  })
+
+  it('should resolve a catch-all page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/catch-all/hello')
+    expect(html).toContain('catch-all')
+  })
+
+  it('should proxy non-existent page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/non-existent')
+    expect(html).toBe('/non-existent')
+  })
+}
+
+describe('Trailing Slash Rewrite Proxying', () => {
+  describe('production mode', () => {
+    beforeAll(async () => {
+      proxyPort = await findPort()
+      proxyServer = await initNextServerScript(
+        join(appDir, 'server.js'),
+        /ready on/i,
+        {
+          ...process.env,
+          PORT: proxyPort,
+        }
+      )
+
+      nextConfig.replace('__EXTERNAL_PORT__', proxyPort)
+
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(async () => {
+      nextConfig.restore()
+      await killApp(app)
+      await killApp(proxyServer)
+    })
+
+    runTests()
+  })
+
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      proxyPort = await findPort()
+      proxyServer = await initNextServerScript(
+        join(appDir, 'server.js'),
+        /ready on/i,
+        {
+          ...process.env,
+          PORT: proxyPort,
+        }
+      )
+
+      nextConfig.replace('__EXTERNAL_PORT__', proxyPort)
+
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(async () => {
+      nextConfig.restore()
+      await killApp(app)
+      await killApp(proxyServer)
+    })
+
+    runTests()
+  })
+})


### PR DESCRIPTION
This fixes page checking failing due to the trailing slash being present which causes pages to proxied by a rewrite when they shouldn't be. This also adds additional tests to ensure rewriting to an external resource is working correctly with `trailingSlash: true`

Fixes: https://github.com/vercel/next.js/issues/15700