### PR TITLE
Append remaining params to query

### DIFF
--- a/packages/next/next-server/lib/router/utils/prepare-destination.ts
+++ b/packages/next/next-server/lib/router/utils/prepare-destination.ts
@@ -128,10 +128,9 @@ export default function prepareDestination(
     paramKeys = paramKeys.filter((name) => name !== 'nextInternalLocale')
   }
 
-  if (
-    appendParamsToQuery &&
-    !paramKeys.some((key) => destPathParams.includes(key))
-  ) {
+  if (appendParamsToQuery) {
+    paramKeys = paramKeys.filter((key) => !destPathParams.includes(key))
+
     for (const key of paramKeys) {
       if (!(key in destQuery)) {
         destQuery[key] = params[key]

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -106,6 +106,10 @@ module.exports = {
         source: '/catchall-query/:path*',
         destination: '/with-params?another=:path*',
       },
+      {
+        source: '/:params/:path',
+        destination: '/:path',
+      },
     ]
   },
   async redirects() {

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -616,6 +616,13 @@ const runTests = (isDev = false) => {
     )
   })
 
+  it('should append remaining rewrite params to query when other params are not used', async () => {
+    const html = await renderViaHTTP(appPort, '/hello/with-params')
+
+    const data = JSON.parse(cheerio.load(html)('p').text())
+    expect(data).toEqual({ params: 'hello' })
+  })
+
   if (!isDev) {
     it('should output routes-manifest successfully', async () => {
       const manifest = await fs.readJSON(
@@ -1076,6 +1083,13 @@ const runTests = (isDev = false) => {
               '^\\/catchall-query(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
             ),
             source: '/catchall-query/:path*',
+          },
+          {
+            destination: '/:path*',
+            regex: normalizeRegEx(
+              '^(?:\\/([^\\/]+?))(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
+            ),
+            source: '/:params/:path*',
           },
         ],
         dynamicRoutes: [


### PR DESCRIPTION
I cannot find any documentation about this behavior, even on the example I'm not seeing this pattern

I'm trying to access `appCtx.ctx.query` from `App.getInitialProps` using this sample code
```
// _app.js
App.getInitialProps = function({ ctx }) {
  console.log(ctx)
  return {}
}

// next.config.js
module.exports = {
  rewrites() {
    return [
      { source: '/:param', destination: '/' }, // rule 1
      { source: '/:param/:path', destination: '/:path' }, // rule 2
    ]
  }
}
```

and when router is executed with `/foo` and `/foo/bar` for those rules
```
// rule 1
ctx.req.url;  // prints '/foo'
ctx.pathname; // prints '/'
ctx.query;    // prints "{ param: 'foo' }"

// rule 2
ctx.req.url;  // prints '/foo/bar'
ctx.pathname; // prints '/bar'
ctx.query;    // prints "{}". param is missing
```

I'm not sure what I said is an expected behavior but this [line](https://github.com/vercel/next.js/pull/20836/files#diff-42054d7ab430b986d5a4ab155dfa42732cd90362f2168fd8aff6d0b32af464abR122-R123) suggest otherwise

therefore this PR will merge the params that are not defined in destination