### PR TITLE
fix example using-router import wrong pathname

### DIFF
--- a/examples/using-router/pages/about.js
+++ b/examples/using-router/pages/about.js
@@ -1,4 +1,4 @@
-import Header from '../components/header'
+import Header from '../components/Header'
 
 export default function About() {
   return (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49720317/103223063-07b23000-4958-11eb-8bf9-09c39231a092.png)

About page import wrong pathname causing warning like this.