### PR TITLE
Prevent error from undefined title tag

### DIFF
--- a/packages/next/client/head-manager.ts
+++ b/packages/next/client/head-manager.ts
@@ -93,7 +93,9 @@ export default function initHeadManager() {
         let title = ''
         if (titleComponent) {
           const { children } = titleComponent.props
-          title = typeof children === 'string' ? children : children.join('')
+          if (children) {
+            title = typeof children === 'string' ? children : children.join('')
+          }
         }
         if (title !== document.title) document.title = title
         ;['meta', 'base', 'link', 'style', 'script'].forEach((type) => {


### PR DESCRIPTION
This PR addresses #6388 

The children of `titleComponent` are either checked as a string or as an array of such, throwing an error at `.join('')` for the second case even for an empty `<title>` tag.