### PR TITLE
Fix invalid console.error link

### DIFF
--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -190,7 +190,7 @@ function checkCustomRoutes(
       console.error(
         `The route ${
           (route as Rewrite).source
-        } rewrites urls outside of the basePath. Please use a destination that starts with \`http://\` or \`https://\` https://err.sh/vercel/next.js/invalid-external-rewrite.md`
+        } rewrites urls outside of the basePath. Please use a destination that starts with \`http://\` or \`https://\` https://err.sh/vercel/next.js/invalid-external-rewrite`
       )
       numInvalidRoutes++
       continue

--- a/test/integration/invalid-custom-routes/test/index.test.js
+++ b/test/integration/invalid-custom-routes/test/index.test.js
@@ -213,7 +213,7 @@ const runTests = () => {
     )
 
     expect(stderr).toContain(
-      `The route /hello rewrites urls outside of the basePath. Please use a destination that starts with \`http://\` or \`https://\` https://err.sh/vercel/next.js/invalid-external-rewrite.md`
+      `The route /hello rewrites urls outside of the basePath. Please use a destination that starts with \`http://\` or \`https://\` https://err.sh/vercel/next.js/invalid-external-rewrite`
     )
 
     expect(stderr).toContain('Invalid rewrites found')


### PR DESCRIPTION
# Issue

This console.log error below is currently opening a path to https://github.com/vercel/next.js/blob/master/errors/invalid-external-rewrite.md.md instead of https://github.com/vercel/next.js/blob/master/errors/invalid-external-rewrite.md.

![image](https://user-images.githubusercontent.com/28912696/111734430-5d032c80-8837-11eb-95f6-ccba047e2ad1.png)


