### PR TITLE
Fallback to default config to enable testing Image component

### DIFF
--- a/packages/next/next-server/server/image-config.ts
+++ b/packages/next/next-server/server/image-config.ts
@@ -1,0 +1,24 @@
+export const VALID_LOADERS = [
+  'default',
+  'imgix',
+  'cloudinary',
+  'akamai',
+] as const
+
+export type LoaderValue = typeof VALID_LOADERS[number]
+
+export type ImageConfig = {
+  deviceSizes: number[]
+  imageSizes: number[]
+  loader: LoaderValue
+  path: string
+  domains?: string[]
+}
+
+export const imageConfigDefault: ImageConfig = {
+  deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+  imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+  path: '/_next/image',
+  loader: 'default',
+  domains: [],
+}

--- a/packages/next/next-server/server/image-optimizer.ts
+++ b/packages/next/next-server/server/image-optimizer.ts
@@ -11,6 +11,7 @@ import { fileExists } from '../../lib/file-exists'
 import isAnimated from 'next/dist/compiled/is-animated'
 import Stream from 'stream'
 import { sendEtagResponse } from './send-payload'
+import { ImageConfig, imageConfigDefault } from './image-config'
 
 let sharp: typeof import('sharp')
 //const AVIF = 'image/avif'
@@ -24,14 +25,6 @@ const MODERN_TYPES = [/* AVIF, */ WEBP]
 const ANIMATABLE_TYPES = [WEBP, PNG, GIF]
 const VECTOR_TYPES = [SVG]
 
-type ImageData = {
-  deviceSizes: number[]
-  imageSizes: number[]
-  loader: string
-  path: string
-  domains?: string[]
-}
-
 export async function imageOptimizer(
   server: Server,
   req: IncomingMessage,
@@ -39,7 +32,7 @@ export async function imageOptimizer(
   parsedUrl: UrlWithParsedQuery
 ) {
   const { nextConfig, distDir } = server
-  const imageData: ImageData = nextConfig.images
+  const imageData: ImageConfig = nextConfig.images || imageConfigDefault
   const { deviceSizes = [], imageSizes = [], domains = [], loader } = imageData
   const sizes = [...deviceSizes, ...imageSizes]
 

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -546,6 +546,31 @@ describe('Image Optimizer', () => {
         'Specified images.imageSizes should be an Array of numbers that are between 1 and 10000, received invalid values (0, 12000)'
       )
     })
+
+    it('should error when loader contains invalid value', async () => {
+      await nextConfig.replace(
+        '{ /* replaceme */ }',
+        JSON.stringify({
+          images: {
+            loader: 'notreal',
+          },
+        })
+      )
+      let stderr = ''
+
+      app = await launchApp(appDir, await findPort(), {
+        onStderr(msg) {
+          stderr += msg || ''
+        },
+      })
+      await waitFor(1000)
+      await killApp(app).catch(() => {})
+      await nextConfig.restore()
+
+      expect(stderr).toContain(
+        'Specified images.loader should be one of (default, imgix, cloudinary, akamai), received invalid value (notreal)'
+      )
+    })
   })
 
   // domains for testing

--- a/test/unit/image-rendering.unit.test.js
+++ b/test/unit/image-rendering.unit.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+import React from 'react'
+import ReactDOM from 'react-dom/server'
+import Image from 'next/image'
+import cheerio from 'cheerio'
+
+describe('Image rendering', () => {
+  it('should render Image on its own', async () => {
+    const element = React.createElement(Image, {
+      id: 'unit-image',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      loading: 'eager',
+    })
+    const html = ReactDOM.renderToString(element)
+    const $ = cheerio.load(html)
+    const img = $('#unit-image')
+    expect(img.attr('id')).toBe('unit-image')
+    expect(img.attr('src')).toContain('/_next/image?url=%2Ftest.png')
+    expect(img.attr('srcset')).toContain('/_next/image?url=%2Ftest.png')
+  })
+})


### PR DESCRIPTION
Fixes #18415 by using the default config as fallback.

Users who wish to use their `next.config.js` values will still need the workaround from https://github.com/vercel/next.js/issues/18415#issuecomment-718180659