### PR TITLE
Add i18n routing docs to manifest

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -184,6 +184,10 @@
             {
               "title": "Codemods",
               "path": "/docs/advanced-features/codemods.md"
+            },
+            {
+              "title": "Internationalized Routing",
+              "path": "/docs/advanced-features/i18n-routing.md"
             }
           ]
         },


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/18067 this adds the manifest item for the new docs