### PR TITLE
feat: add placeholder to next image as optional prop

### DIFF
--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -54,5 +54,6 @@ export default Home
 - `priority` - When true, the image will be considered high priority and [preload](https://web.dev/preload-responsive-images/).
 - `unoptimized` - When true, the source image will be served as-is instead of resizing and changing quality.
 - `unsized` - When true, the `width` and `height` requirement can by bypassed. Should _not_ be used with above-the-fold images. Should _not_ be used with `priority`.
+- `placeholder` - Optional element you can pass that will be rendered while the image is being loaded
 
 All other properties on the `<Image>` component will be passed to the underlying `<img>` element.

--- a/examples/image-component/package.json
+++ b/examples/image-component/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "next": "latest",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "blurhash": "^1.1.3"
   },
   "license": "MIT"
 }

--- a/examples/image-component/pages/index.js
+++ b/examples/image-component/pages/index.js
@@ -1,5 +1,6 @@
-import styles from '../styles.module.css'
 import Image from 'next/image'
+import { Blurhash } from "react-blurhash";
+import styles from '../styles.module.css'
 
 const Code = (p) => <code className={styles.inlineCode} {...p} />
 
@@ -43,6 +44,37 @@ const Index = () => (
         src="https://assets.vercel.com/image/upload/v1538361091/repositories/next-js/next-js.png"
         width={1200}
         height={400}
+      />
+      <hr className={styles.hr} />
+      <p>
+        Passing a placeholder
+      </p>
+      <Image
+        alt="Next.js logo"
+        src="https://assets.vercel.com/image/upload/v1538361091/repositories/next-js/next-js.png"
+        width={1200}
+        height={400}
+        placeholder={<h2>Loading...</h2>}
+      />
+      <hr className={styles.hr} />
+      <p>
+        Passing Blurhash as placeholder
+      </p>
+      <Image
+        alt="Next.js logo"
+        src="https://assets.vercel.com/image/upload/v1538361091/repositories/next-js/next-js.png"
+        width={1200}
+        height={400}
+        placeholder={
+          <Blurhash
+            hash="LEHLk~WB2yk8pyoJadR*.8kCIAnj"
+            width={600}
+            height={600}
+            resolutionX={32}
+            resolutionY={32}
+            punch={1}
+          />
+        }
       />
       <hr className={styles.hr} />
       Checkout the documentation for{' '}

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -1,459 +1,470 @@
-import React, { ReactElement, useEffect, useRef } from 'react'
-import Head from '../next-server/lib/head'
+import React, {
+	ReactElement,
+	ReactNode,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import Head from "next/head";
 
-const VALID_LOADING_VALUES = ['lazy', 'eager', undefined] as const
-type LoadingValue = typeof VALID_LOADING_VALUES[number]
+const VALID_LOADING_VALUES = ["lazy", "eager", undefined] as const;
+type LoadingValue = typeof VALID_LOADING_VALUES[number];
 
 const loaders = new Map<LoaderKey, (props: LoaderProps) => string>([
-  ['imgix', imgixLoader],
-  ['cloudinary', cloudinaryLoader],
-  ['akamai', akamaiLoader],
-  ['default', defaultLoader],
-])
+	["imgix", imgixLoader],
+	["cloudinary", cloudinaryLoader],
+	["akamai", akamaiLoader],
+	["default", defaultLoader],
+]);
 
-type LoaderKey = 'imgix' | 'cloudinary' | 'akamai' | 'default'
+type LoaderKey = "imgix" | "cloudinary" | "akamai" | "default";
 
 type ImageData = {
-  deviceSizes: number[]
-  imageSizes: number[]
-  loader: LoaderKey
-  path: string
-  domains?: string[]
-}
+	deviceSizes: number[];
+	imageSizes: number[];
+	loader: LoaderKey;
+	path: string;
+	domains?: string[];
+};
 
 type ImageProps = Omit<
-  JSX.IntrinsicElements['img'],
-  'src' | 'srcSet' | 'ref' | 'width' | 'height' | 'loading'
+	JSX.IntrinsicElements["img"],
+	"src" | "srcSet" | "ref" | "width" | "height" | "loading" | "placeholder"
 > & {
-  src: string
-  quality?: number | string
-  priority?: boolean
-  loading?: LoadingValue
-  unoptimized?: boolean
+	placeholder?: ReactNode;
+	src: string;
+	quality?: number | string;
+	priority?: boolean;
+	loading?: LoadingValue;
+	unoptimized?: boolean;
 } & (
-    | { width: number | string; height: number | string; unsized?: false }
-    | { width?: number | string; height?: number | string; unsized: true }
-  )
+		| { width: number | string; height: number | string; unsized?: false }
+		| { width?: number | string; height?: number | string; unsized: true }
+	);
 
-const imageData: ImageData = process.env.__NEXT_IMAGE_OPTS as any
+const imageData: ImageData = process.env.__NEXT_IMAGE_OPTS as any;
 const {
-  deviceSizes: configDeviceSizes,
-  imageSizes: configImageSizes,
-  loader: configLoader,
-  path: configPath,
-  domains: configDomains,
-} = imageData
+	deviceSizes: configDeviceSizes,
+	imageSizes: configImageSizes,
+	loader: configLoader,
+	path: configPath,
+	domains: configDomains,
+} = imageData;
 // sort smallest to largest
-configDeviceSizes.sort((a, b) => a - b)
-configImageSizes.sort((a, b) => a - b)
+configDeviceSizes.sort((a, b) => a - b);
+configImageSizes.sort((a, b) => a - b);
 
-let cachedObserver: IntersectionObserver
+let cachedObserver: IntersectionObserver;
 
 function getObserver(): IntersectionObserver | undefined {
-  const IntersectionObserver =
-    typeof window !== 'undefined' ? window.IntersectionObserver : null
-  // Return shared instance of IntersectionObserver if already created
-  if (cachedObserver) {
-    return cachedObserver
-  }
+	const IntersectionObserver =
+		typeof window !== "undefined" ? window.IntersectionObserver : null;
+	// Return shared instance of IntersectionObserver if already created
+	if (cachedObserver) {
+		return cachedObserver;
+	}
 
-  // Only create shared IntersectionObserver if supported in browser
-  if (!IntersectionObserver) {
-    return undefined
-  }
-  return (cachedObserver = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          let lazyImage = entry.target as HTMLImageElement
-          unLazifyImage(lazyImage)
-          cachedObserver.unobserve(lazyImage)
-        }
-      })
-    },
-    { rootMargin: '200px' }
-  ))
+	// Only create shared IntersectionObserver if supported in browser
+	if (!IntersectionObserver) {
+		return undefined;
+	}
+	return (cachedObserver = new IntersectionObserver(
+		(entries) => {
+			entries.forEach((entry) => {
+				if (entry.isIntersecting) {
+					let lazyImage = entry.target as HTMLImageElement;
+					unLazifyImage(lazyImage);
+					cachedObserver.unobserve(lazyImage);
+				}
+			});
+		},
+		{ rootMargin: "200px" }
+	));
 }
 
 function unLazifyImage(lazyImage: HTMLImageElement): void {
-  if (lazyImage.dataset.src) {
-    lazyImage.src = lazyImage.dataset.src
-  }
-  if (lazyImage.dataset.srcset) {
-    lazyImage.srcset = lazyImage.dataset.srcset
-  }
-  lazyImage.style.visibility = 'visible'
-  lazyImage.classList.remove('__lazy')
+	if (lazyImage.dataset.src) {
+		lazyImage.src = lazyImage.dataset.src;
+	}
+	if (lazyImage.dataset.srcset) {
+		lazyImage.srcset = lazyImage.dataset.srcset;
+	}
+	lazyImage.style.visibility = "visible";
+	lazyImage.classList.remove("__lazy");
 }
 
 function getDeviceSizes(width: number | undefined): number[] {
-  if (typeof width !== 'number') {
-    return configDeviceSizes
-  }
-  if (configImageSizes.includes(width)) {
-    return [width]
-  }
-  const widths: number[] = []
-  for (let size of configDeviceSizes) {
-    widths.push(size)
-    if (size >= width) {
-      break
-    }
-  }
-  return widths
+	if (typeof width !== "number") {
+		return configDeviceSizes;
+	}
+	if (configImageSizes.includes(width)) {
+		return [width];
+	}
+	const widths: number[] = [];
+	for (let size of configDeviceSizes) {
+		widths.push(size);
+		if (size >= width) {
+			break;
+		}
+	}
+	return widths;
 }
 
 function computeSrc(
-  src: string,
-  unoptimized: boolean,
-  width?: number,
-  quality?: number
+	src: string,
+	unoptimized: boolean,
+	width?: number,
+	quality?: number
 ): string {
-  if (unoptimized) {
-    return src
-  }
-  const widths = getDeviceSizes(width)
-  const largest = widths[widths.length - 1]
-  return callLoader({ src, width: largest, quality })
+	if (unoptimized) {
+		return src;
+	}
+	const widths = getDeviceSizes(width);
+	const largest = widths[widths.length - 1];
+	return callLoader({ src, width: largest, quality });
 }
 
 type CallLoaderProps = {
-  src: string
-  width: number
-  quality?: number
-}
+	src: string;
+	width: number;
+	quality?: number;
+};
 
 function callLoader(loaderProps: CallLoaderProps) {
-  const load = loaders.get(configLoader) || defaultLoader
-  return load({ root: configPath, ...loaderProps })
+	const load = loaders.get(configLoader) || defaultLoader;
+	return load({ root: configPath, ...loaderProps });
 }
 
 type SrcSetData = {
-  src: string
-  unoptimized: boolean
-  width?: number
-  quality?: number
-}
+	src: string;
+	unoptimized: boolean;
+	width?: number;
+	quality?: number;
+};
 
 function generateSrcSet({
-  src,
-  unoptimized,
-  width,
-  quality,
+	src,
+	unoptimized,
+	width,
+	quality,
 }: SrcSetData): string | undefined {
-  // At each breakpoint, generate an image url using the loader, such as:
-  // ' www.example.com/foo.jpg?w=480 480w, '
-  if (unoptimized) {
-    return undefined
-  }
+	// At each breakpoint, generate an image url using the loader, such as:
+	// ' www.example.com/foo.jpg?w=480 480w, '
+	if (unoptimized) {
+		return undefined;
+	}
 
-  return getDeviceSizes(width)
-    .map((w) => `${callLoader({ src, width: w, quality })} ${w}w`)
-    .join(', ')
+	return getDeviceSizes(width)
+		.map((w) => `${callLoader({ src, width: w, quality })} ${w}w`)
+		.join(", ");
 }
 
 type PreloadData = {
-  src: string
-  unoptimized: boolean
-  width: number | undefined
-  sizes?: string
-  quality?: number
-}
+	src: string;
+	unoptimized: boolean;
+	width: number | undefined;
+	sizes?: string;
+	quality?: number;
+};
 
 function generatePreload({
-  src,
-  width,
-  unoptimized = false,
-  sizes,
-  quality,
+	src,
+	width,
+	unoptimized = false,
+	sizes,
+	quality,
 }: PreloadData): ReactElement {
-  // This function generates an image preload that makes use of the "imagesrcset" and "imagesizes"
-  // attributes for preloading responsive images. They're still experimental, but fully backward
-  // compatible, as the link tag includes all necessary attributes, even if the final two are ignored.
-  // See: https://web.dev/preload-responsive-images/
-  return (
-    <Head>
-      <link
-        rel="preload"
-        as="image"
-        href={computeSrc(src, unoptimized, width, quality)}
-        // @ts-ignore: imagesrcset and imagesizes not yet in the link element type
-        imagesrcset={generateSrcSet({ src, unoptimized, width, quality })}
-        imagesizes={sizes}
-      />
-    </Head>
-  )
+	// This function generates an image preload that makes use of the "imagesrcset" and "imagesizes"
+	// attributes for preloading responsive images. They're still experimental, but fully backward
+	// compatible, as the link tag includes all necessary attributes, even if the final two are ignored.
+	// See: https://web.dev/preload-responsive-images/
+	return (
+		<Head>
+			<link
+				rel="preload"
+				as="image"
+				href={computeSrc(src, unoptimized, width, quality)}
+				// @ts-ignore: imagesrcset and imagesizes not yet in the link element type
+				imagesrcset={generateSrcSet({ src, unoptimized, width, quality })}
+				imagesizes={sizes}
+			/>
+		</Head>
+	);
 }
 
 function getInt(x: unknown): number | undefined {
-  if (typeof x === 'number') {
-    return x
-  }
-  if (typeof x === 'string') {
-    return parseInt(x, 10)
-  }
-  return undefined
+	if (typeof x === "number") {
+		return x;
+	}
+	if (typeof x === "string") {
+		return parseInt(x, 10);
+	}
+	return undefined;
 }
 
 export default function Image({
-  src,
-  sizes,
-  unoptimized = false,
-  priority = false,
-  loading,
-  className,
-  quality,
-  width,
-  height,
-  unsized,
-  ...rest
+	src,
+	sizes,
+	unoptimized = false,
+	priority = false,
+	loading,
+	className,
+	quality,
+	width,
+	height,
+	unsized,
+	placeholder,
+	...rest
 }: ImageProps) {
-  const thisEl = useRef<HTMLImageElement>(null)
+	const [imgLoading, setImgLoading] = useState<boolean>(true);
+	const thisEl = useRef<HTMLImageElement>(null);
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (!src) {
-      throw new Error(
-        `Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
-          { width, height, quality, unsized }
-        )}`
-      )
-    }
-    if (!VALID_LOADING_VALUES.includes(loading)) {
-      throw new Error(
-        `Image with src "${src}" has invalid "loading" property. Provided "${loading}" should be one of ${VALID_LOADING_VALUES.map(
-          String
-        ).join(',')}.`
-      )
-    }
-    if (priority && loading === 'lazy') {
-      throw new Error(
-        `Image with src "${src}" has both "priority" and "loading=lazy" properties. Only one should be used.`
-      )
-    }
-  }
+	if (process.env.NODE_ENV !== "production") {
+		if (!src) {
+			throw new Error(
+				`Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
+					{ width, height, quality, unsized }
+				)}`
+			);
+		}
+		if (!VALID_LOADING_VALUES.includes(loading)) {
+			throw new Error(
+				`Image with src "${src}" has invalid "loading" property. Provided "${loading}" should be one of ${VALID_LOADING_VALUES.map(
+					String
+				).join(",")}.`
+			);
+		}
+		if (priority && loading === "lazy") {
+			throw new Error(
+				`Image with src "${src}" has both "priority" and "loading=lazy" properties. Only one should be used.`
+			);
+		}
+	}
 
-  let lazy = loading === 'lazy'
-  if (!priority && typeof loading === 'undefined') {
-    lazy = true
-  }
+	let lazy = loading === "lazy";
+	if (!priority && typeof loading === "undefined") {
+		lazy = true;
+	}
 
-  if (typeof window !== 'undefined' && !window.IntersectionObserver) {
-    // Rendering client side on browser without intersection observer
-    lazy = false
-  }
+	if (typeof window !== "undefined" && !window.IntersectionObserver) {
+		// Rendering client side on browser without intersection observer
+		lazy = false;
+	}
 
-  useEffect(() => {
-    const target = thisEl.current
+	useEffect(() => {
+		const target = thisEl.current;
 
-    if (target && lazy) {
-      const observer = getObserver()
+		if (target && lazy) {
+			const observer = getObserver();
 
-      if (observer) {
-        observer.observe(target)
+			if (observer) {
+				observer.observe(target);
 
-        return () => {
-          observer.unobserve(target)
-        }
-      } else {
-        //browsers without intersection observer
-        unLazifyImage(target)
-      }
-    }
-  }, [thisEl, lazy])
+				return () => {
+					observer.unobserve(target);
+				};
+			} else {
+				//browsers without intersection observer
+				unLazifyImage(target);
+			}
+		}
+	}, [thisEl, lazy]);
 
-  const widthInt = getInt(width)
-  const heightInt = getInt(height)
-  const qualityInt = getInt(quality)
+	const widthInt = getInt(width);
+	const heightInt = getInt(height);
+	const qualityInt = getInt(quality);
 
-  let divStyle: React.CSSProperties | undefined
-  let imgStyle: React.CSSProperties | undefined
-  let wrapperStyle: React.CSSProperties | undefined
-  if (
-    typeof widthInt !== 'undefined' &&
-    typeof heightInt !== 'undefined' &&
-    !unsized
-  ) {
-    // <Image src="i.png" width={100} height={100} />
-    // <Image src="i.png" width="100" height="100" />
-    const quotient = heightInt / widthInt
-    const ratio = isNaN(quotient) ? 1 : quotient * 100
-    wrapperStyle = {
-      maxWidth: '100%',
-      width: widthInt,
-    }
-    divStyle = {
-      position: 'relative',
-      paddingBottom: `${ratio}%`,
-    }
-    imgStyle = {
-      visibility: lazy ? 'hidden' : 'visible',
-      height: '100%',
-      left: '0',
-      position: 'absolute',
-      top: '0',
-      width: '100%',
-    }
-  } else if (
-    typeof widthInt === 'undefined' &&
-    typeof heightInt === 'undefined' &&
-    unsized
-  ) {
-    // <Image src="i.png" unsized />
-    if (process.env.NODE_ENV !== 'production') {
-      if (priority) {
-        // <Image src="i.png" unsized priority />
-        console.warn(
-          `Image with src "${src}" has both "priority" and "unsized" properties. Only one should be used.`
-        )
-      }
-    }
-  } else {
-    // <Image src="i.png" />
-    if (process.env.NODE_ENV !== 'production') {
-      throw new Error(
-        `Image with src "${src}" must use "width" and "height" properties or "unsized" property.`
-      )
-    }
-  }
+	let divStyle: React.CSSProperties | undefined;
+	let imgStyle: React.CSSProperties | undefined;
+	let wrapperStyle: React.CSSProperties | undefined;
+	if (
+		typeof widthInt !== "undefined" &&
+		typeof heightInt !== "undefined" &&
+		!unsized
+	) {
+		// <Image src="i.png" width={100} height={100} />
+		// <Image src="i.png" width="100" height="100" />
+		const quotient = heightInt / widthInt;
+		const ratio = isNaN(quotient) ? 1 : quotient * 100;
+		wrapperStyle = {
+			maxWidth: "100%",
+			width: widthInt,
+		};
+		divStyle = {
+			position: "relative",
+			paddingBottom: `${ratio}%`,
+		};
+		imgStyle = {
+			visibility: lazy ? "hidden" : "visible",
+			height: "100%",
+			left: "0",
+			position: "absolute",
+			top: "0",
+			width: "100%",
+		};
+	} else if (
+		typeof widthInt === "undefined" &&
+		typeof heightInt === "undefined" &&
+		unsized
+	) {
+		// <Image src="i.png" unsized />
+		if (process.env.NODE_ENV !== "production") {
+			if (priority) {
+				// <Image src="i.png" unsized priority />
+				console.warn(
+					`Image with src "${src}" has both "priority" and "unsized" properties. Only one should be used.`
+				);
+			}
+		}
+	} else {
+		// <Image src="i.png" />
+		if (process.env.NODE_ENV !== "production") {
+			throw new Error(
+				`Image with src "${src}" must use "width" and "height" properties or "unsized" property.`
+			);
+		}
+	}
 
-  // Generate attribute values
-  const imgSrc = computeSrc(src, unoptimized, widthInt, qualityInt)
-  const imgSrcSet = generateSrcSet({
-    src,
-    width: widthInt,
-    unoptimized,
-    quality: qualityInt,
-  })
+	// Generate attribute values
+	const imgSrc = computeSrc(src, unoptimized, widthInt, qualityInt);
+	const imgSrcSet = generateSrcSet({
+		src,
+		width: widthInt,
+		unoptimized,
+		quality: qualityInt,
+	});
 
-  let imgAttributes:
-    | {
-        src: string
-        srcSet?: string
-      }
-    | {
-        'data-src': string
-        'data-srcset'?: string
-      }
-  if (!lazy) {
-    imgAttributes = {
-      src: imgSrc,
-    }
-    if (imgSrcSet) {
-      imgAttributes.srcSet = imgSrcSet
-    }
-  } else {
-    imgAttributes = {
-      'data-src': imgSrc,
-    }
-    if (imgSrcSet) {
-      imgAttributes['data-srcset'] = imgSrcSet
-    }
-    className = className ? className + ' __lazy' : '__lazy'
-  }
+	let imgAttributes:
+		| {
+				src: string;
+				srcSet?: string;
+		  }
+		| {
+				"data-src": string;
+				"data-srcset"?: string;
+		  };
+	if (!lazy) {
+		imgAttributes = {
+			src: imgSrc,
+		};
+		if (imgSrcSet) {
+			imgAttributes.srcSet = imgSrcSet;
+		}
+	} else {
+		imgAttributes = {
+			"data-src": imgSrc,
+		};
+		if (imgSrcSet) {
+			imgAttributes["data-srcset"] = imgSrcSet;
+		}
+		className = className ? className + " __lazy" : "__lazy";
+	}
 
-  // No need to add preloads on the client side--by the time the application is hydrated,
-  // it's too late for preloads
-  const shouldPreload = priority && typeof window === 'undefined'
+	// No need to add preloads on the client side--by the time the application is hydrated,
+	// it's too late for preloads
+	const shouldPreload = priority && typeof window === "undefined";
 
-  return (
-    <div style={wrapperStyle}>
-      <div style={divStyle}>
-        {shouldPreload
-          ? generatePreload({
-              src,
-              width: widthInt,
-              unoptimized,
-              sizes,
-              quality: qualityInt,
-            })
-          : ''}
-        <img
-          {...rest}
-          {...imgAttributes}
-          className={className}
-          sizes={sizes}
-          ref={thisEl}
-          style={imgStyle}
-        />
-      </div>
-    </div>
-  )
+	return (
+		<div style={wrapperStyle}>
+			<div style={divStyle}>
+				{shouldPreload
+					? generatePreload({
+							src,
+							width: widthInt,
+							unoptimized,
+							sizes,
+							quality: qualityInt,
+					  })
+					: ""}
+				{imgLoading && placeholder}
+				<img
+					{...rest}
+					{...imgAttributes}
+					className={className}
+					sizes={sizes}
+					ref={thisEl}
+					style={imgStyle}
+					onLoad={() => setImgLoading(false)}
+				/>
+			</div>
+		</div>
+	);
 }
 
 //BUILT IN LOADERS
 
-type LoaderProps = CallLoaderProps & { root: string }
+type LoaderProps = CallLoaderProps & { root: string };
 
 function normalizeSrc(src: string) {
-  return src[0] === '/' ? src.slice(1) : src
+	return src[0] === "/" ? src.slice(1) : src;
 }
 
 function imgixLoader({ root, src, width, quality }: LoaderProps): string {
-  const params = ['auto=format', 'w=' + width]
-  let paramsString = ''
-  if (quality) {
-    params.push('q=' + quality)
-  }
+	const params = ["auto=format", "w=" + width];
+	let paramsString = "";
+	if (quality) {
+		params.push("q=" + quality);
+	}
 
-  if (params.length) {
-    paramsString = '?' + params.join('&')
-  }
-  return `${root}${normalizeSrc(src)}${paramsString}`
+	if (params.length) {
+		paramsString = "?" + params.join("&");
+	}
+	return `${root}${normalizeSrc(src)}${paramsString}`;
 }
 
 function akamaiLoader({ root, src, width }: LoaderProps): string {
-  return `${root}${normalizeSrc(src)}?imwidth=${width}`
+	return `${root}${normalizeSrc(src)}?imwidth=${width}`;
 }
 
 function cloudinaryLoader({ root, src, width, quality }: LoaderProps): string {
-  const params = ['f_auto', 'w_' + width]
-  let paramsString = ''
-  if (quality) {
-    params.push('q_' + quality)
-  }
-  if (params.length) {
-    paramsString = params.join(',') + '/'
-  }
-  return `${root}${paramsString}${normalizeSrc(src)}`
+	const params = ["f_auto", "w_" + width];
+	let paramsString = "";
+	if (quality) {
+		params.push("q_" + quality);
+	}
+	if (params.length) {
+		paramsString = params.join(",") + "/";
+	}
+	return `${root}${paramsString}${normalizeSrc(src)}`;
 }
 
 function defaultLoader({ root, src, width, quality }: LoaderProps): string {
-  if (process.env.NODE_ENV !== 'production') {
-    const missingValues = []
+	if (process.env.NODE_ENV !== "production") {
+		const missingValues = [];
 
-    // these should always be provided but make sure they are
-    if (!src) missingValues.push('src')
-    if (!width) missingValues.push('width')
+		// these should always be provided but make sure they are
+		if (!src) missingValues.push("src");
+		if (!width) missingValues.push("width");
 
-    if (missingValues.length > 0) {
-      throw new Error(
-        `Next Image Optimization requires ${missingValues.join(
-          ', '
-        )} to be provided. Make sure you pass them as props to the \`next/image\` component. Received: ${JSON.stringify(
-          { src, width, quality }
-        )}`
-      )
-    }
+		if (missingValues.length > 0) {
+			throw new Error(
+				`Next Image Optimization requires ${missingValues.join(
+					", "
+				)} to be provided. Make sure you pass them as props to the \`next/image\` component. Received: ${JSON.stringify(
+					{ src, width, quality }
+				)}`
+			);
+		}
 
-    if (src && !src.startsWith('/') && configDomains) {
-      let parsedSrc: URL
-      try {
-        parsedSrc = new URL(src)
-      } catch (err) {
-        console.error(err)
-        throw new Error(
-          `Failed to parse "${src}" in "next/image", if using relative image it must start with a leading slash "/" or be an absolute URL (http:// or https://)`
-        )
-      }
+		if (src && !src.startsWith("/") && configDomains) {
+			let parsedSrc: URL;
+			try {
+				parsedSrc = new URL(src);
+			} catch (err) {
+				console.error(err);
+				throw new Error(
+					`Failed to parse "${src}" in "next/image", if using relative image it must start with a leading slash "/" or be an absolute URL (http:// or https://)`
+				);
+			}
 
-      if (!configDomains.includes(parsedSrc.hostname)) {
-        throw new Error(
-          `Invalid src prop (${src}) on \`next/image\`, hostname "${parsedSrc.hostname}" is not configured under images in your \`next.config.js\`\n` +
-            `See more info: https://err.sh/nextjs/next-image-unconfigured-host`
-        )
-      }
-    }
-  }
+			if (!configDomains.includes(parsedSrc.hostname)) {
+				throw new Error(
+					`Invalid src prop (${src}) on \`next/image\`, hostname "${parsedSrc.hostname}" is not configured under images in your \`next.config.js\`\n` +
+						`See more info: https://err.sh/nextjs/next-image-unconfigured-host`
+				);
+			}
+		}
+	}
 
-  return `${root}?url=${encodeURIComponent(src)}&w=${width}&q=${quality || 75}`
+	return `${root}?url=${encodeURIComponent(src)}&w=${width}&q=${quality || 75}`;
 }


### PR DESCRIPTION
## What's new?
- Added `placeholder` prop to Next image that is optional and will be rendered while the image is being loaded

## Example
Demo: https://next-image-unsplash.vercel.app/
Source: https://github.com/smakosh/next-image-unsplash

## Edge cases
I wasn't able to compute the width/height and keeping the ratio as it's done with Next image to the placeholder, looking forward on your feedback and suggestions to implement that