### PR TITLE
docs: example added with-apollo-ssr-get-data-from-tree to showcase on component basis ssr data fetching

### DIFF
--- a/examples/with-apollo-ssr-get-data-from-tree/.gitignore
+++ b/examples/with-apollo-ssr-get-data-from-tree/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/with-apollo-ssr-get-data-from-tree/README.md
+++ b/examples/with-apollo-ssr-get-data-from-tree/README.md
@@ -1,6 +1,6 @@
 # Apollo SSR getDataFromTree Example
-In this example you can see how you can achieve SSR data fetching on a per component basis without having to (pre)fetch in getInitialProps.
 
+In this example you can see how you can achieve SSR data fetching on a per component basis without having to (pre)fetch in getInitialProps.
 
 [Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run.
 
@@ -12,10 +12,8 @@ This function walks down the entire tree and executes every required query it en
 
 When the Promise resolves, you're ready to render your React tree and return it, along with the current state of the Apollo Client cache.
 
-
 We use a class instance called ApolloCacheControl to manage all registered caches. So we can have multiple caches in case we have multiple Apollo clients.
 After the getDataFromTree has resolved all promises we get a snapshot of the cache and hydrate that to the client where we use is as an initial state for our Apollo client.
-
 
 For the ease of making this example we took the PostList and other components from the with-apollo-ssr example.
 This example relies on [Prisma + Nexus](https://github.com/prisma-labs/nextjs-graphql-api-examples) for its GraphQL backend.

--- a/examples/with-apollo-ssr-get-data-from-tree/README.md
+++ b/examples/with-apollo-ssr-get-data-from-tree/README.md
@@ -1,0 +1,37 @@
+# Apollo SSR getDataFromTree Example
+
+[Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run.
+
+In this simple example, we integrate Apollo with Apollo's [getDataFromTree](https://www.apollographql.com/docs/react/performance/server-side-rendering/#executing-queries-with-getdatafromtree) to fetch queries on the server from inside any component and hydrate them in the client.
+
+Because our app uses Apollo Client, some of the components in the React tree probably execute a GraphQL query with the useQuery hook. We can instruct Apollo Client to execute all of the queries required by the tree's components with the getDataFromTree function.
+
+This function walks down the entire tree and executes every required query it encounters (including nested queries). It returns a Promise that resolves when all result data is ready in the Apollo Client cache.
+
+When the Promise resolves, you're ready to render your React tree and return it, along with the current state of the Apollo Client cache.
+
+
+We use a class instance called ApolloCacheControl to manage all registered caches. So we can have multiple caches in case we have multiple Apollo clients.
+After the getDataFromTree has resolved all promises we get a snapshot of the cache and hydrate that to the client where we use is as an initial state for our Apollo client.
+
+
+For the ease of making this example we took the PostList and other components from the with-apollo-ssr example.
+This example relies on [Prisma + Nexus](https://github.com/prisma-labs/nextjs-graphql-api-examples) for its GraphQL backend.
+
+## Deploy
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-apollo-ssr-get-data-from-tree&project-name=with-apollo-ssr-get-data-from-tree&repository-name=with-apollo-ssr-get-data-from-tree)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-apollo-ssr-get-data-from-tree with-apollo-ssr-app
+# or
+yarn create next-app --example with-apollo-ssr-get-data-from-tree with-apollo-ssr-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-apollo-ssr-get-data-from-tree/README.md
+++ b/examples/with-apollo-ssr-get-data-from-tree/README.md
@@ -1,4 +1,6 @@
 # Apollo SSR getDataFromTree Example
+In this example you can see how you can achieve SSR data fetching on a per component basis without using getInitialProps.
+
 
 [Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run.
 

--- a/examples/with-apollo-ssr-get-data-from-tree/README.md
+++ b/examples/with-apollo-ssr-get-data-from-tree/README.md
@@ -1,5 +1,5 @@
 # Apollo SSR getDataFromTree Example
-In this example you can see how you can achieve SSR data fetching on a per component basis without using getInitialProps.
+In this example you can see how you can achieve SSR data fetching on a per component basis without having to (pre)fetch in getInitialProps.
 
 
 [Apollo](https://www.apollographql.com/client/) is a GraphQL client that allows you to easily query the exact data you need from a GraphQL server. In addition to fetching and mutating data, Apollo analyzes your queries and their results to construct a client-side cache of your data, which is kept up to date as further queries and mutations are run.

--- a/examples/with-apollo-ssr-get-data-from-tree/components/App.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/components/App.js
@@ -1,0 +1,47 @@
+export default function App({ children }) {
+  return (
+    <main>
+      {children}
+      <style jsx global>{`
+        * {
+          font-family: Menlo, Monaco, 'Lucida Console', 'Liberation Mono',
+            'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New',
+            monospace, serif;
+        }
+        body {
+          margin: 0;
+          padding: 25px 50px;
+        }
+        a {
+          color: #22bad9;
+        }
+        p {
+          font-size: 14px;
+          line-height: 24px;
+        }
+        article {
+          margin: 0 auto;
+          max-width: 650px;
+        }
+        button {
+          align-items: center;
+          background-color: #22bad9;
+          border: 0;
+          color: white;
+          display: flex;
+          padding: 5px 7px;
+          transition: background-color 0.3s;
+        }
+        button:active {
+          background-color: #1b9db7;
+        }
+        button:disabled {
+          background-color: #b5bebf;
+        }
+        button:focus {
+          outline: none;
+        }
+      `}</style>
+    </main>
+  )
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/components/ErrorMessage.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/components/ErrorMessage.js
@@ -1,0 +1,15 @@
+export default function ErrorMessage({ message }) {
+  return (
+    <aside>
+      {message}
+      <style jsx>{`
+        aside {
+          padding: 1.5em;
+          font-size: 14px;
+          color: white;
+          background-color: red;
+        }
+      `}</style>
+    </aside>
+  )
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/components/InfoBox.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/components/InfoBox.js
@@ -1,0 +1,17 @@
+const InfoBox = ({ children }) => (
+  <div className="info">
+    <style jsx>{`
+      .info {
+        margin-top: 20px;
+        margin-bottom: 20px;
+        padding-top: 20px;
+        padding-bottom: 20px;
+        border-top: 1px solid #ececec;
+        border-bottom: 1px solid #ececec;
+      }
+    `}</style>
+    {children}
+  </div>
+)
+
+export default InfoBox

--- a/examples/with-apollo-ssr-get-data-from-tree/components/PostList.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/components/PostList.js
@@ -1,0 +1,111 @@
+import { gql, useQuery, NetworkStatus } from '@apollo/client'
+import ErrorMessage from './ErrorMessage'
+import PostUpvoter from './PostUpvoter'
+
+export const ALL_POSTS_QUERY = gql`
+  query allPosts($first: Int!, $skip: Int!) {
+    allPosts(orderBy: { createdAt: desc }, first: $first, skip: $skip) {
+      id
+      title
+      votes
+      url
+      createdAt
+    }
+    _allPostsMeta {
+      count
+    }
+  }
+`
+
+export const allPostsQueryVars = {
+  skip: 0,
+  first: 10,
+}
+
+export default function PostList() {
+  const { loading, error, data, fetchMore, networkStatus } = useQuery(
+    ALL_POSTS_QUERY,
+    {
+      variables: allPostsQueryVars,
+      // Setting this value to true will make the component rerender when
+      // the "networkStatus" changes, so we are able to know if it is fetching
+      // more data
+      notifyOnNetworkStatusChange: true,
+    }
+  )
+
+  const loadingMorePosts = networkStatus === NetworkStatus.fetchMore
+
+  const loadMorePosts = () => {
+    fetchMore({
+      variables: {
+        skip: allPosts.length,
+      },
+    })
+  }
+
+  if (error) return <ErrorMessage message="Error loading posts." />
+  if (loading && !loadingMorePosts) return <div>Loading</div>
+
+  const { allPosts, _allPostsMeta } = data
+  const areMorePosts = allPosts.length < _allPostsMeta.count
+
+  return (
+    <section>
+      <ul>
+        {allPosts.map((post, index) => (
+          <li key={post.id}>
+            <div>
+              <span>{index + 1}. </span>
+              <a href={post.url}>{post.title}</a>
+              <PostUpvoter id={post.id} votes={post.votes} />
+            </div>
+          </li>
+        ))}
+      </ul>
+      {areMorePosts && (
+        <button onClick={() => loadMorePosts()} disabled={loadingMorePosts}>
+          {loadingMorePosts ? 'Loading...' : 'Show More'}
+        </button>
+      )}
+      <style jsx>{`
+        section {
+          padding-bottom: 20px;
+        }
+        li {
+          display: block;
+          margin-bottom: 10px;
+        }
+        div {
+          align-items: center;
+          display: flex;
+        }
+        a {
+          font-size: 14px;
+          margin-right: 10px;
+          text-decoration: none;
+          padding-bottom: 0;
+          border: 0;
+        }
+        span {
+          font-size: 14px;
+          margin-right: 5px;
+        }
+        ul {
+          margin: 0;
+          padding: 0;
+        }
+        button:before {
+          align-self: center;
+          border-style: solid;
+          border-width: 6px 4px 0 4px;
+          border-color: #ffffff transparent transparent transparent;
+          content: '';
+          height: 0;
+          margin-right: 5px;
+          width: 0;
+        }
+      `}</style>
+    </section>
+  )
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/components/PostUpvoter.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/components/PostUpvoter.js
@@ -1,0 +1,57 @@
+import { gql, useMutation } from '@apollo/client'
+
+const UPDATE_POST_MUTATION = gql`
+  mutation votePost($id: String!) {
+    votePost(id: $id) {
+      id
+      votes
+      __typename
+    }
+  }
+`
+
+export default function PostUpvoter({ votes, id }) {
+  const [updatePost] = useMutation(UPDATE_POST_MUTATION)
+
+  const upvotePost = () => {
+    updatePost({
+      variables: {
+        id,
+      },
+      optimisticResponse: {
+        __typename: 'Mutation',
+        votePost: {
+          __typename: 'Post',
+          id,
+          votes: votes + 1,
+        },
+      },
+    })
+  }
+
+  return (
+    <button onClick={() => upvotePost()}>
+      {votes}
+      <style jsx>{`
+        button {
+          background-color: transparent;
+          border: 1px solid #e4e4e4;
+          color: #000;
+        }
+        button:active {
+          background-color: transparent;
+        }
+        button:before {
+          align-self: center;
+          border-color: transparent transparent #000000 transparent;
+          border-style: solid;
+          border-width: 0 4px 6px 4px;
+          content: '';
+          height: 0;
+          margin-right: 5px;
+          width: 0;
+        }
+      `}</style>
+    </button>
+  )
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/ApolloCacheControl.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/ApolloCacheControl.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+export class ApolloCacheControl {
+  cacheInstances = new Map();
+  storedExtractedCache = new Map();
+
+  static context
+  
+  static getContext() {
+    if (!ApolloCacheControl.context) {
+      ApolloCacheControl.context = React.createContext(null);
+    }
+
+    return ApolloCacheControl.context;
+  }
+
+  registerCache(key, cache) {
+    if (this.cacheInstances.has(key)) {
+      const extractedCache = this.extractCache(key);
+      if (extractedCache) {
+        this.cacheInstances.set(key, cache.restore(extractedCache));
+      }
+      return;
+    }
+    this.cacheInstances.set(key, cache);
+  }
+
+  extractCache(key) {
+    const cache = this.cacheInstances.get(key);
+    if (cache) {
+      return cache.extract();
+    }
+
+    return null;
+  }
+
+  getExtractedCache(key) {
+    return this.storedExtractedCache.get(key);
+  }
+
+  getSnapshot() {
+    const allCacheExtracts = {};
+    this.cacheInstances.forEach((value, key) => {
+      allCacheExtracts[key] = value.extract();
+    });
+    return allCacheExtracts;
+  }
+
+  restoreSnapshot(snapshot) {
+    for (const key in snapshot) {
+      this.storedExtractedCache.set(key, snapshot[key]);
+    }
+  }
+
+  seal() {
+    this.cacheInstances.clear();
+    this.storedExtractedCache.clear();
+  }
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/ApolloCacheControl.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/ApolloCacheControl.js
@@ -1,59 +1,59 @@
-import React from 'react';
+import React from 'react'
 
 export class ApolloCacheControl {
-  cacheInstances = new Map();
-  storedExtractedCache = new Map();
+  cacheInstances = new Map()
+  storedExtractedCache = new Map()
 
   static context
-  
+
   static getContext() {
     if (!ApolloCacheControl.context) {
-      ApolloCacheControl.context = React.createContext(null);
+      ApolloCacheControl.context = React.createContext(null)
     }
 
-    return ApolloCacheControl.context;
+    return ApolloCacheControl.context
   }
 
   registerCache(key, cache) {
     if (this.cacheInstances.has(key)) {
-      const extractedCache = this.extractCache(key);
+      const extractedCache = this.extractCache(key)
       if (extractedCache) {
-        this.cacheInstances.set(key, cache.restore(extractedCache));
+        this.cacheInstances.set(key, cache.restore(extractedCache))
       }
-      return;
+      return
     }
-    this.cacheInstances.set(key, cache);
+    this.cacheInstances.set(key, cache)
   }
 
   extractCache(key) {
-    const cache = this.cacheInstances.get(key);
+    const cache = this.cacheInstances.get(key)
     if (cache) {
-      return cache.extract();
+      return cache.extract()
     }
 
-    return null;
+    return null
   }
 
   getExtractedCache(key) {
-    return this.storedExtractedCache.get(key);
+    return this.storedExtractedCache.get(key)
   }
 
   getSnapshot() {
-    const allCacheExtracts = {};
+    const allCacheExtracts = {}
     this.cacheInstances.forEach((value, key) => {
-      allCacheExtracts[key] = value.extract();
-    });
-    return allCacheExtracts;
+      allCacheExtracts[key] = value.extract()
+    })
+    return allCacheExtracts
   }
 
   restoreSnapshot(snapshot) {
     for (const key in snapshot) {
-      this.storedExtractedCache.set(key, snapshot[key]);
+      this.storedExtractedCache.set(key, snapshot[key])
     }
   }
 
   seal() {
-    this.cacheInstances.clear();
-    this.storedExtractedCache.clear();
+    this.cacheInstances.clear()
+    this.storedExtractedCache.clear()
   }
 }

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/apolloClient.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/apolloClient.js
@@ -1,0 +1,50 @@
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
+import { concatPagination } from '@apollo/client/utilities'
+import { useMemo } from 'react'
+
+let apolloClient
+
+function createApolloClient(registerCache, initialState) {
+  const cache = new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          allPosts: concatPagination(),
+        },
+      },
+    },
+  }).restore(initialState || {});
+
+  if (registerCache) {
+    registerCache(cache);
+  }
+
+  const link = new HttpLink({
+    uri: 'https://nextjs-graphql-with-prisma-simple.vercel.app/api', // Server URL (must be absolute)
+    credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
+  })
+  
+  return new ApolloClient({
+    ssrMode: typeof window === 'undefined',
+    link,
+    cache
+  })
+}
+
+export function initializeApollo(registerCache, initialState) {
+  const _apolloClient = apolloClient ?? createApolloClient(registerCache, initialState)
+
+  // For SSG and SSR always create a new Apollo Client
+  if (typeof window === 'undefined') return _apolloClient
+
+  // Create the Apollo Client once in the client
+  if (!apolloClient) apolloClient = _apolloClient
+
+  return _apolloClient
+}
+
+
+export function useApollo(registerCache, initialState) {
+  const store = useMemo(() => initializeApollo(registerCache, initialState), [registerCache, initialState])
+  return store
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/apolloClient.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/apolloClient.js
@@ -13,26 +13,27 @@ function createApolloClient(registerCache, initialState) {
         },
       },
     },
-  }).restore(initialState || {});
+  }).restore(initialState || {})
 
   if (registerCache) {
-    registerCache(cache);
+    registerCache(cache)
   }
 
   const link = new HttpLink({
     uri: 'https://nextjs-graphql-with-prisma-simple.vercel.app/api', // Server URL (must be absolute)
     credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
   })
-  
+
   return new ApolloClient({
     ssrMode: typeof window === 'undefined',
     link,
-    cache
+    cache,
   })
 }
 
 export function initializeApollo(registerCache, initialState) {
-  const _apolloClient = apolloClient ?? createApolloClient(registerCache, initialState)
+  const _apolloClient =
+    apolloClient ?? createApolloClient(registerCache, initialState)
 
   // For SSG and SSR always create a new Apollo Client
   if (typeof window === 'undefined') return _apolloClient
@@ -43,8 +44,10 @@ export function initializeApollo(registerCache, initialState) {
   return _apolloClient
 }
 
-
 export function useApollo(registerCache, initialState) {
-  const store = useMemo(() => initializeApollo(registerCache, initialState), [registerCache, initialState])
+  const store = useMemo(() => initializeApollo(registerCache, initialState), [
+    registerCache,
+    initialState,
+  ])
   return store
 }

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/useApolloCacheControl.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/useApolloCacheControl.js
@@ -1,11 +1,11 @@
-import { useContext } from 'react';
-import { ApolloCacheControl } from './ApolloCacheControl';
+import { useContext } from 'react'
+import { ApolloCacheControl } from './ApolloCacheControl'
 
 export const useApolloCacheControl = () => {
-  const context = useContext(ApolloCacheControl.getContext());
+  const context = useContext(ApolloCacheControl.getContext())
   if (context === null) {
-    throw new Error('Cannot use useApolloCacheControl without context provider');
+    throw new Error('Cannot use useApolloCacheControl without context provider')
   }
 
-  return context;
-};
+  return context
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/useApolloCacheControl.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/useApolloCacheControl.js
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ApolloCacheControl } from './ApolloCacheControl';
+
+export const useApolloCacheControl = () => {
+  const context = useContext(ApolloCacheControl.getContext());
+  if (context === null) {
+    throw new Error('Cannot use useApolloCacheControl without context provider');
+  }
+
+  return context;
+};

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/withApolloServerSideRender.jsx
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/withApolloServerSideRender.jsx
@@ -1,0 +1,83 @@
+import App from 'next/app';
+import Head from 'next/head';
+import React, { useMemo } from 'react';
+import { ApolloCacheControl } from './ApolloCacheControl';
+
+
+
+// Gets the display name of a JSX component for dev tools
+function getDisplayName(Component) {
+  return Component.displayName || Component.name || 'Unknown';
+}
+
+export default function withApolloServerSideRender(PageComponent) {
+  const ApolloCacheControlContext = ApolloCacheControl.getContext();
+
+  function WithApollo({ apolloCacheControlSnapshot, apolloCacheControl, ...props }) {
+    const _apolloCacheControl = useMemo(
+      () => apolloCacheControl || new ApolloCacheControl(), [apolloCacheControl],
+    );
+
+    if (apolloCacheControlSnapshot && Object.keys(apolloCacheControlSnapshot).length) {
+      _apolloCacheControl.restoreSnapshot(apolloCacheControlSnapshot);
+    }
+    
+    return (
+      <ApolloCacheControlContext.Provider value={_apolloCacheControl}>
+        <PageComponent {...props} />
+      </ApolloCacheControlContext.Provider>
+    );
+  }
+
+  WithApollo.displayName = `WithApollo(${getDisplayName(PageComponent)})`;
+
+  WithApollo.getInitialProps = async (ctx) => {
+    const { AppTree } = ctx;
+    const isInAppContext = Boolean(ctx.ctx);
+
+    let pageProps = {};
+    if (PageComponent.getInitialProps) {
+      pageProps = { ...pageProps, ...(await PageComponent.getInitialProps(ctx)) };
+    } 
+
+    if (typeof window !== 'undefined') {
+      return pageProps;
+    }
+
+    if (ctx.res && (ctx.res.headersSent || ctx.res.writableEnded)) {
+      return pageProps;
+    }
+
+    const apolloCacheControl = new ApolloCacheControl();
+
+    try {
+      const { getDataFromTree } = await import('@apollo/client/react/ssr');
+      // Since AppComponents and PageComponents have different context types
+      // we need to modify their props a little.
+      let props;
+      if (isInAppContext) {
+        props = { ...pageProps, apolloCacheControl };
+      } else {
+        props = { pageProps: { ...pageProps, apolloCacheControl } };
+      }
+
+      await getDataFromTree(<AppTree {...props} />);
+    } catch (error) {
+      // Prevent Apollo Client GraphQL errors from crashing SSR.
+      // Handle them in components via the data.error prop:
+      // https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-query-data-error
+      apolloCacheControl.seal();
+      console.error('Error while running `getDataFromTree`', error);
+    }
+
+    // getDataFromTree does not call componentWillUnmount
+    // head side effect therefore need to be cleared manually
+    Head.rewind();
+    return {
+      ...pageProps,
+      apolloCacheControlSnapshot: apolloCacheControl.getSnapshot(),
+    };
+  };
+
+  return WithApollo;
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/lib/withApolloServerSideRender.jsx
+++ b/examples/with-apollo-ssr-get-data-from-tree/lib/withApolloServerSideRender.jsx
@@ -1,83 +1,91 @@
-import App from 'next/app';
-import Head from 'next/head';
-import React, { useMemo } from 'react';
-import { ApolloCacheControl } from './ApolloCacheControl';
-
-
+import Head from 'next/head'
+import React, { useMemo } from 'react'
+import { ApolloCacheControl } from './ApolloCacheControl'
 
 // Gets the display name of a JSX component for dev tools
 function getDisplayName(Component) {
-  return Component.displayName || Component.name || 'Unknown';
+  return Component.displayName || Component.name || 'Unknown'
 }
 
 export default function withApolloServerSideRender(PageComponent) {
-  const ApolloCacheControlContext = ApolloCacheControl.getContext();
+  const ApolloCacheControlContext = ApolloCacheControl.getContext()
 
-  function WithApollo({ apolloCacheControlSnapshot, apolloCacheControl, ...props }) {
+  function WithApollo({
+    apolloCacheControlSnapshot,
+    apolloCacheControl,
+    ...props
+  }) {
     const _apolloCacheControl = useMemo(
-      () => apolloCacheControl || new ApolloCacheControl(), [apolloCacheControl],
-    );
+      () => apolloCacheControl || new ApolloCacheControl(),
+      [apolloCacheControl]
+    )
 
-    if (apolloCacheControlSnapshot && Object.keys(apolloCacheControlSnapshot).length) {
-      _apolloCacheControl.restoreSnapshot(apolloCacheControlSnapshot);
+    if (
+      apolloCacheControlSnapshot &&
+      Object.keys(apolloCacheControlSnapshot).length
+    ) {
+      _apolloCacheControl.restoreSnapshot(apolloCacheControlSnapshot)
     }
-    
+
     return (
       <ApolloCacheControlContext.Provider value={_apolloCacheControl}>
         <PageComponent {...props} />
       </ApolloCacheControlContext.Provider>
-    );
+    )
   }
 
-  WithApollo.displayName = `WithApollo(${getDisplayName(PageComponent)})`;
+  WithApollo.displayName = `WithApollo(${getDisplayName(PageComponent)})`
 
   WithApollo.getInitialProps = async (ctx) => {
-    const { AppTree } = ctx;
-    const isInAppContext = Boolean(ctx.ctx);
+    const { AppTree } = ctx
+    const isInAppContext = Boolean(ctx.ctx)
 
-    let pageProps = {};
+    let pageProps = {}
     if (PageComponent.getInitialProps) {
-      pageProps = { ...pageProps, ...(await PageComponent.getInitialProps(ctx)) };
-    } 
+      pageProps = {
+        ...pageProps,
+        ...(await PageComponent.getInitialProps(ctx)),
+      }
+    }
 
     if (typeof window !== 'undefined') {
-      return pageProps;
+      return pageProps
     }
 
     if (ctx.res && (ctx.res.headersSent || ctx.res.writableEnded)) {
-      return pageProps;
+      return pageProps
     }
 
-    const apolloCacheControl = new ApolloCacheControl();
+    const apolloCacheControl = new ApolloCacheControl()
 
     try {
-      const { getDataFromTree } = await import('@apollo/client/react/ssr');
+      const { getDataFromTree } = await import('@apollo/client/react/ssr')
       // Since AppComponents and PageComponents have different context types
       // we need to modify their props a little.
-      let props;
+      let props
       if (isInAppContext) {
-        props = { ...pageProps, apolloCacheControl };
+        props = { ...pageProps, apolloCacheControl }
       } else {
-        props = { pageProps: { ...pageProps, apolloCacheControl } };
+        props = { pageProps: { ...pageProps, apolloCacheControl } }
       }
 
-      await getDataFromTree(<AppTree {...props} />);
+      await getDataFromTree(<AppTree {...props} />)
     } catch (error) {
       // Prevent Apollo Client GraphQL errors from crashing SSR.
       // Handle them in components via the data.error prop:
       // https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-query-data-error
-      apolloCacheControl.seal();
-      console.error('Error while running `getDataFromTree`', error);
+      apolloCacheControl.seal()
+      console.error('Error while running `getDataFromTree`', error)
     }
 
     // getDataFromTree does not call componentWillUnmount
     // head side effect therefore need to be cleared manually
-    Head.rewind();
+    Head.rewind()
     return {
       ...pageProps,
       apolloCacheControlSnapshot: apolloCacheControl.getSnapshot(),
-    };
-  };
+    }
+  }
 
-  return WithApollo;
+  return WithApollo
 }

--- a/examples/with-apollo-ssr-get-data-from-tree/package.json
+++ b/examples/with-apollo-ssr-get-data-from-tree/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "with-apollo-ssr-get-data-from-tree",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@apollo/client": "3.1.1",
+    "deepmerge": "^4.2.2",
+    "lodash": "4.17.20",
+    "graphql": "^15.3.0",
+    "next": "latest",
+    "prop-types": "^15.6.2",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "license": "MIT"
+}

--- a/examples/with-apollo-ssr-get-data-from-tree/package.json
+++ b/examples/with-apollo-ssr-get-data-from-tree/package.json
@@ -1,6 +1,11 @@
 {
   "name": "with-apollo-ssr-get-data-from-tree",
   "version": "1.0.0",
+  "author": "Lennard Westerveld",
+  "contributors": [
+    "Lennard Westerveld <mail@lennard.pro>",
+    "Daphne Smit <hi@daphnesmit.nl>"
+  ],
   "scripts": {
     "dev": "next",
     "build": "next build",

--- a/examples/with-apollo-ssr-get-data-from-tree/pages/_app.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/pages/_app.js
@@ -1,0 +1,20 @@
+import { ApolloProvider } from '@apollo/client'
+import { useApollo } from '../lib/apolloClient'
+import withApolloServerSideRender from '../lib/withApolloServerSideRender'
+import { useApolloCacheControl } from '../lib/useApolloCacheControl'
+
+function App({ Component, pageProps }) { 
+  const ApolloCacheControl = useApolloCacheControl();
+  const registerCache = (cache) => ApolloCacheControl.registerCache('cache-1', cache);
+  const initialState = ApolloCacheControl.getExtractedCache('cache-1')
+  
+  const apolloClient = useApollo(registerCache, initialState)
+
+  return (
+    <ApolloProvider client={apolloClient}>
+      <Component {...pageProps} />
+    </ApolloProvider>
+  )
+}
+
+export default withApolloServerSideRender(App);

--- a/examples/with-apollo-ssr-get-data-from-tree/pages/_app.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/pages/_app.js
@@ -3,11 +3,12 @@ import { useApollo } from '../lib/apolloClient'
 import withApolloServerSideRender from '../lib/withApolloServerSideRender'
 import { useApolloCacheControl } from '../lib/useApolloCacheControl'
 
-function App({ Component, pageProps }) { 
-  const ApolloCacheControl = useApolloCacheControl();
-  const registerCache = (cache) => ApolloCacheControl.registerCache('cache-1', cache);
+function App({ Component, pageProps }) {
+  const ApolloCacheControl = useApolloCacheControl()
+  const registerCache = (cache) =>
+    ApolloCacheControl.registerCache('cache-1', cache)
   const initialState = ApolloCacheControl.getExtractedCache('cache-1')
-  
+
   const apolloClient = useApollo(registerCache, initialState)
 
   return (
@@ -17,4 +18,4 @@ function App({ Component, pageProps }) {
   )
 }
 
-export default withApolloServerSideRender(App);
+export default withApolloServerSideRender(App)

--- a/examples/with-apollo-ssr-get-data-from-tree/pages/index.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/pages/index.js
@@ -1,0 +1,19 @@
+import App from '../components/App';
+import InfoBox from '../components/InfoBox';
+import PostList from '../components/PostList';
+
+const IndexPage = () => {
+  return (
+    <App>
+      <InfoBox>ℹ️ This page shows how to use SSR with Apollo's getDataFromTree().</InfoBox>
+      <p>On SSR fetch data from inside your components by only using useQuery and no need to prefetch data in getInitialProps</p>
+      <p>This example uses a cache control object so you can have multiple cache instances usefull for when you have multiple apollo clients in your app.</p>
+      <p>SSR your data from anywhere in your app!</p>
+      <br />
+      <p>This list is server side rendered:</p>
+      <PostList />
+    </App>
+  )
+}
+
+export default IndexPage

--- a/examples/with-apollo-ssr-get-data-from-tree/pages/index.js
+++ b/examples/with-apollo-ssr-get-data-from-tree/pages/index.js
@@ -1,13 +1,21 @@
-import App from '../components/App';
-import InfoBox from '../components/InfoBox';
-import PostList from '../components/PostList';
+import App from '../components/App'
+import InfoBox from '../components/InfoBox'
+import PostList from '../components/PostList'
 
 const IndexPage = () => {
   return (
     <App>
-      <InfoBox>ℹ️ This page shows how to use SSR with Apollo's getDataFromTree().</InfoBox>
-      <p>On SSR fetch data from inside your components by only using useQuery and no need to prefetch data in getInitialProps</p>
-      <p>This example uses a cache control object so you can have multiple cache instances usefull for when you have multiple apollo clients in your app.</p>
+      <InfoBox>
+        ℹ️ This page shows how to use SSR with Apollo's getDataFromTree().
+      </InfoBox>
+      <p>
+        On SSR fetch data from inside your components by only using useQuery and
+        no need to prefetch data in getInitialProps
+      </p>
+      <p>
+        This example uses a cache control object so you can have multiple cache
+        instances usefull for when you have multiple apollo clients in your app.
+      </p>
       <p>SSR your data from anywhere in your app!</p>
       <br />
       <p>This list is server side rendered:</p>


### PR DESCRIPTION
BecauseI heard It was useful for people to see how they could implement SSR with Apollo using getDataFromTree in NextJS.
Therefor I made this example (using a bit of code from with-apollo example).

I think it is usefull to see how you can achieve SSR data fetching on a per component basis without having to (pre)fetch in getInitialProps.

Credits go mostly to [Lennard Westerveld](https://github.com/LennardWesterveld)