### PR TITLE
Consider a file an eligible page regardless of writeability

### DIFF
--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -23,9 +23,9 @@ import {
   normalizePathSep,
 } from '../next-server/server/normalize-page-path'
 import getRouteFromEntrypoint from '../next-server/server/get-route-from-entrypoint'
-import { isWriteable } from '../build/is-writeable'
 import { ClientPagesLoaderOptions } from '../build/webpack/loaders/next-client-pages-loader'
 import { stringify } from 'querystring'
+import { fileExists } from '../lib/file-exists'
 import { Rewrite } from '../lib/load-custom-routes'
 import { difference } from '../build/utils'
 import { NextConfig } from '../next-server/server/config'
@@ -321,7 +321,7 @@ export default class HotReloader {
               clientBundlePath,
               absolutePagePath,
             } = entries[page]
-            const pageExists = await isWriteable(absolutePagePath)
+            const pageExists = await fileExists(absolutePagePath)
             if (!pageExists) {
               // page was removed
               delete entries[page]

--- a/packages/next/server/lib/find-page-file.ts
+++ b/packages/next/server/lib/find-page-file.ts
@@ -1,7 +1,7 @@
 import { join, sep as pathSeparator, normalize } from 'path'
 import chalk from 'chalk'
-import { isWriteable } from '../../build/is-writeable'
 import { warn } from '../../build/output/log'
+import { fileExists } from '../../lib/file-exists'
 import { promises } from 'fs'
 import { denormalizePagePath } from '../../next-server/server/normalize-page-path'
 
@@ -31,14 +31,14 @@ export async function findPageFile(
       const relativePagePath = `${page}.${extension}`
       const pagePath = join(rootDir, relativePagePath)
 
-      if (await isWriteable(pagePath)) {
+      if (await fileExists(pagePath)) {
         foundPagePaths.push(relativePagePath)
       }
     }
 
     const relativePagePathWithIndex = join(page, `index.${extension}`)
     const pagePathWithIndex = join(rootDir, relativePagePathWithIndex)
-    if (await isWriteable(pagePathWithIndex)) {
+    if (await fileExists(pagePathWithIndex)) {
       foundPagePaths.push(relativePagePathWithIndex)
     }
   }


### PR DESCRIPTION
A file only needs to be readable to work as a page (as far as I can tell?), and if the file isn’t readable it seems better to throw a permission error instead of behaving the same as when it doesn’t exist at all.