### PR TITLE
Fix typo in gitignore

### DIFF
--- a/examples/custom-server-typescript/.gitignore
+++ b/examples/custom-server-typescript/.gitignore
@@ -13,7 +13,7 @@
 /out/
 
 # production
-/build
+/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
Build directory is `dist` and not `build`. The typo also makes gitignore not work correctly.