### PR TITLE
fix: convert Set spread calls to Array.from for more universal compatibility #17094

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -56,7 +56,7 @@ function getDocumentFiles(
   return {
     sharedFiles,
     pageFiles,
-    allFiles: [...new Set([...sharedFiles, ...pageFiles])],
+    allFiles: Array.from(new Set([...sharedFiles, ...pageFiles])),
   }
 }
 


### PR DESCRIPTION
For background, see the issue this fixes: https://github.com/vercel/next.js/issues/17094

Please let me know if there's any tests you'd like me to run as part of putting this up here; I attempted to run the headless test suite according to https://github.com/vercel/next.js/blob/4dc32ec0a7bc389d553efcbf976d4a5429c3fc72/contributing.md but eventually the suite bailed out because of a used port. And NOTE: I did see failures in the `SSG Prerender serverless mode` testcase suite - such failures seem unlikely to be caused by this change, but perhaps I'm missing something very obviously wrong here. Either way, if these are important to you I'm happy to dig in further. 

Caniuse lists pretty widespread availability for `Array.from` (outside of IE11 which would need to have the spread polyfilled/converted by the typescript compiler anyway) so I wouldn't expect any compatibility concerns with this either. Again, happy to dig in further if these are of a concern to you.

Example stacktrace from nodejs v14.15.4 that this PR resolves:

```
event - compiled successfully
_app api configured: http://localhost:1338/v1
TypeError: f.endsWith is not a function
    at eval (webpack-internal:///./node_modules/next/dist/pages/_document.js:306:16)
    at Array.filter (<anonymous>)
    at Head.getCssLinks (webpack-internal:///./node_modules/next/dist/pages/_document.js:305:35)
    at Head.render (webpack-internal:///./node_modules/next/dist/pages/_document.js:618:23)
    at processChild (/Users/brianwyant/dev/Golden-Portal/node_modules/react-dom/cjs/react-dom-server.node.development.js:3134:18)
    at resolve (/Users/brianwyant/dev/Golden-Portal/node_modules/react-dom/cjs/react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer.render (/Users/brianwyant/dev/Golden-Portal/node_modules/react-dom/cjs/react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer.read (/Users/brianwyant/dev/Golden-Portal/node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
    at renderToStaticMarkup (/Users/brianwyant/dev/Golden-Portal/node_modules/react-dom/cjs/react-dom-server.node.development.js:4004:27)
    at renderDocument (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/render.js:3:715)
    at renderToHTML (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/render.js:56:103)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async /Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:107:97
    at async /Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:100:142
    at async DevServer.renderToHTMLWithComponents (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:132:387)
    at async DevServer.renderErrorToHTML (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:134:327)
    at async DevServer.renderErrorToHTML (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/server/next-dev-server.js:34:1204)
    at async DevServer.renderToHTML (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:133:1277)
    at async DevServer.renderToHTML (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/server/next-dev-server.js:34:578)
    at async DevServer.render (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:72:236)
    at async Object.fn (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:56:580)
    at async Router.execute (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/router.js:23:67)
    at async DevServer.run (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:66:1042)
    at async DevServer.handleRequest (/Users/brianwyant/dev/Golden-Portal/node_modules/next/dist/next-server/server/next-server.js:34:504)
```