### PR TITLE
Use ya in case xa is false

### DIFF
--- a/examples/with-firebase-authentication/utils/auth/mapUserData.js
+++ b/examples/with-firebase-authentication/utils/auth/mapUserData.js
@@ -1,8 +1,8 @@
 export const mapUserData = (user) => {
-  const { uid, email, xa } = user
+  const { uid, email, xa, ya } = user
   return {
     id: uid,
     email,
-    token: xa,
+    token: xa || ya,
   }
 }


### PR DESCRIPTION
This closes [#18023](https://github.com/vercel/next.js/issues/18023). 

I was following the example mentioned in the issue (https://github.com/vercel/next.js/tree/canary/examples/with-firebase-authentication) and for some reason `xa` was always false, failing fetching food. Through `console.log` I saw that `ya` contained a token value and using `ya` worked. 