### PR TITLE
Add image component support for ImageEngine Image CDN

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -1,5 +1,5 @@
 ---
-description: Next.js supports built-in image optimization, as well as third party loaders for Imgix, Cloudinary, and more! Learn more here.
+description: Next.js supports built-in image optimization, as well as third party loaders for Imgix, Cloudinary, ImageEngine, and more! Learn more here.
 ---
 
 # Image Component and Image Optimization
@@ -87,6 +87,7 @@ The following Image Optimization cloud providers are supported:
 - [Vercel](https://vercel.com): Works automatically when you deploy on Vercel, no configuration necessary. [Learn more](https://vercel.com/docs/next.js/image-optimization)
 - [Imgix](https://www.imgix.com): `loader: 'imgix'`
 - [Cloudinary](https://cloudinary.com): `loader: 'cloudinary'`
+- [ImageEngine](https://imageengine.io): `loader: 'imageengine'`
 - [Akamai](https://www.akamai.com): `loader: 'akamai'`
 - Default: Works automatically with `next dev`, `next start`, or a custom server
 

--- a/errors/invalid-images-config.md
+++ b/errors/invalid-images-config.md
@@ -18,7 +18,7 @@ module.exports = {
     // limit of 50 domains values
     domains: [],
     path: '/_next/image',
-    // loader can be 'default', 'imgix', 'cloudinary', or 'akamai'
+    // loader can be 'default', 'imgix', 'cloudinary', 'imageengine', or 'akamai'
     loader: 'default',
   },
 }

--- a/packages/next/next-server/server/image-config.ts
+++ b/packages/next/next-server/server/image-config.ts
@@ -2,6 +2,7 @@ export const VALID_LOADERS = [
   'default',
   'imgix',
   'cloudinary',
+  'imageengine',
   'akamai',
 ] as const
 

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -568,7 +568,7 @@ describe('Image Optimizer', () => {
       await nextConfig.restore()
 
       expect(stderr).toContain(
-        'Specified images.loader should be one of (default, imgix, cloudinary, akamai), received invalid value (notreal)'
+        'Specified images.loader should be one of (default, imgix, cloudinary, imageengine, akamai), received invalid value (notreal)'
       )
     })
   })


### PR DESCRIPTION
This PR adds support for [ImageEngine](https://imageengine.io), a popular image optimization CDN from the folks at ScientiaMobile (full disclosure: I am one of the open-source devs that started this company).

This integration supports width-based resizing and quality adjustments like the built-in optimizer.

(I closed my previous PR because it was blocked on a change request I had already made)