### PR TITLE
Add an example using @next/plugin-storybook + fix webpack rules

### DIFF
--- a/examples/with-storybook-advanced/.babelrc
+++ b/examples/with-storybook-advanced/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": []
+}

--- a/examples/with-storybook-advanced/.gitignore
+++ b/examples/with-storybook-advanced/.gitignore
@@ -1,0 +1,37 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel
+
+# Storybook
+/storybook-static

--- a/examples/with-storybook-advanced/.storybook/main.js
+++ b/examples/with-storybook-advanced/.storybook/main.js
@@ -1,0 +1,8 @@
+module.exports = {
+  stories: ['../stories/*.stories.@(ts|tsx|js|jsx|mdx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@next/plugin-storybook',
+  ],
+}

--- a/examples/with-storybook-advanced/.storybook/preview.js
+++ b/examples/with-storybook-advanced/.storybook/preview.js
@@ -1,0 +1,16 @@
+export const parameters = {
+  options: {
+    storySort: (a, b) => {
+      // We want the Welcome story at the top
+      if (b[1].kind === 'Welcome') {
+        return 1
+      }
+
+      // Sort the other stories by ID
+      // https://github.com/storybookjs/storybook/issues/548#issuecomment-530305279
+      return a[1].kind === b[1].kind
+        ? 0
+        : a[1].id.localeCompare(b[1].id, { numeric: true })
+    },
+  },
+}

--- a/examples/with-storybook-advanced/README.md
+++ b/examples/with-storybook-advanced/README.md
@@ -1,0 +1,43 @@
+# Example app with Storybook
+
+This example shows a default set up of Storybook that includes the same build features as Next (built-in CSS support, module path aliases...).
+
+/!\ This example includes experimental features. Use `with-storybook` for a simpler but safer example.
+
+## TypeScript
+
+As of v6.0, Storybook has built-in TypeScript support, so no configuration is needed. If you want to customize the default configuration, refer to the [TypeScript docs](https://storybook.js.org/docs/react/configure/typescript).
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-storybook&project-name=with-storybook&repository-name=with-storybook)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-storybook with-storybook-app
+# or
+yarn create next-app --example with-storybook with-storybook-app
+```
+
+### Run Storybook
+
+```bash
+npm run storybook
+# or
+yarn storybook
+```
+
+### Build Static Storybook
+
+```bash
+npm run build-storybook
+# or
+yarn build-storybook
+```
+
+You can use [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) to deploy Storybook. Specify `storybook-static` as the output directory.

--- a/examples/with-storybook-advanced/components/index.js
+++ b/examples/with-storybook-advanced/components/index.js
@@ -1,0 +1,5 @@
+import helloWorld from '@/hello'
+
+export default function Home() {
+  return <div>{helloWorld}</div>
+}

--- a/examples/with-storybook-advanced/jsconfig.json
+++ b/examples/with-storybook-advanced/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["lib/*"]
+    }
+  }
+}

--- a/examples/with-storybook-advanced/lib/hello.js
+++ b/examples/with-storybook-advanced/lib/hello.js
@@ -1,0 +1,1 @@
+export default 'Hello world'

--- a/examples/with-storybook-advanced/package.json
+++ b/examples/with-storybook-advanced/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "with-storybook",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@next/plugin-storybook": "^10.0.8",
+    "@storybook/addon-essentials": "6.0.26",
+    "@storybook/addon-links": "6.0.26",
+    "@storybook/react": "6.0.26",
+    "babel-loader": "^8.0.5"
+  }
+}

--- a/examples/with-storybook-advanced/pages/index.js
+++ b/examples/with-storybook-advanced/pages/index.js
@@ -1,0 +1,10 @@
+import HelloWorld from '../components'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Simple Storybook Example</h1>
+      <HelloWorld />
+    </div>
+  )
+}

--- a/examples/with-storybook-advanced/stories/button.stories.js
+++ b/examples/with-storybook-advanced/stories/button.stories.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Button } from '@storybook/react/demo'
+
+export default {
+  title: 'Button',
+  argTypes: { onClick: { action: 'clicked' } },
+}
+
+const TemplateWithText = (args) => <Button {...args}>Hello Button</Button>
+
+const TemplateWithEmoji = (args) => (
+  <Button {...args}>
+    <span role="img" aria-label="so cool">
+      😀 😎 👍 💯
+    </span>
+  </Button>
+)
+
+export const withText = TemplateWithText.bind({})
+
+withText.args = {}
+
+export const withSomeEmoji = TemplateWithEmoji.bind({})
+
+withSomeEmoji.args = {}

--- a/examples/with-storybook-advanced/stories/helloWorld.stories.js
+++ b/examples/with-storybook-advanced/stories/helloWorld.stories.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import HelloWorld from '../components'
+
+export default { title: 'Hello World' }
+
+export const simpleComponent = () => <HelloWorld />

--- a/examples/with-storybook-advanced/stories/welcome.stories.js
+++ b/examples/with-storybook-advanced/stories/welcome.stories.js
@@ -1,0 +1,7 @@
+import React from 'react'
+import { linkTo } from '@storybook/addon-links'
+import { Welcome } from '@storybook/react/demo'
+
+export default { title: 'Welcome' }
+
+export const toStorybook = () => <Welcome showApp={linkTo('Button')} />

--- a/packages/next-plugin-storybook/preset.js
+++ b/packages/next-plugin-storybook/preset.js
@@ -25,7 +25,7 @@ async function webpackFinal(config) {
     ...nextWebpackConfig.resolve,
   }
 
-  config.module.rules = {
+  config.module.rules = [
     ...filterModuleRules(config),
     ...nextWebpackConfig.module.rules.map((rule) => {
       // we need to resolve next-babel-loader since it's not available
@@ -37,7 +37,7 @@ async function webpackFinal(config) {
       }
       return rule
     }),
-  }
+  ]
 
   return config
 }


### PR DESCRIPTION
This PR replaces #18367 , where I tried (but failed) to make a TS version of @next/plugin-storybook.

This PR:
- fix an issue in previous change @next/plugin-storybook that broke rules (you may want to merge https://github.com/vercel/next.js/pull/22125 first, it fixes this bug as well)
- sets a `with-storybook-advanced` example, that will serve as a basis of future development of this plugin. 
- This example strives to include the same level of "magic" in Storybook, and will help investigating remaining issues for @next/plugin-storybook https://github.com/vercel/next.js/issues/19345

Closes https://github.com/storybookjs/storybook/issues/11639

