### PR TITLE
Ensure correct params are used with i18n revalidation

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -85,6 +85,17 @@ const nextServerlessLoader: loader.Loader = function () {
           .reduce((prev, key) => {
             let value = query[key]
 
+            // if the value matches the default value we can't rely
+            // on the parsed params, this is used to signal if we need
+            // to parse x-now-route-matches or not
+            const isDefaultValue = Array.isArray(value)
+              ? value.every((val, idx) => val === defaultRouteMatches[key][idx])
+              : value === defaultRouteMatches[key]
+
+            if (isDefaultValue) {
+              hasValidParams = false
+            }
+
             ${
               ''
               // non-provided optional values should be undefined so normalize
@@ -127,6 +138,7 @@ const nextServerlessLoader: loader.Loader = function () {
       }
     `
     : ''
+
   const envLoading = `
     const { processEnv } = require('@next/env')
     processEnv(${Buffer.from(loadedEnvFiles, 'base64').toString()})
@@ -155,6 +167,7 @@ const nextServerlessLoader: loader.Loader = function () {
   const dynamicRouteMatcher = pageIsDynamicRoute
     ? `
     const dynamicRouteMatcher = getRouteMatcher(getRouteRegex("${page}"))
+    const defaultRouteMatches = dynamicRouteMatcher("${page}")
   `
     : ''
 
@@ -387,8 +400,6 @@ const nextServerlessLoader: loader.Loader = function () {
 
       ${defaultRouteRegex}
 
-      ${normalizeDynamicRouteParams}
-
       ${handleRewrites}
 
       export default async (req, res) => {
@@ -399,7 +410,9 @@ const nextServerlessLoader: loader.Loader = function () {
           // to ensure we are using the correct values
           const trustQuery = req.headers['${vercelHeader}']
           const parsedUrl = handleRewrites(parseUrl(req.url, true))
+          let hasValidParams = true
 
+          ${normalizeDynamicRouteParams}
           ${handleBasePath}
 
           const params = ${
@@ -484,7 +497,6 @@ const nextServerlessLoader: loader.Loader = function () {
 
     ${dynamicRouteMatcher}
     ${defaultRouteRegex}
-    ${normalizeDynamicRouteParams}
     ${handleRewrites}
 
     export let config = compMod['confi' + 'g'] || (compMod.then && compMod.then(mod => mod['confi' + 'g'])) || {}
@@ -517,6 +529,9 @@ const nextServerlessLoader: loader.Loader = function () {
 
       const fromExport = renderMode === 'export' || renderMode === true;
       const nextStartMode = renderMode === 'passthrough'
+      let hasValidParams = true
+
+      ${normalizeDynamicRouteParams}
 
       setLazyProp({ req }, 'cookies', getCookieParser(req))
 
@@ -620,6 +635,7 @@ const nextServerlessLoader: loader.Loader = function () {
             `
             : `const params = {};`
         }
+
         ${
           // Temporary work around: `x-now-route-matches` is a platform header
           // _only_ set for `Prerender` requests. We should move this logic
@@ -627,7 +643,7 @@ const nextServerlessLoader: loader.Loader = function () {
           // removing reliance on `req.url` and using `req.query` instead
           // (which is needed for "custom routes" anyway).
           pageIsDynamicRoute
-            ? `const nowParams = req.headers && req.headers["x-now-route-matches"]
+            ? `const nowParams = !hasValidParams && req.headers && req.headers["x-now-route-matches"]
               ? getRouteMatcher(
                   (function() {
                     const { re, groups, routeKeys } = getRouteRegex("${page}");

--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -92,7 +92,7 @@ const nextServerlessLoader: loader.Loader = function () {
               ? value.every((val, idx) => val === defaultRouteMatches[key][idx])
               : value === defaultRouteMatches[key]
 
-            if (isDefaultValue) {
+            if (isDefaultValue || typeof value === 'undefined') {
               hasValidParams = false
             }
 

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -280,6 +280,21 @@ describe('Serverless', () => {
     expect(data.query).toEqual({ slug: paramRaw })
   })
 
+  it('should have the correct query string for a now route with invalid matches but correct path', async () => {
+    const paramRaw = 'dr/first'
+    const html = await fetchViaHTTP(appPort, `/dr/first`, '', {
+      headers: {
+        'x-now-route-matches': qs.stringify({
+          1: encodeURIComponent(paramRaw),
+        }),
+      },
+    }).then((res) => res.text())
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#__NEXT_DATA__').html())
+
+    expect(data.query).toEqual({ slug: 'first' })
+  })
+
   it('should have the correct query string for a catch all now route', async () => {
     const paramRaw = ['nested % 1', 'nested/2']
 


### PR DESCRIPTION
This makes sure we don't use invalid `x-now-route-matches` which can occur when `i18n` default locale is visited and a prerendered page is matched. To correct this we first check if we are able to derive the correct params from the URL and then bail on parsing `x-now-route-matches` if we are. Additional test cases are being added in the builder to ensure we don't regress on this

x-ref: https://github.com/vercel/next.js/discussions/18443
Fixes #18602