### PR TITLE
Update redirect query encoding

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -730,9 +730,7 @@ export default class Server {
           const { query } = parsedDestination
           delete (parsedDestination as any).query
 
-          parsedDestination.search = stringifyQs(query, undefined, undefined, {
-            encodeURIComponent: (str: string) => str,
-          } as any)
+          parsedDestination.search = stringifyQs(query)
 
           const updatedDestination = formatUrl(parsedDestination)
 
@@ -774,12 +772,7 @@ export default class Server {
           if (parsedDestination.protocol) {
             const { query } = parsedDestination
             delete (parsedDestination as any).query
-            parsedDestination.search = stringifyQs(
-              query,
-              undefined,
-              undefined,
-              { encodeURIComponent: (str) => str }
-            )
+            parsedDestination.search = stringifyQs(query)
 
             const target = formatUrl(parsedDestination)
             const proxy = new Proxy({

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -210,6 +210,18 @@ const runTests = (isDev = false) => {
     })
   })
 
+  it('should have correct encoding for params with catchall rewrite', async () => {
+    const html = await renderViaHTTP(
+      appPort,
+      '/catchall-rewrite/hello%20world%3Fw%3D24%26focalpoint%3Dcenter?a=b'
+    )
+    const $ = cheerio.load(html)
+    expect(JSON.parse($('#__NEXT_DATA__').html()).query).toEqual({
+      a: 'b',
+      path: ['hello%20world%3Fw%3D24%26focalpoint%3Dcenter'],
+    })
+  })
+
   it('should have correct query for catchall rewrite', async () => {
     const html = await renderViaHTTP(appPort, '/catchall-query/hello/world?a=b')
     const $ = cheerio.load(html)
@@ -240,6 +252,25 @@ const runTests = (isDev = false) => {
     expect(pathname).toBe('/with-params')
     expect(query).toEqual({
       first: 'hello',
+      second: 'world',
+      a: 'b',
+    })
+  })
+
+  it('should have correctly encoded params in query for redirect', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/query-redirect/hello%20world%3Fw%3D24%26focalpoint%3Dcenter/world?a=b',
+      undefined,
+      {
+        redirect: 'manual',
+      }
+    )
+    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    expect(res.status).toBe(307)
+    expect(pathname).toBe('/with-params')
+    expect(query).toEqual({
+      first: 'hello%20world%3Fw%3D24%26focalpoint%3Dcenter',
       second: 'world',
       a: 'b',
     })

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -193,7 +193,7 @@ module.exports = (context) => {
       )
       expect(res.status).toBe(307)
       expect(pathname).toBe(encodeURI('/\\google.com/about'))
-      expect(hostname).not.toBe('google.com')
+      expect(hostname).toBe('localhost')
     })
 
     it('should handle encoded value in the pathname correctly %', async () => {
@@ -211,7 +211,28 @@ module.exports = (context) => {
       )
       expect(res.status).toBe(307)
       expect(pathname).toBe('/%25google.com/about')
-      expect(hostname).not.toBe('google.com')
+      expect(hostname).toBe('localhost')
+    })
+
+    it('should handle encoded value in the query correctly', async () => {
+      const res = await fetchViaHTTP(
+        context.appPort,
+        '/trailing-redirect/?url=https%3A%2F%2Fgoogle.com%2Fimage%3Fcrop%3Dfocalpoint%26w%3D24&w=1200&q=100',
+        undefined,
+        {
+          redirect: 'manual',
+        }
+      )
+
+      const { pathname, hostname, query } = url.parse(
+        res.headers.get('location') || ''
+      )
+      expect(res.status).toBe(308)
+      expect(pathname).toBe('/trailing-redirect')
+      expect(hostname).toBe('localhost')
+      expect(query).toBe(
+        'url=https%3A%2F%2Fgoogle.com%2Fimage%3Fcrop%3Dfocalpoint%26w%3D24&w=1200&q=100'
+      )
     })
   })
 }


### PR DESCRIPTION
This updates to ensure query values are re-encoded before redirecting instead of passing through the decoded version of the values. Tests have been added to ensure the correct encoding is used for these query values in the production and custom-routes suites

Fixes: https://github.com/vercel/next.js/issues/17440
Fixes: https://github.com/vercel/next.js/issues/17907