### PR TITLE
Image Component: Support for Akamai image CDN

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -4,6 +4,7 @@ import Head from '../next-server/lib/head'
 const loaders: { [key: string]: (props: LoaderProps) => string } = {
   imgix: imgixLoader,
   cloudinary: cloudinaryLoader,
+  akamai: akamaiLoader,
   default: defaultLoader,
 }
 
@@ -306,6 +307,10 @@ function imgixLoader({ root, src, width, quality }: LoaderProps): string {
     paramsString = '?' + params.join('&')
   }
   return `${root}${normalizeSrc(src)}${paramsString}`
+}
+
+function akamaiLoader({ root, src, width }: LoaderProps): string {
+  return `${root}${normalizeSrc(src)}${width ? '?imwidth=' + width : ''}`
 }
 
 function cloudinaryLoader({ root, src, width, quality }: LoaderProps): string {


### PR DESCRIPTION
This PR is a simple addition that adds support for using "akamai" as a loader option with the image component. That CDN only supports width as a URL parameter, so the "quality" attribute is simply ignored if you use Akamai (and you can configure the CDN on your side as you normally would to control compression).
 