### PR TITLE
with-zustand example fix for build error on ssr page

### DIFF
--- a/examples/with-zustand/pages/ssr.js
+++ b/examples/with-zustand/pages/ssr.js
@@ -1,5 +1,5 @@
 import Page from '../components/page'
-import { initializeStore } from '../store'
+import { initializeStore } from '../lib/store'
 
 export default function SSR() {
   return <Page />


### PR DESCRIPTION
The example `with-zustand`, in `pages/ssr.js` the import call made to `store` used an invalid relative path breaking the example on run after build. This pull request is a quick fix for this. Nothing fancy, just set the correct path for `store` to be imported correctly.  