### PR TITLE
Update CI docs change diff check

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -15,6 +15,9 @@ jobs:
       docsChange: ${{ steps.docs-change.outputs.DOCS_CHANGE }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 25
+
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js --timings --write-timings -g 1/1
@@ -136,6 +139,8 @@ jobs:
       YARN_COMPRESSION_LEVEL: '0'
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 25
 
       - run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
         id: docs-change
@@ -164,6 +169,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 25
 
       - run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
         id: docs-change
@@ -187,6 +194,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 25
 
       - run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
         id: docs-change

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,10 +1,11 @@
 name: Cancel
 on:
   pull_request_target:
-    branches-ignore:
+    branches:
       # don't run cancel job for branches named canary until
       # it no longer cancels the main canary branches jobs
-      - canary
+      - '**'
+      - '!canary'
     types:
       - edited
       - synchronize

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 25
+
       - run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
         id: docs-change
       - uses: ./.github/actions/next-stats-action

--- a/skip-docs-change.js
+++ b/skip-docs-change.js
@@ -9,7 +9,7 @@ async function main() {
   await exec('git fetch origin canary')
 
   const { stdout: changedFilesOutput } = await exec(
-    'git diff origin/canary --name-only'
+    'git diff origin/canary... --name-only'
   )
   const changedFiles = changedFilesOutput
     .split('\n')


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/21530 which updates the diff to not consider un-merged changes on canary to be included in the diff so that branches don't have to be caught up to `canary` for the diff to detect docs only changes correctly. 