### PR TITLE
Optimize memory usage for Next.js Image 

### DIFF
--- a/packages/next/next-server/server/lib/squoosh/impl.ts
+++ b/packages/next/next-server/server/lib/squoosh/impl.ts
@@ -83,3 +83,7 @@ export async function encodePng(
   })
   return Buffer.from(r)
 }
+
+export function noop() {
+  return null
+}


### PR DESCRIPTION
### Description

We recently noticed that #22253 introduced some high memory usage issue for image-optimizer. Here's a simple way that I'm using to reproduce it:

1. Create [this simple Next.js app](https://gist.github.com/shuding/e2f90ff8aad63a7ed661389070a1ed86), which conditionally optimizes 30 images (each one is ~500kB).
2. Build and start the app with inspector enabled, do a heap dump (1)
3. Click the "Load 30 Images" button, scroll through the page to ensure all images are requested
4. Do another head dump (2)

The memory usage increased from 19.3MB to 52.9MB (+274%), and most of the new allocated memory was taken by `ArrayBuffer` of ImageData, which should have been recollected after an image optimization request was done:

![CleanShot 2021-03-12 at 13 45 14@2x](https://user-images.githubusercontent.com/3676859/110944084-f1bce480-8376-11eb-854d-0ea4d99b9362.png)

When looking at the reference chain I noticed that they're hold by jest-worker (Farm.js) inside the worker thread. Which is very likely a memory leak.

### Root Cause

We are currently using `jest-worker@24.9.0` ([code](https://github.com/facebook/jest/tree/4418e7693e13d56deea7f1e6e10ea3cb0158cce5/packages/jest-worker)) and as suggested in the screenshot above, it keeps task arguments inside a linked list called `_last` ([code](https://github.com/facebook/jest/blob/4418e7693e13d56deea7f1e6e10ea3cb0158cce5/packages/jest-worker/src/Farm.ts#L155-L172)) but there's no removal action for it. So even with GC, the current head of that linked list won't be recollected as it will always have a reference.

After fixing that locally and with some further investigations, I noticed more memory related problems. The `onStart` and `onEnd` callbacks [here](https://github.com/facebook/jest/blob/4418e7693e13d56deea7f1e6e10ea3cb0158cce5/packages/jest-worker/src/Farm.ts#L81-L96) and `...args` will combine together as closures, and `task` will be passed to each worker ([code](https://github.com/facebook/jest/blob/4418e7693e13d56deea7f1e6e10ea3cb0158cce5/packages/jest-worker/src/Farm.ts#L134-L150)) with another closure. Inside the worker there's another closure that keeps the previous values until `_onProcessEnd` ([code](https://github.com/facebook/jest/blob/4418e7693e13d56deea7f1e6e10ea3cb0158cce5/packages/jest-worker/src/workers/NodeThreadsWorker.ts#L206-L218)). 

That means, the arguments (and potentially the return value, due to Promise related closures) of the task we are doing won't be recollected unless the worker receives a new task, so all function references can be replaced.

An estimation of leaked memory size will be ~`N ⨉ SizeOfOriginalImage ⨉ 2`, where N is the number of workers (CPU cores), with some other overheads.

### Fix

I first checked if the latest version `jest-worker@next` has fixed those issue, but unfortunately not. The latest version reimplemented the queue but still holds the reference in these closures internally. Although the same issue was roughly mentioned in the [PR](https://github.com/facebook/jest/pull/10921), the memory problem isn't fixed in my test app:

> ... This diff extracts the current queue implementation into the FifoQueue class and refactors the implementation to reduce the memory footprint. The current implementation added non-worker specific tasks to the queue of each worker. The result is that there are n * tasks queue entries where n is the number of workers for shared tasks. ...

It's not easy to get it fixed by doing more investigations and sending a patch to jest-worker, I suppose that Farm and Worker needs some non-trivial changes. And this problem will mostly only hurt us, because we are sending large objects as task arguments and results. 

Given the priority of this issue inside the image optimizer, a work around is to pass some extra tasks to clear out the current queue head and replace those internal values inside each worker so the previous task can be GC'd completely. I added a no-op method and make sure it will be called N times after a Squoosh task.

<img width="1604" alt="CleanShot 2021-03-12 at 13 43 23@2x" src="https://user-images.githubusercontent.com/3676859/110948594-7fe79980-837c-11eb-9550-7cd2928bd6d5.png">

With the fix the same app will not cause huge memory increase anymore (19.1MB → 19.9MB), and the ImageData and Buffer will be recollected successfully. There's small memory increase due to cache inside the HTTP module and extra loaded code.

Potentially fixes #22925.