### PR TITLE
Transform Serialized Props

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -276,6 +276,11 @@ export default async (opts: { webpackHMR?: any } = {}) => {
     }
   }
 
+  const transformedProps =
+    'transformDeserializedProps' in CachedApp
+      ? (CachedApp as any).transformDeserializedProps(hydrateProps)
+      : hydrateProps
+
   let initialErr = hydrateErr
 
   try {
@@ -342,7 +347,7 @@ export default async (opts: { webpackHMR?: any } = {}) => {
   }
 
   router = createRouter(page, query, asPath, {
-    initialProps: hydrateProps,
+    initialProps: transformedProps,
     pageLoader,
     App: CachedApp,
     Component: CachedComponent,
@@ -372,7 +377,7 @@ export default async (opts: { webpackHMR?: any } = {}) => {
     App: CachedApp,
     initial: true,
     Component: CachedComponent,
-    props: hydrateProps,
+    props: transformedProps,
     err: initialErr,
   }
 

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -14,7 +14,7 @@ import {
   SSG_GET_INITIAL_PROPS_CONFLICT,
   UNSTABLE_REVALIDATE_RENAME_ERROR,
 } from '../../lib/constants'
-import { isSerializableProps } from '../../lib/is-serializable-props'
+import { isSerializableProps } from '../../lib/is-serializable-props' // XXX need to be able to override this.
 import { GetServerSideProps, GetStaticProps } from '../../types'
 import { isInAmpMode } from '../lib/amp'
 import { AmpStateContext } from '../lib/amp-context'

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -29,12 +29,22 @@ async function appGetInitialProps({
   return { pageProps }
 }
 
+/**
+ * This function is applied to initial props after deserializing JSON from the
+ * __NEXT_DATA__ inline script tag. If you override this, you should also
+ * provide Document.transformPropsForSerialization.
+ */
+function transformDeserializedProps(props: any): any {
+  return props
+}
+
 export default class App<P = {}, CP = {}, S = {}> extends React.Component<
   P & AppProps<CP>,
   S
 > {
   static origGetInitialProps = appGetInitialProps
   static getInitialProps = appGetInitialProps
+  static transformDeserializedProps = transformDeserializedProps
 
   // Kept here for backwards compatibility.
   // When someone ended App they could call `super.componentDidCatch`.

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -638,6 +638,27 @@ export class NextScript extends Component<OriginProps> {
     }
   }
 
+  getInlineScriptSource(documentProps: Readonly<DocumentProps>): string {
+    const { __NEXT_DATA__ } = documentProps
+    const { props } = __NEXT_DATA__
+    return NextScript.getInlineScriptSource({
+      ...documentProps,
+      __NEXT_DATA__: {
+        ...__NEXT_DATA__,
+        props: this.transformPropsForSerialization(props),
+      },
+    })
+  }
+
+  /**
+   * This method is applied to initial props before serializing it in to the
+   * __NEXT_DATA__ inline script tag. The result must be serializable to JSON.
+   * If you override this, you should also provide App.transformDeserializedProps.
+   */
+  transformPropsForSerialization(props: Record<string, any>): any {
+    return props
+  }
+
   render() {
     const {
       assetPrefix,
@@ -672,7 +693,7 @@ export class NextScript extends Component<OriginProps> {
                 this.props.crossOrigin || process.env.__NEXT_CROSS_ORIGIN
               }
               dangerouslySetInnerHTML={{
-                __html: NextScript.getInlineScriptSource(this.context),
+                __html: this.getInlineScriptSource(this.context),
               }}
               data-ampdevmode
             />


### PR DESCRIPTION
This is a strawman pull request in an attempt to address the following issues and discussions:

- https://github.com/vercel/next.js/issues/15956
- https://github.com/vercel/next.js/discussions/11498
- https://github.com/vercel/next.js/discussions/13696
- https://github.com/vercel/next.js/discussions/11498

In short, this PR provides hooks for transforming initial props right before serializing in to the __NEXT_DATA__ inline script tag, as well as right after deserializing from there and before hydrating the app component.

The goal is to allow extended datatypes such as Dates to be encoded in to props for hydration. This could work for example by walking the data and looking for a sentinel key/value pair in an object like `{"%TYPE%": "Date", "iso8601": "2020-11-19T04:52:40.464Z"}` and transforming accordingly. Alternatively, a richer encoding embedded in JSON can be used, such as [Transit.js](https://github.com/cognitect/transit-js).

If this functionality is interesting to the maintainers, I'm happy to put in some elbow grease to make it work. Just looking for a little guidance. As is, the code is totally untested, although a similar approach is applied as a patch in our production codebase. I'd like to get some feedback on interest and next steps before committing to the work to get this upstreamed in to Next.js proper.

Some questions:

- What additional context should be made available to the serialization and deserialization functions?
- Am I missing some key places where serialization and deserialization occur? for example in development hot loading scenarios?
- What should be done about the `isSerializableProps` check?