### PR TITLE
Ensure interpolating dynamic href values works correctly

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -257,10 +257,12 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
   const pathname = (router && router.pathname) || '/'
 
   const { href, as } = React.useMemo(() => {
-    const resolvedHref = resolveHref(pathname, props.href)
+    const [resolvedHref, resolvedAs] = resolveHref(pathname, props.href, true)
     return {
       href: resolvedHref,
-      as: props.as ? resolveHref(pathname, props.as) : resolvedHref,
+      as: props.as
+        ? resolveHref(pathname, props.as)
+        : resolvedAs || resolvedHref,
     }
   }, [pathname, props.href, props.as])
 

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -25,6 +25,7 @@ import { searchParamsToUrlQuery } from './utils/querystring'
 import resolveRewrites from './utils/resolve-rewrites'
 import { getRouteMatcher } from './utils/route-matcher'
 import { getRouteRegex } from './utils/route-regex'
+import escapePathDelimiters from './utils/escape-path-delimiters'
 
 interface TransitionOptions {
   shallow?: boolean
@@ -80,11 +81,66 @@ export function isLocalURL(url: string): boolean {
 
 type Url = UrlObject | string
 
+export function interpolateAs(
+  route: string,
+  asPathname: string,
+  query: import('querystring').ParsedUrlQuery
+) {
+  let interpolatedRoute = ''
+
+  const dynamicRegex = getRouteRegex(route)
+  const dynamicGroups = dynamicRegex.groups
+  const dynamicMatches =
+    // Try to match the dynamic route against the asPath
+    (asPathname !== route ? getRouteMatcher(dynamicRegex)(asPathname) : '') ||
+    // Fall back to reading the values from the href
+    // TODO: should this take priority; also need to change in the router.
+    query
+
+  interpolatedRoute = route
+  if (
+    !Object.keys(dynamicGroups).every((param) => {
+      let value = dynamicMatches[param] || ''
+      const { repeat, optional } = dynamicGroups[param]
+
+      // support single-level catch-all
+      // TODO: more robust handling for user-error (passing `/`)
+      let replaced = `[${repeat ? '...' : ''}${param}]`
+      if (optional) {
+        replaced = `${!value ? '/' : ''}[${replaced}]`
+      }
+      if (repeat && !Array.isArray(value)) value = [value]
+
+      return (
+        (optional || param in dynamicMatches) &&
+        // Interpolate group into data URL if present
+        (interpolatedRoute =
+          interpolatedRoute!.replace(
+            replaced,
+            repeat
+              ? (value as string[]).map(escapePathDelimiters).join('/')
+              : escapePathDelimiters(value as string)
+          ) || '/')
+      )
+    })
+  ) {
+    interpolatedRoute = '' // did not satisfy all requirements
+
+    // n.b. We ignore this error because we handle warning for this case in
+    // development in the `<Link>` component directly.
+  }
+  return interpolatedRoute
+}
+
 /**
  * Resolves a given hyperlink with a certain router state (basePath not included).
  * Preserves absolute urls.
  */
-export function resolveHref(currentPath: string, href: Url): string {
+export function resolveHref(
+  currentPath: string,
+  href: Url,
+  resolveAs?: boolean
+): string {
   // we use a dummy base url for relative urls
   const base = new URL(currentPath, 'http://n')
   const urlAsString =
@@ -92,12 +148,31 @@ export function resolveHref(currentPath: string, href: Url): string {
   try {
     const finalUrl = new URL(urlAsString, base)
     finalUrl.pathname = normalizePathTrailingSlash(finalUrl.pathname)
+    let interpolatedAs = ''
+
+    if (
+      isDynamicRoute(finalUrl.pathname) &&
+      finalUrl.searchParams &&
+      resolveAs
+    ) {
+      const query = searchParamsToUrlQuery(finalUrl.searchParams)
+
+      interpolatedAs = interpolateAs(
+        finalUrl.pathname,
+        finalUrl.pathname,
+        query
+      )
+    }
+
     // if the origin didn't change, it means we received a relative href
-    return finalUrl.origin === base.origin
-      ? finalUrl.href.slice(finalUrl.origin.length)
-      : finalUrl.href
+    const resolvedHref =
+      finalUrl.origin === base.origin
+        ? finalUrl.href.slice(finalUrl.origin.length)
+        : finalUrl.href
+
+    return (resolveAs ? [resolvedHref, interpolatedAs] : resolvedHref) as string
   } catch (_) {
-    return urlAsString
+    return (resolveAs ? [urlAsString] : urlAsString) as string
   }
 }
 
@@ -443,6 +518,7 @@ export default class Router implements BaseRouter {
     as: string,
     options: TransitionOptions
   ): Promise<boolean> {
+    console.log({ url, as })
     if (!isLocalURL(url)) {
       window.location.href = url
       return false
@@ -558,6 +634,8 @@ export default class Router implements BaseRouter {
               `Read more: https://err.sh/vercel/next.js/incompatible-href-as`
           )
         }
+      } else if (route === asPathname) {
+        as = interpolateAs(route, asPathname, query)
       } else {
         // Merge params into `query`, overwriting any specified in search
         Object.assign(query, routeMatch)

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -84,7 +84,7 @@ type Url = UrlObject | string
 export function interpolateAs(
   route: string,
   asPathname: string,
-  query: import('querystring').ParsedUrlQuery
+  query: ParsedUrlQuery
 ) {
   let interpolatedRoute = ''
 

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -518,7 +518,6 @@ export default class Router implements BaseRouter {
     as: string,
     options: TransitionOptions
   ): Promise<boolean> {
-    console.log({ url, as })
     if (!isLocalURL(url)) {
       window.location.href = url
       return false

--- a/test/integration/dynamic-routing/pages/index.js
+++ b/test/integration/dynamic-routing/pages/index.js
@@ -10,7 +10,16 @@ const Page = () => {
       </Link>
       <br />
       <Link href="/post-1">
-        <a id="view-post-1-no-as">View post 1</a>
+        <a id="view-post-1-no-as">View post 1 (no as)</a>
+      </Link>
+      <br />
+      <Link
+        href={{
+          pathname: '/[name]',
+          query: { name: 'post-1' },
+        }}
+      >
+        <a id="view-post-1-interpolated">View post 1 (interpolated)</a>
       </Link>
       <br />
       <Link href="/[name]/comments" as="/post-1/comments">
@@ -22,7 +31,18 @@ const Page = () => {
       </Link>
       <br />
       <Link href="/post-1/comment-1">
-        <a id="view-post-1-comment-1-no-as">View comment 1 on post 1</a>
+        <a id="view-post-1-comment-1-no-as">View comment 1 on post 1 (no as)</a>
+      </Link>
+      <br />
+      <Link
+        href={{
+          pathname: '/[name]/[comment]',
+          query: { name: 'post-1', comment: 'comment-1' },
+        }}
+      >
+        <a id="view-post-1-comment-1-interpolated">
+          View comment 1 on post 1 (interpolated)
+        </a>
       </Link>
       <br />
       <Link href="/added-later/first">
@@ -40,42 +60,74 @@ const Page = () => {
       <Link href="/on-mount/[post]" as="/on-mount/test-w-hash#item-400">
         <a id="view-dynamic-with-hash">View test with hash</a>
       </Link>
+      <br />
       <Link href="/p1/p2/all-ssr/[...rest]" as="/p1/p2/all-ssr/hello">
         <a id="catch-all-single">Catch-all route (single)</a>
       </Link>
+      <br />
       <Link href="/p1/p2/all-ssr/[...rest]" as="/p1/p2/all-ssr/hello1/hello2">
         <a id="catch-all-multi">Catch-all route (multi)</a>
       </Link>
+      <br />
       <Link
         href="/p1/p2/all-ssr/[...rest]"
         as="/p1/p2/all-ssr/hello1%2F/he%2Fllo2"
       >
         <a id="catch-all-enc">Catch-all route (encoded)</a>
       </Link>
+      <br />
       <Link href="/p1/p2/all-ssr/[...rest]" as="/p1/p2/all-ssr/:42">
         <a id="catch-all-colonnumber">Catch-all route :42</a>
       </Link>
+      <br />
       <Link href="/p1/p2/all-ssg/[...rest]" as="/p1/p2/all-ssg/hello">
         <a id="ssg-catch-all-single">Catch-all route (single)</a>
       </Link>
+      <br />
+      <Link
+        href={{
+          pathname: '/p1/p2/all-ssg/[...rest]',
+          query: { rest: ['hello'] },
+        }}
+      >
+        <a id="ssg-catch-all-single-interpolated">
+          Catch-all route (single interpolated)
+        </a>
+      </Link>
+      <br />
       <Link href="/p1/p2/all-ssg/[...rest]" as="/p1/p2/all-ssg/hello1/hello2">
         <a id="ssg-catch-all-multi">Catch-all route (multi)</a>
       </Link>
+      <br />
       <Link href="/p1/p2/all-ssg/hello1/hello2">
         <a id="ssg-catch-all-multi-no-as">Catch-all route (multi)</a>
       </Link>
+      <br />
+      <Link
+        href={{
+          pathname: '/p1/p2/all-ssg/[...rest]',
+          query: { rest: ['hello1', 'hello2'] },
+        }}
+      >
+        <a id="ssg-catch-all-multi-interpolated">
+          Catch-all route (multi interpolated)
+        </a>
+      </Link>
+      <br />
       <Link
         href="/p1/p2/nested-all-ssg/[...rest]"
         as="/p1/p2/nested-all-ssg/hello"
       >
         <a id="nested-ssg-catch-all-single">Nested Catch-all route (single)</a>
       </Link>
+      <br />
       <Link
         href="/p1/p2/nested-all-ssg/[...rest]"
         as="/p1/p2/nested-all-ssg/hello1/hello2"
       >
         <a id="nested-ssg-catch-all-multi">Nested Catch-all route (multi)</a>
       </Link>
+      <br />
       <p id="query">{JSON.stringify(Object.keys(useRouter().query))}</p>
     </div>
   )

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -3,6 +3,7 @@
 import webdriver from 'next-webdriver'
 import { join, dirname } from 'path'
 import fs from 'fs-extra'
+import url from 'url'
 import {
   renderViaHTTP,
   fetchViaHTTP,
@@ -117,6 +118,30 @@ function runTests(dev) {
     }
   })
 
+  it('should navigate to a dynamic page successfully interpolated', async () => {
+    let browser
+    try {
+      browser = await webdriver(appPort, '/')
+      await browser.eval('window.beforeNav = 1')
+
+      const href = await browser
+        .elementByCss('#view-post-1-interpolated')
+        .getAttribute('href')
+
+      expect(url.parse(href).pathname).toBe('/post-1')
+
+      await browser.elementByCss('#view-post-1-interpolated').click()
+      await browser.waitForElementByCss('#asdf')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+
+      const text = await browser.elementByCss('#asdf').text()
+      expect(text).toMatch(/this is.*?post-1/i)
+    } finally {
+      if (browser) await browser.close()
+    }
+  })
+
   it('should allow calling Router.push on mount successfully', async () => {
     const browser = await webdriver(appPort, '/post-1/on-mount-redir')
     try {
@@ -177,6 +202,30 @@ function runTests(dev) {
       browser = await webdriver(appPort, '/')
       await browser.eval('window.beforeNav = 1')
       await browser.elementByCss('#view-post-1-comment-1-no-as').click()
+      await browser.waitForElementByCss('#asdf')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+
+      const text = await browser.elementByCss('#asdf').text()
+      expect(text).toMatch(/i am.*comment-1.*on.*post-1/i)
+    } finally {
+      if (browser) await browser.close()
+    }
+  })
+
+  it('should navigate to a nested dynamic page successfully interpolated', async () => {
+    let browser
+    try {
+      browser = await webdriver(appPort, '/')
+      await browser.eval('window.beforeNav = 1')
+
+      const href = await browser
+        .elementByCss('#view-post-1-comment-1-interpolated')
+        .getAttribute('href')
+
+      expect(url.parse(href).pathname).toBe('/post-1/comment-1')
+
+      await browser.elementByCss('#view-post-1-comment-1-interpolated').click()
       await browser.waitForElementByCss('#asdf')
 
       expect(await browser.eval('window.beforeNav')).toBe(1)
@@ -381,8 +430,35 @@ function runTests(dev) {
     let browser
     try {
       browser = await webdriver(appPort, '/')
+      await browser.eval('window.beforeNav = 1')
       await browser.elementByCss('#ssg-catch-all-single').click()
       await browser.waitForElementByCss('#all-ssg-content')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+
+      const text = await browser.elementByCss('#all-ssg-content').text()
+      expect(text).toBe('{"rest":["hello"]}')
+    } finally {
+      if (browser) await browser.close()
+    }
+  })
+
+  it('[ssg: catch-all] should pass params in getStaticProps during client navigation (single interpolated)', async () => {
+    let browser
+    try {
+      browser = await webdriver(appPort, '/')
+      await browser.eval('window.beforeNav = 1')
+
+      const href = await browser
+        .elementByCss('#ssg-catch-all-single-interpolated')
+        .getAttribute('href')
+
+      expect(url.parse(href).pathname).toBe('/p1/p2/all-ssg/hello')
+
+      await browser.elementByCss('#ssg-catch-all-single-interpolated').click()
+      await browser.waitForElementByCss('#all-ssg-content')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
 
       const text = await browser.elementByCss('#all-ssg-content').text()
       expect(text).toBe('{"rest":["hello"]}')
@@ -414,6 +490,30 @@ function runTests(dev) {
       browser = await webdriver(appPort, '/')
       await browser.eval('window.beforeNav = 1')
       await browser.elementByCss('#ssg-catch-all-multi-no-as').click()
+      await browser.waitForElementByCss('#all-ssg-content')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+
+      const text = await browser.elementByCss('#all-ssg-content').text()
+      expect(text).toBe('{"rest":["hello1","hello2"]}')
+    } finally {
+      if (browser) await browser.close()
+    }
+  })
+
+  it('[ssg: catch-all] should pass params in getStaticProps during client navigation (multi interpolated)', async () => {
+    let browser
+    try {
+      browser = await webdriver(appPort, '/')
+      await browser.eval('window.beforeNav = 1')
+
+      const href = await browser
+        .elementByCss('#ssg-catch-all-multi-interpolated')
+        .getAttribute('href')
+
+      expect(url.parse(href).pathname).toBe('/p1/p2/all-ssg/hello1/hello2')
+
+      await browser.elementByCss('#ssg-catch-all-multi-interpolated').click()
       await browser.waitForElementByCss('#all-ssg-content')
 
       expect(await browser.eval('window.beforeNav')).toBe(1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7579,10 +7579,10 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-finally-polyfill@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/finally-polyfill/-/finally-polyfill-0.2.0.tgz#1b34c6e555a6c1603d2ae046e2e176d08687bfdb"
-  integrity sha512-3w46w5Vo4TRtk5jrLT3c8ITGxnPJhMAg3Ogbj4nmgL6thNep9+UgBgk+IRVmRpZDbwNkR7tyGsE3S3J4Qt2zVw==
+finally-polyfill@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/finally-polyfill/-/finally-polyfill-0.1.0.tgz#2a17b16581d9477db16a703c7b79a898ac0b7d50"
+  integrity sha512-J1LEcZ5VXe1l3sEO+S//WqL5wcJ/ep7QeKJA6HhNZrcEEFj0eyC8IW3DEZhxySI2bx3r85dwAXz+vYPGuHx5UA==
 
 find-cache-dir@3.3.1, find-cache-dir@^3.0.0, find-cache-dir@^3.3.1:
   version "3.3.1"


### PR DESCRIPTION
This corrects/makes sure interpolating dynamic route values for `href` works correctly. This provides an alternative approach to building the `href` value with `next/link` so that you don't need to worry about encoding the params manually. 

Closes: https://github.com/vercel/next.js/issues/13473
Closes: https://github.com/vercel/next.js/issues/14959
Closes: https://github.com/vercel/next.js/issues/16771