### PR TITLE
Allow @next/bundle-analyzer to use webpack-bundle-analyzer options

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,10 +1,11 @@
-module.exports = ({ enabled = true } = {}) => (nextConfig = {}) => {
+module.exports = ({ enabled = true, ...bundleAnalyzerOptions } = {}) => (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (enabled) {
         const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
         config.plugins.push(
           new BundleAnalyzerPlugin({
+            ...bundleAnalyzerOptions,
             analyzerMode: 'static',
             reportFilename: options.isServer
               ? '../analyze/server.html'

--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -1,4 +1,6 @@
-module.exports = ({ enabled = true, ...bundleAnalyzerOptions } = {}) => (nextConfig = {}) => {
+module.exports = ({ enabled = true, ...bundleAnalyzerOptions } = {}) => (
+  nextConfig = {}
+) => {
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (enabled) {

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -21,6 +21,9 @@ Create a next.config.js (and make sure you have next-bundle-analyzer set up)
 ```js
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
+
+  // additional webpack-bundle-analyzer options:
+  defaultSizes: 'stat',
 })
 module.exports = withBundleAnalyzer({})
 ```


### PR DESCRIPTION
Updates the configuration for [@next/bundle-analyzer](https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer) to pass options to [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin), allowing for configuration as:

```js
const withBundleAnalyzer = require('@next/bundle-analyzer')({
  enabled: process.env.ANALYZE === 'true',
  defaultSizes: 'stat',
});
```