### PR TITLE
Add standard .env to .gitignore

### DIFF
--- a/packages/create-next-app/templates/default/gitignore
+++ b/packages/create-next-app/templates/default/gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 # vercel
 .vercel


### PR DESCRIPTION
Hey!!

So I'm a big user of the create next app command, but I often add a `.env` file to the folder and then in a few very rare cases I may have committed these files 😱 

I think that we should add the standard `.env` to avoid this. I know many people use different `.env` files such as `.env.local` but I don't see any harm in adding the plain one. Please do correct me if I am wrong :)

Thanks!

\-Sam
