### PR TITLE
Move sharp to optionalDependencies

### DIFF
--- a/errors/install-sharp.md
+++ b/errors/install-sharp.md
@@ -2,7 +2,9 @@
 
 #### Why This Error Occurred
 
-Using Next.js' built-in Image Optimization requires that you bring your own version of `sharp`.
+Using Next.js' built-in Image Optimization requires that you install `sharp`.
+
+Since, `sharp` is optional, it may have been skipped if you install `next` with the [`--no-optional`](https://docs.npmjs.com/cli/install) flag or your platform does not support `sharp`.
 
 #### Possible Ways to Fix It
 
@@ -12,4 +14,15 @@ Please install the `sharp` package in your project.
 npm i sharp
 # or
 yarn add sharp
+```
+
+Or you can configure an external loader in `next.config.js` such as:
+
+```js
+module.exports = {
+  images: {
+    path: 'https://example.com/myaccount/',
+    loader: 'imgix',
+  },
+}
 ```

--- a/errors/install-sharp.md
+++ b/errors/install-sharp.md
@@ -4,11 +4,11 @@
 
 Using Next.js' built-in Image Optimization requires that you install `sharp`.
 
-Since, `sharp` is optional, it may have been skipped if you install `next` with the [`--no-optional`](https://docs.npmjs.com/cli/install) flag or your platform does not support `sharp`.
+Since `sharp` is optional, it may have been skipped if you installed `next` with the [`--no-optional`](https://docs.npmjs.com/cli/install) flag or it may have been skipped if your platform does not support `sharp`.
 
 #### Possible Ways to Fix It
 
-Please install the `sharp` package in your project.
+Option 1: Install the `sharp` package in your project.
 
 ```bash
 npm i sharp
@@ -16,7 +16,7 @@ npm i sharp
 yarn add sharp
 ```
 
-Or you can configure an external loader in `next.config.js` such as:
+Option 2: Configure an external loader in `next.config.js` such as [imgix](https://imgix.com).
 
 ```js
 module.exports = {

--- a/packages/next/next-server/server/image-optimizer.ts
+++ b/packages/next/next-server/server/image-optimizer.ts
@@ -229,11 +229,12 @@ export async function imageOptimizer(
       sharp = require('sharp')
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {
-        error.message +=
-          "\nTo use Next.js' built-in Image Optimization, you first need to install `sharp`."
-        error.message +=
-          '\nRun `npm i sharp` or `yarn add sharp` inside your workspace.'
         error.message += '\n\nLearn more: https://err.sh/next.js/install-sharp'
+        server.logError(error)
+        if (upstreamType) {
+          res.setHeader('Content-Type', upstreamType)
+        }
+        res.end(upstreamBuffer)
       }
       throw error
     }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -125,6 +125,9 @@
     "react": "^16.6.0",
     "react-dom": "^16.6.0"
   },
+  "optionalDependencies": {
+    "sharp": "0.26.2"
+  },
   "devDependencies": {
     "@next/polyfill-nomodule": "9.5.6-canary.9",
     "@taskr/clear": "1.1.0",
@@ -205,7 +208,6 @@
     "resolve": "1.11.0",
     "semver": "7.3.2",
     "send": "0.17.1",
-    "sharp": "0.26.2",
     "source-map": "0.6.1",
     "string-hash": "1.1.3",
     "strip-ansi": "6.0.0",


### PR DESCRIPTION
This moves `sharp` to `optionalDependencies` which prevents the user (in most cases) from needing to manually install sharp like they do with react, for example `yarn add next react react-dom`.

We originally thought it best to make it a peerDependency and use `yarn add next react react-dom sharp` however, this would expose implementation details and makes it harder to swap `sharp` for [something else](https://github.com/silvia-odwyer/photon/issues/51) in the future.

The reason for not using `dependencies` is that `sharp` is more likely to fail during installation because it relies of native binaries or building from source, and we don't want to block someone from using Next.js just because they can't use Image Optimization.

Lastly, some users might choose to ignore Image Optimization and they can use `yarn install --ignore-optional` or `npm install --no-optional`.

Closes #17981 