### PR TITLE
Stop accessing `/_app` exports

### DIFF
--- a/packages/next/build/webpack/loaders/next-client-pages-loader.ts
+++ b/packages/next/build/webpack/loaders/next-client-pages-loader.ts
@@ -25,7 +25,19 @@ function nextClientPagesLoader(this: any) {
     (window.__NEXT_P = window.__NEXT_P || []).push([
       ${stringifiedPage},
       function () {
-        return require(${stringifiedAbsolutePagePath});
+        const mod = require(${stringifiedAbsolutePagePath});
+        ${
+          page === '/_app'
+            ? `
+          const bufferedMetrics = window.__NEXT_REPORT_WEB_VITALS;
+          window.__NEXT_REPORT_WEB_VITALS = { push: mod.reportWebVitals || function() {} };
+          if (Array.isArray(bufferedMetrics)) {
+            bufferedMetrics.forEach(window.__NEXT_REPORT_WEB_VITALS.push)
+          }
+        `
+            : ``
+        }
+        return mod;
       }
     ]);
   `


### PR DESCRIPTION
Ideally, `reportWebVitals` would have just used the plugin system. Since that's not the case, this PR decouples it from next/client.

Instead of reaching into the module for `/_app` to call `reportWebVitals`, `next/client` will just buffer metrics to `window.__NEXT_REPORT_WEB_VITALS`. When an `/_app` page loads, it will just process the buffer and handle any future calls directly. This mirrors how page registration et al is done.

A better approach would have just been to make `reportWebVitals` an actual plugin and shim existing calls for compatibility, but I don't know the status of that RFC, or whether local plugins will ultimately be supported. It should be fairly trivial to port to it though.

---

We need to do this because in the near future, `/_app` will be loaded as a side effect of rendering (via Suspense), which means we don't have a module that we can just reach in and pull exports out of.