### PR TITLE
Ignore .next also in subfolders

### DIFF
--- a/examples/with-yarn-workspaces/.gitignore
+++ b/examples/with-yarn-workspaces/.gitignore
@@ -9,8 +9,7 @@
 /coverage
 
 # next.js
-/.next/
-/out/
+.next
 
 # production
 /build

--- a/examples/with-yarn-workspaces/.gitignore
+++ b/examples/with-yarn-workspaces/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # next.js
-.next
+.next/
 
 # production
 /build


### PR DESCRIPTION
As the example is about Yarn workspaces, it should gitignore `.next` recursively.