### PR TITLE
feat: SSR fetch function to be customizable

### DIFF
--- a/examples/ssr-custom-fetcher/.gitignore
+++ b/examples/ssr-custom-fetcher/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/ssr-custom-fetcher/README.md
+++ b/examples/ssr-custom-fetcher/README.md
@@ -1,0 +1,29 @@
+# SSR Custom Fetcher Example
+
+This example shows how to change the fetch behavior when `getServerSideProps` is executed on the client side. When calling `getServerSideProps` from the client side, the status information of the client is sent to the server. On the server side, when `getServerSideProps` is executed, it refers to the value received from the client and sends the value back to the client after calculation.
+
+Each time you move a link in the example page, the count value increases by 1. Even if the client status is changed by clicking the ʻIncrease count`or`Decrase count` button, the server updates the current client's count value plus 1.
+
+## How to use
+
+Implement the `serverSidePropsFetch` function in the page file and export it. See the sample below.
+
+```js
+/** pages/index.js */
+...
+export const getServerSideProps = (...) => {...};
+export const serverSidePropsFetcher = async (url, options) => {
+  /**
+   * This function replaces the `fetch` function that is used internally
+   * when moving to the page where `getServerSideProps` is defined.
+   * [!] This function only runs in the browser environment.
+   * @see https://www.npmjs.com/package/node-fetch
+   */
+  return fetch(url, {
+    ...options,
+    method: 'put',
+    body: JSON.stringify(window?.__store__ || {}),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+```

--- a/examples/ssr-custom-fetcher/components/counter.js
+++ b/examples/ssr-custom-fetcher/components/counter.js
@@ -1,0 +1,60 @@
+import Link from 'next/link'
+import { useState } from 'react'
+import { useEffect } from 'react'
+
+const Counter = ({ initialCount }) => {
+  const [count, setCount] = useState(initialCount || 0)
+
+  useEffect(() => {
+    window.__store__ = {
+      count: initialCount,
+    }
+    setCount(initialCount)
+  }, [initialCount])
+
+  const setCountWithStore = (count) => {
+    window.__store__ = {
+      count,
+    }
+    setCount(count)
+  }
+
+  const handleClickIncrease = () => {
+    const count = window?.__store__?.count || 0
+    setCountWithStore(count + 1)
+  }
+
+  const handleClickDecrease = () => {
+    const count = window?.__store__?.count || 0
+    setCountWithStore(count - 1)
+  }
+
+  return (
+    <div>
+      <h2>
+        Count: <span>{count}</span>
+      </h2>
+      <button onClick={handleClickIncrease}>Increase count</button>
+      <button onClick={handleClickDecrease}>Decrase count</button>
+      <ul>
+        <li>
+          <Link href="/">
+            <a>Index(SSR)</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/a">
+            <a>Page a(SSR)</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/b">
+            <a>Page b(SSR)</a>
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}
+
+export default Counter

--- a/examples/ssr-custom-fetcher/package.json
+++ b/examples/ssr-custom-fetcher/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ssr-custom-fetcher",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "license": "MIT"
+}

--- a/examples/ssr-custom-fetcher/pages/a.js
+++ b/examples/ssr-custom-fetcher/pages/a.js
@@ -1,0 +1,38 @@
+import Counter from '../components/counter'
+import { bodyParser } from '../utils'
+
+const Page = ({ initialCount }) => {
+  return (
+    <div>
+      <h1>Page A</h1>
+      <Counter initialCount={initialCount} />
+    </div>
+  )
+}
+export default Page
+
+export const getServerSideProps = async ({ req }) => {
+  let initialCount = 0
+  if (req.method === 'PUT') {
+    const data = await bodyParser(req)
+    initialCount = data.count || 0
+  }
+  return {
+    props: {
+      initialCount,
+    },
+  }
+}
+
+export const serverSidePropsFetcher = async (url, options) => {
+  /**
+   * This function replaces the `fetch` function that is used internally
+   * when moving to the page where `getServerSideProps` is defined.
+   */
+  return fetch(url, {
+    ...options,
+    method: 'put',
+    body: JSON.stringify(window?.__store__ || {}),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/examples/ssr-custom-fetcher/pages/b.js
+++ b/examples/ssr-custom-fetcher/pages/b.js
@@ -1,0 +1,38 @@
+import Counter from '../components/counter'
+import { bodyParser } from '../utils'
+
+const Page = ({ initialCount }) => {
+  return (
+    <div>
+      <h1>Page B</h1>
+      <Counter initialCount={initialCount} />
+    </div>
+  )
+}
+export default Page
+
+export const getServerSideProps = async ({ req }) => {
+  let initialCount = 0
+  if (req.method === 'PUT') {
+    const data = await bodyParser(req)
+    initialCount = data.count || 0
+  }
+  return {
+    props: {
+      initialCount,
+    },
+  }
+}
+
+export const serverSidePropsFetcher = async (url, options) => {
+  /**
+   * This function replaces the `fetch` function that is used internally
+   * when moving to the page where `getServerSideProps` is defined.
+   */
+  return fetch(url, {
+    ...options,
+    method: 'put',
+    body: JSON.stringify(window?.__store__ || {}),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/examples/ssr-custom-fetcher/pages/index.js
+++ b/examples/ssr-custom-fetcher/pages/index.js
@@ -1,0 +1,41 @@
+import Counter from '../components/counter'
+import { bodyParser } from '../utils'
+
+const Page = ({ initialCount }) => {
+  return (
+    <div>
+      <h1>Index</h1>
+      <Counter initialCount={initialCount} />
+    </div>
+  )
+}
+export default Page
+
+export const getServerSideProps = async ({ req }) => {
+  let initialCount = 0
+  if (req.method === 'PUT') {
+    const data = await bodyParser(req)
+    initialCount = data.count || 0
+    initialCount += 1
+  }
+  return {
+    props: {
+      initialCount,
+    },
+  }
+}
+
+export const serverSidePropsFetcher = async (url, options) => {
+  /**
+   * This function replaces the `fetch` function that is used internally
+   * when moving to the page where `getServerSideProps` is defined.
+   * [!] This function only runs in the browser environment.
+   * @see https://www.npmjs.com/package/node-fetch
+   */
+  return fetch(url, {
+    ...options,
+    method: 'put',
+    body: JSON.stringify(window?.__store__ || {}),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/examples/ssr-custom-fetcher/utils.js
+++ b/examples/ssr-custom-fetcher/utils.js
@@ -1,0 +1,13 @@
+const bodyParser = (req) =>
+  new Promise((resolve) => {
+    let data = ''
+    req.on('data', (chunk) => {
+      data += chunk
+    })
+    req.on('end', () => {
+      const requestBody = JSON.parse(data || '{}')
+      resolve(requestBody)
+    })
+  })
+
+export { bodyParser }

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -224,6 +224,23 @@ export default class PageLoader {
       : getHrefForSlug(route)
   }
 
+  getCustomFetcher(route: string): Promise<typeof fetch | undefined> {
+    return new Promise((resolve, reject) => {
+      // If there's a cached version of the page, let's use it.
+      const cachedPage = this.pageCache[route]
+      if (cachedPage) {
+        if ('error' in cachedPage) {
+          reject(undefined)
+        } else {
+          const customFetcher = cachedPage.mod.serverSidePropsFetcher
+          // Returns a custom fetcher defined.
+          resolve(customFetcher)
+        }
+        return
+      }
+    })
+  }
+
   /**
    * @param {string} href the route href (file-system path)
    * @param {string} asPath the URL as shown in browser (virtual path); used for dynamic routes


### PR DESCRIPTION
In the case of using getServerSideProps, the customized fetch function can be used when requesting data about the page from the browser.

By using this function, when a browser requests data about a page, it can be transmitted including the client's status information, and the server can use the client's status information for more flexible processing.

- feat(page-loader): add `getCustomFetcher` function (bb443533294f24911e1e60df6373ddd5e18dc252)
- feat(ssr-custom-fetcher): add `ssr-custom-fetcher` example (974d4295e188e1dc47fc5bc209f6bf14806c5694)
- fix(router): use `customFetcher` in `fetchNextData` (0b0ab3793333a0f120d4a412e645661a57e3a8a5)