### PR TITLE
Ensure i18n context values are provided for blocking 404

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -784,7 +784,10 @@ const nextServerlessLoader: loader.Loader = function () {
                 getStaticPaths: undefined,
                 getServerSideProps: undefined,
                 Component: NotFoundComponent,
-                err: undefined
+                err: undefined,
+                locale: detectedLocale,
+                locales,
+                defaultLocale: i18n.defaultLocale,
               }))
 
               sendPayload(req, res, result, 'html', ${

--- a/test/integration/i18n-support/pages/404.js
+++ b/test/integration/i18n-support/pages/404.js
@@ -7,10 +7,12 @@ export default function NotFound(props) {
   )
 }
 
-export const getStaticProps = ({ locale }) => {
+export const getStaticProps = ({ locale, locales, defaultLocale }) => {
   return {
     props: {
       locale,
+      locales,
+      defaultLocale,
       is404: true,
     },
   }


### PR DESCRIPTION
This ensures we provide the current `locale`, `locales`, and `defaultLocale` in the context when rendering the 404 for a blocking SSG page

Fixes: https://github.com/vercel/next.js/issues/18505