### PR TITLE
fix: prevent scrolling to hash if triggered by browser navigation button

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -28,6 +28,7 @@ import { getRouteRegex } from './utils/route-regex'
 
 interface TransitionOptions {
   shallow?: boolean
+  wasBrowserNavigation?: boolean
 }
 
 interface NextHistoryState {
@@ -148,6 +149,7 @@ export type PrivateRouteInfo = {
   props?: Record<string, any>
   err?: Error
   error?: any
+  wasBrowserNavigation: boolean
 }
 
 export type AppProps = Pick<PrivateRouteInfo, 'Component' | 'err'> & {
@@ -400,6 +402,7 @@ export default class Router implements BaseRouter {
       as,
       Object.assign({}, options, {
         shallow: options.shallow && this._shallow,
+        wasBrowserNavigation: true,
       })
     )
   }
@@ -574,6 +577,8 @@ export default class Router implements BaseRouter {
         as,
         shallow
       )
+      routeInfo.wasBrowserNavigation = !!options.wasBrowserNavigation
+
       let { error } = routeInfo
 
       Router.events.emit('beforeHistoryChange', as)

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -149,7 +149,7 @@ export type PrivateRouteInfo = {
   props?: Record<string, any>
   err?: Error
   error?: any
-  wasBrowserNavigation: boolean
+  wasBrowserNavigation?: boolean
 }
 
 export type AppProps = Pick<PrivateRouteInfo, 'Component' | 'err'> & {

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -94,17 +94,17 @@ describe('Build Output', () => {
       expect(parseFloat(indexSize) - 265).toBeLessThanOrEqual(0)
       expect(indexSize.endsWith('B')).toBe(true)
 
-      // should be no bigger than 60.2 kb
-      expect(parseFloat(indexFirstLoad) - 60.2).toBeLessThanOrEqual(0)
+      // should be no bigger than 60.3 kb
+      expect(parseFloat(indexFirstLoad) - 60.3).toBeLessThanOrEqual(0)
       expect(indexFirstLoad.endsWith('kB')).toBe(true)
 
       expect(parseFloat(err404Size) - 3.5).toBeLessThanOrEqual(0)
       expect(err404Size.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(err404FirstLoad) - 63.4).toBeLessThanOrEqual(0)
+      expect(parseFloat(err404FirstLoad) - 63.5).toBeLessThanOrEqual(0)
       expect(err404FirstLoad.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(sharedByAll) - 59.9).toBeLessThanOrEqual(0)
+      expect(parseFloat(sharedByAll) - 60.0).toBeLessThanOrEqual(0)
       expect(sharedByAll.endsWith('kB')).toBe(true)
 
       if (_appSize.endsWith('kB')) {
@@ -118,7 +118,7 @@ describe('Build Output', () => {
       expect(parseFloat(webpackSize) - 752).toBeLessThanOrEqual(0)
       expect(webpackSize.endsWith(' B')).toBe(true)
 
-      expect(parseFloat(mainSize) - 7.1).toBeLessThanOrEqual(0)
+      expect(parseFloat(mainSize) - 7.2).toBeLessThanOrEqual(0)
       expect(mainSize.endsWith('kB')).toBe(true)
 
       expect(parseFloat(frameworkSize) - 41).toBeLessThanOrEqual(0)


### PR DESCRIPTION
Fixes #13653 

This fixes [incorrect scrolling behaviour](https://github.com/vercel/next.js/issues/13653) when soft navigating between pages with an anchor using next router. Please see the [example project](https://github.com/vercel/next.js/issues/13653#issue-628900265) provided by @monae. You can test the expected scrolling behaviour by running [his project](https://github.com/monae/nextjs-scrolltohash-bug) locally and disabling JavaScript.

Would appreciate any advice on how to test this?
