### PR TITLE
Add appDir field to server files manifest

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -407,6 +407,7 @@ export default async function build(
           compress: false,
           configFile: undefined,
         },
+        appDir: dir,
         files: [
           ROUTES_MANIFEST,
           path.relative(distDir, manifestPath),

--- a/test/integration/required-server-files/test/index.test.js
+++ b/test/integration/required-server-files/test/index.test.js
@@ -87,6 +87,7 @@ describe('Required Server Files', () => {
     expect(requiredFilesManifest.ignore.length).toBeGreaterThan(0)
     expect(typeof requiredFilesManifest.config.configFile).toBe('undefined')
     expect(typeof requiredFilesManifest.config.trailingSlash).toBe('boolean')
+    expect(typeof requiredFilesManifest.appDir).toBe('string')
 
     for (const file of requiredFilesManifest.files) {
       console.log('checking', file)


### PR DESCRIPTION
This adds an `appDir` field to the `required-server-files` manifest signifying where the app source is located. 

x-ref: https://github.com/vercel/next.js/issues/22847