### PR TITLE
Test legacy Sass support with Webpack 5

### DIFF
--- a/test/integration/legacy-sass/test/index.test.js
+++ b/test/integration/legacy-sass/test/index.test.js
@@ -7,17 +7,11 @@ import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
 import { join } from 'path'
 import { version } from 'webpack'
 
-const isWebpack5 = parseInt(version) === 5
-
 jest.setTimeout(1000 * 60 * 1)
 
 const appDir = join(__dirname, '../')
 
-// TODO: Make legacy Sass support work with webpack 5
-const describeFn = isWebpack5 ? describe.skip : describe
-
-// TODO: Make legacy Sass support work with webpack 5
-describeFn('Legacy Sass Support Should Disable New CSS', () => {
+describe('Legacy Sass Support Should Disable New CSS', () => {
   beforeAll(async () => {
     await remove(join(appDir, '.next'))
     await nextBuild(appDir)
@@ -33,7 +27,7 @@ describeFn('Legacy Sass Support Should Disable New CSS', () => {
   })
 })
 
-describeFn('Legacy Sass Support should work in development', () => {
+describe('Legacy Sass Support should work in development', () => {
   beforeAll(async () => {
     await remove(join(appDir, '.next'))
   })

--- a/test/integration/legacy-sass/test/index.test.js
+++ b/test/integration/legacy-sass/test/index.test.js
@@ -5,7 +5,6 @@ import { findPort, killApp, launchApp, nextBuild } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
 import { join } from 'path'
-import { version } from 'webpack'
 
 jest.setTimeout(1000 * 60 * 1)
 


### PR DESCRIPTION
at some point, legacy Sass was fixed to work with Webpack 5 but a test for this was never added. This patch enables the test for Webpack 5 and legacy Sass