### PR TITLE
[examples/cms-contentful] Fix getStaticPaths to return proper paths

### DIFF
--- a/examples/cms-contentful/pages/posts/[slug].js
+++ b/examples/cms-contentful/pages/posts/[slug].js
@@ -68,7 +68,7 @@ export async function getStaticProps({ params, preview = false }) {
 export async function getStaticPaths() {
   const allPosts = await getAllPostsWithSlug()
   return {
-    paths: allPosts?.map(({ slug }) => `/posts/${slug}`) ?? [],
+    paths: allPosts?.map(({ slug }) => ({ params: { slug } })) ?? [],
     fallback: true,
   }
 }


### PR DESCRIPTION
[Docs](https://nextjs.org/docs/basic-features/data-fetching#the-paths-key-required)  say that paths should return array of  `{ params: { [slug]:  path } }`,  but as seen in example `paths`  is array of `[ '/[slug]/[path]' ]`. This isn't really a issue since `fallback` is set to `true`, but no pages will be generated at build time.