### PR TITLE
Update trailingSlash parameter name

### DIFF
--- a/docs/api-reference/next.config.js/exportPathMap.md
+++ b/docs/api-reference/next.config.js/exportPathMap.md
@@ -63,7 +63,7 @@ To switch back and add a trailing slash, open `next.config.js` and enable the `e
 
 ```js
 module.exports = {
-  exportTrailingSlash: true,
+  trailingSlash: true,
 }
 ```
 


### PR DESCRIPTION
Reflect the change in `trailingSlash` parameter name.

I found this because of the great warning on the build!
```
Warning: The "exportTrailingSlash" option has been renamed to "trailingSlash". Please update your next.config.js.
```