### PR TITLE
Remove note about Yarn 2 support.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,8 +41,6 @@ npm install next react react-dom
 yarn add next react react-dom
 ```
 
-> **Note**: [Yarn 2](https://yarnpkg.com/getting-started/install) is supported as best-effort within Next.js. For best results, use NPM or Yarn 1.
-
 Open `package.json` and add the following `scripts`:
 
 ```json


### PR DESCRIPTION
My addition of the Yarn 2 caveat was more nuanced than I thought. Apologies. @merceyz has been adding extensive e2e tests for Yarn 2 support. We plan to support Yarn 2 compat.

Reverts https://github.com/vercel/next.js/pull/21657.