### PR TITLE
Improve with-tailwindcss example

### DIFF
--- a/examples/with-tailwindcss/tailwind.config.js
+++ b/examples/with-tailwindcss/tailwind.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   future: {
     removeDeprecatedGapUtilities: true,
+    purgeLayersByDefault: true,
   },
   purge: ['./components/**/*.{js,ts,jsx,tsx}', './pages/**/*.{js,ts,jsx,tsx}'],
   theme: {


### PR DESCRIPTION
## Change

To opt-in to using the new layers mode by default.

## Motivation

- Reduces CSS filesize
- Prevents users from using the already deprecated old layers mode
- Removes the following console warnings:

```log
risk - There are upcoming breaking changes: purgeLayersByDefault
risk - We highly recommend opting-in to these changes now to simplify upgrading Tailwind in the future.
risk - https://tailwindcss.com/docs/upcoming-changes
```

[more info](https://tailwindcss.com/docs/upcoming-changes)