### PR TITLE
fix(create-next-app/packages): Improve error message using using create-next-app #19588

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -48,6 +48,17 @@ export async function createApp({
       }
     }
 
+    const isOnline = await getOnline('github.com')
+
+    if (!isOnline) {
+      console.error(
+        `Could not locate the repository for ${chalk.red(
+          `"${example}"`
+        )}. Please check your internet connection and try again`
+      )
+      process.exit(1)
+    }
+
     if (repoUrl) {
       if (repoUrl.origin !== 'https://github.com') {
         console.error(

--- a/packages/create-next-app/helpers/is-online.ts
+++ b/packages/create-next-app/helpers/is-online.ts
@@ -15,9 +15,11 @@ function getProxy(): string | undefined {
   }
 }
 
-export function getOnline(): Promise<boolean> {
+export function getOnline(
+  domain: string = 'registry.yarnpkg.com'
+): Promise<boolean> {
   return new Promise((resolve) => {
-    dns.lookup('registry.yarnpkg.com', (registryErr) => {
+    dns.lookup(domain, (registryErr) => {
       if (!registryErr) {
         return resolve(true)
       }


### PR DESCRIPTION
Running `npx create-next-app --example with-mongodb` produces the error:
```sh
"Could not locate an example named "with-mongodb". Please check your spelling and try again."
```
this problem might be caused by : 
- `Network connection issues`
-  `Github is down`

