### PR TITLE
Fix scroll position being reset on back and forward navigation

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -725,6 +725,7 @@ export default class Router implements BaseRouter {
       Object.assign<{}, TransitionOptions, TransitionOptions>({}, options, {
         shallow: options.shallow && this._shallow,
         locale: options.locale || this.defaultLocale,
+        scroll: false,
       }),
       forcedScroll
     )

--- a/test/integration/manual-scroll-restoration/pages/another.js
+++ b/test/integration/manual-scroll-restoration/pages/another.js
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+
+export default function Page() {
+  const link = (
+    <Link href="/">
+      <a
+        id="to-index"
+        style={{
+          marginLeft: 8000,
+          width: 15000,
+          display: 'block',
+        }}
+      >
+        to index
+      </a>
+    </Link>
+  )
+
+  return (
+    <>
+      <div
+        style={{
+          width: 11000,
+          height: 13000,
+          background: 'orange',
+        }}
+      />
+      {link}
+      <div id="end-el">hi from another</div>
+      <div
+        style={{
+          width: 11000,
+          height: 13000,
+          background: 'orange',
+        }}
+      />
+    </>
+  )
+}

--- a/test/integration/manual-scroll-restoration/pages/index.js
+++ b/test/integration/manual-scroll-restoration/pages/index.js
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+
+if (typeof window !== 'undefined') {
+  // Manually disable browser scroll restoration
+  window.history.scrollRestoration = 'manual'
+}
+
+const Page = () => {
+  const link = (
+    <Link href="/another">
+      <a
+        id="to-another"
+        style={{
+          marginLeft: 5000,
+          width: 95000,
+          display: 'block',
+        }}
+      >
+        to another
+      </a>
+    </Link>
+  )
+
+  return (
+    <>
+      <div
+        style={{
+          width: 10000,
+          height: 10000,
+          background: 'orange',
+        }}
+      />
+      {link}
+      <div id="end-el">the end</div>
+      <div
+        style={{
+          width: 10000,
+          height: 10000,
+          background: 'orange',
+        }}
+      />
+    </>
+  )
+}
+
+export default Page

--- a/test/integration/manual-scroll-restoration/test/index.test.js
+++ b/test/integration/manual-scroll-restoration/test/index.test.js
@@ -1,0 +1,109 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import webdriver from 'next-webdriver'
+import {
+  killApp,
+  findPort,
+  launchApp,
+  nextStart,
+  nextBuild,
+  check,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../')
+let appPort
+let app
+
+const runTests = () => {
+  it('should not reset the scroll position on navigating back and forward', async () => {
+    const browser = await webdriver(appPort, '/')
+    const scrollRestoration = await browser.eval(
+      () => window.history.scrollRestoration
+    )
+
+    // Make sure browser scroll restoration is disabled
+    expect(scrollRestoration).toBe('manual')
+
+    // scroll on /
+    await browser.eval(() =>
+      document.querySelector('#to-another').scrollIntoView()
+    )
+
+    // go to /another
+    await browser.eval(() => window.next.router.push('/another'))
+    await check(
+      () => browser.eval(() => document.documentElement.innerHTML),
+      /hi from another/
+    )
+
+    let anotherScrollX = Math.floor(await browser.eval(() => window.scrollX))
+    let anotherScrollY = Math.floor(await browser.eval(() => window.scrollY))
+
+    expect(anotherScrollX).toBe(0)
+    expect(anotherScrollY).toBe(0)
+
+    // scroll on /another
+    await browser.eval(() =>
+      document.querySelector('#to-index').scrollIntoView()
+    )
+
+    anotherScrollX = Math.floor(await browser.eval(() => window.scrollX))
+    anotherScrollY = Math.floor(await browser.eval(() => window.scrollY))
+
+    expect(anotherScrollX).not.toBe(0)
+    expect(anotherScrollY).not.toBe(0)
+
+    // back to /
+    await browser.eval(() => window.history.back())
+
+    // it should not change the scroll position
+    let scrollX = Math.floor(await browser.eval(() => window.scrollX))
+    let scrollY = Math.floor(await browser.eval(() => window.scrollY))
+
+    expect(scrollX).toBe(anotherScrollX)
+    expect(scrollY).toBe(anotherScrollY)
+
+    // scroll on /
+    await browser.eval(() =>
+      document.querySelector('#to-another').scrollIntoView()
+    )
+    scrollX = Math.floor(await browser.eval(() => window.scrollX))
+    scrollY = Math.floor(await browser.eval(() => window.scrollY))
+
+    // forward
+    await browser.eval(() => window.history.forward())
+
+    // it should not change the scroll position
+    anotherScrollX = Math.floor(await browser.eval(() => window.scrollX))
+    anotherScrollY = Math.floor(await browser.eval(() => window.scrollY))
+
+    expect(scrollX).toBe(anotherScrollX)
+    expect(scrollY).toBe(anotherScrollY)
+  })
+}
+
+describe('Manual Scroll Restoration', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('server mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+})


### PR DESCRIPTION
This PR fixes the behavior that Next.js always resets the scroll position to (0, 0) on `popState`, it's not noticeable because the browser corrects it after that. When explicitly set `history.scrollRestoration` to `'manual'` we are able to reproduce it.

Also adds a test because the current ones only cover the `scrollRestoration` experimental flag.

Fixes #20951.