### PR TITLE
Add Cloudflare Image Resizing loader to next/image

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -88,6 +88,7 @@ The following Image Optimization cloud providers are included:
 - [Imgix](https://www.imgix.com): `loader: 'imgix'`
 - [Cloudinary](https://cloudinary.com): `loader: 'cloudinary'`
 - [Akamai](https://www.akamai.com): `loader: 'akamai'`
+- [Cloudflare](https://www.cloudflare.com): `loader: 'cloudflare'`
 - Default: Works automatically with `next dev`, `next start`, or a custom server
 
 If you need a different provider, you can use the [`loader`](/docs/api-reference/next/image.md#loader) prop with `next/image`.

--- a/errors/invalid-images-config.md
+++ b/errors/invalid-images-config.md
@@ -18,7 +18,7 @@ module.exports = {
     // limit of 50 domains values
     domains: [],
     path: '/_next/image',
-    // loader can be 'default', 'imgix', 'cloudinary', or 'akamai'
+    // loader can be 'default', 'imgix', 'cloudinary', 'akamai', or 'cloudflare'
     loader: 'default',
   },
 }

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -33,6 +33,7 @@ const loaders = new Map<
   ['imgix', imgixLoader],
   ['cloudinary', cloudinaryLoader],
   ['akamai', akamaiLoader],
+  ['cloudflare', cloudflareLoader],
   ['default', defaultLoader],
 ])
 
@@ -477,6 +478,21 @@ function imgixLoader({
 
 function akamaiLoader({ root, src, width }: DefaultImageLoaderProps): string {
   return `${root}${normalizeSrc(src)}?imwidth=${width}`
+}
+
+function cloudflareLoader({
+  root,
+  src,
+  width,
+  quality,
+}: DefaultImageLoaderProps): string {
+  // https://developers.cloudflare.com/images/url-format
+  let params = ['width=' + width]
+  if (quality) {
+    params.push('quality=' + quality)
+  }
+  const paramsString = params.join(',')
+  return `${root}cdn-cgi/image/${paramsString}/${normalizeSrc(src)}`
 }
 
 function cloudinaryLoader({

--- a/packages/next/next-server/server/image-config.ts
+++ b/packages/next/next-server/server/image-config.ts
@@ -3,6 +3,7 @@ export const VALID_LOADERS = [
   'imgix',
   'cloudinary',
   'akamai',
+  'cloudflare',
 ] as const
 
 export type LoaderValue = typeof VALID_LOADERS[number]

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -606,7 +606,7 @@ describe('Image Optimizer', () => {
       await nextConfig.restore()
 
       expect(stderr).toContain(
-        'Specified images.loader should be one of (default, imgix, cloudinary, akamai), received invalid value (notreal)'
+        'Specified images.loader should be one of (default, imgix, cloudinary, akamai, cloudflare), received invalid value (notreal)'
       )
     })
   })


### PR DESCRIPTION
Very similar to the existing loaders for Imgix, Cloudinary and Akamai, this adds support for Cloudflare Image Resizing to `next/image`.

Documentation for using Cloudflare Image Resizing can be found [here](https://developers.cloudflare.com/images/url-format).