### PR TITLE
fix: webpack 5 invalid config error

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -368,9 +368,12 @@ export default async function getBaseWebpackConfig(
       // Which makes bundles slightly smaller, but also skips parsing a module that we know will result in this alias
       'next/head': 'next/dist/next-server/lib/head.js',
       'next/router': 'next/dist/client/router.js',
-      'next/experimental-script': config.experimental.scriptLoader
-        ? 'next/dist/client/experimental-script.js'
-        : '',
+      ...(config.experimental.scriptLoader
+        ? {
+            'next/experimental-script':
+              'next/dist/client/experimental-script.js',
+          }
+        : undefined),
       'next/config': 'next/dist/next-server/lib/runtime-config.js',
       'next/dynamic': 'next/dist/next-server/lib/dynamic.js',
       next: NEXT_PROJECT_ROOT,


### PR DESCRIPTION
when using latest webpack 5.9.0 build throws with `invalid configuration object` due to `next/experimental-script` being empty string

![Screenshot 2020-12-04 at 11 51 35](https://user-images.githubusercontent.com/927591/101157231-0c6e1780-362a-11eb-8af8-b09e7e8003fd.png)
