### PR TITLE
Remove revert of custom devtool in development mode

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -64,11 +64,12 @@ type ExcludesFalse = <T>(x: T | false) => x is T
 
 const isWebpack5 = parseInt(webpack.version!) === 5
 
-const devtoolRevertWarning = execOnce((devtool: Configuration['devtool']) => {
+const devtoolPerformanceWarning = execOnce(() => {
   console.warn(
     chalk.yellow.bold('Warning: ') +
-      chalk.bold(`Reverting webpack devtool to '${devtool}'.\n`) +
-      'Changing the webpack devtool in development mode will cause severe performance regressions.\n' +
+      'Changing the webpack devtool in development mode will cause ' +
+      chalk.bold('severe') +
+      ' performance regressions.\n' +
       'Read more: https://err.sh/next.js/improper-devtool'
   )
 })
@@ -1219,8 +1220,7 @@ export default async function getBaseWebpackConfig(
     }
 
     if (dev && originalDevtool !== webpackConfig.devtool) {
-      webpackConfig.devtool = originalDevtool
-      devtoolRevertWarning(originalDevtool)
+      devtoolPerformanceWarning()
     }
 
     if (typeof (webpackConfig as any).then === 'function') {

--- a/test/integration/config-devtool-dev/test/index.test.js
+++ b/test/integration/config-devtool-dev/test/index.test.js
@@ -16,7 +16,7 @@ jest.setTimeout(1000 * 30)
 const appDir = join(__dirname, '../')
 
 describe('devtool set in developmemt mode in next config', () => {
-  it('should warn and revert when a devtool is set in development mode', async () => {
+  it('should warn when a devtool is set in development mode', async () => {
     let stderr = ''
 
     const appPort = await findPort()
@@ -29,7 +29,7 @@ describe('devtool set in developmemt mode in next config', () => {
 
     const found = await check(
       () => stderr,
-      /Reverting webpack devtool to /,
+      /devtool in development mode will cause/,
       false
     )
 


### PR DESCRIPTION
Remove the *revert* of `devtool` when manually changed for development mode, leaving in-tact the warning about the effects of its use.

As described in [this discussion (20294)](https://github.com/vercel/next.js/discussions/20294) the revert of the devtool has two knock-on effects:
1) Strict Content Security Policy cannot be used in development mode, causing a severe difference between dev & production
2) SSR debugging on Windows does not work correctly

This allows the user to make a **choice** about the use of `devtool` in development, giving the information in [the example](https://github.com/vercel/next.js/blob/master/errors/improper-devtool.md) as cause not to change it unless absolutely necessary.