### PR TITLE
Filter canary branch for GitHub actions cancelling

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,6 +1,10 @@
 name: Cancel
 on:
   pull_request_target:
+    branches-ignore:
+      # don't run cancel job for branches named canary until
+      # it no longer cancels the main canary branches jobs
+      - canary
     types:
       - edited
       - synchronize


### PR DESCRIPTION
Makes sure the cancel job is filtered for canary branches. 