### PR TITLE
Use archive link for electron-next in the examples

### DIFF
--- a/examples/with-electron-typescript/README.md
+++ b/examples/with-electron-typescript/README.md
@@ -10,7 +10,6 @@ This example show how you can use Next.js inside an Electron application to avoi
 
 For development it's going to run a HTTP server and let Next.js handle routing. In production it use `next export` to pre-generate HTML static files and use them in your app instead of running an HTTP server.
 
-
 ## How to use
 
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:

--- a/examples/with-electron-typescript/README.md
+++ b/examples/with-electron-typescript/README.md
@@ -10,7 +10,7 @@ This example show how you can use Next.js inside an Electron application to avoi
 
 For development it's going to run a HTTP server and let Next.js handle routing. In production it use `next export` to pre-generate HTML static files and use them in your app instead of running an HTTP server.
 
-**You can find a detailed documentation about how to build Electron apps with Next.js [here](https://leo.im/2017/electron-next)!**
+**You can find a detailed documentation about how to build Electron apps with Next.js [here](http://web.archive.org/web/20200917073558/https://leo.im/2017/electron-next)!**
 
 ## How to use
 

--- a/examples/with-electron-typescript/README.md
+++ b/examples/with-electron-typescript/README.md
@@ -10,7 +10,6 @@ This example show how you can use Next.js inside an Electron application to avoi
 
 For development it's going to run a HTTP server and let Next.js handle routing. In production it use `next export` to pre-generate HTML static files and use them in your app instead of running an HTTP server.
 
-**You can find a detailed documentation about how to build Electron apps with Next.js [here](http://web.archive.org/web/20200917073558/https://leo.im/2017/electron-next)!**
 
 ## How to use
 


### PR DESCRIPTION
Original article is no longer present on the site with no clear alternative. Given the article seems to be valid and informative, update the link to use the archive.org.