### PR TITLE
Unify installation scripts for example apps

### DIFF
--- a/examples/amp-story/README.md
+++ b/examples/amp-story/README.md
@@ -13,9 +13,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example amp-story amp-app
+npx create-next-app --example amp-story amp-story-app
 # or
-yarn create next-app --example amp-story amp-app
+yarn create next-app --example amp-story amp-story-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/auth0/README.md
+++ b/examples/auth0/README.md
@@ -16,9 +16,9 @@ Read more: [https://auth0.com/blog/ultimate-guide-nextjs-authentication-auth0/](
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example auth0 auth0
+npx create-next-app --example auth0 auth0-app
 # or
-yarn create next-app --example auth0 auth0
+yarn create next-app --example auth0 auth0-app
 ```
 
 ## Configuring Auth0

--- a/examples/fast-refresh-demo/README.md
+++ b/examples/fast-refresh-demo/README.md
@@ -15,9 +15,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example fast-refresh-demo fast-refresh-demo
+npx create-next-app --example fast-refresh-demo fast-refresh-demo-app
 # or
-yarn create next-app --example fast-refresh-demo fast-refresh-demo
+yarn create next-app --example fast-refresh-demo fast-refresh-demo-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-draft-js/README.md
+++ b/examples/with-draft-js/README.md
@@ -15,7 +15,7 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-draft-js
+npx create-next-app --example with-draft-js with-draft-js-app
 # or
 yarn create next-app --example with-draft-js with-draft-js-app
 ```

--- a/examples/with-env-from-next-config-js/README.md
+++ b/examples/with-env-from-next-config-js/README.md
@@ -23,9 +23,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-env-from-next-config-js
+npx create-next-app --example with-env-from-next-config-js with-env-from-next-config-js-app
 # or
-yarn create next-app --example with-env-from-next-config-js
+yarn create next-app --example with-env-from-next-config-js with-env-from-next-config-js-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-framer-motion/README.md
+++ b/examples/with-framer-motion/README.md
@@ -15,9 +15,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-framer-motion with-framer-motion
+npx create-next-app --example with-framer-motion with-framer-motion-app
 # or
-yarn create next-app --example with-framer-motion with-framer-motion
+yarn create next-app --example with-framer-motion with-framer-motion-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-graphql-faunadb/README.md
+++ b/examples/with-graphql-faunadb/README.md
@@ -37,9 +37,9 @@ At the end, a `.env.local` [file](https://nextjs.org/docs/basic-features/environ
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```
-npx create-next-app --example with-graphql-faunadb with-graphql-faunadb
+npx create-next-app --example with-graphql-faunadb with-graphql-faunadb-app
 # or
-yarn create next-app --example with-graphql-faunadb with-graphql-faunadb
+yarn create next-app --example with-graphql-faunadb with-graphql-faunadb-app
 ```
 
 ### Run locally

--- a/examples/with-i18n-rosetta/README.md
+++ b/examples/with-i18n-rosetta/README.md
@@ -15,9 +15,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-i18n-rosetta with-i18n-rosetta
+npx create-next-app --example with-i18n-rosetta with-i18n-rosetta-app
 # or
-yarn create next-app --example with-i18n-rosetta with-i18n-rosetta
+yarn create next-app --example with-i18n-rosetta with-i18n-rosetta-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-jest/README.md
+++ b/examples/with-jest/README.md
@@ -11,7 +11,9 @@ Quickly get started using [Create Next App](https://github.com/vercel/next.js/tr
 In your terminal, run the following command:
 
 ```bash
-npx create-next-app --example with-jest
+npx create-next-app --example with-jest with-jest-app
+# or
+yarn create next-app --example with-jest with-jest-app
 ```
 
 ## Run Jest Tests

--- a/examples/with-knex/README.md
+++ b/examples/with-knex/README.md
@@ -13,9 +13,9 @@ Once you have access to the environment variables you'll need, deploy the exampl
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-knex with-knex
+npx create-next-app --example with-knex with-knex-app
 # or
-yarn create next-app --example with-knex with-knex
+yarn create next-app --example with-knex with-knex-app
 ```
 
 ## Configuration

--- a/examples/with-mongodb/README.md
+++ b/examples/with-mongodb/README.md
@@ -18,9 +18,9 @@ Once you have access to the environment variables you'll need, deploy the exampl
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-mongodb with-mongodb
+npx create-next-app --example with-mongodb with-mongodb-app
 # or
-yarn create next-app --example with-mongodb with-mongodb
+yarn create next-app --example with-mongodb with-mongodb-app
 ```
 
 ## Configuration

--- a/examples/with-next-page-transitions/README.md
+++ b/examples/with-next-page-transitions/README.md
@@ -15,9 +15,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-next-page-transitions with-next-page-transitions
+npx create-next-app --example with-next-page-transitions with-next-page-transitions-app
 # or
-yarn create next-app --example with-next-page-transitions with-next-page-transitions
+yarn create next-app --example with-next-page-transitions with-next-page-transitions-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-portals-ssr/README.md
+++ b/examples/with-portals-ssr/README.md
@@ -13,9 +13,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-portals-ssr with-portals-ssr
+npx create-next-app --example with-portals-ssr with-portals-ssr-app
 # or
-yarn create next-app --example with-portals-ssr with-portals-ssr
+yarn create next-app --example with-portals-ssr with-portals-ssr-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-native-web/README.md
+++ b/examples/with-react-native-web/README.md
@@ -17,7 +17,7 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-react-native-web
+npx create-next-app --example with-react-native-web with-react-native-web-app
 # or
 yarn create next-app --example with-react-native-web with-react-native-web-app
 ```

--- a/examples/with-reason-relay/README.md
+++ b/examples/with-reason-relay/README.md
@@ -15,9 +15,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-reason-relay with-reason-relay
+npx create-next-app --example with-reason-relay with-reason-relay-app
 # or
-yarn create next-app --example with-reason-relay with-reason-relay
+yarn create next-app --example with-reason-relay with-reason-relay-app
 ```
 
 Download schema introspection data from configured Relay endpoint:

--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -18,9 +18,9 @@ Once you have access to your [Sentry DSN](#step-1-enable-error-tracking), deploy
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-sentry with-sentry
+npx create-next-app --example with-sentry with-sentry-app
 # or
-yarn create next-app --example with-sentry with-sentry
+yarn create next-app --example with-sentry with-sentry-app
 ```
 
 ## Configuration

--- a/examples/with-stitches/README.md
+++ b/examples/with-stitches/README.md
@@ -13,9 +13,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [Create Next App](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-stitches
+npx create-next-app --example with-stitches with-stitches-app
 # or
-yarn create next-app --example with-stitches
+yarn create next-app --example with-stitches with-stitches-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-typescript-styled-components/README.md
+++ b/examples/with-typescript-styled-components/README.md
@@ -13,9 +13,9 @@ Deploy the example using [Vercel](https://vercel.com):
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
 
 ```bash
-npx create-next-app --example with-typescript-styled-components with-typescript-styled-components
+npx create-next-app --example with-typescript-styled-components with-typescript-styled-components-app
 # or
-yarn create next-app --example with-typescript-styled-components with-typescript-styled-components
+yarn create next-app --example with-typescript-styled-components with-typescript-styled-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).


### PR DESCRIPTION
Hi 👋🏻,

This might be a minor one. I noticed that the directory name in installation scripts of a few example apps are either missing or not suffixed with `"-app"`. So I did a global check to make sure all scripts have the following format:

```bash
npx create-next-app --example EXAMPLE_NAME EXAMPLE_NAME-app
# or
yarn create next-app --example EXAMPLE_NAME EXAMPLE_NAME-app
```
