### PR TITLE
Add pr section to azure config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,10 +6,10 @@ trigger:
     include:
       - '*'
     exclude:
-      - bench/*
-      - docs/*
-      - errors/*
-      - examples/*
+      - bench
+      - docs
+      - errors
+      - examples
   # Do not run Azure on `canary`, `master`, or release tags. This unnecessarily
   # increases the backlog, and the change was already tested on the PR.
   branches:
@@ -19,6 +19,19 @@ trigger:
       - canary
       - master
       - refs/tags/*
+
+pr:
+  # Only run latest commit for branches:
+  batch: true
+  # Do not run Azure CI for docs-only/example-only changes:
+  paths:
+    include:
+      - '*'
+    exclude:
+      - bench
+      - docs
+      - errors
+      - examples
 
 variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,6 @@ trigger:
       - refs/tags/*
 
 pr:
-  # Only run latest commit for branches:
-  batch: true
   # Do not run Azure CI for docs-only/example-only changes:
   paths:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ pr:
       - docs
       - errors
       - examples
+      - azure-pipelines.yml
 
 variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,6 @@ pr:
       - docs
       - errors
       - examples
-      - azure-pipelines.yml
 
 variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -14,7 +14,7 @@ import { NextConfig } from '../next-server/server/config'
 type PagesMapping = {
   [page: string]: string
 }
-
+console.log('no-op')
 export function createPagesMapping(
   pagePaths: string[],
   extensions: string[]

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -14,7 +14,7 @@ import { NextConfig } from '../next-server/server/config'
 type PagesMapping = {
   [page: string]: string
 }
-console.log('no-op')
+
 export function createPagesMapping(
   pagePaths: string[],
   extensions: string[]


### PR DESCRIPTION
Adds the `pr` section from https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#pr-triggers to filter paths that don't require test runs on PRs. 