### PR TITLE
Ensure no-op export returns without error

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -425,6 +425,10 @@ export default async function exportApp(
       hasApiRoutes = true
     }
 
+    if (filteredPaths.length === 0) {
+      return
+    }
+
     if (prerenderManifest && !options.buildExport) {
       const fallbackEnabledPages = new Set()
 

--- a/test/integration/no-op-export/test/index.test.js
+++ b/test/integration/no-op-export/test/index.test.js
@@ -1,0 +1,103 @@
+/* eslint-env jest */
+
+import path from 'path'
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild, nextExport } from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../')
+const nextConfig = join(appDir, 'next.config.js')
+
+const addPage = async (page, content) => {
+  const pagePath = join(appDir, 'pages', page)
+  await fs.ensureDir(path.dirname(pagePath))
+  await fs.writeFile(pagePath, content)
+}
+
+describe('no-op export', () => {
+  afterEach(async () => {
+    await Promise.all(
+      ['.next', 'pages', 'next.config.js', 'out'].map((file) =>
+        fs.remove(join(appDir, file))
+      )
+    )
+  })
+
+  it('should not error for all server-side pages build', async () => {
+    await addPage(
+      '_error.js',
+      `
+      import React from 'react'
+      export default class Error extends React.Component {
+        static async getInitialProps() {
+          return {
+            props: {
+              statusCode: 'oops'
+            }
+          }
+        }
+        render() {
+          return 'error page'
+        }
+      }
+    `
+    )
+    await addPage(
+      '[slug].js',
+      `
+      export const getStaticProps = () => {
+        return {
+          props: {}
+        }
+      }
+      export const getStaticPaths = () => {
+        return {
+          paths: [],
+          fallback: false
+        }
+      }
+      export default function Page() {
+        return 'page'
+      }
+    `
+    )
+    const result = await nextBuild(appDir, undefined, {
+      stderr: 'log',
+      stdout: 'log',
+    })
+    expect(result.code).toBe(0)
+  })
+
+  it('should not error for empty exportPathMap', async () => {
+    await addPage(
+      'index.js',
+      `
+      export default function Index() {
+        return 'hello world'
+      }
+    `
+    )
+    await fs.writeFile(
+      nextConfig,
+      `
+      module.exports = {
+        exportPathMap() {
+          return {}
+        }
+      }
+    `
+    )
+    const buildResult = await nextBuild(appDir, undefined, {
+      stderr: 'log',
+      stdout: 'log',
+    })
+    expect(buildResult.code).toBe(0)
+
+    const exportResult = await nextExport(appDir, {
+      outdir: join(appDir, 'out'),
+    })
+    expect(exportResult.code).toBe(0)
+  })
+})

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -121,6 +121,10 @@ export function runNextCommand(argv, options = {}) {
     if (options.stderr) {
       instance.stderr.on('data', function (chunk) {
         stderrOutput += chunk
+
+        if (options.stderr === 'log') {
+          console.log(chunk.toString())
+        }
       })
     }
 
@@ -128,6 +132,10 @@ export function runNextCommand(argv, options = {}) {
     if (options.stdout) {
       instance.stdout.on('data', function (chunk) {
         stdoutOutput += chunk
+
+        if (options.stdout === 'log') {
+          console.log(chunk.toString())
+        }
       })
     }
 


### PR DESCRIPTION
This ensures we don't reach the invariant from trying to create the export progress with no items during `next build` or `next export` by returning immediately when we notice there are no paths being exported. Additional tests have been added to ensure these cases don't error. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

Fixes: https://github.com/vercel/next.js/issues/23724