### PR TITLE
Ensure localeDetection: false doesn't detect from header

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -243,10 +243,12 @@ const nextServerlessLoader: loader.Loader = function () {
       let locales = i18n.locales
       let defaultLocale = i18n.defaultLocale
       let detectedLocale = detectLocaleCookie(req, i18n.locales)
-      let acceptPreferredLocale = accept.language(
-        req.headers['accept-language'],
-        i18n.locales
-      )
+      let acceptPreferredLocale = i18n.localeDetection !== false
+        ? accept.language(
+          req.headers['accept-language'],
+          i18n.locales
+        )
+        : detectedLocale
 
       const { host } = req.headers || {}
       // remove port from host and remove port if present

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -411,7 +411,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       ...i18n.locales.filter((locale: string) => locale !== i18n.defaultLocale),
     ]
 
-    const localeDetectionType = typeof i18n.locales.localeDetection
+    const localeDetectionType = typeof i18n.localeDetection
 
     if (
       localeDetectionType !== 'boolean' &&

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -312,10 +312,10 @@ export default class Server {
       const { pathname, ...parsed } = parseUrl(req.url || '/')
       let defaultLocale = i18n.defaultLocale
       let detectedLocale = detectLocaleCookie(req, i18n.locales)
-      let acceptPreferredLocale = accept.language(
-        req.headers['accept-language'],
-        i18n.locales
-      )
+      let acceptPreferredLocale =
+        i18n.localeDetection !== false
+          ? accept.language(req.headers['accept-language'], i18n.locales)
+          : detectedLocale
 
       const { host } = req?.headers || {}
       // remove port from host and remove port if present

--- a/test/integration/i18n-support/next.config.js
+++ b/test/integration/i18n-support/next.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   // target: 'experimental-serverless-trace',
   i18n: {
+    // localeDetection: false,
     locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en-US', 'en'],
     defaultLocale: 'en-US',
     domains: [

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -1786,4 +1786,91 @@ describe('i18n Support', () => {
 
     runTests()
   })
+
+  describe('with localeDetection disabled', () => {
+    beforeAll(async () => {
+      await fs.remove(join(appDir, '.next'))
+      nextConfig.replace('// localeDetection', 'localeDetection')
+
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(async () => {
+      nextConfig.restore()
+      await killApp(app)
+    })
+
+    it('should have localeDetection in routes-manifest', async () => {
+      const routesManifest = await fs.readJSON(
+        join(appDir, '.next/routes-manifest.json')
+      )
+
+      expect(routesManifest.i18n).toEqual({
+        localeDetection: false,
+        locales: ['en-US', 'nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en'],
+        defaultLocale: 'en-US',
+        domains: [
+          {
+            http: true,
+            domain: 'example.be',
+            defaultLocale: 'nl-BE',
+            locales: ['nl', 'nl-NL', 'nl-BE'],
+          },
+          {
+            http: true,
+            domain: 'example.fr',
+            defaultLocale: 'fr',
+            locales: ['fr-BE'],
+          },
+        ],
+      })
+    })
+
+    it('should not detect locale from accept-language', async () => {
+      const res = await fetchViaHTTP(
+        appPort,
+        '/',
+        {},
+        {
+          redirect: 'manual',
+          headers: {
+            'accept-language': 'fr',
+          },
+        }
+      )
+
+      expect(res.status).toBe(200)
+      const $ = cheerio.load(await res.text())
+      expect($('html').attr('lang')).toBe('en-US')
+      expect($('#router-locale').text()).toBe('en-US')
+      expect(JSON.parse($('#router-locales').text())).toEqual(locales)
+      expect($('#router-pathname').text()).toBe('/')
+      expect($('#router-as-path').text()).toBe('/')
+    })
+
+    it('should set locale from detected path', async () => {
+      for (const locale of locales) {
+        const res = await fetchViaHTTP(
+          appPort,
+          `/${locale}`,
+          {},
+          {
+            redirect: 'manual',
+            headers: {
+              'accept-language': 'en-US,en;q=0.9',
+            },
+          }
+        )
+
+        expect(res.status).toBe(200)
+        const $ = cheerio.load(await res.text())
+        expect($('html').attr('lang')).toBe(locale)
+        expect($('#router-locale').text()).toBe(locale)
+        expect(JSON.parse($('#router-locales').text())).toEqual(locales)
+        expect($('#router-pathname').text()).toBe('/')
+        expect($('#router-as-path').text()).toBe('/')
+      }
+    })
+  })
 })


### PR DESCRIPTION
This ensures we don't detect the locale from the header when `localeDetection` is set to `false`

Fixes: https://github.com/vercel/next.js/issues/18482