### PR TITLE
feat(next-server): detect current domain locale first

### DIFF
--- a/packages/next/next-server/lib/i18n/detect-domain-locale.ts
+++ b/packages/next/next-server/lib/i18n/detect-domain-locale.ts
@@ -24,18 +24,19 @@ export function detectDomainLocale(
       detectedLocale = detectedLocale.toLowerCase()
     }
 
-    for (const item of domainItems) {
-      // remove port if present
-      const domainHostname = item.domain?.split(':')[0].toLowerCase()
-      if (
-        hostname === domainHostname ||
-        detectedLocale === item.defaultLocale.toLowerCase() ||
-        item.locales?.some((locale) => locale.toLowerCase() === detectedLocale)
-      ) {
-        domainItem = item
-        break
-      }
-    }
+    domainItem =
+      // Check whether current hostname is defined in domains and return it
+      domainItems.find(
+        (item) => hostname === item.domain?.split(':')[0].toLowerCase()
+      ) ??
+      // Check for domain item that uses the detected locale
+      domainItems.find(
+        (item) =>
+          detectedLocale === item.defaultLocale.toLowerCase() ||
+          item.locales?.some(
+            (locale) => locale.toLowerCase() === detectedLocale
+          )
+      )
   }
 
   return domainItem


### PR DESCRIPTION
This will check whether the current domain is available in i18n domains before checking all domains for current locale.

This fixes an issue where you can have multiple domains assigned for one locale and the function will return a different domain than the one you're currently on.

E.g. you can have your domains config set up as follows:
```javascript
domains: [
      {
        domain: 'examplebehindcloudfront.com',
        defaultLocale: 'en-US',
      },
      {
        domain: 'examplebehindloadbalancer.com',
        defaultLocale: 'en-US',
      },
    ],
```
Where you will then visit `examplebehindloadbalancer.com` and all your links will send you to `examplebehindcloudfront.com` because it's the first result in the list.