### PR TITLE
Adds an example with next-boost to implement a cache layer with stale-while-revalidate policy

### DIFF
--- a/examples/with-next-boost/.gitignore
+++ b/examples/with-next-boost/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/with-next-boost/.next-boost.js
+++ b/examples/with-next-boost/.next-boost.js
@@ -1,0 +1,13 @@
+module.exports = {
+  cache: {
+    path: "/tmp/demo1",
+    ttl: 3600,
+    tbd: 3600 * 24 * 5,
+  },
+  rules: [
+    {
+      regex: "^/$",
+      ttl: 3,
+    },
+  ],
+};

--- a/examples/with-next-boost/README.md
+++ b/examples/with-next-boost/README.md
@@ -1,0 +1,58 @@
+# next-boost example
+
+[next-boost](https://github.com/rjyo/next-boost/) is a drop-in middleware which adds a disk cache layer to your Next applications. It works with next.js or a custom server like express.js.
+
+It can be considered as an implementation of Incremental Static Regeneration, but works with `getServerSideProps`.
+
+- Drop-in replacement for Next.js's production mode: `next start`
+- Greatly reducing the server TTFB (time-to-first-byte)
+- Non-blocking main process for cache-serving and using `worker_threads` for SSR
+- HTTP API to delete a certain page
+- By using a [database-disk-hybrid cache](https://github.com/rjyo/hybrid-disk-cache), `next-boost` has
+    - no memory capacity limit, and works great on cheap VPSs
+    - no need to add a cache layer server like varnish, nginx Cache and etc.
+    - great performance, and may even have [better performace than pure file system](https://www.sqlite.org/fasterthanfs.html) cache
+    - portability on major platforms
+- Small footprint: [148 LOC](https://coveralls.io/github/rjyo/next-boost?branch=master)
+- Used in production with 300K pages cached
+
+You can find more info and some benchmarks on [next-boost](https://github.com/rjyo/next-boost/)'s github page.
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-next-boost with-next-boost-app
+# or
+yarn create next-app --example with-next-boost with-next-boost-app
+```
+
+### How to run the drop-in next-boost
+
+```bash
+# to build the next.js app
+npm run build
+# start next with next-boost
+npm start
+```
+
+### How to run the custom server with express.js
+
+```bash
+# dev mode
+npm run dev
+# to build the next.js app
+npm run build
+# start the express server in production mode
+node run prod
+```
+
+### Check the results
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result like below,
+
+![demo1](https://i.imgur.com/hYbJLtH.png)
+
+The cache's behavior is defined in `.next-boost.js` and you can find more on the [next-boost](https://github.com/rjyo/next-boost)'s github page.
+

--- a/examples/with-next-boost/init.js
+++ b/examples/with-next-boost/init.js
@@ -1,0 +1,7 @@
+async function init(args) {
+  const app = require('next')(args)
+  await app.prepare()
+  return app.getRequestHandler()
+}
+
+exports.default = init

--- a/examples/with-next-boost/package.json
+++ b/examples/with-next-boost/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "with-next-boost",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "node src/server.js",
+    "build": "next build",
+    "prod": "NODE_ENV=production node src/server.js",
+    "start": "next-boost"
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "next": "10.0.2",
+    "next-boost": "^0.7.8",
+    "react": "17.0.1",
+    "react-dom": "17.0.1"
+  },
+  "license": "MIT"
+}

--- a/examples/with-next-boost/pages/index.js
+++ b/examples/with-next-boost/pages/index.js
@@ -1,0 +1,37 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+export default function Home({ now }) {
+  return (
+    <div>
+      <Head>
+        <title>next-boost with express.js</title>
+      </Head>
+
+      <main
+        style={{
+          margin: '10em auto',
+          maxWidth: '30em',
+          lineHeight: 1.5,
+        }}
+      >
+        <div>
+          The time from server below will be cached for at least 3 seconds in{' '}
+          <strong>production</strong> with <strong>next-boost</strong>.
+          <br />
+          And it will always be refreshed in dev mode.
+        </div>
+        <h2>
+          <strong>{now}</strong>
+        </h2>
+        <p>
+          <Link href="/hello">/hello</Link> is an express.js route.
+        </p>
+      </main>
+    </div>
+  )
+}
+
+export const getServerSideProps = async () => {
+  return { props: { now: new Date().toISOString() } }
+}

--- a/examples/with-next-boost/server.js
+++ b/examples/with-next-boost/server.js
@@ -1,0 +1,32 @@
+const CachedHandler = require('next-boost').default
+const express = require('express')
+const server = express()
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const args = { dir: '.', dev }
+
+async function main() {
+  server.get('/hello', function (req, res) {
+    res.send('hello world')
+  })
+
+  let handler
+  if (dev) {
+    const init = require('./init').default
+    handler = await init(args)
+  } else {
+    const script = require.resolve('./init')
+    const cached = await CachedHandler({ script, args })
+    handler = cached.handler
+  }
+  server.get('*', handler)
+
+  server.listen(port, (err) => {
+    if (err) throw err
+    console.log(
+      `> Ready on http://localhost:${port}, dev ${dev ? 'on' : 'off'} `
+    )
+  })
+}
+
+main()


### PR DESCRIPTION
[`next-boost`](https://github.com/rjyo/next-boost) can be considered as an implementation of Incremental Static Regeneration, but works with `getServerSideProps`.

The background and introduction of next-boost can be found at https://github.com/vercel/next.js/discussions/13705
