### PR TITLE
Allow custom loader and dynamic options in next-mdx

### DIFF
--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -1,17 +1,21 @@
 module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
   const extension = pluginOptions.extension || /\.mdx$/
+  const loader = pluginOptions.loader || require.resolve('@mdx-js/loader')
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       config.module.rules.push({
         test: extension,
-        use: [
-          options.defaultLoaders.babel,
-          {
-            loader: require.resolve('@mdx-js/loader'),
-            options: pluginOptions.options,
-          },
-        ],
+        use:
+          typeof pluginOptions.options === 'function'
+            ? (info) => [
+                options.defaultLoaders.babel,
+                { loader, options: pluginOptions.options(info) },
+              ]
+            : [
+                options.defaultLoaders.babel,
+                { loader, options: pluginOptions.options },
+              ],
       })
 
       if (typeof nextConfig.webpack === 'function') {


### PR DESCRIPTION
This allows `@next/mdx` users to optionally use custom loader and dynamically resolving MDX options.

Example use case: custom configuration/processor for different files.