### PR TITLE
Update GetStaticPathsResult type

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -109,14 +109,20 @@ export type GetStaticPathsContext = {
   defaultLocale?: string
 }
 
-export type GetStaticPathsResult<P extends ParsedUrlQuery = ParsedUrlQuery> = {
-  paths: Array<string | { params: P; locale?: string }>
-  fallback: boolean | 'blocking'
+export type GetStaticPathsPath<Q extends ParsedUrlQuery = ParsedUrlQuery> =
+  | string
+  | { params: Q; locale?: string }
+
+export type GetStaticPathsFallback = boolean | 'blocking';
+
+export type GetStaticPathsResult<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
+  paths: Array<GetStaticPathsPath<Q>>;
+  fallback: GetStaticPathsFallback;
 }
 
-export type GetStaticPaths<P extends ParsedUrlQuery = ParsedUrlQuery> = (
+export type GetStaticPaths<Q extends ParsedUrlQuery = ParsedUrlQuery> = (
   context: GetStaticPathsContext
-) => Promise<GetStaticPathsResult<P>>
+) => Promise<GetStaticPathsResult<Q>>
 
 export type GetServerSidePropsContext<
   Q extends ParsedUrlQuery = ParsedUrlQuery


### PR DESCRIPTION
Currently, the `GetStaticPathsResult` type exposes two properties,
`paths`, and `fallback`.

The definitions for these properties are inline, meaning, the only way
to access them is with some pretty ugly looking TypeScript code.

```ts
type ArrayType<T extends Array<any> | ReadonlyArray<any>> = T extends Array<infer R>
  ? R
  : T extends ReadonlyArray<infer R>
  ? R
  : never;

type GetStaticPathsPath = ArrayType<GetStaticPathsResult<PostQuery>['paths']>;

type GetStaticPathsFallback = GetStaticPathsResult<PostQuery>['fallback'];
```

The use case for `GetStaticPathsPath` can be seen below:

```ts
export const getStaticPaths: GetStaticPaths<PostQuery> = async (
  ctx: GetStaticPathsContext,
): Promise<GetStaticPathsResult<PostQuery>> => {
  const res = await fetch(`https://jsonplaceholder.typicode.com/posts?_limit=3`);
  const posts = (await res.json()) as Array<Post>;
  const paths = posts.map((post: Post): GetStaticPathsPath<PostQuery> => {
    return {
      params: {
        postId: String(post.id),
      },
    };
  });
  return {
    paths,
    fallback: `blocking`,
  };
};
```

In the above example, `GetStaticPathsPath` is used to type hint the
return type for the `.map()` Function.

Coming up with an example for `GetStaticPathsFallback` is a bit more
contrived. That being said, the type is added to ensure consistency.

The tslint [`typedef`](https://palantir.github.io/tslint/rules/typedef/)
linting rule has the ability to enforce return types. Adding these types
would reduce friction for teams that use the `typedef` linting rule.

Furthermore, it would also allow developers who want to type hint the
return value of the `.map()` Function to not have to go to the trouble
of creating these work around types.