### PR TITLE
Update i18n test

### DIFF
--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -37,20 +37,29 @@ export function runTests(ctx) {
         window.next.router.asPath,
         { locale: 'nl' }
       )
+    })()`)
+
+    await check(() => browser.elementByCss('#router-locale').text(), 'nl')
+    expect(await browser.eval('window.beforeNav')).toBe(1)
+
+    await browser.eval(`(function() {
       window.next.router.push(
         '/gssp?page=1'
       )
     })()`)
 
-    await browser.waitForElementByCss('#gssp')
+    await check(async () => {
+      const html = await browser.eval('document.documentElement.innerHTML')
+      const props = JSON.parse(cheerio.load(html)('#props').text())
 
-    const props = JSON.parse(await browser.elementByCss('#props').text())
-    expect(props).toEqual({
-      locale: 'nl',
-      locales,
-      defaultLocale: 'en-US',
-      query: { page: '1' },
-    })
+      assert.deepEqual(props, {
+        locale: 'nl',
+        locales,
+        defaultLocale: 'en-US',
+        query: { page: '1' },
+      })
+      return 'success'
+    }, 'success')
 
     await browser
       .back()
@@ -65,6 +74,7 @@ export function runTests(ctx) {
       defaultLocale: 'en-US',
       query: { page: '1' },
     })
+    expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
   if (!ctx.isDev) {


### PR DESCRIPTION
This tweaks the new i18n query history test to address intermittent failures in CI

x-ref: https://github.com/vercel/next.js/pull/19197#issuecomment-751845314
x-ref: https://github.com/vercel/next.js/pull/19135#issuecomment-751822153
x-ref: https://github.com/vercel/next.js/pull/20379#issuecomment-751821500