### PR TITLE
Make eslint opt-in until it lands on stable

### DIFF
--- a/packages/next/next-server/server/config-shared.ts
+++ b/packages/next/next-server/server/config-shared.ts
@@ -124,7 +124,7 @@ export const defaultConfig: NextConfig = {
   reactStrictMode: false,
   eslint: {
     dev: false,
-    build: true,
+    build: false,
   },
 }
 

--- a/test/integration/eslint/custom-eslint-config/next.config.js
+++ b/test/integration/eslint/custom-eslint-config/next.config.js
@@ -1,0 +1,1 @@
+module.exports = { eslint: { build: true } }

--- a/test/integration/eslint/pkg-json-eslint-config/next.config.js
+++ b/test/integration/eslint/pkg-json-eslint-config/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  eslint: { build: true },
+}


### PR DESCRIPTION
Ensures that the current stable release does not get automatically opted into eslint support until it's been tried out on enough apps.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
