### PR TITLE
Ensure react loadable manifest includes all needed requests

### DIFF
--- a/packages/next/build/webpack/plugins/react-loadable-plugin.ts
+++ b/packages/next/build/webpack/plugins/react-loadable-plugin.ts
@@ -88,6 +88,29 @@ function buildManifest(
           }
         })
       })
+
+      // ensure all requests are included even if no nested chunks
+      if (!manifest[request]) {
+        const requestDependency = chunkGroupOrigin.module.blocks.find(
+          (block: any) => block.request === request
+        ).dependencies[0]
+
+        let requestId
+
+        if (isWebpack5) {
+          // @ts-ignore
+          requestId = compilation.moduleGraph.getModule(requestDependency).id
+        } else {
+          requestId = requestDependency.module.id
+        }
+
+        manifest[request] = [
+          {
+            id: requestId,
+            file: requestId,
+          },
+        ]
+      }
     })
   })
 


### PR DESCRIPTION
In some cases the react loadable manifest might not contain a needed request due to no chunk files being present under the chunk origin. This corrects it by ensuring the request is still recorded in the react loadable manifest. 

TODO: 

- [ ] add test case
- [ ] clean up patch using proper webpack APIs

x-ref: https://github.com/vercel/next.js/issues/22741