### PR TITLE
Make sure `w` parameter is only included when a width is provided.

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -178,5 +178,7 @@ function cloudinaryLoader({ root, src, width }: LoaderProps): string {
 
 function defaultLoader({ root, src, width }: LoaderProps): string {
   // TODO: change quality parameter to be configurable
-  return `${root}?url=${encodeURIComponent(src)}&w=${width}&q=100`
+  return `${root}?url=${encodeURIComponent(src)}&${
+    width ? `w=${width}&` : ''
+  }q=100`
 }


### PR DESCRIPTION
This makes sure there's no `w=undefined` in the url. Tests exist in #17970 but since that's intentionally failing right now this can be landed separately.