### PR TITLE
Remove the `as` prop from the Link component in with-static-export example

### DIFF
--- a/examples/with-static-export/components/post.js
+++ b/examples/with-static-export/components/post.js
@@ -5,7 +5,7 @@ export default function Post({ title, body, id }) {
     <article>
       <h2>{title}</h2>
       <p>{body}</p>
-      <Link href="/post/[id]" as={`/post/${id}`}>
+      <Link href={`/post/${id}`}>
         <a>Read more...</a>
       </Link>
     </article>


### PR DESCRIPTION
This PR closes #19649.