### PR TITLE
IE11 create-next-app template styles fix.

### DIFF
--- a/packages/create-next-app/templates/default/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/styles/Home.module.css
@@ -9,7 +9,6 @@
 
 .main {
   padding: 5rem 0;
-  flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -76,13 +75,13 @@
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  max-width: 800px;
+  max-width: 890px;
   margin-top: 3rem;
 }
 
 .card {
   margin: 1rem;
-  flex-basis: 45%;
+  flex-basis: 360px;
   padding: 1.5rem;
   text-align: left;
   color: inherit;


### PR DESCRIPTION
IE11 had weird issues with few pixels and percentage values. Fixed them evaluating against chrome version, and also checked those fixes with chrome version. 3 lines changed.

Here is the look of the final style on IE11 and Chrome respectively.

IE11: 
![IE11](https://user-images.githubusercontent.com/37347831/107694868-e32ad100-6cd5-11eb-869c-a7e02183c1f6.png)

Chrome:
![Chrome](https://user-images.githubusercontent.com/37347831/107694926-ed4ccf80-6cd5-11eb-8b70-8a4f990342bd.png)

