### PR TITLE
(docs) Fixes for "Migrating from Gatsby" doc

### DIFF
--- a/docs/migrating/from-gatsby.md
+++ b/docs/migrating/from-gatsby.md
@@ -128,7 +128,7 @@ import { join } from 'path'
 const postsDirectory = join(process.cwd(), 'src', 'content', 'blog')
 
 export function getPostBySlug(slug) {
-  const realSlug = slug.replace(/\\.md$/, '')
+  const realSlug = slug.replace(/\.md$/, '')
   const fullPath = join(postsDirectory, `${realSlug}.md`)
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const { data, content } = matter(fileContents)

--- a/docs/migrating/from-gatsby.md
+++ b/docs/migrating/from-gatsby.md
@@ -84,10 +84,10 @@ import { getPostBySlug, getAllPosts } from '../lib/blog'
 
 export async function getStaticProps({ params }) {
   const post = getPostBySlug(params.slug)
-  const content = await remark()
+  const markdown = await remark()
     .use(html)
     .process(post.content || '')
-    .toString()
+  const content = markdown.toString()
 
   return {
     props: {


### PR DESCRIPTION
Noticed there's an extra backslash in the example which causes an error. 

**EDIT:**

Also the promise needs to be resolved using `.toString()` before it can be returned as `content` in props.