### PR TITLE
Support full-width static paths

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1359,9 +1359,9 @@ export default class Server {
         !staticPaths ||
         // static paths always includes locale so make sure it's prefixed
         // with it
-        !staticPaths.includes(
-          `${locale ? '/' + locale : ''}${resolvedUrlPathname}`
-        ))
+        !staticPaths
+          .map(encodeURI)
+          .includes(`${locale ? '/' + locale : ''}${resolvedUrlPathname}`))
     ) {
       if (
         // In development, fall through to render to handle missing

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1359,9 +1359,11 @@ export default class Server {
         !staticPaths ||
         // static paths always includes locale so make sure it's prefixed
         // with it
-        !staticPaths
-          .map(encodeURI)
-          .includes(`${locale ? '/' + locale : ''}${resolvedUrlPathname}`))
+        !staticPaths.includes(
+          `${locale ? '/' + locale : ''}${decodeURIComponent(
+            resolvedUrlPathname
+          )}`
+        ))
     ) {
       if (
         // In development, fall through to render to handle missing
@@ -1379,7 +1381,7 @@ export default class Server {
         // Production already emitted the fallback as static HTML.
         if (isProduction) {
           html = await this.incrementalCache.getFallback(
-            locale ? `/${locale}${pathname}` : pathname
+            `${locale ? '/' + locale : ''}${decodeURIComponent(pathname)}`
           )
         }
         // We need to generate the fallback on-demand for development.

--- a/packages/next/next-server/server/normalize-page-path.ts
+++ b/packages/next/next-server/server/normalize-page-path.ts
@@ -20,5 +20,5 @@ export function normalizePagePath(page: string): string {
       `Requested and resolved page mismatch: ${page} ${resolvedPage}`
     )
   }
-  return page
+  return decodeURI(page)
 }

--- a/test/integration/prerender/pages/dynamic/[slug].js
+++ b/test/integration/prerender/pages/dynamic/[slug].js
@@ -8,7 +8,11 @@ export async function getStaticProps({ params: { slug } }) {
 
 export async function getStaticPaths() {
   return {
-    paths: [{ params: { slug: '[first]' } }, '/dynamic/[second]'],
+    paths: [
+      { params: { slug: '[first]' } },
+      '/dynamic/[second]',
+      '/dynamic/ｆｕｌｌｗｉｄｔｈ',
+    ],
     fallback: false,
   }
 }

--- a/test/integration/prerender/pages/index.js
+++ b/test/integration/prerender/pages/index.js
@@ -69,6 +69,9 @@ const Page = ({ world, time }) => {
       <Link href="/dynamic/[slug]" as="/dynamic/[second]">
         <a id="dynamic-second">to dynamic [second] page</a>
       </Link>
+      <Link href="/dynamic/[slug]" as="/dynamic/ｆｕｌｌｗｉｄｔｈ">
+        <a id="dynamic-fullwidth">to dynamic ｆｕｌｌｗｉｄｔｈ page</a>
+      </Link>
       <br />
       <Link
         href="/catchall-explicit/[...slug]"

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -177,6 +177,11 @@ const expectedManifestRoutes = () => ({
     initialRevalidateSeconds: false,
     srcRoute: '/dynamic/[slug]',
   },
+  '/dynamic/ｆｕｌｌｗｉｄｔｈ': {
+    dataRoute: `/_next/data/${buildId}/dynamic/ｆｕｌｌｗｉｄｔｈ.json`,
+    initialRevalidateSeconds: false,
+    srcRoute: '/dynamic/[slug]',
+  },
   '/index': {
     dataRoute: `/_next/data/${buildId}/index/index.json`,
     initialRevalidateSeconds: false,
@@ -358,6 +363,17 @@ const navigateTest = (dev = false) => {
     await browser.waitForElementByCss('#home')
     text = await browser.elementByCss('#param').text()
     expect(text).toMatch(/Hi \[second\]!/)
+    expect(await browser.eval('window.didTransition')).toBe(1)
+
+    // go to /
+    await browser.elementByCss('#home').click()
+    await browser.waitForElementByCss('#comment-1')
+
+    // go to /dynamic/ｆｕｌｌｗｉｄｔｈ
+    await browser.elementByCss('#dynamic-fullwidth').click()
+    await browser.waitForElementByCss('#home')
+    text = await browser.elementByCss('#param').text()
+    expect(text).toMatch(/Hi ｆｕｌｌｗｉｄｔｈ!/)
     expect(await browser.eval('window.didTransition')).toBe(1)
 
     // go to /
@@ -571,6 +587,12 @@ const runTests = (dev = false, isEmulatedServerless = false) => {
     const html = await renderViaHTTP(appPort, '/dynamic/[second]')
     const $ = cheerio.load(html)
     expect($('#param').text()).toMatch(/Hi \[second\]!/)
+  })
+
+  it('should SSR dynamic page with fullwidth forms in param as string', async () => {
+    const html = await renderViaHTTP(appPort, '/dynamic/ｆｕｌｌｗｉｄｔｈ')
+    const $ = cheerio.load(html)
+    expect($('#param').text()).toMatch(/Hi ｆｕｌｌｗｉｄｔｈ!/)
   })
 
   it('should navigate to dynamic page with brackets in param as string', async () => {

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -78,7 +78,9 @@ export function fetchViaHTTP(appPort, pathname, query, opts) {
   const url = `http://localhost:${appPort}${pathname}${
     query ? `?${qs.stringify(query)}` : ''
   }`
-  return fetch(url, opts)
+  // node-fetch can't use a URL string containing full-width characters directly
+  const u = new URL(url)
+  return fetch(u, opts)
 }
 
 export function findPort() {


### PR DESCRIPTION
`staticPaths` are unencoded and comparison is encoded. To compare correctly, `encodeURI` is required.