### PR TITLE
Fix failing Azure tests

### DIFF
--- a/packages/next/next-server/lib/post-process.ts
+++ b/packages/next/next-server/lib/post-process.ts
@@ -1,7 +1,8 @@
 import { parse, HTMLElement } from 'node-html-parser'
 import { OPTIMIZED_FONT_PROVIDERS } from './constants'
 
-const MIDDLEWARE_TIME_BUDGET = 10
+const MIDDLEWARE_TIME_BUDGET =
+  parseInt(process.env.__POST_PROCESS_MIDDLEWARE_TIME_BUDGET || '', 10) || 10
 const MAXIMUM_IMAGE_PRELOADS = 2
 const IMAGE_PRELOAD_SIZE_THRESHOLD = 2500
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -195,6 +195,7 @@ const configuredTestTypes = [UNIT_TEST_EXT]
             ...(isAzure
               ? {
                   HEADLESS: 'true',
+                  __POST_PROCESS_MIDDLEWARE_TIME_BUDGET: '50',
                 }
               : {}),
             ...(usePolling


### PR DESCRIPTION
Noticed Azure tests have started failing after https://github.com/vercel/next.js/pull/19758 due to the middleware taking longer than the allotted threshold which adds unexpected logs to stderr. This attempts to resolve these test failures by increasing the allotted time for the middleware when running on Azure. 

x-ref: https://dev.azure.com/nextjs/next.js/_build/results?buildId=22617&view=logs&jobId=5ee44de4-e310-59d9-0ba5-4a271a649fb0&j=5ee44de4-e310-59d9-0ba5-4a271a649fb0&t=af3fb693-3771-5a1a-ec97-2ba4cc77f25c
x-ref: https://dev.azure.com/nextjs/next.js/_build/results?buildId=22619&view=logs&jobId=5ee44de4-e310-59d9-0ba5-4a271a649fb0&j=5ee44de4-e310-59d9-0ba5-4a271a649fb0&t=af3fb693-3771-5a1a-ec97-2ba4cc77f25c 