### PR TITLE
Update prerender-error.md

### DIFF
--- a/errors/prerender-error.md
+++ b/errors/prerender-error.md
@@ -9,4 +9,4 @@ While prerendering a page an error occurred. This can occur for many reasons fro
 - Make sure to move any non-pages out of the `pages` folder
 - Check for any code that assumes a prop is available even when it might not be. e.g., have default data for all dynamic pages' props.
 - Check for any out of date modules that you might be relying on
-- Check for any inappropriate use of Element/Component nested, eg:  <Link href="/"><a>{name}</a><span>inappropriate nested `span` will cause this error</span></Link>
+- Check for any inappropriate use of Element/Component nested, eg:  ```<Link href="/"><a>{name}</a><span>inappropriate nested `span` in `Link` will cause this error</span></Link>```

--- a/errors/prerender-error.md
+++ b/errors/prerender-error.md
@@ -9,3 +9,4 @@ While prerendering a page an error occurred. This can occur for many reasons fro
 - Make sure to move any non-pages out of the `pages` folder
 - Check for any code that assumes a prop is available even when it might not be. e.g., have default data for all dynamic pages' props.
 - Check for any out of date modules that you might be relying on
+- Check for any inappropriate use of Element/Component nested, eg:  <Link href="/"><a>{name}</a><span>inappropriate nested `span` will cause this error</span></Link>


### PR DESCRIPTION
Add one more possible cause for `prerender error`

- Check for any inappropriate use of Element/Component nested, 
eg:  
```<Link href="/"><a>{name}</a><span>inappropriate nested `span` in `Link` will cause this error</span>```