### PR TITLE
Cancel idle callback on unmount

### DIFF
--- a/packages/next/client/experimental-script.tsx
+++ b/packages/next/client/experimental-script.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useContext } from 'react'
 import { ScriptHTMLAttributes } from 'react'
 import { HeadManagerContext } from '../next-server/lib/head-manager-context'
 import { DOMAttributeNames } from './head-manager'
-import requestIdleCallback from './request-idle-callback'
+import { requestIdleCallback } from './request-idle-callback'
 
 const ScriptCache = new Map()
 const LoadCache = new Set()

--- a/packages/next/client/request-idle-callback.ts
+++ b/packages/next/client/request-idle-callback.ts
@@ -13,10 +13,11 @@ declare global {
       callback: (deadline: RequestIdleCallbackDeadline) => void,
       opts?: RequestIdleCallbackOptions
     ) => RequestIdleCallbackHandle
+    cancelIdleCallback: (id: RequestIdleCallbackHandle) => void
   }
 }
 
-const requestIdleCallback =
+export const requestIdleCallback =
   (typeof self !== 'undefined' && self.requestIdleCallback) ||
   function (cb: (deadline: RequestIdleCallbackDeadline) => void) {
     let start = Date.now()
@@ -30,4 +31,8 @@ const requestIdleCallback =
     }, 1)
   }
 
-export default requestIdleCallback
+export const cancelIdleCallback =
+  (typeof self !== 'undefined' && self.cancelIdleCallback) ||
+  function (id: RequestIdleCallbackHandle) {
+    return clearTimeout(id)
+  }

--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react'
 import { ClientBuildManifest } from '../build/webpack/plugins/build-manifest-plugin'
 import getAssetPathFromRoute from '../next-server/lib/router/utils/get-asset-path-from-route'
-import requestIdleCallback from './request-idle-callback'
+import { requestIdleCallback } from './request-idle-callback'
 
 // 3.8s was arbitrarily chosen as it's what https://web.dev/interactive
 // considers as "Good" time-to-interactive. We must assume something went

--- a/packages/next/client/use-intersection.tsx
+++ b/packages/next/client/use-intersection.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import requestIdleCallback from './request-idle-callback'
+import {
+  requestIdleCallback,
+  cancelIdleCallback,
+} from './request-idle-callback'
 
 type UseIntersectionObserverInit = Pick<IntersectionObserverInit, 'rootMargin'>
 type UseIntersection = { disabled?: boolean } & UseIntersectionObserverInit
@@ -38,7 +41,10 @@ export function useIntersection<T extends Element>({
 
   useEffect(() => {
     if (!hasIntersectionObserver) {
-      if (!visible) requestIdleCallback(() => setVisible(true))
+      if (!visible) {
+        const idleCallback = requestIdleCallback(() => setVisible(true))
+        return () => cancelIdleCallback(idleCallback)
+      }
     }
   }, [visible])
 

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -104,7 +104,7 @@ describe('Build Output', () => {
       expect(parseFloat(err404FirstLoad)).toBeCloseTo(65.3, 1)
       expect(err404FirstLoad.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(sharedByAll) - 61.8).toBeLessThanOrEqual(0)
+      expect(parseFloat(sharedByAll) - 62).toBeLessThanOrEqual(0)
       expect(sharedByAll.endsWith('kB')).toBe(true)
 
       if (_appSize.endsWith('kB')) {


### PR DESCRIPTION
React complains if you attempt to make changes either outside of `act`
or after the component has unmounted. In tests with this setup, the
idle callback is scheduled and run later, but the component has already
been unmounted. This ensures unmounted components don't run their
idle callback.

Fixes #20048.