### PR TITLE
Update asPath to mention basePath/locale stripping

### DIFF
--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -43,7 +43,7 @@ The following is the definition of the `router` object returned by both [`useRou
 
 - `pathname`: `String` - Current route. That is the path of the page in `/pages`
 - `query`: `Object` - The query string parsed to an object. It will be an empty object during prerendering if the page doesn't have [data fetching requirements](/docs/basic-features/data-fetching.md). Defaults to `{}`
-- `asPath`: `String` - Actual path (including the query) shown in the browser.
+- `asPath`: `String` - The path (including the query) shown in the browser without the configured `basePath` or `locale`.
 - `isFallback`: `boolean` - Whether the current page is in [fallback mode](/docs/basic-features/data-fetching#fallback-pages).
 - `basePath`: `String` - The active [basePath](/docs/api-reference/next.config.js/basepath) (if enabled).
 - `locale`: `String` - The active locale (if enabled).


### PR DESCRIPTION
Tweak `asPath` docs to mention `basePath` and `locale` will not be included in the value. 

Closes: https://github.com/vercel/next.js/issues/18782