### PR TITLE
Fix direct visiting a SSR dynamic page with default params

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1250,7 +1250,7 @@ export default class Server {
   ): Promise<string | null> {
     try {
       const result = await this.findPageComponents(pathname, query)
-      if (result) {
+      if (result && !isDynamicRoute(pathname)) {
         try {
           return await this.renderToHTMLWithComponents(
             req,

--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -3,6 +3,7 @@ import { UrlWithParsedQuery } from 'url'
 
 import pathMatch from '../lib/router/utils/path-match'
 import { removePathTrailingSlash } from '../../client/normalize-trailing-slash'
+import { isDynamicRoute } from '../lib/router/utils'
 
 export const route = pathMatch()
 
@@ -104,6 +105,7 @@ export default class Router {
       if (pageChecks[p]) {
         return pageChecks[p]
       }
+
       const result = this.pageChecker(p)
       pageChecks[p] = result
       return result
@@ -250,7 +252,7 @@ export default class Router {
           let matchedPage = await memoizedPageChecker(fsPathname)
 
           // If we didn't match a page check dynamic routes
-          if (!matchedPage) {
+          if (!matchedPage || isDynamicRoute(fsPathname)) {
             for (const dynamicRoute of this.dynamicRoutes) {
               if (dynamicRoute.match(fsPathname)) {
                 matchedPage = true

--- a/test/integration/getserversideprops/pages/index.js
+++ b/test/integration/getserversideprops/pages/index.js
@@ -40,6 +40,7 @@ const Page = ({ world, time, url }) => {
       <Link href="/blog/[post]" as="/blog/post-1">
         <a id="post-1">to dynamic</a>
       </Link>
+      <br />
       <Link href="/blog/[post]" as="/blog/post-100">
         <a id="broken-post">to broken</a>
       </Link>

--- a/test/integration/getserversideprops/pages/index.js
+++ b/test/integration/getserversideprops/pages/index.js
@@ -41,6 +41,10 @@ const Page = ({ world, time, url }) => {
         <a id="post-1">to dynamic</a>
       </Link>
       <br />
+      <Link href="/blog/[post]?post=[post]">
+        <a id="post-itself">to /blog/[post]</a>
+      </Link>
+      <br />
       <Link href="/blog/[post]" as="/blog/post-100">
         <a id="broken-post">to broken</a>
       </Link>

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -228,6 +228,26 @@ const navigateTest = (dev = false) => {
     expect(text).toMatch(/Comment:.*?comment-1/)
     expect(await browser.eval('window.didTransition')).toBe(1)
 
+    // go to /
+    await browser.elementByCss('#home').click()
+    await browser.waitForElementByCss('#post-itself')
+
+    // go to /blog/[post]
+    await browser.elementByCss('#post-itself').click()
+    await browser.waitForElementByCss('#home')
+    expect(await browser.eval('window.didTransition')).toBe(1)
+    expect(JSON.parse(await browser.elementByCss('#params').text())).toEqual({
+      post: '[post]',
+    })
+    expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
+      post: '[post]',
+    })
+    expect(JSON.parse(await browser.elementByCss('#app-query').text())).toEqual(
+      {
+        post: '[post]',
+      }
+    )
+
     await browser.close()
   })
 }

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -245,6 +245,23 @@ const runTests = (dev = false) => {
     expect(html).toMatch(/Post:.*?post-1/)
   })
 
+  it('should SSR getServerSideProps page correctly visiting dynamic page name itself', async () => {
+    const html = await renderViaHTTP(appPort, '/blog/[post]')
+    const $ = cheerio.load(html)
+
+    expect(JSON.parse($('#params').text())).toEqual({
+      post: '[post]',
+    })
+    expect(JSON.parse($('#query').text())).toEqual({
+      post: '[post]',
+    })
+    expect(JSON.parse($('#app-query').text())).toEqual({
+      post: '[post]',
+    })
+    expect($('#app-url').text()).toBe('/blog/[post]')
+    expect($('#resolved-url').text()).toBe('/blog/[post]')
+  })
+
   it('should handle throw ENOENT correctly', async () => {
     const res = await fetchViaHTTP(appPort, '/enoent')
     const html = await res.text()


### PR DESCRIPTION
This makes sure visiting a SSR dynamic page with the default params provides the param correctly without error. Previously we matched the page directly and rendered it without parsing the params. 

Closes: https://github.com/vercel/next.js/issues/17096