### PR TITLE
Cache-Control: public, ...

### DIFF
--- a/packages/next/next-server/server/send-payload.ts
+++ b/packages/next/next-server/server/send-payload.ts
@@ -28,10 +28,13 @@ export function setRevalidateHeaders(
 
     res.setHeader(
       'Cache-Control',
-      `s-maxage=${options.revalidate}, stale-while-revalidate`
+      `public, s-maxage=${options.revalidate}, stale-while-revalidate`
     )
   } else if (options.revalidate === false) {
-    res.setHeader('Cache-Control', `s-maxage=31536000, stale-while-revalidate`)
+    res.setHeader(
+      'Cache-Control',
+      `public, s-maxage=31536000, stale-while-revalidate`
+    )
   }
 }
 

--- a/test/integration/not-found-revalidate/test/index.test.js
+++ b/test/integration/not-found-revalidate/test/index.test.js
@@ -23,7 +23,7 @@ const runTests = () => {
     let $ = cheerio.load(await res.text())
 
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
@@ -33,7 +33,7 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
@@ -44,7 +44,7 @@ const runTests = () => {
 
     const props = JSON.parse($('#props').text())
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(200)
     expect(props.found).toBe(true)
@@ -57,7 +57,7 @@ const runTests = () => {
 
     const props2 = JSON.parse($('#props').text())
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(200)
     expect(props2.found).toBe(true)
@@ -70,7 +70,7 @@ const runTests = () => {
 
     const props3 = JSON.parse($('#props').text())
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(200)
     expect(props3.found).toBe(true)
@@ -89,7 +89,7 @@ const runTests = () => {
     let $ = cheerio.load(await res.text())
 
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
@@ -100,7 +100,7 @@ const runTests = () => {
 
     const props = JSON.parse($('#props').text())
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(200)
     expect(props.found).toBe(true)
@@ -113,7 +113,7 @@ const runTests = () => {
 
     const props2 = JSON.parse($('#props').text())
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(200)
     expect(props2.found).toBe(true)
@@ -126,7 +126,7 @@ const runTests = () => {
 
     const props3 = JSON.parse($('#props').text())
     expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate'
+      'public, s-maxage=1, stale-while-revalidate'
     )
     expect(res.status).toBe(200)
     expect(props3.found).toBe(true)

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -525,7 +525,7 @@ const runTests = (dev = false, isEmulatedServerless = false) => {
     it('should use correct caching headers for a revalidate page', async () => {
       const initialRes = await fetchViaHTTP(appPort, '/')
       expect(initialRes.headers.get('cache-control')).toBe(
-        's-maxage=2, stale-while-revalidate'
+        'public, s-maxage=2, stale-while-revalidate'
       )
     })
   }

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -1130,7 +1130,7 @@ const runTests = (dev = false, isEmulatedServerless = false) => {
       it('should use correct caching headers for a no-revalidate page', async () => {
         const initialRes = await fetchViaHTTP(appPort, '/something')
         expect(initialRes.headers.get('cache-control')).toBe(
-          's-maxage=31536000, stale-while-revalidate'
+          'public, s-maxage=31536000, stale-while-revalidate'
         )
         const initialHtml = await initialRes.text()
         expect(initialHtml).toMatch(/hello.*?world/)

--- a/test/integration/serverless-trace-revalidate/test/index.test.js
+++ b/test/integration/serverless-trace-revalidate/test/index.test.js
@@ -52,7 +52,7 @@ describe('Serverless Trace', () => {
     const url = `http://localhost:${appPort}/revalidate`
     const res = await fetch(url)
     expect(res.headers.get('Cache-Control')).toMatch(
-      's-maxage=10, stale-while-revalidate'
+      'public, s-maxage=10, stale-while-revalidate'
     )
   })
 })


### PR DESCRIPTION
Our CDN will not cache anything not explicitly marked public:
https://cloud.google.com/cdn/docs/caching#cacheability

> With the `USE_ORIGIN_HEADERS` cache mode, the response must have a `Cache-Control` header with a `public` directive, or an `Expires` header.

This change adds the `public` directive which will unbreak caching on Google's CDN, and  seems generally consistent with other headers set by next.js:
https://github.com/vercel/next.js/search?q=cache-control