### PR TITLE
Removed 'true' parameter - mapUserData.js

### DIFF
--- a/examples/with-firebase-authentication/utils/auth/mapUserData.js
+++ b/examples/with-firebase-authentication/utils/auth/mapUserData.js
@@ -1,6 +1,6 @@
 export const mapUserData = async (user) => {
   const { uid, email } = user
-  const token = await user.getIdToken(true)
+  const token = await user.getIdToken()
   return {
     id: uid,
     email,


### PR DESCRIPTION
Removing 'true' seems to fix the user `if` being called twice in the file being exported to. Not noticed any undesirable effect but I could be wrong.