### PR TITLE
Correct client rewrite resolving with query

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -597,7 +597,7 @@ export default class Router implements BaseRouter {
 
     if (process.env.__NEXT_HAS_REWRITES) {
       resolvedAs = resolveRewrites(
-        as,
+        parseRelativeUrl(as).pathname,
         pages,
         basePath,
         rewrites,

--- a/test/integration/custom-routes/pages/nav.js
+++ b/test/integration/custom-routes/pages/nav.js
@@ -6,8 +6,27 @@ export default () => (
     <Link href="/hello" as="/first">
       <a id="to-hello">to hello</a>
     </Link>
+    <br />
     <Link href="/hello-again" as="/second">
       <a id="to-hello-again">to hello-again</a>
     </Link>
+    <br />
+    <Link
+      href={{
+        pathname: '/with-params',
+        query: {
+          something: 1,
+          another: 'value',
+        },
+      }}
+      as="/params/1?another=value"
+    >
+      <a id="to-params-manual">to params (manual)</a>
+    </Link>
+    <br />
+    <Link href="/params/1?another=value">
+      <a id="to-params">to params</a>
+    </Link>
+    <br />
   </>
 )

--- a/test/integration/custom-routes/pages/with-params.js
+++ b/test/integration/custom-routes/pages/with-params.js
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router'
 
 const Page = () => {
   const { query } = useRouter()
-  return <p>{JSON.stringify(query)}</p>
+  return <p id="query">{JSON.stringify(query)}</p>
 }
 
 Page.getInitialProps = () => ({ hello: 'GIPGIP' })

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -314,6 +314,34 @@ const runTests = (isDev = false) => {
     expect(await getBrowserBodyText(browser)).toMatch(/Hello again/)
   })
 
+  it('should work with rewrite when manually specifying href/as', async () => {
+    const browser = await webdriver(appPort, '/nav')
+    await browser
+      .elementByCss('#to-params-manual')
+      .click()
+      .waitForElementByCss('#query')
+
+    const query = JSON.parse(await browser.elementByCss('#query').text())
+    expect(query).toEqual({
+      something: '1',
+      another: 'value',
+    })
+  })
+
+  it('should work with rewrite when only specifying href', async () => {
+    const browser = await webdriver(appPort, '/nav')
+    await browser
+      .elementByCss('#to-params')
+      .click()
+      .waitForElementByCss('#query')
+
+    const query = JSON.parse(await browser.elementByCss('#query').text())
+    expect(query).toEqual({
+      something: '1',
+      another: 'value',
+    })
+  })
+
   it('should match a page after a rewrite', async () => {
     const html = await renderViaHTTP(appPort, '/to-hello')
     expect(html).toContain('Hello')

--- a/test/integration/dynamic-routing/pages/another.js
+++ b/test/integration/dynamic-routing/pages/another.js
@@ -1,1 +1,3 @@
-export default () => 'hello from another!'
+export default function Another() {
+  return 'hello from another!'
+}


### PR DESCRIPTION
This makes sure we only pass the as value's `pathname` instead of the full value so that we don't accidentally include `query` values while resolving the rewrites. This also adds tests to ensure the rewrites are resolved with the correct query values when only providing `href` and when manually mapping them with `href` and `as`

Fixes: https://github.com/vercel/next.js/issues/16825