### PR TITLE
Ensure redirect from GS(S)P doesn't render

### DIFF
--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -862,9 +862,9 @@ export async function renderToHTML(
     )
   }
 
-  // We only need to do this if we want to support calling
-  // _app's getInitialProps for getServerSideProps if not this can be removed
-  if (isDataReq && !isSSG) return props
+  // Avoid rendering page un-necessarily for getServerSideProps data request
+  // and getServerSideProps/getStaticProps redirects
+  if (isDataReq && (!isSSG || props.pageProps.__N_REDIRECT)) return props
 
   // We don't call getStaticProps or getServerSideProps while generating
   // the fallback so make sure to set pageProps to an empty object

--- a/test/integration/gssp-redirect/pages/gsp-blog/[post].js
+++ b/test/integration/gssp-redirect/pages/gsp-blog/[post].js
@@ -3,6 +3,13 @@ import { useRouter } from 'next/router'
 export default function Post(props) {
   const router = useRouter()
 
+  if (typeof window === 'undefined') {
+    if (router.query.post?.startsWith('redir')) {
+      console.log(router)
+      throw new Error('render should not occur for redirect')
+    }
+  }
+
   if (typeof window !== 'undefined' && !window.initialHref) {
     window.initialHref = window.location.href
   }

--- a/test/integration/gssp-redirect/pages/gssp-blog/[post].js
+++ b/test/integration/gssp-redirect/pages/gssp-blog/[post].js
@@ -1,4 +1,15 @@
+import { useRouter } from 'next/router'
+
 export default function Post(props) {
+  const router = useRouter()
+
+  if (typeof window === 'undefined') {
+    if (router.query.post?.startsWith('redir')) {
+      console.log(router)
+      throw new Error('render should not occur for redirect')
+    }
+  }
+
   return (
     <>
       <p id="gssp">getServerSideProps</p>


### PR DESCRIPTION
This ensures we don't render the page un-necessarily when a redirect is returned from `getStaticProps` or `getServerSideProps`.

Possibly related: https://github.com/vercel/next.js/issues/18735
Closes: https://github.com/vercel/next.js/issues/18747