### PR TITLE
docs(deployment): Update working directory in builder stage

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -95,6 +95,7 @@ RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM node:alpine AS builder
+WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build


### PR DESCRIPTION
Update docker file example in deploy documentation to use correct working directory in builder stage. It will fail to copy files from that stage since it's attempting to copy files that don't exist.