### PR TITLE
Add missing comma in docs example

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -157,19 +157,19 @@ module.exports = {
         headers: [
           {
             key: 'x-hello',
-            value: 'world'
-          }
-        ]
+            value: 'world',
+          },
+        ],
       },
       {
         source: '/without-basePath', // is not modified since basePath: false is set
         headers: [
           {
             key: 'x-hello',
-            value: 'world'
-          }
-        ]
-        basePath: false
+            value: 'world',
+          },
+        ],
+        basePath: false,
       },
     ]
   },


### PR DESCRIPTION
Including prettier changes that were done automatically after the code sample became valid.