### PR TITLE
Option to omit ISR pages from build output

### DIFF
--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -13,6 +13,7 @@ const nextBuild: cliCommand = (argv) => {
     '--help': Boolean,
     '--profile': Boolean,
     '--debug': Boolean,
+    '--no-isr': Boolean,
     // Aliases
     '-h': '--help',
     '-d': '--debug',
@@ -41,6 +42,7 @@ const nextBuild: cliCommand = (argv) => {
 
       Options
       --profile     Can be used to enable React Production Profiling
+      --no-isr      Don't include ISR pages in the output
     `,
       0
     )
@@ -55,7 +57,7 @@ const nextBuild: cliCommand = (argv) => {
     printAndExit(`> No such directory exists as the project root: ${dir}`)
   }
 
-  build(dir, null, args['--profile'], args['--debug'])
+  build(dir, null, args['--profile'], args['--debug'], args['--no-isr'])
     .then(() => process.exit(0))
     .catch((err) => {
       console.error('')


### PR DESCRIPTION
Background: We have an app that talks to a headless CMS, and heavily uses `getStaticProps` with ISR. We're also trying to fit this app into a Nix / NixOS build, which enforces reproducibility using a sandbox (among other things). So no network is available.

Adjusting the app code itself to deal with this was fairly trivial, but `next build` still produces prerenders. These bad prerenders are then served for `initialRevalidateSeconds` after `next start` when the build is deployed on the server.

Our workaround so far has been to trash `.next/server/pages/**/*.{json,html}`, which works because this app happens to not use `getStaticProps` anywhere *without* ISR, but that approach has already bitten us once.

Instead, this PR adds a `next build --no-isr` option that more specifically omits ISR prerenders from the build.

This PR is super crude, but appears to do what I want. The diff is mostly shuffling stuff around so the `continue` statement can short-circuit where I want it to. But I fully understand if a different approach is needed. 😅