### PR TITLE
Remove reference to now env example

### DIFF
--- a/docs/api-reference/next.config.js/environment-variables.md
+++ b/docs/api-reference/next.config.js/environment-variables.md
@@ -10,7 +10,6 @@ description: Learn to add and access environment variables in your Next.js appli
   <summary><b>Examples</b></summary>
   <ul>
     <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-env-from-next-config-js">With env</a></li>
-    <li><a href="https://github.com/vercel/next.js/tree/canary/examples/with-now-env">With Now env</a></li>
   </ul>
 </details>
 


### PR DESCRIPTION
The example has been emptied as it is no longer the recommended way to do it so it shouldn't be linked to