### PR TITLE
Fix the 'Prerendered page' indicator when in incognito mode

### DIFF
--- a/packages/next/client/dev/prerender-indicator.js
+++ b/packages/next/client/dev/prerender-indicator.js
@@ -1,5 +1,9 @@
 import Router from '../router'
-import { localStorageGetItem, localStorageSetItem } from '../storage'
+import {
+  canUseLocalStorage,
+  localStorageGetItem,
+  localStorageSetItem,
+} from '../storage'
 
 export default function initializeBuildWatcher() {
   const shadowHost = document.createElement('div')
@@ -62,7 +66,8 @@ export default function initializeBuildWatcher() {
     toggleTimeout = setTimeout(() => {
       if (expand) {
         expandEl.classList.add(expandedClass)
-        closeEl.style.display = 'flex'
+        // the 'hide indicator' functionality requires local storage
+        if (canUseLocalStorage()) closeEl.style.display = 'flex'
       } else {
         expandEl.classList.remove(expandedClass)
         closeEl.style.display = 'none'

--- a/packages/next/client/dev/prerender-indicator.js
+++ b/packages/next/client/dev/prerender-indicator.js
@@ -1,4 +1,5 @@
 import Router from '../router'
+import { localStorageGetItem, localStorageSetItem } from '../storage'
 
 export default function initializeBuildWatcher() {
   const shadowHost = document.createElement('div')
@@ -40,7 +41,7 @@ export default function initializeBuildWatcher() {
 
   // State
   const dismissKey = '__NEXT_DISMISS_PRERENDER_INDICATOR'
-  const dismissUntil = parseInt(window.localStorage.getItem(dismissKey), 10)
+  const dismissUntil = parseInt(localStorageGetItem(dismissKey), 10)
   const dismissed = dismissUntil > new Date().getTime()
 
   let isVisible = !dismissed && window.__NEXT_DATA__.nextExport
@@ -71,7 +72,7 @@ export default function initializeBuildWatcher() {
 
   closeEl.addEventListener('click', () => {
     const oneHourAway = new Date().getTime() + 1 * 60 * 60 * 1000
-    window.localStorage.setItem(dismissKey, oneHourAway + '')
+    localStorageSetItem(dismissKey, oneHourAway + '')
     isVisible = false
     updateContainer()
   })

--- a/packages/next/client/storage.ts
+++ b/packages/next/client/storage.ts
@@ -11,3 +11,15 @@ export function localStorageSetItem(key: string, value: string): void {
     window.localStorage.setItem(key, value)
   } catch (_) {}
 }
+
+export function canUseLocalStorage(): boolean {
+  const key = '__TEST_LOCAL_STORAGE__'
+  try {
+    window.localStorage.setItem(key, '1')
+    window.localStorage.getItem(key)
+    window.localStorage.removeItem(key)
+    return true
+  } catch (_) {
+    return false
+  }
+}

--- a/packages/next/client/storage.ts
+++ b/packages/next/client/storage.ts
@@ -1,0 +1,13 @@
+export function localStorageGetItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch (_) {
+    return null
+  }
+}
+
+export function localStorageSetItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch (_) {}
+}


### PR DESCRIPTION
- Wrap `localStorage` to avoid runtime exceptions, e.g. when access is denied in private/incognito browsing mode.
- Hide the close button on the _Prerendered page_ indicator when `localStorage` is not available.

Fixes #18124 