### PR TITLE
Fix initialRevalidateSeconds manifest field with i18n

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -959,13 +959,19 @@ export default async function build(
       }
 
       if (isSsg) {
+        const { i18n } = config.experimental
+
         // For a non-dynamic SSG page, we must copy its data file from export.
         if (!isDynamic) {
           await moveExportedPage(page, page, file, true, 'json')
 
+          const revalidationMapPath = i18n
+            ? `/${i18n.defaultLocale}${page}`
+            : page
+
           finalPrerenderRoutes[page] = {
             initialRevalidateSeconds:
-              exportConfig.initialPageRevalidationMap[page],
+              exportConfig.initialPageRevalidationMap[revalidationMapPath],
             srcRoute: null,
             dataRoute: path.posix.join('/_next/data', buildId, `${file}.json`),
           }
@@ -973,7 +979,7 @@ export default async function build(
           const pageInfo = pageInfos.get(page)
           if (pageInfo) {
             pageInfo.initialRevalidateSeconds =
-              exportConfig.initialPageRevalidationMap[page]
+              exportConfig.initialPageRevalidationMap[revalidationMapPath]
             pageInfos.set(page, pageInfo)
           }
         } else {


### PR DESCRIPTION
This makes sure the correct `initialRevalidateSeconds` field is populated in the `prerender-manifest` for non-dynamic SSG pages since they will be inserted into the `initialPageRevalidationMap` under their locale prefixed variant with `i18n` enabled

x-ref: https://github.com/vercel/next.js/pull/17370