### PR TITLE
Update next.config.js

### DIFF
--- a/examples/with-sentry/next.config.js
+++ b/examples/with-sentry/next.config.js
@@ -1,6 +1,6 @@
 // Use the hidden-source-map option when you don't want the source maps to be
 // publicly available on the servers, only to the error reporting
-const withSourceMaps = require('@zeit/next-source-maps')()
+const withSourceMaps = require('@zeit/next-source-maps')
 
 // Use the SentryWebpack plugin to upload the source maps during build step
 const SentryWebpackPlugin = require('@sentry/webpack-plugin')


### PR DESCRIPTION
`const withSourceMaps = require('@zeit/next-source-maps')()`
This line raised the error `withSourceMaps is not a function`

After removing `()` at the end, it works just fine.