### PR TITLE
Add example with well-known password change URL

### DIFF
--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -28,6 +28,13 @@ module.exports = {
         destination: '/',
         permanent: true,
       },
+      // Redirect from well-known password change URL
+      // https://wicg.github.io/change-password-url/
+      {
+        source: '/.well-known/change-password',
+        destination: '/account/change-password',
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
Would it make sense to show an example redirect of the well-known password change URL proposal in the docs?

Ref: https://wicg.github.io/change-password-url/

### Alternatives considered

Adding it as an example here: https://github.com/vercel/next.js/blob/canary/examples/redirects/next.config.js