### PR TITLE
Ensure index basePath is detected correctly

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -92,7 +92,13 @@ export function delLocale(path: string, locale?: string) {
 }
 
 export function hasBasePath(path: string): boolean {
-  return path === basePath || path.startsWith(basePath + '/')
+  const queryIndex = path.indexOf('?')
+  const hashIndex = path.indexOf('#')
+
+  if (queryIndex > -1 || hashIndex > -1) {
+    path = path.substring(0, queryIndex > -1 ? queryIndex : hashIndex)
+  }
+  return path === basePath || path.startsWith(basePath)
 }
 
 export function addBasePath(path: string): string {

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -98,7 +98,7 @@ export function hasBasePath(path: string): boolean {
   if (queryIndex > -1 || hashIndex > -1) {
     path = path.substring(0, queryIndex > -1 ? queryIndex : hashIndex)
   }
-  return path === basePath || path.startsWith(basePath)
+  return path === basePath || path.startsWith(basePath + '/')
 }
 
 export function addBasePath(path: string): string {

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -1020,6 +1020,30 @@ const runTests = (dev = false) => {
 
       const pathname = await browser.elementByCss('#pathname').text()
       expect(pathname).toBe('/hello')
+      expect(await browser.eval('window.location.pathname')).toBe(
+        `${basePath}/hello`
+      )
+      expect(await browser.eval('window.location.search')).toBe('?query=true')
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('should allow URL query strings on index without refresh', async () => {
+    const browser = await webdriver(appPort, `${basePath}?query=true`)
+    try {
+      await browser.eval('window.itdidnotrefresh = "hello"')
+      await new Promise((resolve, reject) => {
+        // Timeout of EventSource created in setupPing()
+        // (on-demand-entries-utils.js) is 5000 ms (see #13132, #13560)
+        setTimeout(resolve, 10000)
+      })
+      expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
+
+      const pathname = await browser.elementByCss('#pathname').text()
+      expect(pathname).toBe('/')
+      expect(await browser.eval('window.location.pathname')).toBe(basePath)
+      expect(await browser.eval('window.location.search')).toBe('?query=true')
     } finally {
       await browser.close()
     }


### PR DESCRIPTION
This ensures we detect the `basePath` correctly for the index `basePath` route when either a `hash` or a `query` are present in the provided path. This also adds this specific test to our basePath test suite. 

Fixes: https://github.com/vercel/next.js/issues/19294
Fixes: https://github.com/vercel/next.js/issues/19437
Closes: https://github.com/vercel/next.js/pull/19444