### PR TITLE
Ensure only backslashes are in pages-manifest with i18n

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -974,13 +974,16 @@ export default async function build(
               continue
             }
 
-            const updatedRelativeDest = path.join(
-              'pages',
-              locale + localeExt,
-              // if it's the top-most index page we want it to be locale.EXT
-              // instead of locale/index.html
-              page === '/' ? '' : relativeDestNoPages
-            )
+            const updatedRelativeDest = path
+              .join(
+                'pages',
+                locale + localeExt,
+                // if it's the top-most index page we want it to be locale.EXT
+                // instead of locale/index.html
+                page === '/' ? '' : relativeDestNoPages
+              )
+              .replace(/\\/g, '/')
+
             const updatedOrig = path.join(
               exportOptions.outdir,
               locale + localeExt,

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -27,6 +27,17 @@ async function addDefaultLocaleCookie(browser) {
 }
 
 export function runTests(ctx) {
+  if (!ctx.isDev) {
+    it('should not contain backslashes in pages-manifest', async () => {
+      const pagesManifestContent = await fs.readFile(
+        join(ctx.buildPagesDir, '../pages-manifest.json'),
+        'utf8'
+      )
+      expect(pagesManifestContent).not.toContain('\\')
+      expect(pagesManifestContent).toContain('/')
+    })
+  }
+
   it('should resolve href correctly when dynamic route matches locale prefixed', async () => {
     const browser = await webdriver(ctx.appPort, `${ctx.basePath}/nl`)
     await browser.eval('window.beforeNav = 1')


### PR DESCRIPTION
This ensures the pages-manifest only includes forward slashes and not backslashes when adding i18n page references, this also adds tests ensuring we don't regress on this in the i18n-support test suite. 

Fixes: https://github.com/vercel/next.js/issues/20330