### PR TITLE
Fix typo

### DIFF
--- a/examples/cms-kontent/README.md
+++ b/examples/cms-kontent/README.md
@@ -35,7 +35,7 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 ```bash
 npx create-next-app --example cms-kontent cms-kontent-app
 # or
-yarn create next-app --example cms-kontent cms-kontent-app
+yarn create-next-app --example cms-kontent cms-kontent-app
 ```
 
 ## Configuration


### PR DESCRIPTION
Missing '-' in `create-next-app`.