### PR TITLE
Fix with-react-intl example

### DIFF
--- a/examples/with-react-intl/package.json
+++ b/examples/with-react-intl/package.json
@@ -6,7 +6,7 @@
     "dev-no-custom-server": "next dev",
     "build": "npm run extract:i18n && npm run compile:i18n && next build && tsc -p tsconfig.server.json",
     "extract:i18n": "formatjs extract '{pages,components}/*.{js,ts,tsx}' --format simple --id-interpolation-pattern '[sha512:contenthash:base64:6]' --out-file lang/en.json",
-    "compile:i18n": "formatjs compile-folder --ast --format simple lang/ compiled-lang/",
+    "compile:i18n": "formatjs compile-folder --ast --format simple lang compiled-lang",
     "start": "cross-env NODE_ENV=production NODE_ICU_DATA=node_modules/full-icu node dist/server",
     "start-no-custom-server": "next start"
   },
@@ -32,7 +32,7 @@
     "@types/accepts": "^1.3.5",
     "cross-spawn": "7.0.3",
     "prettier": "2.0.5",
-    "ts-node": "8.0.0",
+    "ts-node": "8.0.1",
     "typescript": "4.0"
   },
   "prettier": {


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/20713

`yarn dev` and `yarn build` had different issues.

For `yarn build`, the trailing slash in `formatjs compile-folder` command is not necessary.
For `yarn dev`, I updated `ts-node` to 8.0.1 (related to https://github.com/TypeStrong/ts-node/issues/762)