### PR TITLE
Fix cloudinary default quality to use q_auto

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -429,15 +429,9 @@ function akamaiLoader({ root, src, width }: LoaderProps): string {
 }
 
 function cloudinaryLoader({ root, src, width, quality }: LoaderProps): string {
-  // Demo: https://res.cloudinary.com/demo/image/upload/w_300,c_limit/turtles.jpg
-  const params = ['f_auto', 'c_limit', 'w_' + width]
-  let paramsString = ''
-  if (quality) {
-    params.push('q_' + quality)
-  }
-  if (params.length) {
-    paramsString = params.join(',') + '/'
-  }
+  // Demo: https://res.cloudinary.com/demo/image/upload/w_300,c_limit,q_auto/turtles.jpg
+  const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
+  let paramsString = params.join(',') + '/'
   return `${root}${paramsString}${normalizeSrc(src)}`
 }
 


### PR DESCRIPTION
The [default loader](https://github.com/vercel/next.js/blob/17b91e7c76711308707bc8ab3308376af98170e6/packages/next/client/image.tsx#L488) and [imgix loader](https://docs.imgix.com/apis/rendering/format/q) use a quality of 75 if none is specified on the Image component.

This PR does something similar for the cloudinary loader by utilizing `q_auto`, but it should yield even better results.

> This setting can significantly reduce the file size without any degradation noticeable to the human eye, and without the need for you to individually analyze every image.

https://cloudinary.com/documentation/image_optimization#use_q_auto_automatic_quality_and_encoding

### Example
- [Before](https://res.cloudinary.com/demo/image/upload/woman.jpg) - 583KB
- [After](https://res.cloudinary.com/demo/image/upload/q_auto/woman.jpg) - 46KB