### PR TITLE
Custom type or attributes of root element (#__next);

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -717,13 +717,15 @@ export class Head extends Component<
   }
 }
 
-export function Main() {
+export function Main<P extends React.HTMLAttributes<T>, T extends HTMLElement>(
+  props?: { type?: keyof React.ReactHTML } & React.ClassAttributes<T> & Omit<P, "id" | "children" | "dangerouslySetInnerHTML"> | null
+) {
   const { inAmpMode, docComponentsRendered } = useContext(HtmlContext)
 
   docComponentsRendered.Main = true
 
   if (inAmpMode) return <>{BODY_RENDER_TARGET}</>
-  return <div id="__next">{BODY_RENDER_TARGET}</div>
+  return React.createElement(props?.type || "div", { ...props, id: "__next", children: BODY_RENDER_TARGET })
 }
 
 export class NextScript extends Component<OriginProps> {


### PR DESCRIPTION
This PR allowed to custom type or attribute of root element (`#__next`) by `_document.js` or `_document.tsx`.

``` tsx
// _document.tsx
export default class CustomDocument extends Document {
    render(): JSX.Element {
        return (
            <Html>
                <Head />
                <body>
                    <Main type="section" className="section" />
                    <NextScript />
                </body>
            </Html>
        )
    }
}
```

``` html
// rendered html
<section type="section" class="section" id="__next">
  ...
</section>
```