### PR TITLE
Pass quality param of image component to preload

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -285,6 +285,7 @@ export default function Image({
               widths: configSizes,
               unoptimized,
               sizes,
+              quality,
             })
           : ''}
         <img

--- a/test/integration/image-component/basic/pages/index.js
+++ b/test/integration/image-component/basic/pages/index.js
@@ -57,6 +57,14 @@ const Page = () => {
         height={400}
       />
       <Image
+        id="priority-image"
+        priority
+        src="withpriority.png"
+        width={300}
+        height={400}
+        quality={60}
+      />
+      <Image
         id="preceding-slash-image"
         src="/fooslash.jpg"
         priority

--- a/test/integration/image-component/basic/test/index.test.js
+++ b/test/integration/image-component/basic/test/index.test.js
@@ -216,6 +216,13 @@ describe('Image Component Tests', () => {
         )
       ).toBe(true)
     })
+    it('should add a preload tag for a priority image, with quality', async () => {
+      expect(
+        await hasPreloadLinkMatchingUrl(
+          'https://example.com/myaccount/withpriority.png?auto=format&q=60'
+        )
+      ).toBe(true)
+    })
   })
   describe('Client-side Image Component Tests', () => {
     beforeAll(async () => {


### PR DESCRIPTION
If give the `priority` and `quality` attributes to an Image Component, the `quality` attribute will not be given to the preload and a warning will be displayed to the devtool.

![screenshot on devtool](https://user-images.githubusercontent.com/12539/96960307-0837e000-153d-11eb-8c01-e15afd40e04f.png)
