### PR TITLE
Ensure optional catchall prerendered indexes and i18n

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -680,7 +680,11 @@ export async function buildStaticPaths(
       }
       const curLocale = entry.locale || defaultLocale || ''
 
-      prerenderPaths?.add(`${curLocale ? `/${curLocale}` : ''}${builtPage}`)
+      prerenderPaths?.add(
+        `${curLocale ? `/${curLocale}` : ''}${
+          curLocale && builtPage === '/' ? '' : builtPage
+        }`
+      )
     }
   })
 

--- a/packages/next/next-server/server/incremental-cache.ts
+++ b/packages/next/next-server/server/incremental-cache.ts
@@ -87,7 +87,11 @@ export class IncrementalCache {
   }
 
   private calculateRevalidate(pathname: string): number | false {
-    pathname = toRoute(normalizeLocalePath(pathname, this.locales).pathname)
+    pathname = toRoute(pathname)
+
+    if (!this.prerenderManifest.routes[pathname]) {
+      pathname = toRoute(normalizeLocalePath(pathname, this.locales).pathname)
+    }
 
     // in development we don't have a prerender-manifest
     // and default to always revalidating to allow easier debugging

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1302,7 +1302,9 @@ export default class Server {
       isPreviewMode || !isSSG
         ? undefined // Preview mode bypasses the cache
         : `${locale ? `/${locale}` : ''}${
-            pathname === '/' && locale ? '' : resolvedUrlPathname
+            (pathname === '/' || resolvedUrlPathname === '/') && locale
+              ? ''
+              : resolvedUrlPathname
           }${query.amp ? '.amp' : ''}`
 
     if (is404Page && isSSG) {

--- a/test/integration/i18n-support-catchall/pages/[[...slug]].js
+++ b/test/integration/i18n-support-catchall/pages/[[...slug]].js
@@ -41,7 +41,16 @@ export const getStaticProps = ({ locale, locales, defaultLocale, params }) => {
 
 export const getStaticPaths = () => {
   return {
-    paths: [],
+    paths: [
+      {
+        params: { slug: [] },
+        locale: 'en-US',
+      },
+      {
+        params: { slug: undefined },
+        locale: 'fr',
+      },
+    ],
     fallback: 'blocking',
   }
 }

--- a/test/integration/i18n-support-catchall/test/index.test.js
+++ b/test/integration/i18n-support-catchall/test/index.test.js
@@ -24,10 +24,24 @@ const appDir = join(__dirname, '../')
 const nextConfig = new File(join(appDir, 'next.config.js'))
 let app
 let appPort
+let buildPagesDir
 
 const locales = ['en-US', 'nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en']
 
 function runTests(isDev) {
+  if (!isDev) {
+    it('should output prerendered index routes correctly', async () => {
+      expect(await fs.exists(join(buildPagesDir, 'pages/en-US.html'))).toBe(
+        true
+      )
+      expect(await fs.exists(join(buildPagesDir, 'pages/en-US.json'))).toBe(
+        true
+      )
+      expect(await fs.exists(join(buildPagesDir, 'pages/fr.html'))).toBe(true)
+      expect(await fs.exists(join(buildPagesDir, 'pages/fr.json'))).toBe(true)
+    })
+  }
+
   it('should load the index route correctly SSR', async () => {
     const res = await fetchViaHTTP(appPort, '/', undefined, {
       redirect: 'manual',
@@ -194,6 +208,7 @@ describe('i18n Support Root Catch-all', () => {
       await nextBuild(appDir)
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
+      buildPagesDir = join(appDir, '.next/server')
     })
     afterAll(() => killApp(app))
 
@@ -208,6 +223,7 @@ describe('i18n Support Root Catch-all', () => {
       await nextBuild(appDir)
       appPort = await findPort()
       app = await nextStart(appDir, appPort)
+      buildPagesDir = join(appDir, '.next/serverless')
     })
     afterAll(async () => {
       nextConfig.restore()


### PR DESCRIPTION
This ensures root optional-catch-all index routes with i18n are output to the correct location and are also loaded from the `prerender-manifest` correctly. 

Fixes: https://github.com/vercel/next.js/issues/19095