### PR TITLE
Add note to docs for i18n and next export

### DIFF
--- a/docs/advanced-features/i18n-routing.md
+++ b/docs/advanced-features/i18n-routing.md
@@ -269,3 +269,5 @@ export const getStaticPaths = ({ locales }) => {
   }
 }
 ```
+
+Note: i18n routing does not currently support [`next export`](https://nextjs.org/docs/advanced-features/i18n-routing) mode as you are no longer leveraging Next.js' server-side routing.


### PR DESCRIPTION
This adds a note about current `i18n` support and `next export` since it is not currently supported as was mentioned in the [initial RFC](https://github.com/vercel/next.js/discussions/17078)

x-ref: https://github.com/vercel/next.js/issues/18318
