### PR TITLE
feat: sort query string in link construction

### DIFF
--- a/packages/next/next-server/lib/router/utils/querystring.ts
+++ b/packages/next/next-server/lib/router/utils/querystring.ts
@@ -16,7 +16,7 @@ export function searchParamsToUrlQuery(
   return query
 }
 
-function stringifyUrlQueryParam(param: string): string {
+function stringifyUrlQueryParam(param: string | number | boolean): string {
   if (
     typeof param === 'string' ||
     (typeof param === 'number' && !isNaN(param)) ||
@@ -39,6 +39,9 @@ export function urlQueryToSearchParams(
       result.set(key, stringifyUrlQueryParam(value))
     }
   })
+
+  result.sort()
+
   return result
 }
 
@@ -50,5 +53,8 @@ export function assign(
     Array.from(searchParams.keys()).forEach((key) => target.delete(key))
     searchParams.forEach((value, key) => target.append(key, value))
   })
+
+  target.sort()
+
   return target
 }

--- a/test/unit/querystring.test.js
+++ b/test/unit/querystring.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+import {
+  urlQueryToSearchParams,
+  assign,
+} from 'next/dist/next-server/lib/router/utils/querystring'
+
+describe('querystring', () => {
+  describe('urlQueryToSearchParams', () => {
+    it('should construct a sorted url query', () => {
+      const result = urlQueryToSearchParams({
+        foo: 1,
+        baz: false,
+        bar: '2',
+        bla: ['2', 1, false],
+      })
+      expect(result.toString()).toBe(
+        `bar=2&baz=false&bla=2&bla=1&bla=false&foo=1`
+      )
+    })
+
+    it('should convert none string/number/boolean values to empty string', () => {
+      const result = urlQueryToSearchParams({
+        foo: 1,
+        bar: null,
+        baz: undefined,
+        obj: { val: '1' },
+      })
+      expect(result.toString()).toBe(`bar=&baz=&foo=1&obj=`)
+    })
+  })
+
+  describe('assign', () => {
+    it('should assign rest to target and return a sorted URLSearchParams', () => {
+      let target = new URLSearchParams()
+      const result = assign(
+        target,
+        new URLSearchParams('foo=1&bar=false'),
+        new URLSearchParams({ baz: 'val' })
+      )
+      expect(result.toString()).toBe(`bar=false&baz=val&foo=1`)
+    })
+  })
+})


### PR DESCRIPTION
This PR sorts query string in order to construct a consistent urls, since it is important for SEO.

SEO wise, 2 urls with the same qs **but** with a different order considered as 2 separate urls.