### PR TITLE
Add useCreateIndex to mongoose connection options

### DIFF
--- a/examples/with-mongodb-mongoose/utils/dbConnect.js
+++ b/examples/with-mongodb-mongoose/utils/dbConnect.js
@@ -11,6 +11,7 @@ async function dbConnect() {
     useNewUrlParser: true,
     useUnifiedTopology: true,
     useFindAndModify: false,
+    useCreateIndex: true,
   })
 }
 


### PR DESCRIPTION
Fixes the deprecation warning: `DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.`