### PR TITLE
Ease transition to tailwindcss v2.0

### DIFF
--- a/examples/with-tailwindcss/tailwind.config.js
+++ b/examples/with-tailwindcss/tailwind.config.js
@@ -2,6 +2,8 @@ module.exports = {
   future: {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
+    defaultLineHeights: true,
+    standardFontWeights: true,
   },
   purge: ['./components/**/*.{js,ts,jsx,tsx}', './pages/**/*.{js,ts,jsx,tsx}'],
   theme: {


### PR DESCRIPTION
As mentioned in the official documentation of tailwindcss about [upcoming breaking changes](https://tailwindcss.com/docs/upcoming-changes#default-line-heights-for-font-size-utilities), two more flags have been added:
- Default line heights for font size utilities
- Rename font-thin and font-hairline