### PR TITLE
Update reasons array to use module id instead of identifier

### DIFF
--- a/packages/next/build/webpack/plugins/build-stats-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-stats-plugin.ts
@@ -18,7 +18,7 @@ function reduceSize(stats: any) {
     }
 
     for (const module of chunk.modules) {
-      if (!module.identifier) {
+      if (!module.name) {
         continue
       }
 
@@ -26,12 +26,12 @@ function reduceSize(stats: any) {
         type: module.type,
         moduleType: module.moduleType,
         size: module.size,
-        identifier: module.identifier,
+        name: module.name,
       }
 
       if (module.reasons) {
         for (const reason of module.reasons) {
-          if (!reason.moduleIdentifier) {
+          if (!reason.name) {
             continue
           }
 
@@ -44,7 +44,7 @@ function reduceSize(stats: any) {
           })
         }
       }
-      // Identifier is part of the Map
+
       modules.set(module.id, reducedModule)
 
       if (!reducedChunk.modules) {

--- a/packages/next/build/webpack/plugins/build-stats-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-stats-plugin.ts
@@ -39,9 +39,7 @@ function reduceSize(stats: any) {
             reducedModule.reasons = []
           }
 
-          reducedModule.reasons.push({
-            moduleIdentifier: reason.moduleIdentifier,
-          })
+          reducedModule.reasons.push(reason.id)
         }
       }
       // Identifier is part of the Map

--- a/packages/next/build/webpack/plugins/build-stats-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-stats-plugin.ts
@@ -39,7 +39,9 @@ function reduceSize(stats: any) {
             reducedModule.reasons = []
           }
 
-          reducedModule.reasons.push(reason.id)
+          reducedModule.reasons.push({
+            id: reason.id,
+          })
         }
       }
       // Identifier is part of the Map


### PR DESCRIPTION
Missed this then changing the modules array to rely on `module.id`