### PR TITLE
Add support for setting global API route config in next.config.js

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -32,6 +32,16 @@ export type NextConfig = { [key: string]: any } & {
 
   trailingSlash?: boolean
 
+  api?: {
+    externalResolver?: boolean
+    bodyParser?:
+      | {
+          sizeLimit?: string | number
+        }
+      | boolean
+      | null
+  } | null
+
   future: {
     strictPostcssConfiguration: boolean
     excludeDefaultMomentLocales: boolean

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1063,7 +1063,8 @@ export default class Server {
       pageModule,
       this.renderOpts.previewProps,
       false,
-      this.onErrorMiddleware
+      this.onErrorMiddleware,
+      this.nextConfig
     )
     return true
   }


### PR DESCRIPTION
# See #21006 for the "Why" of this PR

This adds support for settings global API route config defaults in `next.config.js` like so:

```JS
// next.config.js

module.exports = {
  api: {
    externalResolver: true
  }
}
```
