### PR TITLE
Update pages.md

### DIFF
--- a/docs/basic-features/pages.md
+++ b/docs/basic-features/pages.md
@@ -160,7 +160,9 @@ export async function getStaticPaths() {
   const posts = await res.json()
 
   // Get the paths we want to pre-render based on posts
-  const paths = posts.map((post) => `/posts/${post.id}`)
+  const paths = posts.map((post) => ({
+    params: { id: post.id },
+  }))
 
   // We'll pre-render only these paths at build time.
   // { fallback: false } means other routes should 404.


### PR DESCRIPTION
The `path` variable must be an array of objects which has a `params` key. This code will prevent reader confusion.