### PR TITLE
Move productionBrowserSourceMaps out of experimental

### DIFF
--- a/docs/advanced-features/source-maps.md
+++ b/docs/advanced-features/source-maps.md
@@ -1,0 +1,23 @@
+---
+description: Save pages under the `src` directory as an alternative to the root `pages` directory.
+---
+
+# Source Maps
+
+Source Maps are enabled by default during development. During production builds they are disabled as generation source maps can significantly increase build times and memory usage while being generated.
+
+Next.js provides a configuration flag you can use to enable browser source map generation during the production build:
+
+```js
+// next.config.js
+module.exports = {
+  productionBrowserSourceMaps: true,
+}
+```
+
+When the `productionBrowserSourceMaps` option is enabled the source maps will be output in the same directory as the JavaScript files, Next.js will automatically serve these files when requested.
+
+## Caveats
+
+- Can increase `next build` time
+- Increases memory usage during `next build`

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -182,6 +182,10 @@
               "path": "/docs/advanced-features/debugging.md"
             },
             {
+              "title": "Source Maps",
+              "path": "/docs/advanced-features/source-maps.md"
+            },
+            {
               "title": "Codemods",
               "path": "/docs/advanced-features/codemods.md"
             },

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -205,7 +205,7 @@ export default async function getBaseWebpackConfig(
   }
 ): Promise<webpack.Configuration> {
   const productionBrowserSourceMaps =
-    config.experimental.productionBrowserSourceMaps && !isServer
+    config.productionBrowserSourceMaps && !isServer
   let plugins: PluginMetaData[] = []
   let babelPresetPlugins: { dir: string; config: any }[] = []
 

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -59,6 +59,7 @@ const defaultConfig: NextConfig = {
   sassOptions: {},
   trailingSlash: false,
   i18n: null,
+  productionBrowserSourceMaps: false,
   experimental: {
     cpus: Math.max(
       1,
@@ -71,7 +72,6 @@ const defaultConfig: NextConfig = {
     reactMode: 'legacy',
     workerThreads: false,
     pageEnv: false,
-    productionBrowserSourceMaps: false,
     optimizeImages: false,
     optimizeCss: false,
     scrollRestoration: false,

--- a/test/integration/production-browser-sourcemaps/next.config.js
+++ b/test/integration/production-browser-sourcemaps/next.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  experimental: {
-    productionBrowserSourceMaps: true,
-  },
+  productionBrowserSourceMaps: true,
 }

--- a/test/integration/production-browser-sourcemaps/test/index.test.js
+++ b/test/integration/production-browser-sourcemaps/test/index.test.js
@@ -43,9 +43,7 @@ describe('Production browser sourcemaps', () => {
         `
         module.exports = {
           target: 'serverless',
-          experimental: {
-            productionBrowserSourceMaps: true
-          }
+          productionBrowserSourceMaps: true
         }
       `
       )


### PR DESCRIPTION
Makes https://www.npmjs.com/package/@zeit/next-source-maps a built-in feature so that it can be deprecated.