### PR TITLE
fix crash when running through an iframe

### DIFF
--- a/packages/next/client/dev/prerender-indicator.js
+++ b/packages/next/client/dev/prerender-indicator.js
@@ -40,8 +40,13 @@ export default function initializeBuildWatcher() {
 
   // State
   const dismissKey = '__NEXT_DISMISS_PRERENDER_INDICATOR'
-  const dismissUntil = parseInt(window.localStorage.getItem(dismissKey), 10)
-  const dismissed = dismissUntil > new Date().getTime()
+  let dismissUntil
+  try {
+    dismissUntil = parseInt(window.localStorage.getItem(dismissKey), 10)
+  } catch (error) {
+    console.log('Could not load prerender indicator data')
+  }
+  const dismissed = dismissUntil && dismissUntil > new Date().getTime()
 
   let isVisible = !dismissed && window.__NEXT_DATA__.nextExport
 
@@ -71,7 +76,11 @@ export default function initializeBuildWatcher() {
 
   closeEl.addEventListener('click', () => {
     const oneHourAway = new Date().getTime() + 1 * 60 * 60 * 1000
-    window.localStorage.setItem(dismissKey, oneHourAway + '')
+    try {
+      window.localStorage.setItem(dismissKey, oneHourAway + '')
+    } catch (error) {
+      console.log('Could not save prerender indicator dismissal')
+    }
     isVisible = false
     updateContainer()
   })


### PR DESCRIPTION
I hope this fixes https://github.com/vercel/next.js/issues/13680

We have a similar issue. We run a SSR page inside an iframe on another website, and locally this causes the client side JS to not work at all. I can't get an error message out, but it is probably related to https://github.com/vercel/next.js/issues/13680

I tried using next.js with this patch to run our app, but I keep getting errors like this:

```
Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.
    at resolveDispatcher (webpack-internal:///../../next.js/node_modules/react/cjs/react.development.js:1590:13)
    at useContext (webpack-internal:///../../next.js/node_modules/react/cjs/react.development.js:1598:20)
    at Main (webpack-internal:///../../next.js/packages/next/dist/pages/_document.js:469:29)
    at processChild (/home/fazo/Documents/Projects/next.js/node_modules/react-dom/cjs/react-dom-server.node.development.js:3204:14)
    at resolve (/home/fazo/Documents/Projects/next.js/node_modules/react-dom/cjs/react-dom-server.node.development.js:3124:5)
    at ReactDOMServerRenderer.render (/home/fazo/Documents/Projects/next.js/node_modules/react-dom/cjs/react-dom-server.node.development.js:3598:22)
    at ReactDOMServerRenderer.read (/home/fazo/Documents/Projects/next.js/node_modules/react-dom/cjs/react-dom-server.node.development.js:3536:29)
    at renderToStaticMarkup (/home/fazo/Documents/Projects/next.js/node_modules/react-dom/cjs/react-dom-server.node.development.js:4261:27)
    at renderDocument (/home/fazo/Documents/Projects/next.js/packages/next/dist/next-server/server/render.js:3:640)
    at renderToHTML (/home/fazo/Documents/Projects/next.js/packages/next/dist/next-server/server/render.js:52:103)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async /home/fazo/Documents/Projects/next.js/packages/next/dist/next-server/server/next-server.js:76:329
    at async /home/fazo/Documents/Projects/next.js/packages/next/dist/next-server/server/next-server.js:75:142
    at async DevServer.renderToHTMLWithComponents (/home/fazo/Documents/Projects/next.js/packages/next/dist/next-server/server/next-server.js:99:365)
    at async DevServer.renderErrorToHTML (/home/fazo/Documents/Projects/next.js/packages/next/dist/next-server/server/next-server.js:101:321)
```

I hope someone more experienced working with this codebase can confirm this fix works.