### PR TITLE
Fix export for linked pages using `getStaticProps`.

### DIFF
--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -81,7 +81,6 @@ export default async function exportPage({
   outDir,
   pagesDataDir,
   renderOpts,
-  buildExport,
   serverRuntimeConfig,
   subFolders,
   serverless,
@@ -173,10 +172,6 @@ export default async function exportPage({
     let curRenderOpts: RenderOpts = {}
     let renderMethod = renderToHTML
 
-    const renderedDuringBuild = (getStaticProps: any) => {
-      return !buildExport && getStaticProps && !isDynamicRoute(path)
-    }
-
     if (serverless) {
       const curUrl = url.parse(req.url!, true)
       req.url = url.format({
@@ -201,11 +196,6 @@ export default async function exportPage({
         html = mod
         queryWithAutoExportWarn()
       } else {
-        // for non-dynamic SSG pages we should have already
-        // prerendered the file
-        if (renderedDuringBuild((mod as ComponentModule).getStaticProps))
-          return results
-
         if (
           (mod as ComponentModule).getStaticProps &&
           !htmlFilepath.endsWith('.html')
@@ -245,12 +235,6 @@ export default async function exportPage({
 
       if (components.getServerSideProps) {
         throw new Error(`Error for page ${page}: ${SERVER_PROPS_EXPORT_ERROR}`)
-      }
-
-      // for non-dynamic SSG pages we should have already
-      // prerendered the file
-      if (renderedDuringBuild(components.getStaticProps)) {
-        return results
       }
 
       // TODO: de-dupe the logic here between serverless and server mode


### PR DESCRIPTION
## Issue

Please refer to: #17356

## Analysis

From my point of view the `about` page is skipped because of a performance optimisation.

- here: https://github.com/vercel/next.js/blob/canary/packages/next/export/worker.ts#L206-L207
- and here: https://github.com/vercel/next.js/blob/canary/packages/next/export/worker.ts#L252-L254

The export script assumes, that the page has been build:

- https://github.com/vercel/next.js/blob/canary/packages/next/export/worker.ts#L176-L178

Since it references the index page (`/index.html`) it forgets to copy it to the about path (`/about/index.html`)

## Solutions

There are multiple possible solutions to this problem.

A. Remove the buggy performance optimisation
B. Copy the original page file and adjust paths accordingly
C. 🤔

In this PR I went for Solution **A.** since **B.** might cause additional bugs due to needed path rewrites. 

## Related

close #17356

## Feedback

@ijjk can you have a look at this?