### PR TITLE
Refactor parseRelativeUrl

### DIFF
--- a/packages/next/next-server/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/next-server/lib/router/utils/parse-relative-url.ts
@@ -1,38 +1,24 @@
-import { getLocationOrigin } from '../../utils'
 import { searchParamsToUrlQuery } from './querystring'
 
-const DUMMY_BASE = new URL(
-  typeof window === 'undefined' ? 'http://n' : getLocationOrigin()
-)
-
 /**
- * Parses path-relative urls (e.g. `/hello/world?foo=bar`). If url isn't path-relative
- * (e.g. `./hello`) then at least base must be.
- * Absolute urls are rejected with one exception, in the browser, absolute urls that are on
- * the current origin will be parsed as relative
+ * Parses path-relative urls (e.g. `/hello/world?foo=bar`).
  */
-export function parseRelativeUrl(url: string, base?: string) {
-  const resolvedBase = base ? new URL(base, DUMMY_BASE) : DUMMY_BASE
-  const {
-    pathname,
-    searchParams,
-    search,
-    hash,
-    href,
-    origin,
-    protocol,
-  } = new URL(url, resolvedBase)
-  if (
-    origin !== DUMMY_BASE.origin ||
-    (protocol !== 'http:' && protocol !== 'https:')
-  ) {
+export function parseRelativeUrl(url: string) {
+  const fakeOrigin = 'http://n'
+  const { pathname, searchParams, search, hash, href, origin } = new URL(
+    url,
+    fakeOrigin
+  )
+
+  if (origin !== fakeOrigin) {
     throw new Error('invariant: invalid relative URL')
   }
+
   return {
     pathname,
     query: searchParamsToUrlQuery(searchParams),
     search,
     hash,
-    href: href.slice(DUMMY_BASE.origin.length),
+    href: href.slice(fakeOrigin.length),
   }
 }


### PR DESCRIPTION
**Status:** draft

## Changes

- removes unused `base` param
- allow other schemes than `http:` and `https:`
- removes unnecessary `new URL` parse roundtrips
- makes `parseRelativeUrl` a pure function

## Related

closes #17216
fixes #16456 #16650 

## Todo

- [ ] add tests
