### PR TITLE
Switch to stable rust for with-webassembly example

### DIFF
--- a/examples/with-webassembly/package.json
+++ b/examples/with-webassembly/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "build-rust": "rustc +nightly --target wasm32-unknown-unknown -O --crate-type=cdylib src/add.rs -o add.wasm",
+    "build-rust": "rustc --target wasm32-unknown-unknown -O --crate-type=cdylib src/add.rs -o add.wasm",
     "start": "next start"
   },
   "license": "MIT"


### PR DESCRIPTION
Since Rust 1.30 (released Oct 2018), the wasm target is supported on stable.

ref: https://rustwasm.github.io/book/game-of-life/setup.html#the-rust-toolchain