### PR TITLE
Update the minimum version of React to use Fast Refresh

### DIFF
--- a/errors/react-version.md
+++ b/errors/react-version.md
@@ -5,7 +5,7 @@
 Your project is using an old version of `react` or `react-dom` that does not
 meet the suggested minimum version requirement.
 
-Next.js suggests using, at a minimum, `react@16.10.0` and `react-dom@16.10.0`.
+Next.js suggests using, at a minimum, `react@16.9.0` and `react-dom@16.9.0`.
 Older versions of `react` and `react-dom` do work with Next.js, however, they do
 not enable all of Next.js' features.
 
@@ -39,8 +39,8 @@ yarn add react@latest react-dom@latest
 ```json
 {
   "dependencies": {
-    "react": "^16.10.0",
-    "react-dom": "^16.10.0"
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   }
 }
 ```

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -68,11 +68,11 @@ const nextDev: cliCommand = (argv) => {
     })
     if (
       reactVersion &&
-      semver.lt(reactVersion, '16.10.0') &&
+      semver.lt(reactVersion, '16.9.0') &&
       semver.coerce(reactVersion)?.version !== '0.0.0'
     ) {
       Log.warn(
-        'Fast Refresh is disabled in your application due to an outdated `react` version. Please upgrade 16.10 or newer!' +
+        'Fast Refresh is disabled in your application due to an outdated `react` version. Please upgrade 16.9 or newer!' +
           ' Read more: https://err.sh/next.js/react-version'
       )
     } else {
@@ -82,11 +82,11 @@ const nextDev: cliCommand = (argv) => {
       })
       if (
         reactDomVersion &&
-        semver.lt(reactDomVersion, '16.10.0') &&
+        semver.lt(reactDomVersion, '16.9.0') &&
         semver.coerce(reactDomVersion)?.version !== '0.0.0'
       ) {
         Log.warn(
-          'Fast Refresh is disabled in your application due to an outdated `react-dom` version. Please upgrade 16.10 or newer!' +
+          'Fast Refresh is disabled in your application due to an outdated `react-dom` version. Please upgrade 16.9 or newer!' +
             ' Read more: https://err.sh/next.js/react-version'
         )
       }

--- a/test/integration/cli/old-react-dom/node_modules/react-dom/package.json
+++ b/test/integration/cli/old-react-dom/node_modules/react-dom/package.json
@@ -1,4 +1,4 @@
 {
   "name": "react-dom",
-  "version": "16.9.0"
+  "version": "16.8.0"
 }

--- a/test/integration/cli/old-react/node_modules/react/package.json
+++ b/test/integration/cli/old-react/node_modules/react/package.json
@@ -1,4 +1,4 @@
 {
   "name": "react",
-  "version": "16.9.0"
+  "version": "16.8.0"
 }


### PR DESCRIPTION
The minimum version of React to use Fast Refresh is `16.9`
So update it.

## Reference
https://github.com/facebook/react/issues/16604#issuecomment-528663101