### PR TITLE
Update font-stylesheet-gathering-plugin to be webpack 5 compatible

### DIFF
--- a/packages/next/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
+++ b/packages/next/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
@@ -145,7 +145,7 @@ export class FontStylesheetGatheringPlugin {
             return `${source}
                 // Font manifest declaration
                 ${
-                  mainTemplate.requireFn
+                  isWebpack5 ? '__webpack_require__' : mainTemplate.requireFn
                 }.__NEXT_FONT_MANIFEST__ = ${JSON.stringify(
               this.manifestContent
             )};`


### PR DESCRIPTION
Solves the following warning:

> (node:1484) [DEP_WEBPACK_MAIN_TEMPLATE_REQUIRE_FN] DeprecationWarning: MainTemplate.requireFn is deprecated (use "__webpack_require__")