### PR TITLE
Add WrapApp prop to AppTree to work in HOC and with apollo

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -508,10 +508,11 @@ export async function renderToHTML(
     pathname,
     query,
     asPath,
-    AppTree: (props: any) => {
+    AppTree: ({ WrapApp, ...props }: any) => {
+      const WrappedApp = WrapApp || App
       return (
         <AppContainer>
-          <App {...props} Component={Component} router={router} />
+          <WrappedApp {...props} Component={Component} router={router} />
         </AppContainer>
       )
     },
@@ -529,7 +530,6 @@ export async function renderToHTML(
   const reactLoadableModules: string[] = []
 
   let head: JSX.Element[] = defaultHead(inAmpMode)
-
   const AppContainer = ({ children }: any) => (
     <RouterContext.Provider value={router}>
       <AmpStateContext.Provider value={ampState}>


### PR DESCRIPTION
## Proplem
All withApollo HOC examples and code dosn't work if we use `AppTree` and if we use `Component` we don't get the right context 

Apollo client context is [singleton ](https://github.com/apollographql/apollo-client/blob/aa338ff73199bffcc181c21f8c2754473ed49e30/src/react/context/ApolloContext.ts#L22-L29) (single Apollo context is created and tracked in global state).
and when we use more then one `ApolloProvider` we [overide client instance](https://github.com/apollographql/apollo-client/blob/aa338ff73199bffcc181c21f8c2754473ed49e30/src/react/context/ApolloProvider.tsx#L20-L22) with most inner `ApolloProvider` client
So when we create HOC APP to get `apolloClient` initial cache state by using `getDataFromTree` by using server side `apolloClient` and then extract cache like this


```js
function withApollo(WrappedApp) {
  const WithApollo = ({ apolloState, ...props }) => {
    const apolloClient = React.useMemo(() => initApollo(apolloState), []);
    return (
      <ApolloProvider client={apolloClient}>
        <WrappedApp {...props} />
      </ApolloProvider>
    );
  };
  WithApollo.getInitialProps = async () => {
    const apolloClient = initApollo({});
    // ...

    // only on server
    await getDataFromTree(
      <ApolloProvider client={apolloClient}>
        <AppTree {...appProps} />
      </ApolloProvider>
    );
    const apolloState = apolloClient.cache.extract();
    // ...
    return {
      // ...
      apolloState,
    };
  };

  return WithApollo;
}
```
on first render in `getDataFromTree` on server `getInitialProps` the `apolloClient` is not used.. the second client in `WithApollo` Component will overide it so when extract cache ` apolloClient.cache.extract()` we get empty result because we extract overwritten client

## Solution
`AppTree` provided  in appContext meant to provide right context (router, head manager, amp, ...)
And for HOC we have app that we want to wrap in this contexts, so we should be able to provide app to wrap.

So we can have one ApolloContext in first Render
To fix example in problem we do this in `getInitialProps`:

```js
// ...
await getDataFromTree(
  <ApolloProvider client={apolloClient}>
    <AppTree WrapApp={WrappedApp} {...appProps} />
  </ApolloProvider>
);
// ...
```

then we have only one `ApolloProvider` on first render and there is no inner one that overwrite it


### working example:
[next-apollo-client-ssr-example](https://github.com/mhhegazy/next-apollo-client-ssr-example)

to try it: 
```sh
yarn add next@npm:@mhhegazy/next@9.5.4-canary.25
```


fixes #9336
Related issue #10126
Related pull request #7732