### PR TITLE
Correct production docker base image tag

### DIFF
--- a/examples/with-docker/Dockerfile.multistage
+++ b/examples/with-docker/Dockerfile.multistage
@@ -14,7 +14,7 @@ RUN yarn install --production --frozen-lockfile
 
 
 # Stage 2: And then copy over node_modules, etc from that stage to the smaller base image
-FROM mhart/alpine-node:base as production
+FROM mhart/alpine-node:slim as production
 
 WORKDIR /app
 


### PR DESCRIPTION
As seen in https://github.com/mhart/alpine-node, the `base` image tag has been renamed to `slim`.