### PR TITLE
Make the incremental cache storage and cache providers extensible.

### DIFF
--- a/packages/next/next-server/server/lib/storage.ts
+++ b/packages/next/next-server/server/lib/storage.ts
@@ -1,0 +1,19 @@
+import { promises } from 'fs'
+
+export interface StorageProfiderInterface {
+  readValue: (key: string) => Promise<string>
+  write: (key: string, value: string | undefined) => Promise<void>
+}
+
+export class FileSystemStorageProvider implements StorageProfiderInterface {
+  async readValue(key: string): Promise<string> {
+    return await promises.readFile(key, 'utf8')
+  }
+
+  async write(key: string, value: string | undefined) {
+    await promises.mkdir(key.substring(0, key.lastIndexOf('/')), {
+      recursive: true,
+    })
+    await promises.writeFile(key, String(value), 'utf8')
+  }
+}

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -272,6 +272,8 @@ export default class Server {
       ),
       locales: this.nextConfig.i18n?.locales,
       flushToDisk: !minimalMode && this.nextConfig.experimental.sprFlushToDisk,
+      storageProvider: this.nextConfig.storageProvider,
+      lruCacheProvider: this.nextConfig.lruCacheProvider,
     })
 
     /**


### PR DESCRIPTION
This will especially allow developers to store pages in object storages like S3 and shared cache like Redis. Thanks to that, all Next instances can share the same cache pool, therefore it increase the overall performances depending on the company infrastructure.

This commit basically changes nothing to the Next.js current features and behaviors. It just allow us to to use plugins to customize that behavior.