### PR TITLE
Added support for Gumlet image CDN.

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -126,6 +126,7 @@ The following Image Optimization cloud providers are supported:
 - [Imgix](https://www.imgix.com): `loader: 'imgix'`
 - [Cloudinary](https://cloudinary.com): `loader: 'cloudinary'`
 - [Akamai](https://www.akamai.com): `loader: 'akamai'`
+- [Gumlet](https://www.gumlet.com): `loader: 'gumlet'`
 
 ## Related
 

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -7,11 +7,12 @@ type LoadingValue = typeof VALID_LOADING_VALUES[number]
 const loaders = new Map<LoaderKey, (props: LoaderProps) => string>([
   ['imgix', imgixLoader],
   ['cloudinary', cloudinaryLoader],
+  ['gumlet', gumletLoader],
   ['akamai', akamaiLoader],
   ['default', defaultLoader],
 ])
 
-type LoaderKey = 'imgix' | 'cloudinary' | 'akamai' | 'default'
+type LoaderKey = 'imgix' | 'cloudinary' | 'gumlet' | 'akamai' | 'default'
 
 type ImageData = {
   deviceSizes: number[]
@@ -379,6 +380,19 @@ function normalizeSrc(src: string) {
 
 function imgixLoader({ root, src, width, quality }: LoaderProps): string {
   const params = ['auto=format', 'w=' + width]
+  let paramsString = ''
+  if (quality) {
+    params.push('q=' + quality)
+  }
+
+  if (params.length) {
+    paramsString = '?' + params.join('&')
+  }
+  return `${root}${normalizeSrc(src)}${paramsString}`
+}
+
+function gumletLoader({ root, src, width, quality }: LoaderProps): string {
+  const params = ['format=auto', 'w=' + width]
   let paramsString = ''
   if (quality) {
     params.push('q=' + quality)


### PR DESCRIPTION
This PR is a simple addition that adds support for using "gumlet" as a loader option with the image component. Gumlet also supports delivering images in latest AVIF format which further optimises images.

Gumlet API docs: https://docs.gumlet.com/developers/api-reference