### PR TITLE
Avoid misleading inline comments in .env example

### DIFF
--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -63,8 +63,12 @@ export async function getStaticProps() {
 > ```bash
 > # .env
 > A=abc
-> WRONG=pre$A # becomes "preabc"
-> CORRECT=pre\$A # becomes "pre$A"
+>
+> # becomes "preabc"
+> WRONG=pre$A
+>
+> # becomes "pre$A"
+> CORRECT=pre\$A
 > ```
 
 ## Exposing Environment Variables to the Browser


### PR DESCRIPTION
dotenv currently doesn't support inline comments (see https://github.com/motdotla/dotenv/issues/484), so it's misleading to use inline comments in documentation examples.