### PR TITLE
Fix typo in create-next-app docs

### DIFF
--- a/docs/api-reference/create-next-app.md
+++ b/docs/api-reference/create-next-app.md
@@ -9,7 +9,7 @@ The easiest way to get started with Next.js is by using `create-next-app`. This 
 ```bash
 npx create-next-app
 # or
-yarn create next-app
+yarn create-next-app
 ```
 
 ### Options


### PR DESCRIPTION
This PR fixes a quick typo fix in the create-next-app docs.