### PR TITLE
Clear the Incremental Cache

### DIFF
--- a/docs/advanced-features/clearing-the-incremental-cache.md
+++ b/docs/advanced-features/clearing-the-incremental-cache.md
@@ -1,0 +1,23 @@
+---
+description: Next.js has the abilility to clear the incremental cache by array of keys. You can learn how it works here.
+---
+
+# Clearing the Incremental Cache
+
+> This document is for Next.js versions 9.5 and up.
+
+In the [Pages documentation](/docs/basic-features/pages.md) and the [Data Fetching documentation](/docs/basic-features/data-fetching.md), we talked about how to pre-render a page at build time (**Static Generation**) using `getStaticProps` and `getStaticPaths`.
+
+Static Generation is useful when your pages fetch data from a headless CMS. However, it’s not ideal when you are wanting your changes to reflect instantly. In this scenario, you would call 'clearIncrementalCache' on the next app and pass in an array of strings.
+
+Note: It is recommend you password protect this route and use it as little as possible.
+
+```js
+export default (req, res) => {
+  // ...
+  app.clearIncrementalCache(['/path-1', '/path-2'])
+  res.send({ message: 'Cache Cleared' })
+
+  // ...
+}
+```

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -93,6 +93,10 @@
           "title": "Advanced Features",
           "routes": [
             {
+              "title": "Clearing the Incremental Cache",
+              "path": "/docs/advanced-features/clearing-the-incremental-cache.md"
+            },
+            {
               "title": "Preview Mode",
               "path": "/docs/advanced-features/preview-mode.md"
             },

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -244,6 +244,14 @@ export default class Server {
     }
   }
 
+  /**
+   * To clear the incremental cache, pass in an array of keys to clear.
+   * @param keys
+   */
+  public clearIncrementalCache = (keys: string[]) => {
+    this.incrementalCache.clear(keys)
+  }
+
   protected currentPhase(): string {
     return PHASE_PRODUCTION_SERVER
   }


### PR DESCRIPTION
This issues has come up numerous times when talking to clients about ISR. The first question they always ask: "what happens if we need to clear the cache instantly" 

This is my first pass at clearing that cache.

```
const next = require('next')
const app = next()

function clearCacheViaAPI = (req, res) => {
  app.clearIncrementalCache(req.body.keys)
}
```

I'm also open to the idea of wildcard removals, but that would take more time to figure out a system that accommodates to everyone's needs. I'm open to feedback.


