### PR TITLE
Fix Symbol.protype.description polyfill

### DIFF
--- a/packages/next-polyfill-module/src/index.js
+++ b/packages/next-polyfill-module/src/index.js
@@ -31,7 +31,7 @@ if (!('trimEnd' in String.prototype)) {
  */
 if (!('description' in Symbol.prototype)) {
   Object.defineProperty(Symbol.prototype, 'description', {
-    configurable:true,
+    configurable: true,
     get: function get() {
       var m = /\((.*)\)/.exec(this.toString())
       return m ? m[1] : undefined

--- a/packages/next-polyfill-module/src/index.js
+++ b/packages/next-polyfill-module/src/index.js
@@ -31,6 +31,7 @@ if (!('trimEnd' in String.prototype)) {
  */
 if (!('description' in Symbol.prototype)) {
   Object.defineProperty(Symbol.prototype, 'description', {
+    configurable:true,
     get: function get() {
       var m = /\((.*)\)/.exec(this.toString())
       return m ? m[1] : undefined


### PR DESCRIPTION
Our code uses `core-js` to polyfill and because core-js [`es.symbol.description`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/es.symbol.description.js#L14-L16) doesn't just check for `Symbol.prototype.description`, it will try to polyfill again but fail to do so because Next.js polyfill is not configurable. By default, `Object.defineProperty` set `configurable` to `false`. 

Here are the screenshots of the error on Edge 44.18362.449.0 using Next.js v10.0.1-canary.1
![Screen Shot 2020-10-30 at 9 44 05 PM](https://user-images.githubusercontent.com/1637627/97771409-da810700-1af9-11eb-8900-fe49d718dc94.png)

![Screen Shot 2020-10-30 at 9 51 43 PM](https://user-images.githubusercontent.com/1637627/97771433-321f7280-1afa-11eb-8928-fa4d902a01dd.png)

 