### PR TITLE
Add note about preloading to routing introduction.

### DIFF
--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -74,6 +74,8 @@ In the example above we have multiple links, each one maps a path (`href`) to a 
 - `/about` → `pages/about.js`
 - `/blog/hello-world` → `pages/blog/[slug].js`
 
+Any `<Link />` in the viewport (initially or through scroll) will be preloaded by default for pages using [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation). Server-rendered routes are _not_ preloaded.
+
 ### Linking to dynamic paths
 
 You can also use interpolation to create the path, which comes in handy for [dynamic route segments](#dynamic-route-segments). For example, to show a list of posts which have been passed to the component as a prop:

--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -74,7 +74,7 @@ In the example above we have multiple links, each one maps a path (`href`) to a 
 - `/about` → `pages/about.js`
 - `/blog/hello-world` → `pages/blog/[slug].js`
 
-Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default including the corresponding data for pages using [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation). The corresponding data for [server-rendered](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) routes is _not_ prefetched.
+Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default (including the corresponding data) for pages using [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation). The corresponding data for [server-rendered](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) routes is _not_ prefetched.
 
 ### Linking to dynamic paths
 

--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -74,7 +74,7 @@ In the example above we have multiple links, each one maps a path (`href`) to a 
 - `/about` → `pages/about.js`
 - `/blog/hello-world` → `pages/blog/[slug].js`
 
-Any `<Link />` in the viewport (initially or through scroll) will be preloaded by default for pages using [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation). Server-rendered routes are _not_ preloaded.
+Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default including the corresponding data for pages using [Static Generation](/docs/basic-features/data-fetching.md#getstaticprops-static-generation). The corresponding data for [server-rendered](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) routes is _not_ prefetched.
 
 ### Linking to dynamic paths
 


### PR DESCRIPTION
Preloading is mentioned in the `next/link` docs, but not in the routing introduction.