### PR TITLE
Update peerdependency to account for React 17

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -122,8 +122,8 @@
     "webpack-sources": "1.4.3"
   },
   "peerDependencies": {
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0"
+    "react": "^16.6.0 || ^17",
+    "react-dom": "^16.6.0 || ^17"
   },
   "optionalDependencies": {
     "sharp": "0.26.2"

--- a/packages/react-dev-overlay/package.json
+++ b/packages/react-dev-overlay/package.json
@@ -28,8 +28,8 @@
     "strip-ansi": "6.0.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
+    "react": "^16.9.0 || ^17",
+    "react-dom": "^16.9.0 || ^17",
     "webpack": "^4 || ^5"
   }
 }


### PR DESCRIPTION
Makes sure you don't see a peerdependency warning when React 17 is installed.