### PR TITLE
fix(plugins): Update plugins collection based on the RFC dependency name format

### DIFF
--- a/packages/next/build/plugins/collect-plugins.ts
+++ b/packages/next/build/plugins/collect-plugins.ts
@@ -187,14 +187,14 @@ async function _collectPlugins(
     // next-plugin-[name]
     const filteredDeps = dependencies.filter((name) => {
       return (
-        name.match(/^@next\/plugin-[a-z0-9\.-_]+/) ||
-        name.match(/^next-plugin-[a-z0-9\.-_]+/) ||
+        name.match(/^@next\/plugin-[a-z0-9.-_]+/) ||
+        name.match(/^next-plugin-[a-z0-9.-_]+/) ||
         /**
          * URL-safe characters (dot, dash, underscore), lower-case only, no leading dots or underscores.
          * https://docs.npmjs.com/using-npm/scope.html
          * https://docs.npmjs.com/files/package.json
          */
-        name.match(/^@[a-z0-9-][a-z0-9\.-_]*\/next-plugin-[a-z0-9\.-_]+/)
+        name.match(/^@[a-z0-9-][a-z0-9.-_]*\/next-plugin-[a-z0-9.-_]+/)
       )
     })
 

--- a/packages/next/build/plugins/collect-plugins.ts
+++ b/packages/next/build/plugins/collect-plugins.ts
@@ -183,8 +183,19 @@ async function _collectPlugins(
 
     // find packages with the naming convention
     // @next/plugin-[name]
+    // @<scope>/next-plugin-[name]
+    // next-plugin-[name]
     const filteredDeps = dependencies.filter((name) => {
-      return name.match(/^@next\/plugin/)
+      return (
+        name.match(/^@next\/plugin-[a-z0-9\.-_]+/) ||
+        name.match(/^next-plugin-[a-z0-9\.-_]+/) ||
+        /**
+         * URL-safe characters (dot, dash, underscore), lower-case only, no leading dots or underscores.
+         * https://docs.npmjs.com/using-npm/scope.html
+         * https://docs.npmjs.com/files/package.json
+         */
+        name.match(/^@[a-z0-9-][a-z0-9\.-_]*\/next-plugin-[a-z0-9\.-_]+/)
+      )
     })
 
     if (nextPluginConfigNames) {


### PR DESCRIPTION
Based on the: https://github.com/vercel/next.js/discussions/9133

Tilde is also url-safe character, but I'm pretty sure npm doesn't allow that. As well as any non-letter or non-digit leading characters, but I trust their docs and left leading dashes.