### PR TITLE
Edited image component - better UX

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -44,6 +44,7 @@ export type ImageProps = Omit<
   unoptimized?: boolean
   objectFit?: ImgElementStyle['objectFit']
   objectPosition?: ImgElementStyle['objectPosition']
+  wrapperProps?: Omit<JSX.IntrinsicElements['div'], 'ref' | 'style'>
 } & (
     | {
         width?: never
@@ -181,6 +182,7 @@ export default function Image({
   height,
   objectFit,
   objectPosition,
+  wrapperProps,
   ...all
 }: ImageProps) {
   let rest: Partial<ImageProps> = all
@@ -374,7 +376,7 @@ export default function Image({
     imgStyle = undefined
   }
   return (
-    <div style={wrapperStyle}>
+    <div {...wrapperProps} style={wrapperStyle} data-isvisible={isVisible}>
       {sizerStyle ? (
         <div style={sizerStyle}>
           {sizerSvg ? (

--- a/test/integration/invalid-custom-routes/next.config.js
+++ b/test/integration/invalid-custom-routes/next.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/feedback/(?!general)',
+        destination: '/feedback/general',
+        permanent: false,
+      },
+      { source: '/learning/?', destination: '/learning', permanent: true },
+    ]
+  },
+}


### PR DESCRIPTION
Hi there!
In this PR im trying to better the DX and UX in one go. 

I absolutely love that we finally have Nextjs image component - but one thing struck me. 
We couldnt really animate the finalized loading state or atleast show that image is loading (maybe kick it with background and leave as is, but hey that isnt really good looking), because next/image doesnt really expose anything from inside.

So I added custom prop named 'data-isvisible' to parent element to the image component. This props represents inner state of image component so whenever image is loaded or not, you can catch it like this.

This is cool and all but you could only catch that in css really hard (or atleast, it wouldnt look nice or would look overly complicated 😄 ) - so I added the ability to add props to parent(wrap) element. Namely I added custom prop 'wrapperProps' that is exposed to the developer.

I removed the ability to catch ref or style tho - to avoid some unnecessary bugs and things (and cuz next/image uses style prop under the hood so I kinda had to leave it as is) .

So now you can just give it some className and catch the state in scss - it would be like this:

```css
.some-className {
   img  {
     opacity: 0;
     transition: opacity .4s; /* now you can animate the heck out of it 😄 */
   }
   &[data-isvisible='true'] {
     opacity: 1;
   }
}
```
I really hope that this helps - or atleast bring this matter in right direction, because this feature is wanted in most cases. 
Let me know if I can make any further modifications! Thanks! ✋ 

