### PR TITLE
Ensure default fallback values are correct with i18n

### DIFF
--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -146,7 +146,10 @@ export default async function exportPage({
       }
 
       // Check if the page is a specified dynamic route
-      if (isDynamic && page !== path) {
+      const nonLocalizedPath = normalizeLocalePath(path, renderOpts.locales)
+        .pathname
+
+      if (isDynamic && page !== nonLocalizedPath) {
         params = getRouteMatcher(getRouteRegex(page))(updatedPath) || undefined
         if (params) {
           // we have to pass these separately for serverless

--- a/test/integration/i18n-support/pages/gsp/fallback/[slug].js
+++ b/test/integration/i18n-support/pages/gsp/fallback/[slug].js
@@ -4,7 +4,14 @@ import { useRouter } from 'next/router'
 export default function Page(props) {
   const router = useRouter()
 
-  if (router.isFallback) return 'Loading...'
+  if (router.isFallback) {
+    return (
+      <>
+        <p>Loading...</p>
+        <p id="router-query">{JSON.stringify(router.query)}</p>
+      </>
+    )
+  }
 
   return (
     <>

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -37,6 +37,18 @@ async function addDefaultLocaleCookie(browser) {
 }
 
 export function runTests(ctx) {
+  it('should have correct initial query values for fallback', async () => {
+    const res = await fetchViaHTTP(
+      ctx.appPort,
+      `${ctx.basePath || '/gsp/fallback/random-' + Date.now()}`
+    )
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+
+    expect(JSON.parse($('#router-query').text())).toEqual({})
+  })
+
   it('should navigate to page with same name as development buildId', async () => {
     const browser = await webdriver(ctx.appPort, `${ctx.basePath || '/'}`)
 


### PR DESCRIPTION
This ensures we don't parse the default params when auto-exporting dynamic routes with i18n since the page and path aren't equal when localized. This adds an additional test case to ensure we don't regress on this behavior in the `i18n-support` test suites.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

Fixes: https://github.com/vercel/next.js/issues/23167