### PR TITLE
Move component check to route loader

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -308,15 +308,6 @@ export default async (opts: { webpackHMR?: any } = {}) => {
       throw pageEntrypoint.error
     }
     CachedComponent = pageEntrypoint.component
-
-    if (process.env.NODE_ENV !== 'production') {
-      const { isValidElementType } = require('react-is')
-      if (!isValidElementType(CachedComponent)) {
-        throw new Error(
-          `The default export is not a React Component in page: "${page}"`
-        )
-      }
-    }
   } catch (error) {
     // This catches errors like throwing in the top level of a module
     initialErr = error

--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -293,10 +293,25 @@ function createRouteLoader(assetPrefix: string): RouteLoader {
       Promise.resolve(execute)
         .then((fn) => fn())
         .then(
-          (exports: any) => ({
-            component: (exports && exports.default) || exports,
-            exports: exports,
-          }),
+          (exports: any) => {
+            const entrypoint = {
+              component: (exports && exports.default) || exports,
+              exports: exports,
+            }
+            if (process.env.NODE_ENV !== 'production') {
+              const { isValidElementType } = require('react-is')
+              if (!isValidElementType(entrypoint.component)) {
+                return {
+                  error: markAssetError(
+                    new Error(
+                      `The default export is not a React Component in page: "${route}"`
+                    )
+                  ),
+                }
+              }
+            }
+            return entrypoint
+          },
           (err) => ({ error: err })
         )
         .then((input: RouteEntrypoint) => {


### PR DESCRIPTION
The route loader loads routes + entrypoints and already has a mechanism for reporting errors, so we should just reuse that instead of checking much later.