### PR TITLE
Fixes #16431

### DIFF
--- a/examples/with-storybook/.babelrc
+++ b/examples/with-storybook/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": []
+}

--- a/examples/with-storybook/components/index.js
+++ b/examples/with-storybook/components/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 export default function Home() {
   return <div>Hello World</div>
 }


### PR DESCRIPTION
Fixes #16431
* Added `.babelrc` with `next/babel` to remove the need of the React import on the `with-storybook` example. 