### PR TITLE
Add support for typescript project using composite option

### DIFF
--- a/packages/next/lib/typescript/runTypeCheck.ts
+++ b/packages/next/lib/typescript/runTypeCheck.ts
@@ -24,12 +24,11 @@ export async function runTypeCheck(
   if (effectiveConfiguration.fileNames.length < 1) {
     return { hasWarnings: false }
   }
-  const requiredConfig = getRequiredConfiguration(ts)
+  const requiredConfig = getRequiredConfiguration(ts, effectiveConfiguration)
 
   const program = ts.createProgram(effectiveConfiguration.fileNames, {
     ...effectiveConfiguration.options,
     ...requiredConfig,
-    noEmit: true,
   })
   const result = program.emit()
 

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -36,13 +36,13 @@ describe('tsconfig.json verifier', () => {
           \\"skipLibCheck\\": true,
           \\"strict\\": false,
           \\"forceConsistentCasingInFileNames\\": true,
-          \\"noEmit\\": true,
           \\"esModuleInterop\\": true,
           \\"module\\": \\"esnext\\",
           \\"moduleResolution\\": \\"node\\",
           \\"resolveJsonModule\\": true,
           \\"isolatedModules\\": true,
-          \\"jsx\\": \\"preserve\\"
+          \\"jsx\\": \\"preserve\\",
+          \\"noEmit\\": true,
         },
         \\"include\\": [
           \\"next-env.d.ts\\",
@@ -80,13 +80,13 @@ describe('tsconfig.json verifier', () => {
           \\"skipLibCheck\\": true,
           \\"strict\\": false,
           \\"forceConsistentCasingInFileNames\\": true,
-          \\"noEmit\\": true,
           \\"esModuleInterop\\": true,
           \\"module\\": \\"esnext\\",
           \\"moduleResolution\\": \\"node\\",
           \\"resolveJsonModule\\": true,
           \\"isolatedModules\\": true,
-          \\"jsx\\": \\"preserve\\"
+          \\"jsx\\": \\"preserve\\",
+          \\"noEmit\\": true
         },
         \\"include\\": [
           \\"next-env.d.ts\\",
@@ -147,11 +147,11 @@ describe('tsconfig.json verifier', () => {
           \\"skipLibCheck\\": true,
           \\"strict\\": false,
           \\"forceConsistentCasingInFileNames\\": true,
-          \\"noEmit\\": true,
           \\"moduleResolution\\": \\"node\\",
           \\"resolveJsonModule\\": true,
           \\"isolatedModules\\": true,
-          \\"jsx\\": \\"preserve\\"
+          \\"jsx\\": \\"preserve\\",
+          \\"noEmit\\": true
         }
         // in-object comment 2
         ,
@@ -195,11 +195,11 @@ describe('tsconfig.json verifier', () => {
           \\"skipLibCheck\\": true,
           \\"strict\\": false,
           \\"forceConsistentCasingInFileNames\\": true,
-          \\"noEmit\\": true,
           \\"moduleResolution\\": \\"node\\",
           \\"resolveJsonModule\\": true,
           \\"isolatedModules\\": true,
-          \\"jsx\\": \\"preserve\\"
+          \\"jsx\\": \\"preserve\\",
+          \\"noEmit\\": true
         },
         \\"include\\": [
           \\"next-env.d.ts\\",
@@ -240,11 +240,54 @@ describe('tsconfig.json verifier', () => {
           \\"skipLibCheck\\": true,
           \\"strict\\": false,
           \\"forceConsistentCasingInFileNames\\": true,
-          \\"noEmit\\": true,
           \\"moduleResolution\\": \\"node\\",
           \\"resolveJsonModule\\": true,
           \\"isolatedModules\\": true,
-          \\"jsx\\": \\"preserve\\"
+          \\"jsx\\": \\"preserve\\",
+          \\"noEmit\\": true
+        },
+        \\"include\\": [
+          \\"next-env.d.ts\\",
+          \\"**/*.ts\\",
+          \\"**/*.tsx\\"
+        ],
+        \\"exclude\\": [
+          \\"node_modules\\"
+        ]
+      }
+      "
+    `)
+  })
+
+  it('allows you to build for project references', async () => {
+    expect(await exists(tsConfig)).toBe(false)
+
+    await writeFile(tsConfig, `{ "compilerOptions": { "composite": true } }`)
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    const { code } = await nextBuild(appDir)
+    expect(code).toBe(0)
+
+    expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
+      "{
+        \\"compilerOptions\\": {
+          \\"composite\\": \\"true\\",
+          \\"target\\": \\"es5\\",
+          \\"lib\\": [
+            \\"dom\\",
+            \\"dom.iterable\\",
+            \\"esnext\\"
+          ],
+          \\"allowJs\\": true,
+          \\"skipLibCheck\\": true,
+          \\"strict\\": false,
+          \\"forceConsistentCasingInFileNames\\": true,
+          \\"esModuleInterop\\": true,
+          \\"module\\": \\"esnext\\",
+          \\"moduleResolution\\": \\"node\\",
+          \\"resolveJsonModule\\": true,
+          \\"isolatedModules\\": true,
+          \\"jsx\\": \\"preserve\\",
+          \\"emitDeclarationOnly\\": true,
         },
         \\"include\\": [
           \\"next-env.d.ts\\",


### PR DESCRIPTION
## What is this solving ?

Fixes https://github.com/vercel/next.js/issues/16364

Currently, when using the typescript [composite](https://www.typescriptlang.org/docs/handbook/compiler-options.html#compiler-options:~:text=composite,-boolean) option in a root `tsconfig.json` file, Next will rewrite the configuration file to add `noEmit: true`. This results in an error when running `tsc` which occurs when both `composite` and `noEmit` are present in a `tsconfig.json`. Here's a thread on the TS error in question https://github.com/microsoft/TypeScript/issues/36917.

## How are you solving it ?

Change `noEmit` for `emitDeclarationOnly` when we detect the `composite` option, making typescript emit only `.d.ts` files. This solution was proposed in both https://github.com/microsoft/TypeScript/issues/36917 and https://github.com/microsoft/TypeScript/issues/33809.

## Notes

* I've successfully tested the changes locally in a typescript project which uses `composite` to build for project reference.
* The newly emitted `.d.ts` files might be problematic for projects that don't include an `outDir` (like most of the examples), since `.d.ts` files will be created next to each `.ts` or `.tsx` file. I personally redirect the output to a `/build/ts` directory and we could suggest something similar if the option is unset.