### PR TITLE
docs: Clarify use of getStaticProps / getServerSideProps with app / document

### DIFF
--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -44,6 +44,7 @@ The `Component` prop is the active `page`, so whenever you navigate between rout
 
 - If your app is running and you just added a custom `App`, you'll need to restart the development server. Only required if `pages/_app.js` didn't exist before.
 - Adding a custom `getInitialProps` in your `App` will disable [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) in pages without [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation).
+- `App` does not support [`getServerSideProps`](/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) or [`getStaticProps`](/docs/basic-features/data-fetching#getstaticprops-static-generation).
 
 ### TypeScript
 

--- a/docs/advanced-features/custom-app.md
+++ b/docs/advanced-features/custom-app.md
@@ -44,7 +44,7 @@ The `Component` prop is the active `page`, so whenever you navigate between rout
 
 - If your app is running and you just added a custom `App`, you'll need to restart the development server. Only required if `pages/_app.js` didn't exist before.
 - Adding a custom `getInitialProps` in your `App` will disable [Automatic Static Optimization](/docs/advanced-features/automatic-static-optimization.md) in pages without [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation).
-- `App` does not support [`getServerSideProps`](/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) or [`getStaticProps`](/docs/basic-features/data-fetching#getstaticprops-static-generation).
+- `App` currently does not support Next.js [Data Fetching methods](/docs/basic-features/data-fetching.md) like [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) or [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering).
 
 ### TypeScript
 

--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -54,7 +54,7 @@ The `ctx` object is equivalent to the one received in [`getInitialProps`](/docs/
 - `Document` is only rendered in the server, event handlers like `onClick` won't work.
 - React components outside of `<Main />` will not be initialized by the browser. Do _not_ add application logic here or custom CSS (like `styled-jsx`). If you need shared components in all your pages (like a menu or a toolbar), take a look at the [`App`](/docs/advanced-features/custom-app.md) component instead.
 - `Document`'s `getInitialProps` function is not called during client-side transitions, nor when a page is [statically optimized](/docs/advanced-features/automatic-static-optimization.md).
-- `Document` does not support [`getServerSideProps`](/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) or [`getStaticProps`](/docs/basic-features/data-fetching#getstaticprops-static-generation).
+- `Document` currently does not support Next.js [Data Fetching methods](/docs/basic-features/data-fetching.md) like [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) or [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering).
 
 ## Customizing `renderPage`
 

--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -51,9 +51,10 @@ The `ctx` object is equivalent to the one received in [`getInitialProps`](/docs/
 
 ## Caveats
 
-- `Document` is only rendered in the server, event handlers like `onClick` won't work
-- React components outside of `<Main />` will not be initialized by the browser. Do _not_ add application logic here or custom CSS (like `styled-jsx`). If you need shared components in all your pages (like a menu or a toolbar), take a look at the [`App`](/docs/advanced-features/custom-app.md) component instead
-- `Document`'s `getInitialProps` function is not called during client-side transitions, nor when a page is [statically optimized](/docs/advanced-features/automatic-static-optimization.md)
+- `Document` is only rendered in the server, event handlers like `onClick` won't work.
+- React components outside of `<Main />` will not be initialized by the browser. Do _not_ add application logic here or custom CSS (like `styled-jsx`). If you need shared components in all your pages (like a menu or a toolbar), take a look at the [`App`](/docs/advanced-features/custom-app.md) component instead.
+- `Document`'s `getInitialProps` function is not called during client-side transitions, nor when a page is [statically optimized](/docs/advanced-features/automatic-static-optimization.md).
+- `Document` does not support [`getServerSideProps`](/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) or [`getStaticProps`](/docs/basic-features/data-fetching#getstaticprops-static-generation).
 
 ## Customizing `renderPage`
 


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/17828.

This change adds a caveat to both the "Custom `App`" and "Custom `Document`" pages about how both `getStaticProps` and `getServerSideProps` aren't supported.