### PR TITLE
Allow quiet error logs option to be set from next.config.js

### DIFF
--- a/packages/next/next-server/server/config-shared.ts
+++ b/packages/next/next-server/server/config-shared.ts
@@ -80,6 +80,7 @@ export const defaultConfig: NextConfig = {
     scriptLoader: false,
     stats: false,
     externalDir: false,
+    quietErrorLog: false,
   },
   future: {
     strictPostcssConfiguration: false,

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -174,7 +174,7 @@ export default class Server {
     customServer = true,
   }: ServerConstructor & { conf: NextConfig; minimalMode?: boolean }) {
     this.dir = resolve(dir)
-    this.quiet = quiet
+    this.quiet = quiet || conf.experimental.quietErrorLog || false
     loadEnvConfig(this.dir, dev, Log)
 
     this.nextConfig = conf


### PR DESCRIPTION
This PR adds an option to next.config.js, `experimental.quietErrorLog`, which has the same effect as `quiet: true`.

Background:

There have been some issues raised related to custom logging, notably #4808. A basic part of the need is to disable built-in logging of thrown errors, so you can get to a clean slate and then add your own logs.

That feature exists: You can pass the `quiet: true` option when creating the server. However you must build a custom server implementation to do that. I'd rather avoid it, because staying current with a stock configuration pays benefits, and I'm happy with Next's standard routing. Furthermore, the [custom server documentation page](https://nextjs.org/docs/advanced-features/custom-server) indicates that building a custom server will sacrifice some standard features:

>Before deciding to use a custom server please keep in mind that it should only be used when the integrated router of Next.js can't meet your app requirements. A custom server will remove important performance optimizations…

In summary, I want to use the `quiet: true` option without making a custom server, and next.config.js seems like a suitable place to expose the option.

I'm happy to do additional legwork if this feature is wanted. Thank you!