### PR TITLE
[Example] with-react-intl: fix doubling messages

### DIFF
--- a/examples/with-react-intl/pages/_app.tsx
+++ b/examples/with-react-intl/pages/_app.tsx
@@ -71,7 +71,7 @@ const getInitialProps: typeof App.getInitialProps = async appContext => {
     App.getInitialProps(appContext),
   ]);
 
-  return {...(appProps as any), locale: supportedLocale, messages};
+  return {...(appProps as any), locale: supportedLocale, messages: messages.default};
 };
 
 MyApp.getInitialProps = getInitialProps;

--- a/examples/with-react-intl/pages/_app.tsx
+++ b/examples/with-react-intl/pages/_app.tsx
@@ -71,7 +71,11 @@ const getInitialProps: typeof App.getInitialProps = async appContext => {
     App.getInitialProps(appContext),
   ]);
 
-  return {...(appProps as any), locale: supportedLocale, messages: messages.default};
+  return {
+    ...(appProps as any),
+    locale: supportedLocale,
+    messages: messages.default,
+  };
 };
 
 MyApp.getInitialProps = getInitialProps;


### PR DESCRIPTION
Because `import()` for .json files return object like this:

```json
{
  "default": {
     "some": ...
  },
 "some": ...
}
```

![image](https://user-images.githubusercontent.com/2598671/93468826-4156b200-f8f8-11ea-8e39-42df2df83057.png)
