### PR TITLE
Investigate surfacing next/image errors in overlay in dev

### DIFF
--- a/packages/next/client/dev/error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev/error-overlay/hot-dev-client.js
@@ -45,6 +45,14 @@ let customHmrEventHandler
 export default function connect(options) {
   DevOverlay.register()
 
+  if (window.nextImageErrors) {
+    window.nextImageErrors.forEach((err) =>
+      setTimeout(() => {
+        throw err
+      }, 1)
+    )
+  }
+
   getEventSourceWrapper(options).addMessageListener((event) => {
     // This is the heartbeat event
     if (event.data === '\uD83D\uDC93') {

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -221,6 +221,7 @@ export default function Image({
 
   let divStyle: React.CSSProperties | undefined
   let imgStyle: React.CSSProperties | undefined
+
   if (typeof height === 'number' && typeof width === 'number' && !unsized) {
     // <Image src="i.png" width=100 height=100 />
     const quotient = height / width
@@ -236,25 +237,20 @@ export default function Image({
       top: '0',
       width: '100%',
     }
-  } else if (
-    typeof height === 'undefined' &&
-    typeof width === 'undefined' &&
-    unsized
-  ) {
-    // <Image src="i.png" unsized />
-    if (process.env.NODE_ENV !== 'production') {
-      if (priority) {
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof height === 'undefined' && typeof width === 'undefined') {
+      if (!unsized) {
+        console.error(
+          `Image with src ${src} must use width and height attributes or unsized attribute.`
+        )
+      } else if (priority) {
         // <Image src="i.png" unsized priority />
         console.warn(
           `Image with src ${src} has both priority and unsized attributes. Only one should be used.`
         )
       }
-    }
-  } else {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error(
-        `Image with src ${src} must use width and height attributes or unsized attribute.`
-      )
     }
   }
 


### PR DESCRIPTION
This adds handling to allow detecting image loading errors for `next/image` and displaying them in the error-overlay. Since image loading errors can occur before react has had the chance to hydrate the error listener needs to be attached in the initial HTML or else the error can be missed and never caught. 

This achieves catching image loading errors before react has been hydrated by adding an initial method in.a script in the head of the document which is then used by scripts that are injected after each image tag which are used to locate and attach a listener to each image created by `next/image`. This can potentially be cleaned up some to use a global listener and an identifier attribute on each image to let us know the tag was created by `next/image`. 

Tests still need to be added if this is the approach we decide to go with for capturing and displaying these errors

<details>

<summary>Example of current dev-overlay from image loading error</summary>

<img width="1301" alt="Screen Shot 2020-10-22 at 00 20 27" src="https://user-images.githubusercontent.com/22380829/96828601-9016d080-13fd-11eb-8a11-fd566ac6aaf9.png">
</details>
 