### PR TITLE
fix(.babelrc): Removing unnecessary attributes.

### DIFF
--- a/examples/with-ant-design/.babelrc
+++ b/examples/with-ant-design/.babelrc
@@ -4,10 +4,9 @@
     [
       "import",
       {
-        "libraryName": "antd",
-        "libraryDirectory": "lib",
-        "style": "index.css"
-      }
+        "libraryName": "antd"
+      },
+      "antd"
     ],
     [
       "import",


### PR DESCRIPTION
According to <https://github.com/ant-design/babel-plugin-import/blob/master/src/Plugin.js>, `libraryDirectory` defaults to `lib`, and `"style": "index.css"` isn't a valid value. Valid values are: `true`, for less; `"css"`, for css; or a [custom function](https://github.com/ant-design/babel-plugin-import/blob/e86af59e9c91bd9942e056a0b04e6ae5ef4183f4/src/Plugin.js#L90).