### PR TITLE
Add new example for dark mode switch with styled-components and TypeScript

### DIFF
--- a/examples/darkmode-styled-components-typescript/.babelrc
+++ b/examples/darkmode-styled-components-typescript/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true }]]
+}

--- a/examples/darkmode-styled-components-typescript/.gitignore
+++ b/examples/darkmode-styled-components-typescript/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/darkmode-styled-components-typescript/README.md
+++ b/examples/darkmode-styled-components-typescript/README.md
@@ -1,0 +1,21 @@
+# Example Name
+
+Description
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com/now):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/vercel/next.js/tree/canary/examples/DIRECTORY_NAME)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
+# or
+yarn create next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/darkmode-styled-components-typescript/README.md
+++ b/examples/darkmode-styled-components-typescript/README.md
@@ -1,6 +1,6 @@
-# Example Name
+# Dark mode with styled components and typescript
 
-Description
+Due to the pre-rendering (SSG / SSR), placing a dark mode that can be saved in localStorage becomes surprisingly complicated, because during compilation time we do not have access to localStorage. This causes several complications, because the only way to access localStorage is on the client side and trying to do this only on the client side causes a bug that is the flash in changing themes. There are several ways to solve this ... like this example using CSS variables and styled-components.
 
 ## Deploy your own
 
@@ -13,9 +13,9 @@ Deploy the example using [Vercel](https://vercel.com/now):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
+npx create-next-app --example darkmode-styled-components-typescript darkmode-styled-components-typescript-app
 # or
-yarn create next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
+yarn create next-app --example darkmode-styled-components-typescript darkmode-styled-components-typescript-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/darkmode-styled-components-typescript/README.md
+++ b/examples/darkmode-styled-components-typescript/README.md
@@ -6,7 +6,7 @@ Description
 
 Deploy the example using [Vercel](https://vercel.com/now):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/vercel/next.js/tree/canary/examples/DIRECTORY_NAME)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/vercel/next.js/tree/canary/examples/darkmode-styled-components-ts)
 
 ## How to use
 

--- a/examples/darkmode-styled-components-typescript/components/ThemeProvider/index.tsx
+++ b/examples/darkmode-styled-components-typescript/components/ThemeProvider/index.tsx
@@ -1,0 +1,47 @@
+import { createContext, ReactNode, useEffect, useState } from 'react'
+
+import { Theme } from '../../styles/Theme'
+
+interface ThemeContext {
+  colorMode: string
+  setColorMode: (newValue: string) => void
+}
+
+export const ThemeContext = createContext<ThemeContext>({} as ThemeContext)
+
+interface Props {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: Props): JSX.Element {
+  const [colorMode, rawSetColorMode] = useState('')
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    const initialColorValue = root.style.getPropertyValue(
+      '--initial-color-mode'
+    )
+    rawSetColorMode(initialColorValue)
+  }, [])
+
+  function setColorMode(newValue: string): void {
+    const root = window.document.documentElement
+    // 1. Update React color-mode state
+    rawSetColorMode(newValue)
+    // 2. Update localStorage
+    localStorage.setItem('color-mode', newValue)
+
+    // 3. Update each color
+    Object.entries(Theme[newValue]).forEach(([name, colorByTheme]) => {
+      const cssVarName = `--color-${name}`
+
+      root.style.setProperty(cssVarName, String(colorByTheme))
+    })
+  }
+
+  return (
+    <ThemeContext.Provider value={{ colorMode, setColorMode }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/examples/darkmode-styled-components-typescript/lib/ScriptHydrationTheme.tsx
+++ b/examples/darkmode-styled-components-typescript/lib/ScriptHydrationTheme.tsx
@@ -1,0 +1,49 @@
+import { Theme } from '../styles/Theme'
+
+function injection() {
+  const theme = 'substitutedForTheme'
+  function getInitialColorMode() {
+    const persistedColorPreference = window.localStorage.getItem('color-mode')
+    const hasPersistedPreference = typeof persistedColorPreference === 'string'
+    // If the user has explicitly chosen light or dark,
+    // let's use it. Otherwise, this value will be null.
+    if (hasPersistedPreference) {
+      return persistedColorPreference
+    }
+    // If they haven't been explicit, let's check the media
+    // query
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const hasMediaQueryPreference = typeof mql.matches === 'boolean'
+    if (hasMediaQueryPreference) {
+      return mql.matches ? 'dark' : 'light'
+    }
+    // If they are using a browser/OS that doesn't support
+    // color themes, let's default to 'light'.
+    return 'light'
+  }
+
+  const colorMode = getInitialColorMode()
+  const root = document.documentElement
+
+  root.style.setProperty('--initial-color-mode', colorMode)
+
+  Object.entries(theme[colorMode]).forEach(([name, colorByTheme]) => {
+    const cssVarName = `--color-${name}`
+    root.style.setProperty(cssVarName, String(colorByTheme))
+  })
+}
+
+export function ScriptHydrationTheme(): JSX.Element {
+  const functionString = String(injection).replace(
+    "'substitutedForTheme'",
+    JSON.stringify(Theme)
+  )
+  const codeToRunOnClient = `(${functionString})()`
+  // eslint-disable-next-line react/no-danger
+  return (
+    <script
+      id="theme-rehydrate"
+      dangerouslySetInnerHTML={{ __html: codeToRunOnClient }}
+    />
+  )
+}

--- a/examples/darkmode-styled-components-typescript/next-env.d.ts
+++ b/examples/darkmode-styled-components-typescript/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/examples/darkmode-styled-components-typescript/next.config.js
+++ b/examples/darkmode-styled-components-typescript/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+}

--- a/examples/darkmode-styled-components-typescript/package.json
+++ b/examples/darkmode-styled-components-typescript/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "darkmode-styled-components-typescript",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "styled-components": "^5.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.10",
+    "@types/react": "^17.0.0",
+    "@types/styled-components": "^5.1.4"
+  },
+  "license": "MIT"
+}

--- a/examples/darkmode-styled-components-typescript/pages/_app.tsx
+++ b/examples/darkmode-styled-components-typescript/pages/_app.tsx
@@ -1,13 +1,15 @@
 import { AppProps } from 'next/app'
 
-import GlobalStyle from '../styles/globals'
+import { ThemeProvider } from '../components/ThemeProvider'
+
+import GlobalStyle from '../styles/global'
 
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return (
-    <>
+    <ThemeProvider>
       <Component {...pageProps} />
       <GlobalStyle />
-    </>
+    </ThemeProvider>
   )
 }
 

--- a/examples/darkmode-styled-components-typescript/pages/_app.tsx
+++ b/examples/darkmode-styled-components-typescript/pages/_app.tsx
@@ -1,0 +1,14 @@
+import { AppProps } from 'next/app'
+
+import GlobalStyle from '../styles/globals'
+
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+  return (
+    <>
+      <Component {...pageProps} />
+      <GlobalStyle />
+    </>
+  )
+}
+
+export default MyApp

--- a/examples/darkmode-styled-components-typescript/pages/_document.tsx
+++ b/examples/darkmode-styled-components-typescript/pages/_document.tsx
@@ -9,6 +9,8 @@ import Document, {
 
 import { ServerStyleSheet } from 'styled-components'
 
+import { ScriptHydrationTheme } from '../lib/ScriptHydrationTheme'
+
 export default class MyDocument extends Document {
   static async getInitialProps(
     ctx: DocumentContext
@@ -40,9 +42,10 @@ export default class MyDocument extends Document {
 
   render(): JSX.Element {
     return (
-      <Html lang="pt-BR">
+      <Html lang="en">
         <Head />
         <body>
+          <ScriptHydrationTheme />
           <Main />
           <NextScript />
         </body>

--- a/examples/darkmode-styled-components-typescript/pages/_document.tsx
+++ b/examples/darkmode-styled-components-typescript/pages/_document.tsx
@@ -1,0 +1,52 @@
+import Document, {
+  DocumentContext,
+  DocumentInitialProps,
+  Head,
+  Html,
+  Main,
+  NextScript,
+} from 'next/document'
+
+import { ServerStyleSheet } from 'styled-components'
+
+export default class MyDocument extends Document {
+  static async getInitialProps(
+    ctx: DocumentContext
+  ): Promise<DocumentInitialProps> {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (MyApp) => (props) =>
+            sheet.collectStyles(<MyApp {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+
+  render(): JSX.Element {
+    return (
+      <Html lang="pt-BR">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}

--- a/examples/darkmode-styled-components-typescript/pages/index.tsx
+++ b/examples/darkmode-styled-components-typescript/pages/index.tsx
@@ -1,0 +1,7 @@
+export default function Home(): JSX.Element {
+  return (
+    <div>
+      <label htmlFor="darkmode">Darkmode</label>
+    </div>
+  )
+}

--- a/examples/darkmode-styled-components-typescript/pages/index.tsx
+++ b/examples/darkmode-styled-components-typescript/pages/index.tsx
@@ -1,7 +1,27 @@
+import { useContext } from 'react'
+
+import { ThemeContext } from '../components/ThemeProvider'
+
 export default function Home(): JSX.Element {
+  const { colorMode, setColorMode } = useContext(ThemeContext)
+
+  if (!colorMode) {
+    return null
+  }
+
+  const isDark = colorMode === 'dark' ? true : false
+
   return (
     <div>
-      <label htmlFor="darkmode">Darkmode</label>
+      <label htmlFor="darkmode">Dark</label>
+      <input
+        type="checkbox"
+        name="Dark"
+        id=""
+        checked={!!isDark}
+        aria-label="Dark"
+        onChange={() => (isDark ? setColorMode('light') : setColorMode('dark'))}
+      />
     </div>
   )
 }

--- a/examples/darkmode-styled-components-typescript/styles/Theme.ts
+++ b/examples/darkmode-styled-components-typescript/styles/Theme.ts
@@ -1,0 +1,10 @@
+export const Theme = {
+  light: {
+    background: '#EEEE',
+    text: '#000',
+  },
+  dark: {
+    background: '#0E141B',
+    text: '#FFFF',
+  },
+}

--- a/examples/darkmode-styled-components-typescript/styles/global.ts
+++ b/examples/darkmode-styled-components-typescript/styles/global.ts
@@ -1,0 +1,9 @@
+import { createGlobalStyle } from 'styled-components'
+
+export default createGlobalStyle`
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+`

--- a/examples/darkmode-styled-components-typescript/styles/global.ts
+++ b/examples/darkmode-styled-components-typescript/styles/global.ts
@@ -6,4 +6,9 @@ export default createGlobalStyle`
     padding: 0;
     box-sizing: border-box;
   }
+
+  body {
+    background-color: var(--color-background);
+    color: var(--color-text);
+  }
 `

--- a/examples/darkmode-styled-components-typescript/tsconfig.json
+++ b/examples/darkmode-styled-components-typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Adds an example of dark mode with [styled-components](https://styled-components.com/), CSS variables and TypeScript.

**Demo:** https://darkmode-styled-components-ts.vercel.app/