### PR TITLE
Fix export-cli progress label default value

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -57,7 +57,7 @@ function divideSegments(number: number, segments: number): number[] {
   return result
 }
 
-const createProgress = (total: number, label = 'Exporting') => {
+const createProgress = (total: number, label: string) => {
   const segments = divideSegments(total, 4)
 
   let currentSegmentTotal = segments.shift()
@@ -381,7 +381,7 @@ export default async function exportApp(
     !options.silent &&
     createProgress(
       filteredPaths.length,
-      `${Log.prefixes.info} ${options.statusMessage}`
+      `${Log.prefixes.info} ${options.statusMessage || 'Exporting'}`
     )
   const pagesDataDir = options.buildExport
     ? outDir

--- a/test/integration/export-progress-status-message/pages/index.js
+++ b/test/integration/export-progress-status-message/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <p>I am a home page</p>

--- a/test/integration/export-progress-status-message/test/index.test.js
+++ b/test/integration/export-progress-status-message/test/index.test.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import { nextBuild, nextExportDefault } from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 5)
+const appDir = join(__dirname, '../')
+
+describe('Export cli prints progress info', () => {
+  let buildStdout
+  let exportStdout
+  beforeAll(async () => {
+    const buildResult = await nextBuild(appDir, [], { stdout: true })
+    buildStdout = buildResult.stdout
+    const exportResult = await nextExportDefault(appDir, { stdout: true })
+    exportStdout = exportResult.stdout
+  })
+
+  it('build: should log with internally passed statusMessage', async () => {
+    const lines = buildStdout.split('\n')
+    // Search `info  - Generating static pages (n/m)` line
+    const found = lines.some((line) =>
+      /Generating static pages \(\d+\/\d+\)/.test(line)
+    )
+
+    expect(found).toBeTruthy()
+  })
+
+  it('export: should log with default label', async () => {
+    const lines = exportStdout.split('\n')
+    // Search `info  - Exporting (n/m)` line
+    const found = lines.some((line) => /Exporting \(\d+\/\d+\)/.test(line))
+
+    expect(found).toBeTruthy()
+  })
+})


### PR DESCRIPTION
This PR fixes `info  - undefined (N/N)` log for `export` cli.

![image](https://user-images.githubusercontent.com/6259812/93186247-5d801500-f779-11ea-89ec-e20939d7b7c1.png)

Default parameter `label` for `createProgress()` was always ignored by `${Log.prefixes.info} undefined` 😅 .