### PR TITLE
Use X-Forwarded-Host for Domain Routing

### DIFF
--- a/docs/advanced-features/i18n-routing.md
+++ b/docs/advanced-features/i18n-routing.md
@@ -122,6 +122,19 @@ For example if you have `pages/blog.js` the following urls will be available:
 - `example.nl/blog`
 - `example.nl/nl-BE/blog`
 
+### Domain Routing Behind a Proxy
+
+When running a Next.js app behind a proxy, hostname can be derived from the `X-Forwarded-Host` header with:
+
+```js
+// next.config.js
+module.exports = {
+  i18n: {
+    trustProxy: true,
+  },
+}
+```
+
 ## Automatic Locale Detection
 
 When a user visits the application root (generally `/`), Next.js will try to automatically detect which locale the user prefers based on the [`Accept-Language`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) header and the current domain.

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -343,7 +343,9 @@ export function getUtils({
 
     const { host } = req.headers || {}
     // remove port from host and remove port if present
-    const hostname = host && host.split(':')[0].toLowerCase()
+    let hostname = host && host.split(':')[0].toLowerCase()
+
+    if (i18n.trustProxy) hostname = req.headers['x-forwarded-host']?.toString()
 
     const detectedDomain = detectDomainLocale(i18n.domains, hostname)
     if (detectedDomain) {

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -24,6 +24,7 @@ export type NextConfig = { [key: string]: any } & {
     defaultLocale: string
     domains?: DomainLocales
     localeDetection?: false
+    trustProxy?: false
   } | null
 
   headers?: () => Promise<Header[]>

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -344,7 +344,10 @@ export default class Server {
 
       const { host } = req?.headers || {}
       // remove port from host and remove port if present
-      const hostname = host?.split(':')[0].toLowerCase()
+      let hostname = host?.split(':')[0].toLowerCase()
+
+      if (i18n.trustProxy)
+        hostname = req.headers['x-forwarded-host']?.toString()
 
       const detectedDomain = detectDomainLocale(i18n.domains, hostname)
       if (detectedDomain) {
@@ -697,7 +700,11 @@ export default class Server {
           if (i18n) {
             const { host } = req?.headers || {}
             // remove port from host and remove port if present
-            const hostname = host?.split(':')[0].toLowerCase()
+            let hostname = host?.split(':')[0].toLowerCase()
+
+            if (i18n.trustProxy)
+              hostname = req.headers['x-forwarded-host']?.toString()
+
             const localePathResult = normalizeLocalePath(pathname, i18n.locales)
             const { defaultLocale } =
               detectDomainLocale(i18n.domains, hostname) || {}


### PR DESCRIPTION
I was having trouble using [Domain Routing](https://nextjs.org/docs/advanced-features/i18n-routing#domain-routing) behind a proxy so thought it might be worth taking some inspiration from [what Express does](https://expressjs.com/en/guide/behind-proxies.html) in this scenario.

The idea is you add this in your config:

```js
// next.config.js
module.exports = {
  i18n: {
    trustProxy: true,
  },
}
```

And then the `X-Forwarded-Host` header is used in place of `hostname`.