### PR TITLE
updating clearer docs for redirecting externally

### DIFF
--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -666,7 +666,7 @@ The `context` parameter is an object containing the following keys:
   }
   ```
 
-- `redirect` - An **optional** redirect value to allow redirecting to internal and external resources. It should match the shape of `{ destination: string, permanent: boolean }`. In some rare cases, you might need to assign a custom status code for older HTTP Clients to properly redirect. In these cases, you can use the `statusCode` property instead of the `permanent` property, but not both. Below is an example of how it works:
+- `redirect` - An **optional** redirect value to allow redirecting to internal and external resources. It should match the shape of `{ destination: string, permanent: boolean, basePath?: boolean }`. In some rare cases, you might need to assign a custom status code for older HTTP Clients to properly redirect. In these cases, you can use the `statusCode` property instead of the `permanent` property, but not both. Do `basePath: false` for scenaries when you have a basePath and need to redirect externally. Below is an example of how it works:
 
   ```js
   export async function getServerSideProps(context) {


### PR DESCRIPTION
I encountered a scenario where I had a basePath and needed to redirect externally. example:
```
return {
    redirect: {
      destination: 'https://www.google.com',
      permanent: false
    }
}
```
This would append 'https://www.google.com' to the end of my internal app. After going on an excavation hunt and digging through the source code, I found this https://github.com/vercel/next.js/blob/0d5baf2c70eec21b92b75a2c2c2ea1fd9c3aa8c7/packages/next/next-server/server/next-server.ts#L1485.

This quick PR would save others time, by adding `basePath: false` to the redirect object.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
