### PR TITLE
fix hydration mismatch on href for url with anchor refs

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -266,7 +266,11 @@ export function resolveHref(
     typeof href === 'string' ? href : formatWithValidation(href)
   // Return because it cannot be routed by the Next.js router
   if (!isLocalURL(urlAsString)) {
-    return (resolveAs ? [urlAsString] : urlAsString) as string
+    // prevent a hydration mismatch on href for url with anchor refs
+    const resolvedHref = urlAsString.startsWith('#')
+      ? `/${urlAsString}`
+      : urlAsString
+    return (resolveAs ? [resolvedHref] : resolvedHref) as string
   }
   try {
     const finalUrl = new URL(urlAsString, base)


### PR DESCRIPTION


This PR fixes hydration mismatch on `<Link >` with anchor refs.
Since only client side is prefixed with `/` when you use Link with hash like this `<Link href="#hash" />`,  this will make sure that it is also prefixed in server side.