### PR TITLE
Add activeClassName to Link examples

### DIFF
--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -8,7 +8,7 @@ description: Enable client-side transitions between routes with the built-in Lin
   <summary><b>Examples</b></summary>
   <ul>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/hello-world">Hello World</a></li>
-    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/active-class-name">activeClassName</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/active-class-name">Active className on Link</a></li>
   </ul>
 </details>
 

--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -8,6 +8,7 @@ description: Enable client-side transitions between routes with the built-in Lin
   <summary><b>Examples</b></summary>
   <ul>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/hello-world">Hello World</a></li>
+    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/active-class-name">activeClassName</a></li>
   </ul>
 </details>
 


### PR DESCRIPTION
Allows people to more easily find how to style active links if they are wanting to