### PR TITLE
Use `Array.from(new Set())` instead of `[...new Set()]`

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -61,7 +61,7 @@ function getDocumentFiles(
   return {
     sharedFiles,
     pageFiles,
-    allFiles: [...new Set([...sharedFiles, ...pageFiles])],
+    allFiles: Array.from(new Set([...sharedFiles, ...pageFiles])),
   }
 }
 


### PR DESCRIPTION
I can't explain why, but without the code change in this PR I get a `RangeError: Invalid array length` error in the node server when serving my app with `NODE_ENV=production`. It works fine in dev mode though.

The error seems to have been introduced in [this PR](https://github.com/vercel/next.js/pull/16184) and shipped in v9.5.3.

Full stack trace of the error:
```
RangeError: Invalid array length
    at __spreadArrays (.next/server/pages/_document.js:52:18)
    at getDocumentFiles (.next/server/pages/_document.js:884:13)
    at Head.module.exports.VDXt.Head.render (.next/server/pages/_document.js:1141:19)
    at d (node_modules/react-dom/cjs/react-dom-server.node.production.min.js:38:231)
    at $a (node_modules/react-dom/cjs/react-dom-server.node.production.min.js:39:16)
    at a.b.render (node_modules/react-dom/cjs/react-dom-server.node.production.min.js:44:476)
    at a.b.read (node_modules/react-dom/cjs/react-dom-server.node.production.min.js:44:18)
    at renderToStaticMarkup (node_modules/react-dom/cjs/react-dom-server.node.production.min.js:54:462)
    at renderDocument (node_modules/next/next-server/server/render.tsx:216:5)
    at renderToHTML (node_modules/next/next-server/server/render.tsx:768:14)
```