### PR TITLE
Fix bug in Mobile Safari

### DIFF
--- a/packages/next/client/head-manager.ts
+++ b/packages/next/client/head-manager.ts
@@ -79,7 +79,7 @@ function updateElements(type: string, components: JSX.Element[]): void {
     }
   )
 
-  oldTags.forEach((t) => t.parentNode!.removeChild(t))
+  oldTags.forEach((t) => t.parentNode?.removeChild(t))
   newTags.forEach((t) => headEl.insertBefore(t, headCountEl))
   headCountEl.content = (headCount - oldTags.length + newTags.length).toString()
 }


### PR DESCRIPTION
Was seeing an issue in production on our Bugsnag logs for mobile safari.

TypeError · null is not an object (evaluating 't.parentNode.removeChild')