### PR TITLE
fix: resolve two peer dep install warnings

### DIFF
--- a/packages/react-dev-overlay/package.json
+++ b/packages/react-dev-overlay/package.json
@@ -30,7 +30,6 @@
   },
   "peerDependencies": {
     "react": "^16.9.0 || ^17",
-    "react-dom": "^16.9.0 || ^17",
-    "webpack": "^4 || ^5"
+    "react-dom": "^16.9.0 || ^17"
   }
 }

--- a/packages/react-dev-overlay/src/middleware.ts
+++ b/packages/react-dev-overlay/src/middleware.ts
@@ -9,8 +9,8 @@ import {
 } from 'source-map'
 import { StackFrame } from 'stacktrace-parser'
 import url from 'url'
-// eslint-disable-next-line import/no-extraneous-dependencies
 // @ts-ignore
+// eslint-disable-next-line import/no-extraneous-dependencies
 import webpack from 'webpack'
 import { getRawSourceMap } from './internal/helpers/getRawSourceMap'
 import { launchEditor } from './internal/helpers/launchEditor'

--- a/packages/react-refresh-utils/package.json
+++ b/packages/react-refresh-utils/package.json
@@ -22,6 +22,11 @@
     "react-refresh": "0.8.3",
     "webpack": "^4 || ^5"
   },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "react-refresh": "0.8.3"
   }


### PR DESCRIPTION
This removes the peer dep on `webpack` from `react-dev-overlay`, as it is for types only.

This makes the peer dep on `webpack` optional for `react-refresh-utils`, as you can provide webpack via the constructor (how Next.js does).