### PR TITLE
polish: remove confusing usage of useAmp

### DIFF
--- a/examples/amp/pages/index.js
+++ b/examples/amp/pages/index.js
@@ -1,5 +1,4 @@
 import Head from 'next/head'
-import { useAmp } from 'next/amp'
 import Layout from '../components/Layout'
 import Byline from '../components/Byline'
 
@@ -33,40 +32,40 @@ export default function IndexPage() {
         ></amp-img>
       </amp-img>
       <p>
-        Cat ipsum dolor <a href="/dog?amp=1">sit amet</a>,
-        eat grass, throw it back up but refuse to leave cardboard box or groom
-        yourself 4 hours - checked, have your beauty sleep 18 hours - checked,
-        be fabulous for the rest of the day - checked!. Hide from vacuum
-        cleaner. Chirp at birds chew foot chase the pig around the house and
-        meoooow!. Chase ball of string climb a tree, wait for a fireman jump to
-        fireman then scratch his face claw drapes, for meow to be let in yet
-        attack dog, run away and pretend to be victim meow loudly just to annoy
-        owners. Touch water with paw then recoil in horror hide when guests come
-        over, and tuxedo cats always looking dapper so has closed eyes but still
-        sees you or a nice warm laptop for me to sit on pee in human's bed until
-        he cleans the litter box. Steal the warm chair right after you get up
-        cat not kitten around yet claws in your leg eat all the power cords.
-        Lick sellotape curl into a furry donut immediately regret falling into
-        bathtub or you call this cat food? and fall asleep on the washing
-        machine. Purr for no reason hack up furballs and pelt around the house
-        and up and down stairs chasing phantoms. If it smells like fish eat as
-        much as you wish. Unwrap toilet paper chew iPad power cord white cat
-        sleeps on a black shirt lick the other cats. Lounge in doorway mew. Has
-        closed eyes but still sees you sleep on keyboard, so hunt anything that
-        moves lick sellotape but slap owner's face at 5am until human fills food
-        dish if it smells like fish eat as much as you wish. Meow to be let in
-        find empty spot in cupboard and sleep all day and thug cat sit by the
-        fire burrow under covers always hungry. Swat at dog hide when guests
-        come over purrrrrr chew on cable so mark territory, yet howl on top of
-        tall thing or find something else more interesting. Chase mice kitten is
-        playing with dead mouse. Sit and stare if it fits, i sits. Mark
-        territory damn that dog , but step on your keyboard while you're gaming
-        and then turn in a circle put butt in owner's face human give me
-        attention meow or eat and than sleep on your face. Friends are not food
-        jump around on couch, meow constantly until given food, or walk on car
-        leaving trail of paw prints on hood and windshield, and spread kitty
-        litter all over house, going to catch the red dot today going to catch
-        the red dot today. Jump off balcony, onto stranger's head.
+        Cat ipsum dolor <a href="/dog?amp=1">sit amet</a>, eat grass, throw it
+        back up but refuse to leave cardboard box or groom yourself 4 hours -
+        checked, have your beauty sleep 18 hours - checked, be fabulous for the
+        rest of the day - checked!. Hide from vacuum cleaner. Chirp at birds
+        chew foot chase the pig around the house and meoooow!. Chase ball of
+        string climb a tree, wait for a fireman jump to fireman then scratch his
+        face claw drapes, for meow to be let in yet attack dog, run away and
+        pretend to be victim meow loudly just to annoy owners. Touch water with
+        paw then recoil in horror hide when guests come over, and tuxedo cats
+        always looking dapper so has closed eyes but still sees you or a nice
+        warm laptop for me to sit on pee in human's bed until he cleans the
+        litter box. Steal the warm chair right after you get up cat not kitten
+        around yet claws in your leg eat all the power cords. Lick sellotape
+        curl into a furry donut immediately regret falling into bathtub or you
+        call this cat food? and fall asleep on the washing machine. Purr for no
+        reason hack up furballs and pelt around the house and up and down stairs
+        chasing phantoms. If it smells like fish eat as much as you wish. Unwrap
+        toilet paper chew iPad power cord white cat sleeps on a black shirt lick
+        the other cats. Lounge in doorway mew. Has closed eyes but still sees
+        you sleep on keyboard, so hunt anything that moves lick sellotape but
+        slap owner's face at 5am until human fills food dish if it smells like
+        fish eat as much as you wish. Meow to be let in find empty spot in
+        cupboard and sleep all day and thug cat sit by the fire burrow under
+        covers always hungry. Swat at dog hide when guests come over purrrrrr
+        chew on cable so mark territory, yet howl on top of tall thing or find
+        something else more interesting. Chase mice kitten is playing with dead
+        mouse. Sit and stare if it fits, i sits. Mark territory damn that dog ,
+        but step on your keyboard while you're gaming and then turn in a circle
+        put butt in owner's face human give me attention meow or eat and than
+        sleep on your face. Friends are not food jump around on couch, meow
+        constantly until given food, or walk on car leaving trail of paw prints
+        on hood and windshield, and spread kitty litter all over house, going to
+        catch the red dot today going to catch the red dot today. Jump off
+        balcony, onto stranger's head.
       </p>
       <p>
         Meow to be let out damn that dog howl uncontrollably for no reason

--- a/examples/amp/pages/index.js
+++ b/examples/amp/pages/index.js
@@ -8,8 +8,6 @@ export const config = {
 }
 
 export default function IndexPage() {
-  const isAmp = useAmp()
-
   return (
     <Layout>
       <Head>
@@ -35,7 +33,7 @@ export default function IndexPage() {
         ></amp-img>
       </amp-img>
       <p>
-        Cat ipsum dolor <a href={isAmp ? '/dog?amp=1' : '/dog'}>sit amet</a>,
+        Cat ipsum dolor <a href="/dog?amp=1">sit amet</a>,
         eat grass, throw it back up but refuse to leave cardboard box or groom
         yourself 4 hours - checked, have your beauty sleep 18 hours - checked,
         be fabulous for the rest of the day - checked!. Hide from vacuum


### PR DESCRIPTION
While looking at the `next/amp` package, I went through the examples and found this usage of `useAmp` to be somewhat at odds with the [docs](https://nextjs.org/docs/api-reference/next/amp#amp-first-page) on `amp: true`.

When running locally I see that `isAmp` is true regardless of if `?amp=1` is appended to the URL, so using this hook and the ternary below seems misleading.

<img width="507" alt="스크린샷 2020-12-22 오후 4 28 45" src="https://user-images.githubusercontent.com/15968012/102889059-63218100-4473-11eb-8a12-be13da3e1b57.png">
<img width="496" alt="스크린샷 2020-12-22 오후 4 28 32" src="https://user-images.githubusercontent.com/15968012/102889070-661c7180-4473-11eb-8395-bb035a72b74a.png">


Apologies if I have misunderstood something about how this should work!