### PR TITLE
Ensure index rewrite is matched with i18n correctly

### DIFF
--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -407,7 +407,9 @@ function processRoutes<T>(
 
       r.source = `/:nextInternalLocale(${config.i18n.locales
         .map((locale: string) => escapeStringRegexp(locale))
-        .join('|')})${r.source}`
+        .join('|')})${
+        r.source === '/' && !config.trailingSlash ? '' : r.source
+      }`
 
       if (r.destination && r.destination?.startsWith('/')) {
         r.destination = `/:nextInternalLocale${

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1366,8 +1366,11 @@ export default class Server {
       ? (req as any)._nextRewroteUrl
       : urlPathname
 
-    resolvedUrlPathname = removePathTrailingSlash(resolvedUrlPathname)
     urlPathname = removePathTrailingSlash(urlPathname)
+    resolvedUrlPathname = normalizeLocalePath(
+      removePathTrailingSlash(resolvedUrlPathname),
+      this.nextConfig.i18n?.locales
+    ).pathname
 
     const stripNextDataPath = (path: string) => {
       if (path.includes(this.buildId)) {

--- a/test/integration/i18n-support-index-rewrite/next.config.js
+++ b/test/integration/i18n-support-index-rewrite/next.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+  i18n: {
+    // localeDetection: false,
+    locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en'],
+    defaultLocale: 'en',
+    domains: [
+      {
+        // used for testing, this should not be needed in most cases
+        // as production domains should always use https
+        http: true,
+        domain: 'example.be',
+        defaultLocale: 'nl-BE',
+        locales: ['nl', 'nl-NL', 'nl-BE'],
+      },
+      {
+        http: true,
+        domain: 'example.fr',
+        defaultLocale: 'fr',
+        locales: ['fr-BE'],
+      },
+    ],
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/',
+        destination: '/company/about-us',
+      },
+    ]
+  },
+}

--- a/test/integration/i18n-support-index-rewrite/pages/[...slug].js
+++ b/test/integration/i18n-support-index-rewrite/pages/[...slug].js
@@ -7,24 +7,33 @@ const DynamicPage = (props) => (
   </>
 )
 
-export const getStaticPaths = async () => ({
-  fallback: false,
-  paths: [
-    {
+export const getStaticPaths = async ({ locales }) => {
+  const paths = []
+
+  for (const locale of locales) {
+    paths.push({
       params: {
         slug: ['hello'],
       },
-    },
-    {
+      locale,
+    })
+    paths.push({
       params: {
         slug: ['company', 'about-us'],
       },
-    },
-  ],
-})
+      locale,
+    })
+  }
 
-export const getStaticProps = async ({ params }) => ({
+  return {
+    fallback: false,
+    paths,
+  }
+}
+
+export const getStaticProps = async ({ params, locale }) => ({
   props: {
+    locale,
     params,
     hello: 'world',
   },

--- a/test/integration/i18n-support-index-rewrite/pages/[...slug].js
+++ b/test/integration/i18n-support-index-rewrite/pages/[...slug].js
@@ -1,0 +1,33 @@
+import React from 'react'
+
+const DynamicPage = (props) => (
+  <>
+    <div>DynamicPage</div>
+    <div id="props">{JSON.stringify(props)}</div>
+  </>
+)
+
+export const getStaticPaths = async () => ({
+  fallback: false,
+  paths: [
+    {
+      params: {
+        slug: ['hello'],
+      },
+    },
+    {
+      params: {
+        slug: ['company', 'about-us'],
+      },
+    },
+  ],
+})
+
+export const getStaticProps = async ({ params }) => ({
+  props: {
+    params,
+    hello: 'world',
+  },
+})
+
+export default DynamicPage

--- a/test/integration/i18n-support-index-rewrite/test/index.test.js
+++ b/test/integration/i18n-support-index-rewrite/test/index.test.js
@@ -1,0 +1,84 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import assert from 'assert'
+import cheerio from 'cheerio'
+import webdriver from 'next-webdriver'
+import {
+  launchApp,
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  renderViaHTTP,
+  check,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '..')
+let appPort
+let app
+
+const runTests = () => {
+  it('should rewrite index route correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    const $ = cheerio.load(html)
+
+    expect(JSON.parse($('#props').text())).toEqual({
+      params: {
+        slug: ['company', 'about-us'],
+      },
+      hello: 'world',
+    })
+  })
+
+  it('should handle index rewrite on client correctly', async () => {
+    const browser = await webdriver(appPort, '/hello')
+
+    expect(JSON.parse(await browser.elementByCss('#props').text())).toEqual({
+      params: {
+        slug: ['hello'],
+      },
+      hello: 'world',
+    })
+    await browser.eval(`(function() {
+      window.beforeNav = 1
+      window.next.router.push('/')
+    })()`)
+
+    await check(async () => {
+      assert.deepEqual(
+        JSON.parse(await browser.elementByCss('#props').text()),
+        {
+          params: {
+            slug: ['company', 'about-us'],
+          },
+          hello: 'world',
+        }
+      )
+      return 'success'
+    }, 'success')
+  })
+}
+
+describe('Custom routes i18n', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+    runTests(true)
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+    runTests()
+  })
+})


### PR DESCRIPTION
This makes sure we don't generate the wrong locale source variant for the rewrite requiring a `/` on the end which won't ever be added causing the rewrite to never match. Additional tests have been added to ensure this specific rewrite is working correctly. 


Fixes: https://github.com/vercel/next.js/issues/20508