### PR TITLE
fix(next): add missing peer dependencies for sass support

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -115,6 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--unhandled-rejections=strict'
+      YARN_COMPRESSION_LEVEL: '0'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -120,15 +120,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile --check-files
 
-      - run: |
-          mkdir -p ./e2e-tests/next-pnp
-          cp -r ./examples/with-typescript/. ./e2e-tests/next-pnp
-          cd ./e2e-tests/next-pnp
-          touch yarn.lock
-          yarn set version berry
-          yarn config set pnpFallbackMode none
-          yarn link --all --private ../..
-          yarn build
+      - run: bash ./test-pnp.sh
 
   testsPass:
     name: thank you, next

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -107,12 +107,26 @@
     "webpack": "4.44.1",
     "webpack-sources": "1.4.3"
   },
+  "optionalDependencies": {
+    "sharp": "0.26.2"
+  },
   "peerDependencies": {
     "react": "^16.6.0 || ^17",
-    "react-dom": "^16.6.0 || ^17"
+    "react-dom": "^16.6.0 || ^17",
+    "node-sass": "^4.0.0",
+    "sass": "^1.3.0",
+    "fibers": ">= 3.1.0"
   },
-  "optionalDependencies": {
-    "sharp": "0.26.3"
+  "peerDependenciesMeta": {
+    "node-sass": {
+      "optional": true
+    },
+    "sass": {
+      "optional": true
+    },
+    "fibers": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/code-frame": "7.12.11",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -108,7 +108,7 @@
     "webpack-sources": "1.4.3"
   },
   "optionalDependencies": {
-    "sharp": "0.26.2"
+    "sharp": "0.26.3"
   },
   "peerDependencies": {
     "react": "^16.6.0 || ^17",

--- a/test-pnp.sh
+++ b/test-pnp.sh
@@ -1,5 +1,6 @@
 declare -a testCases=(
   "with-typescript"
+  "with-next-sass"
 )
 
 set -e

--- a/test-pnp.sh
+++ b/test-pnp.sh
@@ -1,0 +1,29 @@
+declare -a testCases=(
+  "with-typescript"
+)
+
+set -e
+
+# Speeds up testing locally
+export CI=1
+
+rm -rf ./e2e-tests
+
+initialDir=$(pwd)
+
+for testCase in "${testCases[@]}"
+do
+  cd $initialDir
+
+  echo "--- Testing $testCase ---"
+  mkdir -p "./e2e-tests/$testCase"
+  cp -r "./examples/$testCase/." "./e2e-tests/$testCase"
+  cd "./e2e-tests/$testCase"
+
+  touch yarn.lock
+  yarn set version berry
+  yarn config set pnpFallbackMode none
+  yarn link --all --private -r ../..
+
+  yarn build
+done


### PR DESCRIPTION
**What's the problem this PR addresses?**

`next` inherits optional peer dependencies  from `sass-loader` but doesn't declare them.

Fixes https://github.com/vercel/next.js/issues/14157

**How did you fix it?**

- Added `node-sass`, `sass`, and `fibers` as optional peer dependencies
- Updated the pnp e2e test to cover sass support