### PR TITLE
Fix react-dev-overlay and prerender-indicator for IE11

### DIFF
--- a/packages/next/client/dev/prerender-indicator.js
+++ b/packages/next/client/dev/prerender-indicator.js
@@ -183,7 +183,7 @@ function createCss(prefix) {
     }
 
     #${prefix}container.${prefix}visible {
-      display: flex;
+      display: ${prefix ? 'block' : 'flex'};
       bottom: 10px;
       opacity: 1;
     }

--- a/packages/react-dev-overlay/src/internal/components/ShadowPortal.tsx
+++ b/packages/react-dev-overlay/src/internal/components/ShadowPortal.tsx
@@ -16,7 +16,9 @@ export const ShadowPortal: React.FC<ShadowPortalProps> = function Portal({
   React.useLayoutEffect(() => {
     const ownerDocument = mountNode.current!.ownerDocument!
     portalNode.current = ownerDocument.createElement('nextjs-portal')
-    shadowNode.current = portalNode.current.attachShadow({ mode: 'open' })
+    shadowNode.current = portalNode.current.attachShadow
+      ? portalNode.current.attachShadow({ mode: 'open' })
+      : null
     ownerDocument.body.appendChild(portalNode.current)
     forceUpdate({})
     return () => {


### PR DESCRIPTION
This PR fixes 2 issues with the IE11 development mode:

1. attachShadow function call failed
IE11 requires an exception because it does not support attachShadow.
In next.js v9, errors occur immediately upon execution, and in v10, errors occur infinitely when the next.js development server is stopped in the terminal.

2. Prerender indicator is not visible
If the `#container` is `display: flex`, IE11 does not show properly.
prerender-indicator already had an exception to the attachShadow, so it could be easily modified.
Support for attachShadow and flex does not exactly match, but in most cases it does.
When the property of `#container` is `display: block`, there was no side effect even in modern browsers.

https://github.com/vercel/next.js/blob/61981da9e00493da9aa1cfa8c95ed7a75fde27ee/packages/next/client/dev/prerender-indicator.js#L18-L28

Related issue: #13231