### PR TITLE
Add handling fo beforeFiles, afterFiles, and fallback rewrites

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -43,6 +43,11 @@ module.exports = {
 
 - `source` is the incoming request path pattern.
 - `headers` is an array of header objects with the `key` and `value` properties.
+- `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
+- `locale`: `false` or `undefined` - whether the locale should not be included when matching.
+- `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
+
+Headers are checked before the filesystem which includes pages and `/public` files.
 
 ## Header Overriding Behavior
 

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -38,6 +38,11 @@ module.exports = {
 - `source` is the incoming request path pattern.
 - `destination` is the path you want to route to.
 - `permanent` if the redirect is permanent or not.
+- `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
+- `locale`: `false` or `undefined` - whether the locale should not be included when matching.
+- `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
+
+Redirects are checked before the filesystem which includes pages and `/public` files.
 
 ## Path Matching
 

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -40,14 +40,16 @@ module.exports = {
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
 
-Rewrites are applied after checking the filesystem (pages and `/public` files) and dynamic routes by default. This behavior can be changed by instead returning an object instead of an array from the `rewrites` function:
+Rewrites are applied after checking the filesystem (pages and `/public` files) and before dynamic routes by default. This behavior can be changed by instead returning an object instead of an array from the `rewrites` function:
 
 ```js
 module.exports = {
   async rewrites() {
     return {
       beforeFiles: [
-        // allows override pages/public files
+        // These rewrites are checked after headers/redirects
+        // and before pages/public files which allows overriding
+        // page files
         {
           source: '/some-page',
           destination: '/somewhere-else',
@@ -55,15 +57,16 @@ module.exports = {
         },
       ],
       afterFiles: [
-        // before dynamic routes which allows rewriting to a dynamic route
+        // These rewrites are checked after pages/public files
+        // are checked but before dynamic routes
         {
           source: '/non-existent',
           destination: '/somewhere-else',
         },
       ],
       fallback: [
-        // allows incremental adoption without a no-op rewrite to
-        // trigger checking dynamic routes
+        // These rewrites are checked after both pages/public files
+        // and dynamic routes are checked
         {
           source: '/:path*',
           destination: 'https://my-old-site.com',

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -36,8 +36,14 @@ module.exports = {
 
 `rewrites` is an async function that expects an array to be returned holding objects with `source` and `destination` properties:
 
-- `source` is the incoming request path pattern.
-- `destination` is the path you want to route to.
+- `source`: `String` - is the incoming request path pattern.
+- `destination`: `String` is the path you want to route to.
+- `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
+- `locale`: `false` or `undefined` - whether the locale should not be included when matching.
+- `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
+- `override`: `true` or `undefined` - whether the rewrite should be checked before the filesystem (pages and `/public` files).
+
+Rewrites are applied after checking the filesystem (pages and `/public` files) and dynamic routes by default. This behavior can be changed by setting `override: true` on a rewrite.
 
 ## Rewrite parameters
 

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -17,8 +17,6 @@ Rewrites allow you to map an incoming request path to a different destination pa
 
 Rewrites are only available on the Node.js environment and do not affect client-side routing.
 
-Rewrites are not able to override public files or routes in the pages directory as these have higher priority than rewrites. For example, if you have `pages/index.js` you are not able to rewrite `/` to another location unless you rename the `pages/index.js` file.
-
 To use rewrites you can use the `rewrites` key in `next.config.js`:
 
 ```js
@@ -41,9 +39,40 @@ module.exports = {
 - `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
-- `override`: `true` or `undefined` - whether the rewrite should be checked before the filesystem (pages and `/public` files).
 
-Rewrites are applied after checking the filesystem (pages and `/public` files) and dynamic routes by default. This behavior can be changed by setting `override: true` on a rewrite.
+Rewrites are applied after checking the filesystem (pages and `/public` files) and dynamic routes by default. This behavior can be changed by instead returning an object instead of an array from the `rewrites` function:
+
+```js
+module.exports = {
+  async rewrites() {
+    return {
+      beforeFiles: [
+        // allows override pages/public files
+        {
+          source: '/some-page',
+          destination: '/somewhere-else',
+          has: [{ type: 'query', key: 'overrideMe' }],
+        },
+      ],
+      afterFiles: [
+        // before dynamic routes which allows rewriting to a dynamic route
+        {
+          source: '/non-existent',
+          destination: '/somewhere-else',
+        },
+      ],
+      fallback: [
+        // allows incremental adoption without a no-op rewrite to
+        // trigger checking dynamic routes
+        {
+          source: '/:path*',
+          destination: 'https://my-old-site.com',
+        },
+      ],
+    }
+  },
+}
+```
 
 ## Rewrite parameters
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -21,6 +21,7 @@ import loadCustomRoutes, {
   getRedirectStatus,
   normalizeRouteRegex,
   Redirect,
+  Rewrite,
   RouteType,
 } from '../lib/load-custom-routes'
 import { nonNullable } from '../lib/non-nullable'
@@ -475,6 +476,8 @@ export default async function build(
         ignore: [] as string[],
       }))
 
+    const combinedRewrites: Rewrite[] = [...overrideRewrites, ...rewrites]
+
     const configs = await nextBuildSpan
       .traceChild('generate-webpack-config')
       .traceAsyncFn(() =>
@@ -487,7 +490,7 @@ export default async function build(
             target,
             pagesDir,
             entrypoints: entrypoints.client,
-            rewrites,
+            rewrites: combinedRewrites,
           }),
           getBaseWebpackConfig(dir, {
             buildId,
@@ -497,7 +500,7 @@ export default async function build(
             target,
             pagesDir,
             entrypoints: entrypoints.server,
-            rewrites,
+            rewrites: combinedRewrites,
           }),
         ])
       )

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -295,11 +295,10 @@ export function printCustomRoutes({
   redirects,
   rewrites,
   headers,
-  overrideRewrites,
 }: CustomRoutes) {
   const printRoutes = (
     routes: Redirect[] | Rewrite[] | Header[],
-    type: 'Redirects' | 'Rewrites' | 'Headers' | 'Override Rewrites'
+    type: 'Redirects' | 'Rewrites' | 'Headers'
   ) => {
     const isRedirects = type === 'Redirects'
     const isHeaders = type === 'Headers'
@@ -355,11 +354,14 @@ export function printCustomRoutes({
   if (headers.length) {
     printRoutes(headers, 'Headers')
   }
-  if (overrideRewrites.length) {
-    printRoutes(overrideRewrites, 'Override Rewrites')
-  }
-  if (rewrites.length) {
-    printRoutes(rewrites, 'Rewrites')
+
+  const combinedRewrites = [
+    ...rewrites.beforeFiles,
+    ...rewrites.afterFiles,
+    ...rewrites.fallback,
+  ]
+  if (combinedRewrites.length) {
+    printRoutes(combinedRewrites, 'Rewrites')
   }
 }
 

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -295,10 +295,11 @@ export function printCustomRoutes({
   redirects,
   rewrites,
   headers,
+  overrideRewrites,
 }: CustomRoutes) {
   const printRoutes = (
     routes: Redirect[] | Rewrite[] | Header[],
-    type: 'Redirects' | 'Rewrites' | 'Headers'
+    type: 'Redirects' | 'Rewrites' | 'Headers' | 'Override Rewrites'
   ) => {
     const isRedirects = type === 'Redirects'
     const isHeaders = type === 'Headers'
@@ -351,11 +352,14 @@ export function printCustomRoutes({
   if (redirects.length) {
     printRoutes(redirects, 'Redirects')
   }
-  if (rewrites.length) {
-    printRoutes(rewrites, 'Rewrites')
-  }
   if (headers.length) {
     printRoutes(headers, 'Headers')
+  }
+  if (overrideRewrites.length) {
+    printRoutes(overrideRewrites, 'Override Rewrites')
+  }
+  if (rewrites.length) {
+    printRoutes(rewrites, 'Rewrites')
   }
 }
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -16,7 +16,6 @@ import {
 } from '../lib/constants'
 import { fileExists } from '../lib/file-exists'
 import { getPackageVersion } from '../lib/get-package-version'
-import { Rewrite } from '../lib/load-custom-routes'
 import { getTypeScriptConfiguration } from '../lib/typescript/getTypeScriptConfiguration'
 import {
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
@@ -61,6 +60,7 @@ import WebpackConformancePlugin, {
 import { WellKnownErrorsPlugin } from './webpack/plugins/wellknown-errors-plugin'
 import { NextConfig } from '../next-server/server/config'
 import { relative as relativePath, join as pathJoin } from 'path'
+import { CustomRoutes } from '../lib/load-custom-routes.js'
 
 type ExcludesFalse = <T>(x: T | false) => x is T
 
@@ -201,13 +201,16 @@ export default async function getBaseWebpackConfig(
     target?: string
     reactProductionProfiling?: boolean
     entrypoints: WebpackEntrypoints
-    rewrites: Rewrite[]
+    rewrites: CustomRoutes['rewrites']
   }
 ): Promise<webpack.Configuration> {
   let plugins: PluginMetaData[] = []
   let babelPresetPlugins: { dir: string; config: any }[] = []
 
-  const hasRewrites = rewrites.length > 0
+  const hasRewrites =
+    rewrites.beforeFiles.length > 0 ||
+    rewrites.afterFiles.length > 0 ||
+    rewrites.fallback.length > 0
 
   if (config.experimental.plugins) {
     plugins = await collectPlugins(dir, config.env, config.plugins)

--- a/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
@@ -109,6 +109,7 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
         const apiHandler = getApiHandler({
           pageModule: require("${absolutePagePath}"),
           rewrites: routesManifest.rewrites,
+          overrideRewrites: routesManifest.overrideRewrites,
           i18n: ${i18n || 'undefined'},
           page: "${page}",
           basePath: "${basePath}",
@@ -184,6 +185,7 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
         reactLoadableManifest,
 
         rewrites: routesManifest.rewrites,
+        overrideRewrites: routesManifest.overrideRewrites,
         i18n: ${i18n || 'undefined'},
         page: "${page}",
         buildId: "${buildId}",

--- a/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
@@ -106,10 +106,19 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
 
         import { getApiHandler } from 'next/dist/build/webpack/loaders/next-serverless-loader/api-handler'
 
+        const combinedRewrites = Array.isArray(routesManifest.rewrites)
+          ? routesManifest.rewrites
+          : []
+
+        if (!Array.isArray(routesManifest.rewrites)) {
+          combinedRewrites.push(...routesManifest.rewrites.beforeFiles)
+          combinedRewrites.push(...routesManifest.rewrites.afterFiles)
+          combinedRewrites.push(...routesManifest.rewrites.fallback)
+        }
+
         const apiHandler = getApiHandler({
           pageModule: require("${absolutePagePath}"),
-          rewrites: routesManifest.rewrites,
-          overrideRewrites: routesManifest.overrideRewrites,
+          rewrites: combinedRewrites,
           i18n: ${i18n || 'undefined'},
           page: "${page}",
           basePath: "${basePath}",
@@ -161,6 +170,16 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
       export let config = compMod['confi' + 'g'] || (compMod.then && compMod.then(mod => mod['confi' + 'g'])) || {}
       export const _app = App
 
+      const combinedRewrites = Array.isArray(routesManifest.rewrites)
+        ? routesManifest.rewrites
+        : []
+
+      if (!Array.isArray(routesManifest.rewrites)) {
+        combinedRewrites.push(...routesManifest.rewrites.beforeFiles)
+        combinedRewrites.push(...routesManifest.rewrites.afterFiles)
+        combinedRewrites.push(...routesManifest.rewrites.fallback)
+      }
+
       const { renderReqToHTML, render } = getPageHandler({
         pageModule: compMod,
         pageComponent: Component,
@@ -184,8 +203,7 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
         buildManifest,
         reactLoadableManifest,
 
-        rewrites: routesManifest.rewrites,
-        overrideRewrites: routesManifest.overrideRewrites,
+        rewrites: combinedRewrites,
         i18n: ${i18n || 'undefined'},
         page: "${page}",
         buildId: "${buildId}",

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -48,7 +48,6 @@ export type ServerlessHandlerCtx = {
   reactLoadableManifest?: any
   basePath: string
   rewrites: Rewrite[]
-  overrideRewrites: Rewrite[]
   pageIsDynamic: boolean
   generateEtags: boolean
   distDir: string
@@ -70,14 +69,12 @@ export function getUtils({
   i18n,
   basePath,
   rewrites,
-  overrideRewrites,
   pageIsDynamic,
 }: {
   page: ServerlessHandlerCtx['page']
   i18n?: ServerlessHandlerCtx['i18n']
   basePath: ServerlessHandlerCtx['basePath']
   rewrites: ServerlessHandlerCtx['rewrites']
-  overrideRewrites: ServerlessHandlerCtx['rewrites']
   pageIsDynamic: ServerlessHandlerCtx['pageIsDynamic']
 }) {
   let defaultRouteRegex: ReturnType<typeof getRouteRegex> | undefined
@@ -91,7 +88,7 @@ export function getUtils({
   }
 
   function handleRewrites(req: IncomingMessage, parsedUrl: UrlWithParsedQuery) {
-    for (const rewrite of [...overrideRewrites, ...rewrites]) {
+    for (const rewrite of rewrites) {
       const matcher = getCustomRouteMatcher(rewrite.source)
       let params = matcher(parsedUrl.pathname)
 

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -48,6 +48,7 @@ export type ServerlessHandlerCtx = {
   reactLoadableManifest?: any
   basePath: string
   rewrites: Rewrite[]
+  overrideRewrites: Rewrite[]
   pageIsDynamic: boolean
   generateEtags: boolean
   distDir: string
@@ -69,12 +70,14 @@ export function getUtils({
   i18n,
   basePath,
   rewrites,
+  overrideRewrites,
   pageIsDynamic,
 }: {
   page: ServerlessHandlerCtx['page']
   i18n?: ServerlessHandlerCtx['i18n']
   basePath: ServerlessHandlerCtx['basePath']
   rewrites: ServerlessHandlerCtx['rewrites']
+  overrideRewrites: ServerlessHandlerCtx['rewrites']
   pageIsDynamic: ServerlessHandlerCtx['pageIsDynamic']
 }) {
   let defaultRouteRegex: ReturnType<typeof getRouteRegex> | undefined
@@ -88,7 +91,7 @@ export function getUtils({
   }
 
   function handleRewrites(req: IncomingMessage, parsedUrl: UrlWithParsedQuery) {
-    for (const rewrite of rewrites) {
+    for (const rewrite of [...overrideRewrites, ...rewrites]) {
       const matcher = getCustomRouteMatcher(rewrite.source)
       let params = matcher(parsedUrl.pathname)
 

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -117,11 +117,9 @@ export default class PageLoader {
   }
 
   /**
-   * @param {string} href the route href (file-system path)
+   * @param {string} route - the route (file-system path)
    */
-  _isSsg(href: string): Promise<boolean> {
-    const { pathname: hrefPathname } = parseRelativeUrl(href)
-    const route = normalizeRoute(hrefPathname)
+  _isSsg(route: string): Promise<boolean> {
     return this.promisedSsgManifest!.then((s: ClientSsgManifest) =>
       s.has(route)
     )

--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -191,7 +191,7 @@ export function getClientBuildManifest(): Promise<ClientBuildManifest> {
     // Mandatory because this is not concurrent safe:
     const cb = self.__BUILD_MANIFEST_CB
     self.__BUILD_MANIFEST_CB = () => {
-      resolve(self.__BUILD_MANIFEST)
+      resolve(self.__BUILD_MANIFEST!)
       cb && cb()
     }
   })

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -540,22 +540,29 @@ async function loadRewrites(config: NextConfig) {
   let afterFiles: Rewrite[] = []
   let fallback: Rewrite[] = []
 
-  if (!Array.isArray(_rewrites) && typeof _rewrites === 'object' && _rewrites) {
+  if (
+    !Array.isArray(_rewrites) &&
+    typeof _rewrites === 'object' &&
+    Object.keys(_rewrites).every(
+      (key) =>
+        key === 'beforeFiles' || key === 'afterFiles' || key === 'fallback'
+    )
+  ) {
     beforeFiles = _rewrites.beforeFiles || []
     afterFiles = _rewrites.afterFiles || []
     fallback = _rewrites.fallback || []
   } else {
-    afterFiles = _rewrites
+    afterFiles = _rewrites as any
   }
 
-  checkCustomRoutes(afterFiles, 'rewrite')
   checkCustomRoutes(beforeFiles, 'rewrite')
+  checkCustomRoutes(afterFiles, 'rewrite')
   checkCustomRoutes(fallback, 'rewrite')
 
   return {
-    fallback,
-    afterFiles,
-    beforeFiles,
+    beforeFiles: processRoutes(beforeFiles, config, 'rewrite'),
+    afterFiles: processRoutes(afterFiles, config, 'rewrite'),
+    fallback: processRoutes(fallback, config, 'rewrite'),
   }
 }
 

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -958,30 +958,32 @@ export default class Router implements BaseRouter {
       ? removePathTrailingSlash(delBasePath(pathname))
       : pathname
 
-    if (process.env.__NEXT_HAS_REWRITES && as.startsWith('/')) {
-      const rewritesResult = resolveRewrites(
-        addBasePath(addLocale(delBasePath(as), this.locale)),
-        pages,
-        rewrites,
-        query,
-        (p: string) => resolveDynamicRoute(p, pages),
-        this.locales
-      )
-      resolvedAs = rewritesResult.asPath
+    if (pathname !== '/_error') {
+      if (process.env.__NEXT_HAS_REWRITES && as.startsWith('/')) {
+        const rewritesResult = resolveRewrites(
+          addBasePath(addLocale(delBasePath(as), this.locale)),
+          pages,
+          rewrites,
+          query,
+          (p: string) => resolveDynamicRoute(p, pages),
+          this.locales
+        )
+        resolvedAs = rewritesResult.asPath
 
-      if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
-        // if this directly matches a page we need to update the href to
-        // allow the correct page chunk to be loaded
-        pathname = rewritesResult.resolvedHref
-        parsed.pathname = pathname
-        url = formatWithValidation(parsed)
-      }
-    } else {
-      parsed.pathname = resolveDynamicRoute(pathname, pages)
+        if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
+          // if this directly matches a page we need to update the href to
+          // allow the correct page chunk to be loaded
+          pathname = rewritesResult.resolvedHref
+          parsed.pathname = pathname
+          url = formatWithValidation(parsed)
+        }
+      } else {
+        parsed.pathname = resolveDynamicRoute(pathname, pages)
 
-      if (parsed.pathname !== pathname) {
-        pathname = parsed.pathname
-        url = formatWithValidation(parsed)
+        if (parsed.pathname !== pathname) {
+          pathname = parsed.pathname
+          url = formatWithValidation(parsed)
+        }
       }
     }
 

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -929,6 +929,9 @@ export default class Router implements BaseRouter {
       return true
     }
 
+    let parsed = parseRelativeUrl(url)
+    let { pathname, query } = parsed
+
     // The build manifest needs to be loaded before auto-static dynamic pages
     // get their query parameters to allow ensuring they can be parsed properly
     // when rewritten to
@@ -943,18 +946,6 @@ export default class Router implements BaseRouter {
       return false
     }
 
-    const urlToPageResult = await this._urlToPage(
-      url,
-      as,
-      rewrites,
-      pages,
-      options.locale
-    )
-    const parsed = urlToPageResult.parsedUrl
-    const route = urlToPageResult.route
-    let resolvedAs = urlToPageResult.resolvedAs
-
-    let { pathname, query } = parsed
     // url and as should always be prefixed with basePath by this
     // point by either next/link or router.push/replace so strip the
     // basePath from the pathname to match the pages dir 1-to-1
@@ -969,6 +960,40 @@ export default class Router implements BaseRouter {
     // We should compare the new asPath to the current asPath, not the url
     if (!this.urlIsNew(cleanedAs) && !localeChange) {
       method = 'replaceState'
+    }
+
+    let route = removePathTrailingSlash(pathname)
+
+    // we need to resolve the as value using rewrites for dynamic SSG
+    // pages to allow building the data URL correctly
+    let resolvedAs = as
+
+    if (process.env.__NEXT_HAS_REWRITES && as.startsWith('/')) {
+      const rewritesResult = resolveRewrites(
+        addBasePath(addLocale(delBasePath(as), this.locale)),
+        pages,
+        rewrites,
+        query,
+        (p: string) => resolveDynamicRoute({ pathname: p }, pages).pathname!,
+        this.locales
+      )
+      resolvedAs = rewritesResult.asPath
+
+      if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
+        // if this directly matches a page we need to update the href to
+        // allow the correct page chunk to be loaded
+        route = rewritesResult.resolvedHref
+        pathname = rewritesResult.resolvedHref
+        parsed.pathname = pathname
+        url = formatWithValidation(parsed)
+      }
+    } else {
+      parsed = resolveDynamicRoute(parsed, pages) as typeof parsed
+
+      if (parsed.pathname !== pathname) {
+        pathname = parsed.pathname
+        url = formatWithValidation(parsed)
+      }
     }
 
     if (!isLocalURL(as)) {
@@ -1425,86 +1450,6 @@ export default class Router implements BaseRouter {
     return this.asPath !== asPath
   }
 
-  // This applies the Next.js automatic href resolution which matches the server
-  // side resolution by checking rewrites and dynamic routes in the correct
-  // order
-  async _urlToPage(
-    url: string,
-    asPath: string,
-    rewrites: {
-      beforeFiles: any[]
-      afterFiles: any[]
-      fallback: any[]
-    },
-    pages: string[],
-    locale?: string | false
-  ) {
-    let parsedUrl = parseRelativeUrl(url)
-    const parsedAs = parseRelativeUrl(asPath)
-    let { pathname } = parsedUrl
-
-    if (process.env.__NEXT_I18N_SUPPORT) {
-      if (locale === false) {
-        pathname = normalizeLocalePath!(pathname, this.locales).pathname
-        parsedUrl.pathname = pathname
-        url = formatWithValidation(parsedUrl)
-
-        const localePathResult = normalizeLocalePath!(
-          parsedAs.pathname,
-          this.locales
-        )
-        parsedAs.pathname = localePathResult.pathname
-        locale = localePathResult.detectedLocale || this.defaultLocale
-        asPath = formatWithValidation(parsedAs)
-      }
-    }
-    let resolvedAs = asPath
-    let matchedPage = false
-
-    if (
-      process.env.__NEXT_HAS_REWRITES &&
-      asPath.startsWith('/') &&
-      !matchedPage
-    ) {
-      const rewritesResult = resolveRewrites(
-        addBasePath(addLocale(delBasePath(asPath), this.locale)),
-        pages,
-        rewrites,
-        parsedUrl.query,
-        (p: string) => resolveDynamicRoute({ pathname: p }, pages).pathname!,
-        this.locales
-      )
-
-      if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
-        // if this directly matches a page we need to update the href to
-        // allow the correct page chunk to be loaded
-        matchedPage = true
-        parsedUrl.pathname = rewritesResult.resolvedHref
-        resolvedAs = rewritesResult.asPath
-      }
-    }
-
-    if (!matchedPage) {
-      parsedUrl = resolveDynamicRoute(
-        parsedUrl,
-        pages,
-        false
-      ) as typeof parsedUrl
-    }
-
-    url = formatWithValidation(parsedUrl)
-
-    return {
-      url,
-      asPath,
-      parsedUrl,
-      parsedAs,
-      resolvedAs,
-      locale,
-      route: removePathTrailingSlash(parsedUrl.pathname),
-    }
-  }
-
   /**
    * Prefetch page code, you may wait for the data during page rendering.
    * This feature only works in production!
@@ -1516,32 +1461,75 @@ export default class Router implements BaseRouter {
     asPath: string = url,
     options: PrefetchOptions = {}
   ): Promise<void> {
-    let rewrites: any
+    let parsed = parseRelativeUrl(url)
+
+    let { pathname } = parsed
+
+    if (process.env.__NEXT_I18N_SUPPORT) {
+      if (options.locale === false) {
+        pathname = normalizeLocalePath!(pathname, this.locales).pathname
+        parsed.pathname = pathname
+        url = formatWithValidation(parsed)
+
+        let parsedAs = parseRelativeUrl(asPath)
+        const localePathResult = normalizeLocalePath!(
+          parsedAs.pathname,
+          this.locales
+        )
+        parsedAs.pathname = localePathResult.pathname
+        options.locale = localePathResult.detectedLocale || this.defaultLocale
+        asPath = formatWithValidation(parsedAs)
+      }
+    }
+
     const pages = await this.pageLoader.getPageList()
 
-    if (process.env.__NEXT_HAS_REWRITES) {
+    let route = removePathTrailingSlash(pathname)
+    let resolvedAs = asPath
+
+    if (process.env.__NEXT_HAS_REWRITES && asPath.startsWith('/')) {
+      let rewrites: any
       ;({ __rewrites: rewrites } = await getClientBuildManifest())
+
+      const rewritesResult = resolveRewrites(
+        addBasePath(addLocale(delBasePath(asPath), this.locale)),
+        pages,
+        rewrites,
+        parsed.query,
+        (p: string) => resolveDynamicRoute({ pathname: p }, pages).pathname!,
+        this.locales
+      )
+
+      if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
+        // if this directly matches a page we need to update the href to
+        // allow the correct page chunk to be loaded
+        route = rewritesResult.resolvedHref
+        pathname = rewritesResult.resolvedHref
+        parsed.pathname = pathname
+        url = formatWithValidation(parsed)
+        resolvedAs = rewritesResult.asPath
+      }
+    } else {
+      parsed = resolveDynamicRoute(parsed, pages, false) as typeof parsed
+
+      if (parsed.pathname !== pathname) {
+        pathname = parsed.pathname
+        url = formatWithValidation(parsed)
+      }
     }
-    const urlToPageResult = await this._urlToPage(
-      url,
-      asPath,
-      rewrites,
-      pages,
-      options.locale
-    )
-    options.locale = urlToPageResult.locale
+
     // Prefetch is not supported in development mode because it would trigger on-demand-entries
     if (process.env.NODE_ENV !== 'production') {
       return
     }
 
     await Promise.all([
-      this.pageLoader._isSsg(urlToPageResult.route).then((isSsg: boolean) => {
+      this.pageLoader._isSsg(url).then((isSsg: boolean) => {
         return isSsg
           ? this._getStaticData(
               this.pageLoader.getDataHref(
-                urlToPageResult.url,
-                urlToPageResult.resolvedAs,
+                url,
+                resolvedAs,
                 true,
                 typeof options.locale !== 'undefined'
                   ? options.locale
@@ -1550,9 +1538,7 @@ export default class Router implements BaseRouter {
             )
           : false
       }),
-      this.pageLoader[options.priority ? 'loadPage' : 'prefetch'](
-        urlToPageResult.route
-      ),
+      this.pageLoader[options.priority ? 'loadPage' : 'prefetch'](route),
     ])
   }
 

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -1482,8 +1482,6 @@ export default class Router implements BaseRouter {
     }
 
     const pages = await this.pageLoader.getPageList()
-
-    let route = removePathTrailingSlash(pathname)
     let resolvedAs = asPath
 
     if (process.env.__NEXT_HAS_REWRITES && asPath.startsWith('/')) {
@@ -1498,25 +1496,25 @@ export default class Router implements BaseRouter {
         (p: string) => resolveDynamicRoute({ pathname: p }, pages).pathname!,
         this.locales
       )
+      resolvedAs = rewritesResult.asPath
 
       if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
         // if this directly matches a page we need to update the href to
         // allow the correct page chunk to be loaded
-        route = rewritesResult.resolvedHref
         pathname = rewritesResult.resolvedHref
         parsed.pathname = pathname
         url = formatWithValidation(parsed)
-        resolvedAs = rewritesResult.asPath
       }
     } else {
       parsed = resolveDynamicRoute(parsed, pages, false) as typeof parsed
 
       if (parsed.pathname !== pathname) {
         pathname = parsed.pathname
-        route = removePathTrailingSlash(pathname)
         url = formatWithValidation(parsed)
       }
     }
+    const route = removePathTrailingSlash(pathname)
+    resolvedAs = delLocale(delBasePath(resolvedAs), this.locale)
 
     // Prefetch is not supported in development mode because it would trigger on-demand-entries
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
@@ -12,7 +12,11 @@ const customRouteMatcher = pathMatch(true)
 export default function resolveRewrites(
   asPath: string,
   pages: string[],
-  rewrites: Rewrite[],
+  rewrites: {
+    beforeFiles: Rewrite[]
+    afterFiles: Rewrite[]
+    fallback: Rewrite[]
+  },
   query: ParsedUrlQuery,
   resolveHref: (path: string) => string,
   locales?: string[]
@@ -29,72 +33,109 @@ export default function resolveRewrites(
   )
   let resolvedHref
 
-  if (!pages.includes(fsPathname)) {
-    for (const rewrite of rewrites) {
-      const matcher = customRouteMatcher(rewrite.source)
-      let params = matcher(parsedAs.pathname)
+  const handleRewrite = (rewrite: Rewrite) => {
+    const matcher = customRouteMatcher(rewrite.source)
+    let params = matcher(parsedAs.pathname)
 
-      if (rewrite.has && params) {
-        const hasParams = matchHas(
-          {
-            headers: {
-              host: document.location.hostname,
-            },
-            cookies: Object.fromEntries(
-              document.cookie.split('; ').map((item) => {
-                const [key, ...value] = item.split('=')
-                return [key, value.join('=')]
-              })
-            ),
-          } as any,
-          rewrite.has,
-          parsedAs.query
-        )
+    if (rewrite.has && params) {
+      const hasParams = matchHas(
+        {
+          headers: {
+            host: document.location.hostname,
+          },
+          cookies: Object.fromEntries(
+            document.cookie.split('; ').map((item) => {
+              const [key, ...value] = item.split('=')
+              return [key, value.join('=')]
+            })
+          ),
+        } as any,
+        rewrite.has,
+        parsedAs.query
+      )
 
-        if (hasParams) {
-          Object.assign(params, hasParams)
-        } else {
-          params = false
-        }
+      if (hasParams) {
+        Object.assign(params, hasParams)
+      } else {
+        params = false
+      }
+    }
+
+    if (params) {
+      if (!rewrite.destination) {
+        // this is a proxied rewrite which isn't handled on the client
+        return true
+      }
+      const destRes = prepareDestination(
+        rewrite.destination,
+        params,
+        query,
+        true
+      )
+      parsedAs = destRes.parsedDestination
+      asPath = destRes.newUrl
+      Object.assign(query, destRes.parsedDestination.query)
+
+      fsPathname = removePathTrailingSlash(
+        normalizeLocalePath(delBasePath(asPath), locales).pathname
+      )
+
+      if (pages.includes(fsPathname)) {
+        // check if we now match a page as this means we are done
+        // resolving the rewrites
+        matchedPage = true
+        resolvedHref = fsPathname
+        return true
       }
 
-      if (params) {
-        if (!rewrite.destination) {
-          // this is a proxied rewrite which isn't handled on the client
+      // check if we match a dynamic-route, if so we break the rewrites chain
+      resolvedHref = resolveHref(fsPathname)
+
+      if (resolvedHref !== asPath && pages.includes(resolvedHref)) {
+        matchedPage = true
+        return true
+      }
+    }
+  }
+  let finished = false
+
+  for (let i = 0; i < rewrites.beforeFiles.length; i++) {
+    const rewrite = rewrites.beforeFiles[i]
+
+    if (handleRewrite(rewrite)) {
+      finished = true
+      break
+    }
+  }
+
+  if (!pages.includes(fsPathname)) {
+    if (!finished) {
+      for (let i = 0; i < rewrites.afterFiles.length; i++) {
+        const rewrite = rewrites.afterFiles[i]
+        if (handleRewrite(rewrite)) {
+          finished = true
           break
         }
-        const destRes = prepareDestination(
-          rewrite.destination,
-          params,
-          query,
-          true
-        )
-        parsedAs = destRes.parsedDestination
-        asPath = destRes.newUrl
-        Object.assign(query, destRes.parsedDestination.query)
+      }
+    }
 
-        fsPathname = removePathTrailingSlash(
-          normalizeLocalePath(delBasePath(asPath), locales).pathname
-        )
+    // check dynamic route before processing fallback rewrites
+    if (!finished) {
+      resolvedHref = resolveHref(fsPathname)
+      finished = pages.includes(resolvedHref)
+    }
 
-        if (pages.includes(fsPathname)) {
-          // check if we now match a page as this means we are done
-          // resolving the rewrites
-          matchedPage = true
-          resolvedHref = fsPathname
-          break
-        }
-
-        // check if we match a dynamic-route, if so we break the rewrites chain
-        resolvedHref = resolveHref(fsPathname)
-
-        if (resolvedHref !== asPath && pages.includes(resolvedHref)) {
-          matchedPage = true
+    if (!finished) {
+      for (let i = 0; i < rewrites.fallback.length; i++) {
+        const rewrite = rewrites.fallback[i]
+        if (handleRewrite(rewrite)) {
+          finished = true
           break
         }
       }
     }
   }
+
   return {
     asPath,
     parsedAs,

--- a/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
@@ -122,7 +122,8 @@ export default function resolveRewrites(
     // check dynamic route before processing fallback rewrites
     if (!finished) {
       resolvedHref = resolveHref(fsPathname)
-      finished = pages.includes(resolvedHref)
+      matchedPage = pages.includes(resolvedHref)
+      finished = matchedPage
     }
 
     if (!finished) {

--- a/packages/next/next-server/server/config-shared.ts
+++ b/packages/next/next-server/server/config-shared.ts
@@ -18,7 +18,14 @@ export type NextConfig = { [key: string]: any } & {
   } | null
 
   headers?: () => Promise<Header[]>
-  rewrites?: () => Promise<Rewrite[]>
+  rewrites?: () => Promise<
+    | Rewrite[]
+    | {
+        beforeFiles: Rewrite[]
+        afterFiles: Rewrite[]
+        fallback: Rewrite[]
+      }
+  >
   redirects?: () => Promise<Redirect[]>
 
   trailingSlash?: boolean

--- a/packages/next/next-server/server/config-shared.ts
+++ b/packages/next/next-server/server/config-shared.ts
@@ -24,9 +24,34 @@ export type NextConfig = { [key: string]: any } & {
   trailingSlash?: boolean
 
   future: {
-    strictPostcssConfiguration: boolean
-    excludeDefaultMomentLocales: boolean
-    webpack5: boolean
+    strictPostcssConfiguration?: boolean
+    excludeDefaultMomentLocales?: boolean
+    webpack5?: boolean
+  }
+
+  experimental: {
+    cpus?: number
+    plugins?: boolean
+    profiling?: boolean
+    sprFlushToDisk?: boolean
+    reactMode?: 'legacy' | 'concurrent' | 'blocking'
+    workerThreads?: boolean
+    pageEnv?: boolean
+    optimizeFonts?: boolean
+    optimizeImages?: boolean
+    optimizeCss?: boolean
+    scrollRestoration?: boolean
+    scriptLoader?: boolean
+    stats?: boolean
+    externalDir?: boolean
+    serialWebpackBuild?: boolean
+    babelMultiThread?: boolean
+    conformance?: boolean
+    amp?: {
+      optimizer?: any
+      validator?: string
+      skipValidation?: boolean
+    }
   }
 }
 

--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -55,6 +55,7 @@ export default class Router {
   redirects: Route[]
   catchAllRoute: Route
   pageChecker: PageChecker
+  overrideRewrites: Route[]
   dynamicRoutes: DynamicRoutes
   useFileSystemPublicRoutes: boolean
   locales: string[]
@@ -68,6 +69,7 @@ export default class Router {
     catchAllRoute,
     dynamicRoutes = [],
     pageChecker,
+    overrideRewrites = [],
     useFileSystemPublicRoutes,
     locales = [],
   }: {
@@ -77,6 +79,7 @@ export default class Router {
     rewrites: Route[]
     redirects: Route[]
     catchAllRoute: Route
+    overrideRewrites: Route[]
     dynamicRoutes: DynamicRoutes | undefined
     pageChecker: PageChecker
     useFileSystemPublicRoutes: boolean
@@ -90,6 +93,7 @@ export default class Router {
     this.pageChecker = pageChecker
     this.catchAllRoute = catchAllRoute
     this.dynamicRoutes = dynamicRoutes
+    this.overrideRewrites = overrideRewrites
     this.useFileSystemPublicRoutes = useFileSystemPublicRoutes
     this.locales = locales
   }
@@ -133,6 +137,7 @@ export default class Router {
     const allRoutes = [
       ...this.headers,
       ...this.redirects,
+      ...this.overrideRewrites,
       ...this.fsRoutes,
       // We only check the catch-all route if public page routes hasn't been
       // disabled

--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -51,11 +51,14 @@ export default class Router {
   basePath: string
   headers: Route[]
   fsRoutes: Route[]
-  rewrites: Route[]
   redirects: Route[]
+  rewrites: {
+    beforeFiles: Route[]
+    afterFiles: Route[]
+    fallback: Route[]
+  }
   catchAllRoute: Route
   pageChecker: PageChecker
-  overrideRewrites: Route[]
   dynamicRoutes: DynamicRoutes
   useFileSystemPublicRoutes: boolean
   locales: string[]
@@ -64,22 +67,28 @@ export default class Router {
     basePath = '',
     headers = [],
     fsRoutes = [],
-    rewrites = [],
+    rewrites = {
+      beforeFiles: [],
+      afterFiles: [],
+      fallback: [],
+    },
     redirects = [],
     catchAllRoute,
     dynamicRoutes = [],
     pageChecker,
-    overrideRewrites = [],
     useFileSystemPublicRoutes,
     locales = [],
   }: {
     basePath: string
     headers: Route[]
     fsRoutes: Route[]
-    rewrites: Route[]
+    rewrites: {
+      beforeFiles: Route[]
+      afterFiles: Route[]
+      fallback: Route[]
+    }
     redirects: Route[]
     catchAllRoute: Route
-    overrideRewrites: Route[]
     dynamicRoutes: DynamicRoutes | undefined
     pageChecker: PageChecker
     useFileSystemPublicRoutes: boolean
@@ -93,7 +102,6 @@ export default class Router {
     this.pageChecker = pageChecker
     this.catchAllRoute = catchAllRoute
     this.dynamicRoutes = dynamicRoutes
-    this.overrideRewrites = overrideRewrites
     this.useFileSystemPublicRoutes = useFileSystemPublicRoutes
     this.locales = locales
   }
@@ -126,6 +134,53 @@ export default class Router {
 
     let parsedUrlUpdated = parsedUrl
 
+    const applyCheckTrue = async (checkParsedUrl: UrlWithParsedQuery) => {
+      const originalFsPathname = checkParsedUrl.pathname
+      const fsPathname = replaceBasePath(this.basePath, originalFsPathname!)
+
+      for (const fsRoute of this.fsRoutes) {
+        const fsParams = fsRoute.match(fsPathname)
+
+        if (fsParams) {
+          checkParsedUrl.pathname = fsPathname
+
+          const fsResult = await fsRoute.fn(req, res, fsParams, checkParsedUrl)
+
+          if (fsResult.finished) {
+            return true
+          }
+
+          checkParsedUrl.pathname = originalFsPathname
+        }
+      }
+
+      let matchedPage = await memoizedPageChecker(fsPathname)
+
+      // If we didn't match a page check dynamic routes
+      if (!matchedPage) {
+        for (const dynamicRoute of this.dynamicRoutes) {
+          if (dynamicRoute.match(fsPathname)) {
+            matchedPage = true
+          }
+        }
+      }
+
+      // Matched a page or dynamic route so render it using catchAllRoute
+      if (matchedPage) {
+        checkParsedUrl.pathname = fsPathname
+
+        const pageParams = this.catchAllRoute.match(checkParsedUrl.pathname)
+
+        await this.catchAllRoute.fn(
+          req,
+          res,
+          pageParams as Params,
+          checkParsedUrl
+        )
+        return true
+      }
+    }
+
     /*
       Desired routes order
       - headers
@@ -137,7 +192,7 @@ export default class Router {
     const allRoutes = [
       ...this.headers,
       ...this.redirects,
-      ...this.overrideRewrites,
+      ...this.rewrites.beforeFiles,
       ...this.fsRoutes,
       // We only check the catch-all route if public page routes hasn't been
       // disabled
@@ -169,7 +224,29 @@ export default class Router {
             } as Route,
           ]
         : []),
-      ...this.rewrites,
+      ...this.rewrites.afterFiles,
+      ...(this.rewrites.fallback.length
+        ? [
+            {
+              type: 'route',
+              name: 'dynamic route/page check',
+              requireBasePath: false,
+              match: route('/:path*'),
+              fn: async (
+                _checkerReq,
+                _checkerRes,
+                _params,
+                parsedCheckerUrl
+              ) => {
+                return {
+                  finished: await applyCheckTrue(parsedCheckerUrl),
+                }
+              },
+            } as Route,
+            ...this.rewrites.fallback,
+          ]
+        : []),
+
       // We only check the catch-all route if public page routes hasn't been
       // disabled
       ...(this.useFileSystemPublicRoutes ? [this.catchAllRoute] : []),
@@ -288,55 +365,7 @@ export default class Router {
 
         // check filesystem
         if (testRoute.check === true) {
-          const originalFsPathname = parsedUrlUpdated.pathname
-          const fsPathname = replaceBasePath(this.basePath, originalFsPathname!)
-
-          for (const fsRoute of this.fsRoutes) {
-            const fsParams = fsRoute.match(fsPathname)
-
-            if (fsParams) {
-              parsedUrlUpdated.pathname = fsPathname
-
-              const fsResult = await fsRoute.fn(
-                req,
-                res,
-                fsParams,
-                parsedUrlUpdated
-              )
-
-              if (fsResult.finished) {
-                return true
-              }
-
-              parsedUrlUpdated.pathname = originalFsPathname
-            }
-          }
-
-          let matchedPage = await memoizedPageChecker(fsPathname)
-
-          // If we didn't match a page check dynamic routes
-          if (!matchedPage) {
-            for (const dynamicRoute of this.dynamicRoutes) {
-              if (dynamicRoute.match(fsPathname)) {
-                matchedPage = true
-              }
-            }
-          }
-
-          // Matched a page or dynamic route so render it using catchAllRoute
-          if (matchedPage) {
-            parsedUrlUpdated.pathname = fsPathname
-
-            const pageParams = this.catchAllRoute.match(
-              parsedUrlUpdated.pathname
-            )
-
-            await this.catchAllRoute.fn(
-              req,
-              res,
-              pageParams as Params,
-              parsedUrlUpdated
-            )
+          if (await applyCheckTrue(parsedUrlUpdated)) {
             return true
           }
         }

--- a/packages/next/server/hot-reloader.ts
+++ b/packages/next/server/hot-reloader.ts
@@ -26,9 +26,9 @@ import getRouteFromEntrypoint from '../next-server/server/get-route-from-entrypo
 import { isWriteable } from '../build/is-writeable'
 import { ClientPagesLoaderOptions } from '../build/webpack/loaders/next-client-pages-loader'
 import { stringify } from 'querystring'
-import { Rewrite } from '../lib/load-custom-routes'
 import { difference } from '../build/utils'
 import { NextConfig } from '../next-server/server/config'
+import { CustomRoutes } from '../lib/load-custom-routes'
 
 export async function renderScriptError(
   res: ServerResponse,
@@ -143,7 +143,7 @@ export default class HotReloader {
   private onDemandEntries: any
   private previewProps: __ApiPreviewProps
   private watcher: any
-  private rewrites: Rewrite[]
+  private rewrites: CustomRoutes['rewrites']
 
   constructor(
     dir: string,
@@ -158,7 +158,7 @@ export default class HotReloader {
       pagesDir: string
       buildId: string
       previewProps: __ApiPreviewProps
-      rewrites: Rewrite[]
+      rewrites: CustomRoutes['rewrites']
     }
   ) {
     this.buildId = buildId

--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -271,12 +271,14 @@ export default class DevServer extends Server {
     this.customRoutes = await loadCustomRoutes(this.nextConfig)
 
     // reload router
-    const { redirects, rewrites, headers, overrideRewrites } = this.customRoutes
+    const { redirects, rewrites, headers } = this.customRoutes
+
     if (
+      rewrites.beforeFiles.length ||
+      rewrites.afterFiles.length ||
+      rewrites.fallback.length ||
       redirects.length ||
-      rewrites.length ||
-      headers.length ||
-      overrideRewrites.length
+      headers.length
     ) {
       this.router = new Router(this.generateRoutes())
     }
@@ -286,10 +288,7 @@ export default class DevServer extends Server {
       config: this.nextConfig,
       previewProps: this.getPreviewProps(),
       buildId: this.buildId,
-      rewrites: [
-        ...this.customRoutes.overrideRewrites,
-        ...this.customRoutes.rewrites,
-      ],
+      rewrites,
     })
     await super.prepare()
     await this.addExportPathMapRoutes()
@@ -423,7 +422,11 @@ export default class DevServer extends Server {
   // override production loading of routes-manifest
   protected getCustomRoutes(): CustomRoutes {
     // actual routes will be loaded asynchronously during .prepare()
-    return { redirects: [], rewrites: [], headers: [], overrideRewrites: [] }
+    return {
+      redirects: [],
+      rewrites: { beforeFiles: [], afterFiles: [], fallback: [] },
+      headers: [],
+    }
   }
 
   private _devCachedPreviewProps: __ApiPreviewProps | undefined

--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -286,7 +286,10 @@ export default class DevServer extends Server {
       config: this.nextConfig,
       previewProps: this.getPreviewProps(),
       buildId: this.buildId,
-      rewrites: this.customRoutes.rewrites,
+      rewrites: [
+        ...this.customRoutes.overrideRewrites,
+        ...this.customRoutes.rewrites,
+      ],
     })
     await super.prepare()
     await this.addExportPathMapRoutes()

--- a/packages/next/server/next-dev-server.ts
+++ b/packages/next/server/next-dev-server.ts
@@ -271,8 +271,13 @@ export default class DevServer extends Server {
     this.customRoutes = await loadCustomRoutes(this.nextConfig)
 
     // reload router
-    const { redirects, rewrites, headers } = this.customRoutes
-    if (redirects.length || rewrites.length || headers.length) {
+    const { redirects, rewrites, headers, overrideRewrites } = this.customRoutes
+    if (
+      redirects.length ||
+      rewrites.length ||
+      headers.length ||
+      overrideRewrites.length
+    ) {
       this.router = new Router(this.generateRoutes())
     }
 
@@ -415,7 +420,7 @@ export default class DevServer extends Server {
   // override production loading of routes-manifest
   protected getCustomRoutes(): CustomRoutes {
     // actual routes will be loaded asynchronously during .prepare()
-    return { redirects: [], rewrites: [], headers: [] }
+    return { redirects: [], rewrites: [], headers: [], overrideRewrites: [] }
   }
 
   private _devCachedPreviewProps: __ApiPreviewProps | undefined

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -95,7 +95,7 @@ describe('Build Output', () => {
       expect(indexSize.endsWith('B')).toBe(true)
 
       // should be no bigger than 64.8 kb
-      expect(parseFloat(indexFirstLoad)).toBeCloseTo(65.4, 1)
+      expect(parseFloat(indexFirstLoad)).toBeCloseTo(65.3, 1)
       expect(indexFirstLoad.endsWith('kB')).toBe(true)
 
       expect(parseFloat(err404Size) - 3.7).toBeLessThanOrEqual(0)
@@ -104,7 +104,7 @@ describe('Build Output', () => {
       expect(parseFloat(err404FirstLoad)).toBeCloseTo(68.5, 0)
       expect(err404FirstLoad.endsWith('kB')).toBe(true)
 
-      expect(parseFloat(sharedByAll)).toBeCloseTo(65.1, 1)
+      expect(parseFloat(sharedByAll)).toBeCloseTo(65, 1)
       expect(sharedByAll.endsWith('kB')).toBe(true)
 
       if (_appSize.endsWith('kB')) {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -148,6 +148,17 @@ module.exports = {
         ],
         destination: '/with-params?host=1',
       },
+      {
+        source: '/hello',
+        has: [
+          {
+            type: 'query',
+            key: 'overrideMe',
+          },
+        ],
+        destination: '/with-params?overridden=1',
+        override: true,
+      },
     ]
   },
   async redirects() {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -1,165 +1,168 @@
 module.exports = {
   // target: 'serverless',
   async rewrites() {
-    return [
-      ...(process.env.ADD_NOOP_REWRITE === 'true'
-        ? [
+    return {
+      afterFiles: [
+        ...(process.env.ADD_NOOP_REWRITE === 'true'
+          ? [
+              {
+                source: '/:path*',
+                destination: '/:path*',
+              },
+            ]
+          : []),
+        {
+          source: '/rewriting-to-auto-export',
+          destination: '/auto-export/hello',
+        },
+        {
+          source: '/to-another',
+          destination: '/another/one',
+        },
+        {
+          source: '/nav',
+          destination: '/404',
+        },
+        {
+          source: '/hello-world',
+          destination: '/static/hello.txt',
+        },
+        {
+          source: '/',
+          destination: '/another',
+        },
+        {
+          source: '/another',
+          destination: '/multi-rewrites',
+        },
+        {
+          source: '/first',
+          destination: '/hello',
+        },
+        {
+          source: '/second',
+          destination: '/hello-again',
+        },
+        {
+          source: '/to-hello',
+          destination: '/hello',
+        },
+        {
+          source: '/blog/post-1',
+          destination: '/blog/post-2',
+        },
+        {
+          source: '/test/:path',
+          destination: '/:path',
+        },
+        {
+          source: '/test-overwrite/:something/:another',
+          destination: '/params/this-should-be-the-value',
+        },
+        {
+          source: '/params/:something',
+          destination: '/with-params',
+        },
+        {
+          source: '/query-rewrite/:section/:name',
+          destination: '/with-params?first=:section&second=:name',
+        },
+        {
+          source: '/hidden/_next/:path*',
+          destination: '/_next/:path*',
+        },
+        {
+          source: '/proxy-me/:path*',
+          destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
+        },
+        {
+          source: '/api-hello',
+          destination: '/api/hello',
+        },
+        {
+          source: '/api-hello-regex/:first(.*)',
+          destination: '/api/hello?name=:first*',
+        },
+        {
+          source: '/api-hello-param/:name',
+          destination: '/api/hello?hello=:name',
+        },
+        {
+          source: '/api-dynamic-param/:name',
+          destination: '/api/dynamic/:name?hello=:name',
+        },
+        {
+          source: '/:path/post-321',
+          destination: '/with-params',
+        },
+        {
+          source: '/unnamed-params/nested/(.*)/:test/(.*)',
+          destination: '/with-params',
+        },
+        {
+          source: '/catchall-rewrite/:path*',
+          destination: '/with-params',
+        },
+        {
+          source: '/catchall-query/:path*',
+          destination: '/with-params?another=:path*',
+        },
+        {
+          source: '/has-rewrite-1',
+          has: [
             {
-              source: '/:path*',
-              destination: '/:path*',
+              type: 'header',
+              key: 'x-my-header',
+              value: '(?<myHeader>.*)',
             },
-          ]
-        : []),
-      {
-        source: '/rewriting-to-auto-export',
-        destination: '/auto-export/hello',
-      },
-      {
-        source: '/to-another',
-        destination: '/another/one',
-      },
-      {
-        source: '/nav',
-        destination: '/404',
-      },
-      {
-        source: '/hello-world',
-        destination: '/static/hello.txt',
-      },
-      {
-        source: '/',
-        destination: '/another',
-      },
-      {
-        source: '/another',
-        destination: '/multi-rewrites',
-      },
-      {
-        source: '/first',
-        destination: '/hello',
-      },
-      {
-        source: '/second',
-        destination: '/hello-again',
-      },
-      {
-        source: '/to-hello',
-        destination: '/hello',
-      },
-      {
-        source: '/blog/post-1',
-        destination: '/blog/post-2',
-      },
-      {
-        source: '/test/:path',
-        destination: '/:path',
-      },
-      {
-        source: '/test-overwrite/:something/:another',
-        destination: '/params/this-should-be-the-value',
-      },
-      {
-        source: '/params/:something',
-        destination: '/with-params',
-      },
-      {
-        source: '/query-rewrite/:section/:name',
-        destination: '/with-params?first=:section&second=:name',
-      },
-      {
-        source: '/hidden/_next/:path*',
-        destination: '/_next/:path*',
-      },
-      {
-        source: '/proxy-me/:path*',
-        destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
-      },
-      {
-        source: '/api-hello',
-        destination: '/api/hello',
-      },
-      {
-        source: '/api-hello-regex/:first(.*)',
-        destination: '/api/hello?name=:first*',
-      },
-      {
-        source: '/api-hello-param/:name',
-        destination: '/api/hello?hello=:name',
-      },
-      {
-        source: '/api-dynamic-param/:name',
-        destination: '/api/dynamic/:name?hello=:name',
-      },
-      {
-        source: '/:path/post-321',
-        destination: '/with-params',
-      },
-      {
-        source: '/unnamed-params/nested/(.*)/:test/(.*)',
-        destination: '/with-params',
-      },
-      {
-        source: '/catchall-rewrite/:path*',
-        destination: '/with-params',
-      },
-      {
-        source: '/catchall-query/:path*',
-        destination: '/with-params?another=:path*',
-      },
-      {
-        source: '/has-rewrite-1',
-        has: [
-          {
-            type: 'header',
-            key: 'x-my-header',
-            value: '(?<myHeader>.*)',
-          },
-        ],
-        destination: '/with-params?myHeader=:myHeader',
-      },
-      {
-        source: '/has-rewrite-2',
-        has: [
-          {
-            type: 'query',
-            key: 'my-query',
-          },
-        ],
-        destination: '/with-params?value=:myquery',
-      },
-      {
-        source: '/has-rewrite-3',
-        has: [
-          {
-            type: 'cookie',
-            key: 'loggedIn',
-            value: 'true',
-          },
-        ],
-        destination: '/with-params?authorized=1',
-      },
-      {
-        source: '/has-rewrite-4',
-        has: [
-          {
-            type: 'host',
-            value: 'example.com',
-          },
-        ],
-        destination: '/with-params?host=1',
-      },
-      {
-        source: '/hello',
-        has: [
-          {
-            type: 'query',
-            key: 'overrideMe',
-          },
-        ],
-        destination: '/with-params?overridden=1',
-        override: true,
-      },
-    ]
+          ],
+          destination: '/with-params?myHeader=:myHeader',
+        },
+        {
+          source: '/has-rewrite-2',
+          has: [
+            {
+              type: 'query',
+              key: 'my-query',
+            },
+          ],
+          destination: '/with-params?value=:myquery',
+        },
+        {
+          source: '/has-rewrite-3',
+          has: [
+            {
+              type: 'cookie',
+              key: 'loggedIn',
+              value: 'true',
+            },
+          ],
+          destination: '/with-params?authorized=1',
+        },
+        {
+          source: '/has-rewrite-4',
+          has: [
+            {
+              type: 'host',
+              value: 'example.com',
+            },
+          ],
+          destination: '/with-params?host=1',
+        },
+      ],
+      beforeFiles: [
+        {
+          source: '/hello',
+          has: [
+            {
+              type: 'query',
+              key: 'overrideMe',
+            },
+          ],
+          destination: '/with-params?overridden=1',
+        },
+      ],
+    }
   },
   async redirects() {
     return [

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -692,7 +692,7 @@ const runTests = (isDev = false) => {
     expect(res2.status).toBe(404)
   })
 
-  it('should match has override rewrite correctly', async () => {
+  it('should match has rewrite correctly before files', async () => {
     const res1 = await fetchViaHTTP(appPort, '/hello')
     expect(res1.status).toBe(200)
     const $1 = cheerio.load(await res1.text())
@@ -878,8 +878,9 @@ const runTests = (isDev = false) => {
 
       for (const route of [
         ...manifest.dynamicRoutes,
-        ...manifest.rewrites,
-        ...manifest.overrideRewrites,
+        ...manifest.rewrites.beforeFiles,
+        ...manifest.rewrites.afterFiles,
+        ...manifest.rewrites.fallback,
         ...manifest.redirects,
         ...manifest.headers,
       ]) {
@@ -1313,202 +1314,204 @@ const runTests = (isDev = false) => {
             source: '/has-header-4',
           },
         ],
-        rewrites: [
-          {
-            destination: '/auto-export/hello',
-            regex: normalizeRegEx('^\\/rewriting-to-auto-export$'),
-            source: '/rewriting-to-auto-export',
-          },
-          {
-            destination: '/another/one',
-            regex: normalizeRegEx('^\\/to-another$'),
-            source: '/to-another',
-          },
-          {
-            destination: '/404',
-            regex: '^\\/nav$',
-            source: '/nav',
-          },
-          {
-            source: '/hello-world',
-            destination: '/static/hello.txt',
-            regex: normalizeRegEx('^\\/hello-world$'),
-          },
-          {
-            source: '/',
-            destination: '/another',
-            regex: normalizeRegEx('^\\/$'),
-          },
-          {
-            source: '/another',
-            destination: '/multi-rewrites',
-            regex: normalizeRegEx('^\\/another$'),
-          },
-          {
-            source: '/first',
-            destination: '/hello',
-            regex: normalizeRegEx('^\\/first$'),
-          },
-          {
-            source: '/second',
-            destination: '/hello-again',
-            regex: normalizeRegEx('^\\/second$'),
-          },
-          {
-            destination: '/hello',
-            regex: normalizeRegEx('^\\/to-hello$'),
-            source: '/to-hello',
-          },
-          {
-            destination: '/blog/post-2',
-            regex: normalizeRegEx('^\\/blog\\/post-1$'),
-            source: '/blog/post-1',
-          },
-          {
-            source: '/test/:path',
-            destination: '/:path',
-            regex: normalizeRegEx('^\\/test(?:\\/([^\\/]+?))$'),
-          },
-          {
-            source: '/test-overwrite/:something/:another',
-            destination: '/params/this-should-be-the-value',
-            regex: normalizeRegEx(
-              '^\\/test-overwrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$'
-            ),
-          },
-          {
-            source: '/params/:something',
-            destination: '/with-params',
-            regex: normalizeRegEx('^\\/params(?:\\/([^\\/]+?))$'),
-          },
-          {
-            destination: '/with-params?first=:section&second=:name',
-            regex: normalizeRegEx(
-              '^\\/query-rewrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$'
-            ),
-            source: '/query-rewrite/:section/:name',
-          },
-          {
-            destination: '/_next/:path*',
-            regex: normalizeRegEx(
-              '^\\/hidden\\/_next(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
-            ),
-            source: '/hidden/_next/:path*',
-          },
-          {
-            destination: `http://localhost:${externalServerPort}/:path*`,
-            regex: normalizeRegEx(
-              '^\\/proxy-me(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
-            ),
-            source: '/proxy-me/:path*',
-          },
-          {
-            destination: '/api/hello',
-            regex: normalizeRegEx('^\\/api-hello$'),
-            source: '/api-hello',
-          },
-          {
-            destination: '/api/hello?name=:first*',
-            regex: normalizeRegEx('^\\/api-hello-regex(?:\\/(.*))$'),
-            source: '/api-hello-regex/:first(.*)',
-          },
-          {
-            destination: '/api/hello?hello=:name',
-            regex: normalizeRegEx('^\\/api-hello-param(?:\\/([^\\/]+?))$'),
-            source: '/api-hello-param/:name',
-          },
-          {
-            destination: '/api/dynamic/:name?hello=:name',
-            regex: normalizeRegEx('^\\/api-dynamic-param(?:\\/([^\\/]+?))$'),
-            source: '/api-dynamic-param/:name',
-          },
-          {
-            destination: '/with-params',
-            regex: normalizeRegEx('^(?:\\/([^\\/]+?))\\/post-321$'),
-            source: '/:path/post-321',
-          },
-          {
-            destination: '/with-params',
-            regex: normalizeRegEx(
-              '^\\/unnamed-params\\/nested(?:\\/(.*))(?:\\/([^\\/]+?))(?:\\/(.*))$'
-            ),
-            source: '/unnamed-params/nested/(.*)/:test/(.*)',
-          },
-          {
-            destination: '/with-params',
-            regex: normalizeRegEx(
-              '^\\/catchall-rewrite(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
-            ),
-            source: '/catchall-rewrite/:path*',
-          },
-          {
-            destination: '/with-params?another=:path*',
-            regex: normalizeRegEx(
-              '^\\/catchall-query(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
-            ),
-            source: '/catchall-query/:path*',
-          },
-          {
-            destination: '/with-params?myHeader=:myHeader',
-            has: [
-              {
-                key: 'x-my-header',
-                type: 'header',
-                value: '(?<myHeader>.*)',
-              },
-            ],
-            regex: normalizeRegEx('^\\/has-rewrite-1$'),
-            source: '/has-rewrite-1',
-          },
-          {
-            destination: '/with-params?value=:myquery',
-            has: [
-              {
-                key: 'my-query',
-                type: 'query',
-              },
-            ],
-            regex: normalizeRegEx('^\\/has-rewrite-2$'),
-            source: '/has-rewrite-2',
-          },
-          {
-            destination: '/with-params?authorized=1',
-            has: [
-              {
-                key: 'loggedIn',
-                type: 'cookie',
-                value: 'true',
-              },
-            ],
-            regex: normalizeRegEx('^\\/has-rewrite-3$'),
-            source: '/has-rewrite-3',
-          },
-          {
-            destination: '/with-params?host=1',
-            has: [
-              {
-                type: 'host',
-                value: 'example.com',
-              },
-            ],
-            regex: '^\\/has-rewrite-4$',
-            source: '/has-rewrite-4',
-          },
-        ],
-        overrideRewrites: [
-          {
-            destination: '/with-params?overridden=1',
-            has: [
-              {
-                key: 'overrideMe',
-                type: 'query',
-              },
-            ],
-            override: true,
-            regex: normalizeRegEx('^\\/hello$'),
-            source: '/hello',
-          },
-        ],
+        rewrites: {
+          beforeFiles: [
+            {
+              destination: '/with-params?overridden=1',
+              has: [
+                {
+                  key: 'overrideMe',
+                  type: 'query',
+                },
+              ],
+              regex: normalizeRegEx('^\\/hello$'),
+              source: '/hello',
+            },
+          ],
+          afterFiles: [
+            {
+              destination: '/auto-export/hello',
+              regex: normalizeRegEx('^\\/rewriting-to-auto-export$'),
+              source: '/rewriting-to-auto-export',
+            },
+            {
+              destination: '/another/one',
+              regex: normalizeRegEx('^\\/to-another$'),
+              source: '/to-another',
+            },
+            {
+              destination: '/404',
+              regex: '^\\/nav$',
+              source: '/nav',
+            },
+            {
+              source: '/hello-world',
+              destination: '/static/hello.txt',
+              regex: normalizeRegEx('^\\/hello-world$'),
+            },
+            {
+              source: '/',
+              destination: '/another',
+              regex: normalizeRegEx('^\\/$'),
+            },
+            {
+              source: '/another',
+              destination: '/multi-rewrites',
+              regex: normalizeRegEx('^\\/another$'),
+            },
+            {
+              source: '/first',
+              destination: '/hello',
+              regex: normalizeRegEx('^\\/first$'),
+            },
+            {
+              source: '/second',
+              destination: '/hello-again',
+              regex: normalizeRegEx('^\\/second$'),
+            },
+            {
+              destination: '/hello',
+              regex: normalizeRegEx('^\\/to-hello$'),
+              source: '/to-hello',
+            },
+            {
+              destination: '/blog/post-2',
+              regex: normalizeRegEx('^\\/blog\\/post-1$'),
+              source: '/blog/post-1',
+            },
+            {
+              source: '/test/:path',
+              destination: '/:path',
+              regex: normalizeRegEx('^\\/test(?:\\/([^\\/]+?))$'),
+            },
+            {
+              source: '/test-overwrite/:something/:another',
+              destination: '/params/this-should-be-the-value',
+              regex: normalizeRegEx(
+                '^\\/test-overwrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$'
+              ),
+            },
+            {
+              source: '/params/:something',
+              destination: '/with-params',
+              regex: normalizeRegEx('^\\/params(?:\\/([^\\/]+?))$'),
+            },
+            {
+              destination: '/with-params?first=:section&second=:name',
+              regex: normalizeRegEx(
+                '^\\/query-rewrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))$'
+              ),
+              source: '/query-rewrite/:section/:name',
+            },
+            {
+              destination: '/_next/:path*',
+              regex: normalizeRegEx(
+                '^\\/hidden\\/_next(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
+              ),
+              source: '/hidden/_next/:path*',
+            },
+            {
+              destination: `http://localhost:${externalServerPort}/:path*`,
+              regex: normalizeRegEx(
+                '^\\/proxy-me(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
+              ),
+              source: '/proxy-me/:path*',
+            },
+            {
+              destination: '/api/hello',
+              regex: normalizeRegEx('^\\/api-hello$'),
+              source: '/api-hello',
+            },
+            {
+              destination: '/api/hello?name=:first*',
+              regex: normalizeRegEx('^\\/api-hello-regex(?:\\/(.*))$'),
+              source: '/api-hello-regex/:first(.*)',
+            },
+            {
+              destination: '/api/hello?hello=:name',
+              regex: normalizeRegEx('^\\/api-hello-param(?:\\/([^\\/]+?))$'),
+              source: '/api-hello-param/:name',
+            },
+            {
+              destination: '/api/dynamic/:name?hello=:name',
+              regex: normalizeRegEx('^\\/api-dynamic-param(?:\\/([^\\/]+?))$'),
+              source: '/api-dynamic-param/:name',
+            },
+            {
+              destination: '/with-params',
+              regex: normalizeRegEx('^(?:\\/([^\\/]+?))\\/post-321$'),
+              source: '/:path/post-321',
+            },
+            {
+              destination: '/with-params',
+              regex: normalizeRegEx(
+                '^\\/unnamed-params\\/nested(?:\\/(.*))(?:\\/([^\\/]+?))(?:\\/(.*))$'
+              ),
+              source: '/unnamed-params/nested/(.*)/:test/(.*)',
+            },
+            {
+              destination: '/with-params',
+              regex: normalizeRegEx(
+                '^\\/catchall-rewrite(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
+              ),
+              source: '/catchall-rewrite/:path*',
+            },
+            {
+              destination: '/with-params?another=:path*',
+              regex: normalizeRegEx(
+                '^\\/catchall-query(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$'
+              ),
+              source: '/catchall-query/:path*',
+            },
+            {
+              destination: '/with-params?myHeader=:myHeader',
+              has: [
+                {
+                  key: 'x-my-header',
+                  type: 'header',
+                  value: '(?<myHeader>.*)',
+                },
+              ],
+              regex: normalizeRegEx('^\\/has-rewrite-1$'),
+              source: '/has-rewrite-1',
+            },
+            {
+              destination: '/with-params?value=:myquery',
+              has: [
+                {
+                  key: 'my-query',
+                  type: 'query',
+                },
+              ],
+              regex: normalizeRegEx('^\\/has-rewrite-2$'),
+              source: '/has-rewrite-2',
+            },
+            {
+              destination: '/with-params?authorized=1',
+              has: [
+                {
+                  key: 'loggedIn',
+                  type: 'cookie',
+                  value: 'true',
+                },
+              ],
+              regex: normalizeRegEx('^\\/has-rewrite-3$'),
+              source: '/has-rewrite-3',
+            },
+            {
+              destination: '/with-params?host=1',
+              has: [
+                {
+                  type: 'host',
+                  value: 'example.com',
+                },
+              ],
+              regex: '^\\/has-rewrite-4$',
+              source: '/has-rewrite-4',
+            },
+          ],
+          fallback: [],
+        },
         dynamicRoutes: [
           {
             namedRegex: '^/another/(?<id>[^/]+?)(?:/)?$',
@@ -1557,7 +1560,12 @@ const runTests = (isDev = false) => {
       expect(cleanStdout).toMatch(/source.*?/i)
       expect(cleanStdout).toMatch(/destination.*?/i)
 
-      for (const route of [...manifest.redirects, ...manifest.rewrites]) {
+      for (const route of [
+        ...manifest.redirects,
+        ...manifest.rewrites.beforeFiles,
+        ...manifest.rewrites.afterFiles,
+        ...manifest.rewrites.fallback,
+      ]) {
         expect(cleanStdout).toContain(route.source)
         expect(cleanStdout).toContain(route.destination)
       }

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -954,7 +954,7 @@ function runTests(dev) {
         basePath: '',
         headers: [],
         rewrites: [],
-        overridesRewrites: [],
+        overrideRewrites: [],
         redirects: expect.arrayContaining([]),
         dataRoutes: [
           {

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -954,7 +954,6 @@ function runTests(dev) {
         basePath: '',
         headers: [],
         rewrites: [],
-        overrideRewrites: [],
         redirects: expect.arrayContaining([]),
         dataRoutes: [
           {

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -954,6 +954,7 @@ function runTests(dev) {
         basePath: '',
         headers: [],
         rewrites: [],
+        overridesRewrites: [],
         redirects: expect.arrayContaining([]),
         dataRoutes: [
           {


### PR DESCRIPTION
This adds support for returning an object from `rewrites` in `next.config.js` with `beforeFiles`, `afterFiles`, and `fallback` to allow specifying rewrites at different stages of routing. The existing support for returning an array for rewrites is still supported and behaves the same way. The documentation has been updated to include information on these new stages that can be rewritten and removes the outdated note of rewrites not being able to override pages. 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
