### PR TITLE
fix(example): Add react version settings on .eslintrc.json in with-typescript-eslint-jest example

### DIFF
--- a/examples/with-typescript-eslint-jest/.eslintrc.json
+++ b/examples/with-typescript-eslint-jest/.eslintrc.json
@@ -16,6 +16,11 @@
     "jest": true,
     "node": true
   },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "rules": {
     "react/react-in-jsx-scope": 0,
     "react/display-name": 0,


### PR DESCRIPTION
closes vercel/next.js#21162

- Add react version settings on `.eslintrc.json`