### PR TITLE
Add missing next/image package file

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -30,6 +30,8 @@
     "error.d.ts",
     "head.js",
     "head.d.ts",
+    "image.js",
+    "image.d.ts",
     "link.js",
     "link.d.ts",
     "router.js",


### PR DESCRIPTION
Noticed this was missing so `next/image` would not be exposed.