### PR TITLE
Add documentation for new static 500 behavior

### DIFF
--- a/docs/advanced-features/custom-error-page.md
+++ b/docs/advanced-features/custom-error-page.md
@@ -33,7 +33,7 @@ To create a custom 500 page you can create a `pages/500.js` file. This file is s
 
 ```jsx
 // pages/500.js
-export default function Custom404() {
+export default function Custom500() {
   return <h1>500 - Server-side error occurred</h1>
 }
 ```

--- a/docs/advanced-features/custom-error-page.md
+++ b/docs/advanced-features/custom-error-page.md
@@ -25,9 +25,22 @@ export default function Custom404() {
 
 ## 500 Page
 
-By default Next.js provides a 500 error page that matches the default 404 page’s style. This page is not statically optimized as it allows server-side errors to be reported. This is why 404 and 500 (other errors) are separated.
+Server-rendering an error page for every visit adds complexity to responding to errors. To help users get responses to errors as fast as possible, Next.js provides a static 500 page by default without having to add any additional files.
 
-### Customizing The Error Page
+### Customizing The 500 Page
+
+To create a custom 500 page you can create a `pages/500.js` file. This file is statically generated at build time.
+
+```jsx
+// pages/500.js
+export default function Custom404() {
+  return <h1>500 - Server-side error occurred</h1>
+}
+```
+
+> **Note**: You can use [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) inside this page if you need to fetch data at build time.
+
+### More Advanced Error Page Customizing
 
 500 errors are handled both client-side and server-side by the `Error` component. If you wish to override it, define the file `pages/_error.js` and add the following code:
 

--- a/docs/advanced-features/custom-error-page.md
+++ b/docs/advanced-features/custom-error-page.md
@@ -29,7 +29,7 @@ Server-rendering an error page for every visit adds complexity to responding to 
 
 ### Customizing The 500 Page
 
-To create a custom 500 page you can create a `pages/500.js` file. This file is statically generated at build time.
+To customize the 500 page you can create a `pages/500.js` file. This file is statically generated at build time.
 
 ```jsx
 // pages/500.js


### PR DESCRIPTION
This adds documentation for the new static 500 page handling. This also leaves the more advanced custom `_error` documentation in place for now.

x-ref: https://github.com/vercel/next.js/issues/22815
x-ref: https://github.com/vercel/next.js/pull/22139