### PR TITLE
Fix typo in German translation

### DIFF
--- a/examples/with-i18n-rosetta/locales/de.json
+++ b/examples/with-i18n-rosetta/locales/de.json
@@ -2,7 +2,7 @@
   "intro": {
     "welcome": "Willkommen, {{username}}!",
     "text": "Ich hoffe, du findest das nützlich.",
-    "description": "Das Beispiel zeigt, wie man die Sprache für SSG und SSG optimierte Seiten wechselt."
+    "description": "Das Beispiel zeigt, wie man die Sprache für SSG und SSR optimierte Seiten wechselt."
   },
   "dashboard": {
     "description": "Das Beispiel zeigt, wie man die Sprache nur Frontendseitig verändert. Nützlich für Dashboards wo SEO nicht relevant ist."


### PR DESCRIPTION
Fixes a small typo in the with-rosetta-i18n example.