### PR TITLE
Ensure getStaticProps isn't called without params with i18n

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -808,7 +808,7 @@ export default async function build(
               }
             }
 
-            if (isSsg && !isFallback) {
+            if (isSsg) {
               // remove non-locale prefixed variant from defaultMap
               delete defaultMap[page]
             }

--- a/test/integration/i18n-support/pages/gsp/fallback/[slug].js
+++ b/test/integration/i18n-support/pages/gsp/fallback/[slug].js
@@ -24,6 +24,11 @@ export default function Page(props) {
 }
 
 export const getStaticProps = ({ params, locale, locales, defaultLocale }) => {
+  // ensure getStaticProps isn't called without params
+  if (!params || !params.slug) {
+    throw new Error(`missing params ${JSON.stringify(params)}`)
+  }
+
   return {
     props: {
       params,

--- a/test/integration/i18n-support/pages/gsp/no-fallback/[slug].js
+++ b/test/integration/i18n-support/pages/gsp/no-fallback/[slug].js
@@ -24,6 +24,11 @@ export default function Page(props) {
 }
 
 export const getStaticProps = ({ params, locale, locales, defaultLocale }) => {
+  // ensure getStaticProps isn't called without params
+  if (!params || !params.slug) {
+    throw new Error(`missing params ${JSON.stringify(params)}`)
+  }
+
   return {
     props: {
       params,

--- a/test/integration/i18n-support/pages/not-found/blocking-fallback/[slug].js
+++ b/test/integration/i18n-support/pages/not-found/blocking-fallback/[slug].js
@@ -22,6 +22,11 @@ export default function Page(props) {
 }
 
 export const getStaticProps = ({ params, locale, locales }) => {
+  // ensure getStaticProps isn't called without params
+  if (!params || !params.slug) {
+    throw new Error(`missing params ${JSON.stringify(params)}`)
+  }
+
   if (locale === 'en' || locale === 'nl') {
     return {
       notFound: true,

--- a/test/integration/i18n-support/pages/not-found/fallback/[slug].js
+++ b/test/integration/i18n-support/pages/not-found/fallback/[slug].js
@@ -24,6 +24,11 @@ export default function Page(props) {
 }
 
 export const getStaticProps = ({ params, locale, locales }) => {
+  // ensure getStaticProps isn't called without params
+  if (!params || !params.slug) {
+    throw new Error(`missing params ${JSON.stringify(params)}`)
+  }
+
   if (locale === 'en' || locale === 'nl') {
     return {
       notFound: true,


### PR DESCRIPTION
This corrects additional fallback pages being generated without the fallback flag causing `getStaticProps` to be called without params with i18n. The revalidation aspect of the issue has been corrected separately in https://github.com/vercel/next.js/pull/18569

Fixes: https://github.com/vercel/next.js/issues/18404