### PR TITLE
Expose configured default locale in GS(S)P methods

### DIFF
--- a/docs/advanced-features/i18n-routing.md
+++ b/docs/advanced-features/i18n-routing.md
@@ -137,7 +137,7 @@ You can access the locale information via the Next.js router. For example, using
 
 When [pre-rendering](/docs/basic-features/pages#static-generation-recommended) pages with `getStaticProps` or `getServerSideProps`, the locale information is provided in [the context](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation) provided to the function.
 
-When leveraging `getStaticPaths`, the supported locales are provided in the context parameter of the function under `locales`.
+When leveraging `getStaticPaths`, the configured locales are provided in the context parameter of the function under `locales` and the configured defaultLocale under `defaultLocale`.
 
 ## Transition between locales
 

--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -56,6 +56,7 @@ The `context` parameter is an object containing the following keys:
 - `previewData` contains the preview data set by `setPreviewData`. See the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
 - `locale` contains the active locale (if enabled).
 - `locales` contains all supported locales (if enabled).
+- `defaultLocale` contains the configured default locale (if enabled).
 
 `getStaticProps` should return an object with:
 
@@ -547,6 +548,9 @@ The `context` parameter is an object containing the following keys:
 - `preview`: `preview` is `true` if the page is in the preview mode and `false` otherwise. See the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
 - `previewData`: The preview data set by `setPreviewData`. See the [Preview Mode documentation](/docs/advanced-features/preview-mode.md).
 - `resolvedUrl`: A normalized version of the request URL that strips the `_next/data` prefix for client transitions and includes original query values.
+- `locale` contains the active locale (if enabled).
+- `locales` contains all supported locales (if enabled).
+- `defaultLocale` contains the configured default locale (if enabled).
 
 > **Note**: You can import modules in top-level scope for use in `getServerSideProps`.
 > Imports used in `getServerSideProps` will not be bundled for the client-side.

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -544,7 +544,7 @@ export async function buildStaticPaths(
   // Get the default list of allowed params.
   const _validParamKeys = Object.keys(_routeMatcher(page))
 
-  const staticPathsResult = await getStaticPaths({ locales })
+  const staticPathsResult = await getStaticPaths({ locales, defaultLocale })
 
   const expectedReturnVal =
     `Expected: { paths: [], fallback: boolean }\n` +

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -606,6 +606,7 @@ export async function renderToHTML(
             : undefined),
           locales: renderOpts.locales,
           locale: renderOpts.locale,
+          defaultLocale: renderOpts.defaultLocale,
         })
       } catch (staticPropsError) {
         // remove not found error code to prevent triggering legacy
@@ -738,6 +739,7 @@ export async function renderToHTML(
             : undefined),
           locales: renderOpts.locales,
           locale: renderOpts.locale,
+          defaultLocale: renderOpts.defaultLocale,
         })
       } catch (serverSidePropsError) {
         // remove not found error code to prevent triggering legacy

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -83,6 +83,7 @@ export type GetStaticPropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
   previewData?: any
   locale?: string
   locales?: string[]
+  defaultLocale?: string
 }
 
 export type GetStaticPropsResult<P> = {
@@ -107,6 +108,7 @@ export type InferGetStaticPropsType<T> = T extends GetStaticProps<infer P, any>
 
 export type GetStaticPathsContext = {
   locales?: string[]
+  defaultLocale?: string
 }
 
 export type GetStaticPathsResult<P extends ParsedUrlQuery = ParsedUrlQuery> = {
@@ -130,6 +132,7 @@ export type GetServerSidePropsContext<
   resolvedUrl: string
   locale?: string
   locales?: string[]
+  defaultLocale?: string
 }
 
 export type GetServerSidePropsResult<P> = {

--- a/test/integration/i18n-support/pages/another.js
+++ b/test/integration/i18n-support/pages/another.js
@@ -21,11 +21,12 @@ export default function Page(props) {
   )
 }
 
-export const getServerSideProps = ({ locale, locales }) => {
+export const getServerSideProps = ({ locale, locales, defaultLocale }) => {
   return {
     props: {
       locale,
       locales,
+      defaultLocale,
     },
   }
 }

--- a/test/integration/i18n-support/pages/gsp/fallback/[slug].js
+++ b/test/integration/i18n-support/pages/gsp/fallback/[slug].js
@@ -23,22 +23,27 @@ export default function Page(props) {
   )
 }
 
-export const getStaticProps = ({ params, locale, locales }) => {
+export const getStaticProps = ({ params, locale, locales, defaultLocale }) => {
   return {
     props: {
       params,
       locale,
       locales,
+      defaultLocale,
     },
   }
 }
 
-export const getStaticPaths = ({ locales }) => {
+export const getStaticPaths = ({ locales, defaultLocale }) => {
   // make sure locales were provided correctly
   if (!locales || locales.length !== 7) {
     throw new Error(
       'locales missing in getStaticPaths!! got: ' + JSON.stringify(locales)
     )
+  }
+
+  if (!defaultLocale) {
+    throw new Error('missing defaultLocale in getStaticPaths')
   }
 
   return {

--- a/test/integration/i18n-support/pages/gsp/index.js
+++ b/test/integration/i18n-support/pages/gsp/index.js
@@ -21,11 +21,12 @@ export default function Page(props) {
   )
 }
 
-export const getStaticProps = ({ locale, locales }) => {
+export const getStaticProps = ({ locale, locales, defaultLocale }) => {
   return {
     props: {
       locale,
       locales,
+      defaultLocale,
     },
   }
 }

--- a/test/integration/i18n-support/pages/gsp/no-fallback/[slug].js
+++ b/test/integration/i18n-support/pages/gsp/no-fallback/[slug].js
@@ -23,12 +23,13 @@ export default function Page(props) {
   )
 }
 
-export const getStaticProps = ({ params, locale, locales }) => {
+export const getStaticProps = ({ params, locale, locales, defaultLocale }) => {
   return {
     props: {
       params,
       locale,
       locales,
+      defaultLocale,
     },
   }
 }

--- a/test/integration/i18n-support/pages/gssp/[slug].js
+++ b/test/integration/i18n-support/pages/gssp/[slug].js
@@ -21,12 +21,18 @@ export default function Page(props) {
   )
 }
 
-export const getServerSideProps = ({ params, locale, locales }) => {
+export const getServerSideProps = ({
+  params,
+  locale,
+  locales,
+  defaultLocale,
+}) => {
   return {
     props: {
       params,
       locale,
       locales,
+      defaultLocale,
     },
   }
 }

--- a/test/integration/i18n-support/pages/gssp/index.js
+++ b/test/integration/i18n-support/pages/gssp/index.js
@@ -21,11 +21,12 @@ export default function Page(props) {
   )
 }
 
-export const getServerSideProps = ({ locale, locales }) => {
+export const getServerSideProps = ({ locale, locales, defaultLocale }) => {
   return {
     props: {
       locale,
       locales,
+      defaultLocale,
     },
   }
 }

--- a/test/integration/i18n-support/pages/index.js
+++ b/test/integration/i18n-support/pages/index.js
@@ -45,11 +45,12 @@ export default function Page(props) {
   )
 }
 
-export const getStaticProps = ({ locale, locales }) => {
+export const getStaticProps = ({ locale, locales, defaultLocale }) => {
   return {
     props: {
       locale,
       locales,
+      defaultLocale,
     },
   }
 }

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -917,6 +917,7 @@ function runTests(isDev) {
     expect(JSON.parse($('#props').text())).toEqual({
       locale: 'en-US',
       locales,
+      defaultLocale: 'en-US',
     })
     expect($('#router-locale').text()).toBe('en-US')
     expect(JSON.parse($('#router-locales').text())).toEqual(locales)
@@ -933,6 +934,7 @@ function runTests(isDev) {
       params: {
         slug: 'first',
       },
+      defaultLocale: 'en-US',
     })
     expect(JSON.parse($('#router-query').text())).toEqual({
       slug: 'first',
@@ -953,6 +955,7 @@ function runTests(isDev) {
       params: {
         slug: 'another',
       },
+      defaultLocale: 'en-US',
     })
     expect(
       JSON.parse(await browser.elementByCss('#router-query').text())
@@ -1039,6 +1042,7 @@ function runTests(isDev) {
     expect(JSON.parse($('#props').text())).toEqual({
       locale: 'en-US',
       locales,
+      defaultLocale: 'en-US',
     })
     expect($('#router-locale').text()).toBe('en-US')
     expect(JSON.parse($('#router-locales').text())).toEqual(locales)
@@ -1055,6 +1059,7 @@ function runTests(isDev) {
       params: {
         slug: 'first',
       },
+      defaultLocale: 'en-US',
     })
     expect(JSON.parse($('#router-query').text())).toEqual({
       slug: 'first',
@@ -1075,6 +1080,7 @@ function runTests(isDev) {
       params: {
         slug: 'another',
       },
+      defaultLocale: 'en-US',
     })
     expect(
       JSON.parse(await browser.elementByCss('#router-query').text())
@@ -1096,6 +1102,7 @@ function runTests(isDev) {
     expect(JSON.parse($('#props').text())).toEqual({
       locale: 'en-US',
       locales,
+      defaultLocale: 'en-US',
     })
     expect($('#router-locale').text()).toBe('en-US')
     expect(JSON.parse($('#router-locales').text())).toEqual(locales)
@@ -1130,6 +1137,7 @@ function runTests(isDev) {
     expect(JSON.parse(await browser.elementByCss('#props').text())).toEqual({
       locale: 'en-US',
       locales,
+      defaultLocale: 'en-US',
     })
     expect(await browser.elementByCss('#router-locale').text()).toBe('en-US')
     expect(
@@ -1159,6 +1167,7 @@ function runTests(isDev) {
     expect(JSON.parse(await browser.elementByCss('#props').text())).toEqual({
       locale: 'en-US',
       locales,
+      defaultLocale: 'en-US',
     })
     expect(await browser.elementByCss('#router-locale').text()).toBe('en-US')
     expect(
@@ -1192,6 +1201,7 @@ function runTests(isDev) {
       params: {
         slug: 'another',
       },
+      defaultLocale: 'en-US',
     })
     expect(
       JSON.parse(await browser.elementByCss('#router-query').text())
@@ -1215,6 +1225,7 @@ function runTests(isDev) {
       params: {
         slug: 'first',
       },
+      defaultLocale: 'en-US',
     })
     expect(
       JSON.parse(await browser.elementByCss('#router-query').text())
@@ -1241,6 +1252,7 @@ function runTests(isDev) {
       params: {
         slug: 'second',
       },
+      defaultLocale: 'en-US',
     })
     expect(
       JSON.parse(await browser.elementByCss('#router-query').text())
@@ -1275,6 +1287,7 @@ function runTests(isDev) {
       params: {
         slug: 'second',
       },
+      defaultLocale: 'en-US',
     })
     expect(JSON.parse($('#router-query').text())).toEqual({
       slug: 'second',
@@ -1291,6 +1304,7 @@ function runTests(isDev) {
     expect(JSON.parse($('#props').text())).toEqual({
       locale: 'en-US',
       locales,
+      defaultLocale: 'en-US',
     })
     expect($('#router-locale').text()).toBe('en-US')
     expect(JSON.parse($('#router-locales').text())).toEqual(locales)
@@ -1303,6 +1317,7 @@ function runTests(isDev) {
     expect(JSON.parse($2('#props').text())).toEqual({
       locale: 'nl-NL',
       locales,
+      defaultLocale: 'en-US',
     })
     expect($2('#router-locale').text()).toBe('nl-NL')
     expect(JSON.parse($2('#router-locales').text())).toEqual(locales)
@@ -1320,6 +1335,7 @@ function runTests(isDev) {
       params: {
         slug: 'first',
       },
+      defaultLocale: 'en-US',
     })
     expect($('#router-locale').text()).toBe('en-US')
     expect(JSON.parse($('#router-locales').text())).toEqual(locales)
@@ -1335,6 +1351,7 @@ function runTests(isDev) {
       params: {
         slug: 'first',
       },
+      defaultLocale: 'en-US',
     })
     expect($2('#router-locale').text()).toBe('nl-NL')
     expect(JSON.parse($2('#router-locales').text())).toEqual(locales)
@@ -1365,6 +1382,7 @@ function runTests(isDev) {
     expect(JSON.parse(await browser.elementByCss('#props').text())).toEqual({
       locale: 'en',
       locales,
+      defaultLocale: 'en-US',
     })
     expect(
       JSON.parse(await browser.elementByCss('#router-query').text())
@@ -1393,6 +1411,7 @@ function runTests(isDev) {
     expect(JSON.parse(await browser.elementByCss('#props').text())).toEqual({
       locale: 'en',
       locales,
+      defaultLocale: 'en-US',
     })
     expect(
       JSON.parse(await browser.elementByCss('#router-query').text())


### PR DESCRIPTION
This exposes the default locale configured in `next.config.js` to `getStaticProps`, `getStaticPaths`, and `getServerSideProps`. Documentation has also been updated in this PR to reflect this value being exposed along with tests ensuring it is exposed everywhere as expected

x-ref: https://github.com/vercel/next.js/pull/17370