### PR TITLE
Ensure auto-export dynamic routes work with i18n next start

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -985,7 +985,10 @@ export default class Server {
     ]
   }
 
-  protected getDynamicRoutes() {
+  protected getDynamicRoutes(): Array<{
+    page: string
+    match: ReturnType<typeof getRouteMatcher>
+  }> {
     const addedPages = new Set<string>()
 
     return getSortedRoutes(Object.keys(this.pagesManifest!))
@@ -999,7 +1002,7 @@ export default class Server {
           match: getRouteMatcher(getRouteRegex(page)),
         }
       })
-      .filter(Boolean)
+      .filter(Boolean) as any
   }
 
   private handleCompression(req: IncomingMessage, res: ServerResponse): void {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -986,12 +986,19 @@ export default class Server {
   }
 
   protected getDynamicRoutes() {
+    const addedPages = new Set<string>()
+
     return getSortedRoutes(Object.keys(this.pagesManifest!))
       .filter(isDynamicRoute)
-      .map((page) => ({
-        page,
-        match: getRouteMatcher(getRouteRegex(page)),
-      }))
+      .map((page) => {
+        page = normalizeLocalePath(page, this.nextConfig.i18n?.locales).pathname
+        if (addedPages.has(page)) return null
+        return {
+          page,
+          match: getRouteMatcher(getRouteRegex(page)),
+        }
+      })
+      .filter(Boolean)
   }
 
   private handleCompression(req: IncomingMessage, res: ServerResponse): void {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -100,6 +100,11 @@ type FindComponentsResult = {
   query: ParsedUrlQuery
 }
 
+type DynamicRouteItem = {
+  page: string
+  match: ReturnType<typeof getRouteMatcher>
+}
+
 export type ServerConstructor = {
   /**
    * Where the Next project is located - @default '.'
@@ -985,10 +990,7 @@ export default class Server {
     ]
   }
 
-  protected getDynamicRoutes(): Array<{
-    page: string
-    match: ReturnType<typeof getRouteMatcher>
-  }> {
+  protected getDynamicRoutes(): Array<DynamicRouteItem> {
     const addedPages = new Set<string>()
 
     return getSortedRoutes(Object.keys(this.pagesManifest!))
@@ -1002,7 +1004,7 @@ export default class Server {
           match: getRouteMatcher(getRouteRegex(page)),
         }
       })
-      .filter(Boolean) as any
+      .filter((item): item is DynamicRouteItem => Boolean(item))
   }
 
   private handleCompression(req: IncomingMessage, res: ServerResponse): void {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -993,6 +993,7 @@ export default class Server {
       .map((page) => {
         page = normalizeLocalePath(page, this.nextConfig.i18n?.locales).pathname
         if (addedPages.has(page)) return null
+        addedPages.add(page)
         return {
           page,
           match: getRouteMatcher(getRouteRegex(page)),

--- a/test/integration/i18n-support/pages/dynamic/[slug].js
+++ b/test/integration/i18n-support/pages/dynamic/[slug].js
@@ -6,8 +6,7 @@ export default function Page(props) {
 
   return (
     <>
-      <p id="index">index page</p>
-      <p id="props">{JSON.stringify(props)}</p>
+      <p id="dynamic">dynamic page</p>
       <p id="router-locale">{router.locale}</p>
       <p id="router-default-locale">{router.defaultLocale}</p>
       <p id="router-locales">{JSON.stringify(router.locales)}</p>
@@ -16,10 +15,6 @@ export default function Page(props) {
       <p id="router-as-path">{router.asPath}</p>
       <Link href="/another">
         <a id="to-another">to /another</a>
-      </Link>
-      <br />
-      <Link href="/dynamic/first">
-        <a id="to-dynamic">to /dynamic/first</a>
       </Link>
       <br />
       <Link href="/gsp">
@@ -48,14 +43,4 @@ export default function Page(props) {
       <br />
     </>
   )
-}
-
-export const getStaticProps = ({ locale, locales, defaultLocale }) => {
-  return {
-    props: {
-      locale,
-      locales,
-      defaultLocale,
-    },
-  }
 }


### PR DESCRIPTION
This ensures dynamic routes are correctly generated for `next start` with i18n and adds tests to the i18n suite to ensure they are working correctly. 

Closes: https://github.com/vercel/next.js/issues/18397