### PR TITLE
Export function `loadEnvConfig` from `next/env`

### DIFF
--- a/packages/next/env.d.ts
+++ b/packages/next/env.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/lib/load-env-config'

--- a/packages/next/env.js
+++ b/packages/next/env.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/lib/load-env-config')

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -26,6 +26,8 @@
     "document.d.ts",
     "dynamic.js",
     "dynamic.d.ts",
+    "env.js",
+    "env.d.ts",
     "error.js",
     "error.d.ts",
     "head.js",


### PR DESCRIPTION
New to NextJS, first try at a PR request here..

Discussion: https://github.com/vercel/next.js/discussions/16270

Export the same function Next configures environment variables for dev and build, so we can also use it for setting them up for test in our apps, e.g.

package.json

```
  "jest": {
    "globalSetup": "<rootDir>/setupTestEnv.js"
  }
```

setupTestEnv.js:

```
import { loadEnvConfig } from 'next/env'
import { resolve } from 'path'

module.exports = async () => {
  console.log()
  loadEnvConfig(resolve(__dirname, './'), false)
}
```

stdout:

```
% yarn test
yarn run v1.22.4
$ jest
Determining test suites to run...
info  - Loaded env from /Users/erik/Coding/erkde/environment-variables-app/.env.test
info  - Loaded env from /Users/erik/Coding/erkde/environment-variables-app/.env
…
```