### PR TITLE
delete entry from url query parameter if it's null or undefined

### DIFF
--- a/packages/next/next-server/lib/router/utils/querystring.ts
+++ b/packages/next/next-server/lib/router/utils/querystring.ts
@@ -33,7 +33,9 @@ export function urlQueryToSearchParams(
 ): URLSearchParams {
   const result = new URLSearchParams()
   Object.entries(urlQuery).forEach(([key, value]) => {
-    if (Array.isArray(value)) {
+    if (value === null || value === undefined) {
+      result.delete(key)
+    } else if (Array.isArray(value)) {
       value.forEach((item) => result.append(key, stringifyUrlQueryParam(item)))
     } else {
       result.set(key, stringifyUrlQueryParam(value))


### PR DESCRIPTION
Problem:
Consider the following URL: `http://localhost:3000/user?name=prasanna&action=view`. If we need to remove the `action` from the query parameter, then using router.push or router.replace results in this awkward url: `http://localhost:3000/user?name=prasanna&action=`.

Code:
```
router.push({
  query: {
    name: null
  }
})
```

Solution:
This PR fixes the problem by adding conditional check while parsing the querystring.