### PR TITLE
Upgrade all http links to https

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ The easiest way to deploy Next.js to production is to use the **[Vercel platform
 
 ### Getting started
 
-If you haven’t already done so, push your Next.js app to a Git provider of your choice: [GitHub](http://github.com/), [GitLab](https://gitlab.com/), or [BitBucket](https://bitbucket.org/). Your repository can be private or public.
+If you haven’t already done so, push your Next.js app to a Git provider of your choice: [GitHub](https://github.com/), [GitLab](https://gitlab.com/), or [BitBucket](https://bitbucket.org/). Your repository can be private or public.
 
 Then, follow these steps:
 

--- a/examples/custom-server-koa/README.md
+++ b/examples/custom-server-koa/README.md
@@ -2,7 +2,7 @@
 
 Most of the times the default Next server will be enough but sometimes you want to run your own server to customize routes or other kind of the app behavior. Next provides a [Custom server and routing](https://nextjs.org/docs/advanced-features/custom-server) so you can customize as much as you want.
 
-Because the Next.js server is just a node.js module you can combine it with any other part of the node.js ecosystem. in this case we are using [Koa](http://koajs.com/) to build a custom router on top of Next.
+Because the Next.js server is just a node.js module you can combine it with any other part of the node.js ecosystem. in this case we are using [Koa](https://koajs.com/) to build a custom router on top of Next.
 
 The example shows a server that serves the component living in `pages/a.js` when the route `/b` is requested and `pages/b.js` when the route `/a` is accessed. This is obviously a non-standard routing strategy. You can see how this custom routing is being made inside `server.js`.
 

--- a/examples/with-ant-design-less/README.md
+++ b/examples/with-ant-design-less/README.md
@@ -1,6 +1,6 @@
 # Ant Design example
 
-This example shows how to use Next.js along with [Ant Design of React](http://ant.design). This is intended to show the integration of this UI toolkit with the Framework.
+This example shows how to use Next.js along with [Ant Design of React](https://ant.design). This is intended to show the integration of this UI toolkit with the Framework.
 
 ## Deploy your own
 

--- a/examples/with-ant-design/README.md
+++ b/examples/with-ant-design/README.md
@@ -1,6 +1,6 @@
 # Ant Design example
 
-This example shows how to use Next.js along with [Ant Design of React](http://ant.design). This is intended to show the integration of this UI toolkit with the Framework.
+This example shows how to use Next.js along with [Ant Design of React](https://ant.design). This is intended to show the integration of this UI toolkit with the Framework.
 
 ## Deploy your own
 

--- a/examples/with-carbon-components/README.md
+++ b/examples/with-carbon-components/README.md
@@ -1,8 +1,8 @@
 # Example app with carbon-components-react
 
-This example features how you use IBM's [carbon-components-react](https://github.com/IBM/carbon-components-react) [(Carbon Design System)](http://www.carbondesignsystem.com/components/overview) with Next.js.
+This example features how you use IBM's [carbon-components-react](https://github.com/IBM/carbon-components-react) [(Carbon Design System)](https://www.carbondesignsystem.com/components/overview) with Next.js.
 
-Create your own theme with Carbon Design System's [theming tools](http://themes.carbondesignsystem.com/) and put it all together as demonstrated in `static/myCustomTheme.scss`
+Create your own theme with Carbon Design System's [theming tools](https://themes.carbondesignsystem.com/) and put it all together as demonstrated in `static/myCustomTheme.scss`
 
 ## Deploy your own
 

--- a/examples/with-knex/README.md
+++ b/examples/with-knex/README.md
@@ -1,6 +1,6 @@
 ## Example app using Knex
 
-[Knex](http://knexjs.org/) is a SQL query builder that works with a variety of SQL databases including Postgres and MySQL. This example shows you how to use Knex with Next.js to connect and query a Postgres database. The same code can also connect to all other databases supported by Knex.
+[Knex](https://knexjs.org/) is a SQL query builder that works with a variety of SQL databases including Postgres and MySQL. This example shows you how to use Knex with Next.js to connect and query a Postgres database. The same code can also connect to all other databases supported by Knex.
 
 ## Deploy your own
 

--- a/examples/with-rebass/README.md
+++ b/examples/with-rebass/README.md
@@ -1,6 +1,6 @@
 # Example app with Rebass
 
-This example features how you use [Rebass](http://jxnblk.com/rebass/) functional UI library with Next.js.
+This example features how you use [Rebass](https://jxnblk.com/rebass/) functional UI library with Next.js.
 
 ![Screenshot](https://cloud.githubusercontent.com/assets/304265/22472564/b2e04ff0-e7de-11e6-921e-d0c9833ac805.png)
 

--- a/examples/with-redux-saga/README.md
+++ b/examples/with-redux-saga/README.md
@@ -26,7 +26,7 @@ Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&ut
 
 In the first example we are going to display a digital clock that updates every second. The first render is happening in the server and then the browser will take over. To illustrate this, the server rendered clock will have a different background color than the client one.
 
-![](http://i.imgur.com/JCxtWSj.gif)
+![](https://i.imgur.com/JCxtWSj.gif)
 
 Our page is located at `pages/index.js` so it will map the route `/`. To get the initial data for rendering we are implementing the static method `getInitialProps`, initializing the redux store and dispatching the required actions until we are ready to return the initial state to be rendered. Since the component is wrapped with `next-redux-wrapper`, the component is automatically connected to Redux and wrapped with `react-redux Provider`, that allows us to access redux state immediately and send the store down to children components so they can access to the state when required.
 

--- a/examples/with-redux-wrapper/README.md
+++ b/examples/with-redux-wrapper/README.md
@@ -24,7 +24,7 @@ Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&ut
 
 In the first example we are going to display a digital clock that updates every second. The first render is happening in the server and then the browser will take over. To illustrate this, the server rendered clock will have a different background color than the client one.
 
-![](http://i.imgur.com/JCxtWSj.gif)
+![](https://i.imgur.com/JCxtWSj.gif)
 
 Our page is located at `pages/index.js` so it will map the route `/`. To get the initial data for rendering we are implementing the static method `getInitialProps`, initializing the redux store and dispatching the required actions until we are ready to return the initial state to be rendered. Since the component is wrapped with `next-redux-wrapper`, the component is automatically connected to Redux and wrapped with `react-redux Provider`, that allows us to access redux state immediately and send the store down to children components so they can access to the state when required.
 

--- a/examples/with-semantic-ui/README.md
+++ b/examples/with-semantic-ui/README.md
@@ -1,6 +1,6 @@
 # Semantic UI example
 
-This example shows how to use Next.js along with [Semantic UI React](http://react.semantic-ui.com) including handling of external styles and assets. This is intended to show the integration of this UI toolkit with the Framework.
+This example shows how to use Next.js along with [Semantic UI React](https://react.semantic-ui.com) including handling of external styles and assets. This is intended to show the integration of this UI toolkit with the Framework.
 
 ## Deploy your own
 

--- a/examples/with-stomp/README.md
+++ b/examples/with-stomp/README.md
@@ -1,6 +1,6 @@
 # Stomp example
 
-This example show how to use [STOMP](http://stomp.github.io/) inside a Next.js application.
+This example show how to use [STOMP](https://stomp.github.io/) inside a Next.js application.
 
 STOMP is a simple text-orientated messaging protocol. It defines an interoperable wire format so that any of the available STOMP clients can communicate with any STOMP message broker.
 

--- a/examples/with-videojs/README.md
+++ b/examples/with-videojs/README.md
@@ -1,6 +1,6 @@
 # video.js example
 
-This example shows how to use Next.js along with [Video.js](http://videojs.com) including handling of default styles.
+This example shows how to use Next.js along with [Video.js](https://videojs.com) including handling of default styles.
 
 ## Deploy your own
 


### PR DESCRIPTION
Upgraded all `http` links to `https` that support the `https` protocol.

Llinks
-----
- https://github.com/
- https://koajs.com
- https://ant.design
- https://www.carbondesignsystem.com/components/overview
- https://themes.carbondesignsystem.com
- https://knexjs.org
- https://jxnblk.com/rebass
- https://i.imgur.com/JCxtWSj.gif
- https://react.semantic-ui.com
- https://stomp.github.io
- https://videojs.com