### PR TITLE
Fix GSP page titles in i18n-routing example

### DIFF
--- a/examples/i18n-routing/pages/gsp/[slug].js
+++ b/examples/i18n-routing/pages/gsp/[slug].js
@@ -11,7 +11,7 @@ export default function GspPage(props) {
 
   return (
     <div>
-      <h1>getServerSideProps page</h1>
+      <h1>getStaticProps page</h1>
       <p>Current slug: {query.slug}</p>
       <p>Current locale: {props.locale}</p>
       <p>Default locale: {defaultLocale}</p>

--- a/examples/i18n-routing/pages/gsp/index.js
+++ b/examples/i18n-routing/pages/gsp/index.js
@@ -7,7 +7,7 @@ export default function GspPage(props) {
 
   return (
     <div>
-      <h1>getServerSideProps page</h1>
+      <h1>getStaticProps page</h1>
       <p>Current locale: {props.locale}</p>
       <p>Default locale: {defaultLocale}</p>
       <p>Configured locales: {JSON.stringify(props.locales)}</p>


### PR DESCRIPTION
The page titles are wrong on the static and dynamic `getStaticProps` example pages. This fixes that.