### PR TITLE
Add pnpm integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "npm-run-all": "4.1.5",
     "nprogress": "0.2.0",
     "pixrem": "5.0.0",
+    "pnpm": "5.8.0",
     "postcss-nested": "4.2.1",
     "postcss-pseudoelements": "5.0.0",
     "postcss-short-size": "4.0.0",

--- a/test/integration/pnpm/app/package.json
+++ b/test/integration/pnpm/app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pnpm-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  }
+}

--- a/test/integration/pnpm/app/pages/index.js
+++ b/test/integration/pnpm/app/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <h1>Hello World</h1>

--- a/test/integration/pnpm/test/index.test.js
+++ b/test/integration/pnpm/test/index.test.js
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+import execa from 'execa'
+import fs from 'fs-extra'
+import os from 'os'
+import path from 'path'
+
+const pnpmExecutable = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'node_modules',
+  '.bin',
+  'pnpm'
+)
+const nextPackageDir = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'packages',
+  'next'
+)
+const appDir = path.join(__dirname, '..', 'app')
+
+jest.setTimeout(1000 * 60 * 5)
+
+const runPnpm = (cwd, ...args) => execa(pnpmExecutable, [...args], { cwd })
+
+async function usingTempDir(fn) {
+  const folder = path.join(os.tmpdir(), Math.random().toString(36).substring(2))
+  await fs.mkdirp(folder)
+  try {
+    return await fn(folder)
+  } finally {
+    await fs.remove(folder)
+  }
+}
+
+async function packNextTarball(fn) {
+  const { stdout } = await execa(pnpmExecutable, ['pack'], {
+    cwd: nextPackageDir,
+  })
+  const tarballFilename = stdout.match(/.*\.tgz/)[0]
+
+  if (!tarballFilename) {
+    throw new Error(
+      `pnpm failed to pack "next" package tarball in directory ${nextPackageDir}.`
+    )
+  }
+
+  const tarballPath = path.join(nextPackageDir, tarballFilename)
+  try {
+    return await fn(tarballPath)
+  } finally {
+    await fs.unlink(tarballPath)
+  }
+}
+
+describe('pnpm support', () => {
+  it('should build with dependencies installed via pnpm', async () => {
+    // Create a Next.js app in a temporary directory, and install dependencies with pnpm.
+    // "next" is installed by packing a tarball from 'next.js/packages/next', because installing
+    // "next" directly via `pnpm add path/to/next.js/packages/next` results in a symlink:
+    // 'app/node_modules/next' -> 'path/to/next.js/packages/next'. This is undesired since modules
+    // inside "next" would be resolved to the next.js monorepo 'node_modules'; installing from a
+    // tarball avoids this issue.
+    await usingTempDir(async (cwd) => {
+      await packNextTarball(async (nextTarballPath) => {
+        await fs.copy(appDir, cwd)
+        await runPnpm(cwd, 'install')
+        await runPnpm(cwd, 'add', nextTarballPath)
+
+        expect(
+          require(path.join(cwd, 'package.json')).dependencies['next']
+        ).toBe(`file:${nextTarballPath}`)
+        expect(
+          await fs.pathExists(path.join(cwd, 'pnpm-lock.yaml'))
+        ).toBeTruthy()
+
+        const { stdout } = await runPnpm(cwd, 'run', 'build')
+        expect(stdout).toMatch(/Compiled successfully/)
+      })
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -12587,6 +12587,11 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+pnpm@5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/pnpm/-/pnpm-5.8.0.tgz#a933d6c756efe8795b12004bbff1b82c622e771b"
+  integrity sha512-J2rAxEXnohwcDkR4KNI6UsYhDs9hJ/tje/BahHpXawi406pmxd6caJUXfRxZPbKvKdyVqfBRKhlX1vyhYbM8lQ==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"


### PR DESCRIPTION
Add a (failing) pnpm integration test.

This is also included in https://github.com/vercel/next.js/pull/16369, but creating this pull request to demonstrate via a CI build that the test fails without the fix.

Going to close this as soon as the build fails with the correct error.