### PR TITLE
Update authentication.md SSR example

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -68,7 +68,6 @@ Let's transform the profile example to use [server-side rendering](/docs/basic-f
 // pages/profile.js
 
 import withSession from '../lib/session'
-import useUser from '../lib/useUser'
 import Layout from '../components/Layout'
 
 export const getServerSideProps = withSession(async function ({ req, res }) {


### PR DESCRIPTION
There are two examples, one (a) for "Authenticating Statically Generated Pages" and one (b) for "Authenticating Server-Rendered Pages".

(a) uses a sudo `useUser` hook to fetch the user client-side.

It looks like the example for (b) was copied and pasted then edited from (a), but in (b) this `useUser` hook is not used (instead using `req.session.get('user')`).

This PR simply removes the unused import in the (b) example.