### PR TITLE
Add handling for domain to locale mapping

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -780,7 +780,6 @@ export default async function build(
             const isFallback = isSsg && ssgStaticFallbackPages.has(page)
 
             for (const locale of i18n.locales) {
-              if (!isSsg && locale === i18n.defaultLocale) continue
               // skip fallback generation for SSG pages without fallback mode
               if (isSsg && isDynamic && !isFallback) continue
               const outputPath = `/${locale}${page === '/' ? '' : page}`
@@ -869,22 +868,19 @@ export default async function build(
       // for SSG files with i18n the non-prerendered variants are
       // output with the locale prefixed so don't attempt moving
       // without the prefix
-      if (!i18n || !isSsg || additionalSsgFile) {
+      if (!i18n || additionalSsgFile) {
         await promises.mkdir(path.dirname(dest), { recursive: true })
         await promises.rename(orig, dest)
+      } else if (i18n && !isSsg) {
+        // this will be updated with the locale prefixed variant
+        // since all files are output with the locale prefix
+        delete pagesManifest[page]
       }
 
       if (i18n) {
         if (additionalSsgFile) return
 
         for (const locale of i18n.locales) {
-          // auto-export default locale files exist at root
-          // TODO: should these always be prefixed with locale
-          // similar to SSG prerender/fallback files?
-          if (!isSsg && locale === i18n.defaultLocale) {
-            continue
-          }
-
           const localeExt = page === '/' ? path.extname(file) : ''
           const relativeDestNoPages = relativeDest.substr('pages/'.length)
 

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -269,7 +269,6 @@ const nextServerlessLoader: loader.Loader = function () {
         return
       }
 
-      // TODO: domain based locales (domain to locale mapping needs to be provided in next.config.js)
       const localePathResult = normalizeLocalePath(parsedUrl.pathname, locales)
 
       if (localePathResult.detectedLocale) {

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -222,24 +222,33 @@ const nextServerlessLoader: loader.Loader = function () {
       const i18n = ${i18n}
       const accept = require('@hapi/accept')
       const { detectLocaleCookie } = require('next/dist/next-server/lib/i18n/detect-locale-cookie')
+      const { detectDomainLocales } = require('next/dist/next-server/lib/i18n/detect-domain-locales')
       const { normalizeLocalePath } = require('next/dist/next-server/lib/i18n/normalize-locale-path')
       let detectedLocale = detectLocaleCookie(req, i18n.locales)
+
+      const { defaultLocale, locales } = detectDomainLocales(
+        req,
+        i18n.domains,
+        i18n.locales,
+        i18n.defaultLocale,
+      )
 
       if (!detectedLocale) {
         detectedLocale = accept.language(
           req.headers['accept-language'],
-          i18n.locales
+          locales
         )
       }
 
       const denormalizedPagePath = denormalizePagePath(parsedUrl.pathname || '/')
-      const detectedDefaultLocale = detectedLocale === i18n.defaultLocale
+      const detectedDefaultLocale = !detectedLocale || detectedLocale === defaultLocale
       const shouldStripDefaultLocale =
         detectedDefaultLocale &&
-        denormalizedPagePath === \`/\${i18n.defaultLocale}\`
+        denormalizedPagePath === \`/\${defaultLocale}\`
       const shouldAddLocalePrefix =
         !detectedDefaultLocale && denormalizedPagePath === '/'
-      detectedLocale = detectedLocale || i18n.defaultLocale
+
+      detectedLocale = detectedLocale || defaultLocale
 
       if (
         !fromExport &&
@@ -261,7 +270,7 @@ const nextServerlessLoader: loader.Loader = function () {
       }
 
       // TODO: domain based locales (domain to locale mapping needs to be provided in next.config.js)
-      const localePathResult = normalizeLocalePath(parsedUrl.pathname, i18n.locales)
+      const localePathResult = normalizeLocalePath(parsedUrl.pathname, locales)
 
       if (localePathResult.detectedLocale) {
         detectedLocale = localePathResult.detectedLocale
@@ -272,11 +281,13 @@ const nextServerlessLoader: loader.Loader = function () {
         parsedUrl.pathname = localePathResult.pathname
       }
 
-      detectedLocale = detectedLocale || i18n.defaultLocale
+      detectedLocale = detectedLocale || defaultLocale
     `
     : `
       const i18n = {}
       const detectedLocale = undefined
+      const defaultLocale = undefined
+      const locales = undefined
     `
 
   if (page.match(API_ROUTE)) {
@@ -468,8 +479,8 @@ const nextServerlessLoader: loader.Loader = function () {
             nextExport: fromExport,
             isDataReq: _nextData,
             locale: detectedLocale,
-            locales: i18n.locales,
-            defaultLocale: i18n.defaultLocale,
+            locales,
+            defaultLocale,
           },
           options,
         )

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -11,11 +11,7 @@ import type {
   AppProps,
   PrivateRouteInfo,
 } from '../next-server/lib/router/router'
-import {
-  delBasePath,
-  hasBasePath,
-  delLocale,
-} from '../next-server/lib/router/router'
+import { delBasePath, hasBasePath } from '../next-server/lib/router/router'
 import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
 import * as querystring from '../next-server/lib/router/utils/querystring'
 import * as envConfig from '../next-server/lib/runtime-config'
@@ -65,10 +61,9 @@ const {
   isFallback,
   head: initialHeadData,
   locales,
-  defaultLocale,
 } = data
 
-let { locale } = data
+let { locale, defaultLocale } = data
 
 const prefix = assetPrefix || ''
 
@@ -88,19 +83,21 @@ if (hasBasePath(asPath)) {
   asPath = delBasePath(asPath)
 }
 
-asPath = delLocale(asPath, locale)
-
 if (process.env.__NEXT_i18n_SUPPORT) {
   const {
     normalizeLocalePath,
   } = require('../next-server/lib/i18n/normalize-locale-path')
 
-  if (isFallback && locales) {
+  if (locales) {
     const localePathResult = normalizeLocalePath(asPath, locales)
 
     if (localePathResult.detectedLocale) {
       asPath = asPath.substr(localePathResult.detectedLocale.length + 1)
-      locale = localePathResult.detectedLocale
+    } else {
+      // derive the default locale if it wasn't detected in the asPath
+      // since we don't prerender static pages with all possible default
+      // locales
+      defaultLocale = locale
     }
   }
 }

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -203,23 +203,13 @@ export default class PageLoader {
    * @param {string} href the route href (file-system path)
    * @param {string} asPath the URL as shown in browser (virtual path); used for dynamic routes
    */
-  getDataHref(
-    href: string,
-    asPath: string,
-    ssg: boolean,
-    locale?: string,
-    defaultLocale?: string
-  ) {
+  getDataHref(href: string, asPath: string, ssg: boolean, locale?: string) {
     const { pathname: hrefPathname, query, search } = parseRelativeUrl(href)
     const { pathname: asPathname } = parseRelativeUrl(asPath)
     const route = normalizeRoute(hrefPathname)
 
     const getHrefForSlug = (path: string) => {
-      const dataRoute = addLocale(
-        getAssetPathFromRoute(path, '.json'),
-        locale,
-        defaultLocale
-      )
+      const dataRoute = addLocale(getAssetPathFromRoute(path, '.json'), locale)
       return addBasePath(
         `/_next/data/${this.buildId}${dataRoute}${ssg ? '' : search}`
       )
@@ -239,12 +229,7 @@ export default class PageLoader {
    * @param {string} href the route href (file-system path)
    * @param {string} asPath the URL as shown in browser (virtual path); used for dynamic routes
    */
-  prefetchData(
-    href: string,
-    asPath: string,
-    locale?: string,
-    defaultLocale?: string
-  ) {
+  prefetchData(href: string, asPath: string, locale?: string) {
     const { pathname: hrefPathname } = parseRelativeUrl(href)
     const route = normalizeRoute(hrefPathname)
     return this.promisedSsgManifest!.then(
@@ -252,13 +237,7 @@ export default class PageLoader {
         // Check if the route requires a data file
         s.has(route) &&
         // Try to generate data href, noop when falsy
-        (_dataHref = this.getDataHref(
-          href,
-          asPath,
-          true,
-          locale,
-          defaultLocale
-        )) &&
+        (_dataHref = this.getDataHref(href, asPath, true, locale)) &&
         // noop when data has already been prefetched (dedupe)
         !document.querySelector(
           `link[rel="${relPrefetch}"][href^="${_dataHref}"]`

--- a/packages/next/next-server/lib/i18n/detect-domain-locales.ts
+++ b/packages/next/next-server/lib/i18n/detect-domain-locales.ts
@@ -1,0 +1,37 @@
+import { IncomingMessage } from 'http'
+
+export function detectDomainLocales(
+  req: IncomingMessage,
+  domainItems:
+    | Array<{
+        domain: string
+        locales: string[]
+        defaultLocale: string
+      }>
+    | undefined,
+  locales: string[],
+  defaultLocale: string
+) {
+  let curDefaultLocale = defaultLocale
+  let curLocales = locales
+
+  const { host } = req.headers
+
+  if (host && domainItems) {
+    // remove port from host and remove port if present
+    const hostname = host.split(':')[0].toLowerCase()
+
+    for (const item of domainItems) {
+      if (hostname === item.domain.toLowerCase()) {
+        curDefaultLocale = item.defaultLocale
+        curLocales = item.locales
+        break
+      }
+    }
+  }
+
+  return {
+    defaultLocale: curDefaultLocale,
+    locales: curLocales,
+  }
+}

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -974,8 +974,7 @@ export default class Router implements BaseRouter {
           formatWithValidation({ pathname, query }),
           delBasePath(as),
           __N_SSG,
-          this.locale,
-          this.defaultLocale
+          this.locale
         )
       }
 

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -227,6 +227,47 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       throw new Error(`Specified i18n.defaultLocale should be a string`)
     }
 
+    if (typeof i18n.domains !== 'undefined' && !Array.isArray(i18n.domains)) {
+      throw new Error(
+        `Specified i18n.domains must be an array of domain objects e.g. [ { domain: 'example.fr', defaultLocale: 'fr', locales: ['fr'] } ] received ${typeof i18n.domains}`
+      )
+    }
+
+    if (i18n.domains) {
+      const invalidDomainItems = i18n.domains.filter((item: any) => {
+        if (!item || typeof item !== 'object') return true
+        if (!item.defaultLocale) return true
+        if (!item.domain || typeof item.domain !== 'string') return true
+        if (!item.locales || !Array.isArray(item.locales)) return true
+
+        const invalidLocales = item.locales.filter(
+          (locale: string) => !i18n.locales.includes(locale)
+        )
+
+        if (invalidLocales.length > 0) {
+          console.error(
+            `i18n.domains item "${
+              item.domain
+            }" has the following locales (${invalidLocales.join(
+              ', '
+            )}) that aren't provided in the main i18n.locales. Add them to the i18n.locales list or remove them from the domains item locales to continue.\n`
+          )
+          return true
+        }
+        return false
+      })
+
+      if (invalidDomainItems.length > 0) {
+        throw new Error(
+          `Invalid i18n.domains values:\n${invalidDomainItems
+            .map((item: any) => JSON.stringify(item))
+            .join(
+              '\n'
+            )}\n\ndomains value must follow format { domain: 'example.fr', defaultLocale: 'fr', locales: ['fr'] }`
+        )
+      }
+    }
+
     if (!Array.isArray(i18n.locales)) {
       throw new Error(
         `Specified i18n.locales must be an array of locale strings e.g. ["en-US", "nl-NL"] received ${typeof i18n.locales}`

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -79,6 +79,7 @@ import accept from '@hapi/accept'
 import { normalizeLocalePath } from '../lib/i18n/normalize-locale-path'
 import { detectLocaleCookie } from '../lib/i18n/detect-locale-cookie'
 import * as Log from '../../build/output/log'
+import { detectDomainLocales } from '../lib/i18n/detect-domain-locales'
 
 const getCustomRouteMatcher = pathMatch(true)
 
@@ -193,8 +194,6 @@ export default class Server {
           ? requireFontManifest(this.distDir, this._isLikeServerless)
           : null,
       optimizeImages: this.nextConfig.experimental.optimizeImages,
-      locales: this.nextConfig.experimental.i18n?.locales,
-      defaultLocale: this.nextConfig.experimental.i18n?.defaultLocale,
     }
 
     // Only the `publicRuntimeConfig` key is exposed to the client side
@@ -309,21 +308,29 @@ export default class Server {
       const { pathname, ...parsed } = parseUrl(req.url || '/')
       let detectedLocale = detectLocaleCookie(req, i18n.locales)
 
+      const { defaultLocale, locales } = detectDomainLocales(
+        req,
+        i18n.domains,
+        i18n.locales,
+        i18n.defaultLocale
+      )
+
       if (!detectedLocale) {
         detectedLocale = accept.language(
           req.headers['accept-language'],
-          i18n.locales
+          locales
         )
       }
 
       const denormalizedPagePath = denormalizePagePath(pathname || '/')
-      const detectedDefaultLocale = detectedLocale === i18n.defaultLocale
+      const detectedDefaultLocale =
+        !detectedLocale || detectedLocale === defaultLocale
       const shouldStripDefaultLocale =
-        detectedDefaultLocale &&
-        denormalizedPagePath === `/${i18n.defaultLocale}`
+        detectedDefaultLocale && denormalizedPagePath === `/${defaultLocale}`
       const shouldAddLocalePrefix =
         !detectedDefaultLocale && denormalizedPagePath === '/'
-      detectedLocale = detectedLocale || i18n.defaultLocale
+
+      detectedLocale = detectedLocale || defaultLocale
 
       if (
         i18n.localeDetection !== false &&
@@ -342,8 +349,7 @@ export default class Server {
         return
       }
 
-      // TODO: domain based locales (domain to locale mapping needs to be provided in next.config.js)
-      const localePathResult = normalizeLocalePath(pathname!, i18n.locales)
+      const localePathResult = normalizeLocalePath(pathname!, locales)
 
       if (localePathResult.detectedLocale) {
         detectedLocale = localePathResult.detectedLocale
@@ -354,7 +360,12 @@ export default class Server {
         parsedUrl.pathname = localePathResult.pathname
       }
 
-      parsedUrl.query.__nextLocale = detectedLocale || i18n.defaultLocale
+      // TODO: render with domain specific locales and defaultLocale also?
+      // Currently locale specific domains will have all locales populated
+      // under router.locales instead of only the domain specific ones
+      parsedUrl.query.__nextLocales = i18n.locales
+      // parsedUrl.query.__nextDefaultLocale = defaultLocale
+      parsedUrl.query.__nextLocale = detectedLocale || defaultLocale
     }
 
     res.statusCode = 200
@@ -504,13 +515,21 @@ export default class Server {
 
           if (i18n) {
             const localePathResult = normalizeLocalePath(pathname, i18n.locales)
-            let detectedLocale = detectLocaleCookie(req, i18n.locales)
+            const { defaultLocale } = detectDomainLocales(
+              req,
+              i18n.domains,
+              i18n.locales,
+              i18n.defaultLocale
+            )
+            let detectedLocale = defaultLocale
 
             if (localePathResult.detectedLocale) {
               pathname = localePathResult.pathname
               detectedLocale = localePathResult.detectedLocale
             }
-            _parsedUrl.query.__nextLocale = detectedLocale || i18n.defaultLocale
+            _parsedUrl.query.__nextLocales = i18n.locales
+            _parsedUrl.query.__nextLocale = detectedLocale
+            // _parsedUrl.query.__nextDefaultLocale = defaultLocale
           }
           pathname = getRouteFromAssetPath(pathname, '.json')
 
@@ -1037,6 +1056,18 @@ export default class Server {
           pagePath!,
           !this.renderOpts.dev && this._isLikeServerless
         )
+        // if loading an static HTML file the locale is required
+        // to be present since all HTML files are output under their locale
+        if (
+          query.__nextLocale &&
+          typeof components.Component === 'string' &&
+          !pagePath?.startsWith(`/${query.__nextLocale}`)
+        ) {
+          const err = new Error('NOT_FOUND')
+          ;(err as any).code = 'ENOENT'
+          throw err
+        }
+
         return {
           components,
           query: {
@@ -1045,6 +1076,8 @@ export default class Server {
                   amp: query.amp,
                   _nextDataReq: query._nextDataReq,
                   __nextLocale: query.__nextLocale,
+                  __nextLocales: query.__nextLocales,
+                  // __nextDefaultLocale: query.__nextDefaultLocale,
                 }
               : query),
             ...(params || {}),
@@ -1156,7 +1189,11 @@ export default class Server {
     }
 
     const locale = query.__nextLocale as string
+    const locales = query.__nextLocales as string[]
+    // const defaultLocale = query.__nextDefaultLocale as string
     delete query.__nextLocale
+    delete query.__nextLocales
+    // delete query.__nextDefaultLocale
 
     const ssgCacheKey =
       isPreviewMode || !isSSG
@@ -1230,7 +1267,8 @@ export default class Server {
             {
               fontManifest: this.renderOpts.fontManifest,
               locale,
-              locales: this.renderOpts.locales,
+              locales,
+              // defaultLocale,
             }
           )
 
@@ -1251,6 +1289,8 @@ export default class Server {
             isDataReq,
             resolvedUrl,
             locale,
+            locales,
+            // defaultLocale,
             // For getServerSideProps we need to ensure we use the original URL
             // and not the resolved URL to prevent a hydration mismatch on
             // asPath

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -414,6 +414,8 @@ export async function renderToHTML(
   const isFallback = !!query.__nextFallback
   delete query.__nextFallback
   delete query.__nextLocale
+  delete query.__nextLocales
+  delete query.__nextDefaultLocale
 
   const isSSG = !!getStaticProps
   const isBuildTimeSSG = isSSG && renderOpts.nextExport

--- a/test/integration/i18n-support/next.config.js
+++ b/test/integration/i18n-support/next.config.js
@@ -2,8 +2,20 @@ module.exports = {
   // target: 'experimental-serverless-trace',
   experimental: {
     i18n: {
-      locales: ['nl-NL', 'nl-BE', 'nl', 'en-US', 'en'],
+      locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en-US', 'en'],
       defaultLocale: 'en-US',
+      domains: [
+        {
+          domain: 'example.be',
+          defaultLocale: 'nl-BE',
+          locales: ['nl-BE', 'fr-BE'],
+        },
+        {
+          domain: 'example.fr',
+          locales: ['fr', 'fr-BE'],
+          defaultLocale: 'fr',
+        },
+      ],
     },
   },
 }


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/17370 this adds mapping of locales to domains and handles default locales for specific domains also allowing specifying which locales can be visited for each domain. 

This PR also updates to output all statically generated pages under the locale prefix to make it easier to locate/lookup and to not redirect to the default locale prefixed path when no `accept-language` header is provided. 