### PR TITLE
Remove outdated incremental adoption section in rewrites doc

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -276,31 +276,6 @@ module.exports = {
 }
 ```
 
-### Incremental adoption of Next.js
-
-You can also make Next.js check the application routes before falling back to proxying to the previous website.
-
-This way you don't have to change the rewrites configuration when migrating more pages to Next.js
-
-```js
-module.exports = {
-  async rewrites() {
-    return [
-      // we need to define a no-op rewrite to trigger checking
-      // all pages/static files before we attempt proxying
-      {
-        source: '/:path*',
-        destination: '/:path*',
-      },
-      {
-        source: '/:path*',
-        destination: `https://custom-routes-proxying-endpoint.vercel.app/:path*`,
-      },
-    ]
-  },
-}
-```
-
 ### Rewrites with basePath support
 
 When leveraging [`basePath` support](/docs/api-reference/next.config.js/basepath.md) with rewrites each `source` and `destination` is automatically prefixed with the `basePath` unless you add `basePath: false` to the rewrite:


### PR DESCRIPTION
Fixes #23699

The document says

> Rewrites are applied after checking the filesystem

so "check the application routes before falling back" is default
behavior and this config does nothing.

Also, at the beginning of the document it describes `beforeFiles`, `afterFiles` and `fallback` so this section seems just not necessary.

## Documentation / Examples

- [x] Make sure the linting passes
