### PR TITLE
Add dev error when using data URLs with next/image

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -425,6 +425,12 @@ function defaultLoader({ root, src, width, quality }: LoaderProps): string {
     }
 
     if (src && !src.startsWith('/') && configDomains) {
+      if (src.startsWith('data:')) {
+        throw new Error(
+          `Failed to use data url "${src}". Image must be relative image path with leading slash "/" or an absolute URL`
+        );
+      }
+
       let parsedSrc: URL
       try {
         parsedSrc = new URL(src)


### PR DESCRIPTION
Using the new `next/image` (which is great by the way!) with things like image loaders for Webpack (e.g. next-images) can cause odd developer warnings now. This PR adds a special case for Data URLs to be more helpful with the errors returned in development mode.

---

## Reasoning/explonation

Inside the `defaultLoader` now, `new URL` is used to validate if it is a valid URL or not. If not parsable it shows an error on missing slash prefix. Or if it is a valid URL, it is validated with pre-configured allowed URLs. But there is a third option here with valid URLs but that doesn't have hostnames: Data URLs.

Using the component with Data URLs now you get an error of invalid hostname, but it is not clear that data URLs are not supported. Of course, this is natural when you see how the loaders work, but might not be as natural when using third-party plugins like `next-images` which can convert small images to Data URLs by default. So this PR tries to help those cases, as `next-images` itself is compatible as a concept.

We could also check if the hostname is set or not, but that wouldn't allow us to give a specific error in return.