### PR TITLE
fix wrong url in HttpLink

### DIFF
--- a/examples/with-typescript-graphql/lib/apollo.ts
+++ b/examples/with-typescript-graphql/lib/apollo.ts
@@ -21,7 +21,7 @@ function createIsomorphLink(context: ResolverContext = {}) {
   } else {
     const { HttpLink } = require('@apollo/client')
     return new HttpLink({
-      uri: '/api/graphql',
+      uri: 'http://localhost:3000/api/graphql',
       credentials: 'same-origin',
     })
   }


### PR DESCRIPTION
HttpLink's url field can not get relative path. It should take absolute path.
