### PR TITLE
Add MDX remote blog example

### DIFF
--- a/examples/mdx-remote-blog/README.md
+++ b/examples/mdx-remote-blog/README.md
@@ -1,0 +1,42 @@
+# MDX Remote Blog Example
+
+This example shows an example of how a simple blog might be built using the [next-mdx-remote](https://github.com/hashicorp/next-mdx-remote) library, which allows mdx content to be loaded via `getStaticProps` or `getServerSideProps`. In this example, the mdx content is loaded from a local folder, but it could be loaded from a database or anywhere else. The demo also showcases [next-remote-watch](https://github.com/hashicorp/next-remote-watch), a library that allows next.js to watch files outside the `pages` folder that are not explicitly imported, which enables the mdx content here to trigger a live reload on change.
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/vercel/next.js/tree/canary/examples/mdx-remote-blog)
+
+## How to use
+
+### Using `create-next-app`
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example mdx-remote-blog mdx-remote-blog-app
+# or
+yarn create next-app --example mdx-remote-blog mdx-remote-blog-app
+```
+
+### Download manually
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/vercel/next.js/tar.gz/canary | tar -xz --strip=2 next.js-canary/examples/mdx-remote-blog
+cd mdx-remote-blog
+```
+
+Install it and run:
+
+```bash
+npm install
+npm run dev
+# or
+yarn
+yarn dev
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/mdx-remote-blog/components/test.jsx
+++ b/examples/mdx-remote-blog/components/test.jsx
@@ -1,0 +1,3 @@
+export default function TestComponent() {
+  return <p>hello from the test component</p>
+}

--- a/examples/mdx-remote-blog/content/first-post.mdx
+++ b/examples/mdx-remote-blog/content/first-post.mdx
@@ -1,0 +1,7 @@
+---
+title: 'My First Post'
+---
+
+Hello friends, this is my first post. What a good post it is.
+
+<TestComponent />

--- a/examples/mdx-remote-blog/content/second-post.mdx
+++ b/examples/mdx-remote-blog/content/second-post.mdx
@@ -1,0 +1,7 @@
+---
+title: 'My Second Post'
+---
+
+I bet you thought it was impossible that there would ever be a post better than the first post. But guess what, you were wrong. I'm back again with a second post and it's over 9000 times better than the first post. Better strap the socks on your feet, because here it comes!
+
+<TestComponent />

--- a/examples/mdx-remote-blog/package.json
+++ b/examples/mdx-remote-blog/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "blog",
+  "version": "1.0.0",
+  "description": "example next-mdx-remote blog",
+  "main": "index.js",
+  "scripts": {
+    "start": "next-remote-watch ./content",
+    "dev": "npm start",
+    "export": "next build && next export"
+  },
+  "author": "Jeff Escalante",
+  "license": "MIT",
+  "dependencies": {
+    "gray-matter": "^4.0.2",
+    "next": "^9.5.2",
+    "next-mdx-remote": "^1.0.0",
+    "next-remote-watch": "^0.2.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  }
+}

--- a/examples/mdx-remote-blog/pages/blog/[slug].jsx
+++ b/examples/mdx-remote-blog/pages/blog/[slug].jsx
@@ -1,0 +1,38 @@
+import renderToString from 'next-mdx-remote/render-to-string'
+import hydrate from 'next-mdx-remote/hydrate'
+import matter from 'gray-matter'
+import fs from 'fs'
+import path from 'path'
+import TestComponent from '../../components/test'
+
+const root = process.cwd()
+const components = { TestComponent }
+
+export default function BlogPost({ mdxSource, frontMatter }) {
+  const content = hydrate(mdxSource, { components })
+  return (
+    <>
+      <h1>{frontMatter.title}</h1>
+      {content}
+    </>
+  )
+}
+
+export async function getStaticPaths() {
+  return {
+    fallback: false,
+    paths: fs
+      .readdirSync(path.join(root, 'content'))
+      .map((p) => ({ params: { slug: p.replace(/\.mdx/, '') } })),
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const source = fs.readFileSync(
+    path.join(root, 'content', `${params.slug}.mdx`),
+    'utf8'
+  )
+  const { data, content } = matter(source)
+  const mdxSource = await renderToString(content, { components })
+  return { props: { mdxSource, frontMatter: data } }
+}

--- a/examples/mdx-remote-blog/pages/index.jsx
+++ b/examples/mdx-remote-blog/pages/index.jsx
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import Link from 'next/link'
+
+const root = process.cwd()
+
+export default function IndexPage({ postData }) {
+  return (
+    <>
+      <h1>My Cool Blog</h1>
+      <ul>
+        {postData.map((data) => (
+          <li key={data.slug}>
+            <Link href="/blog/[slug]" as={`/blog/${data.slug}`}>
+              <a>{data.frontMatter.title}</a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  const contentRoot = path.join(root, 'content')
+  const postData = fs.readdirSync(contentRoot).map((p) => {
+    const content = fs.readFileSync(path.join(contentRoot, p), 'utf8')
+    return {
+      slug: p.replace(/\.mdx/, ''),
+      content,
+      frontMatter: matter(content).data,
+    }
+  })
+  return { props: { postData } }
+}


### PR DESCRIPTION
This example showcases how a simple blog could be built using [next-mdx-remote](https://github.com/hashicorp/next-mdx-remote), including layouts and frontmatter processing.