### PR TITLE
Remove an undefined parameter

### DIFF
--- a/examples/with-magic/pages/api/logout.js
+++ b/examples/with-magic/pages/api/logout.js
@@ -4,7 +4,7 @@ import { getLoginSession } from '../../lib/auth'
 
 export default async function logout(req, res) {
   try {
-    const session = await getLoginSession(req, false)
+    const session = await getLoginSession(req)
 
     if (session) {
       await magic.users.logoutByIssuer(session.issuer)


### PR DESCRIPTION
`getLoginSession` takes only one argument