### PR TITLE
Fixed link for expo

### DIFF
--- a/examples/with-expo-typescript/next.config.js
+++ b/examples/with-expo-typescript/next.config.js
@@ -1,5 +1,5 @@
 // @generated: @expo/next-adapter@2.1.9
-// Learn more: https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/using-nextjs.md#withexpo
+// Learn more: https://github.com/expo/expo/blob/master/docs/pages/guides/using-nextjs.md
 
 const { withExpo } = require('@expo/next-adapter')
 

--- a/examples/with-expo/next.config.js
+++ b/examples/with-expo/next.config.js
@@ -1,5 +1,5 @@
 // @generated: @expo/next-adapter@2.1.5
-// Learn more: https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/guides/using-nextjs.md#withexpo
+// Learn more: https://github.com/expo/expo/blob/master/docs/pages/guides/using-nextjs.md
 
 const { withExpo } = require('@expo/next-adapter')
 


### PR DESCRIPTION
The link was broken, so I changed it.

https://github.com/expo/expo/blob/master/docs/pages/guides/using-nextjs.md