### PR TITLE
Correct initial fallback route param values

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -399,9 +399,7 @@ const nextServerlessLoader: loader.Loader = function () {
           pageIsDynamicRoute
             ? `
             const params = (
-              fromExport &&
-              !getStaticProps &&
-              !getServerSideProps
+              fromExport
             ) ? {}
               : normalizeDynamicRouteParams(
                 trustQuery

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -402,7 +402,7 @@ export async function renderToHTML(
       )
     }
 
-    if (isAutoExport) {
+    if (isAutoExport || isFallback) {
       // remove query values except ones that will be set during export
       query = {
         ...(query.amp

--- a/test/integration/fallback-route-params/pages/[slug].js
+++ b/test/integration/fallback-route-params/pages/[slug].js
@@ -1,0 +1,34 @@
+import { useRouter } from 'next/router'
+
+export const getStaticProps = () => {
+  return {
+    props: {
+      world: 'world',
+    },
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}
+
+export default function Page({ world }) {
+  const router = useRouter()
+
+  if (typeof window !== 'undefined' && !window.setInitialSlug) {
+    window.setInitialSlug = true
+    window.initialSlug = router.query.slug
+  }
+
+  if (router.isFallback) return 'Loading...'
+
+  return (
+    <>
+      <p>hello {world}</p>
+      <p id="query">{JSON.stringify(router.query)}</p>
+    </>
+  )
+}

--- a/test/integration/fallback-route-params/test/index.test.js
+++ b/test/integration/fallback-route-params/test/index.test.js
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import cheerio from 'cheerio'
+import webdriver from 'next-webdriver'
+import {
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  renderViaHTTP,
+  launchApp,
+  File,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../')
+const nextConfig = new File(join(appDir, 'next.config.js'))
+let appPort
+let app
+
+const runTests = () => {
+  it('should have correct fallback query (skeleton)', async () => {
+    const html = await renderViaHTTP(appPort, '/first')
+    const $ = cheerio.load(html)
+    const { query } = JSON.parse($('#__NEXT_DATA__').text())
+    expect(query).toEqual({})
+  })
+
+  it('should have correct fallback query (hydration)', async () => {
+    const browser = await webdriver(appPort, '/second')
+    const initialSlug = await browser.eval(() => window.initialSlug)
+    expect(initialSlug).toBe(null)
+
+    await browser.waitForElementByCss('#query')
+
+    const hydratedQuery = JSON.parse(
+      await browser.elementByCss('#query').text()
+    )
+    expect(hydratedQuery).toEqual({ slug: 'second' })
+  })
+}
+
+describe('Fallback Dynamic Route Params', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      await fs.remove(join(appDir, '.next'))
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await fs.remove(join(appDir, '.next'))
+      await nextBuild(appDir, [])
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('serverless mode', () => {
+    beforeAll(async () => {
+      nextConfig.write(`
+        module.exports = {
+          target: 'experimental-serverless-trace'
+        }
+      `)
+      await fs.remove(join(appDir, '.next'))
+      await nextBuild(appDir, [], { stdout: true })
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(async () => {
+      await killApp(app)
+      nextConfig.delete()
+    })
+
+    runTests()
+  })
+})


### PR DESCRIPTION
This fixes invalid initial route params in development mode and serverless production mode. It also adds tests to ensure these values are correct in development, production, and serverless mode.

x-ref: https://github.com/vercel/next.js/pull/16084
Fixes: https://github.com/vercel/next.js/issues/16481
Fixes: https://github.com/vercel/next.js/issues/16482 