### PR TITLE
fix: image component wrapper

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -267,8 +267,8 @@ export default function Image({
   const heightInt = getInt(height)
   const qualityInt = getInt(quality)
 
-  let wrapperStyle: JSX.IntrinsicElements['div']['style'] | undefined
-  let sizerStyle: JSX.IntrinsicElements['div']['style'] | undefined
+  let wrapperStyle: JSX.IntrinsicElements['span']['style'] | undefined
+  let sizerStyle: JSX.IntrinsicElements['span']['style'] | undefined
   let sizerSvg: string | undefined
   let imgStyle: ImgElementStyle | undefined = {
     visibility: isVisible ? 'inherit' : 'hidden',
@@ -394,9 +394,9 @@ export default function Image({
     imgStyle = undefined
   }
   return (
-    <div style={wrapperStyle}>
+    <span style={wrapperStyle}>
       {sizerStyle ? (
-        <div style={sizerStyle}>
+        <span style={sizerStyle}>
           {sizerSvg ? (
             <img
               style={{
@@ -412,7 +412,7 @@ export default function Image({
               src={`data:image/svg+xml;base64,${toBase64(sizerSvg)}`}
             />
           ) : null}
-        </div>
+        </span>
       ) : null}
       <img
         {...rest}
@@ -446,7 +446,7 @@ export default function Image({
           ></link>
         </Head>
       ) : null}
-    </div>
+    </span>
   )
 }
 


### PR DESCRIPTION
Just got the same issue reported here #21433.
In short, `next/image` into tags `<p>` are generating the following error:
![Screen Shot 2021-01-23 at 16 47 44](https://user-images.githubusercontent.com/9276511/105612554-be5cd100-5d9b-11eb-83ef-ebaf4e8c291e.png)

### Solution
Change the current wrapper which is a tag `<div>` into a `<span>`
