### PR TITLE
Correct comment on --help

### DIFF
--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -50,8 +50,9 @@ if (args['--version']) {
 // Check if we are running `next <subcommand>` or `next`
 const foundCommand = Boolean(commands[args._[0]])
 
-// Makes sure the `next <subcommand> --help` case is covered
+// Makes sure the `next --help` case is covered
 // This help message is only showed for `next --help`
+// `next <subcommand> --help` falls through to be handled later
 if (!foundCommand && args['--help']) {
   console.log(`
     Usage


### PR DESCRIPTION
The comment on the two different `--help` sections matched, though their logic if what was handled was slightly different.

This adjusts the comments to clarify that difference.

This is completely unrelated to function, but I noticed it while reviewing code and thought I'd PR the fix. 