### PR TITLE
Fix serverless with next start error case

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader.ts
@@ -631,7 +631,7 @@ const nextServerlessLoader: loader.Loader = function () {
           const {
             default: getRouteNoAssetPath,
           } = require('next/dist/next-server/lib/router/utils/get-route-from-asset-path');
-          _nextData = true;
+          _nextData = ${page === '/_error' ? 'false' : 'true'};
           parsedUrl.pathname = getRouteNoAssetPath(
             parsedUrl.pathname.replace(
               new RegExp('/_next/data/${escapedBuildId}/'),

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -1785,6 +1785,11 @@ const runTests = (dev = false, isEmulatedServerless = false) => {
       })
     }
   }
+
+  // this should come very last
+  it('should not have attempted sending invalid payload', async () => {
+    expect(stderr).not.toContain('argument entity must be string')
+  })
 }
 
 describe('SSG Prerender', () => {


### PR DESCRIPTION
This fixes the case where we were returning page data when rendering `/_error` in `serverless` mode with `next start`

Closes: https://github.com/vercel/next.js/issues/19068