### PR TITLE
Examples blogs: fix spelling

### DIFF
--- a/examples/blog-starter-typescript/components/date-formatter.tsx
+++ b/examples/blog-starter-typescript/components/date-formatter.tsx
@@ -1,6 +1,12 @@
 import { parseISO, format } from 'date-fns'
 
-export default function DateFormater({ dateString }) {
+type Props = {
+  dateString: string
+}
+
+const DateFormatter = ({ dateString }: Props) => {
   const date = parseISO(dateString)
   return <time dateTime={dateString}>{format(date, 'LLLL	d, yyyy')}</time>
 }
+
+export default DateFormatter

--- a/examples/blog-starter-typescript/components/hero-post.tsx
+++ b/examples/blog-starter-typescript/components/hero-post.tsx
@@ -1,5 +1,5 @@
 import Avatar from './avatar'
-import DateFormater from './date-formater'
+import DateFormatter from './date-formatter'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 import Author from '../types/author'
@@ -34,7 +34,7 @@ const HeroPost = ({
             </Link>
           </h3>
           <div className="mb-4 md:mb-0 text-lg">
-            <DateFormater dateString={date} />
+            <DateFormatter dateString={date} />
           </div>
         </div>
         <div>

--- a/examples/blog-starter-typescript/components/post-header.tsx
+++ b/examples/blog-starter-typescript/components/post-header.tsx
@@ -1,5 +1,5 @@
 import Avatar from './avatar'
-import DateFormater from './date-formater'
+import DateFormatter from './date-formatter'
 import CoverImage from './cover-image'
 import PostTitle from './post-title'
 import Author from '../types/author'
@@ -26,7 +26,7 @@ const PostHeader = ({ title, coverImage, date, author }: Props) => {
           <Avatar name={author.name} picture={author.picture} />
         </div>
         <div className="mb-6 text-lg">
-          <DateFormater dateString={date} />
+          <DateFormatter dateString={date} />
         </div>
       </div>
     </>

--- a/examples/blog-starter-typescript/components/post-preview.tsx
+++ b/examples/blog-starter-typescript/components/post-preview.tsx
@@ -1,5 +1,5 @@
 import Avatar from './avatar'
-import DateFormater from './date-formater'
+import DateFormatter from './date-formatter'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 import Author from '../types/author'
@@ -32,7 +32,7 @@ const PostPreview = ({
         </Link>
       </h3>
       <div className="text-lg mb-4">
-        <DateFormater dateString={date} />
+        <DateFormatter dateString={date} />
       </div>
       <p className="text-lg leading-relaxed mb-4">{excerpt}</p>
       <Avatar name={author.name} picture={author.picture} />

--- a/examples/blog-starter/components/date-formatter.js
+++ b/examples/blog-starter/components/date-formatter.js
@@ -1,12 +1,6 @@
 import { parseISO, format } from 'date-fns'
 
-type Props = {
-  dateString: string
-}
-
-const DateFormater = ({ dateString }: Props) => {
+export default function DateFormatter({ dateString }) {
   const date = parseISO(dateString)
   return <time dateTime={dateString}>{format(date, 'LLLL	d, yyyy')}</time>
 }
-
-export default DateFormater

--- a/examples/blog-starter/components/hero-post.js
+++ b/examples/blog-starter/components/hero-post.js
@@ -1,5 +1,5 @@
 import Avatar from '../components/avatar'
-import DateFormater from '../components/date-formater'
+import DateFormatter from '../components/date-formatter'
 import CoverImage from '../components/cover-image'
 import Link from 'next/link'
 
@@ -24,7 +24,7 @@ export default function HeroPost({
             </Link>
           </h3>
           <div className="mb-4 md:mb-0 text-lg">
-            <DateFormater dateString={date} />
+            <DateFormatter dateString={date} />
           </div>
         </div>
         <div>

--- a/examples/blog-starter/components/post-header.js
+++ b/examples/blog-starter/components/post-header.js
@@ -1,5 +1,5 @@
 import Avatar from '../components/avatar'
-import DateFormater from '../components/date-formater'
+import DateFormatter from '../components/date-formatter'
 import CoverImage from '../components/cover-image'
 import PostTitle from '../components/post-title'
 
@@ -18,7 +18,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
           <Avatar name={author.name} picture={author.picture} />
         </div>
         <div className="mb-6 text-lg">
-          <DateFormater dateString={date} />
+          <DateFormatter dateString={date} />
         </div>
       </div>
     </>

--- a/examples/blog-starter/components/post-preview.js
+++ b/examples/blog-starter/components/post-preview.js
@@ -1,5 +1,5 @@
 import Avatar from '../components/avatar'
-import DateFormater from '../components/date-formater'
+import DateFormatter from '../components/date-formatter'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 
@@ -22,7 +22,7 @@ export default function PostPreview({
         </Link>
       </h3>
       <div className="text-lg mb-4">
-        <DateFormater dateString={date} />
+        <DateFormatter dateString={date} />
       </div>
       <p className="text-lg leading-relaxed mb-4">{excerpt}</p>
       <Avatar name={author.name} picture={author.picture} />

--- a/examples/cms-kontent/components/date-formater.js
+++ b/examples/cms-kontent/components/date-formater.js
@@ -1,6 +1,6 @@
 import { parseISO, format } from 'date-fns'
 
-export default function DateFormater({ dateString }) {
+export default function DateFormatter({ dateString }) {
   const date = parseISO(dateString)
   return <time dateTime={dateString}>{format(date, 'LLLL	d, yyyy')}</time>
 }

--- a/examples/cms-kontent/components/hero-post.js
+++ b/examples/cms-kontent/components/hero-post.js
@@ -1,5 +1,5 @@
 import Avatar from '../components/avatar'
-import DateFormater from '../components/date-formater'
+import DateFormatter from '../components/date-formatter'
 import CoverImage from '../components/cover-image'
 import Link from 'next/link'
 
@@ -24,7 +24,7 @@ export default function HeroPost({
             </Link>
           </h3>
           <div className="mb-4 md:mb-0 text-lg">
-            <DateFormater dateString={date} />
+            <DateFormatter dateString={date} />
           </div>
         </div>
         <div>

--- a/examples/cms-kontent/components/post-header.js
+++ b/examples/cms-kontent/components/post-header.js
@@ -1,5 +1,5 @@
 import Avatar from '../components/avatar'
-import DateFormater from '../components/date-formater'
+import DateFormatter from '../components/date-formatter'
 import CoverImage from '../components/cover-image'
 import PostTitle from '../components/post-title'
 
@@ -18,7 +18,7 @@ export default function PostHeader({ title, coverImage, date, author }) {
           <Avatar name={author.name} picture={author.picture} />
         </div>
         <div className="mb-6 text-lg">
-          <DateFormater dateString={date} />
+          <DateFormatter dateString={date} />
         </div>
       </div>
     </>

--- a/examples/cms-kontent/components/post-preview.js
+++ b/examples/cms-kontent/components/post-preview.js
@@ -1,5 +1,5 @@
 import Avatar from '../components/avatar'
-import DateFormater from '../components/date-formater'
+import DateFormatter from '../components/date-formatter'
 import CoverImage from './cover-image'
 import Link from 'next/link'
 
@@ -22,7 +22,7 @@ export default function PostPreview({
         </Link>
       </h3>
       <div className="text-lg mb-4">
-        <DateFormater dateString={date} />
+        <DateFormatter dateString={date} />
       </div>
       <p className="text-lg leading-relaxed mb-4">{excerpt}</p>
       <Avatar name={author.name} picture={author.picture} />


### PR DESCRIPTION
Throughout some of the blog examples word `formatter` is spelled as `formater`, this PR changes all of them to `formatter`