### PR TITLE
docs(deployment): Update user ownership in docker deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,16 +105,19 @@ FROM node:alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
-USER nextjs
-EXPOSE 3000
 
 # You only need to copy next.config.js if you are NOT using the default configuration
 # COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
+
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+RUN chown -R nextjs:nodejs /app/.next
+USER nextjs
+
+EXPOSE 3000
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry


### PR DESCRIPTION
After testing the new docker deployment documentation, ran into the following error when running the container if you're using `next/image`:

```
[Error: EACCES: permission denied, unlink '/app/.next/cache/images/2+fKe4RlpMaSTNc8npKwiCItZgik9aOX9qkxnVSrsUo=/1613616499089.3hEMhfux5+SolMDEVHEaVPK2O0OlcLoYNao0yKpmYeg=.webp'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'unlink',
  path: '/app/.next/cache/images/2+fKe4RlpMaSTNc8npKwiCItZgik9aOX9qkxnVSrsUo=/1613616499089.3hEMhfux5+SolMDEVHEaVPK2O0OlcLoYNao0yKpmYeg=.webp'
}
```

This change gives the user correct ownership to have the correct permissions.