### PR TITLE
Update release stats workflow step to restore cache

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -190,7 +190,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publishRelease]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}
       - run: ./release-stats.sh
       - uses: ./.github/actions/next-stats-action
         env:


### PR DESCRIPTION
This matches the publish step to make sure we re-use the checked out version of the repo with the tags already pulled so that we can detect the current commit being tagged. 