### PR TITLE
Add Cloudflare image loader

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -87,6 +87,7 @@ The following Image Optimization cloud providers are supported:
 - [Vercel](https://vercel.com): Works automatically when you deploy on Vercel, no configuration necessary. [Learn more](https://vercel.com/docs/next.js/image-optimization)
 - [Imgix](https://www.imgix.com): `loader: 'imgix'`
 - [Cloudinary](https://cloudinary.com): `loader: 'cloudinary'`
+- [Cloudflare](https://developers.cloudflare.com/images/): `loader: 'cloudflare'`
 - [Akamai](https://www.akamai.com): `loader: 'akamai'`
 - Default: Works automatically with `next dev`, `next start`, or a custom server
 

--- a/errors/invalid-images-config.md
+++ b/errors/invalid-images-config.md
@@ -18,7 +18,7 @@ module.exports = {
     // limit of 50 domains values
     domains: [],
     path: '/_next/image',
-    // loader can be 'default', 'imgix', 'cloudinary', or 'akamai'
+    // loader can be 'default', 'imgix', 'cloudinary', 'cloudflare' or 'akamai'
     loader: 'default',
   },
 }

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -19,6 +19,7 @@ const loaders = new Map<LoaderValue, (props: LoaderProps) => string>([
   ['imgix', imgixLoader],
   ['cloudinary', cloudinaryLoader],
   ['akamai', akamaiLoader],
+  ['cloudflare', cloudflareLoader],
   ['default', defaultLoader],
 ])
 
@@ -439,6 +440,12 @@ function cloudinaryLoader({ root, src, width, quality }: LoaderProps): string {
     paramsString = params.join(',') + '/'
   }
   return `${root}${paramsString}${normalizeSrc(src)}`
+}
+
+function cloudflareLoader({ root, src, width, quality }: LoaderProps): string {
+  return `${root}cdn-cgi/image/width=${width}${
+    quality ? `,quality=${quality}` : ''
+  }/${normalizeSrc(src)}`
 }
 
 function defaultLoader({ root, src, width, quality }: LoaderProps): string {

--- a/packages/next/next-server/server/image-config.ts
+++ b/packages/next/next-server/server/image-config.ts
@@ -2,6 +2,7 @@ export const VALID_LOADERS = [
   'default',
   'imgix',
   'cloudinary',
+  'cloudflare',
   'akamai',
 ] as const
 

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -568,7 +568,7 @@ describe('Image Optimizer', () => {
       await nextConfig.restore()
 
       expect(stderr).toContain(
-        'Specified images.loader should be one of (default, imgix, cloudinary, akamai), received invalid value (notreal)'
+        'Specified images.loader should be one of (default, imgix, cloudinary, cloudflare, akamai), received invalid value (notreal)'
       )
     })
   })


### PR DESCRIPTION
This makes Cloudflare's [Image Resizing](https://developers.cloudflare.com/images/url-format) a supported cloud provider for [Image Optimization](https://nextjs.org/docs/basic-features/image-optimization).