### PR TITLE
Update CI publish step to trigger after build

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -282,7 +282,7 @@ jobs:
   publishRelease:
     name: Potentially publish release
     runs-on: ubuntu-latest
-    needs: [testsPass]
+    needs: build
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:


### PR DESCRIPTION
This lets the publish step occur faster instead of waiting for other CI tasks to finish first