### PR TITLE
Solve last mini-css-plugin webpack 5 warning

### DIFF
--- a/packages/next/build/webpack/plugins/mini-css-extract-plugin/src/CssModule.js
+++ b/packages/next/build/webpack/plugins/mini-css-extract-plugin/src/CssModule.js
@@ -53,8 +53,8 @@ class CssModule extends webpack.Module {
     callback()
   }
 
-  updateHash(hash) {
-    super.updateHash(hash)
+  updateHash(hash, context) {
+    super.updateHash(hash, context)
     hash.update(this.content)
     hash.update(this.media || '')
     hash.update(this.sourceMap ? JSON.stringify(this.sourceMap) : '')


### PR DESCRIPTION
Adds missing context parameter