### PR TITLE
Upgrade Tailwindcss to 2.0.2

### DIFF
--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "autoprefixer": "10.0.2",
     "postcss": "8.1.7",
-    "tailwindcss": "^2.0.1"
+    "tailwindcss": "^2.0.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Normally I wouldn't make a PR for a minor version upgrade, but the 2.0.2 version contains some important performance improvements.
https://github.com/tailwindlabs/tailwindcss/pull/3032