### PR TITLE
Add experimental + unstable Bridge component

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -25,6 +25,7 @@ import initHeadManager from './head-manager'
 import PageLoader, { StyleSheetTuple } from './page-loader'
 import measureWebVitals from './performance-relayer'
 import { createRouter, makePublicRouterInstance } from './router'
+import { BridgeContext } from '../next-server/lib/experimental-bridge'
 
 /// <reference types="react-dom/experimental" />
 
@@ -509,12 +510,19 @@ function renderReactElement(reactEl: JSX.Element, domEl: HTMLElement): void {
           ? (ReactDOM as any).unstable_createRoot(domEl, opts)
           : (ReactDOM as any).unstable_createBlockingRoot(domEl, opts)
     }
-    reactRoot.render(reactEl)
+    reactRoot.render(
+      <BridgeContext.Provider value={process.env.__NEXT_REACT_MODE as any}>
+        {reactEl}
+      </BridgeContext.Provider>
+    )
   } else {
     // mark start of hydrate/render
     if (ST) {
       performance.mark('beforeRender')
     }
+    reactEl = (
+      <BridgeContext.Provider value="legacy">{reactEl}</BridgeContext.Provider>
+    )
 
     // The check for `.hydrate` is there to support React alternatives like preact
     if (shouldUseHydrate) {

--- a/packages/next/experimental-bridge.d.ts
+++ b/packages/next/experimental-bridge.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/next-server/lib/experimental-bridge'
+export { default } from './dist/next-server/lib/experimental-bridge'

--- a/packages/next/experimental-bridge.js
+++ b/packages/next/experimental-bridge.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/next-server/lib/experimental-bridge')

--- a/packages/next/next-server/lib/experimental-bridge.tsx
+++ b/packages/next/next-server/lib/experimental-bridge.tsx
@@ -1,0 +1,198 @@
+import React, {
+  cloneElement,
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import ReactDOM from 'react-dom'
+
+export type BridgeProps = {
+  children: React.ReactHTMLElement<any>
+}
+
+export type ReactMode = 'concurrent' | 'blocking' | 'legacy'
+
+// INTERNAL!!!
+export const BridgeContext = createContext<ReactMode | null>(null)
+
+interface RootConstructor {
+  new (element: HTMLElement): RootInstance
+}
+
+interface RootInstance {
+  render(node: React.ReactElement): void
+  unmount(): void
+}
+
+export function createBridge({
+  context,
+  mode,
+}: {
+  // TODO: Consider allowing mapping to a string too, for the old context API
+  context: React.Context<any>[]
+  mode: ReactMode
+}) {
+  const useAllContext = () => {
+    const contexts: any[] = []
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    context.forEach((ctx) => contexts.push(useContext(ctx)))
+    return contexts
+  }
+  const useContent = (children: React.ReactNode) => {
+    const currentMode = useContext(BridgeContext)
+    if (!currentMode) {
+      throw new Error(
+        "Could not determine mode. Make sure you're only rendering this component inside a page."
+      )
+    }
+
+    const contexts = useAllContext()
+    const content = useMemo(
+      () =>
+        context.reduce(
+          (innerChildren, Context, i) => (
+            <Context.Provider value={contexts[i]}>
+              {innerChildren}
+            </Context.Provider>
+          ),
+          <>{children}</>
+        ),
+      [children, contexts]
+    )
+    return content
+  }
+  const useHostId = (element: React.ReactHTMLElement<any>): string => {
+    const id = element.props.id
+    if (typeof element.type !== 'string' || typeof id !== 'string') {
+      throw new Error(
+        'Bridge requires a host element child (e.g. `div`) with a unique `id` prop'
+      )
+    }
+    return id
+  }
+  const Root: RootConstructor = {
+    concurrent: ConcurrentRoot,
+    blocking: BlockingRoot,
+    legacy: LegacyRoot,
+  }[mode]
+
+  function ServerBridge({ children }: BridgeProps) {
+    useHostId(children)
+    const content = useContent(children.props.children)
+
+    // We `renderToStaticMarkup` on the server to match the client semantics.
+    // TODO: Ensure `renderToStaticMarkup` is tree-shaken from client builds.
+    return cloneElement(
+      children,
+      {
+        dangerouslySetInnerHTML: { __html: renderToStaticMarkup(content) },
+      },
+      null
+    )
+  }
+
+  function ClientBridge({ children }: BridgeProps) {
+    const content = useContent(children.props.children)
+    const containerRef = useRef<HTMLElement>(null)
+    const rootRef: React.MutableRefObject<RootInstance | null> = useRef(null)
+
+    useLayoutEffect(() => {
+      if (!rootRef.current) {
+        rootRef.current = new Root(containerRef.current!)
+      }
+      const root = rootRef.current
+      return () => {
+        root.unmount()
+      }
+    }, [])
+
+    useLayoutEffect(() => {
+      const root = rootRef.current
+      if (root) {
+        root.render(content)
+      }
+    }, [content])
+
+    const id = useHostId(children)
+    const bridgedContent = useMemo(
+      () =>
+        cloneElement(
+          children,
+          {
+            ref: containerRef,
+            dangerouslySetInnerHTML: {
+              __html: document.getElementById(id)!.innerHTML,
+            },
+          },
+          null
+        ),
+      [containerRef, children, id]
+    )
+
+    return bridgedContent
+  }
+
+  return typeof window === 'undefined' ? ServerBridge : ClientBridge
+}
+
+class ConcurrentRoot implements RootInstance {
+  _root: any
+
+  constructor(element: HTMLElement) {
+    this._root = (ReactDOM as any).unstable_createRoot(element, {
+      hydrate: true,
+    })
+  }
+
+  render(node: React.ReactElement) {
+    this._root.render(node)
+  }
+
+  unmount() {
+    this._root.unmount()
+  }
+}
+
+class BlockingRoot implements RootInstance {
+  _root: any
+
+  constructor(element: HTMLElement) {
+    this._root = (ReactDOM as any).unstable_createBlockingRoot(element, {
+      hydrate: true,
+    })
+  }
+
+  render(node: React.ReactElement) {
+    this._root.render(node)
+  }
+
+  unmount() {
+    this._root.unmount()
+  }
+}
+
+class LegacyRoot implements RootInstance {
+  _element: HTMLElement
+  _hydrate: boolean
+
+  constructor(element: HTMLElement) {
+    this._element = element
+    this._hydrate = true
+  }
+
+  render(node: React.ReactElement) {
+    if (this._hydrate) {
+      this._hydrate = false
+      ReactDOM.hydrate(node, this._element)
+    } else {
+      ReactDOM.render(node, this._element)
+    }
+  }
+
+  unmount() {
+    ReactDOM.unmountComponentAtNode(this._element)
+  }
+}

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -60,6 +60,7 @@ import {
   Redirect,
 } from '../../lib/load-custom-routes'
 import { DomainLocales } from './config'
+import { BridgeContext } from '../lib/experimental-bridge'
 
 function noRouter() {
   const message =
@@ -584,28 +585,32 @@ export async function renderToHTML(
   let scriptLoader: any = {}
 
   const AppContainer = ({ children }: any) => (
-    <RouterContext.Provider value={router}>
-      <AmpStateContext.Provider value={ampState}>
-        <HeadManagerContext.Provider
-          value={{
-            updateHead: (state) => {
-              head = state
-            },
-            updateScripts: (scripts) => {
-              scriptLoader = scripts
-            },
-            scripts: {},
-            mountedInstances: new Set(),
-          }}
-        >
-          <LoadableContext.Provider
-            value={(moduleName) => reactLoadableModules.push(moduleName)}
+    <BridgeContext.Provider
+      value={process.env.__NEXT_REACT_MODE ?? ('legacy' as any)}
+    >
+      <RouterContext.Provider value={router}>
+        <AmpStateContext.Provider value={ampState}>
+          <HeadManagerContext.Provider
+            value={{
+              updateHead: (state) => {
+                head = state
+              },
+              updateScripts: (scripts) => {
+                scriptLoader = scripts
+              },
+              scripts: {},
+              mountedInstances: new Set(),
+            }}
           >
-            {children}
-          </LoadableContext.Provider>
-        </HeadManagerContext.Provider>
-      </AmpStateContext.Provider>
-    </RouterContext.Provider>
+            <LoadableContext.Provider
+              value={(moduleName) => reactLoadableModules.push(moduleName)}
+            >
+              {children}
+            </LoadableContext.Provider>
+          </HeadManagerContext.Provider>
+        </AmpStateContext.Provider>
+      </RouterContext.Provider>
+    </BridgeContext.Provider>
   )
 
   try {


### PR DESCRIPTION
Adds an experimental, unstable `Bridge` component. This uses a similar mechanism as the [react-gradual-upgrade-demo](https://github.com/reactjs/react-gradual-upgrade-demo), except it's intended to be used for nesting e.g. a legacy tree inside of a Concurrent one, where both otherwise use the same version of React.

There are still some questions that need to be answered, such as:
* Does it make sense to allow a concurrent or blocking tree to be embedded in a legacy one? My instinct is no, but I'm not sure yet, so I haven't explicitly disabled it yet
* Should the bridge component itself allow bridge components to be nested? This just seems like it's asking for trouble. I think we want to make the top-level of Next concurrent, and you can wrap your page (via a custom `/_app`) in `<Bridge>{/* ... */}</Bridge>` if it's not compatible yet.
* Should we support the legacy context API too? 

---

Using this is pretty simple:

```jsx
const tryConcurrentMode = props.user.isEmployee
const Bridge = useMemo(() => createBridge({
    context: [RouterContext],
    mode: tryConcurrentMode ? "concurrent" : "legacy",
}), [tryConcurrentMode])

return <Bridge><Component {...props} /></Bridge>
```

It's a component (as opposed to e.g. per-page configuration) for the most flexibility and to allow A/B testing or employee dogfooding as shown in the example, but we'll need to document the recommended patterns.