### PR TITLE
Feature pageignore pattern for build

### DIFF
--- a/docs/api-reference/next.config.js/pageIgnorePattern.md
+++ b/docs/api-reference/next.config.js/pageIgnorePattern.md
@@ -1,0 +1,17 @@
+---
+description: By using `pageIgnorePattern` you can filter files to not be included in production build.
+---
+
+# Ignoring pages by pattern
+
+Next.js allows you to ignore files under pages -folder on production build. This is especially convenient for teams that have a coding convention to locate unit tests close to the actual code.
+
+The ignore pattern allows you to ignore files by defining a RegExp-pattern. As default, the pageIgnorePattern is undefined and all files under pages are treated as pages.
+
+To ignore all test files and test-folders under pages, you can use:
+
+```js
+module.exports = {
+  pageIgnorePattern: /__test__|__specs__|\.test|\.spec|\.snap/,
+}
+```

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -169,15 +169,21 @@ export default async function build(
 
   let pageIgnorePattern = config.pageIgnorePattern
 
-  try {
-    if (pageIgnorePattern) {
-      pageIgnorePattern =
-        typeof pageIgnorePattern === 'string'
-          ? new RegExp(pageIgnorePattern)
-          : pageIgnorePattern
+  if (pageIgnorePattern) {
+    switch (typeof pageIgnorePattern) {
+      case 'string':
+        pageIgnorePattern = new RegExp(pageIgnorePattern)
+        break
+
+      case 'object':
+        if (!(pageIgnorePattern instanceof RegExp)) {
+          throw new Error(PAGE_IGNORE_PATTERN_ERROR)
+        }
+        break
+
+      default:
+        throw new Error(PAGE_IGNORE_PATTERN_ERROR)
     }
-  } catch (error) {
-    throw new Error(PAGE_IGNORE_PATTERN_ERROR)
   }
 
   const pagePaths: string[] = await collectPages(

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -10,6 +10,7 @@ import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
 import path from 'path'
 import formatWebpackMessages from '../client/dev/error-overlay/format-webpack-messages'
 import {
+  PAGE_IGNORE_PATTERN_ERROR,
   PAGES_404_GET_INITIAL_PROPS_ERROR,
   PUBLIC_DIR_MIDDLEWARE_CONFLICT,
 } from '../lib/constants'
@@ -166,9 +167,23 @@ export default async function build(
 
   const isLikeServerless = isTargetLikeServerless(target)
 
+  let pageIgnorePattern = config.pageIgnorePattern
+
+  try {
+    if (pageIgnorePattern) {
+      pageIgnorePattern =
+        typeof pageIgnorePattern === 'string'
+          ? new RegExp(pageIgnorePattern)
+          : pageIgnorePattern
+    }
+  } catch (error) {
+    throw new Error(PAGE_IGNORE_PATTERN_ERROR)
+  }
+
   const pagePaths: string[] = await collectPages(
     pagesDir,
-    config.pageExtensions
+    config.pageExtensions,
+    pageIgnorePattern
   )
 
   // needed for static exporting since we want to replace with HTML

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -37,11 +37,13 @@ const fsStatGzip = (file: string) => {
 
 export function collectPages(
   directory: string,
-  pageExtensions: string[]
+  pageExtensions: string[],
+  pageIgnorePattern?: RegExp
 ): Promise<string[]> {
   return recursiveReadDir(
     directory,
-    new RegExp(`\\.(?:${pageExtensions.join('|')})$`)
+    new RegExp(`\\.(?:${pageExtensions.join('|')})$`),
+    pageIgnorePattern
   )
 }
 

--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -24,6 +24,8 @@ export const DOT_NEXT_ALIAS = 'private-dot-next'
 
 export const PUBLIC_DIR_MIDDLEWARE_CONFLICT = `You can not have a '_next' folder inside of your public folder. This conflicts with the internal '/_next' route. https://err.sh/vercel/next.js/public-next-folder-conflict`
 
+export const PAGE_IGNORE_PATTERN_ERROR = `The page ignore pattern must be a RegEx -pattern or a string presentation of it.`
+
 export const SSG_GET_INITIAL_PROPS_CONFLICT = `You can not use getInitialProps with getStaticProps. To use SSG, please remove your getInitialProps`
 
 export const SERVER_PROPS_GET_INIT_PROPS_CONFLICT = `You can not use getInitialProps with getServerSideProps. Please remove getInitialProps.`


### PR DESCRIPTION
This is a suggested feature for making it possible to ignore files under pages -folder. This solution will add a new `pageIgnorePattern` -attribute into ´next.config.js´-file. When the value is set, page scanning will ignore files matching the given RegExp -pattern. 

This is a widely debated issue should this feature exist (https://github.com/vercel/next.js/issues/8974, https://github.com/vercel/next.js/issues/10377 and here https://github.com/vercel/next.js/issues/2332) . I decided to participate in dialog by making an implementation for the feature. There are two sides in this story, from semantical perspective the pages folder is dedicated for pages that will have an URL counter pair in the application. At the same time, there are several software development teams that have convention to keep the unit test code close to the actual code. This has been proven to be a good convention especially for big projects and for people doing multiple projects at the time. So for these teams missing this feature makes it quite hard to follow the convention used elsewhere. 

This feature is a small change for the code base and if you just don't use the configuration attribute, it does no harm for anyone. At the same time, for teams like us using tests close to code, it helps a lot.

