### PR TITLE
Typo in err.sh url nextjs instead of next.js

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -586,7 +586,7 @@ function defaultLoader({ root, src, width, quality }: LoaderProps): string {
       if (!configDomains.includes(parsedSrc.hostname)) {
         throw new Error(
           `Invalid src prop (${src}) on \`next/image\`, hostname "${parsedSrc.hostname}" is not configured under images in your \`next.config.js\`\n` +
-            `See more info: https://err.sh/nextjs/next-image-unconfigured-host`
+            `See more info: https://err.sh/next.js/next-image-unconfigured-host`
         )
       }
     }


### PR DESCRIPTION
I just usesd next/image for the first time and stumbled upton the **unconfigured image host** error.
The err.sh info url from the thrown error has a small typo, `nextjs` instead of `next.js`, so the link isn't working.

Right now the error message is only available in canary, so the link will work after the error messages are merged into master.

