### PR TITLE
fix: avoid CLS issues with Google Page Speed img role="presentation"

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -427,6 +427,8 @@ export default function Image({
               aria-hidden={true}
               role="presentation"
               src={`data:image/svg+xml;base64,${toBase64(sizerSvg)}`}
+              width={widthInt}
+              height={heightInt}
             />
           ) : null}
         </div>


### PR DESCRIPTION
This PR fix an error with Google Page Speed that takes the images with `role="presentation"` as a reference of a real image and cause problems analyzing the page:

This is the current output from GPS:

![image (1)](https://user-images.githubusercontent.com/31737273/109556378-1ed2e280-7aad-11eb-97c7-785438ef3b63.png)

And this is the URL used to test: https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fseeed.us%2F&tab=mobile