### PR TITLE
Fix link to developer plan in Kontent example

### DIFF
--- a/examples/cms-kontent/README.md
+++ b/examples/cms-kontent/README.md
@@ -44,7 +44,7 @@ yarn create next-app --example cms-kontent cms-kontent-app
 
 First, [create an account on Kontent.ai](https://app.kontent.ai/sign-up?utm_source=nextjs_docs_example&utm_medium=devrel&utm_campaign=extended_trial).
 
-> The link above will provide you with the 90-days trial. Once you finish the trial, or even during the trial period, you could switch to the [**developer plan**](https://kontent.ai/blog/a-new-developer-plan) which is **free of charge** and offers all the features you'll need to test out the example capabilities.
+> The link above will provide you with the 90-days trial. Once you finish the trial, or even during the trial period, you could switch to the [**developer plan**](https://kontent.ai/developer-plan) which is **free of charge** and offers all the features you'll need to test out the example capabilities.
 
 After signing up, [create an empty project](https://docs.kontent.ai/tutorials/set-up-kontent/projects/manage-projects#a-creating-projects).
 


### PR DESCRIPTION
Use the newly published developer plan page instead of the announcement blog post link.