### PR TITLE
Default development hostname to 127.0.0.1

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -111,7 +111,7 @@ const nextDev: cliCommand = (argv) => {
   startServer(
     { dir, dev: true, isNextDevCommand: true },
     port,
-    args['--hostname']
+    args['--hostname'] || '127.0.0.1'
   )
     .then(async (app) => {
       startedDevelopmentServer(appUrl)


### PR DESCRIPTION
# Overview
This makes the default host for the development environment `127.0.0.1:3000` instead of `*:3000`, which better matches the output `started server on http://localhost:3000`. 

It fixes #20137, as suggested by @rsms [on twitter](https://twitter.com/rsms/status/1337845477283221504).  