### PR TITLE
Fix with-msw example

### DIFF
--- a/examples/with-msw/.env
+++ b/examples/with-msw/.env
@@ -1,4 +1,0 @@
-# Enable API mocking in all environments, this is only for the sake of the example.
-# In a real app you should move this variable to `.env.development`, as mocking the
-# API should only be done for development.
-NEXT_PUBLIC_API_MOCKING="enabled"

--- a/examples/with-msw/package.json
+++ b/examples/with-msw/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "msw": "^0.21.0",
+    "msw": "^0.21.2",
     "next": "latest",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/examples/with-msw/pages/_app.js
+++ b/examples/with-msw/pages/_app.js
@@ -1,6 +1,12 @@
-if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
+// Enable API mocking in all environments, this is only for the sake of the example.
+// In a real app you should remove this code and uncomment the code below.
+if (true) {
   require('../mocks')
 }
+
+// if (process.env.NODE_ENV !== 'production') {
+//   require('../mocks')
+// }
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/examples/with-msw/pages/_app.js
+++ b/examples/with-msw/pages/_app.js
@@ -1,12 +1,8 @@
-// Enable API mocking in all environments, this is only for the sake of the example.
-// In a real app you should remove this code and uncomment the code below.
-if (true) {
+// Enable API mocking in all environments except production.
+// This is recommended for real-world apps.
+if (process.env.NODE_ENV !== 'production') {
   require('../mocks')
 }
-
-// if (process.env.NODE_ENV !== 'production') {
-//   require('../mocks')
-// }
 
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/examples/with-msw/pages/index.js
+++ b/examples/with-msw/pages/index.js
@@ -1,21 +1,23 @@
 import { useState } from 'react'
 
-export default function Home({ book, error }) {
+export default function Home({ book, inProduction }) {
   const [reviews, setReviews] = useState(null)
 
   const handleGetReviews = () => {
     // Client-side request are mocked by `mocks/browser.js`.
-    // This request will fail in production, as MSW is only run in development.
-    // In a real-world app this request would hit the actual backend.
     fetch('/reviews')
       .then((res) => res.json())
       .then(setReviews)
   }
 
-  if (error) {
+  if (inProduction) {
     return (
       <div>
-        <p>Failed to fetch book</p>
+        <p>
+          This example does not work in production, as MSW is not intended for
+          use in production. In a real-world app, your request will hit the
+          actual backend instead.
+        </p>
       </div>
     )
   }
@@ -42,7 +44,6 @@ export default function Home({ book, error }) {
 
 export async function getServerSideProps() {
   // Server-side requests are mocked by `mocks/server.js`.
-  // This request will fail in production, as MSW is only run in development.
   // In a real-world app this request would hit the actual backend.
   try {
     const res = await fetch('https://my.backend/book')
@@ -56,7 +57,7 @@ export async function getServerSideProps() {
   } catch (error) {
     return {
       props: {
-        error: true,
+        inProduction: true,
       },
     }
   }

--- a/examples/with-msw/pages/index.js
+++ b/examples/with-msw/pages/index.js
@@ -1,13 +1,23 @@
 import { useState } from 'react'
 
-export default function Home({ book }) {
+export default function Home({ book, error }) {
   const [reviews, setReviews] = useState(null)
 
   const handleGetReviews = () => {
     // Client-side request are mocked by `mocks/browser.js`.
+    // This request will fail in production, as MSW is only run in development.
+    // In a real-world app this request would hit the actual backend.
     fetch('/reviews')
       .then((res) => res.json())
       .then(setReviews)
+  }
+
+  if (error) {
+    return (
+      <div>
+        <p>Failed to fetch book</p>
+      </div>
+    )
   }
 
   return (
@@ -32,12 +42,22 @@ export default function Home({ book }) {
 
 export async function getServerSideProps() {
   // Server-side requests are mocked by `mocks/server.js`.
-  const res = await fetch('https://my.backend/book')
-  const book = await res.json()
+  // This request will fail in production, as MSW is only run in development.
+  // In a real-world app this request would hit the actual backend.
+  try {
+    const res = await fetch('https://my.backend/book')
+    const book = await res.json()
 
-  return {
-    props: {
-      book,
-    },
+    return {
+      props: {
+        book,
+      },
+    }
+  } catch (error) {
+    return {
+      props: {
+        error: true,
+      },
+    }
   }
 }


### PR DESCRIPTION
When using the `with-msw` example I noticed it increased my bundle size in production, even through MSW is meant to be used in development only. 

**Build size before implementing MSW**
```
Page                                                           Size     First Load JS
┌ λ /                                                          479 B          58.9 kB
├   /_app                                                      0 B            58.4 kB
└ ○ /404                                                       3.44 kB        61.9 kB
+ First Load JS shared by all                                  58.4 kB
  ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.b1b405.js  10.3 kB
  ├ chunks/framework.cb05d5.js                                 39.9 kB
  ├ chunks/main.a140d5.js                                      7.28 kB
  ├ chunks/pages/_app.b90a57.js                                277 B
  └ chunks/webpack.e06743.js                                   751 B

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
   (ISR)     incremental static regeneration (uses revalidate in getStaticProps)
```
**Build size after implementing MSW according to the `with-msw` example**
```
Page                                                           Size     First Load JS
┌ λ /                                                          479 B          71.6 kB
├   /_app                                                      0 B            71.1 kB
└ ○ /404                                                       3.44 kB        74.6 kB
+ First Load JS shared by all                                  71.1 kB
  ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.b1b405.js  10.3 kB
  ├ chunks/framework.cb05d5.js                                 39.9 kB
  ├ chunks/main.a140d5.js                                      7.28 kB
  ├ chunks/pages/_app.c58a6f.js                                13 kB
  └ chunks/webpack.e06743.js                                   751 B

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
   (ISR)     incremental static regeneration (uses revalidate in getStaticProps)
```

There was a 12.7 kB large increase in the `_app` First Load JS which increased the pages' First Load JS size. I tracked the problem down to the following code: 
```js
if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
  require('../mocks')
}
```
Removing this reduces the `_app` First Load JS to what it was previously. The `NEXT_PUBLIC_API_MOCKING` environment variable is defined in the `.env.development` file, as this means that Next.js will only activate MSW during development/testing, which is what MSW is intended for.

After discussing with @kettanaito, the author of MSW, I did some investigation. This dynamic require statement is intended to allow tree-shaking of the MSW package for production. Unfortunately this did not seem to be working. To fix this, I changed the code to the following:
```js
if (process.env.NODE_ENV !== 'production') {
  require('../mocks')
}
```
This means I could remove the `NEXT_PUBLIC_API_MOCKING` environment variable  from `.env.development`, as it is no longer used. 

It is important to note that this still achieves the same functionality as before: MSW runs in development / testing, and not in production. If MSW must be enabled in production for some reason, the following code can be used to run MSW regardless of the environment:
```js
if (true) {
  require('../mocks')
}
```

If possible, I'd love to hear from the Next.js maintainers regarding the tree-shaking process when using environment variables.

Lastly, I made the necessary changes to have the example work in production mode as well, because there is no real backend. Of course there is a comment explaining what should be changed in a real world app.