### PR TITLE
Fix width param name for Image Optimizer

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -180,5 +180,5 @@ function cloudinaryLoader({ root, src, width }: LoaderProps): string {
 
 function defaultLoader({ root, src, width }: LoaderProps): string {
   // TODO: change quality parameter to be configurable
-  return `${root}?url=${encodeURIComponent(src)}&width=${width}&q=100`
+  return `${root}?url=${encodeURIComponent(src)}&w=${width}&q=100`
 }


### PR DESCRIPTION
Image Optimizer only accepts the name of the width parameter as a `w`.

ref https://github.com/vercel/next.js/blob/v9.5.6-canary.3/packages/next/next-server/server/image-optimizer.ts#L71