### PR TITLE
Add test and errsh for mixed notFound/redirect error

### DIFF
--- a/errors/gssp-mixed-not-found-redirect.md
+++ b/errors/gssp-mixed-not-found-redirect.md
@@ -1,0 +1,16 @@
+# Mixed `notFound` and `redirect`
+
+#### Why This Error Occurred
+
+In one of your page's `getStaticProps` or `getServerSideProps` `notFound` and `redirect` values were both returned.
+
+These values can not both be returned at the same time and one or the other needs to be returned at a time.
+
+#### Possible Ways to Fix It
+
+Make sure only `notFound` **or** `redirect` is being returned on your page's `getStaticProps` or `getServerSideProps`
+
+### Useful Links
+
+- [`getStaticProps` Documentation](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation)
+- [`getServerSideProps` Documentation](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering)

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -634,11 +634,14 @@ export async function renderToHTML(
       }
 
       if (process.env.NODE_ENV !== 'production') {
-        if ('notFound' in data && 'redirect' in data) {
+        if (
+          typeof (data as any).notFound !== 'undefined' &&
+          typeof (data as any).redirect !== 'undefined'
+        ) {
           throw new Error(
             `\`redirect\` and \`notFound\` can not both be returned from ${
               isSSG ? 'getStaticProps' : 'getServerSideProps'
-            } at the same time. Page: ${pathname}`
+            } at the same time. Page: ${pathname}\nSee more info here: https://err.sh/next.js/gssp-mixed-not-found-redirect`
           )
         }
       }

--- a/test/integration/i18n-support/pages/gsp/fallback/[slug].js
+++ b/test/integration/i18n-support/pages/gsp/fallback/[slug].js
@@ -30,6 +30,16 @@ export const getStaticProps = ({ params, locale, locales, defaultLocale }) => {
     throw new Error(`missing params ${JSON.stringify(params)}`)
   }
 
+  if (params && params.slug === 'mixed-not-found-redirect') {
+    return {
+      notFound: true,
+      redirect: {
+        destination: '/another',
+        permanent: false,
+      },
+    }
+  }
+
   return {
     props: {
       params,

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -42,6 +42,19 @@ async function addDefaultLocaleCookie(browser) {
 }
 
 function runTests(isDev) {
+  if (isDev) {
+    it('should show error for redirect and notFound returned at same time', async () => {
+      const html = await renderViaHTTP(
+        appPort,
+        '/_next/data/development/gsp/fallback/mixed-not-found-redirect.json'
+      )
+
+      expect(html).toContain(
+        '`redirect` and `notFound` can not both be returned from getStaticProps at the same time. Page: /gsp/fallback/[slug]'
+      )
+    })
+  }
+
   it('should have correct values for non-prefixed path', async () => {
     for (const paths of [
       ['/links', '/links'],


### PR DESCRIPTION
This ensures the mixed `notFound`/`redirect` error is shown correctly and adds an err.sh for the error. 

Closes: https://github.com/vercel/next.js/issues/18727