### PR TITLE
Remove preload for priority images

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -1,5 +1,4 @@
-import React, { ReactElement } from 'react'
-import Head from '../next-server/lib/head'
+import React from 'react'
 import { toBase64 } from '../next-server/lib/to-base-64'
 import { useIntersection } from './use-intersection'
 
@@ -155,47 +154,6 @@ function generateSrcSet({
         }${kind}`
     )
     .join(', ')
-}
-
-type PreloadData = {
-  src: string
-  unoptimized: boolean
-  layout: LayoutValue
-  width: number | undefined
-  sizes?: string
-  quality?: number
-}
-
-function generatePreload({
-  src,
-  unoptimized = false,
-  layout,
-  width,
-  sizes,
-  quality,
-}: PreloadData): ReactElement {
-  // This function generates an image preload that makes use of the "imagesrcset" and "imagesizes"
-  // attributes for preloading responsive images. They're still experimental, but fully backward
-  // compatible, as the link tag includes all necessary attributes, even if the final two are ignored.
-  // See: https://web.dev/preload-responsive-images/
-  return (
-    <Head>
-      <link
-        rel="preload"
-        as="image"
-        href={computeSrc(src, unoptimized, layout, width, quality)}
-        // @ts-ignore: imagesrcset and imagesizes not yet in the link element type
-        imagesrcset={generateSrcSet({
-          src,
-          unoptimized,
-          layout,
-          width,
-          quality,
-        })}
-        imagesizes={sizes}
-      />
-    </Head>
-  )
 }
 
 function getInt(x: unknown): number | undefined {
@@ -411,10 +369,6 @@ export default function Image({
     imgAttributes.srcSet = imgSrcSet
   }
 
-  // No need to add preloads on the client side--by the time the application is hydrated,
-  // it's too late for preloads
-  const shouldPreload = priority && typeof window === 'undefined'
-
   if (unsized) {
     wrapperStyle = undefined
     sizerStyle = undefined
@@ -422,16 +376,6 @@ export default function Image({
   }
   return (
     <div style={wrapperStyle}>
-      {shouldPreload
-        ? generatePreload({
-            src,
-            layout,
-            unoptimized,
-            width: widthInt,
-            sizes,
-            quality: qualityInt,
-          })
-        : null}
       {sizerStyle ? (
         <div style={sizerStyle}>
           {sizerSvg ? (

--- a/test/integration/image-component/basic/test/index.test.js
+++ b/test/integration/image-component/basic/test/index.test.js
@@ -219,28 +219,28 @@ describe('Image Component Tests', () => {
       browser = null
     })
     runTests()
-    it('should add a preload tag for a priority image', async () => {
+    it.skip('should add a preload tag for a priority image', async () => {
       expect(
         await hasPreloadLinkMatchingUrl(
           'https://example.com/myaccount/withpriority.png?auto=format&fit=max&w=1024&q=60'
         )
       ).toBe(true)
     })
-    it('should add a preload tag for a priority image with preceding slash', async () => {
+    it.skip('should add a preload tag for a priority image with preceding slash', async () => {
       expect(
         await hasPreloadLinkMatchingUrl(
           'https://example.com/myaccount/fooslash.jpg?auto=format&fit=max&w=1024'
         )
       ).toBe(true)
     })
-    it('should add a preload tag for a priority image, with arbitrary host', async () => {
+    it.skip('should add a preload tag for a priority image, with arbitrary host', async () => {
       expect(
         await hasPreloadLinkMatchingUrl(
           'https://arbitraryurl.com/withpriority3.png'
         )
       ).toBe(true)
     })
-    it('should add a preload tag for a priority image, with quality', async () => {
+    it.skip('should add a preload tag for a priority image, with quality', async () => {
       expect(
         await hasPreloadLinkMatchingUrl(
           'https://example.com/myaccount/withpriority.png?auto=format&fit=max&w=1024&q=60'


### PR DESCRIPTION
Fixes #18720

This removes image preloading. It doesn't work correctly on any browser other than Chrome (with Chrome's real engine). On all other browsers, it triggers 2x the bytes to be downloaded. The tradeoff isn't worth it here IMO.

Chrome itself should be smart enough to bump an `<img />` tag's priority over other preloads that are script type during the preparse phase.

We can reintroduce this when we don't hurt non-Chrome users.