### PR TITLE
Adjust how CSS files are fetched

### DIFF
--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -246,7 +246,7 @@ function createRouteLoader(assetPrefix: string): RouteLoader {
 
     styleSheets.set(
       href,
-      (prom = fetch(href, { credentials: 'include' })
+      (prom = fetch(href)
         .then((res) => {
           if (!res.ok) {
             throw new Error(`Failed to load stylesheet: ${href}`)


### PR DESCRIPTION
We shouldn't unconditionally pass `credentials: 'include'` because this doesn't allow you to use `*`-allowed origins with CORS. The default behavior of Fetch is to already include them for same-origin only, so we never needed this to be configured.