### PR TITLE
Update Custom App TypeScript docs to use React.SFC

### DIFF
--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -101,11 +101,12 @@ If you have a [custom `App`](/docs/advanced-features/custom-app.md), you can use
 
 ```ts
 // import App from "next/app";
+import React from 'react';
 import type { AppProps /*, AppContext */ } from 'next/app'
 
-function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
-}
+const MyApp: React.SFC<AppProps> = ({ Component, pageProps }) => {
+    return <Component {...pageProps} />;
+};
 
 // Only uncomment this method if you have blocking data requirements for
 // every single page in your application. This disables the ability to


### PR DESCRIPTION
When I was converting my custom `_app.js` to use TypeScript, I kept running into this TS error when using code from the docs:

```
// TS Error:
Missing return type on function. eslint@typescript-eslint/explicit-module-boundary-types
```

![image](https://user-images.githubusercontent.com/4185382/91666871-10881780-eac6-11ea-97a5-b30a67a5440c.png)

I'm not exactly sure if this has to do with my own TS and/or ESLint setup but I was able to fix this by using `React.SFC<AppProps>`.

For what it's worth, I'm using the following:
- next@9.5.2
- react@16.13.1

And here's a public gist to the [package.json, .eslintrc.js and tsconfig.json I'm using](https://gist.github.com/hellobrian/d54be957aec44e4da0c24696378cfa0b)