### PR TITLE
Added Feature - getServerSidePostRenderProps

### DIFF
--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -26,6 +26,8 @@ export const PUBLIC_DIR_MIDDLEWARE_CONFLICT = `You can not have a '_next' folder
 
 export const SSG_GET_INITIAL_PROPS_CONFLICT = `You can not use getInitialProps with getStaticProps. To use SSG, please remove your getInitialProps`
 
+export const NON_SSG_GET__POST_RENDER_SERVER_SIDE_PROPS = `You can not use getServerSidePostRenderProps with getServerSideProps. getServerSidePostRenderProps is only for SSG pages (getStaticProps)`
+
 export const SERVER_PROPS_GET_INIT_PROPS_CONFLICT = `You can not use getInitialProps with getServerSideProps. Please remove getInitialProps.`
 
 export const SERVER_PROPS_SSG_CONFLICT = `You can not use getStaticProps or getStaticPaths with getServerSideProps. To use SSG, please remove getServerSideProps`

--- a/packages/next/next-server/server/load-components.ts
+++ b/packages/next/next-server/server/load-components.ts
@@ -7,6 +7,7 @@ import {
   PageConfig,
   GetStaticPaths,
   GetServerSideProps,
+  GetServerSidePostRenderProps,
   GetStaticProps,
 } from 'next/types'
 
@@ -32,6 +33,7 @@ export type LoadComponentsReturnType = {
   getStaticProps?: GetStaticProps
   getStaticPaths?: GetStaticPaths
   getServerSideProps?: GetServerSideProps
+  getServerSidePostRenderProps?: GetServerSidePostRenderProps
 }
 
 export async function loadComponents(
@@ -41,11 +43,17 @@ export async function loadComponents(
 ): Promise<LoadComponentsReturnType> {
   if (serverless) {
     const Component = await requirePage(pathname, distDir, serverless)
-    let { getStaticProps, getStaticPaths, getServerSideProps } = Component
+    let {
+      getStaticProps,
+      getStaticPaths,
+      getServerSideProps,
+      getServerSidePostRenderProps,
+    } = Component
 
     getStaticProps = await getStaticProps
     getStaticPaths = await getStaticPaths
     getServerSideProps = await getServerSideProps
+    getServerSidePostRenderProps = await getServerSidePostRenderProps
     const pageConfig = (await Component.config) || {}
 
     return {
@@ -54,6 +62,7 @@ export async function loadComponents(
       getStaticProps,
       getStaticPaths,
       getServerSideProps,
+      getServerSidePostRenderProps,
     } as LoadComponentsReturnType
   }
 
@@ -77,7 +86,12 @@ export async function loadComponents(
     interopDefault(AppMod),
   ])
 
-  const { getServerSideProps, getStaticProps, getStaticPaths } = ComponentMod
+  const {
+    getServerSideProps,
+    getStaticProps,
+    getStaticPaths,
+    getServerSidePostRenderProps,
+  } = ComponentMod
 
   return {
     App,
@@ -87,6 +101,7 @@ export async function loadComponents(
     reactLoadableManifest,
     pageConfig: ComponentMod.config || {},
     getServerSideProps,
+    getServerSidePostRenderProps,
     getStaticProps,
     getStaticPaths,
   }

--- a/packages/next/server/htmlescape.ts
+++ b/packages/next/server/htmlescape.ts
@@ -9,8 +9,17 @@ const ESCAPE_LOOKUP: { [match: string]: string } = {
   '\u2029': '\\u2029',
 }
 
-const ESCAPE_REGEX = /[&><\u2028\u2029]/g
+const ESCAPE_REGEX = /(\\u0026|\\u003e|\\u003c|\\u2028|\\u2029)/g
+const DEESCAPE_REGEX = /[&><\u2028\u2029]/g
+const DEESCAPE_LOOKUP: typeof ESCAPE_LOOKUP = Object.keys(ESCAPE_LOOKUP).reduce(
+  (prev, key) => ({ ...prev, [ESCAPE_LOOKUP[key]]: key }),
+  {} as typeof ESCAPE_LOOKUP
+)
 
 export function htmlEscapeJsonString(str: string): string {
   return str.replace(ESCAPE_REGEX, (match) => ESCAPE_LOOKUP[match])
+}
+
+export function htmlDeEscapeJsonString(str: string): string {
+  return str.replace(DEESCAPE_REGEX, (match) => DEESCAPE_LOOKUP[match])
 }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -155,6 +155,8 @@ export type GetServerSideProps<
   context: GetServerSidePropsContext<Q>
 ) => Promise<GetServerSidePropsResult<P>>
 
+export type GetServerSidePostRenderProps = GetServerSideProps
+
 export type InferGetServerSidePropsType<T> = T extends GetServerSideProps<
   infer P,
   any


### PR DESCRIPTION
For some time I thought that feature is quite essential to next.js and after having workarounds all over I decided to implement it

**Note:** The PR is not final, there are still some pieces of code that need to be done (tests, redirects, serverless) but I thought it would be better to first hear your thoughts and only then do that.

The core issue I'm addressing is that in next.js there is quite a dichotomy between pre-rendering and server-side rendering. But in a lot of cases I found myself trying to add custom data to a pre-rendered page - so the client side would get the same HTML, but behave slightly differently for different users. Some examples: 

- Initialize form - If I know what the user is or the IP location you could initialize the form with some of the data that would be mostly right for them (currency, country, email). 
- Redirect unseen users to it's default locale
- Showing users from different countries the correct privacy popup (or not show at all...) 
- Redirecting users that we don't want to allow this page (according to user / IP location / Black list)
- Having a super quick response with pre-rendered HTML (for SCO and server workloads) and still show user details on header (name, avatar etc.) if logged in

I'm sure there are some ways to do some of these in other ways, but this seems to me pretty essential for the level of customizability and control over the apps I want to make.

**In Practice...**

The way I it work (currently anyway...)  is that in addition to `getStaticProps` and `getStaticPaths` we would add a new function - `getServerSidePostRenderProps` that would run on the server-side and add some props to the `<script id="__NEXT_DATA__"...` tag so the hydration function would pick it up and render it on hydration. Old API remains the same. 

That's all, hope you guys would see the potential in it