### PR TITLE
Update locale domain detection to include subdomains

### DIFF
--- a/packages/next/next-server/lib/i18n/detect-domain-locale.ts
+++ b/packages/next/next-server/lib/i18n/detect-domain-locale.ts
@@ -29,6 +29,7 @@ export function detectDomainLocale(
       const domainHostname = item.domain?.split(':')[0].toLowerCase()
       if (
         hostname === domainHostname ||
+        hostname?.includes(domainHostname) ||
         detectedLocale === item.defaultLocale.toLowerCase() ||
         item.locales?.some((locale) => locale.toLowerCase() === detectedLocale)
       ) {


### PR DESCRIPTION
This should allow the i18n domain config to detect the correct locale even if the website is running on a development or staging environment, without needing to add dozens of entries to the `domains` array.