### PR TITLE
Fix error when using with worker-loader

### DIFF
--- a/packages/react-refresh-utils/ReactRefreshWebpackPlugin.ts
+++ b/packages/react-refresh-utils/ReactRefreshWebpackPlugin.ts
@@ -95,7 +95,14 @@ function webpack5(compiler: Compiler) {
       // @ts-ignore This exists in webpack 5
       const { runtimeTemplate } = this.compilation
       return Template.asString([
-        `${
+        `if (!${
+          RuntimeGlobals.interceptModuleExecution
+        }) {
+          ${
+            RuntimeGlobals.interceptModuleExecution
+          } = [];
+        }
+        ${
           RuntimeGlobals.interceptModuleExecution
         }.push(${runtimeTemplate.basicFunction('options', [
           `${


### PR DESCRIPTION
When importing `worker` under developing mode, using worker-loader like below, it will course error since `ReactFreshWebpackPlugin` will be also used in worker context

```ts
import Worker from 'worker-loader!@workers/editor.worker';
```

So I'd like to define `__webpack_require__.i` to prevent errors

```js
__webpack_require__.i = []
```

<img width="693" alt="スクリーンショット 2020-10-25 2 12 20" src="https://user-images.githubusercontent.com/2508691/97087782-898b9180-1667-11eb-981a-241c9c6de7a9.png">
