### PR TITLE
example fix: hydrate method of the mobx store needs to be an action

### DIFF
--- a/examples/with-mobx-react-lite/store.js
+++ b/examples/with-mobx-react-lite/store.js
@@ -12,6 +12,7 @@ export class Store {
       lastUpdate: observable,
       light: observable,
       start: action,
+      hydrate: action,
       timeString: computed,
     })
   }

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -34,7 +34,7 @@ class Store {
 
   stop = () => clearInterval(this.timer)
 
-  hydrate = (data) => {
+  @action hydrate = (data) => {
     if (!data) return
 
     this.lastUpdate = data.lastUpdate !== null ? data.lastUpdate : Date.now()


### PR DESCRIPTION
By default, MobX 6 and later require that you use `actions` to make changes to the state, otherwise, it issues a warning in the console, because the `hydrate` method of the `store.js` class hasn't been declared an action, you can see this warning if you try to load pages that use hydration (ssg, ssr).
This pull request fixes that.

More info about the behavior:
https://mobx.js.org/actions.html#disabling-mandatory-actions-