### PR TITLE
Remove unstable_ prefix from unstable_blocking

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -594,7 +594,7 @@ export default async function build(
               ssgPageRoutes = workerResult.prerenderRoutes
             }
 
-            if (workerResult.prerenderFallback === 'unstable_blocking') {
+            if (workerResult.prerenderFallback === 'blocking') {
               ssgBlockingFallbackPages.add(page)
             } else if (workerResult.prerenderFallback === true) {
               ssgStaticFallbackPages.add(page)

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -575,7 +575,7 @@ export async function buildStaticPaths(
   if (
     !(
       typeof staticPathsResult.fallback === 'boolean' ||
-      staticPathsResult.fallback === 'unstable_blocking'
+      staticPathsResult.fallback === 'blocking'
     )
   ) {
     throw new Error(
@@ -700,7 +700,7 @@ export async function isPageStatic(
   hasServerProps?: boolean
   hasStaticProps?: boolean
   prerenderRoutes?: string[] | undefined
-  prerenderFallback?: boolean | 'unstable_blocking' | undefined
+  prerenderFallback?: boolean | 'blocking' | undefined
 }> {
   try {
     require('../next-server/lib/runtime-config').setConfig(runtimeEnvConfig)
@@ -775,7 +775,7 @@ export async function isPageStatic(
     }
 
     let prerenderRoutes: Array<string> | undefined
-    let prerenderFallback: boolean | 'unstable_blocking' | undefined
+    let prerenderFallback: boolean | 'blocking' | undefined
     if (hasStaticProps && hasStaticPaths) {
       ;({
         paths: prerenderRoutes,

--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -556,7 +556,7 @@ export default class DevServer extends Server {
     return {
       staticPaths,
       fallbackMode:
-        fallback === 'unstable_blocking'
+        fallback === 'blocking'
           ? 'blocking'
           : fallback === true
           ? 'static'

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -111,7 +111,7 @@ export type GetStaticPathsContext = {
 
 export type GetStaticPathsResult<P extends ParsedUrlQuery = ParsedUrlQuery> = {
   paths: Array<string | { params: P; locale?: string }>
-  fallback: boolean | 'unstable_blocking'
+  fallback: boolean | 'blocking'
 }
 
 export type GetStaticPaths<P extends ParsedUrlQuery = ParsedUrlQuery> = (

--- a/test/integration/prerender/pages/blocking-fallback-once/[slug].js
+++ b/test/integration/prerender/pages/blocking-fallback-once/[slug].js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router'
 export async function getStaticPaths() {
   return {
     paths: [],
-    fallback: 'unstable_blocking',
+    fallback: 'blocking',
   }
 }
 

--- a/test/integration/prerender/pages/blocking-fallback-some/[slug].js
+++ b/test/integration/prerender/pages/blocking-fallback-some/[slug].js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router'
 export async function getStaticPaths() {
   return {
     paths: [{ params: { slug: 'a' } }, { params: { slug: 'b' } }],
-    fallback: 'unstable_blocking',
+    fallback: 'blocking',
   }
 }
 

--- a/test/integration/prerender/pages/blocking-fallback/[slug].js
+++ b/test/integration/prerender/pages/blocking-fallback/[slug].js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router'
 export async function getStaticPaths() {
   return {
     paths: [],
-    fallback: 'unstable_blocking',
+    fallback: 'blocking',
   }
 }
 

--- a/test/integration/prerender/pages/non-json-blocking/[p].js
+++ b/test/integration/prerender/pages/non-json-blocking/[p].js
@@ -7,7 +7,7 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return { paths: [], fallback: 'unstable_blocking' }
+  return { paths: [], fallback: 'blocking' }
 }
 
 const Page = ({ time }) => {

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -2101,7 +2101,7 @@ describe('SSG Prerender', () => {
         await fs.writeFile(
           pagePath,
           fallbackBlockingPageContents[page].replace(
-            "fallback: 'unstable_blocking'",
+            "fallback: 'blocking'",
             'fallback: false'
           )
         )


### PR DESCRIPTION
This removes the `unstable_` prefix to prepare for stabilizing the feature