### PR TITLE
Fix CORS error fetching external CSS

### DIFF
--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -176,10 +176,10 @@ export default class PageLoader {
 
   private fetchStyleSheet(href: string): Promise<StyleSheetTuple> {
     if (!this.cssc[href]) {
-      this.cssc[href] = fetch(href).then((res) => {
+      this.cssc[href] = fetch(href, { mode: "no-cors" }).then((res) => {
         if (!res.ok) throw pageLoadError(href)
         return res.text()
-      })
+      }).catch(() => null))
     }
     return this.cssc[href].then((text) => ({ href, text }))
   }

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -179,7 +179,7 @@ export default class PageLoader {
       this.cssc[href] = fetch(href, { mode: "no-cors" }).then((res) => {
         if (!res.ok) throw pageLoadError(href)
         return res.text()
-      }).catch(() => null))
+      })
     }
     return this.cssc[href].then((text) => ({ href, text }))
   }
@@ -368,7 +368,7 @@ export default class PageLoader {
           ).then((cssFiles) =>
             // These files should've already been fetched by now, so this
             // should resolve instantly.
-            Promise.all(cssFiles.map((d) => this.fetchStyleSheet(d))).catch(
+            Promise.all(cssFiles.map((d) => document.querySelector(`link[href^="${d}"]`) || this.fetchStyleSheet(d))).catch(
               (err) => {
                 if (isInitialLoad) {
                   Object.defineProperty(err, INITIAL_CSS_LOAD_ERROR, {})


### PR DESCRIPTION
When fetching css, it is called with the mode set to no-cors.
And if css is loaded at the time of server-side rendering, No more calls to fetchStyleSheet unnecessarily.

@Timer It seems to work, but please check if it is correct.

Fixes https://github.com/vercel/next.js/issues/17029