### PR TITLE
Do not rely on `cssText`

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -17,7 +17,7 @@ import * as envConfig from '../next-server/lib/runtime-config'
 import { getURL, loadGetInitialProps, ST } from '../next-server/lib/utils'
 import type { NEXT_DATA } from '../next-server/lib/utils'
 import initHeadManager from './head-manager'
-import PageLoader, { StyleSheetTuple } from './page-loader'
+import PageLoader, { looseToArray, StyleSheetTuple } from './page-loader'
 import measureWebVitals from './performance-relayer'
 import { createRouter, makePublicRouterInstance } from './router'
 
@@ -83,8 +83,6 @@ if (hasBasePath(asPath)) {
 }
 
 type RegisterFn = (input: [string, () => void]) => void
-
-const looseToArray = <T extends {}>(input: any): T[] => [].slice.call(input)
 
 const pageLoader = new PageLoader(buildId, prefix, page)
 const register: RegisterFn = ([r, f]) => pageLoader.registerPage(r, f)

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -86,24 +86,7 @@ type RegisterFn = (input: [string, () => void]) => void
 
 const looseToArray = <T extends {}>(input: any): T[] => [].slice.call(input)
 
-const pageLoader = new PageLoader(
-  buildId,
-  prefix,
-  page,
-  looseToArray<CSSStyleSheet>(document.styleSheets)
-    .filter(
-      (el: CSSStyleSheet) =>
-        el.ownerNode &&
-        (el.ownerNode as Element).tagName === 'LINK' &&
-        (el.ownerNode as Element).hasAttribute('data-n-p')
-    )
-    .map((sheet) => ({
-      href: (sheet.ownerNode as Element).getAttribute('href')!,
-      text: looseToArray<CSSRule>(sheet.cssRules)
-        .map((r) => r.cssText)
-        .join(''),
-    }))
-)
+const pageLoader = new PageLoader(buildId, prefix, page)
 const register: RegisterFn = ([r, f]) => pageLoader.registerPage(r, f)
 if (window.__NEXT_P) {
   // Defer page registration for another tick. This will increase the overall

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -434,7 +434,7 @@ export default class PageLoader {
               )
           ).then((cssFiles) =>
             // These files should've already been fetched by now, so this
-            // should resolve pretty much instantly.
+            // should resolve instantly.
             Promise.all(cssFiles.map((d) => fetchStyleSheet(d)))
           )
     promisedDeps.then(

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -415,7 +415,6 @@ export default class PageLoader {
       })
     }
 
-    // route === this.initialPage
     const promisedDeps: Promise<StyleSheetTuple[]> =
       // Shared styles will already be on the page:
       route === '/_app' ||


### PR DESCRIPTION
Browsers do not reliably handle `cssText` for `CSSRule` classes returned from `document.styleSheets`.

For example, Safari's `cssText` property has been broken since 2013:
https://bugs.webkit.org/show_bug.cgi?id=107149

![image](https://user-images.githubusercontent.com/616428/91348841-643aee00-e7b2-11ea-8123-bf86f5a5785e.png)

---

Fixes #16610