### PR TITLE
Ensure multi-level basePath works properly

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -966,8 +966,19 @@ export default class Server {
 
           // if basePath is defined require it be present
           if (basePath) {
-            if (pathParts[0] !== basePath.substr(1)) return { finished: false }
-            pathParts.shift()
+            const basePathParts = basePath.split('/')
+            // remove first empty value
+            basePathParts.shift()
+
+            if (
+              !basePathParts.every((part: string, idx: number) => {
+                return part === pathParts[idx]
+              })
+            ) {
+              return { finished: false }
+            }
+
+            pathParts.splice(0, basePathParts.length)
           }
 
           const path = `/${pathParts.join('/')}`

--- a/test/integration/basepath/pages/absolute-url-basepath.js
+++ b/test/integration/basepath/pages/absolute-url-basepath.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 export async function getServerSideProps({ query: { port } }) {
   if (!port) {
@@ -9,10 +10,14 @@ export async function getServerSideProps({ query: { port } }) {
 }
 
 export default function Page({ port }) {
+  const router = useRouter()
   return (
     <>
-      <Link href={`http://localhost:${port}/docs/something-else`}>
-        <a id="absolute-link">http://localhost:{port}/docs/something-else</a>
+      <Link href={`http://localhost:${port}${router.basePath}/something-else`}>
+        <a id="absolute-link">
+          http://localhost:{port}
+          {router.basePath}/something-else
+        </a>
       </Link>
     </>
   )

--- a/test/integration/basepath/pages/invalid-manual-basepath.js
+++ b/test/integration/basepath/pages/invalid-manual-basepath.js
@@ -1,8 +1,9 @@
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 export default () => (
   <>
-    <Link href="/docs/other-page">
+    <Link href={`${useRouter().basePath}/other-page`}>
       <a id="other-page-link">
         <h1>Hello World</h1>
       </a>

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -4,13 +4,10 @@ import webdriver from 'next-webdriver'
 import { join, resolve } from 'path'
 import url from 'url'
 import {
-  nextServer,
   launchApp,
   findPort,
   killApp,
   nextBuild,
-  startApp,
-  stopApp,
   waitFor,
   check,
   getBrowserBodyText,
@@ -36,6 +33,9 @@ jest.setTimeout(1000 * 60 * 2)
 const appDir = join(__dirname, '..')
 
 let externalApp
+let app
+let appPort
+let basePath = '/docs'
 
 const nextConfig = new File(resolve(appDir, 'next.config.js'))
 
@@ -52,10 +52,327 @@ afterAll(async () => {
   externalApp.close()
 })
 
-const runTests = (context, dev = false) => {
+const runTests = (dev = false) => {
   if (dev) {
+    describe('Hot Module Reloading', () => {
+      describe('delete a page and add it back', () => {
+        it('should load the page properly', async () => {
+          const contactPagePath = join(
+            __dirname,
+            '../',
+            'pages',
+            'hmr',
+            'contact.js'
+          )
+          const newContactPagePath = join(
+            __dirname,
+            '../',
+            'pages',
+            'hmr',
+            '_contact.js'
+          )
+          let browser
+          try {
+            browser = await webdriver(appPort, `${basePath}/hmr/contact`)
+            const text = await browser.elementByCss('p').text()
+            expect(text).toBe('This is the contact page.')
+
+            // Rename the file to mimic a deleted page
+            renameSync(contactPagePath, newContactPagePath)
+
+            await check(
+              () => getBrowserBodyText(browser),
+              /This page could not be found/
+            )
+
+            // Rename the file back to the original filename
+            renameSync(newContactPagePath, contactPagePath)
+
+            // wait until the page comes back
+            await check(
+              () => getBrowserBodyText(browser),
+              /This is the contact page/
+            )
+          } finally {
+            if (browser) {
+              await browser.close()
+            }
+            if (existsSync(newContactPagePath)) {
+              renameSync(newContactPagePath, contactPagePath)
+            }
+          }
+        })
+      })
+
+      describe('editing a page', () => {
+        it('should detect the changes and display it', async () => {
+          let browser
+          try {
+            browser = await webdriver(appPort, `${basePath}/hmr/about`)
+            const text = await browser.elementByCss('p').text()
+            expect(text).toBe('This is the about page.')
+
+            const aboutPagePath = join(
+              __dirname,
+              '../',
+              'pages',
+              'hmr',
+              'about.js'
+            )
+
+            const originalContent = readFileSync(aboutPagePath, 'utf8')
+            const editedContent = originalContent.replace(
+              'This is the about page',
+              'COOL page'
+            )
+
+            // change the content
+            writeFileSync(aboutPagePath, editedContent, 'utf8')
+
+            await check(() => getBrowserBodyText(browser), /COOL page/)
+
+            // add the original content
+            writeFileSync(aboutPagePath, originalContent, 'utf8')
+
+            await check(
+              () => getBrowserBodyText(browser),
+              /This is the about page/
+            )
+          } finally {
+            if (browser) {
+              await browser.close()
+            }
+          }
+        })
+
+        it('should not reload unrelated pages', async () => {
+          let browser
+          try {
+            browser = await webdriver(appPort, `${basePath}/hmr/counter`)
+            const text = await browser
+              .elementByCss('button')
+              .click()
+              .elementByCss('button')
+              .click()
+              .elementByCss('p')
+              .text()
+            expect(text).toBe('COUNT: 2')
+
+            const aboutPagePath = join(
+              __dirname,
+              '../',
+              'pages',
+              'hmr',
+              'about.js'
+            )
+
+            const originalContent = readFileSync(aboutPagePath, 'utf8')
+            const editedContent = originalContent.replace(
+              'This is the about page',
+              'COOL page'
+            )
+
+            // Change the about.js page
+            writeFileSync(aboutPagePath, editedContent, 'utf8')
+
+            // wait for 5 seconds
+            await waitFor(5000)
+
+            // Check whether the this page has reloaded or not.
+            const newText = await browser.elementByCss('p').text()
+            expect(newText).toBe('COUNT: 2')
+
+            // restore the about page content.
+            writeFileSync(aboutPagePath, originalContent, 'utf8')
+          } finally {
+            if (browser) {
+              await browser.close()
+            }
+          }
+        })
+
+        // Added because of a regression in react-hot-loader, see issues: #4246 #4273
+        // Also: https://github.com/zeit/styled-jsx/issues/425
+        it('should update styles correctly', async () => {
+          let browser
+          try {
+            browser = await webdriver(appPort, `${basePath}/hmr/style`)
+            const pTag = await browser.elementByCss('.hmr-style-page p')
+            const initialFontSize = await pTag.getComputedCss('font-size')
+
+            expect(initialFontSize).toBe('100px')
+
+            const pagePath = join(__dirname, '../', 'pages', 'hmr', 'style.js')
+
+            const originalContent = readFileSync(pagePath, 'utf8')
+            const editedContent = originalContent.replace('100px', '200px')
+
+            // Change the page
+            writeFileSync(pagePath, editedContent, 'utf8')
+
+            try {
+              // Check whether the this page has reloaded or not.
+              await check(async () => {
+                const editedPTag = await browser.elementByCss(
+                  '.hmr-style-page p'
+                )
+                return editedPTag.getComputedCss('font-size')
+              }, /200px/)
+            } finally {
+              // Finally is used so that we revert the content back to the original regardless of the test outcome
+              // restore the about page content.
+              writeFileSync(pagePath, originalContent, 'utf8')
+            }
+          } finally {
+            if (browser) {
+              await browser.close()
+            }
+          }
+        })
+
+        // Added because of a regression in react-hot-loader, see issues: #4246 #4273
+        // Also: https://github.com/zeit/styled-jsx/issues/425
+        it('should update styles in a stateful component correctly', async () => {
+          let browser
+          const pagePath = join(
+            __dirname,
+            '../',
+            'pages',
+            'hmr',
+            'style-stateful-component.js'
+          )
+          const originalContent = readFileSync(pagePath, 'utf8')
+          try {
+            browser = await webdriver(
+              appPort,
+              `${basePath}/hmr/style-stateful-component`
+            )
+            const pTag = await browser.elementByCss('.hmr-style-page p')
+            const initialFontSize = await pTag.getComputedCss('font-size')
+
+            expect(initialFontSize).toBe('100px')
+            const editedContent = originalContent.replace('100px', '200px')
+
+            // Change the page
+            writeFileSync(pagePath, editedContent, 'utf8')
+
+            // Check whether the this page has reloaded or not.
+            await check(async () => {
+              const editedPTag = await browser.elementByCss('.hmr-style-page p')
+              return editedPTag.getComputedCss('font-size')
+            }, /200px/)
+          } finally {
+            if (browser) {
+              await browser.close()
+            }
+            writeFileSync(pagePath, originalContent, 'utf8')
+          }
+        })
+
+        // Added because of a regression in react-hot-loader, see issues: #4246 #4273
+        // Also: https://github.com/zeit/styled-jsx/issues/425
+        it('should update styles in a dynamic component correctly', async () => {
+          let browser = null
+          let secondBrowser = null
+          const pagePath = join(
+            __dirname,
+            '../',
+            'components',
+            'hmr',
+            'dynamic.js'
+          )
+          const originalContent = readFileSync(pagePath, 'utf8')
+          try {
+            browser = await webdriver(
+              appPort,
+              `${basePath}/hmr/style-dynamic-component`
+            )
+            const div = await browser.elementByCss('#dynamic-component')
+            const initialClientClassName = await div.getAttribute('class')
+            const initialFontSize = await div.getComputedCss('font-size')
+
+            expect(initialFontSize).toBe('100px')
+
+            const initialHtml = await renderViaHTTP(
+              appPort,
+              `${basePath}/hmr/style-dynamic-component`
+            )
+            expect(initialHtml.includes('100px')).toBeTruthy()
+
+            const $initialHtml = cheerio.load(initialHtml)
+            const initialServerClassName = $initialHtml(
+              '#dynamic-component'
+            ).attr('class')
+
+            expect(
+              initialClientClassName === initialServerClassName
+            ).toBeTruthy()
+
+            const editedContent = originalContent.replace('100px', '200px')
+
+            // Change the page
+            writeFileSync(pagePath, editedContent, 'utf8')
+
+            // wait for 5 seconds
+            await waitFor(5000)
+
+            secondBrowser = await webdriver(
+              appPort,
+              `${basePath}/hmr/style-dynamic-component`
+            )
+            // Check whether the this page has reloaded or not.
+            const editedDiv = await secondBrowser.elementByCss(
+              '#dynamic-component'
+            )
+            const editedClientClassName = await editedDiv.getAttribute('class')
+            const editedFontSize = await editedDiv.getComputedCss('font-size')
+            const browserHtml = await secondBrowser
+              .elementByCss('html')
+              .getAttribute('innerHTML')
+
+            expect(editedFontSize).toBe('200px')
+            expect(browserHtml.includes('font-size:200px;')).toBe(true)
+            expect(browserHtml.includes('font-size:100px;')).toBe(false)
+
+            const editedHtml = await renderViaHTTP(
+              appPort,
+              `${basePath}/hmr/style-dynamic-component`
+            )
+            expect(editedHtml.includes('200px')).toBeTruthy()
+            const $editedHtml = cheerio.load(editedHtml)
+            const editedServerClassName = $editedHtml(
+              '#dynamic-component'
+            ).attr('class')
+
+            expect(editedClientClassName === editedServerClassName).toBe(true)
+          } finally {
+            // Finally is used so that we revert the content back to the original regardless of the test outcome
+            // restore the about page content.
+            writeFileSync(pagePath, originalContent, 'utf8')
+
+            if (browser) {
+              await browser.close()
+            }
+
+            if (secondBrowser) {
+              secondBrowser.close()
+            }
+          }
+        })
+      })
+    })
+
+    it('should respect basePath in amphtml link rel', async () => {
+      const html = await renderViaHTTP(appPort, `${basePath}/amp-hybrid`)
+      const $ = cheerio.load(html)
+      const expectedAmpHtmlUrl = `${basePath}/amp-hybrid?amp=1`
+      expect($('link[rel=amphtml]').first().attr('href')).toBe(
+        expectedAmpHtmlUrl
+      )
+    })
+
     it('should render error in dev overlay correctly', async () => {
-      const browser = await webdriver(context.appPort, '/docs/hello')
+      const browser = await webdriver(appPort, `${basePath}/hello`)
       await browser.elementByCss('#trigger-error').click()
       expect(await hasRedbox(browser)).toBe(true)
 
@@ -79,11 +396,11 @@ const runTests = (context, dev = false) => {
       const routesManifest = await fs.readJSON(
         join(appDir, '.next/routes-manifest.json')
       )
-      expect(routesManifest.basePath).toBe('/docs')
+      expect(routesManifest.basePath).toBe(basePath)
     })
 
     it('should prefetch pages correctly when manually called', async () => {
-      const browser = await webdriver(context.appPort, '/docs/other-page')
+      const browser = await webdriver(appPort, `${basePath}/other-page`)
       await browser.eval('window.next.router.prefetch("/gssp")')
 
       await check(
@@ -107,7 +424,7 @@ const runTests = (context, dev = false) => {
     })
 
     it('should prefetch pages correctly in viewport with <Link>', async () => {
-      const browser = await webdriver(context.appPort, '/docs/hello')
+      const browser = await webdriver(appPort, `${basePath}/hello`)
       await browser.eval('window.next.router.prefetch("/gssp")')
 
       await check(
@@ -136,56 +453,53 @@ const runTests = (context, dev = false) => {
   }
 
   it('should 404 for public file without basePath', async () => {
-    const res = await fetchViaHTTP(context.appPort, '/data.txt')
+    const res = await fetchViaHTTP(appPort, '/data.txt')
     expect(res.status).toBe(404)
   })
 
   it('should serve public file with basePath correctly', async () => {
-    const res = await fetchViaHTTP(context.appPort, '/docs/data.txt')
+    const res = await fetchViaHTTP(appPort, `${basePath}/data.txt`)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('hello world')
   })
 
   it('should rewrite with basePath by default', async () => {
-    const html = await renderViaHTTP(context.appPort, '/docs/rewrite-1')
+    const html = await renderViaHTTP(appPort, `${basePath}/rewrite-1`)
     expect(html).toContain('getServerSideProps')
   })
 
   it('should not rewrite without basePath without disabling', async () => {
-    const res = await fetchViaHTTP(context.appPort, '/rewrite-1')
+    const res = await fetchViaHTTP(appPort, '/rewrite-1')
     expect(res.status).toBe(404)
   })
 
   it('should not rewrite with basePath when set to false', async () => {
     // won't 404 as it matches the dynamic [slug] route
-    const html = await renderViaHTTP(
-      context.appPort,
-      '/docs/rewrite-no-basePath'
-    )
+    const html = await renderViaHTTP(appPort, `${basePath}/rewrite-no-basePath`)
     expect(html).toContain('slug')
   })
 
   it('should rewrite without basePath when set to false', async () => {
-    const html = await renderViaHTTP(context.appPort, '/rewrite-no-basePath')
+    const html = await renderViaHTTP(appPort, '/rewrite-no-basePath')
     expect(html).toContain('hello from external')
   })
 
   it('should redirect with basePath by default', async () => {
     const res = await fetchViaHTTP(
-      context.appPort,
-      '/docs/redirect-1',
+      appPort,
+      `${basePath}/redirect-1`,
       undefined,
       {
         redirect: 'manual',
       }
     )
     const { pathname } = url.parse(res.headers.get('location') || '')
-    expect(pathname).toBe('/docs/somewhere-else')
+    expect(pathname).toBe(`${basePath}/somewhere-else`)
     expect(res.status).toBe(307)
   })
 
   it('should not redirect without basePath without disabling', async () => {
-    const res = await fetchViaHTTP(context.appPort, '/redirect-1', undefined, {
+    const res = await fetchViaHTTP(appPort, '/redirect-1', undefined, {
       redirect: 'manual',
     })
     expect(res.status).toBe(404)
@@ -193,16 +507,13 @@ const runTests = (context, dev = false) => {
 
   it('should not redirect with basePath when set to false', async () => {
     // won't 404 as it matches the dynamic [slug] route
-    const html = await renderViaHTTP(
-      context.appPort,
-      '/docs/rewrite-no-basePath'
-    )
+    const html = await renderViaHTTP(appPort, `${basePath}/rewrite-no-basePath`)
     expect(html).toContain('slug')
   })
 
   it('should redirect without basePath when set to false', async () => {
     const res = await fetchViaHTTP(
-      context.appPort,
+      appPort,
       '/redirect-no-basepath',
       undefined,
       {
@@ -216,66 +527,69 @@ const runTests = (context, dev = false) => {
 
   //
   it('should add header with basePath by default', async () => {
-    const res = await fetchViaHTTP(context.appPort, '/docs/add-header')
+    const res = await fetchViaHTTP(appPort, `${basePath}/add-header`)
     expect(res.headers.get('x-hello')).toBe('world')
   })
 
   it('should not add header without basePath without disabling', async () => {
-    const res = await fetchViaHTTP(context.appPort, '/add-header')
+    const res = await fetchViaHTTP(appPort, '/add-header')
     expect(res.headers.get('x-hello')).toBe(null)
   })
 
   it('should not add header with basePath when set to false', async () => {
     const res = await fetchViaHTTP(
-      context.appPort,
-      '/docs/add-header-no-basepath'
+      appPort,
+      `${basePath}/add-header-no-basepath`
     )
     expect(res.headers.get('x-hello')).toBe(null)
   })
 
   it('should add header without basePath when set to false', async () => {
-    const res = await fetchViaHTTP(context.appPort, '/add-header-no-basepath')
+    const res = await fetchViaHTTP(appPort, '/add-header-no-basepath')
     expect(res.headers.get('x-hello')).toBe('world')
   })
 
   it('should not update URL for a 404', async () => {
-    const browser = await webdriver(context.appPort, '/missing')
+    const browser = await webdriver(appPort, '/missing')
     const pathname = await browser.eval(() => window.location.pathname)
     expect(await browser.eval(() => window.next.router.asPath)).toBe('/missing')
     expect(pathname).toBe('/missing')
   })
 
   it('should handle 404 urls that start with basePath', async () => {
-    const browser = await webdriver(context.appPort, '/docshello')
+    const browser = await webdriver(appPort, `${basePath}hello`)
     expect(await browser.eval(() => window.next.router.asPath)).toBe(
-      '/docshello'
+      `${basePath}hello`
     )
     expect(await browser.eval(() => window.location.pathname)).toBe(
-      '/docshello'
+      `${basePath}hello`
     )
   })
 
   it('should navigate back to a non-basepath 404 that starts with basepath', async () => {
-    const browser = await webdriver(context.appPort, '/docshello')
+    const browser = await webdriver(appPort, `${basePath}hello`)
     await browser.eval(() => (window.navigationMarker = true))
     await browser.eval(() => window.next.router.push('/hello'))
     await browser.waitForElementByCss('#pathname')
     await browser.back()
-    check(() => browser.eval(() => window.location.pathname), '/docshello')
+    check(
+      () => browser.eval(() => window.location.pathname),
+      `${basePath}hello`
+    )
     expect(await browser.eval(() => window.next.router.asPath)).toBe(
-      '/docshello'
+      `${basePath}hello`
     )
     expect(await browser.eval(() => window.navigationMarker)).toBe(true)
   })
 
   it('should update dynamic params after mount correctly', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello-dynamic')
+    const browser = await webdriver(appPort, `${basePath}/hello-dynamic`)
     const text = await browser.elementByCss('#slug').text()
     expect(text).toContain('slug: hello-dynamic')
   })
 
   it('should navigate to index page with getStaticProps', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.eval('window.beforeNavigate = "hi"')
 
     await browser.elementByCss('#index-gsp').click()
@@ -296,7 +610,7 @@ const runTests = (context, dev = false) => {
         const href = url.parse(fullHref).pathname
 
         if (
-          href.startsWith('/docs/_next/data') &&
+          href.startsWith(`${basePath}/_next/data`) &&
           href.endsWith('index.json') &&
           !href.endsWith('index/index.json')
         ) {
@@ -309,7 +623,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should navigate to nested index page with getStaticProps', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.eval('window.beforeNavigate = "hi"')
 
     await browser.elementByCss('#nested-index-gsp').click()
@@ -330,7 +644,7 @@ const runTests = (context, dev = false) => {
         const href = url.parse(fullHref).pathname
 
         if (
-          href.startsWith('/docs/_next/data') &&
+          href.startsWith(`${basePath}/_next/data`) &&
           href.endsWith('index/index.json')
         ) {
           found = true
@@ -342,17 +656,17 @@ const runTests = (context, dev = false) => {
   })
 
   it('should work with nested folder with same name as basePath', async () => {
-    const html = await renderViaHTTP(context.appPort, '/docs/docs/another')
+    const html = await renderViaHTTP(appPort, `${basePath}/docs/another`)
     expect(html).toContain('hello from another')
 
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.eval('window.next.router.push("/docs/another")')
 
     await check(() => browser.elementByCss('p').text(), /hello from another/)
   })
 
   it('should work with normal dynamic page', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.elementByCss('#dynamic-link').click()
     await check(
       () => browser.eval(() => document.documentElement.innerHTML),
@@ -361,15 +675,15 @@ const runTests = (context, dev = false) => {
   })
 
   it('should work with hash links', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.elementByCss('#hashlink').click()
     const url = new URL(await browser.eval(() => window.location.href))
-    expect(url.pathname).toBe('/docs/hello')
+    expect(url.pathname).toBe(`${basePath}/hello`)
     expect(url.hash).toBe('#hashlink')
   })
 
   it('should work with catch-all page', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.elementByCss('#catchall-link').click()
     await check(
       () => browser.eval(() => document.documentElement.innerHTML),
@@ -379,30 +693,30 @@ const runTests = (context, dev = false) => {
 
   it('should redirect trailing slash correctly', async () => {
     const res = await fetchViaHTTP(
-      context.appPort,
-      '/docs/hello/',
+      appPort,
+      `${basePath}/hello/`,
       {},
       { redirect: 'manual' }
     )
     expect(res.status).toBe(308)
     const { pathname } = new URL(res.headers.get('location'))
-    expect(pathname).toBe('/docs/hello')
+    expect(pathname).toBe(`${basePath}/hello`)
   })
 
   it('should redirect trailing slash on root correctly', async () => {
     const res = await fetchViaHTTP(
-      context.appPort,
-      '/docs/',
+      appPort,
+      `${basePath}/`,
       {},
       { redirect: 'manual' }
     )
     expect(res.status).toBe(308)
     const { pathname } = new URL(res.headers.get('location'))
-    expect(pathname).toBe('/docs')
+    expect(pathname).toBe(`${basePath}`)
   })
 
   it('should navigate an absolute url', async () => {
-    const browser = await webdriver(context.appPort, `/docs/absolute-url`)
+    const browser = await webdriver(appPort, `${basePath}/absolute-url`)
     await browser.waitForElementByCss('#absolute-link').click()
     await check(
       () => browser.eval(() => window.location.origin),
@@ -412,8 +726,8 @@ const runTests = (context, dev = false) => {
 
   it('should navigate an absolute local url with basePath', async () => {
     const browser = await webdriver(
-      context.appPort,
-      `/docs/absolute-url-basepath?port=${context.appPort}`
+      appPort,
+      `${basePath}/absolute-url-basepath?port=${appPort}`
     )
     await browser.eval(() => (window._didNotNavigate = true))
     await browser.waitForElementByCss('#absolute-link').click()
@@ -427,8 +741,8 @@ const runTests = (context, dev = false) => {
 
   it('should navigate an absolute local url without basePath', async () => {
     const browser = await webdriver(
-      context.appPort,
-      `/docs/absolute-url-no-basepath?port=${context.appPort}`
+      appPort,
+      `${basePath}/absolute-url-no-basepath?port=${appPort}`
     )
     await browser.waitForElementByCss('#absolute-link').click()
     await check(
@@ -442,8 +756,8 @@ const runTests = (context, dev = false) => {
 
   it('should 404 when manually adding basePath with <Link>', async () => {
     const browser = await webdriver(
-      context.appPort,
-      '/docs/invalid-manual-basepath'
+      appPort,
+      `${basePath}/invalid-manual-basepath`
     )
     await browser.eval('window.beforeNav = "hi"')
     await browser.elementByCss('#other-page-link').click()
@@ -459,9 +773,9 @@ const runTests = (context, dev = false) => {
   })
 
   it('should 404 when manually adding basePath with router.push', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.eval('window.beforeNav = "hi"')
-    await browser.eval('window.next.router.push("/docs/other-page")')
+    await browser.eval(`window.next.router.push("${basePath}/other-page")`)
 
     await check(() => browser.eval('window.beforeNav'), {
       test(content) {
@@ -474,9 +788,9 @@ const runTests = (context, dev = false) => {
   })
 
   it('should 404 when manually adding basePath with router.replace', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.eval('window.beforeNav = "hi"')
-    await browser.eval('window.next.router.replace("/docs/other-page")')
+    await browser.eval(`window.next.router.replace("${basePath}/other-page")`)
 
     await check(() => browser.eval('window.beforeNav'), {
       test(content) {
@@ -489,7 +803,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should show the hello page under the /docs prefix', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     try {
       const text = await browser.elementByCss('h1').text()
       expect(text).toBe('Hello World')
@@ -499,7 +813,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should have correct router paths on first load of /', async () => {
-    const browser = await webdriver(context.appPort, '/docs')
+    const browser = await webdriver(appPort, `${basePath}`)
     await browser.waitForElementByCss('#pathname')
     const pathname = await browser.elementByCss('#pathname').text()
     expect(pathname).toBe('/')
@@ -508,7 +822,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should have correct router paths on first load of /hello', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.waitForElementByCss('#pathname')
     const pathname = await browser.elementByCss('#pathname').text()
     expect(pathname).toBe('/hello')
@@ -517,7 +831,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should fetch data for getStaticProps without reloading', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.eval('window.beforeNavigate = true')
     await browser.elementByCss('#gsp-link').click()
     await browser.waitForElementByCss('#gsp')
@@ -531,7 +845,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should fetch data for getServerSideProps without reloading', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     await browser.eval('window.beforeNavigate = true')
     await browser.elementByCss('#gssp-link').click()
     await browser.waitForElementByCss('#gssp')
@@ -547,27 +861,27 @@ const runTests = (context, dev = false) => {
   })
 
   it('should have correct href for a link', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     const href = await browser.elementByCss('a').getAttribute('href')
     const { pathname } = url.parse(href)
-    expect(pathname).toBe('/docs/other-page')
+    expect(pathname).toBe(`${basePath}/other-page`)
   })
 
   it('should have correct href for a link to /', async () => {
-    const browser = await webdriver(context.appPort, '/docs/link-to-root')
+    const browser = await webdriver(appPort, `${basePath}/link-to-root`)
     const href = await browser.elementByCss('#link-back').getAttribute('href')
     const { pathname } = url.parse(href)
-    expect(pathname).toBe('/docs')
+    expect(pathname).toBe(`${basePath}`)
   })
 
   it('should show 404 for page not under the /docs prefix', async () => {
-    const text = await renderViaHTTP(context.appPort, '/hello')
+    const text = await renderViaHTTP(appPort, '/hello')
     expect(text).not.toContain('Hello World')
     expect(text).toContain('This page could not be found')
   })
 
   it('should show the other-page page under the /docs prefix', async () => {
-    const browser = await webdriver(context.appPort, '/docs/other-page')
+    const browser = await webdriver(appPort, `${basePath}/other-page`)
     try {
       const text = await browser.elementByCss('h1').text()
       expect(text).toBe('Hello Other')
@@ -577,13 +891,13 @@ const runTests = (context, dev = false) => {
   })
 
   it('should have basePath field on Router', async () => {
-    const html = await renderViaHTTP(context.appPort, '/docs/hello')
+    const html = await renderViaHTTP(appPort, `${basePath}/hello`)
     const $ = cheerio.load(html)
-    expect($('#base-path').text()).toBe('/docs')
+    expect($('#base-path').text()).toBe(`${basePath}`)
   })
 
   it('should navigate to the page without refresh', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     try {
       await browser.eval('window.itdidnotrefresh = "hello"')
       const text = await browser
@@ -601,7 +915,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should use urls with basepath in router events', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     try {
       await browser.eval('window._clearEventLog()')
       await browser
@@ -611,9 +925,9 @@ const runTests = (context, dev = false) => {
 
       const eventLog = await browser.eval('window._getEventLog()')
       expect(eventLog).toEqual([
-        ['routeChangeStart', '/docs/other-page'],
-        ['beforeHistoryChange', '/docs/other-page'],
-        ['routeChangeComplete', '/docs/other-page'],
+        ['routeChangeStart', `${basePath}/other-page`],
+        ['beforeHistoryChange', `${basePath}/other-page`],
+        ['routeChangeComplete', `${basePath}/other-page`],
       ])
     } finally {
       await browser.close()
@@ -621,15 +935,15 @@ const runTests = (context, dev = false) => {
   })
 
   it('should use urls with basepath in router events for hash changes', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     try {
       await browser.eval('window._clearEventLog()')
       await browser.elementByCss('#hash-change').click()
 
       const eventLog = await browser.eval('window._getEventLog()')
       expect(eventLog).toEqual([
-        ['hashChangeStart', '/docs/hello#some-hash'],
-        ['hashChangeComplete', '/docs/hello#some-hash'],
+        ['hashChangeStart', `${basePath}/hello#some-hash`],
+        ['hashChangeComplete', `${basePath}/hello#some-hash`],
       ])
     } finally {
       await browser.close()
@@ -637,7 +951,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should use urls with basepath in router events for cancelled routes', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     try {
       await browser.eval('window._clearEventLog()')
       await browser
@@ -649,11 +963,11 @@ const runTests = (context, dev = false) => {
 
       const eventLog = await browser.eval('window._getEventLog()')
       expect(eventLog).toEqual([
-        ['routeChangeStart', '/docs/slow-route'],
-        ['routeChangeError', 'Route Cancelled', true, '/docs/slow-route'],
-        ['routeChangeStart', '/docs/other-page'],
-        ['beforeHistoryChange', '/docs/other-page'],
-        ['routeChangeComplete', '/docs/other-page'],
+        ['routeChangeStart', `${basePath}/slow-route`],
+        ['routeChangeError', 'Route Cancelled', true, `${basePath}/slow-route`],
+        ['routeChangeStart', `${basePath}/other-page`],
+        ['beforeHistoryChange', `${basePath}/other-page`],
+        ['routeChangeComplete', `${basePath}/other-page`],
       ])
     } finally {
       await browser.close()
@@ -661,7 +975,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should use urls with basepath in router events for failed route change', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello')
+    const browser = await webdriver(appPort, `${basePath}/hello`)
     try {
       await browser.eval('window._clearEventLog()')
       await browser.elementByCss('#error-route').click()
@@ -670,12 +984,12 @@ const runTests = (context, dev = false) => {
 
       const eventLog = await browser.eval('window._getEventLog()')
       expect(eventLog).toEqual([
-        ['routeChangeStart', '/docs/error-route'],
+        ['routeChangeStart', `${basePath}/error-route`],
         [
           'routeChangeError',
           'Failed to load static props',
           null,
-          '/docs/error-route',
+          `${basePath}/error-route`,
         ],
       ])
     } finally {
@@ -684,7 +998,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should allow URL query strings without refresh', async () => {
-    const browser = await webdriver(context.appPort, '/docs/hello?query=true')
+    const browser = await webdriver(appPort, `${basePath}/hello?query=true`)
     try {
       await browser.eval('window.itdidnotrefresh = "hello"')
       await new Promise((resolve, reject) => {
@@ -702,7 +1016,7 @@ const runTests = (context, dev = false) => {
   })
 
   it('should correctly replace state when same asPath but different url', async () => {
-    const browser = await webdriver(context.appPort, '/docs')
+    const browser = await webdriver(appPort, `${basePath}`)
     try {
       await browser.elementByCss('#hello-link').click()
       await browser.waitForElementByCss('#something-else-link')
@@ -719,386 +1033,94 @@ const runTests = (context, dev = false) => {
 }
 
 describe('basePath development', () => {
-  let server
-
-  let context = {}
-
   beforeAll(async () => {
-    context.appPort = await findPort()
-    server = await launchApp(join(__dirname, '..'), context.appPort, {
+    appPort = await findPort()
+    app = await launchApp(join(__dirname, '..'), appPort, {
       env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
     })
   })
-  afterAll(async () => {
-    await killApp(server)
-  })
+  afterAll(() => killApp(app))
 
-  runTests(context, true)
-
-  describe('Hot Module Reloading', () => {
-    describe('delete a page and add it back', () => {
-      it('should load the page properly', async () => {
-        const contactPagePath = join(
-          __dirname,
-          '../',
-          'pages',
-          'hmr',
-          'contact.js'
-        )
-        const newContactPagePath = join(
-          __dirname,
-          '../',
-          'pages',
-          'hmr',
-          '_contact.js'
-        )
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/docs/hmr/contact')
-          const text = await browser.elementByCss('p').text()
-          expect(text).toBe('This is the contact page.')
-
-          // Rename the file to mimic a deleted page
-          renameSync(contactPagePath, newContactPagePath)
-
-          await check(
-            () => getBrowserBodyText(browser),
-            /This page could not be found/
-          )
-
-          // Rename the file back to the original filename
-          renameSync(newContactPagePath, contactPagePath)
-
-          // wait until the page comes back
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the contact page/
-          )
-        } finally {
-          if (browser) {
-            await browser.close()
-          }
-          if (existsSync(newContactPagePath)) {
-            renameSync(newContactPagePath, contactPagePath)
-          }
-        }
-      })
-    })
-
-    describe('editing a page', () => {
-      it('should detect the changes and display it', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/docs/hmr/about')
-          const text = await browser.elementByCss('p').text()
-          expect(text).toBe('This is the about page.')
-
-          const aboutPagePath = join(
-            __dirname,
-            '../',
-            'pages',
-            'hmr',
-            'about.js'
-          )
-
-          const originalContent = readFileSync(aboutPagePath, 'utf8')
-          const editedContent = originalContent.replace(
-            'This is the about page',
-            'COOL page'
-          )
-
-          // change the content
-          writeFileSync(aboutPagePath, editedContent, 'utf8')
-
-          await check(() => getBrowserBodyText(browser), /COOL page/)
-
-          // add the original content
-          writeFileSync(aboutPagePath, originalContent, 'utf8')
-
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
-        } finally {
-          if (browser) {
-            await browser.close()
-          }
-        }
-      })
-
-      it('should not reload unrelated pages', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/docs/hmr/counter')
-          const text = await browser
-            .elementByCss('button')
-            .click()
-            .elementByCss('button')
-            .click()
-            .elementByCss('p')
-            .text()
-          expect(text).toBe('COUNT: 2')
-
-          const aboutPagePath = join(
-            __dirname,
-            '../',
-            'pages',
-            'hmr',
-            'about.js'
-          )
-
-          const originalContent = readFileSync(aboutPagePath, 'utf8')
-          const editedContent = originalContent.replace(
-            'This is the about page',
-            'COOL page'
-          )
-
-          // Change the about.js page
-          writeFileSync(aboutPagePath, editedContent, 'utf8')
-
-          // wait for 5 seconds
-          await waitFor(5000)
-
-          // Check whether the this page has reloaded or not.
-          const newText = await browser.elementByCss('p').text()
-          expect(newText).toBe('COUNT: 2')
-
-          // restore the about page content.
-          writeFileSync(aboutPagePath, originalContent, 'utf8')
-        } finally {
-          if (browser) {
-            await browser.close()
-          }
-        }
-      })
-
-      // Added because of a regression in react-hot-loader, see issues: #4246 #4273
-      // Also: https://github.com/zeit/styled-jsx/issues/425
-      it('should update styles correctly', async () => {
-        let browser
-        try {
-          browser = await webdriver(context.appPort, '/docs/hmr/style')
-          const pTag = await browser.elementByCss('.hmr-style-page p')
-          const initialFontSize = await pTag.getComputedCss('font-size')
-
-          expect(initialFontSize).toBe('100px')
-
-          const pagePath = join(__dirname, '../', 'pages', 'hmr', 'style.js')
-
-          const originalContent = readFileSync(pagePath, 'utf8')
-          const editedContent = originalContent.replace('100px', '200px')
-
-          // Change the page
-          writeFileSync(pagePath, editedContent, 'utf8')
-
-          try {
-            // Check whether the this page has reloaded or not.
-            await check(async () => {
-              const editedPTag = await browser.elementByCss('.hmr-style-page p')
-              return editedPTag.getComputedCss('font-size')
-            }, /200px/)
-          } finally {
-            // Finally is used so that we revert the content back to the original regardless of the test outcome
-            // restore the about page content.
-            writeFileSync(pagePath, originalContent, 'utf8')
-          }
-        } finally {
-          if (browser) {
-            await browser.close()
-          }
-        }
-      })
-
-      // Added because of a regression in react-hot-loader, see issues: #4246 #4273
-      // Also: https://github.com/zeit/styled-jsx/issues/425
-      it('should update styles in a stateful component correctly', async () => {
-        let browser
-        const pagePath = join(
-          __dirname,
-          '../',
-          'pages',
-          'hmr',
-          'style-stateful-component.js'
-        )
-        const originalContent = readFileSync(pagePath, 'utf8')
-        try {
-          browser = await webdriver(
-            context.appPort,
-            '/docs/hmr/style-stateful-component'
-          )
-          const pTag = await browser.elementByCss('.hmr-style-page p')
-          const initialFontSize = await pTag.getComputedCss('font-size')
-
-          expect(initialFontSize).toBe('100px')
-          const editedContent = originalContent.replace('100px', '200px')
-
-          // Change the page
-          writeFileSync(pagePath, editedContent, 'utf8')
-
-          // Check whether the this page has reloaded or not.
-          await check(async () => {
-            const editedPTag = await browser.elementByCss('.hmr-style-page p')
-            return editedPTag.getComputedCss('font-size')
-          }, /200px/)
-        } finally {
-          if (browser) {
-            await browser.close()
-          }
-          writeFileSync(pagePath, originalContent, 'utf8')
-        }
-      })
-
-      // Added because of a regression in react-hot-loader, see issues: #4246 #4273
-      // Also: https://github.com/zeit/styled-jsx/issues/425
-      it('should update styles in a dynamic component correctly', async () => {
-        let browser = null
-        let secondBrowser = null
-        const pagePath = join(
-          __dirname,
-          '../',
-          'components',
-          'hmr',
-          'dynamic.js'
-        )
-        const originalContent = readFileSync(pagePath, 'utf8')
-        try {
-          browser = await webdriver(
-            context.appPort,
-            '/docs/hmr/style-dynamic-component'
-          )
-          const div = await browser.elementByCss('#dynamic-component')
-          const initialClientClassName = await div.getAttribute('class')
-          const initialFontSize = await div.getComputedCss('font-size')
-
-          expect(initialFontSize).toBe('100px')
-
-          const initialHtml = await renderViaHTTP(
-            context.appPort,
-            '/docs/hmr/style-dynamic-component'
-          )
-          expect(initialHtml.includes('100px')).toBeTruthy()
-
-          const $initialHtml = cheerio.load(initialHtml)
-          const initialServerClassName = $initialHtml(
-            '#dynamic-component'
-          ).attr('class')
-
-          expect(initialClientClassName === initialServerClassName).toBeTruthy()
-
-          const editedContent = originalContent.replace('100px', '200px')
-
-          // Change the page
-          writeFileSync(pagePath, editedContent, 'utf8')
-
-          // wait for 5 seconds
-          await waitFor(5000)
-
-          secondBrowser = await webdriver(
-            context.appPort,
-            '/docs/hmr/style-dynamic-component'
-          )
-          // Check whether the this page has reloaded or not.
-          const editedDiv = await secondBrowser.elementByCss(
-            '#dynamic-component'
-          )
-          const editedClientClassName = await editedDiv.getAttribute('class')
-          const editedFontSize = await editedDiv.getComputedCss('font-size')
-          const browserHtml = await secondBrowser
-            .elementByCss('html')
-            .getAttribute('innerHTML')
-
-          expect(editedFontSize).toBe('200px')
-          expect(browserHtml.includes('font-size:200px;')).toBe(true)
-          expect(browserHtml.includes('font-size:100px;')).toBe(false)
-
-          const editedHtml = await renderViaHTTP(
-            context.appPort,
-            '/docs/hmr/style-dynamic-component'
-          )
-          expect(editedHtml.includes('200px')).toBeTruthy()
-          const $editedHtml = cheerio.load(editedHtml)
-          const editedServerClassName = $editedHtml('#dynamic-component').attr(
-            'class'
-          )
-
-          expect(editedClientClassName === editedServerClassName).toBe(true)
-        } finally {
-          // Finally is used so that we revert the content back to the original regardless of the test outcome
-          // restore the about page content.
-          writeFileSync(pagePath, originalContent, 'utf8')
-
-          if (browser) {
-            await browser.close()
-          }
-
-          if (secondBrowser) {
-            secondBrowser.close()
-          }
-        }
-      })
-    })
-  })
-
-  it('should respect basePath in amphtml link rel', async () => {
-    const html = await renderViaHTTP(context.appPort, '/docs/amp-hybrid')
-    const $ = cheerio.load(html)
-    const expectedAmpHtmlUrl = '/docs/amp-hybrid?amp=1'
-    expect($('link[rel=amphtml]').first().attr('href')).toBe(expectedAmpHtmlUrl)
-  })
+  runTests(true)
 })
 
 describe('basePath production', () => {
-  let context = {}
-  let server
-  let app
-
   beforeAll(async () => {
     await nextBuild(appDir, [], {
       env: {
         EXTERNAL_APP: `http://localhost:${externalApp.address().port}`,
       },
     })
-    app = nextServer({
-      dir: join(__dirname, '../'),
-      dev: false,
-      quiet: true,
-    })
-
-    server = await startApp(app)
-    context.appPort = server.address().port
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
   })
+  afterAll(() => killApp(app))
 
-  afterAll(() => stopApp(server))
-
-  runTests(context)
+  runTests()
 
   it('should respect basePath in amphtml link rel', async () => {
-    const html = await renderViaHTTP(context.appPort, '/docs/amp-hybrid')
+    const html = await renderViaHTTP(appPort, `${basePath}/amp-hybrid`)
     const $ = cheerio.load(html)
-    const expectedAmpHtmlUrl = '/docs/amp-hybrid.amp'
+    const expectedAmpHtmlUrl = `${basePath}/amp-hybrid.amp`
     expect($('link[rel=amphtml]').first().attr('href')).toBe(expectedAmpHtmlUrl)
   })
 })
 
-describe('basePath serverless', () => {
-  let context = {}
-  let app
+describe('multi-level basePath development', () => {
+  beforeAll(async () => {
+    basePath = '/hello/world'
+    nextConfig.replace(`basePath: '/docs'`, `basePath: '/hello/world'`)
+    appPort = await findPort()
+    app = await launchApp(join(__dirname, '..'), appPort, {
+      env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
+    })
+  })
+  afterAll(async () => {
+    basePath = '/docs'
+    nextConfig.replace(`basePath: '/hello/world'`, `basePath: '/docs'`)
+    await killApp(app)
+  })
 
+  runTests(true)
+})
+
+describe('multi-level basePath production', () => {
+  beforeAll(async () => {
+    basePath = '/hello/world'
+    nextConfig.replace(`basePath: '/docs'`, `basePath: '/hello/world'`)
+    await nextBuild(appDir, [], {
+      env: {
+        EXTERNAL_APP: `http://localhost:${externalApp.address().port}`,
+      },
+    })
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
+  })
+  afterAll(async () => {
+    basePath = '/docs'
+    nextConfig.replace(`basePath: '/hello/world'`, `basePath: '/docs'`)
+    await killApp(app)
+  })
+
+  runTests()
+})
+
+describe('basePath serverless', () => {
   beforeAll(async () => {
     await nextConfig.replace(
       '// replace me',
       `target: 'experimental-serverless-trace',`
     )
     await nextBuild(appDir)
-    context.appPort = await findPort()
-    app = await nextStart(appDir, context.appPort)
+    appPort = await findPort()
+    app = await nextStart(appDir, appPort)
   })
   afterAll(async () => {
     await killApp(app)
     await nextConfig.restore()
   })
 
-  runTests(context)
+  runTests()
 
   it('should always strip basePath in serverless-loader', async () => {
     const appPort = await findPort()


### PR DESCRIPTION
This ensures the `basePath` property works correctly when a multi-level value is defined (`/hello/world`)

Fixes: https://github.com/vercel/next.js/issues/17889