### PR TITLE
Add experimental note to docs for has

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -156,6 +156,8 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
+Note: this feature is still experimental and not covered by semver and is to be used at your own risk until it is made stable.
+
 To only apply a header when either header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the header to be applied.
 
 `has` items have the following fields:

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -100,6 +100,8 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
+Note: this feature is still experimental and not covered by semver and is to be used at your own risk until it is made stable.
+
 To only match a redirect when header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the redirect to be applied.
 
 `has` items have the following fields:

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -180,6 +180,8 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
+Note: this feature is still experimental and not covered by semver and is to be used at your own risk until it is made stable.
+
 To only match a rewrite when header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the rewrite to be applied.
 
 `has` items have the following fields:


### PR DESCRIPTION
This adds a note the `has` documentation mentioning the feature is still experimental as we currently show a warning when the feature is used stating the same. 

## Documentation / Examples

- [x] Make sure the linting passes
