### PR TITLE
Add webpack-bundle-analyzer config overrides

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,4 +1,4 @@
-module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
+module.exports = ({ enabled = true, ...pluginProps } = {}) => (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (enabled) {
@@ -9,6 +9,7 @@ module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
             reportFilename: options.isServer
               ? '../analyze/server.html'
               : './analyze/client.html',
+            ...pluginProps,
           })
         )
       }

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -33,6 +33,8 @@ module.exports = (phase, defaultConfig) => {
 }
 ```
 
+Since this plugin extends the [default analyzer config](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin), you may provide overrides accordingly.
+
 Then you can run the command below:
 
 ```bash

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -33,7 +33,7 @@ module.exports = (phase, defaultConfig) => {
 }
 ```
 
-Since this plugin extends the [default analyzer config](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin), you may provide overrides accordingly.
+ℹ️ Since this plugin extends the [default analyzer config](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin), you may provide overrides accordingly.
 
 Then you can run the command below:
 

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -33,7 +33,15 @@ module.exports = (phase, defaultConfig) => {
 }
 ```
 
-ℹ️ Since this plugin extends the [default analyzer config](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin), you may provide overrides accordingly.
+ℹ️ Since this plugin extends the [default analyzer config](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin), you may provide overrides accordingly:
+
+```js
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+  generateStatsFile: true
+})
+module.exports = withBundleAnalyzer({})
+```
 
 Then you can run the command below:
 


### PR DESCRIPTION
Currently don't have enough control with `nextBundleAnalyzer` options and would like opt-in config for CI:

```
const withBundleAnalyzer = nextBundleAnalyzer({
  enabled: process.env.ANALYZE === 'true',
  analyzerMode: process.env.CI === 'true' ? 'static' : 'server',
  generateStatsFile: true
})
```

Proposing we add the ability to do this so devs don't have to remove this plugin and use `webpack-bundle-analyzer` directly in order to utilize the extra config.