### PR TITLE
enabling using getStaticProps and getServerSideProps at the same time

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     { "language": "typescript", "autoFix": true },
     { "language": "typescriptreact", "autoFix": true }
   ],
-  "debug.javascript.unmapMissingSources": true
+  "debug.javascript.unmapMissingSources": true,
+  "git.ignoreLimitWarning": true
 }

--- a/packages/next/build/babel/plugins/next-ssg-transform.ts
+++ b/packages/next/build/babel/plugins/next-ssg-transform.ts
@@ -3,7 +3,6 @@ import {
   PluginObj,
   types as BabelTypes,
 } from 'next/dist/compiled/babel/core'
-import { SERVER_PROPS_SSG_CONFLICT } from '../../../lib/constants'
 import {
   SERVER_PROPS_ID,
   STATIC_PROPS_ID,
@@ -82,16 +81,9 @@ function decorateSsgExport(
 const isDataIdentifier = (name: string, state: PluginState): boolean => {
   if (ssgExports.has(name)) {
     if (name === EXPORT_NAME_GET_SERVER_PROPS) {
-      if (state.isPrerender) {
-        throw new Error(SERVER_PROPS_SSG_CONFLICT)
-      }
       state.isServerProps = true
-    } else {
-      if (state.isServerProps) {
-        throw new Error(SERVER_PROPS_SSG_CONFLICT)
-      }
-      state.isPrerender = true
     }
+    state.isPrerender = true
     return true
   }
   return false

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -14,7 +14,6 @@ import {
 import {
   SSG_GET_INITIAL_PROPS_CONFLICT,
   SERVER_PROPS_GET_INIT_PROPS_CONFLICT,
-  SERVER_PROPS_SSG_CONFLICT,
 } from '../lib/constants'
 import prettyBytes from '../lib/pretty-bytes'
 import { recursiveReadDir } from '../lib/recursive-readdir'
@@ -775,10 +774,6 @@ export async function isPageStatic(
 
     if (hasGetInitialProps && hasServerProps) {
       throw new Error(SERVER_PROPS_GET_INIT_PROPS_CONFLICT)
-    }
-
-    if (hasStaticProps && hasServerProps) {
-      throw new Error(SERVER_PROPS_SSG_CONFLICT)
     }
 
     const pageIsDynamic = isDynamicRoute(page)

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -8,7 +8,6 @@ import { isDynamicRoute } from '../next-server/lib/router/utils/is-dynamic'
 import { getRouteMatcher } from '../next-server/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../next-server/lib/router/utils/route-regex'
 import { normalizePagePath } from '../next-server/server/normalize-page-path'
-import { SERVER_PROPS_EXPORT_ERROR } from '../lib/constants'
 import 'next/dist/next-server/server/node-polyfill-fetch'
 import { IncomingMessage, ServerResponse } from 'http'
 import { ComponentType } from 'react'
@@ -214,15 +213,7 @@ export default async function exportPage({
           ...query,
         },
       })
-      const { Component: mod, getServerSideProps } = await loadComponents(
-        distDir,
-        page,
-        serverless
-      )
-
-      if (getServerSideProps) {
-        throw new Error(`Error for page ${page}: ${SERVER_PROPS_EXPORT_ERROR}`)
-      }
+      const { Component: mod } = await loadComponents(distDir, page, serverless)
 
       // if it was auto-exported the HTML is loaded here
       if (typeof mod === 'string') {
@@ -274,10 +265,6 @@ export default async function exportPage({
       }
     } else {
       const components = await loadComponents(distDir, page, serverless)
-
-      if (components.getServerSideProps) {
-        throw new Error(`Error for page ${page}: ${SERVER_PROPS_EXPORT_ERROR}`)
-      }
 
       // for non-dynamic SSG pages we should have already
       // prerendered the file

--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -28,11 +28,7 @@ export const SSG_GET_INITIAL_PROPS_CONFLICT = `You can not use getInitialProps w
 
 export const SERVER_PROPS_GET_INIT_PROPS_CONFLICT = `You can not use getInitialProps with getServerSideProps. Please remove getInitialProps.`
 
-export const SERVER_PROPS_SSG_CONFLICT = `You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps`
-
 export const PAGES_404_GET_INITIAL_PROPS_ERROR = `\`pages/404\` can not have getInitialProps/getServerSideProps, https://err.sh/next.js/404-get-initial-props`
-
-export const SERVER_PROPS_EXPORT_ERROR = `pages with \`getServerSideProps\` can not be exported. See more info here: https://err.sh/next.js/gssp-export`
 
 export const GSP_NO_RETURNED_VALUE =
   'Your `getStaticProps` function did not return an object. Did you forget to add a `return`?'

--- a/test/integration/font-optimization/next.config.js
+++ b/test/integration/font-optimization/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/integration/getserversideprops-export-error/test/index.test.js
+++ b/test/integration/getserversideprops-export-error/test/index.test.js
@@ -16,16 +16,13 @@ const runTests = () => {
   })
 
   it('should show error for GSSP during export', async () => {
-    const { stderr, code } = await nextExport(
+    const { code } = await nextExport(
       appDir,
       { outdir: join(appDir, 'out') },
       { stderr: true }
     )
 
-    expect(code).toBe(1)
-    expect(stderr).toMatch(
-      /pages with `getServerSideProps` can not be exported. See more info here: https/
-    )
+    expect(code).toBe(0)
   })
 }
 

--- a/test/integration/mixed-ssg-serverprops-error/test/index.test.js
+++ b/test/integration/mixed-ssg-serverprops-error/test/index.test.js
@@ -3,7 +3,6 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import { nextBuild } from 'next-test-utils'
-import { SERVER_PROPS_SSG_CONFLICT } from 'next/dist/lib/constants'
 
 jest.setTimeout(1000 * 60 * 1)
 const appDir = join(__dirname, '..')
@@ -13,20 +12,19 @@ const indexPageBak = `${indexPage}.bak`
 
 describe('Mixed getStaticProps and getServerSideProps error', () => {
   it('should error when exporting both getStaticProps and getServerSideProps', async () => {
-    const { stderr } = await nextBuild(appDir, [], { stderr: true })
-    expect(stderr).toContain(SERVER_PROPS_SSG_CONFLICT)
+    const { code } = await nextBuild(appDir, [], { stderr: true })
+    expect(code).not.toBe(1)
   })
 
   it('should error when exporting both getStaticPaths and getServerSideProps', async () => {
     await fs.move(indexPage, indexPageBak)
     await fs.move(indexPageAlt, indexPage)
 
-    const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
+    const { code } = await nextBuild(appDir, [], { stderr: true })
 
     await fs.move(indexPage, indexPageAlt)
     await fs.move(indexPageBak, indexPage)
 
-    expect(code).toBe(1)
-    expect(stderr).toContain(SERVER_PROPS_SSG_CONFLICT)
+    expect(code).not.toBe(1)
   })
 })

--- a/test/integration/src-dir-support/next.config.js
+++ b/test/integration/src-dir-support/next.config.js
@@ -1,1 +1,3 @@
-module.exports = {}
+module.exports = {
+  target: 'serverless',
+}

--- a/test/integration/typescript-ignore-errors/next.config.js
+++ b/test/integration/typescript-ignore-errors/next.config.js
@@ -1,0 +1,1 @@
+module.exports = { typescript: { ignoreBuildErrors: false } }

--- a/test/unit/babel-plugin-next-ssg-transform.unit.test.js
+++ b/test/unit/babel-plugin-next-ssg-transform.unit.test.js
@@ -505,7 +505,7 @@ describe('babel plugin (next-ssg-transform)', () => {
           export function getStaticProps() {}
           export function getServerSideProps() {}
         `)
-      ).toThrowError(
+      ).not.toThrowError(
         `You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps`
       )
 
@@ -514,7 +514,7 @@ describe('babel plugin (next-ssg-transform)', () => {
           export function getServerSideProps() {}
           export function getStaticProps() {}
         `)
-      ).toThrowError(
+      ).not.toThrowError(
         `You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps`
       )
 
@@ -523,7 +523,7 @@ describe('babel plugin (next-ssg-transform)', () => {
           export function getStaticPaths() {}
           export function getServerSideProps() {}
         `)
-      ).toThrowError(
+      ).not.toThrowError(
         `You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps`
       )
 
@@ -532,7 +532,7 @@ describe('babel plugin (next-ssg-transform)', () => {
           export function getServerSideProps() {}
           export function getStaticPaths() {}
         `)
-      ).toThrowError(
+      ).not.toThrowError(
         `You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps`
       )
     })


### PR DESCRIPTION
I am trying to be able to implement both methods getStaticProps and getServerSideProps and use them only if implemented under the appropriate circumstances.

The idea is this:

We are developing an application that allows us to do runtime-level context/configurations switching for multiple tenants. 

In some cases, a tenant wants to export their entire site and self-host it on something like netlify or whatever platform they have chosen.

This would force us to have to maintain two different implementations of our application which I'm trying to avoid doing. 

Since implementing getServerSideProps (ISR) still blocks exporting static by default, there should be no issues with when both are implemented, using one over the other at compile-time/runtime.

When both are implemented, getServerSideProps is used when running the application from the `start` or `dev` commands. 

When building, implementing getServerSideProps automatically prefers ISR.

When exporting, implementing getStaticProps automatically prefers SSG and the fallback behavior is the same as current state.


