### PR TITLE
I18n with base path

### DIFF
--- a/packages/next/next-server/lib/i18n/normalize-locale-path.ts
+++ b/packages/next/next-server/lib/i18n/normalize-locale-path.ts
@@ -10,9 +10,12 @@ export function normalizeLocalePath(
   const pathnameParts = pathname.split('/')
 
   ;(locales || []).some((locale) => {
-    if (pathnameParts[1].toLowerCase() === locale.toLowerCase()) {
+    const partIndex = pathnameParts.findIndex(
+      (part) => part.toLowerCase() === locale.toLowerCase()
+    )
+    if (partIndex !== -1) {
       detectedLocale = locale
-      pathnameParts.splice(1, 1)
+      pathnameParts.splice(partIndex, 1)
       pathname = pathnameParts.join('/') || '/'
       return true
     }

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -71,7 +71,7 @@ export function addLocale(
   return path
 }
 
-export function delLocale(path: string, locale?: string) {
+export function delLocale(path: string, locale?: string): string {
   if (process.env.__NEXT_I18N_SUPPORT) {
     if (hasBasePath(path)) {
       return addBasePath(delLocale(delBasePath(path), locale))

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -63,7 +63,9 @@ export function addLocale(
 ) {
   if (process.env.__NEXT_I18N_SUPPORT) {
     return locale && locale !== defaultLocale && !path.startsWith('/' + locale)
-      ? addPathPrefix(path, '/' + locale)
+      ? hasBasePath(path)
+        ? addBasePath(addPathPrefix(delBasePath(path), '/' + locale))
+        : addPathPrefix(path, '/' + locale)
       : path
   }
   return path
@@ -71,6 +73,9 @@ export function addLocale(
 
 export function delLocale(path: string, locale?: string) {
   if (process.env.__NEXT_I18N_SUPPORT) {
+    if (hasBasePath(path)) {
+      return addBasePath(delLocale(delBasePath(path), locale))
+    }
     return locale && path.startsWith('/' + locale)
       ? path.substr(locale.length + 1) || '/'
       : path
@@ -79,7 +84,9 @@ export function delLocale(path: string, locale?: string) {
 }
 
 export function hasBasePath(path: string): boolean {
-  return path === basePath || path.startsWith(basePath + '/')
+  return (
+    path === basePath || (basePath !== '' && path.startsWith(basePath + '/'))
+  )
 }
 
 export function addBasePath(path: string): string {
@@ -614,6 +621,7 @@ export default class Router implements BaseRouter {
       } = require('../i18n/normalize-locale-path') as typeof import('../i18n/normalize-locale-path')
 
       const localePathResult = normalizeLocalePath(as, this.locales)
+      as = localePathResult.pathname
 
       if (localePathResult.detectedLocale) {
         this.locale = localePathResult.detectedLocale

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -422,7 +422,7 @@ export default class Server {
               ? localeDomainRedirect
               : shouldStripDefaultLocale
               ? '/'
-              : `/${detectedLocale}`,
+              : `${basePath}/${detectedLocale}`,
           })
         )
         res.statusCode = 307


### PR DESCRIPTION
When basePath and i18n is set in next.config.js it dose not work togetter. The locale route gets inserted bevor base path:
`{locale}/{basePath}/{rest}` it should be
`{basePath}/{locale}/{rest}`

Auto redirect to a locale should consider basePath to.

I tried to fix these issues. i tested it manually and it seemed to work.