### PR TITLE
Update error message for next export and next/image.

### DIFF
--- a/errors/export-image-api.md
+++ b/errors/export-image-api.md
@@ -11,8 +11,9 @@ This is because Next.js optimizes images on-demand, as users request them (not a
 #### Possible Ways to Fix It
 
 - Use `next start` to run a server, which includes the Image Optimization API.
-- Use Vercel to deploy, which supports [Image Optimization](https://vercel.com/docs/next.js/image-optimization).
+- Use any provider which supports Image Optimization (like [Vercel](https://vercel.com/docs/next.js/image-optimization)).
 - Configure a third-party [loader](https://nextjs.org/docs/basic-features/image-optimization#loader) in `next.config.js`.
+- Use the [`loader`](https://nextjs.org/docs/api-reference/next/image#loader) prop for `next/image`.
 
 ### Useful Links
 

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -341,9 +341,10 @@ export default async function exportApp(
         throw new Error(
           `Image Optimization using Next.js' default loader is not compatible with \`next export\`.
   Possible solutions:
-    - Use \`next start\`, which starts the Image Optimization API.
-    - Use Vercel to deploy, which supports Image Optimization.
+    - Use \`next start\` to run a server, which includes the Image Optimization API.
+    - Use any provider which supports Image Optimization (like Vercel).
     - Configure a third-party loader in \`next.config.js\`.
+    - Use the \`loader\` prop for \`next/image\`.
   Read more: https://err.sh/next.js/export-image-api`
         )
       }


### PR DESCRIPTION
This wasn't reflecting the new `loader` prop for `next/image`.