### PR TITLE
Enable `purgeLayersByDefault` on examples using tailwindcss

### DIFF
--- a/examples/blog-starter-typescript/tailwind.config.js
+++ b/examples/blog-starter-typescript/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.tsx', './pages/**/*.tsx'],
   theme: {
     extend: {

--- a/examples/blog-starter/tailwind.config.js
+++ b/examples/blog-starter/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-buttercms/tailwind.config.js
+++ b/examples/cms-buttercms/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-cosmic/tailwind.config.js
+++ b/examples/cms-cosmic/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-datocms/tailwind.config.js
+++ b/examples/cms-datocms/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-graphcms/tailwind.config.js
+++ b/examples/cms-graphcms/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-kontent/tailwind.config.js
+++ b/examples/cms-kontent/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-storyblok/tailwind.config.js
+++ b/examples/cms-storyblok/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-strapi/tailwind.config.js
+++ b/examples/cms-strapi/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {

--- a/examples/cms-wordpress/tailwind.config.js
+++ b/examples/cms-wordpress/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  future: {
+    purgeLayersByDefault: true,
+  },
   purge: ['./components/**/*.js', './pages/**/*.js'],
   theme: {
     extend: {


### PR DESCRIPTION
The newer tailwindcss emits the warning, like:
```
warn - The `conservative` purge mode will be removed in Tailwind 2.0.
warn - Please switch to the new `layers` mode instead.
```

This should remove it on the examples using tailwindcss with the `purge` config. #17742 applied the new config to one example but this applies it to (hopefully) all the examples here.
ref. https://tailwindcss.com/docs/upcoming-changes#purge-layers-by-default