### PR TITLE
Allow customizing of locale cookie name in config

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -336,7 +336,11 @@ export function getUtils({
     const pathname = parsedUrl.pathname || '/'
 
     let defaultLocale = i18n.defaultLocale
-    let detectedLocale = detectLocaleCookie(req, i18n.locales)
+    let detectedLocale = detectLocaleCookie(
+      req,
+      i18n.locales,
+      i18n.localeCookie
+    )
     let acceptPreferredLocale =
       i18n.localeDetection !== false
         ? accept.language(req.headers['accept-language'], i18n.locales)
@@ -414,7 +418,7 @@ export function getUtils({
         shouldAddLocalePrefix ||
         shouldStripDefaultLocale)
     ) {
-      // set the NEXT_LOCALE cookie when a user visits the default locale
+      // set the locale cookie when a user visits the default locale
       // with the locale prefix so that they aren't redirected back to
       // their accept-language preferred locale
       if (shouldStripDefaultLocale && acceptPreferredLocale !== defaultLocale) {
@@ -426,7 +430,7 @@ export function getUtils({
             : Array.isArray(previous)
             ? previous
             : []),
-          cookie.serialize('NEXT_LOCALE', defaultLocale, {
+          cookie.serialize(i18n.localeCookie, defaultLocale, {
             httpOnly: true,
             path: '/',
           }),

--- a/packages/next/next-server/lib/i18n/detect-locale-cookie.ts
+++ b/packages/next/next-server/lib/i18n/detect-locale-cookie.ts
@@ -1,10 +1,15 @@
 import { IncomingMessage } from 'http'
 
-export function detectLocaleCookie(req: IncomingMessage, locales: string[]) {
-  if (req.headers.cookie && req.headers.cookie.includes('NEXT_LOCALE')) {
-    const { NEXT_LOCALE } = (req as any).cookies
+export function detectLocaleCookie(
+  req: IncomingMessage,
+  locales: string[],
+  localeCookie: string
+) {
+  if (req.headers.cookie && req.headers.cookie.includes(localeCookie)) {
+    const localeFromCookie = (req as any).cookies[localeCookie]
     return locales.find(
-      (locale: string) => NEXT_LOCALE.toLowerCase() === locale.toLowerCase()
+      (locale: string) =>
+        localeFromCookie.toLowerCase() === locale.toLowerCase()
     )
   }
 }

--- a/packages/next/next-server/server/config-shared.ts
+++ b/packages/next/next-server/server/config-shared.ts
@@ -15,6 +15,7 @@ export type NextConfig = { [key: string]: any } & {
     defaultLocale: string
     domains?: DomainLocales
     localeDetection?: false
+    localeCookie: string
   } | null
 
   headers?: () => Promise<Header[]>

--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -385,6 +385,29 @@ function assignDefaults(userConfig: { [key: string]: any }) {
         `Specified i18n.localeDetection should be undefined or a boolean received ${localeDetectionType}.\nSee more info here: https://err.sh/next.js/invalid-i18n-config`
       )
     }
+
+    if (i18n.localeCookie) {
+      if (typeof i18n.localeCookie !== 'string') {
+        throw new Error(`Specified i18n.localeCookie should be a string`)
+      }
+
+      i18n.localeCookie = i18n.localeCookie.trim()
+
+      if (!i18n.localeCookie) {
+        throw new Error(`Specified i18n.localeCookie should not be empty`)
+      }
+
+      // This only checks for characters not allowed in a cookie name but does
+      // not stop users from creating a cookie name with only non alpha-numeric
+      // characters
+      if (!/^[$a-zA-Z0-9_-]+$/.test(i18n.localeCookie)) {
+        throw new Error(
+          `Specified i18n.localeCookie contains invalid characters`
+        )
+      }
+    }
+
+    i18n.localeCookie = i18n.localeCookie || 'NEXT_LOCALE'
   }
 
   return result

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -427,7 +427,11 @@ export default class Server {
       pathname = pathname || '/'
 
       let defaultLocale = i18n.defaultLocale
-      let detectedLocale = detectLocaleCookie(req, i18n.locales)
+      let detectedLocale = detectLocaleCookie(
+        req,
+        i18n.locales,
+        i18n.localeCookie
+      )
       let acceptPreferredLocale =
         i18n.localeDetection !== false
           ? accept.language(req.headers['accept-language'], i18n.locales)
@@ -512,7 +516,7 @@ export default class Server {
           shouldAddLocalePrefix ||
           shouldStripDefaultLocale)
       ) {
-        // set the NEXT_LOCALE cookie when a user visits the default locale
+        // set the locale cookie when a user visits the default locale
         // with the locale prefix so that they aren't redirected back to
         // their accept-language preferred locale
         if (
@@ -527,7 +531,7 @@ export default class Server {
               : Array.isArray(previous)
               ? previous
               : []),
-            cookie.serialize('NEXT_LOCALE', defaultLocale, {
+            cookie.serialize(i18n.localeCookie, defaultLocale, {
               httpOnly: true,
               path: '/',
             }),


### PR DESCRIPTION
Addresses feature request #23059 

Allows user to change locale cookie name in `next.config.js`:

```
{
  i18n: {
    localeCookie: 'locale'
  }
}
```