### PR TITLE
Upgrade web-vitals

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -112,7 +112,7 @@
     "use-subscription": "1.4.1",
     "vm-browserify": "1.1.2",
     "watchpack": "2.0.0-beta.13",
-    "web-vitals": "0.2.1",
+    "web-vitals": "0.2.4",
     "webpack": "4.44.1",
     "webpack-sources": "1.4.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16808,9 +16808,10 @@ web-streams-polyfill@2.1.1:
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz#2c82b6193849ccb9efaa267772c28260ef68d6d2"
   integrity sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==
 
-web-vitals@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.1.tgz#60782fa690243fe35613759a0c26431f57ba7b2d"
+web-vitals@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
+  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
ref https://github.com/GoogleChrome/web-vitals/pull/68

won't fail the new [`no-unload-listeners`](https://github.com/GoogleChrome/lighthouse/pull/11085) Lighthouse audit.