### PR TITLE
Remove unnecessary unfetch polyfill for dev

### DIFF
--- a/packages/next/client/dev/amp-dev.js
+++ b/packages/next/client/dev/amp-dev.js
@@ -1,5 +1,4 @@
 /* globals __webpack_hash__ */
-import fetch from 'next/dist/build/polyfills/unfetch'
 import EventSourcePolyfill from './event-source-polyfill'
 import { getEventSourceWrapper } from './error-overlay/eventsource'
 import { setupPing } from './on-demand-entries-utils'

--- a/packages/next/client/dev/event-source-polyfill.js
+++ b/packages/next/client/dev/event-source-polyfill.js
@@ -2,8 +2,6 @@
 // Improved version of https://github.com/Yaffle/EventSource/
 // Available under MIT License (MIT)
 // Only tries to support IE11 and nothing below
-import fetch from 'next/dist/build/polyfills/unfetch'
-
 var document = window.document
 var Response = window.Response
 var TextDecoder = window.TextDecoder

--- a/packages/next/client/dev/on-demand-entries-utils.js
+++ b/packages/next/client/dev/on-demand-entries-utils.js
@@ -1,6 +1,4 @@
 /* global location */
-
-import fetch from 'next/dist/build/polyfills/unfetch'
 import { getEventSourceWrapper } from './error-overlay/eventsource'
 
 let evtSource

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -218,7 +218,6 @@
     "text-table": "0.2.0",
     "thread-loader": "2.1.3",
     "typescript": "3.8.3",
-    "unfetch": "4.1.0",
     "unistore": "3.4.1",
     "web-vitals": "0.2.4"
   },

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -731,6 +731,7 @@ export class NextScript extends Component<OriginProps> {
 
       const ampDevFiles = [
         ...buildManifest.devFiles,
+        ...buildManifest.polyfillFiles,
         ...buildManifest.ampDevFiles,
       ]
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -11,14 +11,8 @@ export async function next__polyfill_nomodule(task, opts) {
     .target('dist/build/polyfills')
 }
 
-export async function unfetch(task, opts) {
-  await task
-    .source(opts.src || relative(__dirname, require.resolve('unfetch')))
-    .target('dist/build/polyfills')
-}
-
 export async function browser_polyfills(task) {
-  await task.parallel(['next__polyfill_nomodule', 'unfetch'])
+  await task.parallel(['next__polyfill_nomodule'])
 }
 
 const externals = {

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -8,7 +8,6 @@ declare module 'cssnano-simple' {
   export = cssnanoSimple
 }
 declare module 'styled-jsx/server'
-declare module 'unfetch'
 declare module 'webpack/lib/GraphHelpers'
 declare module 'webpack/lib/DynamicEntryPlugin'
 declare module 'webpack/lib/Entrypoint'

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -298,7 +298,20 @@ describe('AMP Usage', () => {
       const html = await renderViaHTTP(dynamicAppPort, '/only-amp')
       const $ = cheerio.load(html)
       expect($('html').attr('data-ampdevmode')).toBe('')
-      expect($('script[data-ampdevmode]').length).toBe(4)
+      expect(
+        [].slice
+          .apply($('script[data-ampdevmode]'))
+          .map((el) => el.attribs.src || el.attribs.id)
+          .map((e) =>
+            e.startsWith('/') ? new URL(e, 'http://x.x').pathname : e
+          )
+      ).toEqual([
+        '__NEXT_DATA__',
+        '/_next/static/chunks/react-refresh.js',
+        '/_next/static/chunks/polyfills.js',
+        '/_next/static/chunks/webpack.js',
+        '/_next/static/chunks/amp.js',
+      ])
     })
 
     it('should detect the changes and display it', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15475,7 +15475,7 @@ umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
 
-unfetch@4.1.0, unfetch@^4.0.0:
+unfetch@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
 


### PR DESCRIPTION
Fetch is always polyfilled in legacy browsers by `@next/polyfill-nomodule`, so we do not need to import unfetch for IE11 support.

Fixes #20588