### PR TITLE
Fix index revalidate with dynamic route in minimal mode

### DIFF
--- a/packages/next/next-server/server/config-utils.ts
+++ b/packages/next/next-server/server/config-utils.ts
@@ -51,7 +51,7 @@ export async function shouldLoadWithWebpack5(
 
 export async function loadWebpackHook(phase: string, dir: string) {
   let useWebpack5 = false
-  const worker: any = new Worker(__filename, { enableWorkerThreads: true })
+  const worker: any = new Worker(__filename, { enableWorkerThreads: false })
   try {
     useWebpack5 = Boolean(await worker.shouldLoadWithWebpack5(phase, dir))
   } catch {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -340,7 +340,7 @@ export default class Server {
       const { pathname, query } = parsedPath
       let matchedPathname = pathname as string
 
-      const matchedPathnameNoExt = isDataUrl
+      let matchedPathnameNoExt = isDataUrl
         ? matchedPathname.replace(/\.json$/, '')
         : matchedPathname
 
@@ -353,6 +353,11 @@ export default class Server {
         if (localePathResult.detectedLocale) {
           parsedUrl.query.__nextLocale = localePathResult.detectedLocale
         }
+      }
+
+      if (isDataUrl) {
+        matchedPathname = denormalizePagePath(matchedPathname)
+        matchedPathnameNoExt = denormalizePagePath(matchedPathnameNoExt)
       }
 
       const pageIsDynamic = isDynamicRoute(matchedPathnameNoExt)

--- a/test/integration/required-server-files/pages/[slug].js
+++ b/test/integration/required-server-files/pages/[slug].js
@@ -1,0 +1,18 @@
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'world',
+    },
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}
+
+export default function Page(props) {
+  return <p id="slug-page">[slug] page</p>
+}

--- a/test/integration/required-server-files/test/index.test.js
+++ b/test/integration/required-server-files/test/index.test.js
@@ -508,4 +508,30 @@ describe('Required Server Files', () => {
     expect(json.query).toEqual({ another: 'value' })
     expect(json.url).toBe('/api/optional?another=value')
   })
+
+  it('should match the index page correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/', undefined, {
+      headers: {
+        'x-matched-path': '/index',
+      },
+      redirect: 'manual',
+    })
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    expect($('#index').text()).toBe('index page')
+  })
+
+  it('should match the root dyanmic page correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/index', undefined, {
+      headers: {
+        'x-matched-path': '/[slug]',
+      },
+      redirect: 'manual',
+    })
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    expect($('#slug-page').text()).toBe('[slug] page')
+  })
 })


### PR DESCRIPTION
This fixes the case where index page revalidation would match a dynamic page instead of the index page from the pathname not being denormalized. 

Fixes: https://github.com/vercel/next.js/issues/22750