### PR TITLE
Rename exportTrailingSlash to trailingSlash in docs

### DIFF
--- a/docs/advanced-features/amp-support/amp-in-static-html-export.md
+++ b/docs/advanced-features/amp-support/amp-in-static-html-export.md
@@ -27,7 +27,7 @@ And the AMP version of your page will include a link to the HTML page:
 <link rel="canonical" href="/about" />
 ```
 
-When [`exportTrailingSlash`](/docs/api-reference/next.config.js/exportPathMap.md#0cf7d6666b394c5d8d08a16a933e86ea) is enabled the exported pages for `pages/about.js` would be:
+When [`trailingSlash`](/docs/api-reference/next.config.js/trailing-slash.md) is enabled the exported pages for `pages/about.js` would be:
 
 - `out/about/index.html` - HTML page
 - `out/about.amp/index.html` - AMP page

--- a/docs/api-reference/next.config.js/exportPathMap.md
+++ b/docs/api-reference/next.config.js/exportPathMap.md
@@ -59,7 +59,7 @@ The returned object is a map of pages where the `key` is the `pathname` and the 
 
 It is possible to configure Next.js to export pages as `index.html` files and require trailing slashes, `/about` becomes `/about/index.html` and is routable via `/about/`. This was the default behavior prior to Next.js 9.
 
-To switch back and add a trailing slash, open `next.config.js` and enable the `exportTrailingSlash` config:
+To switch back and add a trailing slash, open `next.config.js` and enable the `trailingSlash` config:
 
 ```js
 module.exports = {

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -146,7 +146,7 @@ You can revert to the previous behavior by creating a `next.config.js` with the 
 ```js
 // next.config.js
 module.exports = {
-  exportTrailingSlash: true,
+  trailingSlash: true,
 }
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/vercel/next.js/pull/17228 requested by https://github.com/vercel/next.js/pull/17228#pullrequestreview-492123162

Also fixed an unexpected relative path that was being used in the page 🤔 