### PR TITLE
Importing CSS from Third Party React Components

### DIFF
--- a/docs/basic-features/built-in-css-support.md
+++ b/docs/basic-features/built-in-css-support.md
@@ -52,7 +52,47 @@ In production, all CSS files will be automatically concatenated into a single mi
 
 ### Import styles from `node_modules`
 
-If you’d like to import CSS files from `node_modules`, you must do so inside `pages/_app.js`.
+Importing a CSS file from `node_modules` is permitted in anywhere your application.
+
+For global stylesheets, like `bootstrap` or `nprogress`, you should import the file inside `pages/_app.js`.
+For example:
+
+```jsx
+// pages/_app.js
+import 'bootstrap/dist/css/bootstrap.css'
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+```
+
+For importing CSS required by a third party component, you can do so in your component. For example:
+
+```tsx
+// components/ExampleDialog.js
+import { useState } from 'react'
+import { Dialog } from '@reach/dialog'
+import '@reach/dialog/styles.css'
+
+function ExampleDialog(props) {
+  const [showDialog, setShowDialog] = useState(false)
+  const open = () => setShowDialog(true)
+  const close = () => setShowDialog(false)
+
+  return (
+    <div>
+      <button onClick={open}>Open Dialog</button>
+      <Dialog isOpen={showDialog} onDismiss={close}>
+        <button className="close-button" onClick={close}>
+          <VisuallyHidden>Close</VisuallyHidden>
+          <span aria-hidden>×</span>
+        </button>
+        <p>Hello there. I am a dialog</p>
+      </Dialog>
+    </div>
+  )
+}
+```
 
 ## Adding Component-Level CSS
 

--- a/test/integration/css-fixtures/import-global-from-module/node_modules/example/index.css
+++ b/test/integration/css-fixtures/import-global-from-module/node_modules/example/index.css
@@ -1,0 +1,3 @@
+.red-text {
+  color: 'red';
+}

--- a/test/integration/css-fixtures/import-global-from-module/node_modules/example/index.js
+++ b/test/integration/css-fixtures/import-global-from-module/node_modules/example/index.js
@@ -1,0 +1,1 @@
+module.exports = 'hello'

--- a/test/integration/css-fixtures/import-global-from-module/node_modules/example/index.mjs
+++ b/test/integration/css-fixtures/import-global-from-module/node_modules/example/index.mjs
@@ -1,0 +1,1 @@
+export default 'hello'

--- a/test/integration/css-fixtures/import-global-from-module/node_modules/example/package.json
+++ b/test/integration/css-fixtures/import-global-from-module/node_modules/example/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "example",
+  "main": "index"
+}

--- a/test/integration/css-fixtures/import-global-from-module/pages/index.js
+++ b/test/integration/css-fixtures/import-global-from-module/pages/index.js
@@ -1,0 +1,7 @@
+import 'example/index.css'
+
+function Home() {
+  return <div className="red-text">This should be red text.</div>
+}
+
+export default Home

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -287,6 +287,35 @@ describe('CSS Support', () => {
     })
   })
 
+  describe('Valid Global CSS from npm', () => {
+    const appDir = join(fixturesDir, 'import-global-from-module')
+
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
+
+    it('should compile successfully', async () => {
+      const { code, stdout } = await nextBuild(appDir, [], {
+        stdout: true,
+      })
+      expect(code).toBe(0)
+      expect(stdout).toMatch(/Compiled successfully/)
+    })
+
+    it(`should've emitted a single CSS file`, async () => {
+      const cssFolder = join(appDir, '.next/static/css')
+
+      const files = await readdir(cssFolder)
+      const cssFiles = files.filter((f) => /\.css$/.test(f))
+
+      expect(cssFiles.length).toBe(1)
+      const cssContent = await readFile(join(cssFolder, cssFiles[0]), 'utf8')
+      expect(
+        cssContent.replace(/\/\*.*?\*\//g, '').trim()
+      ).toMatchInlineSnapshot(`".red-text{color:\\"red\\"}"`)
+    })
+  })
+
   describe('Invalid Global CSS with Custom App', () => {
     const appDir = join(fixturesDir, 'invalid-global-with-app')
 


### PR DESCRIPTION
This PR implements a simplified version of the [RFC: Importing CSS from Third Party React Components #15208](https://github.com/vercel/next.js/discussions/15208).

This pull requests adds the ability to **import Global CSS anywhere in your application**, so long that it originates from npm (`node_modules`).

This is a best-effort heuristic that makes a safety trade-off for better interoperability with npm packages that require CSS.
The assumption being made is that npm packages should be good citizens and not override global styles.

Without this ability, the component's CSS would have to be included for the entire app instead of specific page (or component) where it's required.

The **only intent** of this PR is to allow components to use third-party component CSS like so:

```tsx
// components/MySlider.tsx
import { Slider } from "@reach/slider";
import "@reach/slider/styles.css";

function Example() {
  return <Slider min={0} max={200} step={10} />;
}
```

---

Misusing this behavior to import first-party Global CSS within your application will lead to unexpected results, and we provide no semver guarantees for the behavior.

---

Fixes #12079 
Fixes #16563