### PR TITLE
Allow passing bundle-analyzer options

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,4 +1,4 @@
-module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
+module.exports = ({ enabled = true, ...config } = {}, serverConfig = {}, clientConfig = {}) => (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (enabled) {
@@ -9,6 +9,8 @@ module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
             reportFilename: options.isServer
               ? '../analyze/server.html'
               : './analyze/client.html',
+            ...config,
+            ...(options.isServer ? serverConfig : clientConfig),
           })
         )
       }

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -42,6 +42,19 @@ ANALYZE=true yarn build
 
 When enabled two HTML files (client.html and server.html) will be outputted to `<distDir>/analyze/`. One will be for the server bundle, one for the browser bundle.
 
+You can also customize `webpack-bundle-analyzer` configuration:
+
+```js
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+  openAnalyzer: false, // both server and client
+}, {
+  generateStatsFile: true, // server only
+}, {
+  defaultSizes: 'gzip', // client only
+})
+```
+
 ### Usage with next-compose-plugins
 
 From version 2.0.0 of next-compose-plugins you need to call bundle-analyzer in this way to work


### PR DESCRIPTION
Allow for customization of `webpack-bundle-analyzer`:

```js
const withBundleAnalyzer = require('@next/bundle-analyzer')({
  enabled: process.env.ANALYZE === 'true',
  openAnalyzer: false, // both server and client
}, {
  generateStatsFile: true, // server only
}, {
  defaultSizes: 'gzip', // client only
})
```