### PR TITLE
Add note about multiple requests when using incremental static generation

### DIFF
--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -355,6 +355,8 @@ When a page with `getStaticProps` is pre-rendered at build time, in addition to 
 
 This JSON file will be used in client-side routing through `next/link` ([documentation](/docs/api-reference/next/link.md)) or `next/router` ([documentation](/docs/api-reference/next/router.md)). When you navigate to a page that’s pre-rendered using `getStaticProps`, Next.js fetches this JSON file (pre-computed at build time) and uses it as the props for the page component. This means that client-side page transitions will **not** call `getStaticProps` as only the exported JSON is used.
 
+When using Incremental Static Generation `getStaticProps` will be executed out of band to generate the JSON needed for client-side navigation. You may see this in the form of multiple requests being made for the same page, however, this is intended and has no impact on end-user performance
+
 #### Only allowed in a page
 
 `getStaticProps` can only be exported from a **page**. You can’t export it from non-page files.


### PR DESCRIPTION
To avoid some confusion around people thinking that getStaticProps will run twice in the same request.
