### PR TITLE
[build] Upgrade next, preact

### DIFF
--- a/examples/using-preact/next.config.js
+++ b/examples/using-preact/next.config.js
@@ -26,7 +26,7 @@ module.exports = withPrefresh({
     aliases.react = aliases['react-dom'] = 'preact/compat'
 
     // Automatically inject Preact DevTools:
-    if (dev && !isServer) {
+    if (process.env.NODE_ENV === 'development' && dev && !isServer) {
       const entry = config.entry
       config.entry = () =>
         entry().then((entries) => {

--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@prefresh/next": "^0.3.0",
-    "next": "^9.4.0",
-    "preact": "^10.4.4",
-    "preact-render-to-string": "^5.1.9",
+    "next": "9.5.4",
+    "preact": "10.5.4",
+    "preact-render-to-string": "5.1.10",
     "react": "github:preact-compat/react#1.0.0",
     "react-dom": "github:preact-compat/react-dom#1.0.0",
     "react-ssr-prepass": "npm:preact-ssr-prepass@^1.0.1"

--- a/examples/using-preact/pages/_app.js
+++ b/examples/using-preact/pages/_app.js
@@ -1,0 +1,42 @@
+const MyApp = ({ Component, pageProps, router }) => {
+  // Custom logic here
+
+  return <Component {...{ ...pageProps }} />
+}
+
+/**
+ * Custom implementation, see: https://github.com/facebook/react/issues/16604#issuecomment-528663101
+ */
+
+const MyReactRefresh = (props) => {
+  if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
+    const runtime = require('react-refresh/runtime')
+    runtime.injectIntoGlobalHook(window)
+    window.$RefreshReg$ = () => {}
+    window.$RefreshSig$ = () => (type) => type
+
+    // BEFORE EVERY MODULE EXECUTES
+
+    var prevRefreshReg = window.$RefreshReg$
+    var prevRefreshSig = window.$RefreshSig$
+    var RefreshRuntime = require('react-refresh/runtime')
+
+    window.$RefreshReg$ = (type, id) => {
+      // Note module.id is webpack-specific, this may vary in other bundlers
+      const fullId = module.id + ' ' + id
+      RefreshRuntime.register(type, fullId)
+    }
+    window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform
+
+    try {
+      return MyApp(props)
+    } finally {
+      window.$RefreshReg$ = prevRefreshReg
+      window.$RefreshSig$ = prevRefreshSig
+    }
+  }
+  // For production, hosted on Vercel
+  else return MyApp(props)
+}
+
+export default MyReactRefresh


### PR DESCRIPTION
- next from 9.4.0 to 9.5.4
- preact from 10.4.4 to 10.5.4
- preact-render-to-string from 5.1.9 to 5.1.10

[feat] Add React Refresh

- added _app.js
- contains custom implementation of React Refresh

## Comments

When we upgraded next from `9.5.3` to `9.5.4` everything stopped working for us. Spent this morning trying to figure out a workaround and finally found something that works for us, so sharing here. Since I’m a bit of a noob, may need another set of eyes on this.