### PR TITLE
Update docs for `basePath: false` rewrite

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -154,9 +154,10 @@ module.exports = {
         destination: '/another', // automatically becomes /docs/another
       },
       {
-        // does not add /docs since basePath: false is set
+        // does not add /docs to /without-basePath since basePath: false is set
+        // Note: this can not be used for internal rewrites e.g. `destination: '/another'`
         source: '/without-basePath',
-        destination: '/another',
+        destination: 'https://example.com',
         basePath: false,
       },
     ]


### PR DESCRIPTION
When using rewrites with `basePath: false` we don't allow the destination to point to an internal location `/` and require it point to an external location. This makes sure this is noted in the documentation since an error is thrown with the current `basePath: false` rewrite example. 

x-ref: https://github.com/vercel/next.js/discussions/16958