### PR TITLE
Fix aggressive image visibility value

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -254,7 +254,7 @@ export default function Image({
   let sizerStyle: JSX.IntrinsicElements['div']['style'] | undefined
   let sizerSvg: string | undefined
   let imgStyle: ImgElementStyle | undefined = {
-    visibility: isVisible ? 'visible' : 'hidden',
+    visibility: isVisible ? 'inherit' : 'hidden',
 
     position: 'absolute',
     top: 0,


### PR DESCRIPTION
Fixes images being visible / occupying interactive space in elements with `visibility: hidden`.

Discussed in issue https://github.com/vercel/next.js/issues/20198.