### PR TITLE
IE11 compatibility for top-level await

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -107,9 +107,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - run: cat packages/next/package.json | jq '.resolutions.webpack = "^5.0.0-beta.30"' > package.json.tmp && mv package.json.tmp packages/next/package.json
-      - run: cat packages/next/package.json | jq '.resolutions.react = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmp packages/next/package.json
-      - run: cat packages/next/package.json | jq '.resolutions."react-dom" = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmp packages/next/package.json
+      - run: cat package.json | jq '.resolutions.webpack = "^5.0.0-beta.30"' > package.json.tmp && mv package.json.tmp package.json
+      - run: cat package.json | jq '.resolutions.react = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmppackage.json
+      - run: cat package.json | jq '.resolutions."react-dom" = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmp package.json
       - run: yarn install --check-files
       - run: node run-tests.js test/integration/production/test/index.test.js
       - run: node run-tests.js test/integration/basic/test/index.test.js

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: cat package.json | jq '.resolutions.webpack = "^5.0.0-beta.30"' > package.json.tmp && mv package.json.tmp package.json
-      - run: cat package.json | jq '.resolutions.react = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmppackage.json
+      - run: cat package.json | jq '.resolutions.react = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmp package.json
       - run: cat package.json | jq '.resolutions."react-dom" = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmp package.json
       - run: yarn install --check-files
       - run: node run-tests.js test/integration/production/test/index.test.js

--- a/test/integration/async-modules/test/index.test.js
+++ b/test/integration/async-modules/test/index.test.js
@@ -90,7 +90,6 @@ function runTests(dev = false) {
       if (browser) await browser.close()
     }
   })
-
   ;(dev ? it.skip : it)('can render async error page', async () => {
     let browser
     try {
@@ -102,11 +101,12 @@ function runTests(dev = false) {
       if (browser) await browser.close()
     }
   })
-
   ;(dev ? it.skip : it)('compiles the source to es5', async () => {
     const html = await renderViaHTTP(appPort, '/')
 
-    const appScriptMatch = html.match(/\/_next\/static\/chunks\/pages\/_app-.+?\.js/)
+    const appScriptMatch = html.match(
+      /\/_next\/static\/chunks\/pages\/_app-.+?\.js/
+    )
     expect(appScriptMatch).toBeTruthy()
 
     const appScript = appScriptMatch[0]

--- a/test/integration/async-modules/test/index.test.js
+++ b/test/integration/async-modules/test/index.test.js
@@ -90,6 +90,7 @@ function runTests(dev = false) {
       if (browser) await browser.close()
     }
   })
+
   ;(dev ? it.skip : it)('can render async error page', async () => {
     let browser
     try {
@@ -100,6 +101,18 @@ function runTests(dev = false) {
     } finally {
       if (browser) await browser.close()
     }
+  })
+
+  ;(dev ? it.skip : it)('compiles the source to es5', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+
+    const appScriptMatch = html.match(/\/_next\/static\/chunks\/pages\/_app-.+?\.js/)
+    expect(appScriptMatch).toBeTruthy()
+
+    const appScript = appScriptMatch[0]
+    const appScriptContent = await renderViaHTTP(appPort, appScript)
+    expect(appScriptContent).not.toMatch(/async\(\)=>/)
+    expect(appScriptContent).not.toMatch(/await\s/)
   })
 }
 


### PR DESCRIPTION
I noticed that when the top-level await feature is used, the compiled output contains async/await and will therefore throw in IE11.

Do you have an idea what's causing this?

**Update**: I think this has to be solved on the webpack side. I've created an issue here: https://github.com/webpack/webpack/issues/11874.

Related to https://github.com/vercel/next.js/pull/17590

/cc @Janpot 