### PR TITLE
Fix invalid config export errors

### DIFF
--- a/test/integration/page-config/pages/valid/config-import.js
+++ b/test/integration/page-config/pages/valid/config-import.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line no-unused-vars
+import { config } from '../../config'
+
+export const getServerSideProps = () => {
+  return {
+    props: {},
+  }
+}
+
+export default () => <p>hello world</p>

--- a/test/integration/page-config/pages/valid/not-config-export.js
+++ b/test/integration/page-config/pages/valid/not-config-export.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line no-unused-vars
+export { config as notConfig } from '../../config'
+
+export const getServerSideProps = () => {
+  return {
+    props: {},
+  }
+}
+
+export default () => <p>hello world</p>

--- a/test/integration/page-config/pages/valid/not-config-import-export.js
+++ b/test/integration/page-config/pages/valid/not-config-import-export.js
@@ -1,0 +1,12 @@
+// eslint-disable-next-line no-unused-vars
+import { config } from '../../config'
+
+export { config as notConfig }
+
+export const getServerSideProps = () => {
+  return {
+    props: {},
+  }
+}
+
+export default () => <p>hello world</p>


### PR DESCRIPTION
This corrects detecting of invalid page config exports and adds additional test cases for non-invalid config import/exports

Closes: https://github.com/vercel/next.js/issues/16775