### PR TITLE
Use exports.__esModule = true in package sub-path exports so Rollup recognizes ESM

### DIFF
--- a/packages/next/amp.js
+++ b/packages/next/amp.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/next-server/lib/amp')
+exports.__esModule = true;

--- a/packages/next/amp.js
+++ b/packages/next/amp.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/next-server/lib/amp')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/app.js
+++ b/packages/next/app.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/pages/_app')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/app.js
+++ b/packages/next/app.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/pages/_app')
+exports.__esModule = true;

--- a/packages/next/babel.js
+++ b/packages/next/babel.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/build/babel/preset')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/babel.js
+++ b/packages/next/babel.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/build/babel/preset')
+exports.__esModule = true;

--- a/packages/next/client.js
+++ b/packages/next/client.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/client/index')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/client.js
+++ b/packages/next/client.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/client/index')
+exports.__esModule = true;

--- a/packages/next/config.js
+++ b/packages/next/config.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/next-server/lib/runtime-config')
+exports.__esModule = true;

--- a/packages/next/config.js
+++ b/packages/next/config.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/next-server/lib/runtime-config')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/constants.js
+++ b/packages/next/constants.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/next-server/lib/constants')
+exports.__esModule = true;

--- a/packages/next/constants.js
+++ b/packages/next/constants.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/next-server/lib/constants')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/data.js
+++ b/packages/next/data.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/lib/data')
+exports.__esModule = true;

--- a/packages/next/data.js
+++ b/packages/next/data.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/lib/data')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/document.js
+++ b/packages/next/document.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/pages/_document')
-exports.__esModule = true;
+exports.__esModule = true

--- a/packages/next/document.js
+++ b/packages/next/document.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/pages/_document')
+exports.__esModule = true;

--- a/packages/next/dynamic.js
+++ b/packages/next/dynamic.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/next-server/lib/dynamic')
+exports.__esModule = true

--- a/packages/next/error.js
+++ b/packages/next/error.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/pages/_error')
+exports.__esModule = true


### PR DESCRIPTION
This PR is more like an issue ticket that happens to provide one possible solution, just because it was trivial to do.

## The Problem

tl;dr if already familiar with `__esModule` is that Next.js's intermediate CJS files prevent Rollup from recognizing default exports correctly.

---

If you use Rollup and try and import the default export from one of the `next/*` files e.g. `import Link from "next/link"` it will incorrectly resolve to the full `exports` object itself that contains the `exports.default` on it.

The cause is, as these things are, a bit involved, but the gist is that [`@rollup/commonjs`](https://github.com/rollup/plugins/tree/master/packages/commonjs) is used to take packages and files that have CommonJS exports and automatically attempt to convert them to the equivalent ES Module export. ESM's behavior of a "default export" is syntactic sugar for a named property called `default`,  but the CommonJS conventions don't use that pattern, but rather just exporting the value itself as the entire export `modules.exports = value`.

It's easy enough to just say the interop is that `module.export` in CJS files should be treated as if it were the `export default` of an ESM. Trouble is, there are desirable reasons for ESM compilers to emit CJS that does not use `module.exports = value` but instead uses `exports.default = value` e.g. if the default export is a function, it would have to assign the other named exports to it, which is a non-starter.

To solve the inconsistency a convention the community has settled on is that if a CommonJS file has an `exports.__esModule = true` that it was originally written using ESM but was compiled down to `exports.default` property, so tooling knows to treat it as such.

Next.js internally uses TypeScript for most things, however has [hand written CJS files](https://github.com/vercel/next.js/blob/b403e9ec15668c98a802c42bd17cb3f3678535cd/packages/next/link.js#L1) that act as the actual entry points when imported from the published package. e.g. just simply `module.exports = require('./dist/client/link')`. This is a problem with Rollup (and presumably tooling like it) because while [the TypeScript compiled output has `exports.__esModule`](https://unpkg.com/next@10.0.3/dist/client/link.js), Rollup doesn't treat it as such because of this intermediate CJS file.

## The Use Case

Admittedly, this is a weird one for Next.js because "importing next.js packages from Rollup" is probably not something you thought anyone would try to do. 😅 

We at @outsmartly [have a product](https://outsmartly.org/features) that _other developers_ use with their regular Next.js apps. Long story short, it does static analysis and program slicing do to fast, selective re-rendering of only a portion of your code, at the Edge. One part of that magic leans on Rollup to bundle some of the developer's code from their normal Next.js app. Code that uses things like `import Link from 'next/link'` and you can probably see where this is going 😆 that these intermediate files break that.

It took me quite a bit of digging to realize the issue, as seen in my demo of the problem here: https://github.com/jayphelps/rollup-cjs-issue

## The Solution(s)

1. The most obvious solution is to just add `exports.__esModule = true;` to each of these files and call it a day. The pros is that it's simple, requires very little changes (just the ones included in this PR) and is unlikely to break anyone, unless they happen to be also running into this issue and just working around it using `import link from 'next/link'; const { default: Link = link;` which is unlikely (but I bring it up for transparency.) Even if they were, they would probably be thrilled this was fixed.

2. Alternatively, one could change these offending CJS files to be TS files too, thus acquiring the `exports.__esModule` automatically. This was [tried two years ago](https://github.com/timneutkens/next.js/commit/15bb1c5e7963361c9c592923ef28cd819092e49a#diff-299477910394fec52f35b42306ed660762c2967d5b8ef775a6d5876c53fc2747L1) but then was quickly reverted #5815 due to backwards compatibility issues. It is unclear whether these issues have since been resolved.

3. Do nothing. Which is obviously bad for me and @outsmartly, but I can imagine that supporting Rollup is quite low on the list, if it even is at all so I at least want to acknowledge that I realize this is an unusual request.

:shipit: