### PR TITLE
Install tailwindcss as a development dependency

### DIFF
--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "next": "latest",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react-dom": "^17.0.1"
+  },
+  "devDependencies": {
     "autoprefixer": "^10.0.4",
     "postcss": "^8.1.10",
     "tailwindcss": "^2.0.2"


### PR DESCRIPTION
Set tailwindcss as a development dependency https://tailwindcss.com/docs/guides/nextjs#install-tailwind-via-npm