### PR TITLE
Fix double-quoted hotlinks in dev error panel

### DIFF
--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -58,7 +58,7 @@ const HotlinkedText: React.FC<{
 }> = function HotlinkedText(props) {
   const { text } = props
 
-  const linkRegex = /https?:\/\/[^\s/$.?#].[^\s]*/i
+  const linkRegex = /https?:\/\/[^\s/$.?#].[^\s"]*/i
   return (
     <>
       {linkRegex.test(text)


### PR DESCRIPTION
Fixes #19923.

Before:
<img width="564" alt="Screen Shot 2020-12-08 at 3 07 11 PM" src="https://user-images.githubusercontent.com/5074763/101535738-1adc6c00-3967-11eb-8c80-c7f2e75f8de5.png">

After:
<img width="574" alt="Screen Shot 2020-12-08 at 3 07 18 PM" src="https://user-images.githubusercontent.com/5074763/101535742-1b750280-3967-11eb-828b-1ecac08c6511.png">

