### PR TITLE
Add "title" as the source for "slug" in cms-sanity example

### DIFF
--- a/examples/cms-sanity/schemas/schema.js
+++ b/examples/cms-sanity/schemas/schema.js
@@ -71,6 +71,9 @@ export default createSchema({
           name: 'slug',
           title: 'Slug',
           type: 'slug',
+          options: {
+            source: "title"
+          }
         },
       ],
     },

--- a/examples/cms-sanity/schemas/schema.js
+++ b/examples/cms-sanity/schemas/schema.js
@@ -72,8 +72,8 @@ export default createSchema({
           title: 'Slug',
           type: 'slug',
           options: {
-            source: "title"
-          }
+            source: 'title',
+          },
         },
       ],
     },


### PR DESCRIPTION
The cms "sanity" has a feature for slugs to be generated from another field.

This change adds the title as source to slug, so in the editor you will have a button like this to generate.

![Screenshot_2](https://user-images.githubusercontent.com/5216601/101246558-2e989000-3725-11eb-8ea0-560b1d1fbe6b.png)
