### PR TITLE
Public `NextApiError` class with default status messages

### DIFF
--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse } from 'http'
+import { IncomingMessage, ServerResponse, STATUS_CODES } from 'http'
 import { ParsedUrlQuery } from 'querystring'
 import { ComponentType } from 'react'
 import { UrlObject } from 'url'
@@ -266,6 +266,18 @@ export type NextApiHandler<T = any> = (
   req: NextApiRequest,
   res: NextApiResponse<T>
 ) => void | Promise<void>
+
+/**
+ * Next `API` route error
+ */
+export class NextApiError extends Error {
+  readonly statusCode: number
+
+  constructor(statusCode: number, message?: string) {
+    super(message || STATUS_CODES[statusCode])
+    this.statusCode = statusCode
+  }
+}
 
 /**
  * Utils

--- a/packages/next/next-server/server/api-utils.ts
+++ b/packages/next/next-server/server/api-utils.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse } from 'http'
+import { IncomingMessage, ServerResponse, STATUS_CODES } from 'http'
 import { parse } from 'next/dist/compiled/content-type'
 import { CookieSerializeOptions } from 'next/dist/compiled/cookie'
 import generateETag from 'next/dist/compiled/etag'
@@ -511,8 +511,8 @@ function clearPreviewData<T>(res: NextApiResponse<T>): NextApiResponse<T> {
 export class ApiError extends Error {
   readonly statusCode: number
 
-  constructor(statusCode: number, message: string) {
-    super(message)
+  constructor(statusCode: number, message?: string) {
+    super(message || STATUS_CODES[statusCode])
     this.statusCode = statusCode
   }
 }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -12,6 +12,7 @@ import {
   NextApiResponse,
   NextApiRequest,
   NextApiHandler,
+  NextApiError,
   // @ts-ignore This path is generated at build time and conflicts otherwise
 } from '../dist/next-server/lib/utils'
 
@@ -70,6 +71,7 @@ export {
   NextApiResponse,
   NextApiRequest,
   NextApiHandler,
+  NextApiError,
 }
 
 type Redirect = {


### PR DESCRIPTION
This PR makes the [`ApiError` class](https://github.com/vercel/next.js/blob/71d798ce889932311f2ef575c4c80b09ad57bb6f/packages/next/next-server/server/api-utils.ts#L508-L518) available for public use in API routes. It's useful when reusing authorization logic between HTTP methods for a given endpoint, e.g.:

```js
import { NextApiError } from 'next'
import { getSession } from 'next-auth/client'

export default async function handler(req, res) {
  async function authorize() {
    const session = await getSession({ req });

    if (!session) {
      res.setHeader('WWW-Authenticate', 'OAuth')
      throw new NextApiError(401, 'Authentication required')
    }

    if (session.user.email !== 'admin@example.com') {
      throw NextApiError(403) // Message gets set to 'Forbidden', as in RFC 7231
    }
  }

  if (req.method === 'DELETE') {
    await authorize() // Can be reused across mutating HTTP methods
    database.delete(/* Custom business logic... */)
    res.status(204).end()
  } else if (req.method === 'POST') {
    await authorize()
    /* ... */
  } else if (req.method === 'GET') {
    // No authorization is necessary here
    res.json({ hello: 'world' })
  }
}
```