### PR TITLE
Avoid calling setState in callback ref

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -107,10 +107,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - run: cat packages/next/package.json | jq '.resolutions.webpack = "^5.0.0-beta.30"' > package.json.tmp && mv package.json.tmp packages/next/package.json
-      - run: cat packages/next/package.json | jq '.resolutions.react = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmp packages/next/package.json
-      - run: cat packages/next/package.json | jq '.resolutions."react-dom" = "^17.0.0-rc.1"' > package.json.tmp && mv package.json.tmp packages/next/package.json
+      - run: cat package.json | jq '.resolutions.webpack = "^5.0.0-beta.30"' > package.json.tmp && mv package.json.tmp package.json
+      - run: cat package.json | jq '.resolutions.react = "^17.0.1"' > package.json.tmp && mv package.json.tmp package.json
+      - run: cat package.json | jq '.resolutions."react-dom" = "^17.0.1"' > package.json.tmp && mv package.json.tmp package.json
       - run: yarn install --check-files
+      - run: yarn list webpack react react-dom
+      - run: node run-tests.js test/integration/link-ref/test/index.test.js
       - run: node run-tests.js test/integration/production/test/index.test.js
       - run: node run-tests.js test/integration/basic/test/index.test.js
       - run: node run-tests.js test/integration/async-modules/test/index.test.js

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -282,11 +282,17 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
 
   // This will return the first child, if multiple are provided it will throw an error
   const child: any = Children.only(children)
+  const childRef: any = child && typeof child === 'object' && child.ref
 
-  const cleanup = React.useRef(() => {})
+  const cleanup = React.useRef<() => void>()
   const setRef = React.useCallback(
     (el: Element) => {
-      cleanup.current()
+      // cleanup previous event handlers
+      if (cleanup.current) {
+        cleanup.current()
+        cleanup.current = undefined
+      }
+
       if (p && IntersectionObserver && el && el.tagName && isLocalURL(href)) {
         // Join on an invalid URI character
         const isPrefetched = prefetched[href + '%' + as]
@@ -295,18 +301,16 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
             prefetch(router, href, as)
           })
         }
-      } else {
-        cleanup.current = () => {}
       }
 
-      if (child && typeof child === 'object' && child.ref) {
-        if (typeof child.ref === 'function') child.ref(el)
-        else if (typeof child.ref === 'object') {
-          child.ref.current = el
+      if (childRef) {
+        if (typeof childRef === 'function') childRef(el)
+        else if (typeof childRef === 'object') {
+          childRef.current = el
         }
       }
     },
-    [p, child, href, as, router]
+    [p, childRef, href, as, router]
   )
 
   const childProps: {

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -261,7 +261,7 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
   }
   const p = props.prefetch !== false
 
-  const [childElm, setChildElm] = React.useState<Element>()
+  const childElm = React.useRef<Element>()
 
   const router = useRouter()
   const pathname = (router && router.pathname) || '/'
@@ -280,19 +280,19 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
     if (
       p &&
       IntersectionObserver &&
-      childElm &&
-      childElm.tagName &&
+      childElm.current &&
+      childElm.current.tagName &&
       isLocalURL(href)
     ) {
       // Join on an invalid URI character
       const isPrefetched = prefetched[href + '%' + as]
       if (!isPrefetched) {
-        return listenToIntersections(childElm, () => {
+        return listenToIntersections(childElm.current, () => {
           prefetch(router, href, as)
         })
       }
     }
-  }, [p, childElm, href, as, router])
+  }, [p, href, as, router])
 
   let { children, replace, shallow, scroll, locale } = props
   // Deprecated. Warning shown by propType check. If the children provided is a string (<Link>example</Link>) we wrap it in an <a> tag
@@ -308,8 +308,8 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
     href?: string
     ref?: any
   } = {
-    ref: (el: any) => {
-      if (el) setChildElm(el)
+    ref: (el: Element) => {
+      childElm.current = el
 
       if (child && typeof child === 'object' && child.ref) {
         if (typeof child.ref === 'function') child.ref(el)

--- a/test/integration/link-ref/pages/click-away-race-condition.js
+++ b/test/integration/link-ref/pages/click-away-race-condition.js
@@ -1,0 +1,50 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+
+const useClickAway = (ref, onClickAway) => {
+  useEffect(() => {
+    const handler = (event) => {
+      const el = ref.current
+
+      // when menu is open and clicked inside menu, A is expected to be false
+      // when menu is open and clicked outside menu, A is expected to be true
+      console.log('A', el && !el.contains(event.target))
+
+      el && !el.contains(event.target) && onClickAway(event)
+    }
+
+    document.addEventListener('click', handler)
+
+    return () => {
+      document.removeEventListener('click', handler)
+    }
+  }, [onClickAway, ref])
+}
+
+export default function App() {
+  const [open, setOpen] = useState(false)
+
+  const menuRef = useRef(null)
+
+  const onClickAway = useCallback(() => {
+    console.log('click away, open', open)
+    if (open) {
+      setOpen(false)
+    }
+  }, [open])
+
+  useClickAway(menuRef, onClickAway)
+
+  return (
+    <div>
+      <div id="click-me" onClick={() => setOpen(true)}>
+        Open Menu
+      </div>
+      {open && (
+        <div ref={menuRef} id="the-menu">
+          <Link href="/">some link</Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/test/integration/link-ref/test/index.test.js
+++ b/test/integration/link-ref/test/index.test.js
@@ -49,6 +49,15 @@ const didPrefetch = async (pathname) => {
   await browser.close()
 }
 
+function runCommonTests() {
+  // See https://github.com/vercel/next.js/issues/18437
+  it('should not have a race condition with a click handler', async () => {
+    const browser = await webdriver(appPort, '/click-away-race-condition')
+    await browser.elementByCss('#click-me').click()
+    await browser.waitForElementByCss('#the-menu')
+  })
+}
+
 describe('Invalid hrefs', () => {
   describe('dev mode', () => {
     beforeAll(async () => {
@@ -56,6 +65,8 @@ describe('Invalid hrefs', () => {
       app = await launchApp(appDir, appPort)
     })
     afterAll(() => killApp(app))
+
+    runCommonTests()
 
     it('should not show error for function component with forwardRef', async () => {
       await noError('/function')
@@ -81,6 +92,8 @@ describe('Invalid hrefs', () => {
       app = await nextStart(appDir, appPort)
     })
     afterAll(() => killApp(app))
+
+    runCommonTests()
 
     it('should preload with forwardRef', async () => {
       await didPrefetch('/function')


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/18437

Looks like the reason for using `setState` was to be able to leverage `useEffect` to handle cleanup of event handlers on the element. Wwe can replicate the useEffect behavior ourselves in a ref callback with a cleanup function. This avoids calling `setState`. Looking at the old code I'm going to assume it used to have a few more edge-cases.

@amannn found out that the [yarn resolution wasn't actually working](https://github.com/vercel/next.js/pull/18487#discussion_r514373778) in the webpack 5, react 17 tests. So included those changes in this PR as well