### PR TITLE
fix(examples/with-firebase-cloud-messaging): replace deprecated method

### DIFF
--- a/examples/with-firebase-cloud-messaging/utils/webPush.js
+++ b/examples/with-firebase-cloud-messaging/utils/webPush.js
@@ -21,7 +21,7 @@ const firebaseCloudMessaging = {
       }
 
       const messaging = firebase.messaging()
-      await messaging.requestPermission()
+      await Notification.requestPermission()
       const token = await messaging.getToken()
 
       localforage.setItem('fcm_token', token)


### PR DESCRIPTION
Resolves #19079