### PR TITLE
Add error for unstable_blocking usage post-rename

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -788,6 +788,12 @@ export async function isPageStatic(
       ))
     }
 
+    if ((prerenderFallback as any) === 'unstable_blocking') {
+      throw new Error(
+        `unstable_blocking has been renamed to blocking, please update the field to continue. Page: ${page}`
+      )
+    }
+
     const config = mod.config || {}
     return {
       isStatic: !hasStaticProps && !hasGetInitialProps && !hasServerProps,


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/18276 adding an error when the previous name for this mode is used