### PR TITLE
Fix error in example

### DIFF
--- a/examples/blog-starter-typescript/package.json
+++ b/examples/blog-starter-typescript/package.json
@@ -24,6 +24,8 @@
     "@types/node": "^14.0.1",
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
+    "autoprefixer": "^10.2.1",
+    "postcss": "^8.2.4",
     "postcss-preset-env": "^6.7.0",
     "tailwindcss": "^2.0.2"
   },

--- a/examples/blog-starter/package.json
+++ b/examples/blog-starter/package.json
@@ -17,10 +17,10 @@
     "remark-html": "13.0.1"
   },
   "devDependencies": {
-    "autoprefixer": "10.0.4",
-    "postcss": "8.1.10",
+    "autoprefixer": "^10.2.1",
+    "postcss": "^8.2.4",
     "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "2.0.1"
+    "tailwindcss": "^2.0.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
When you do a fresh install of the `blog-starter-typescript` example package, you get the following error after running `yarn dev`:

> giraffesyo@Michaels-MacBook-Pro blog-starter-typescript-app % yarn dev
yarn run v1.22.10
$ next
ready - started server on http://localhost:3000
error - ./styles/index.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-6-1!./node_modules/next/dist/compiled/postcss-loader/cjs.js??ref--5-oneOf-6-2!./styles/index.css)
Error: PostCSS plugin postcss-nested requires PostCSS 8.
Migration guide for end-users:
https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users

Tailwindcss 2.0 has moved autoprefixer and postcss to peer dependencies instead of dependencies. Their [installation guide](https://tailwindcss.com/docs/installation#install-tailwind-via-npm) mentions this. We need to add these as dev dependencies to resolve this error. This was already done in the non-typescript example but was missed here. 