### PR TITLE
[Example] with-react-intl: fix getInitialProps props ordering

### DIFF
--- a/examples/with-react-intl/pages/_app.tsx
+++ b/examples/with-react-intl/pages/_app.tsx
@@ -65,7 +65,7 @@ const getInitialProps: typeof App.getInitialProps = async appContext => {
 
   const [supportedLocale, messagePromise] = getMessages(requestedLocales);
 
-  const [appProps, messages] = await Promise.all([
+  const [, messages, appProps] = await Promise.all([
     polyfill(supportedLocale),
     messagePromise,
     App.getInitialProps(appContext),


### PR DESCRIPTION
Invalid ordering in Promise.all and in receiving destruction.

Now appProps receives result of polyfill(supportedLocale) call.