### PR TITLE
Revert "fix: Promise.prototype.finally is object (#16620)"

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -21,8 +21,6 @@ import PageLoader, { looseToArray, StyleSheetTuple } from './page-loader'
 import measureWebVitals from './performance-relayer'
 import { createRouter, makePublicRouterInstance } from './router'
 
-require('next/dist/build/polyfills/finally-polyfill.min')
-
 /// <reference types="react-dom/experimental" />
 
 declare let __webpack_public_path__: string
@@ -42,6 +40,10 @@ declare global {
 
 type RenderRouteInfo = PrivateRouteInfo & { App: AppComponent }
 type RenderErrorProps = Omit<RenderRouteInfo, 'Component' | 'styleSheets'>
+
+if (!('finally' in Promise.prototype)) {
+  ;(Promise.prototype as PromiseConstructor['prototype']).finally = require('next/dist/build/polyfills/finally-polyfill.min')
+}
 
 const data: typeof window['__NEXT_DATA__'] = JSON.parse(
   document.getElementById('__NEXT_DATA__')!.textContent!

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -181,7 +181,7 @@
     "escape-string-regexp": "2.0.0",
     "etag": "1.8.1",
     "file-loader": "6.0.0",
-    "finally-polyfill": "0.2.0",
+    "finally-polyfill": "0.1.0",
     "find-up": "4.1.0",
     "fresh": "0.5.2",
     "gzip-size": "5.1.1",


### PR DESCRIPTION
This change causes a syntax error in ie11 due to arrow functions being used in the polyfill and them not being transpiled. We'll need to investigate updating this polyfill to not use arrow functions or make sure it is being transpiled correctly for ie11

x-ref: https://github.com/vercel/next.js/pull/16620
This reverts commit 6926ab7b2ac6fe6795fa4ce3f5ecb450fbe70e82.