### PR TITLE
Allows . (dot) to be a valid value for basePath

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -219,9 +219,9 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       )
     }
 
-    if (!result.basePath.startsWith('/')) {
+    if (!result.basePath.startsWith('/') && result.basePath !== '.') {
       throw new Error(
-        `Specified basePath has to start with a /, found "${result.basePath}"`
+        `Specified basePath has to start with a / or be a . (dot), found "${result.basePath}"`
       )
     }
 


### PR DESCRIPTION
Over at CERN, we're experiencing an issue when we need to deploy multiple versions of exactly the same, statically exported websites, on one domain. Think like this:

https://department.cern.ch/group/service1/

https://department.cern.ch/group/service2/

https://department.cern.ch/group/service3/

... and we have about 10 different services like that (all on the same domain).

Exporting and deploying 10 versions where the only difference is the value of `basePath` seems very inefficient and cumbersome. Therefore, we suggest to lift the restriction that prohibits us from using `.` as a `basePath`. This ensures that all paths are relative and static files come from the same service (`/group/serviceX/`) from which `index.html` was requested.

I made a small sample app (that's a slight modification of one of the out-of-the-box samples) to showcase that this indeed works:
https://github.com/andrius-k/relative-imports-nextjs

This contribution was made following the procedure outlined here: https://github.com/andrius-k/next.js/blob/canary/contributing.md
