### PR TITLE
Update Preview Mode docs for developing locally

### DIFF
--- a/docs/advanced-features/preview-mode.md
+++ b/docs/advanced-features/preview-mode.md
@@ -221,9 +221,7 @@ export default function myApiRoute(req, res) {
 Both the bypass cookie value and the private key for encrypting the `previewData` change when `next build` is completed.
 This ensures that the bypass cookie can’t be guessed.
 
-### Developing locally
-
-To test Preview Mode locally over HTTP, ensure the `NODE_ENV` environment variable is set to `development`. Your browser will need to allow third-party cookies and local storage access.
+> **Note:** To test Preview Mode locally over HTTP your browser will need to allow third-party cookies and local storage access.
 
 ## Learn more
 

--- a/docs/advanced-features/preview-mode.md
+++ b/docs/advanced-features/preview-mode.md
@@ -221,9 +221,9 @@ export default function myApiRoute(req, res) {
 Both the bypass cookie value and the private key for encrypting the `previewData` change when `next build` is completed.
 This ensures that the bypass cookie can’t be guessed.
 
-### Works locally
+### Developing locally
 
-To test preview mode locally over HTTP make sure the `NODE_ENV` environment variable is set to `development`.
+To test Preview Mode locally over HTTP, ensure the `NODE_ENV` environment variable is set to `development`. Your browser will need to allow third-party cookies and local storage access.
 
 ## Learn more
 

--- a/docs/advanced-features/preview-mode.md
+++ b/docs/advanced-features/preview-mode.md
@@ -221,6 +221,10 @@ export default function myApiRoute(req, res) {
 Both the bypass cookie value and the private key for encrypting the `previewData` change when `next build` is completed.
 This ensures that the bypass cookie can’t be guessed.
 
+### Works locally
+
+To test preview mode locally over HTTP make sure the `NODE_ENV` environment variable is set to `development`.
+
 ## Learn more
 
 The following pages might also be useful.


### PR DESCRIPTION
It took me a while to find out why preview mode wasn't working for me locally. As I'm not the only one (see for example https://github.com/vercel/next.js/discussions/11315) I thought it might be a good idea to mention this explicitly in the docs.