### PR TITLE
Update to only handle domain specific locales

### DIFF
--- a/docs/advanced-features/i18n-routing.md
+++ b/docs/advanced-features/i18n-routing.md
@@ -39,14 +39,17 @@ module.exports = {
       {
         domain: 'example.com',
         defaultLocale: 'en-US',
+        locales: ['en-US'],
       },
       {
         domain: 'example.nl',
         defaultLocale: 'nl-NL',
+        locales: ['nl-NL'],
       },
       {
         domain: 'example.fr',
         defaultLocale: 'fr',
+        locales: ['fr'],
       },
     ],
   },

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -264,6 +264,18 @@ const nextServerlessLoader: loader.Loader = function () {
         })
         parsedUrl.pathname = localePathResult.pathname
 
+        // if we are on a locale domain and a locale path is detected
+        // but isn't configured for that domain render the 404
+        if (
+          detectedDomain &&
+          !detectedDomain.locales.includes(localePathResult.detectedLocale)
+        ) {
+          // TODO: should this 404 for the default locale until we provide
+          // redirecting to strip default locale from the path?
+          parsedUrl.query.__nextLocale = detectedDomain.defaultLocale
+          return this.render404(req, res, parsedUrl)
+        }
+
         // check if the locale prefix matches a domain's defaultLocale
         // and we're on a locale specific domain if so redirect to that domain
         // if (detectedDomain) {

--- a/packages/next/next-server/lib/i18n/detect-domain-locale.ts
+++ b/packages/next/next-server/lib/i18n/detect-domain-locale.ts
@@ -3,6 +3,7 @@ export function detectDomainLocale(
     | Array<{
         http?: boolean
         domain: string
+        locales: string[]
         defaultLocale: string
       }>
     | undefined,
@@ -13,6 +14,7 @@ export function detectDomainLocale(
     | {
         http?: boolean
         domain: string
+        locales: string[]
         defaultLocale: string
       }
     | undefined

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -295,6 +295,32 @@ function assignDefaults(userConfig: { [key: string]: any }) {
         if (!item.defaultLocale) return true
         if (!item.domain || typeof item.domain !== 'string') return true
 
+        if (Array.isArray(item.locales)) {
+          const invalidLocaleItems = item.locales.filter((locale: any) => {
+            if (typeof locale !== 'string') return true
+
+            // automatically add the locale to the main locales config
+            // so pre-rendering and such can use this as the source of all
+            // configured locales
+            if (!i18n.locales.includes(locale)) {
+              i18n.locales.push(locale)
+            }
+            return false
+          })
+
+          if (invalidLocaleItems.length > 0) {
+            console.error(
+              `Invalid domain locales for ${
+                item.domain
+              }, received (${invalidLocaleItems.map(String).join(', ')}). ` +
+                `Items must be valid locale strings`
+            )
+            return true
+          }
+        } else {
+          item.locales = []
+        }
+
         return false
       })
 

--- a/test/integration/i18n-support/next.config.js
+++ b/test/integration/i18n-support/next.config.js
@@ -11,11 +11,13 @@ module.exports = {
           http: true,
           domain: 'example.be',
           defaultLocale: 'nl-BE',
+          locales: ['nl', 'nl-NL', 'nl-BE'],
         },
         {
           http: true,
           domain: 'example.fr',
           defaultLocale: 'fr',
+          locales: ['fr', 'fr-BE'],
         },
       ],
     },


### PR DESCRIPTION
As discussed this re-adds handling to only serve locales from specific domains with locale specific domains. This helps prevent duplicate content from multiple domains which can impact SEO

x-ref: https://github.com/vercel/next.js/pull/17370