### PR TITLE
clean up async module loading

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -504,7 +504,8 @@ export default async function build(
     (await hasCustomGetInitialProps(
       getPagePath('/_error', distDir, isLikeServerless),
       runtimeEnvConfig,
-      false
+      false,
+      isLikeServerless
     ))
 
   const analysisBegin = process.hrtime()
@@ -536,7 +537,8 @@ export default async function build(
               ? serverBundle
               : getPagePath('/_app', distDir, isLikeServerless),
             runtimeEnvConfig,
-            true
+            true,
+            isLikeServerless
           )
 
           namedExports = getNamedExports(
@@ -565,7 +567,8 @@ export default async function build(
             serverBundle,
             runtimeEnvConfig,
             config.experimental.i18n?.locales,
-            config.experimental.i18n?.defaultLocale
+            config.experimental.i18n?.defaultLocale,
+            isLikeServerless
           )
 
           if (workerResult.isHybridAmp) {

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -504,8 +504,7 @@ export default async function build(
     (await hasCustomGetInitialProps(
       getPagePath('/_error', distDir, isLikeServerless),
       runtimeEnvConfig,
-      false,
-      isLikeServerless
+      false
     ))
 
   const analysisBegin = process.hrtime()
@@ -537,8 +536,7 @@ export default async function build(
               ? serverBundle
               : getPagePath('/_app', distDir, isLikeServerless),
             runtimeEnvConfig,
-            true,
-            isLikeServerless
+            true
           )
 
           namedExports = getNamedExports(

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -692,7 +692,8 @@ export async function isPageStatic(
   serverBundle: string,
   runtimeEnvConfig: any,
   locales?: string[],
-  defaultLocale?: string
+  defaultLocale?: string,
+  serverless?: boolean
 ): Promise<{
   isStatic?: boolean
   isAmpOnly?: boolean
@@ -704,21 +705,23 @@ export async function isPageStatic(
 }> {
   try {
     require('../next-server/lib/runtime-config').setConfig(runtimeEnvConfig)
-    const mod = await require(serverBundle)
-    const Comp = await (mod.default || mod)
+    const mod = await (serverless
+      ? require(serverBundle)._page
+      : require(serverBundle))
+    const Comp = mod.default || mod
 
     if (!Comp || !isValidElementType(Comp) || typeof Comp === 'string') {
       throw new Error('INVALID_DEFAULT_EXPORT')
     }
 
     const hasGetInitialProps = !!(Comp as any).getInitialProps
-    const hasStaticProps = !!(await mod.getStaticProps)
-    const hasStaticPaths = !!(await mod.getStaticPaths)
-    const hasServerProps = !!(await mod.getServerSideProps)
-    const hasLegacyServerProps = !!(await mod.unstable_getServerProps)
-    const hasLegacyStaticProps = !!(await mod.unstable_getStaticProps)
-    const hasLegacyStaticPaths = !!(await mod.unstable_getStaticPaths)
-    const hasLegacyStaticParams = !!(await mod.unstable_getStaticParams)
+    const hasStaticProps = !!mod.getStaticProps
+    const hasStaticPaths = !!mod.getStaticPaths
+    const hasServerProps = !!mod.getServerSideProps
+    const hasLegacyServerProps = !!mod.unstable_getServerProps
+    const hasLegacyStaticProps = !!mod.unstable_getStaticProps
+    const hasLegacyStaticPaths = !!mod.unstable_getStaticPaths
+    const hasLegacyStaticParams = !!mod.unstable_getStaticParams
 
     if (hasLegacyStaticParams) {
       throw new Error(
@@ -810,14 +813,18 @@ export async function hasCustomGetInitialProps(
   checkingApp: boolean
 ): Promise<boolean> {
   require('../next-server/lib/runtime-config').setConfig(runtimeEnvConfig)
-  let mod = require(bundle)
+  let mod = await require(bundle)
 
   if (checkingApp) {
-    mod = (await mod._app) || mod.default || mod
+    mod =
+      (await mod._app)?.default ||
+      (await mod._page)?.default ||
+      mod.default ||
+      mod
   } else {
-    mod = mod.default || mod
+    mod = (await mod._page)?.default || mod.default || mod
   }
-  mod = await mod
+
   return mod.getInitialProps !== mod.origGetInitialProps
 }
 

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -419,51 +419,34 @@ const nextServerlessLoader: loader.Loader = function () {
     const reactLoadableManifest = require('${reactLoadableManifest}');
 
     const appMod = require('${absoluteAppPath}')
-    let App = appMod.default || appMod.then && appMod.then(mod => mod.default);
 
     ${dynamicRouteImports}
     ${rewriteImports}
 
-    const compMod = require('${absolutePagePath}')
-
-    let Component = compMod.default || compMod.then && compMod.then(mod => mod.default)
-    export default Component
-    export let getStaticProps = compMod['getStaticProp' + 's'] || compMod.then && compMod.then(mod => mod['getStaticProp' + 's'])
-    export let getStaticPaths = compMod['getStaticPath' + 's'] || compMod.then && compMod.then(mod => mod['getStaticPath' + 's'])
-    export let getServerSideProps = compMod['getServerSideProp' + 's'] || compMod.then && compMod.then(mod => mod['getServerSideProp' + 's'])
-
-    // kept for detecting legacy exports
-    export const unstable_getStaticParams = compMod['unstable_getStaticParam' + 's'] || compMod.then && compMod.then(mod => mod['unstable_getStaticParam' + 's'])
-    export const unstable_getStaticProps = compMod['unstable_getStaticProp' + 's'] || compMod.then && compMod.then(mod => mod['unstable_getStaticProp' + 's'])
-    export const unstable_getStaticPaths = compMod['unstable_getStaticPath' + 's'] || compMod.then && compMod.then(mod => mod['unstable_getStaticPath' + 's'])
-    export const unstable_getServerProps = compMod['unstable_getServerProp' + 's'] || compMod.then && compMod.then(mod => mod['unstable_getServerProp' + 's'])
+    const pageMod = require('${absolutePagePath}')
 
     ${dynamicRouteMatcher}
     ${defaultRouteRegex}
     ${normalizeDynamicRouteParams}
     ${handleRewrites}
 
-    export let config = compMod['confi' + 'g'] || (compMod.then && compMod.then(mod => mod['confi' + 'g'])) || {}
-    export const _app = App
+    export const _app = appMod
+    export const _page = pageMod
     export async function renderReqToHTML(req, res, renderMode, _renderOpts, _params) {
-      let Document
-      let Error
-      ;[
-        getStaticProps,
-        getServerSideProps,
-        getStaticPaths,
-        Component,
-        App,
-        config,
+      const [
+        {
+          default: Component,
+          getStaticProps,
+          getServerSideProps,
+          getStaticPaths,
+          config
+        },
+        { default: App },
         { default: Document },
         { default: Error }
       ] = await Promise.all([
-        getStaticProps,
-        getServerSideProps,
-        getStaticPaths,
-        Component,
-        App,
-        config,
+        pageMod,
+        appMod,
         require('${absoluteDocumentPath}'),
         require('${absoluteErrorPath}')
       ])

--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -40,17 +40,12 @@ export async function loadComponents(
   serverless: boolean
 ): Promise<LoadComponentsReturnType> {
   if (serverless) {
-    const Component = await requirePage(pathname, distDir, serverless)
-    let { getStaticProps, getStaticPaths, getServerSideProps } = Component
-
-    getStaticProps = await getStaticProps
-    getStaticPaths = await getStaticPaths
-    getServerSideProps = await getServerSideProps
-    const pageConfig = (await Component.config) || {}
+    const Component = await requirePage(pathname, distDir, serverless)._page
+    const { getStaticProps, getStaticPaths, getServerSideProps } = Component
 
     return {
       Component,
-      pageConfig,
+      pageConfig: Component.config || {},
       getStaticProps,
       getStaticPaths,
       getServerSideProps,


### PR DESCRIPTION
Realized that with a small refactor, https://github.com/vercel/next.js/pull/17590 can be implemented a lot cleaner.

Basically, we should just re-export the whole page and app module promise from the serverless bundle, instead of trying re-exporting the individual exports from those modules as maybe-promises