### PR TITLE
Update to use hasNextSupport for custom-routes in next export check

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -171,7 +171,7 @@ export default async function exportApp(
   )
 
   if (
-    hasNextSupport &&
+    !hasNextSupport &&
     !options.buildExport &&
     customRoutesDetected.length > 0
   ) {

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -33,6 +33,7 @@ import loadConfig, {
   isTargetLikeServerless,
 } from '../next-server/server/config'
 import { eventCliSession } from '../telemetry/events'
+import { hasNextSupport } from '../telemetry/ci-info'
 import { Telemetry } from '../telemetry/storage'
 import {
   normalizePagePath,
@@ -170,7 +171,7 @@ export default async function exportApp(
   )
 
   if (
-    !process.env.NOW_BUILDER &&
+    hasNextSupport &&
     !options.buildExport &&
     customRoutesDetected.length > 0
   ) {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/17538 per https://github.com/vercel/next.js/pull/17538#discussion_r499647323 this updates the check to use the existing `hasNextSupport` export instead of checking the environment variable directly