### PR TITLE
docs(authentication): rephrase next-iron-session/next-auth

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -119,10 +119,8 @@ Now that we've discussed authentication patterns, let's look at specific provide
 
 If you have an existing database with user data, you'll likely want to utilize an open-source solution that's provider agnostic.
 
-- If you need email/password log-in, use [`next-iron-session`](https://github.com/vercel/next.js/tree/canary/examples/with-iron-session).
-- If you need to persist session data on the server, use [`next-auth`](https://github.com/nextauthjs/next-auth-example).
-- If you need to support social login (Google, Facebook, etc.), use [`next-auth`](https://github.com/nextauthjs/next-auth-example).
-- If you want to use [JWTs](https://jwt.io/), use [`next-auth`](https://github.com/nextauthjs/next-auth-example).
+- If you want a low-level, encrypted, and stateless session utility use [`next-iron-session`](https://github.com/vercel/next.js/tree/canary/examples/with-iron-session).
+- If you want a full-featured authentication system with built-in providers (Google, Facebook, ...), JWT, JWE, email/password, magic links and more… use [`next-auth`](https://github.com/nextauthjs/next-auth-example).
 
 Both of these libraries support either authentication pattern. If you're interested in [Passport](http://www.passportjs.org/), we also have examples for it using secure and encrypted cookies:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -120,7 +120,7 @@ Now that we've discussed authentication patterns, let's look at specific provide
 If you have an existing database with user data, you'll likely want to utilize an open-source solution that's provider agnostic.
 
 - If you want a low-level, encrypted, and stateless session utility use [`next-iron-session`](https://github.com/vercel/next.js/tree/canary/examples/with-iron-session).
-- If you want a full-featured authentication system with built-in providers (Google, Facebook, ...), JWT, JWE, email/password, magic links and more… use [`next-auth`](https://github.com/nextauthjs/next-auth-example).
+- If you want a full-featured authentication system with built-in providers (Google, Facebook, GitHub…), JWT, JWE, email/password, magic links and more… use [`next-auth`](https://github.com/nextauthjs/next-auth-example).
 
 Both of these libraries support either authentication pattern. If you're interested in [Passport](http://www.passportjs.org/), we also have examples for it using secure and encrypted cookies:
 


### PR DESCRIPTION
I thought that the current wording was not accurate both for next-iron-session and next-auth.

- next-auth is a full-featured authentication system like passport
- next-iron-session is a session utility

The previous copy was less clear about that and, for example, said you should go for next-iron-session for user/password and next-auth for everything else. Which is not the case. I use next-iron-session with only a Slack login, and you can implement email/password with next-auth.

Hope you like it!

PS: I have no preference between the two, I think they serve a different purpose. I used the two (and authored one).

I used next-auth on https://sourcekarma.vercel.app/