### PR TITLE
Add debug flag for extra build output

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -102,7 +102,8 @@ export type PrerenderManifest = {
 export default async function build(
   dir: string,
   conf = null,
-  reactProductionProfiling = false
+  reactProductionProfiling = false,
+  debugOutput = false
 ): Promise<void> {
   if (!(await isWriteable(dir))) {
     throw new Error(
@@ -1024,7 +1025,10 @@ export default async function build(
       isModern: config.experimental.modern,
     }
   )
-  printCustomRoutes({ redirects, rewrites, headers })
+
+  if (debugOutput) {
+    printCustomRoutes({ redirects, rewrites, headers })
+  }
 
   if (tracer) {
     const parsedResults = await tracer.profiler.stopProfiling()

--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -12,8 +12,10 @@ const nextBuild: cliCommand = (argv) => {
     // Types
     '--help': Boolean,
     '--profile': Boolean,
+    '--debug': Boolean,
     // Aliases
     '-h': '--help',
+    '-d': '--debug',
   }
 
   let args: arg.Result<arg.Spec>
@@ -53,7 +55,7 @@ const nextBuild: cliCommand = (argv) => {
     printAndExit(`> No such directory exists as the project root: ${dir}`)
   }
 
-  build(dir, null, args['--profile'])
+  build(dir, null, args['--profile'], args['--debug'])
     .then(() => process.exit(0))
     .catch((err) => {
       console.error('')

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -988,7 +988,7 @@ const runTests = (isDev = false) => {
       })
     })
 
-    it('should have redirects/rewrites in build output', async () => {
+    it('should have redirects/rewrites in build output with debug flag', async () => {
       const manifest = await fs.readJSON(
         join(appDir, '.next/routes-manifest.json')
       )
@@ -1073,7 +1073,7 @@ describe('Custom routes', () => {
 
   describe('server mode', () => {
     beforeAll(async () => {
-      const { stdout: buildStdout } = await nextBuild(appDir, [], {
+      const { stdout: buildStdout } = await nextBuild(appDir, ['-d'], {
         stdout: true,
       })
       stdout = buildStdout
@@ -1093,7 +1093,7 @@ describe('Custom routes', () => {
         nextConfigContent.replace(/\/\/ target/, 'target'),
         'utf8'
       )
-      const { stdout: buildStdout } = await nextBuild(appDir, [], {
+      const { stdout: buildStdout } = await nextBuild(appDir, ['-d'], {
         stdout: true,
       })
       stdout = buildStdout


### PR DESCRIPTION
This adds a `-d` or `--debug` flag which enables outputting additional build output information like the rewrites, redirects, and headers

Fixes #15281