### PR TITLE
Make getInlineScriptSource arg Readonly

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -648,7 +648,7 @@ export class NextScript extends Component<OriginProps> {
       ))
   }
 
-  static getInlineScriptSource(documentProps: DocumentProps): string {
+  static getInlineScriptSource(documentProps: Readonly<DocumentProps>): string {
     const { __NEXT_DATA__ } = documentProps
     try {
       const data = JSON.stringify(__NEXT_DATA__)


### PR DESCRIPTION
The rule [total-functions/no-unsafe-readonly-mutable-assignment](https://github.com/danielnixon/eslint-plugin-total-functions#total-functionsno-unsafe-readonly-mutable-assignment) triggers with this error message:
> Assigning a readonly type to a mutable type can lead to unexpected mutation in the readonly value

when invoking
```
      NextScript.getInlineScriptSource(this.props)
```
inside a `_document.tsx`'s render function.
due to `this.props` having the type:
```
props: Readonly<P> & Readonly<{ children?: ReactNode }>
```
in `@types/react`

On the other hand, this is a small, low-priority change (IMO), so an alternative work around is just to disable the lint rule for that line of course.

Lint, tests, and build passes.

Lint error was discovered using typescript@next, version `4.1.0-dev.20200921` and eslint-plugin-total-functions version `4.1.0`, but I tested the change to nextjs using typescript version `3.8.3`.