### PR TITLE
Force ssl

### DIFF
--- a/docs/api-reference/next.config.js/force-ssl.md
+++ b/docs/api-reference/next.config.js/force-ssl.md
@@ -1,0 +1,27 @@
+---
+description: Configure Next.js to redirect requests from http to https (does not create a secure server)
+---
+
+# Force SSL
+
+
+By default Next.js does not deal with SSL/https connetions. This config will redirect any request that uses http to https. It does not create a secure server or even listen for https connections but is extremely useful in some hosting situations like Heroku where the SSL/https connection is terminated before interacting with the Next.js server and the user does not want to create a custom server.
+
+Open `next.config.js` and add the `forceSsl` config:
+
+```js
+module.exports = {
+  forceSsl: true,
+}
+```
+
+With this option set, urls like `http://hello.com/about?test=hi#scroll` will redirect to `https://hello.com/about?test=hi#scroll`. 
+
+## Related
+
+<div class="card">
+  <a href="/docs/api-reference/next.config.js/introduction.md">
+    <b>Introduction to next.config.js:</b>
+    <small>Learn more about the configuration file used by Next.js.</small>
+  </a>
+</div>

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "node-sass": "4.12.0",
     "npm-run-all": "4.1.5",
     "nprogress": "0.2.0",
+    "original-url": "1.2.3",
     "pixrem": "5.0.0",
     "postcss-nested": "4.2.1",
     "postcss-pseudoelements": "5.0.0",

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -280,6 +280,16 @@ export default class Server {
 
     const { basePath } = this.nextConfig
 
+    if (true) {
+      parsedUrl.protocol = 'https'
+      res.statusCode = 302
+      console.dir(parsedUrl)
+      console.dir(req.url)
+      res.setHeader('Location', parsedUrl.toString())
+      res.end()
+      return
+    }
+
     if (basePath && req.url?.startsWith(basePath)) {
       // store original URL to allow checking if basePath was
       // provided or not

--- a/yarn.lock
+++ b/yarn.lock
@@ -7715,6 +7715,11 @@ formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
+forwarded-parse@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.0.tgz#1ae9d7a4be3af884f74d936d856f7d8c6abd0439"
+  integrity sha512-as9a7Xelt0CvdUy7/qxrY73dZq2vMx49F556fwjjFrUyzq5uHHfeLgD2cCq/6P4ZvusGZzjD6aL2NdgGdS5Cew==
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -11991,6 +11996,13 @@ ora@4.0.4:
     mute-stream "0.0.8"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
+
+original-url@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/original-url/-/original-url-1.2.3.tgz#133aff4b2d27e38a98d736f7629c56262b7153e1"
+  integrity sha512-BYm+pKYLtS4mVe/mgT3YKGtWV5HzN/XKiaIu1aK4rsxyjuHeTW9N+xVBEpJcY1onB3nccfH0RbzUEoimMqFUHQ==
+  dependencies:
+    forwarded-parse "^2.1.0"
 
 os-browserify@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Hi, I wanted to submit this idea for adding a config to force SSL when using the next server. It would be very useful for hosting on Heroku where it's slightly more difficult to setup next behind nginx or another reverse proxy. We had to setup a custom server.js and then we lost the optimizations that next serve provides. This PR has a require statement and code that doesn't meet the typescript requirements for the project, but I wasn't sure what those were as far as 3rd party/external dependencies. If this force SSL is an idea that is of interest, I can adapt the rest of the code, either moving it internal or adapting to whatever requirements exist for external dependencies