### PR TITLE
test: add webpack 5 basic build test

### DIFF
--- a/test/integration/webpack-5/app/package.json
+++ b/test/integration/webpack-5/app/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "webpack-5-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "resolutions": {
+    "webpack": "5.12.3"
+  }
+}

--- a/test/integration/webpack-5/app/pages/index.js
+++ b/test/integration/webpack-5/app/pages/index.js
@@ -1,0 +1,3 @@
+const Home = () => <h1>Hello World</h1>
+
+export default Home

--- a/test/integration/webpack-5/test/index.test.js
+++ b/test/integration/webpack-5/test/index.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+import fs from 'fs-extra'
+import path from 'path'
+import { runYarn, usingTempDir, pack } from '../../../lib/npm-utils'
+
+const appDir = path.join(__dirname, '..', 'app')
+
+jest.setTimeout(1000 * 60 * 5)
+
+describe('webpack 5 support', () => {
+  it('should build with webpack 5', async () => {
+    await usingTempDir(async (tempDir) => {
+      const nextTarballPath = await pack(tempDir, 'next')
+
+      const tempAppDir = path.join(tempDir, 'app')
+      await fs.copy(appDir, tempAppDir)
+
+      await runYarn(tempAppDir, 'add', nextTarballPath)
+      await runYarn(tempAppDir, 'install')
+
+      const { stdout, stderr } = await runYarn(tempAppDir, 'run', 'build')
+      console.log(stdout, stderr)
+      expect(stdout).toMatch(/Compiled successfully/)
+    })
+  })
+})

--- a/test/lib/npm-utils.js
+++ b/test/lib/npm-utils.js
@@ -1,0 +1,45 @@
+import execa from 'execa'
+import fs from 'fs-extra'
+import os from 'os'
+import path from 'path'
+
+const packagesDir = path.join(__dirname, '..', '..', 'packages')
+
+export const runYarn = (cwd, ...args) => execa('yarn', [...args], { cwd })
+
+export async function usingTempDir(fn) {
+  const folder = path.join(os.tmpdir(), Math.random().toString(36).substring(2))
+  await fs.mkdirp(folder)
+  try {
+    return await fn(folder)
+  } finally {
+    await fs.remove(folder)
+  }
+}
+
+/**
+ * Using 'npm pack', create a tarball of the given package in
+ * directory `pkg` and write it to `cwd`.
+ *
+ * `pkg` is relative to the monorepo 'packages/' directory.
+ *
+ * Return the absolute path to the tarball.
+ */
+export async function pack(cwd, pkg) {
+  const pkgDir = path.join(packagesDir, pkg)
+  const { stdout } = await execa(
+    'npm',
+    ['pack', '--ignore-scripts', path.join(packagesDir, pkg)],
+    { cwd }
+  )
+
+  const tarballFilename = stdout.match(/.*\.tgz/)[0]
+
+  if (!tarballFilename) {
+    throw new Error(
+      `npm failed to pack "next" package tarball in directory ${pkgDir}.`
+    )
+  }
+
+  return path.join(cwd, tarballFilename)
+}


### PR DESCRIPTION
# WIP

Add webpack 5 basic build test. Based on https://github.com/vercel/next.js/blob/canary/test/package-managers/pnpm/test/index.test.js.

Eventually I plan to add more complex cases, like importing CSS or using worker-loader.