### PR TITLE
body parsing middleware is bundled with express >= 4.16.0

### DIFF
--- a/examples/custom-server-express/README.md
+++ b/examples/custom-server-express/README.md
@@ -18,22 +18,12 @@ yarn create next-app --example custom-server-express custom-server-express-app
 
 ### Populate body property
 
-Without the use of the body-parser package `req.body` will return undefined. To get express to populate `req.body` you need to install the body parser package and call the package within server.js.
-
-Install the package:
-
-```bash
-npm install body-parser
-```
-
-Use the package within server.js:
+Without the use of body parsing middleware `req.body` will return undefined. To get express to populate `req.body` you need to use middleware within server.js:
 
 ```js
-const bodyParser = require('body-parser')
-
 app.prepare().then(() => {
   const server = express()
-  server.use(bodyParser.urlencoded({ extended: true }))
-  server.use(bodyParser.json())
+  server.use(express.urlencoded({ extended: true }))
+  server.use(express.json())
 })
 ```


### PR DESCRIPTION
The external body-parser package is not required in express versions >= 4.16.0. Body parsing middleware is bundled with express.