### PR TITLE
Enable fetchOptions for next/image

### DIFF
--- a/packages/next/next-server/server/image-config.ts
+++ b/packages/next/next-server/server/image-config.ts
@@ -13,6 +13,7 @@ export type ImageConfig = {
   loader: LoaderValue
   path: string
   domains?: string[]
+  fetchOptions?: RequestInit
 }
 
 export const imageConfigDefault: ImageConfig = {

--- a/packages/next/next-server/server/image-optimizer.ts
+++ b/packages/next/next-server/server/image-optimizer.ts
@@ -33,7 +33,13 @@ export async function imageOptimizer(
 ) {
   const { nextConfig, distDir } = server
   const imageData: ImageConfig = nextConfig.images || imageConfigDefault
-  const { deviceSizes = [], imageSizes = [], domains = [], loader } = imageData
+  const {
+    deviceSizes = [],
+    imageSizes = [],
+    domains = [],
+    loader,
+    fetchOptions,
+  } = imageData
 
   if (loader !== 'default') {
     await server.render404(req, res, parsedUrl)
@@ -163,7 +169,7 @@ export async function imageOptimizer(
   let maxAge: number
 
   if (isAbsolute) {
-    const upstreamRes = await fetch(href)
+    const upstreamRes = await fetch(href, fetchOptions)
 
     if (!upstreamRes.ok) {
       res.statusCode = upstreamRes.status


### PR DESCRIPTION
Hey,

there was an [issue](https://github.com/vercel/next.js/issues/20837) opened about being able to pass some options to the fetch request issued by the image optimizer. 
I'm not sure that this is the best way to resolve it. If not, please let me know.