### PR TITLE
Unlazify images if no intersection observer found

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -75,7 +75,7 @@ function getObserver(): IntersectionObserver | undefined {
   ))
 }
 
-function unLazifyImage(lazyImage: HTMLImageElement) {
+function unLazifyImage(lazyImage: HTMLImageElement): void {
   if (lazyImage.dataset.src) {
     lazyImage.src = lazyImage.dataset.src
   }

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -48,10 +48,10 @@ configDeviceSizes.sort((a, b) => a - b)
 configImageSizes.sort((a, b) => a - b)
 
 let cachedObserver: IntersectionObserver
-const IntersectionObserver =
-  typeof window !== 'undefined' ? window.IntersectionObserver : null
 
 function getObserver(): IntersectionObserver | undefined {
+  const IntersectionObserver =
+    typeof window !== 'undefined' ? window.IntersectionObserver : null
   // Return shared instance of IntersectionObserver if already created
   if (cachedObserver) {
     return cachedObserver
@@ -61,26 +61,29 @@ function getObserver(): IntersectionObserver | undefined {
   if (!IntersectionObserver) {
     return undefined
   }
-
   return (cachedObserver = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           let lazyImage = entry.target as HTMLImageElement
-          if (lazyImage.dataset.src) {
-            lazyImage.src = lazyImage.dataset.src
-          }
-          if (lazyImage.dataset.srcset) {
-            lazyImage.srcset = lazyImage.dataset.srcset
-          }
-          lazyImage.style.visibility = 'visible'
-          lazyImage.classList.remove('__lazy')
+          unLazifyImage(lazyImage)
           cachedObserver.unobserve(lazyImage)
         }
       })
     },
     { rootMargin: '200px' }
   ))
+}
+
+function unLazifyImage(lazyImage: HTMLImageElement) {
+  if (lazyImage.dataset.src) {
+    lazyImage.src = lazyImage.dataset.src
+  }
+  if (lazyImage.dataset.srcset) {
+    lazyImage.srcset = lazyImage.dataset.srcset
+  }
+  lazyImage.style.visibility = 'visible'
+  lazyImage.classList.remove('__lazy')
 }
 
 function getDeviceSizes(width: number | undefined): number[] {
@@ -234,6 +237,11 @@ export default function Image({
     lazy = true
   }
 
+  if (typeof window !== 'undefined' && !window.IntersectionObserver) {
+    // Rendering client side on browser without intersection observer
+    lazy = false
+  }
+
   useEffect(() => {
     const target = thisEl.current
 
@@ -246,6 +254,9 @@ export default function Image({
         return () => {
           observer.unobserve(target)
         }
+      } else {
+        //browsers without intersection observer
+        unLazifyImage(target)
       }
     }
   }, [thisEl, lazy])

--- a/test/integration/image-component/basic/pages/lazy.js
+++ b/test/integration/image-component/basic/pages/lazy.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 
 const Lazy = () => {
   return (
@@ -45,6 +46,9 @@ const Lazy = () => {
         height={400}
         width={1900}
       ></Image>
+      <Link href="/missing-observer">
+        <a id="observerlink">observer</a>
+      </Link>
     </div>
   )
 }

--- a/test/integration/image-component/basic/pages/missing-observer.js
+++ b/test/integration/image-component/basic/pages/missing-observer.js
@@ -1,0 +1,25 @@
+import React, { useLayoutEffect } from 'react'
+import Image from 'next/image'
+
+const Lazy = () => {
+  useLayoutEffect(() => {
+    IntersectionObserver = null //eslint-disable-line
+  })
+  return (
+    <div>
+      <p id="stubtext">
+        This is a page with one lazy-loaded image, to be used in the test for
+        browsers without intersection observer.
+      </p>
+      <Image
+        id="lazy-no-observer"
+        src="foox.jpg"
+        height={400}
+        width={1024}
+        loading="lazy"
+      ></Image>
+    </div>
+  )
+}
+
+export default Lazy

--- a/test/integration/image-component/basic/test/index.test.js
+++ b/test/integration/image-component/basic/test/index.test.js
@@ -176,6 +176,17 @@ function lazyLoadingTests() {
       await browser.elementById('eager-loading').getAttribute('srcset')
     ).toBeTruthy()
   })
+  it('should automatically load images if observer does not exist', async () => {
+    browser = await webdriver(appPort, '/missing-observer')
+    expect(
+      await browser.elementById('lazy-no-observer').getAttribute('src')
+    ).toBe('https://example.com/myaccount/foox.jpg?auto=format&w=1024')
+    expect(
+      await browser.elementById('lazy-no-observer').getAttribute('srcset')
+    ).toBe(
+      'https://example.com/myaccount/foox.jpg?auto=format&w=480 480w, https://example.com/myaccount/foox.jpg?auto=format&w=1024 1024w'
+    )
+  })
 }
 
 async function hasPreloadLinkMatchingUrl(url) {

--- a/test/integration/image-component/basic/test/index.test.js
+++ b/test/integration/image-component/basic/test/index.test.js
@@ -176,17 +176,6 @@ function lazyLoadingTests() {
       await browser.elementById('eager-loading').getAttribute('srcset')
     ).toBeTruthy()
   })
-  it('should automatically load images if observer does not exist', async () => {
-    browser = await webdriver(appPort, '/missing-observer')
-    expect(
-      await browser.elementById('lazy-no-observer').getAttribute('src')
-    ).toBe('https://example.com/myaccount/foox.jpg?auto=format&w=1024')
-    expect(
-      await browser.elementById('lazy-no-observer').getAttribute('srcset')
-    ).toBe(
-      'https://example.com/myaccount/foox.jpg?auto=format&w=480 480w, https://example.com/myaccount/foox.jpg?auto=format&w=1024 1024w'
-    )
-  })
 }
 
 async function hasPreloadLinkMatchingUrl(url) {
@@ -291,6 +280,17 @@ describe('Image Component Tests', () => {
       browser = null
     })
     lazyLoadingTests()
+    it('should automatically load images if observer does not exist', async () => {
+      browser = await webdriver(appPort, '/missing-observer')
+      expect(
+        await browser.elementById('lazy-no-observer').getAttribute('src')
+      ).toBe('https://example.com/myaccount/foox.jpg?auto=format&w=1024')
+      expect(
+        await browser.elementById('lazy-no-observer').getAttribute('srcset')
+      ).toBe(
+        'https://example.com/myaccount/foox.jpg?auto=format&w=480 480w, https://example.com/myaccount/foox.jpg?auto=format&w=1024 1024w'
+      )
+    })
   })
   describe('Client-side Lazy Loading Tests', () => {
     beforeAll(async () => {
@@ -302,5 +302,18 @@ describe('Image Component Tests', () => {
       browser = null
     })
     lazyLoadingTests()
+    it('should automatically load images if observer does not exist', async () => {
+      await browser.waitForElementByCss('#observerlink').click()
+      await waitFor(500)
+      browser = await webdriver(appPort, '/missing-observer')
+      expect(
+        await browser.elementById('lazy-no-observer').getAttribute('src')
+      ).toBe('https://example.com/myaccount/foox.jpg?auto=format&w=1024')
+      expect(
+        await browser.elementById('lazy-no-observer').getAttribute('srcset')
+      ).toBe(
+        'https://example.com/myaccount/foox.jpg?auto=format&w=480 480w, https://example.com/myaccount/foox.jpg?auto=format&w=1024 1024w'
+      )
+    })
   })
 })


### PR DESCRIPTION
This PR does two things to handle the case of a browser without intersection observer:
1) If the image component is rendering on the client, it simply disables the lazy flag, so it will fall back to loading eagerly.
2) If the image was rendered on the server, then as the component hydrates it will detect no observer and automatically unlazify itself (change src to data-src etc). The "unlazification" logic is refactored to support this.

A test is also added to simulate a browser without intersection observer. This test does fail if you remove the "unlazification" logic added in this PR. 