### PR TITLE
[Example] With TS Eslint Jest - unnecessary package

### DIFF
--- a/examples/with-typescript-eslint-jest/package.json
+++ b/examples/with-typescript-eslint-jest/package.json
@@ -35,7 +35,6 @@
     "@types/jest": "^25.1.4",
     "@types/node": "^13.9.5",
     "@types/react": "^16.9.27",
-    "@types/testing-library__react": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
     "babel-jest": "^25.2.3",


### PR DESCRIPTION
As mentioned in [here](https://www.npmjs.com/package/@types/testing-library__react), the package has been deprecated and not necessary to be installed.
By removing this from `package.json` will give other devs have more understanding when learning typescript with eslint and jest about what need to be installed on the project.