### PR TITLE
add rewrites in storybook preset

### DIFF
--- a/packages/next-plugin-storybook/preset.js
+++ b/packages/next-plugin-storybook/preset.js
@@ -15,7 +15,7 @@ async function webpackFinal(config) {
     target: 'server',
     config: nextConfig,
     buildId: 'storybook',
-    rewrites: []
+    rewrites: [],
   })
 
   config.plugins = [...config.plugins, ...nextWebpackConfig.plugins]

--- a/packages/next-plugin-storybook/preset.js
+++ b/packages/next-plugin-storybook/preset.js
@@ -15,6 +15,7 @@ async function webpackFinal(config) {
     target: 'server',
     config: nextConfig,
     buildId: 'storybook',
+    rewrites: []
   })
 
   config.plugins = [...config.plugins, ...nextWebpackConfig.plugins]


### PR DESCRIPTION
Hi,

The absence of a `rewrites` option in Storybook preset was failing it at runtime.

It now works and solves https://github.com/storybookjs/storybook/issues/11639 (it allows Storybook to support `tsconfig` `paths` out of the box like Next does).

There is also an issue in line `if (!(rule.test instanceof RegExp)) return true`, it is missing parenthesis. I'll try to provide another PR with a TS version and fix this issue too, because both issues are caught easily by TypeScript.