### PR TITLE
Check if parentspan is provided in profiler

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,17 @@
       "outFiles": ["${workspaceFolder}/packages/next/dist/**/*"]
     },
     {
+      "name": "Launch app build trace",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["run", "trace-debug", "build", "test/integration/basic"],
+      "skipFiles": ["<node_internals>/**"],
+      "port": 9229,
+      "outFiles": ["${workspaceFolder}/packages/next/dist/**/*"]
+    },
+    {
       "name": "Launch app production",
       "type": "node",
       "request": "launch",

--- a/packages/next/build/tracer.ts
+++ b/packages/next/build/tracer.ts
@@ -13,9 +13,13 @@ export function stackPush(compiler: any, spanName: string, attrs?: any): any {
     span = tracer.startSpan(spanName, attrs ? attrs() : undefined)
   } else {
     const parent = stack[stack.length - 1]
-    tracer.withSpan(parent, () => {
+    if (parent) {
+      tracer.withSpan(parent, () => {
+        span = tracer.startSpan(spanName, attrs ? attrs() : undefined)
+      })
+    } else {
       span = tracer.startSpan(spanName, attrs ? attrs() : undefined)
-    })
+    }
   }
 
   stack.push(span)

--- a/packages/next/build/tracer.ts
+++ b/packages/next/build/tracer.ts
@@ -3,6 +3,7 @@ import api, { Span } from '@opentelemetry/api'
 export const tracer = api.trace.getTracer('next', process.env.__NEXT_VERSION)
 
 const compilerStacks = new WeakMap()
+const compilerStoppedSpans = new WeakMap()
 
 export function stackPush(compiler: any, spanName: string, attrs?: any): any {
   let stack = compilerStacks.get(compiler)
@@ -26,9 +27,7 @@ export function stackPush(compiler: any, spanName: string, attrs?: any): any {
   return span
 }
 
-export function stackPop(compiler: any, span: any) {
-  span.end()
-
+export function stackPop(compiler: any, span: any, associatedName?: string) {
   let stack = compilerStacks.get(compiler)
   if (!stack) {
     console.warn(
@@ -36,15 +35,40 @@ export function stackPop(compiler: any, span: any) {
     )
     return
   }
-  const poppedSpan = stack.pop()
-  if (poppedSpan !== span) {
-    stack.push(poppedSpan)
-    const spanIdx = stack.indexOf(span)
-    console.warn('Attempted to pop span that was not at top of stack.')
-    if (spanIdx !== -1) {
-      console.info(
-        `Span was found at index ${spanIdx} with stack size ${stack.length}`
+
+  let stoppedSpans: Set<Span> = compilerStoppedSpans.get(compiler)
+  if (!stoppedSpans) {
+    stoppedSpans = new Set()
+    compilerStoppedSpans.set(compiler, stoppedSpans)
+  }
+  if (stoppedSpans.has(span)) {
+    console.warn(
+      `Attempted to terminate tracing span that was already stopped for ${associatedName}`
+    )
+    return
+  }
+
+  while (true) {
+    let poppedSpan = stack.pop()
+
+    if (poppedSpan === span) {
+      stoppedSpans.add(poppedSpan)
+      span.end()
+      stoppedSpans.add(span)
+      break
+    } else if (poppedSpan === undefined || stack.indexOf(span) === -1) {
+      // We've either reached the top of the stack or the stack doesn't contain
+      // the span for another reason.
+      console.warn(`Tracing span was not found in stack for: ${associatedName}`)
+      stoppedSpans.add(span)
+      span.end()
+      break
+    } else if (stack.indexOf(span) !== -1) {
+      console.warn(
+        `Attempted to pop span that was not at top of stack for: ${associatedName}`
       )
+      stoppedSpans.add(poppedSpan)
+      poppedSpan.end()
     }
   }
 }

--- a/packages/next/build/webpack/plugins/profiling-plugin.ts
+++ b/packages/next/build/webpack/plugins/profiling-plugin.ts
@@ -54,7 +54,13 @@ export class ProfilingPlugin {
       onSetSpan?.(span)
     })
     stopHook.tap(pluginName, () => {
-      stackPop(this.compiler, span)
+      // `stopHook` may be triggered when `startHook` has not in cases
+      // where `stopHook` is used as the terminating event for more
+      // than one pair of hooks.
+      if (!span) {
+        return
+      }
+      stackPop(this.compiler, span, spanName)
     })
   }
 
@@ -66,7 +72,7 @@ export class ProfilingPlugin {
       }
     })
     stopHook.tap(pluginName, () => {
-      stackPop(this.compiler, span)
+      stackPop(this.compiler, span, spanName)
     })
   }
 


### PR DESCRIPTION
Fixes the issue that webpack-compile ended up as a separate trace because `parent` was undefined