### PR TITLE
Fix source map config description

### DIFF
--- a/docs/advanced-features/source-maps.md
+++ b/docs/advanced-features/source-maps.md
@@ -1,5 +1,5 @@
 ---
-description: Save pages under the `src` directory as an alternative to the root `pages` directory.
+description: Enables browser source map generation during the production build.
 ---
 
 # Source Maps


### PR DESCRIPTION
This should fix  source map config description text.