### PR TITLE
Click-to-open error state for development overlay #14461

### DIFF
--- a/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
+++ b/packages/react-dev-overlay/src/internal/components/CodeFrame/CodeFrame.tsx
@@ -55,7 +55,7 @@ export const CodeFrame: React.FC<CodeFrameProps> = function CodeFrame({
       .then(
         () => {},
         () => {
-          // TODO: report error
+          console.error('There was an issue opening this code in your editor.')
         }
       )
   }, [stackFrame])

--- a/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
+++ b/packages/react-dev-overlay/src/internal/container/RuntimeError.tsx
@@ -33,7 +33,7 @@ const CallStackFrame: React.FC<{
       .then(
         () => {},
         () => {
-          // TODO: report error
+          console.error('There was an issue opening this code in your editor.')
         }
       )
   }, [hasSource, f])


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49683353/106792886-0363eb80-6657-11eb-98e9-f95a5f25de64.png)
Fix #14461 
The error was ignored when click on "open in your editor" failed. As we have the code error already in the modal, the alert is not a good approach. Also because of this error about "open in your editor" is not that critique, we think it is sufficient to put just a log in the console. 