### PR TITLE
Remove bugfix needed for webpack 4 when webpack 5 is used

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,7 @@
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["run", "debug", "dev", "test/integration/basic"],
       "skipFiles": ["<node_internals>/**"],
+      "outFiles": ["${workspaceFolder}/packages/next/dist/**/*"],
       "port": 9229
     },
     {

--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events'
 import { IncomingMessage, ServerResponse } from 'http'
 import { join, posix } from 'path'
 import { parse } from 'url'
-import { webpack } from 'next/dist/compiled/webpack/webpack'
+import { webpack, isWebpack5 } from 'next/dist/compiled/webpack/webpack'
 import * as Log from '../build/output/log'
 import {
   normalizePagePath,
@@ -293,12 +293,14 @@ class Invalidator {
     }
 
     this.building = true
-    // Work around a bug in webpack, calling `invalidate` on Watching.js
-    // doesn't trigger the invalid call used to keep track of the `.done` hook on multiCompiler
-    for (const compiler of this.multiCompiler.compilers) {
-      // @ts-ignore TODO: Check if this is still needed with webpack 5
-      compiler.hooks.invalid.call()
+    if (!isWebpack5) {
+      // Work around a bug in webpack, calling `invalidate` on Watching.js
+      // doesn't trigger the invalid call used to keep track of the `.done` hook on multiCompiler
+      for (const compiler of this.multiCompiler.compilers) {
+        compiler.hooks.invalid.call()
+      }
     }
+
     this.watcher.invalidate()
   }
 


### PR DESCRIPTION
Tobias has fixed the `compiler.hooks.invalid.call()` bug in webpack 5 so this is no longer needed

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
