### PR TITLE
Add `custom-server-subdomain` example

### DIFF
--- a/examples/custom-server-subdomain/.gitignore
+++ b/examples/custom-server-subdomain/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/custom-server-subdomain/README.md
+++ b/examples/custom-server-subdomain/README.md
@@ -1,0 +1,23 @@
+# Custom Server Subdomain Example
+
+Most of the times the default Next server will be enough but sometimes you want to run your own server to customize routes or other kind of the app behavior. Next provides a [Custom server and routing](https://nextjs.org/docs/advanced-features/custom-server) so you can customize as much as you want.
+
+Because the Next.js server is just a node.js module you can combine it with any other part of the node.js ecosystem. In this case we are using express to build a custom router on top of Next.
+
+The example shows a server that serves the components living in `pages/admin` when the route `http://admin.lvh.me:3000` is requested and `pages/member` when the route `http://lvh.me:3000` is accessed. This is obviously a non-standard routing strategy. You can see how this custom routing is being made inside `server.js`.
+
+Available routes:
+* http://admin.lvh.me:3000
+* http://admin.lvh.me:3000/sample-page
+* http://lvh.me:3000
+* http://lvh.me:3000/accounts/dashboard
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example custom-server-subdomain custom-server-subdomain-app
+# or
+yarn create next-app --example custom-server-subdomain custom-server-subdomain-app
+```

--- a/examples/custom-server-subdomain/package.json
+++ b/examples/custom-server-subdomain/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "custom-server-subdomain",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build",
+    "start": "cross-env NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "cross-env": "^5.2.0",
+    "express": "^4.17.1",
+    "next": "latest",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "vhost": "^3.0.2"
+  },
+  "license": "MIT"
+}

--- a/examples/custom-server-subdomain/pages/admin/index.js
+++ b/examples/custom-server-subdomain/pages/admin/index.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Admin() {
+  return <div>Admin</div>
+}

--- a/examples/custom-server-subdomain/pages/admin/sample-page.js
+++ b/examples/custom-server-subdomain/pages/admin/sample-page.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function SamplePage() {
+  return <div>SamplePage</div>
+}

--- a/examples/custom-server-subdomain/pages/member/accounts/dashboard.js
+++ b/examples/custom-server-subdomain/pages/member/accounts/dashboard.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function MemberDashboard() {
+  return <div>MEMBER DASHBOARD</div>
+}

--- a/examples/custom-server-subdomain/pages/member/index.js
+++ b/examples/custom-server-subdomain/pages/member/index.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Member() {
+  return <div>Member</div>
+}

--- a/examples/custom-server-subdomain/server.js
+++ b/examples/custom-server-subdomain/server.js
@@ -1,0 +1,47 @@
+const express = require('express')
+const next = require('next')
+const vhost = require('vhost')
+
+const port = process.env.PORT || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const mainServer = express()
+  const adminServer = express()
+  const memberServer = express()
+
+  adminServer.get('/', (req, res) => {
+    return app.render(req, res, '/admin', req.query)
+  })
+
+  adminServer.get('/*', (req, res) => {
+    return app.render(req, res, `/admin${req.path}`, req.query)
+  })
+
+  adminServer.all('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  memberServer.get('/', (req, res) => {
+    return app.render(req, res, '/member', req.query)
+  })
+
+  memberServer.get('/*', (req, res) => {
+    return app.render(req, res, `/member${req.path}`, req.query)
+  })
+
+  memberServer.all('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  mainServer.use(vhost('admin.lvh.me', adminServer))
+  mainServer.use(vhost('lvh.me', memberServer))
+  mainServer.use(vhost('www.lvh.me', memberServer))
+  mainServer.listen(port, (err) => {
+    if (err) throw err
+
+    console.log(`> Ready on http://lvh.me:${port}`)
+  })
+})


### PR DESCRIPTION
This PR adds an example Next.js project with subdomain support using a custom server.

Even though the issue is closed this can be a reference to #5682

Based on: https://github.com/dcangulo/nextjs-subdomain-example