### PR TITLE
Update fallback 404 handling to prevent reload loop

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -79,6 +79,7 @@ export function createEntrypoints(
     absoluteAppPath: pages['/_app'],
     absoluteDocumentPath: pages['/_document'],
     absoluteErrorPath: pages['/_error'],
+    absolute404Path: pages['/404'] || '',
     distDir: DOT_NEXT_ALIAS,
     buildId,
     assetPrefix: config.assetPrefix,

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1144,7 +1144,6 @@ export default class Server {
             ...(components.getStaticProps
               ? {
                   amp: query.amp,
-                  __next404: query.__next404,
                   _nextDataReq: query._nextDataReq,
                   __nextLocale: query.__nextLocale,
                 }
@@ -1269,15 +1268,6 @@ export default class Server {
         : `${locale ? `/${locale}` : ''}${resolvedUrlPathname}${
             query.amp ? '.amp' : ''
           }`
-
-    // In development we use a __next404 query to allow signaling we should
-    // render the 404 page after attempting to fetch the _next/data for a
-    // fallback page since the fallback page will always be available after
-    // reload and we don't want to re-serve it and instead want to 404.
-    if (this.renderOpts.dev && isSSG && query.__next404) {
-      delete query.__next404
-      throw new NoFallbackError()
-    }
 
     // Complete the response with cached data if its present
     const cachedData = ssgCacheKey

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -414,7 +414,6 @@ export async function renderToHTML(
   const isFallback = !!query.__nextFallback
   delete query.__nextFallback
   delete query.__nextLocale
-  delete query.__next404
 
   const isSSG = !!getStaticProps
   const isBuildTimeSSG = isSSG && renderOpts.nextExport

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -95,16 +95,16 @@ describe('Build Output', () => {
       expect(indexSize.endsWith('B')).toBe(true)
 
       // should be no bigger than 60.8 kb
-      expect(parseFloat(indexFirstLoad) - 61).toBeLessThanOrEqual(0)
+      expect(parseFloat(indexFirstLoad) - 61.2).toBeLessThanOrEqual(0)
       expect(indexFirstLoad.endsWith('kB')).toBe(true)
 
       expect(parseFloat(err404Size) - 3.5).toBeLessThanOrEqual(0)
       expect(err404Size.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(err404FirstLoad) - 64.2).toBeLessThanOrEqual(0)
+      expect(parseFloat(err404FirstLoad) - 64.4).toBeLessThanOrEqual(0)
       expect(err404FirstLoad.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(sharedByAll) - 60.8).toBeLessThanOrEqual(0)
+      expect(parseFloat(sharedByAll) - 61).toBeLessThanOrEqual(0)
       expect(sharedByAll.endsWith('kB')).toBe(true)
 
       if (_appSize.endsWith('kB')) {

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -697,7 +697,7 @@ function runTests(isDev) {
       true
     )
     expect(parsedUrl.pathname).toBe('/en/not-found/fallback/first')
-    expect(parsedUrl.query).toEqual(isDev ? { __next404: '1' } : {})
+    expect(parsedUrl.query).toEqual({})
 
     if (isDev) {
       // make sure page doesn't reload un-necessarily in development


### PR DESCRIPTION
This updates the fallback 404 handling to render the correct 404 page on the client when a 404 is returned from fetching the data route on a fallback page on the client. This prevents us from having to rely on a cache to be updated by the time we reload the page to prevent non-stop reloading. 

This also adds handling in serverless mode to ensure the correct 404 page is rendered when leveraging fallback: 'blocking' mode. 

Additional tests for the fallback: 'blocking' 404 handling will be added in a follow-up where returning notFound from `getServerSideProps` is also added. 