### PR TITLE
fix(next): Arrow function replaced by old function

### DIFF
--- a/packages/next/client/normalize-trailing-slash.ts
+++ b/packages/next/client/normalize-trailing-slash.ts
@@ -10,7 +10,7 @@ export function removePathTrailingSlash(path: string): string {
  * in `next.config.js`.
  */
 export const normalizePathTrailingSlash = process.env.__NEXT_TRAILING_SLASH
-  ? (path: string): string => {
+  ? function (path: string): string {
       if (/\.[^/]+\/?$/.test(path)) {
         return removePathTrailingSlash(path)
       } else if (path.endsWith('/')) {


### PR DESCRIPTION
## What
The error occurred because arrow function was left in the code when used in IE11.
A correction was made to replace the arrow function of the relevant part with the function of the old format.