### PR TITLE
configure terser to do two passes

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -400,6 +400,8 @@ export default async function getBaseWebpackConfig(
       ecma: 8,
     },
     compress: {
+      // improves tree-shaking
+      passes: 2,
       ecma: 5,
       warnings: false,
       // The following two options are known to break valid JavaScript code


### PR DESCRIPTION
Terser sets `passes` to `1` by [default](https://github.com/terser/terser#compress-options), but [webpack sets it to `2`](https://github.com/webpack/webpack/blob/84720287e10d5151e70900e2cafd0c3c323dd63d/lib/config/defaults.js#L896-L898)

Fixes #20804 