### PR TITLE
Resolve case-sensitive cwd with realpathSync.native

### DIFF
--- a/packages/next/cli/next-build.ts
+++ b/packages/next/cli/next-build.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync } from 'fs'
+import { existsSync, realpathSync } from 'fs'
 import arg from 'next/dist/compiled/arg/index.js'
 import { resolve } from 'path'
 import * as Log from '../build/output/log'
@@ -48,7 +48,7 @@ const nextBuild: cliCommand = (argv) => {
   if (args['--profile']) {
     Log.warn('Profiling is enabled. Note: This may affect performance')
   }
-  const dir = resolve(args._[0] || '.')
+  const dir = resolve(args._[0] || realpathSync.native('.'))
 
   // Check if the provided directory exists
   if (!existsSync(dir)) {

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { resolve } from 'path'
 import arg from 'next/dist/compiled/arg/index.js'
-import { existsSync } from 'fs'
+import { existsSync, realpathSync } from 'fs'
 import startServer from '../server/lib/start-server'
 import { printAndExit } from '../server/lib/utils'
 import * as Log from '../build/output/log'
@@ -49,7 +49,7 @@ const nextDev: cliCommand = (argv) => {
     process.exit(0)
   }
 
-  const dir = resolve(args._[0] || '.')
+  const dir = resolve(args._[0] || realpathSync.native('.'))
 
   // Check if pages dir exists and warn if not
   if (!existsSync(dir)) {

--- a/packages/next/cli/next-export.ts
+++ b/packages/next/cli/next-export.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { resolve, join } from 'path'
-import { existsSync } from 'fs'
+import { existsSync, realpathSync } from 'fs'
 import arg from 'next/dist/compiled/arg/index.js'
 import exportApp from '../export'
 import { printAndExit } from '../server/lib/utils'
@@ -47,7 +47,7 @@ const nextExport: cliCommand = (argv) => {
     process.exit(0)
   }
 
-  const dir = resolve(args._[0] || '.')
+  const dir = resolve(args._[0] || realpathSync.native('.'))
 
   // Check if pages dir exists and warn if not
   if (!existsSync(dir)) {


### PR DESCRIPTION
## Motivation
Currently the way the current working directory is resolved doesn't take into account the case-insensitivity of the path name. Generally this is not a problem in shells that enforce case sensitive directories. However, in shells like PowerShell this can be a problem as shown in #16535 and can be reproduced as shown in https://github.com/vercel/next.js/issues/16535#issuecomment-723429500

## Solution
Resolving case-sensitive cwd with realpathSync.native, this will resolve the real case-sensitive cwd even if it is in a wrong casing in the shell executing the script