### PR TITLE
Preserve asPath while resolving rewrites

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -213,7 +213,7 @@ export default async function getBaseWebpackConfig(
   let plugins: PluginMetaData[] = []
   let babelPresetPlugins: { dir: string; config: any }[] = []
 
-  const hasRewrites = rewrites.length > 0 || dev
+  const hasRewrites = rewrites.length > 0
 
   if (config.experimental.plugins) {
     plugins = await collectPlugins(dir, config.env, config.plugins)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -341,6 +341,13 @@ export default async function getBaseWebpackConfig(
     }
   }
 
+  const clientResolveRewrites = require.resolve(
+    'next/dist/next-server/lib/router/utils/resolve-rewrites'
+  )
+  const clientResolveRewritesNoop = require.resolve(
+    'next/dist/next-server/lib/router/utils/resolve-rewrites-noop'
+  )
+
   const resolveConfig = {
     // Disable .mjs for node_modules bundling
     extensions: isServer
@@ -379,6 +386,9 @@ export default async function getBaseWebpackConfig(
       [DOT_NEXT_ALIAS]: distDir,
       ...getOptimizedAliases(isServer),
       ...getReactProfilingInProduction(),
+      [clientResolveRewrites]: hasRewrites
+        ? clientResolveRewrites
+        : clientResolveRewritesNoop,
     },
     mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
     plugins: isWebpack5

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -341,10 +341,6 @@ export default async function getBaseWebpackConfig(
     }
   }
 
-  const clientResolveRewrites = require.resolve(
-    'next/dist/next-server/lib/router/utils/resolve-rewrites'
-  )
-
   const resolveConfig = {
     // Disable .mjs for node_modules bundling
     extensions: isServer
@@ -383,9 +379,6 @@ export default async function getBaseWebpackConfig(
       [DOT_NEXT_ALIAS]: distDir,
       ...getOptimizedAliases(isServer),
       ...getReactProfilingInProduction(),
-      [clientResolveRewrites]: hasRewrites
-        ? clientResolveRewrites
-        : require.resolve('next/dist/client/dev/noop.js'),
     },
     mainFields: isServer ? ['main', 'module'] : ['browser', 'module', 'main'],
     plugins: isWebpack5

--- a/packages/next/next-server/lib/router/utils/resolve-rewrites-noop.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites-noop.ts
@@ -1,0 +1,1 @@
+export default function resolveRewrites() {}

--- a/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
@@ -16,7 +16,12 @@ export default function resolveRewrites(
   query: ParsedUrlQuery,
   resolveHref: (path: string) => string,
   locales?: string[]
-) {
+): {
+  matchedPage: boolean
+  parsedAs: ReturnType<typeof parseRelativeUrl>
+  asPath: string
+  resolvedHref?: string
+} {
   let matchedPage = false
   let parsedAs = parseRelativeUrl(asPath)
   let fsPathname = removePathTrailingSlash(
@@ -69,7 +74,6 @@ export default function resolveRewrites(
   return {
     asPath,
     parsedAs,
-    fsPathname,
     matchedPage,
     resolvedHref,
   }

--- a/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
@@ -4,6 +4,8 @@ import prepareDestination from './prepare-destination'
 import { Rewrite } from '../../../../lib/load-custom-routes'
 import { removePathTrailingSlash } from '../../../../client/normalize-trailing-slash'
 import { normalizeLocalePath } from '../../i18n/normalize-locale-path'
+import { parseRelativeUrl } from './parse-relative-url'
+import { delBasePath } from '../router'
 
 const customRouteMatcher = pathMatch(true)
 
@@ -15,10 +17,17 @@ export default function resolveRewrites(
   resolveHref: (path: string) => string,
   locales?: string[]
 ) {
-  if (!pages.includes(normalizeLocalePath(asPath, locales).pathname)) {
+  let matchedPage = false
+  let parsedAs = parseRelativeUrl(asPath)
+  let fsPathname = removePathTrailingSlash(
+    normalizeLocalePath(delBasePath(parsedAs.pathname), locales).pathname
+  )
+  let resolvedHref
+
+  if (!pages.includes(fsPathname)) {
     for (const rewrite of rewrites) {
       const matcher = customRouteMatcher(rewrite.source)
-      const params = matcher(asPath)
+      const params = matcher(parsedAs.pathname)
 
       if (params) {
         if (!rewrite.destination) {
@@ -31,30 +40,37 @@ export default function resolveRewrites(
           query,
           true
         )
-        asPath = destRes.parsedDestination.pathname!
+        parsedAs = destRes.parsedDestination
+        asPath = destRes.newUrl
         Object.assign(query, destRes.parsedDestination.query)
 
-        const fsPathname = normalizeLocalePath(
-          removePathTrailingSlash(asPath),
-          locales
-        ).pathname
+        fsPathname = removePathTrailingSlash(
+          normalizeLocalePath(delBasePath(asPath), locales).pathname
+        )
 
         if (pages.includes(fsPathname)) {
-          asPath = fsPathname
           // check if we now match a page as this means we are done
           // resolving the rewrites
+          matchedPage = true
+          resolvedHref = fsPathname
           break
         }
 
         // check if we match a dynamic-route, if so we break the rewrites chain
-        const resolvedHref = resolveHref(fsPathname)
+        resolvedHref = resolveHref(fsPathname)
 
         if (resolvedHref !== asPath && pages.includes(resolvedHref)) {
-          asPath = fsPathname
+          matchedPage = true
           break
         }
       }
     }
   }
-  return asPath
+  return {
+    asPath,
+    parsedAs,
+    fsPathname,
+    matchedPage,
+    resolvedHref,
+  }
 }

--- a/test/integration/custom-routes-i18n/test/index.test.js
+++ b/test/integration/custom-routes-i18n/test/index.test.js
@@ -94,7 +94,13 @@ const runTests = () => {
       await browser.elementByCss('#to-about').click()
 
       await check(async () => {
-        const data = JSON.parse(await browser.elementByCss('#data').text())
+        const data = JSON.parse(
+          cheerio
+            .load(await browser.eval('document.documentElement.innerHTML'))(
+              '#data'
+            )
+            .text()
+        )
         console.log(data)
         return data.url === `${expectedIndex ? '/fr' : ''}/about`
           ? 'success'
@@ -108,7 +114,13 @@ const runTests = () => {
         .click()
 
       await check(async () => {
-        const data = JSON.parse(await browser.elementByCss('#data').text())
+        const data = JSON.parse(
+          cheerio
+            .load(await browser.eval('document.documentElement.innerHTML'))(
+              '#data'
+            )
+            .text()
+        )
         console.log(data)
         return data.url === `${expectedIndex ? '/fr' : ''}/hello`
           ? 'success'

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -10,6 +10,7 @@ import {
   stopApp,
   waitFor,
   getPageFileFromPagesManifest,
+  check,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import {
@@ -858,6 +859,27 @@ describe('Production Usage', () => {
       }
     }
     expect(missing).toBe(false)
+  })
+
+  it('should preserve query when hard navigating from page 404', async () => {
+    const browser = await webdriver(appPort, '/')
+    await browser.eval(`(function() {
+      window.beforeNav = 1
+      window.next.router.push({
+        pathname: '/non-existent',
+        query: { hello: 'world' }
+      })
+    })()`)
+
+    await check(
+      () => browser.eval('document.documentElement.innerHTML'),
+      /page could not be found/
+    )
+
+    expect(await browser.eval('window.beforeNav')).toBe(null)
+    expect(await browser.eval('window.location.hash')).toBe('')
+    expect(await browser.eval('window.location.search')).toBe('?hello=world')
+    expect(await browser.eval('window.location.pathname')).toBe('/non-existent')
   })
 
   dynamicImportTests(context, (p, q) => renderViaHTTP(context.appPort, p, q))


### PR DESCRIPTION
This ensures we don't modify the provided `asPath` value when resolving rewrites on the client since this value is used when triggering a full-navigation due to a page's data not being able to load. This also ensures that the rewrites resolving is only run when rewrites are present and not always enabled as it was in development since we didn't need to dead-code eliminate it. An additional test has been added to the production suite to ensure the `asPath` isn't modified by ensuring the query is still present since it was previously being dropped after resolving during a hard navigation.

Fixes: https://github.com/vercel/next.js/issues/21267
Fixes: https://github.com/vercel/next.js/issues/20058 