### PR TITLE
[examples/with-typescript] Upgrade to React v17

### DIFF
--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -9,13 +9,13 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "devDependencies": {
     "@types/node": "^12.12.21",
-    "@types/react": "^16.9.16",
-    "@types/react-dom": "^16.9.4",
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.1",
     "typescript": "4.0"
   },
   "license": "MIT"


### PR DESCRIPTION
This avoids the warning when you init a new Next.js app with the example:

```
warn  - React 17.0.1 or newer will be required to leverage all of the upcoming features in Next.js 11. Read more: https://err.sh/next.js/react-version
```