### PR TITLE
allow to pass className to `__next` container

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -518,7 +518,7 @@ export class Head extends Component<
   }
 }
 
-export function Main() {
+export function Main(props: { className?: string }) {
   const { inAmpMode, html, docComponentsRendered } = useContext(
     DocumentComponentContext
   )
@@ -526,7 +526,7 @@ export function Main() {
   docComponentsRendered.Main = true
 
   if (inAmpMode) return <>{AMP_RENDER_TARGET}</>
-  return <div id="__next" dangerouslySetInnerHTML={{ __html: html }} />
+  return <div id="__next" className={props.className} dangerouslySetInnerHTML={{ __html: html }} />
 }
 
 export class NextScript extends Component<OriginProps> {


### PR DESCRIPTION
I would like to pass the className as follow

```tsx
render() {
    return (
      <Html>
        <Head></Head>
        <body className="bg-gray-100 text-base">
          <Main className="flex flex-col" />
          <NextScript />
        </body>
      </Html>
    );
  }
```

I am using Tailwind, and I would  prefer to avoid creating my own classes or overwrite, I would prefer to pass the `className`