### PR TITLE
Upgrade to ncc@0.24.1

### DIFF
--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -33,7 +33,7 @@
     "@types/rimraf": "3.0.0",
     "@types/tar": "4.0.3",
     "@types/validate-npm-package-name": "3.0.0",
-    "@zeit/ncc": "^0.20.4",
+    "@vercel/ncc": "^0.24.1",
     "async-retry": "1.3.1",
     "chalk": "2.4.2",
     "commander": "2.20.0",

--- a/packages/next-env/package.json
+++ b/packages/next-env/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/dotenv": "8.2.0",
-    "@zeit/ncc": "^0.20.4",
+    "@vercel/ncc": "^0.24.1",
     "dotenv": "8.2.0",
     "dotenv-expand": "5.1.0"
   }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -165,7 +165,7 @@
     "@types/styled-jsx": "2.2.8",
     "@types/text-table": "0.2.1",
     "@types/webpack-sources": "0.1.5",
-    "@zeit/ncc": "0.22.0",
+    "@vercel/ncc": "0.24.1",
     "amphtml-validator": "1.0.33",
     "arg": "4.1.0",
     "async-retry": "1.2.3",

--- a/packages/next/taskfile-ncc.js
+++ b/packages/next/taskfile-ncc.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-const ncc = require('@zeit/ncc')
+const ncc = require('@vercel/ncc')
 const { existsSync, readFileSync } = require('fs')
 const { basename, dirname, extname, join } = require('path')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,6 +3535,11 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@vercel/ncc@0.24.1", "@vercel/ncc@^0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.24.1.tgz#3ea2932c85ba87f4de6fe550d60e1bf5c005985e"
+  integrity sha512-r9m7brz2hNmq5TF3sxrK4qR/FhXn44XIMglQUir4sT7Sh5GOaYXlMYikHFwJStf8rmQGTlvOoBXt4yHVonRG8A==
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3669,14 +3674,6 @@
 "@xtuc/long@4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
-
-"@zeit/ncc@0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.22.0.tgz#1a4132a375a2ffd1d6d632b0fdd9027154f6141a"
-
-"@zeit/ncc@^0.20.4":
-  version "0.20.5"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.5.tgz#a41af6e6bcab4a58f4612bae6137f70bce0192e3"
 
 "@zeit/next-css@1.0.2-canary.2":
   version "1.0.2-canary.2"


### PR DESCRIPTION
This upgrades to the latest ncc@0.24.1 including the recent Webpack upgrade that should resolve the previous issues on this upgrade path I believe.