### PR TITLE
Fix typo on `api-reference/image`

### DIFF
--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -129,7 +129,7 @@ When true, the source image will be served as-is instead of changing quality, si
 
 ## Other Props
 
-All other properties on the `Image` component will be passed to the underlying `img` element, except for `style`. Use `className` isntead.
+All other properties on the `Image` component will be passed to the underlying `img` element, except for `style`. Use `className` instead.
 
 ## Related
 


### PR DESCRIPTION
Great updates guys, I'm always reading from the canaries version to keep me up to date and found this very small typo =)