### PR TITLE
fix: Revert #18921 and inline absolute babel runtime only for YarnPnp

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -1,6 +1,4 @@
 import { PluginItem } from 'next/dist/compiled/babel/core'
-import { dirname } from 'path'
-
 const env = process.env.NODE_ENV
 const isProduction = env === 'production'
 const isDevelopment = env === 'development'
@@ -170,9 +168,7 @@ module.exports = (
           helpers: true,
           regenerator: true,
           useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
-          absoluteRuntime: dirname(
-            require.resolve('@babel/runtime/package.json')
-          ),
+          absoluteRuntime: process.versions.pnp ? __dirname : undefined,
           ...options['transform-runtime'],
         },
       ],

--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -1,4 +1,5 @@
 import { PluginItem } from 'next/dist/compiled/babel/core'
+import { dirname } from 'path'
 const env = process.env.NODE_ENV
 const isProduction = env === 'production'
 const isDevelopment = env === 'development'
@@ -168,7 +169,9 @@ module.exports = (
           helpers: true,
           regenerator: true,
           useESModules: supportsESM && presetEnvConfig.modules !== 'commonjs',
-          absoluteRuntime: process.versions.pnp ? __dirname : undefined,
+          absoluteRuntime: process.versions.pnp
+            ? dirname(require.resolve('@babel/runtime/package.json'))
+            : undefined,
           ...options['transform-runtime'],
         },
       ],

--- a/test/unit/next-babel.unit.test.js
+++ b/test/unit/next-babel.unit.test.js
@@ -64,8 +64,8 @@ describe('next/babel', () => {
       expect(output).toMatch(`__jsx(${react}.Fragment`)
       expect(output).toMatch(`__jsx("a",{href:"/"`)
 
-      expect(babel(`const a = ()=><a href="/">home</a>`)).toMatch(
-        `var _react=_interopRequireDefault(require("react"));var __jsx=_react["default"].createElement;var a=function a(){return __jsx("a",{href:"/"},"home");};`
+      expect(babel(`const a = ()=><a href="/">home</a>`)).toMatchInlineSnapshot(
+        `"\\"use strict\\";var _interopRequireDefault=require(\\"@babel/runtime/helpers/interopRequireDefault\\");var _react=_interopRequireDefault(require(\\"react\\"));var __jsx=_react[\\"default\\"].createElement;var a=function a(){return __jsx(\\"a\\",{href:\\"/\\"},\\"home\\");};"`
       )
     })
 


### PR DESCRIPTION
This reverts #18921 and ensures that the Babel runtime is only inlined as an absolute path when using PnP as before, but then including the correction this resolution as implemented by @merceyz only in the PnP cases, while keeping the diff to a minimum.