### PR TITLE
Update incremental migration doc and add version for new rewrites

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -40,7 +40,7 @@ module.exports = {
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.
 
-Rewrites are applied after checking the filesystem (pages and `/public` files) and before dynamic routes by default. This behavior can be changed by instead returning an object instead of an array from the `rewrites` function:
+Rewrites are applied after checking the filesystem (pages and `/public` files) and before dynamic routes by default. This behavior can be changed by instead returning an object instead of an array from the `rewrites` function since `v10.1` of Next.js:
 
 ```js
 module.exports = {

--- a/docs/migrating/incremental-adoption.md
+++ b/docs/migrating/incremental-adoption.md
@@ -46,6 +46,18 @@ For example, let's say you created a Next.js app to be served from `example.com`
 
 module.exports = {
   async rewrites() {
+    return {
+      // After checking all Next.js pages (including dynamic routes)
+      // and static files we proxy any other requests
+      fallback: [
+        {
+          source: '/:path*',
+          destination: `https://proxy.example.com/:path*`,
+        },
+      ],
+    }
+
+    // For versions of Next.js < v10.1 you can use a no-op rewrite instead
     return [
       // we need to define a no-op rewrite to trigger checking
       // all pages/static files before we attempt proxying


### PR DESCRIPTION
This updates the incremental migration doc to mention the new fallback rewrites over the previous no-op rewrite behavior. This also mentions the version the new rewrites modes were added to the rewrites doc.  

## Documentation / Examples

- [x] Make sure the linting passes
