### PR TITLE
fix(examples/with-redux-wrapper): wrong initial state (close #17299)

### DIFF
--- a/examples/with-redux-wrapper/store/store.js
+++ b/examples/with-redux-wrapper/store/store.js
@@ -23,7 +23,7 @@ const reducer = (state, action) => {
       ...state, // use previous state
       ...action.payload, // apply delta from hydration
     }
-    if (state.count) nextState.count = state.count // preserve count value on client side navigation
+    if (state.count.count) nextState.count.count = state.count.count // preserve count value on client side navigation
     return nextState
   } else {
     return combinedReducer(state, action)


### PR DESCRIPTION
Wrong variable was being checked for the hydrate action on redux. This was causing the count to be reset to 0 instead of being 1 when initially loading index.js page.

Fixes #17299