### PR TITLE
Add config limit checks for image optimizer

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -235,6 +235,13 @@ function assignDefaults(userConfig: { [key: string]: any }) {
           `Specified images.domains should be an Array received ${typeof images.domains}`
         )
       }
+
+      if (images.domains.length > 50) {
+        throw new Error(
+          `Specified images.domains exceeds length of 50, received length (${images.domains.length}), please reduce the length of the array to continue`
+        )
+      }
+
       const invalid = images.domains.filter(
         (d: unknown) => typeof d !== 'string'
       )
@@ -252,10 +259,20 @@ function assignDefaults(userConfig: { [key: string]: any }) {
           `Specified images.sizes should be an Array received ${typeof images.sizes}`
         )
       }
-      const invalid = images.sizes.filter((d: unknown) => typeof d !== 'number')
+
+      if (images.sizes.length > 50) {
+        throw new Error(
+          `Specified images.sizes exceeds length of 50, received length (${images.sizes.length}), please reduce the length of the array to continue`
+        )
+      }
+
+      const invalid = images.sizes.filter((d: unknown) => {
+        return typeof d !== 'number' || d < 0 || d > 10000
+      })
+
       if (invalid.length > 0) {
         throw new Error(
-          `Specified images.sizes should be an Array of numbers received invalid values (${invalid.join(
+          `Specified images.sizes should be an Array of numbers that are between 0 and 10,000, received invalid values (${invalid.join(
             ', '
           )})`
         )

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -267,12 +267,12 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       }
 
       const invalid = images.sizes.filter((d: unknown) => {
-        return typeof d !== 'number' || d < 0 || d > 10000
+        return typeof d !== 'number' || d < 1 || d > 10000
       })
 
       if (invalid.length > 0) {
         throw new Error(
-          `Specified images.sizes should be an Array of numbers that are between 0 and 10,000, received invalid values (${invalid.join(
+          `Specified images.sizes should be an Array of numbers that are between 1 and 10000, received invalid values (${invalid.join(
             ', '
           )})`
         )

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -10,6 +10,7 @@ import {
   nextBuild,
   nextStart,
   File,
+  waitFor,
 } from 'next-test-utils'
 import sharp from 'sharp'
 
@@ -321,6 +322,83 @@ function runTests({ w, isDev, domains }) {
 }
 
 describe('Image Optimizer', () => {
+  describe('config checks', () => {
+    it('should error when domains length exceeds 50', async () => {
+      await nextConfig.replace(
+        '{ /* replaceme */ }',
+        JSON.stringify({
+          images: {
+            domains: new Array(51).fill('google.com'),
+          },
+        })
+      )
+      let stderr = ''
+
+      app = await launchApp(appDir, await findPort(), {
+        onStderr(msg) {
+          stderr += msg || ''
+        },
+      })
+      await waitFor(1000)
+      await killApp(app).catch(() => {})
+      await nextConfig.restore()
+
+      expect(stderr).toContain(
+        'Specified images.domains exceeds length of 50, received length (51), please reduce the length of the array to continue'
+      )
+    })
+
+    it('should error when sizes length exceeds 50', async () => {
+      await nextConfig.replace(
+        '{ /* replaceme */ }',
+        JSON.stringify({
+          images: {
+            sizes: new Array(51).fill(1024),
+          },
+        })
+      )
+      let stderr = ''
+
+      app = await launchApp(appDir, await findPort(), {
+        onStderr(msg) {
+          stderr += msg || ''
+        },
+      })
+      await waitFor(1000)
+      await killApp(app).catch(() => {})
+      await nextConfig.restore()
+
+      expect(stderr).toContain(
+        'Specified images.sizes exceeds length of 50, received length (51), please reduce the length of the array to continue'
+      )
+    })
+
+    it('should error when sizes contains invalid sizes', async () => {
+      await nextConfig.replace(
+        '{ /* replaceme */ }',
+        JSON.stringify({
+          images: {
+            sizes: [-1, 12000, 64, 128, 256],
+          },
+        })
+      )
+      let stderr = ''
+
+      app = await launchApp(appDir, await findPort(), {
+        onStderr(msg) {
+          stderr += msg || ''
+        },
+      })
+      await waitFor(1000)
+      await killApp(app).catch(() => {})
+      await nextConfig.restore()
+
+      expect(stderr).toContain(
+        'Specified images.sizes should be an Array of numbers that are between 0 and 10,000, received invalid values (-1, 12000)'
+      )
+    })
+  })
+
   // domains for testing
   const domains = ['localhost', 'example.com']
 

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -378,7 +378,7 @@ describe('Image Optimizer', () => {
         '{ /* replaceme */ }',
         JSON.stringify({
           images: {
-            sizes: [-1, 12000, 64, 128, 256],
+            sizes: [0, 12000, 64, 128, 256],
           },
         })
       )
@@ -394,7 +394,7 @@ describe('Image Optimizer', () => {
       await nextConfig.restore()
 
       expect(stderr).toContain(
-        'Specified images.sizes should be an Array of numbers that are between 0 and 10,000, received invalid values (-1, 12000)'
+        'Specified images.sizes should be an Array of numbers that are between 1 and 10000, received invalid values (0, 12000)'
       )
     })
   })


### PR DESCRIPTION
This adds checks to ensure that less than 50 domain and size items are configured and no sizes are less than 1 or greater than 10,000 

x-ref: https://github.com/vercel/next.js/issues/18122