### PR TITLE
Mark this.router protected

### DIFF
--- a/packages/next/next-server/server/image-optimizer.ts
+++ b/packages/next/next-server/server/image-optimizer.ts
@@ -8,6 +8,7 @@ import isAnimated from 'next/dist/compiled/is-animated'
 import { join } from 'path'
 import Stream from 'stream'
 import nodeUrl, { UrlWithParsedQuery } from 'url'
+import { NextConfig } from '../../next-server/server/config-shared'
 import { fileExists } from '../../lib/file-exists'
 import { ImageConfig, imageConfigDefault } from './image-config'
 import { processBuffer, Operation } from './lib/squoosh/main'
@@ -30,9 +31,10 @@ export async function imageOptimizer(
   server: Server,
   req: IncomingMessage,
   res: ServerResponse,
-  parsedUrl: UrlWithParsedQuery
+  parsedUrl: UrlWithParsedQuery,
+  nextConfig: NextConfig,
+  distDir: string
 ) {
-  const { nextConfig, distDir } = server
   const imageData: ImageConfig = nextConfig.images || imageConfigDefault
   const { deviceSizes = [], imageSizes = [], domains = [], loader } = imageData
 

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -784,7 +784,14 @@ export default class Server {
         type: 'route',
         name: '_next/image catchall',
         fn: (req, res, _params, parsedUrl) =>
-          imageOptimizer(server, req, res, parsedUrl),
+          imageOptimizer(
+            server,
+            req,
+            res,
+            parsedUrl,
+            server.nextConfig,
+            server.distDir
+          ),
       },
       {
         match: route('/_next/:path*'),

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -161,7 +161,7 @@ export default class Server {
   private compression?: Middleware
   private onErrorMiddleware?: ({ err }: { err: Error }) => Promise<void>
   private incrementalCache: IncrementalCache
-  router: Router
+  protected router: Router
   protected dynamicRoutes?: DynamicRoutes
   protected customRoutes: CustomRoutes
 

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -124,18 +124,18 @@ export type ServerConstructor = {
 }
 
 export default class Server {
-  dir: string
-  quiet: boolean
-  nextConfig: NextConfig
-  distDir: string
-  pagesDir?: string
-  publicDir: string
-  hasStaticDir: boolean
-  serverBuildDir: string
-  pagesManifest?: PagesManifest
-  buildId: string
-  minimalMode: boolean
-  renderOpts: {
+  protected dir: string
+  protected quiet: boolean
+  protected nextConfig: NextConfig
+  protected distDir: string
+  protected pagesDir?: string
+  protected publicDir: string
+  protected hasStaticDir: boolean
+  protected serverBuildDir: string
+  protected pagesManifest?: PagesManifest
+  protected buildId: string
+  protected minimalMode: boolean
+  protected renderOpts: {
     poweredByHeader: boolean
     buildId: string
     generateEtags: boolean


### PR DESCRIPTION
Seems that some people (#23558) are using Next.js internals based on the typings that TS generates automatically even though these values are not documented / should not be used in applications. This ensures the router value on Server is not used by accident.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
