### PR TITLE
Allow React automatic runtime to be enforced with an option

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -65,9 +65,9 @@ module.exports = (
   const supportsESM = api.caller(supportsStaticESM)
   const isServer = api.caller((caller: any) => !!caller && caller.isServer)
   const isModern = api.caller((caller: any) => !!caller && caller.isModern)
-  const hasJsxRuntime = Boolean(
-    api.caller((caller: any) => !!caller && caller.hasJsxRuntime)
-  )
+  const hasJsxRuntime =
+    options['preset-react']?.runtime === 'automatic' ||
+    Boolean(api.caller((caller: any) => !!caller && caller.hasJsxRuntime))
 
   const isLaxModern =
     isModern ||


### PR DESCRIPTION
fixes https://github.com/vercel/next.js/issues/18096 (somewhat)

I'm the Emotion maintainer and we've recently released support for the new JSX runtimes that support `css` prop API in a more automatic way than what has been the default in the past and which is putting a `/** @jsx jsx */` into your files. In the past, it could be automated using `@emotion/babel-preset-css-prop` but tools like CRA doesn't allow u to change Babel config, so you could always resort to the pragma approach (which will still be true with the new transforms - people will just have to use `/** @jsxImportSource @emotion/core */` now).

Given that we had this preset it made sense to just add support for the `runtime` option to it for anyone who has been already using that preset. It also made sense because that preset includes our `babel-plugin-emotion` so I thought that people could just use a single preset to configure JSX and our Babel plugin at the same time. I also have always thought that plugins are overridden through presets as this is described in the [Babel docs](https://babeljs.io/docs/en/options#pluginpreset-merging), it doesn't go into details and it turns out it doesn't apply to presets but only for "env" configurations. I've reached out to the Babel team and they are going to think about potential changes around this logic but given that it has been out for quite a long time there is near-zero chance for this to be changed in Babel 7. You can check my original expectations which are, unfortunately, failing [here](https://github.com/Andarist/babel/commit/15809cc3250c41b245166947b08ee072eeb49ade).

So what happens now? If you have 2 presets that include the same plugin that plugin will be applied twice and it seems that this is problematic when it comes to the JSX plugin:
https://github.com/vercel/next.js/issues/18096
https://github.com/emotion-js/emotion/issues/2064
https://github.com/emotion-js/emotion/issues/2069

So the answer is that one should never configure the JSX plugin twice. In the case of Emotion, it means that we need to deprecate `runtime` option in our preset and we need to recommend using this simple config:
```js
module.exports = {
  presets: [
    [
      "@babel/preset-react",
      {
        runtime: "automatic",
        importSource: "@emotion/core",
      },
    ],
  ],
  plugins: ["babel-plugin-emotion"],
};
```

But as Next users very often use `next/babel` and it uses `@babel/preset-react` under the hood that recommendation is not good either for Next users and for them it should be this:
```js
module.exports = {
  presets: [
    [
      "next/babel",
      {
        "preset-react": {
          runtime: "automatic",
          importSource: "@emotion/core",
        },
      },
    ],
  ],
  plugins: ["babel-plugin-emotion"],
};
```

So far so good, but... people usually want to use a single config for all tools that they use. So this doesn't quite work with Jest because `hasJsxRuntime` depends on the caller object that you configure when creating webpack config etc and thus this very config results in 2 JSX plugins being applied (when used with Jest). 

I believe that the easiest way to solve this is what I'm proposing in this PR. If you have any other preferences please let me know and I will adjust the PR accordingly.