### PR TITLE
Ensure static 500 hydrates correctly with query

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -1110,6 +1110,18 @@ export default class Router implements BaseRouter {
 
       // shallow routing is only allowed for same page URL changes.
       const isValidShallowRoute = options.shallow && this.route === route
+
+      if (
+        (options as any)._h &&
+        pathname === '/_error' &&
+        self.__NEXT_DATA__.props?.pageProps?.statusCode === 500 &&
+        props?.pageProps
+      ) {
+        // ensure statusCode is still correct for static 500 page
+        // when updating query information
+        props.pageProps.statusCode = 500
+      }
+
       await this.set(
         route,
         pathname!,

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -95,7 +95,7 @@ describe('Build Output', () => {
       expect(indexSize.endsWith('B')).toBe(true)
 
       // should be no bigger than 63.9 kb
-      expect(parseFloat(indexFirstLoad)).toBeCloseTo(63.9, 1)
+      expect(parseFloat(indexFirstLoad)).toBeCloseTo(64, 1)
       expect(indexFirstLoad.endsWith('kB')).toBe(true)
 
       expect(parseFloat(err404Size) - 3.7).toBeLessThanOrEqual(0)
@@ -168,7 +168,7 @@ describe('Build Output', () => {
       expect(parseFloat(indexSize)).toBeGreaterThanOrEqual(2)
       expect(indexSize.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(indexFirstLoad)).toBeLessThanOrEqual(66.7)
+      expect(parseFloat(indexFirstLoad)).toBeLessThanOrEqual(66.8)
       expect(parseFloat(indexFirstLoad)).toBeGreaterThanOrEqual(60)
       expect(indexFirstLoad.endsWith('kB')).toBe(true)
     })

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -1,6 +1,7 @@
 import spawn from 'cross-spawn'
 import express from 'express'
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { writeFile } from 'fs-extra'
 import getPort from 'get-port'
 import http from 'http'
 // `next` here is the symlink in `test/node_modules/next` which points to the root directory.
@@ -584,6 +585,18 @@ export function getPagesManifest(dir) {
     return readJson(serverFile)
   }
   return readJson(path.join(dir, '.next/serverless/pages-manifest.json'))
+}
+
+export function updatePagesManifest(dir, content) {
+  const serverFile = path.join(dir, '.next/server/pages-manifest.json')
+
+  if (existsSync(serverFile)) {
+    return writeFile(serverFile, content)
+  }
+  return writeFile(
+    path.join(dir, '.next/serverless/pages-manifest.json'),
+    content
+  )
 }
 
 export function getPageFileFromPagesManifest(dir, page) {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/22139 this ensures the default 500 error page hydrates with the correct `statusCode` prop when updating query values on the client since currently it will switch the 404 `statusCode` when one isn't present. An additional test case has been added to ensure this is handled correctly. 