### PR TITLE
chore(collect-plugins.ts): removes duplicated entries

### DIFF
--- a/packages/next/build/plugins/collect-plugins.ts
+++ b/packages/next/build/plugins/collect-plugins.ts
@@ -19,8 +19,6 @@ export const VALID_MIDDLEWARE = [
   'document-head-tags-server',
   'on-init-client',
   'on-init-server',
-  'on-error-server',
-  'on-error-client',
   'on-error-client',
   'on-error-server',
   'babel-preset-build',


### PR DESCRIPTION
Removes two duplicated entries in the `VALID_MIDDLEWARE` array.