### PR TITLE
Add image base path configuration option

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -93,6 +93,18 @@ The following Image Optimization cloud providers are included:
 If you need a different provider, you can use the [`loader`](/docs/api-reference/next/image.md#loader) prop with `next/image`.
 
 > The `next/image` component's default loader is not supported when using [`next export`](/docs/advanced-features/static-html-export.md). However, other loader options will work.
+> 
+
+### Base path
+If you have deployed your application under a sub-path of a domain using the `basePath` config option, you will need to configure your images to reference this path.
+
+```js
+module.exports = {
+  images: {
+    path: `yourBasePath/_next/image`,
+  },
+}
+```
 
 ## Caching
 

--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -93,10 +93,10 @@ The following Image Optimization cloud providers are included:
 If you need a different provider, you can use the [`loader`](/docs/api-reference/next/image.md#loader) prop with `next/image`.
 
 > The `next/image` component's default loader is not supported when using [`next export`](/docs/advanced-features/static-html-export.md). However, other loader options will work.
-> 
 
 ### Base path
-If you have deployed your application under a sub-path of a domain using the `basePath` config option, you will need to configure your images to reference this path.
+
+If you have deployed your application under a sub-path of a domain using the [`basePath`](/docs/api-reference/next.config.js/basepath.md) option, you will need to configure your images to reference this path.
 
 ```js
 module.exports = {
@@ -104,7 +104,6 @@ module.exports = {
     path: `yourBasePath/_next/image`,
   },
 }
-```
 
 ## Caching
 

--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -104,6 +104,7 @@ module.exports = {
     path: `yourBasePath/_next/image`,
   },
 }
+```
 
 ## Caching
 


### PR DESCRIPTION
I similarly [couldn't find this info](https://github.com/vercel/next.js/issues/19711#issuecomment-750414110) in the docs about configuring the image path when using an app `basePath`, so thought I'd add it.