### PR TITLE
Refactor: remove the usage of realSlug in example and doc

### DIFF
--- a/docs/migrating/from-gatsby.md
+++ b/docs/migrating/from-gatsby.md
@@ -148,17 +148,18 @@ import { join } from 'path'
 const postsDirectory = join(process.cwd(), 'src', 'content', 'blog')
 
 export function getPostBySlug(slug) {
-  const realSlug = slug.replace(/\.md$/, '')
-  const fullPath = join(postsDirectory, `${realSlug}.md`)
+  const fullPath = join(postsDirectory, `${slug}.md`)
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const { data, content } = matter(fileContents)
   const date = format(parseISO(data.date), 'MMMM dd, yyyy')
 
-  return { slug: realSlug, frontmatter: { ...data, date }, content }
+  return { slug, frontmatter: { ...data, date }, content }
 }
 
 export function getAllPosts() {
-  const slugs = fs.readdirSync(postsDirectory)
+  const slugs = fs
+    .readdirSync(postsDirectory)
+    .map((post) => post.replace(/\.md$/, ''))
   const posts = slugs.map((slug) => getPostBySlug(slug))
 
   return posts

--- a/examples/blog-starter-typescript/lib/api.ts
+++ b/examples/blog-starter-typescript/lib/api.ts
@@ -5,12 +5,11 @@ import matter from 'gray-matter'
 const postsDirectory = join(process.cwd(), '_posts')
 
 export function getPostSlugs() {
-  return fs.readdirSync(postsDirectory)
+  return fs.readdirSync(postsDirectory).map((post) => post.replace(/\.md$/, ''))
 }
 
 export function getPostBySlug(slug: string, fields: string[] = []) {
-  const realSlug = slug.replace(/\.md$/, '')
-  const fullPath = join(postsDirectory, `${realSlug}.md`)
+  const fullPath = join(postsDirectory, `${slug}.md`)
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const { data, content } = matter(fileContents)
 
@@ -23,7 +22,7 @@ export function getPostBySlug(slug: string, fields: string[] = []) {
   // Ensure only the minimal needed data is exposed
   fields.forEach((field) => {
     if (field === 'slug') {
-      items[field] = realSlug
+      items[field] = slug
     }
     if (field === 'content') {
       items[field] = content

--- a/examples/blog-starter/lib/api.js
+++ b/examples/blog-starter/lib/api.js
@@ -5,12 +5,11 @@ import matter from 'gray-matter'
 const postsDirectory = join(process.cwd(), '_posts')
 
 export function getPostSlugs() {
-  return fs.readdirSync(postsDirectory)
+  return fs.readdirSync(postsDirectory).map((post) => post.replace(/\.md$/, ''))
 }
 
 export function getPostBySlug(slug, fields = []) {
-  const realSlug = slug.replace(/\.md$/, '')
-  const fullPath = join(postsDirectory, `${realSlug}.md`)
+  const fullPath = join(postsDirectory, `${slug}.md`)
   const fileContents = fs.readFileSync(fullPath, 'utf8')
   const { data, content } = matter(fileContents)
 
@@ -19,7 +18,7 @@ export function getPostBySlug(slug, fields = []) {
   // Ensure only the minimal needed data is exposed
   fields.forEach((field) => {
     if (field === 'slug') {
-      items[field] = realSlug
+      items[field] = slug
     }
     if (field === 'content') {
       items[field] = content


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes

When I was reading the blog-starter example, the usage of `realSlug` confuses me a lot. I feel origin behavior of replacing `.md` from slug parameter first then concat it back again is hard to follow. It would be much straightforward to replace them in the `getPostSlugs` function, which is more close to this function's name. This PR also updates the similar code in  `docs/migrating/from-gatsby.md`.
