### PR TITLE
next/image: Support passing of the rootMargin prop

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -55,6 +55,7 @@ export type ImageProps = Omit<
   loader?: ImageLoader
   quality?: number | string
   priority?: boolean
+  rootMargin?: string,
   loading?: LoadingValue
   unoptimized?: boolean
   objectFit?: ImgElementStyle['objectFit']
@@ -190,6 +191,7 @@ export default function Image({
   sizes,
   unoptimized = false,
   priority = false,
+  rootMargin,
   loading,
   className,
   quality,
@@ -258,7 +260,7 @@ export default function Image({
   }
 
   const [setRef, isIntersected] = useIntersection<HTMLImageElement>({
-    rootMargin: '200px',
+    rootMargin: rootMargin || '200px',
     disabled: !isLazy,
   })
   const isVisible = !isLazy || isIntersected


### PR DESCRIPTION
## Concept
In some cases it's beneficial to load the images earlier for example with slower image hosts.

## How to use
```
<Image rootMargin="600px">
```