### PR TITLE
update @now/next to @vercel/next

### DIFF
--- a/docs/advanced-features/multi-zones.md
+++ b/docs/advanced-features/multi-zones.md
@@ -33,8 +33,8 @@ For [Vercel](https://vercel.com/), you can use a single `vercel.json` to deploy 
 {
   "version": 2,
   "builds": [
-    { "src": "blog/package.json", "use": "@now/next" },
-    { "src": "home/package.json", "use": "@now/next" }
+    { "src": "blog/package.json", "use": "@vercel/next" },
+    { "src": "home/package.json", "use": "@vercel/next" }
   ],
   "routes": [
     { "src": "/blog/_next(.*)", "dest": "blog/_next$1" },


### PR DESCRIPTION
Resolves https://github.com/vercel/next.js/issues/18163 . I'd like to update all the examples/docs containing @now repos instead of @vercel . Do you agree with that?