### PR TITLE
Refactor GS(S)P notFound client-side handling

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -856,7 +856,7 @@ export default class Router implements BaseRouter {
         route,
         pathname,
         query,
-        as,
+        resolvedAs,
         routeProps
       )
       let { error, props, __N_SSG, __N_SSP } = routeInfo

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -856,7 +856,7 @@ export default class Router implements BaseRouter {
         route,
         pathname,
         query,
-        resolvedAs,
+        addBasePath(addLocale(resolvedAs, this.locale)),
         routeProps
       )
       let { error, props, __N_SSG, __N_SSP } = routeInfo

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -332,7 +332,7 @@ const manualScrollRestoration =
   typeof window !== 'undefined' &&
   'scrollRestoration' in window.history
 
-const SSG_DATA_NOT_FOUND = '__NEXT_SSG_DATA_NOT_FOUND'
+const SSG_DATA_NOT_FOUND = Symbol('SSG_DATA_NOT_FOUND')
 
 function fetchRetry(url: string, attempts: number): Promise<any> {
   return fetch(url, {
@@ -354,7 +354,7 @@ function fetchRetry(url: string, attempts: number): Promise<any> {
         return fetchRetry(url, attempts - 1)
       }
       if (res.status === 404) {
-        return { [SSG_DATA_NOT_FOUND]: true }
+        return { notFound: SSG_DATA_NOT_FOUND }
       }
       throw new Error(`Failed to load static props`)
     }
@@ -893,7 +893,7 @@ export default class Router implements BaseRouter {
         }
 
         // handle SSG data 404
-        if (props[SSG_DATA_NOT_FOUND]) {
+        if (props.notFound === SSG_DATA_NOT_FOUND) {
           let notFoundRoute
 
           try {
@@ -1367,9 +1367,7 @@ export default class Router implements BaseRouter {
       return Promise.resolve(this.sdc[cacheKey])
     }
     return fetchNextData(dataHref, this.isSsr).then((data) => {
-      if (!data[SSG_DATA_NOT_FOUND]) {
-        this.sdc[cacheKey] = data
-      }
+      this.sdc[cacheKey] = data
       return data
     })
   }

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -271,7 +271,7 @@ const runTests = (dev = false) => {
     expect(await browser.elementByCss('html').text()).toContain(
       'This page could not be found'
     )
-    expect(await browser.eval('window.beforeNav')).toBe(null)
+    expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
   it('should render 404 correctly when notFound is returned (dynamic)', async () => {
@@ -294,7 +294,7 @@ const runTests = (dev = false) => {
     expect(await browser.elementByCss('html').text()).toContain(
       'This page could not be found'
     )
-    expect(await browser.eval('window.beforeNav')).toBe(null)
+    expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
   it('should SSR normal page correctly', async () => {

--- a/test/integration/i18n-support-index-rewrite/test/index.test.js
+++ b/test/integration/i18n-support-index-rewrite/test/index.test.js
@@ -71,6 +71,8 @@ const runTests = () => {
         })
         return 'success'
       }, 'success')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
     }
   })
 }

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -140,6 +140,7 @@ export function runTests(ctx) {
             '/fr/gsp.json',
             '/fr/gsp/fallback/first.json',
             '/fr/gsp/fallback/hello.json',
+            '/fr/gsp/no-fallback/first.json',
           ]
         )
         return 'yes'
@@ -686,6 +687,7 @@ export function runTests(ctx) {
             '/fr/gsp.json',
             '/fr/gsp/fallback/first.json',
             '/fr/gsp/fallback/hello.json',
+            '/fr/gsp/no-fallback/first.json',
           ]
         )
         return 'yes'
@@ -898,6 +900,7 @@ export function runTests(ctx) {
             '/fr/gsp.json',
             '/fr/gsp/fallback/first.json',
             '/fr/gsp/fallback/hello.json',
+            '/fr/gsp/no-fallback/first.json',
           ]
         )
         return 'yes'

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -1601,7 +1601,7 @@ export function runTests(ctx) {
 
     expect(props.is404).toBe(true)
     expect(props.locale).toBe('en')
-    expect(await browser.eval('window.beforeNav')).toBe(null)
+    expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
   it('should render 404 for fallback page that returned 404 on client transition', async () => {


### PR DESCRIPTION
This refactors to instead of throwing a specific error when a SSG data route 404s, we return it through props and render the 404 outside of the error handling flow. No additional tests have been added as existing tests should cover this. 

Closes: https://github.com/vercel/next.js/issues/19243