### PR TITLE
[examples] Wrap entire app with Styletron provider for with-styletron

### DIFF
--- a/examples/with-styletron/package.json
+++ b/examples/with-styletron/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "styletron-engine-atomic": "^1.1.2",
-    "styletron-react": "^5.0.1"
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "styletron-engine-atomic": "1.4.6",
+    "styletron-react": "5.2.7"
   },
   "license": "MIT"
 }

--- a/examples/with-styletron/pages/_document.js
+++ b/examples/with-styletron/pages/_document.js
@@ -3,14 +3,22 @@ import { Provider as StyletronProvider } from 'styletron-react'
 import { styletron } from '../styletron'
 
 class MyDocument extends Document {
-  static getInitialProps(props) {
-    const page = props.renderPage((App) => (props) => (
-      <StyletronProvider value={styletron}>
-        <App {...props} />
-      </StyletronProvider>
-    ))
+  static async getInitialProps(context) {
+    const renderPage = () =>
+      context.renderPage({
+        enhanceApp: (App) => (props) => (
+          <StyletronProvider value={styletron}>
+            <App {...props} />
+          </StyletronProvider>
+        ),
+      })
+
+    const initialProps = await Document.getInitialProps({
+      ...context,
+      renderPage,
+    })
     const stylesheets = styletron.getStylesheets() || []
-    return { ...page, stylesheets }
+    return { ...initialProps, stylesheets }
   }
 
   render() {


### PR DESCRIPTION
This PR fixes #21825. The user was having issues where the `Layout` they were defining wasn't available on page load, so they saw different styling when performing client side routing vs server side rendering. This was brought up once before on the [styletron repo](https://github.com/styletron/styletron/issues/367).

At the same time, I've updated React to 17 in this PR to clear up the message about Next 11. If this should be split out into a separate request, please advise. 

