### PR TITLE
SSR: serialize undefined value

### DIFF
--- a/packages/next/lib/is-serializable-props.ts
+++ b/packages/next/lib/is-serializable-props.ts
@@ -45,8 +45,9 @@ export function isSerializableProps(
   ): true {
     const type = typeof value
     if (
-      // `null` can be serialized, but not `undefined`.
+      // `null` can be serialized.
       value === null ||
+      type === 'undefined' ||
       // n.b. `bigint`, `function`, `symbol`, and `undefined` cannot be
       // serialized.
       //
@@ -57,15 +58,6 @@ export function isSerializableProps(
       type === 'string'
     ) {
       return true
-    }
-
-    if (type === 'undefined') {
-      throw new SerializableError(
-        page,
-        method,
-        path,
-        '`undefined` cannot be serialized as JSON. Please use `null` or omit this value all together.'
-      )
     }
 
     if (isPlainObject(value)) {

--- a/test/integration/ssr-type-undefined/pages/index.js
+++ b/test/integration/ssr-type-undefined/pages/index.js
@@ -1,0 +1,17 @@
+function Page(props) {
+  if (props.name === undefined) {
+    return <h1>ValueIsUndefined</h1>
+  }
+  return <h1>Error</h1>
+}
+
+export async function getServerSideProps(context) {
+  return {
+    props: {
+      name: undefined,
+      hello: 'World',
+    },
+  }
+}
+
+export default Page

--- a/test/integration/ssr-type-undefined/test/index.test.js
+++ b/test/integration/ssr-type-undefined/test/index.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import {
+  killApp,
+  findPort,
+  nextBuild,
+  launchApp,
+  renderViaHTTP,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 30)
+
+const appDir = join(__dirname, '../')
+let appPort
+let app
+
+describe('SSR serialize undefined value', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    appPort = await findPort()
+    app = await launchApp(appDir, appPort, { dev: true })
+  })
+  afterAll(() => killApp(app))
+
+  it('should serialize undefined value', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    expect(html).toMatch(/ValueIsUndefined/)
+  })
+})


### PR DESCRIPTION
Make undefined is serializable.
Serialization of undefined value works perfectly - value on client side exactly matches value on server side for object field (see test/integration/ssr-type-undefined/) and converts to null for item of array. 
There no reason to not serialize undefined.
Undefined is not valid JSON value. It's true. But it could be correctly serialized as item of array or field of object:
```
JSON.stringify({hello: undefined}) === "{}"
JSON.parse(JSON.stringify({hello: undefined})).hello === undefined
JSON.stringify([undefined]) === "[null]"
```