### PR TITLE
Silence trace debug messages

### DIFF
--- a/packages/next/telemetry/trace/autoparent.ts
+++ b/packages/next/telemetry/trace/autoparent.ts
@@ -1,4 +1,5 @@
 import { trace, Span } from './trace'
+import { debugLog } from './shared'
 
 const stacks = new WeakMap<any, Array<Span>>()
 const stoppedSpansSets = new WeakMap<any, Set<Span>>()
@@ -27,7 +28,7 @@ export function stackPush(keyObj: any, spanName: string, attrs?: any): Span {
 export function stackPop(keyObj: any, span: any): void {
   let stack = stacks.get(keyObj)
   if (!stack) {
-    console.info(
+    debugLog(
       'Attempted to pop from non-existent stack. Key reference must be bad.'
     )
     return
@@ -39,7 +40,7 @@ export function stackPop(keyObj: any, span: any): void {
     stoppedSpansSets.set(keyObj, stoppedSpans)
   }
   if (stoppedSpans.has(span)) {
-    console.info(
+    debugLog(
       `Attempted to terminate tracing span that was already stopped for ${span.name}`
     )
     return
@@ -56,12 +57,12 @@ export function stackPop(keyObj: any, span: any): void {
     } else if (poppedSpan === undefined || stack.indexOf(span) === -1) {
       // We've either reached the top of the stack or the stack doesn't contain
       // the span for another reason.
-      console.info(`Tracing span was not found in stack for: ${span.name}`)
+      debugLog(`Tracing span was not found in stack for: ${span.name}`)
       stoppedSpans.add(span)
       span.stop()
       break
     } else if (stack.indexOf(span) !== -1) {
-      console.info(
+      debugLog(
         `Attempted to pop span that was not at top of stack for: ${span.name}`
       )
       stoppedSpans.add(poppedSpan)

--- a/packages/next/telemetry/trace/shared.ts
+++ b/packages/next/telemetry/trace/shared.ts
@@ -10,3 +10,7 @@ export const traceGlobals: Map<any, any> = new Map()
 export const setGlobal = (key: any, val: any) => {
   traceGlobals.set(key, val)
 }
+
+export const debugLog = !!process.env.TRACE_DEBUG
+  ? console.info
+  : function noop() {}


### PR DESCRIPTION
These messages aren't necessary in the normal course of using Next.js.  Hiding behind a flag to reduce the noise.