### PR TITLE
next/image: replace for ... of loop with polyfilled alternative

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -119,14 +119,10 @@ function getDeviceSizes(
   if (configImageSizes.includes(width)) {
     return [width]
   }
-  const widths: number[] = []
-  for (let size of configDeviceSizes) {
-    widths.push(size)
-    if (size >= width) {
-      break
-    }
-  }
-  return widths
+  const largestIndex = configDeviceSizes.findIndex((size) => size >= width)
+  return largestIndex === -1
+    ? configDeviceSizes
+    : configDeviceSizes.slice(0, largestIndex + 1)
 }
 
 function computeSrc(


### PR DESCRIPTION
As long as I remember, next.js doesn't include the `for ... of` polyfill.