### PR TITLE
Fix higherOrderComponent causing broken layout

### DIFF
--- a/docs/basic-features/fast-refresh.md
+++ b/docs/basic-features/fast-refresh.md
@@ -75,7 +75,7 @@ local state being reset on every edit to a file:
 - The file you're editing might have _other_ exports in addition to a React
   component.
 - Sometimes, a file would export the result of calling higher-order component
-  like `higherOrderComponent(WrappedComponent)`. If the returned component is a
+  like `HOC(WrappedComponent)`. If the returned component is a
   class, state will be reset.
 
 As more of your codebase moves to function components and Hooks, you can expect


### PR DESCRIPTION
`higherOrderComponent(WrappedComponent)` causing the layout broken in mobile screen. 
* refer to screenshots below.


![image](https://user-images.githubusercontent.com/43801058/95730641-faaa6c80-0c97-11eb-9951-2a47b61cefad.png)
![image](https://user-images.githubusercontent.com/43801058/95730661-0138e400-0c98-11eb-9f02-b4d0676fd21b.png)

if we could make it `HOC(WrappedComponent)` it will not break the layout in mobile screen
![image](https://user-images.githubusercontent.com/43801058/95730673-04cc6b00-0c98-11eb-8782-2fa1f760f8fd.png)
