### PR TITLE
Improve @next/plugin-sentry support and expose additional to plugin hooks

### DIFF
--- a/packages/next-plugin-sentry/config.js
+++ b/packages/next-plugin-sentry/config.js
@@ -1,0 +1,6 @@
+/**
+ * TODO(kamil): Unify SDK configuration options.
+ * Workaround for callbacks, integrations and any unserializable config options.
+ **/
+exports.serverConfig = {}
+exports.clientConfig = {}

--- a/packages/next-plugin-sentry/env.js
+++ b/packages/next-plugin-sentry/env.js
@@ -1,0 +1,9 @@
+export const getDsn = () =>
+  process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+
+export const getRelease = () =>
+  process.env.SENTRY_RELEASE ||
+  process.env.NEXT_PUBLIC_SENTRY_RELEASE ||
+  process.env.VERCEL_GITHUB_COMMIT_SHA ||
+  process.env.VERCEL_GITLAB_COMMIT_SHA ||
+  process.env.VERCEL_BITBUCKET_COMMIT_SHA

--- a/packages/next-plugin-sentry/index.js
+++ b/packages/next-plugin-sentry/index.js
@@ -1,0 +1,11 @@
+const { serverConfig, clientConfig } = require('./config.js')
+
+const Sentry = require('@sentry/minimal')
+// NOTE(kamiL): @sentry/minimal doesn't expose this method, as it's not env-agnostic, but we still want to test it here
+Sentry.showReportDialog = (...args) => {
+  Sentry._callOnClient('showReportDialog', ...args)
+}
+
+exports.Sentry = Sentry
+exports.serverConfig = serverConfig
+exports.clientConfig = clientConfig

--- a/packages/next-plugin-sentry/package.json
+++ b/packages/next-plugin-sentry/package.json
@@ -7,16 +7,15 @@
   },
   "nextjs": {
     "name": "Sentry",
-    "required-env": [
-      "SENTRY_DSN",
-      "SENTRY_RELEASE"
-    ]
+    "required-env": []
   },
   "peerDependencies": {
     "next": "*"
   },
   "dependencies": {
-    "@sentry/browser": "5.7.1",
-    "@sentry/node": "5.7.1"
+    "@sentry/integrations": "5.27.0",
+    "@sentry/node": "5.27.0",
+    "@sentry/browser": "5.27.0",
+    "@sentry/minimal": "5.27.0"
   }
 }

--- a/packages/next-plugin-sentry/readme.md
+++ b/packages/next-plugin-sentry/readme.md
@@ -1,3 +1,98 @@
-# Unstable @next/plugin-sentry
+# Next.js + Sentry
 
-This package is still very experimental and should not be used at this point
+Capture unhandled exceptions with Sentry in your Next.js project.
+
+## Installation
+
+```
+npm install @next/plugin-sentry
+```
+
+or
+
+```
+yarn add @next/plugin-sentry
+```
+
+Provide necessary env variables through `.env` or available way
+
+```
+NEXT_PUBLIC_SENTRY_DSN
+
+// variables below are required only when using with @next/sentry-source-maps
+NEXT_PUBLIC_SENTRY_RELEASE
+SENTRY_PROJECT
+SENTRY_ORG
+SENTRY_AUTH_TOKEN
+```
+
+### Usage
+
+Create a next.config.js
+
+```js
+// next.config.js
+module.exports = {
+  experimental: { plugins: true },
+}
+```
+
+With only that, you'll get a complete error coverage for your application.
+If you want to use Sentry SDK APIs, you can do so in both, server-side and client-side code with the same namespace from the plugin.
+
+```js
+import { Sentry } from '@next/plugin-sentry'
+
+const MyComponent = () => <h1>Server Test 1</h1>
+
+export function getServerSideProps() {
+  if (!this.veryImportantValue) {
+    Sentry.withScope((scope) => {
+      scope.setTag('method', 'getServerSideProps')
+      Sentry.captureMessage('veryImportantValue is missing')
+    })
+  }
+
+  return {}
+}
+
+export default MyComponent
+```
+
+### Configuration
+
+There are two ways to configure Sentry SDK. One through `next.config.js` which allows for the full configuration of the server-side code, and partial configuration of client-side code. And additional method for client-side code.
+
+```js
+// next.config.js
+module.exports = {
+  experimental: { plugins: true },
+  // Sentry.init config for server-side code. Can accept any available config option.
+  serverRuntimeConfig: {
+    sentry: {
+      type: 'server',
+    },
+  },
+  // Sentry.init config for client-side code (and fallback for server-side)
+  // can accept only serializeable values. For more granular control see below.
+  publicRuntimeConfig: {
+    sentry: {
+      type: 'client',
+    },
+  },
+}
+```
+
+If you need to pass config options for the client-side, that are non-serializable, for example `beforeSend` or `beforeBreadcrumb`:
+
+```js
+// _app.js
+import { clientConfig } from '@next/plugin-sentry'
+
+clientConfig.beforeSend = () => {
+  /* ... */
+}
+clientConfig.beforeBreadcrumb = () => {
+  /* ... */
+}
+```

--- a/packages/next-plugin-sentry/src/on-error-client.js
+++ b/packages/next-plugin-sentry/src/on-error-client.js
@@ -1,5 +1,12 @@
-import * as Sentry from '@sentry/browser'
+import { withScope, captureException } from '@sentry/browser'
 
-export default async function onErrorClient({ err }) {
-  Sentry.captureException(err)
+export default async function onErrorClient({ err, errorInfo }) {
+  withScope((scope) => {
+    if (typeof errorInfo?.componentStack === 'string') {
+      scope.setContext('react', {
+        componentStack: errorInfo.componentStack.trim(),
+      })
+    }
+    captureException(err)
+  })
 }

--- a/packages/next-plugin-sentry/src/on-error-server.js
+++ b/packages/next-plugin-sentry/src/on-error-server.js
@@ -1,5 +1,27 @@
-import * as Sentry from '@sentry/node'
+import { captureException, flush, Handlers, withScope } from '@sentry/node'
+import getConfig from 'next/config'
 
-export default async function onErrorServer({ err }) {
-  Sentry.captureException(err)
+const { parseRequest } = Handlers
+
+export default async function onErrorServer({ err, req }) {
+  const { serverRuntimeConfig = {}, publicRuntimeConfig = {} } =
+    getConfig() || {}
+  const sentryTimeout =
+    serverRuntimeConfig.sentryTimeout ||
+    publicRuntimeConfig.sentryTimeout ||
+    2000
+
+  withScope((scope) => {
+    if (req) {
+      scope.addEventProcessor((event) =>
+        parseRequest(event, req, {
+          // TODO(kamil): 'cookies' and 'query_string' use `dynamicRequire` which has a bug in SSR envs right now.
+          request: ['data', 'headers', 'method', 'url'],
+        })
+      )
+    }
+    captureException(err)
+  })
+
+  await flush(sentryTimeout)
 }

--- a/packages/next-plugin-sentry/src/on-init-client.js
+++ b/packages/next-plugin-sentry/src/on-init-client.js
@@ -1,10 +1,21 @@
-import * as Sentry from '@sentry/browser'
+import { init } from '@sentry/browser'
+import getConfig from 'next/config'
+
+import { getDsn, getRelease } from '../env'
+import { clientConfig } from '../config'
 
 export default async function initClient() {
-  // by default `@sentry/browser` is configured with defaultIntegrations
-  // which capture uncaughtExceptions and unhandledRejections
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    release: process.env.SENTRY_RELEASE,
+  /**
+   * TODO(kamil): Unify SDK configuration options.
+   * RuntimeConfig cannot be used for callbacks and integrations as it supports only serializable data.
+   **/
+  const { publicRuntimeConfig = {} } = getConfig() || {}
+  const runtimeConfig = publicRuntimeConfig.sentry || {}
+
+  init({
+    dsn: getDsn(),
+    ...(getRelease() && { release: getRelease() }),
+    ...runtimeConfig,
+    ...clientConfig,
   })
 }

--- a/packages/next-plugin-sentry/src/on-init-server.js
+++ b/packages/next-plugin-sentry/src/on-init-server.js
@@ -1,11 +1,39 @@
-import * as Sentry from '@sentry/node'
+import { init } from '@sentry/node'
+import { RewriteFrames } from '@sentry/integrations'
+import getConfig from 'next/config'
+
+import { getDsn, getRelease } from '../env'
+import { serverConfig } from '../config'
 
 export default async function initServer() {
-  // by default `@sentry/node` is configured with defaultIntegrations
-  // which capture uncaughtExceptions and unhandledRejections
-  // see here for more https://github.com/getsentry/sentry-javascript/blob/46a02209bafcbc1603c769476ba0a1eaa450759d/packages/node/src/sdk.ts#L22
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    release: process.env.SENTRY_RELEASE,
+  /**
+   * TODO(kamil): Unify SDK configuration options.
+   * RuntimeConfig cannot be used for callbacks and integrations as it supports only serializable data.
+   **/
+  const { serverRuntimeConfig = {}, publicRuntimeConfig = {} } =
+    getConfig() || {}
+  const runtimeConfig =
+    serverRuntimeConfig.sentry || publicRuntimeConfig.sentry || {}
+
+  init({
+    dsn: getDsn(),
+    ...(getRelease() && { release: getRelease() }),
+    ...runtimeConfig,
+    ...serverConfig,
+    integrations: [
+      new RewriteFrames({
+        iteratee: (frame) => {
+          try {
+            const [, path] = frame.filename.split('.next/')
+            if (path) {
+              frame.filename = `app:///_next/${path}`
+            }
+          } catch {}
+          return frame
+        },
+      }),
+      ...(runtimeConfig.integrations || []),
+      ...(serverConfig.integrations || []),
+    ],
   })
 }

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -428,7 +428,7 @@ const nextServerlessLoader: loader.Loader = function () {
           )
         } catch (err) {
           console.error(err)
-          await onError(err)
+          await onError({ err, req, res })
 
           // TODO: better error for DECODE_FAILED?
           if (err.code === 'DECODE_FAILED') {
@@ -846,7 +846,7 @@ const nextServerlessLoader: loader.Loader = function () {
         }
       } catch(err) {
         console.error(err)
-        await onError(err)
+        await onError({ err, req, res })
         // Throw the error to crash the serverless function
         throw err
       }

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -271,6 +271,10 @@ export type PrefetchOptions = {
   priority?: boolean
 }
 
+export type ErrorInfo = {
+  componentStack?: string
+}
+
 export type PrivateRouteInfo = {
   Component: ComponentType
   styleSheets: StyleSheetTuple[]
@@ -279,6 +283,7 @@ export type PrivateRouteInfo = {
   props?: Record<string, any>
   err?: Error
   error?: any
+  errorInfo?: ErrorInfo
 }
 
 export type AppProps = Pick<PrivateRouteInfo, 'Component' | 'err'> & {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -280,7 +280,10 @@ export default class Server {
     return PHASE_PRODUCTION_SERVER
   }
 
-  public logError(err: Error): void {
+  public logError(err: Error, req: IncomingMessage, res: ServerResponse): void {
+    if (this.onErrorMiddleware) {
+      this.onErrorMiddleware({ err, req, res })
+    }
     if (this.quiet) return
     console.error(err)
   }
@@ -442,10 +445,7 @@ export default class Server {
     try {
       return await this.run(req, res, parsedUrl)
     } catch (err) {
-      if (this.onErrorMiddleware) {
-        this.onErrorMiddleware({ err, req, res })
-      }
-      this.logError(err)
+      this.logError(err, req, res)
       res.statusCode = 500
       res.end('Internal Server Error')
     }
@@ -1593,10 +1593,7 @@ export default class Server {
         }
       }
     } catch (err) {
-      if (this.onErrorMiddleware) {
-        this.onErrorMiddleware({ err, req, res })
-      }
-      this.logError(err)
+      this.logError(err, req, res)
 
       if (err && err.code === 'DECODE_FAILED') {
         res.statusCode = 400


### PR DESCRIPTION
`required-env` is currently removed, as it doesn't respect `NEXT_PUBLIC_` presence, so despite providing `NEXT_PUBLIC_SENTRY_DSN` it would still complain that it's not there, unless `{ env: { NEXT_PUBLIC_SENTRY_DSN } }` would be manually provided in `next.config.js`.