### PR TITLE
Update to show build indicator while re-fetching GS(S)P data in dev

### DIFF
--- a/packages/next/client/dev/dev-build-watcher.js
+++ b/packages/next/client/dev/dev-build-watcher.js
@@ -1,6 +1,6 @@
 import { getEventSourceWrapper } from './error-overlay/eventsource'
 
-export default function initializeBuildWatcher() {
+export default function initializeBuildWatcher(toggleCallback) {
   const shadowHost = document.createElement('div')
   shadowHost.id = '__next-build-watcher'
   // Make sure container is fixed and on a high zIndex so it shows
@@ -52,7 +52,8 @@ export default function initializeBuildWatcher() {
   })
 
   function handleMessage(event) {
-    const obj = JSON.parse(event.data)
+    const obj =
+      typeof event === 'string' ? { action: event } : JSON.parse(event.data)
 
     // eslint-disable-next-line default-case
     switch (obj.action) {
@@ -74,6 +75,8 @@ export default function initializeBuildWatcher() {
         break
     }
   }
+
+  toggleCallback(handleMessage)
 
   function updateContainer() {
     if (isBuilding) {

--- a/test/integration/gssp-ssr-change-reloading/pages/gsp-blog/[post].js
+++ b/test/integration/gssp-ssr-change-reloading/pages/gsp-blog/[post].js
@@ -13,8 +13,12 @@ export default function Gsp(props) {
   )
 }
 
-export const getStaticProps = ({ params }) => {
+export const getStaticProps = async ({ params }) => {
   const count = 1
+
+  if (params.post === 'second') {
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+  }
 
   return {
     props: {


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/16744 which shows the build/activity indicator while the data is being re-fetched to let the user know the re-fetching is occurring 

Closes: https://github.com/vercel/next.js/issues/16790