### PR TITLE
docs: fix missing comma in invalid redirect gssp

### DIFF
--- a/errors/invalid-redirect-gssp.md
+++ b/errors/invalid-redirect-gssp.md
@@ -13,7 +13,7 @@ export const getStaticProps = ({ params }) => {
   if (params.slug === 'deleted-post') {
     return {
       redirect: {
-        permanent: true // or false
+        permanent: true, // or false
         destination: '/some-location'
       }
     }

--- a/errors/invalid-redirect-gssp.md
+++ b/errors/invalid-redirect-gssp.md
@@ -14,15 +14,15 @@ export const getStaticProps = ({ params }) => {
     return {
       redirect: {
         permanent: true, // or false
-        destination: '/some-location'
-      }
+        destination: '/some-location',
+      },
     }
   }
 
   return {
     props: {
       // data
-    }
+    },
   }
 }
 ```


### PR DESCRIPTION
Fix missing comma in invalid redirect gssp, so it's correct. 