### PR TITLE
with-google-analytics-amp needs <Head /> in Document component

### DIFF
--- a/examples/with-google-analytics-amp/pages/_document.js
+++ b/examples/with-google-analytics-amp/pages/_document.js
@@ -1,4 +1,4 @@
-import Document, { Html, Main, NextScript } from 'next/document'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { useAmp } from 'next/amp'
 
 import { GA_TRACKING_ID } from '../lib/gtag'
@@ -14,6 +14,7 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html>
+        <Head />
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
If this component is missing, an error will be printed to the console

```
Expected Document Component Head was not rendered. Make sure you render them in your custom `_document`
See more info here https://err.sh/next.js/missing-document-component
```

Additionally, any components which use CSS modules will fail with an error.

This is documented in https://nextjs.org/docs/advanced-features/custom-document