### PR TITLE
Allow enabling jsx runtime manually

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -66,7 +66,8 @@ module.exports = (
   const isServer = api.caller((caller: any) => !!caller && caller.isServer)
   const isModern = api.caller((caller: any) => !!caller && caller.isModern)
   const hasJsxRuntime = Boolean(
-    api.caller((caller: any) => !!caller && caller.hasJsxRuntime)
+    api.caller((caller: any) => !!caller && caller.hasJsxRuntime) ||
+      options['preset-react']?.runtime === 'automatic'
   )
 
   const isLaxModern =


### PR DESCRIPTION
Currently next.js allows to use jsx runtime only with react 17 though
jsx runtime was backported also for 14, 15 adnd 16.

Would be good to be able to enable it at least manually for these
versions.