### PR TITLE
Add version note to path aliases docs

### DIFF
--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -4,7 +4,7 @@ description: Configure module path aliases that allow you to remap certain impor
 
 # Absolute Imports and Module path aliases
 
-Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options since version 9.4.
+Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options since [Next.js 9.4](https://nextjs.org/blog/next-9-4).
 
 > Note: `jsconfig.json` can be used when you don't use TypeScript
 

--- a/docs/advanced-features/module-path-aliases.md
+++ b/docs/advanced-features/module-path-aliases.md
@@ -4,7 +4,7 @@ description: Configure module path aliases that allow you to remap certain impor
 
 # Absolute Imports and Module path aliases
 
-Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options.
+Next.js automatically supports the `tsconfig.json` and `jsconfig.json` `"paths"` and `"baseUrl"` options since version 9.4.
 
 > Note: `jsconfig.json` can be used when you don't use TypeScript
 


### PR DESCRIPTION
This makes sure to mention the required version for the path aliases support

Closes: https://github.com/vercel/next.js/issues/16478