### PR TITLE
Make gS(S)P return values discriminated unions

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -100,9 +100,19 @@ export type GetStaticPropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> = {
 }
 
 export type GetStaticPropsResult<P> =
-  | { props: P; revalidate?: number | boolean }
-  | { redirect: Redirect; revalidate?: number | boolean }
-  | { notFound: true }
+  | {
+      props: P
+      revalidate?: number | boolean
+      redirect?: never
+      notFound?: never
+    }
+  | {
+      redirect: Redirect
+      revalidate?: number | boolean
+      props?: never
+      notFound?: never
+    }
+  | { notFound: true; props?: never; revalidate?: never; redirect?: never }
 
 export type GetStaticProps<
   P extends { [key: string]: any } = { [key: string]: any },
@@ -149,9 +159,9 @@ export type GetServerSidePropsContext<
 }
 
 export type GetServerSidePropsResult<P> =
-  | { props: P }
-  | { redirect: Redirect }
-  | { notFound: true }
+  | { props: P; redirect?: never; notFound?: never }
+  | { redirect: Redirect; props?: never; notFound?: never }
+  | { notFound: true; props?: never; redirect?: never }
 
 export type GetServerSideProps<
   P extends { [key: string]: any } = { [key: string]: any },


### PR DESCRIPTION
When a `getStaticProps`/`getServerSideProps` function is invoked by another page to provide base data, it could be useful to check for the existence of e.g. `props` like below:

```ts
import { getServerSideProps as getServerSidePropsBase } from "./base";

export const getServerSideProps: GetServerSideProps<PageProps> = async (
	context,
) => {
	const baseServerSideProps = await getServerSidePropsBase(context);
	if (!baseServerSideProps.props) return baseServerSideProps; // TS could narrow types here
	return {
		...baseServerSideProps,
		props: {
			...baseServerSideProps.props,
			customProp: "Something which extends the base props of another page",
		},
	};
};
```