### PR TITLE
tests(create-next-app): prevent catch assertions

### DIFF
--- a/test/integration/create-next-app/index.test.js
+++ b/test/integration/create-next-app/index.test.js
@@ -8,10 +8,7 @@ const cli = require.resolve('create-next-app/dist/index.js')
 
 jest.setTimeout(1000 * 60 * 5)
 
-const run = (cwd, args, input) => {
-  const options = input ? { cwd, input } : { cwd }
-  return execa('node', [cli].concat(args), options)
-}
+const run = (args, options) => execa('node', [cli].concat(args), options)
 
 async function usingTempDir(fn, options) {
   const folder = path.join(os.tmpdir(), Math.random().toString(36).substring(2))
@@ -31,13 +28,8 @@ describe('create next app', () => {
       const pkg = path.join(cwd, projectName, 'package.json')
       fs.writeFileSync(pkg, '{ "foo": "bar" }')
 
-      expect.assertions(1)
-      try {
-        await run(cwd, [projectName])
-      } catch (e) {
-        // eslint-disable-next-line jest/no-try-expect
-        expect(e.stdout).toMatch(/contains files that could conflict/)
-      }
+      const res = await run([projectName], { cwd, reject: false })
+      expect(res.stdout).toMatch(/contains files that could conflict/)
     })
   })
 
@@ -47,7 +39,7 @@ describe('create next app', () => {
     it('empty directory', async () => {
       await usingTempDir(async (cwd) => {
         const projectName = 'empty-directory'
-        const res = await run(cwd, [projectName])
+        const res = await run([projectName], { cwd })
 
         expect(res.exitCode).toBe(0)
         expect(
@@ -63,13 +55,12 @@ describe('create next app', () => {
   it('invalid example name', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'invalid-example-name'
-      expect.assertions(2)
-      try {
-        await run(cwd, [projectName, '--example', 'not a real example'])
-      } catch (e) {
-        // eslint-disable-next-line jest/no-try-expect
-        expect(e.stderr).toMatch(/Could not locate an example named/i)
-      }
+      const res = await run([projectName, '--example', 'not a real example'], {
+        cwd,
+        reject: false,
+      })
+
+      expect(res.stderr).toMatch(/Could not locate an example named/i)
       expect(
         fs.existsSync(path.join(cwd, projectName, 'package.json'))
       ).toBeFalsy()
@@ -79,7 +70,7 @@ describe('create next app', () => {
   it('valid example', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'valid-example'
-      const res = await run(cwd, [projectName, '--example', 'basic-css'])
+      const res = await run([projectName, '--example', 'basic-css'], { cwd })
       expect(res.exitCode).toBe(0)
 
       expect(
@@ -98,11 +89,16 @@ describe('create next app', () => {
   it('should allow example with GitHub URL', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'github-app'
-      const res = await run(cwd, [
-        projectName,
-        '--example',
-        'https://github.com/zeit/next-learn-demo/tree/master/1-navigate-between-pages',
-      ])
+      const res = await run(
+        [
+          projectName,
+          '--example',
+          'https://github.com/zeit/next-learn-demo/tree/master/1-navigate-between-pages',
+        ],
+        {
+          cwd,
+        }
+      )
 
       expect(res.exitCode).toBe(0)
       expect(
@@ -123,13 +119,18 @@ describe('create next app', () => {
   it('should allow example with GitHub URL and example-path', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'github-example-path'
-      const res = await run(cwd, [
-        projectName,
-        '--example',
-        'https://github.com/zeit/next-learn-demo/tree/master',
-        '--example-path',
-        '1-navigate-between-pages',
-      ])
+      const res = await run(
+        [
+          projectName,
+          '--example',
+          'https://github.com/zeit/next-learn-demo/tree/master',
+          '--example-path',
+          '1-navigate-between-pages',
+        ],
+        {
+          cwd,
+        }
+      )
 
       expect(res.exitCode).toBe(0)
       expect(
@@ -150,13 +151,18 @@ describe('create next app', () => {
   it('should use --example-path over the file path in the GitHub URL', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'github-example-path-2'
-      const res = await run(cwd, [
-        projectName,
-        '--example',
-        'https://github.com/zeit/next-learn-demo/tree/master/1-navigate-between-pages',
-        '--example-path',
-        '1-navigate-between-pages',
-      ])
+      const res = await run(
+        [
+          projectName,
+          '--example',
+          'https://github.com/zeit/next-learn-demo/tree/master/1-navigate-between-pages',
+          '--example-path',
+          '1-navigate-between-pages',
+        ],
+        {
+          cwd,
+        }
+      )
 
       expect(res.exitCode).toBe(0)
       expect(
@@ -180,7 +186,7 @@ describe('create next app', () => {
     it('should fall back to default template', async () => {
       await usingTempDir(async (cwd) => {
         const runExample = (...args) => {
-          const res = run(cwd, args)
+          const res = run(args, { cwd })
 
           function fallbackToTemplate(data) {
             if (
@@ -211,7 +217,7 @@ describe('create next app', () => {
   it('should allow an example named default', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'default-example'
-      const res = await run(cwd, [projectName, '--example', 'default'])
+      const res = await run([projectName, '--example', 'default'], { cwd })
       expect(res.exitCode).toBe(0)
 
       expect(
@@ -229,43 +235,33 @@ describe('create next app', () => {
 
   it('should exit if example flag is empty', async () => {
     await usingTempDir(async (cwd) => {
-      try {
-        const projectName = 'no-example-provided'
-        await run(cwd, [projectName, '--example'])
-      } catch (e) {
-        // eslint-disable-next-line jest/no-try-expect
-        expect(e.exitCode).toBe(1)
-      }
+      const projectName = 'no-example-provided'
+      const res = await run([projectName, '--example'], { cwd, reject: false })
+      expect(res.exitCode).toBe(1)
     })
   })
 
   it('should exit if the folder is not writable', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'not-writable'
-      expect.assertions(2)
-      try {
-        const res = await run(cwd, [projectName])
+      const res = await run([projectName], { cwd, reject: false })
 
-        if (process.platform === 'win32') {
-          expect(res.exitCode).toBe(0)
-          expect(
-            fs.existsSync(path.join(cwd, projectName, 'package.json'))
-          ).toBeTruthy()
-        }
-      } catch (e) {
-        // eslint-disable-next-line jest/no-try-expect
-        expect(e.exitCode).toBe(1)
-        // eslint-disable-next-line jest/no-try-expect
-        expect(e.stderr).toMatch(
-          /you do not have write permissions for this folder/
-        )
+      if (process.platform === 'win32') {
+        expect(res.exitCode).toBe(0)
+        expect(
+          fs.existsSync(path.join(cwd, projectName, 'package.json'))
+        ).toBeTruthy()
       }
+      expect(res.exitCode).toBe(1)
+      expect(res.stderr).toMatch(
+        /you do not have write permissions for this folder/
+      )
     }, 0o500)
   })
 
   it('should create a project in the current directory', async () => {
     await usingTempDir(async (cwd) => {
-      const res = await run(cwd, ['.'])
+      const res = await run(['.'], { cwd })
       expect(res.exitCode).toBe(0)
 
       const files = ['package.json', 'pages/index.js', '.gitignore']
@@ -278,7 +274,7 @@ describe('create next app', () => {
   it('should ask the user for a name for the project if none supplied', async () => {
     await usingTempDir(async (cwd) => {
       const projectName = 'test-project'
-      const res = await run(cwd, [], `${projectName}\n`)
+      const res = await run([], { cwd, input: `${projectName}\n` })
       expect(res.exitCode).toBe(0)
 
       const files = ['package.json', 'pages/index.js', '.gitignore']

--- a/test/integration/create-next-app/index.test.js
+++ b/test/integration/create-next-app/index.test.js
@@ -29,6 +29,7 @@ describe('create next app', () => {
       fs.writeFileSync(pkg, '{ "foo": "bar" }')
 
       const res = await run([projectName], { cwd, reject: false })
+      expect(res.exitCode).toBe(1)
       expect(res.stdout).toMatch(/contains files that could conflict/)
     })
   })
@@ -60,6 +61,7 @@ describe('create next app', () => {
         reject: false,
       })
 
+      expect(res.exitCode).toBe(1)
       expect(res.stderr).toMatch(/Could not locate an example named/i)
       expect(
         fs.existsSync(path.join(cwd, projectName, 'package.json'))

--- a/test/integration/create-next-app/index.test.js
+++ b/test/integration/create-next-app/index.test.js
@@ -251,6 +251,7 @@ describe('create next app', () => {
         expect(
           fs.existsSync(path.join(cwd, projectName, 'package.json'))
         ).toBeTruthy()
+        return
       }
       expect(res.exitCode).toBe(1)
       expect(res.stderr).toMatch(


### PR DESCRIPTION
Prevent `catch` assertions in tests.