### PR TITLE
Ensure minimal mode SSR 404 handling is correct

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -1288,6 +1288,7 @@ export default class Server {
     // we don't modify the URL for _next/data request but still
     // call render so we special case this to prevent an infinite loop
     if (
+      !this.minimalMode &&
       !query._nextDataReq &&
       (url.match(/^\/_next\//) ||
         (this.hasStaticDir && url.match(/^\/static\//)))

--- a/test/integration/required-server-files-ssr-404/lib/config.js
+++ b/test/integration/required-server-files-ssr-404/lib/config.js
@@ -1,0 +1,13 @@
+let curConfig
+
+const idk = Math.random()
+
+export default () => {
+  console.log('returning config', idk, curConfig)
+  return curConfig
+}
+
+export function setConfig(configValue) {
+  curConfig = configValue
+  console.log('set config', idk, configValue)
+}

--- a/test/integration/required-server-files-ssr-404/next.config.js
+++ b/test/integration/required-server-files-ssr-404/next.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  // ensure incorrect target is overridden by env
+  target: 'serverless',
+  rewrites() {
+    return [
+      {
+        source: '/some-catch-all/:path*',
+        destination: '/',
+      },
+    ]
+  },
+}

--- a/test/integration/required-server-files-ssr-404/pages/404.js
+++ b/test/integration/required-server-files-ssr-404/pages/404.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return 'custom 404'
+}

--- a/test/integration/required-server-files-ssr-404/pages/[slug].js
+++ b/test/integration/required-server-files-ssr-404/pages/[slug].js
@@ -1,0 +1,18 @@
+export const getStaticProps = () => {
+  return {
+    props: {
+      hello: 'world',
+    },
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}
+
+export default function Page(props) {
+  return <p id="slug-page">[slug] page</p>
+}

--- a/test/integration/required-server-files-ssr-404/pages/_app.js
+++ b/test/integration/required-server-files-ssr-404/pages/_app.js
@@ -1,0 +1,17 @@
+import App from 'next/app'
+import { setConfig } from '../lib/config'
+
+setConfig({ hello: 'world' })
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+MyApp.getInitialProps = async (appContext) => {
+  // calls page's `getInitialProps` and fills `appProps.pageProps`
+  const appProps = await App.getInitialProps(appContext)
+
+  return { ...appProps }
+}
+
+export default MyApp

--- a/test/integration/required-server-files-ssr-404/pages/api/optional/[[...rest]].js
+++ b/test/integration/required-server-files-ssr-404/pages/api/optional/[[...rest]].js
@@ -1,0 +1,7 @@
+export default (req, res) => {
+  console.log(req.url, 'query', req.query)
+  res.json({
+    url: req.url,
+    query: req.query,
+  })
+}

--- a/test/integration/required-server-files-ssr-404/pages/catch-all/[[...rest]].js
+++ b/test/integration/required-server-files-ssr-404/pages/catch-all/[[...rest]].js
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router'
+
+export const getStaticProps = ({ params }) => {
+  return {
+    props: {
+      hello: 'world',
+      params: params || null,
+      random: Math.random(),
+    },
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: ['/catch-all/hello'],
+    fallback: true,
+  }
+}
+
+export default function Page(props) {
+  const router = useRouter()
+  return (
+    <>
+      <p id="catch-all">optional catch-all page</p>
+      <p id="router">{JSON.stringify(router)}</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  )
+}

--- a/test/integration/required-server-files-ssr-404/pages/dynamic/[slug].js
+++ b/test/integration/required-server-files-ssr-404/pages/dynamic/[slug].js
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router'
+
+export const getServerSideProps = ({ params }) => {
+  return {
+    props: {
+      hello: 'world',
+      slug: params.slug,
+      random: Math.random(),
+    },
+  }
+}
+
+export default function Page(props) {
+  const router = useRouter()
+  return (
+    <>
+      <p id="dynamic">dynamic page</p>
+      <p id="slug">{props.slug}</p>
+      <p id="router">{JSON.stringify(router)}</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  )
+}

--- a/test/integration/required-server-files-ssr-404/pages/errors/gip.js
+++ b/test/integration/required-server-files-ssr-404/pages/errors/gip.js
@@ -1,0 +1,14 @@
+function Page(props) {
+  return <p>here comes an error</p>
+}
+
+Page.getInitialProps = ({ query }) => {
+  if (query.crash) {
+    throw new Error('gip hit an oops')
+  }
+  return {
+    hello: 'world',
+  }
+}
+
+export default Page

--- a/test/integration/required-server-files-ssr-404/pages/errors/gsp/[post].js
+++ b/test/integration/required-server-files-ssr-404/pages/errors/gsp/[post].js
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router'
+
+function Page(props) {
+  if (useRouter().isFallback) {
+    return <p>loading...</p>
+  }
+  return <p>here comes an error</p>
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}
+
+export const getStaticProps = ({ params }) => {
+  if (params.post === 'crash') {
+    throw new Error('gsp hit an oops')
+  }
+  return {
+    props: {
+      hello: 'world',
+    },
+  }
+}
+
+export default Page

--- a/test/integration/required-server-files-ssr-404/pages/errors/gssp.js
+++ b/test/integration/required-server-files-ssr-404/pages/errors/gssp.js
@@ -1,0 +1,16 @@
+function Page(props) {
+  return <p>here comes an error</p>
+}
+
+export const getServerSideProps = ({ query }) => {
+  if (query.crash) {
+    throw new Error('gssp hit an oops')
+  }
+  return {
+    props: {
+      hello: 'world',
+    },
+  }
+}
+
+export default Page

--- a/test/integration/required-server-files-ssr-404/pages/fallback/[slug].js
+++ b/test/integration/required-server-files-ssr-404/pages/fallback/[slug].js
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router'
+
+export const getStaticProps = ({ params }) => {
+  return {
+    props: {
+      hello: 'world',
+      slug: params.slug,
+      random: Math.random(),
+    },
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: ['/fallback/first'],
+    fallback: true,
+  }
+}
+
+export default function Page(props) {
+  const router = useRouter()
+  return (
+    <>
+      <p id="fallback">fallback page</p>
+      <p id="slug">{props.slug}</p>
+      <p id="router">{JSON.stringify(router)}</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  )
+}

--- a/test/integration/required-server-files-ssr-404/pages/index.js
+++ b/test/integration/required-server-files-ssr-404/pages/index.js
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router'
+import getConfig from '../lib/config'
+
+const localConfig = getConfig()
+
+if (localConfig.hello !== 'world') {
+  throw new Error('oof import order is wrong, _app comes first')
+}
+
+export const getServerSideProps = ({ req }) => {
+  return {
+    props: {
+      hello: 'world',
+      random: Math.random(),
+    },
+  }
+}
+
+export default function Page(props) {
+  const router = useRouter()
+  return (
+    <>
+      <p id="index">index page</p>
+      <p id="router">{JSON.stringify(router)}</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  )
+}

--- a/test/integration/required-server-files-ssr-404/pages/optional-ssg/[[...rest]].js
+++ b/test/integration/required-server-files-ssr-404/pages/optional-ssg/[[...rest]].js
@@ -1,0 +1,20 @@
+export const getStaticProps = ({ params }) => {
+  return {
+    props: {
+      random: Math.random(),
+      params: params || null,
+    },
+    revalidate: 1,
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}
+
+export default function Page(props) {
+  return <p id="props">{JSON.stringify(props)}</p>
+}

--- a/test/integration/required-server-files-ssr-404/pages/optional-ssp/[[...rest]].js
+++ b/test/integration/required-server-files-ssr-404/pages/optional-ssp/[[...rest]].js
@@ -1,0 +1,13 @@
+export const getServerSideProps = ({ query, params }) => {
+  return {
+    props: {
+      random: Math.random(),
+      query: query,
+      params: params || null,
+    },
+  }
+}
+
+export default function Page(props) {
+  return <p id="props">{JSON.stringify(props)}</p>
+}

--- a/test/integration/required-server-files-ssr-404/test/index.test.js
+++ b/test/integration/required-server-files-ssr-404/test/index.test.js
@@ -1,0 +1,557 @@
+/* eslint-env jest */
+
+import http from 'http'
+import fs from 'fs-extra'
+import { join } from 'path'
+import cheerio from 'cheerio'
+import { nextServer } from 'next-test-utils'
+import {
+  fetchViaHTTP,
+  findPort,
+  nextBuild,
+  renderViaHTTP,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '..')
+let server
+let nextApp
+let appPort
+let buildId
+let requiredFilesManifest
+let errors = []
+
+describe('Required Server Files', () => {
+  beforeAll(async () => {
+    await fs.remove(join(appDir, '.next'))
+    await nextBuild(appDir, undefined, {
+      env: {
+        NOW_BUILDER: '1',
+      },
+    })
+
+    buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
+    requiredFilesManifest = await fs.readJSON(
+      join(appDir, '.next/required-server-files.json')
+    )
+
+    let files = await fs.readdir(join(appDir, '.next'))
+
+    for (const file of files) {
+      if (
+        file === 'server' ||
+        file === 'required-server-files.json' ||
+        requiredFilesManifest.files.includes(join('.next', file))
+      ) {
+        continue
+      }
+      console.log('removing', join('.next', file))
+      await fs.remove(join(appDir, '.next', file))
+    }
+    await fs.rename(join(appDir, 'pages'), join(appDir, 'pages-bak'))
+
+    nextApp = nextServer({
+      conf: {},
+      dir: appDir,
+      quiet: false,
+      minimalMode: true,
+    })
+    appPort = await findPort()
+
+    server = http.createServer(async (req, res) => {
+      try {
+        await nextApp.getRequestHandler()(req, res)
+      } catch (err) {
+        console.error('top-level', err)
+        errors.push(err)
+        res.statusCode = 500
+        res.end('error')
+      }
+    })
+    await new Promise((res, rej) => {
+      server.listen(appPort, (err) => (err ? rej(err) : res()))
+    })
+    console.log(`Listening at ::${appPort}`)
+  })
+  afterAll(async () => {
+    if (server) server.close()
+    await fs.rename(join(appDir, 'pages-bak'), join(appDir, 'pages'))
+  })
+
+  it('should output required-server-files manifest correctly', async () => {
+    expect(requiredFilesManifest.version).toBe(1)
+    expect(Array.isArray(requiredFilesManifest.files)).toBe(true)
+    expect(Array.isArray(requiredFilesManifest.ignore)).toBe(true)
+    expect(requiredFilesManifest.files.length).toBeGreaterThan(0)
+    expect(requiredFilesManifest.ignore.length).toBeGreaterThan(0)
+    expect(typeof requiredFilesManifest.config.configFile).toBe('undefined')
+    expect(typeof requiredFilesManifest.config.trailingSlash).toBe('boolean')
+    expect(typeof requiredFilesManifest.appDir).toBe('string')
+
+    for (const file of requiredFilesManifest.files) {
+      console.log('checking', file)
+      expect(await fs.exists(join(appDir, file))).toBe(true)
+    }
+
+    expect(await fs.exists(join(appDir, '.next/server'))).toBe(true)
+  })
+
+  it('should render SSR page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/')
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#index').text()).toBe('index page')
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(appPort, '/')
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#index').text()).toBe('index page')
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+  })
+
+  it('should render dynamic SSR page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/dynamic/first')
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#dynamic').text()).toBe('dynamic page')
+    expect($('#slug').text()).toBe('first')
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(appPort, '/dynamic/second')
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#dynamic').text()).toBe('dynamic page')
+    expect($2('#slug').text()).toBe('second')
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+  })
+
+  it('should render fallback page correctly', async () => {
+    const html = await renderViaHTTP(appPort, '/fallback/first')
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#fallback').text()).toBe('fallback page')
+    expect($('#slug').text()).toBe('first')
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(appPort, '/fallback/first')
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#fallback').text()).toBe('fallback page')
+    expect($2('#slug').text()).toBe('first')
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+
+    const html3 = await renderViaHTTP(appPort, '/fallback/second')
+    const $3 = cheerio.load(html3)
+    const data3 = JSON.parse($3('#props').text())
+
+    expect($3('#fallback').text()).toBe('fallback page')
+    expect($3('#slug').text()).toBe('second')
+    expect(isNaN(data3.random)).toBe(false)
+
+    const { pageProps: data4 } = JSON.parse(
+      await renderViaHTTP(appPort, `/_next/data/${buildId}/fallback/third.json`)
+    )
+    expect(data4.hello).toBe('world')
+    expect(data4.slug).toBe('third')
+  })
+
+  it('should render SSR page correctly with x-matched-path', async () => {
+    const html = await renderViaHTTP(appPort, '/some-other-path', undefined, {
+      headers: {
+        'x-matched-path': '/',
+      },
+    })
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#index').text()).toBe('index page')
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
+      headers: {
+        'x-matched-path': '/',
+      },
+    })
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#index').text()).toBe('index page')
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+  })
+
+  it('should render dynamic SSR page correctly with x-matched-path', async () => {
+    const html = await renderViaHTTP(appPort, '/some-other-path', undefined, {
+      headers: {
+        'x-matched-path': '/dynamic/[slug]?slug=first',
+      },
+    })
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#dynamic').text()).toBe('dynamic page')
+    expect($('#slug').text()).toBe('first')
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
+      headers: {
+        'x-matched-path': '/dynamic/[slug]?slug=second',
+      },
+    })
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#dynamic').text()).toBe('dynamic page')
+    expect($2('#slug').text()).toBe('second')
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+  })
+
+  it('should render fallback page correctly with x-matched-path and routes-matches', async () => {
+    const html = await renderViaHTTP(appPort, '/fallback/first', undefined, {
+      headers: {
+        'x-matched-path': '/fallback/first',
+        'x-now-route-matches': '1=first',
+      },
+    })
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#fallback').text()).toBe('fallback page')
+    expect($('#slug').text()).toBe('first')
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(appPort, `/fallback/[slug]`, undefined, {
+      headers: {
+        'x-matched-path': '/fallback/[slug]',
+        'x-now-route-matches': '1=second',
+      },
+    })
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#fallback').text()).toBe('fallback page')
+    expect($2('#slug').text()).toBe('second')
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+  })
+
+  it('should return data correctly with x-matched-path', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      `/_next/data/${buildId}/dynamic/first.json`,
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/dynamic/[slug]?slug=first',
+        },
+      }
+    )
+
+    const { pageProps: data } = await res.json()
+
+    expect(data.slug).toBe('first')
+    expect(data.hello).toBe('world')
+
+    const res2 = await fetchViaHTTP(
+      appPort,
+      `/_next/data/${buildId}/fallback/[slug].json`,
+      undefined,
+      {
+        headers: {
+          'x-matched-path': `/_next/data/${buildId}/fallback/[slug].json`,
+          'x-now-route-matches': '1=second',
+        },
+      }
+    )
+
+    const { pageProps: data2 } = await res2.json()
+
+    expect(data2.slug).toBe('second')
+    expect(data2.hello).toBe('world')
+  })
+
+  it('should render fallback optional catch-all route correctly with x-matched-path and routes-matches', async () => {
+    const html = await renderViaHTTP(
+      appPort,
+      '/catch-all/[[...rest]]',
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/catch-all/[[...rest]]',
+          'x-now-route-matches': '',
+        },
+      }
+    )
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#catch-all').text()).toBe('optional catch-all page')
+    expect(data.params).toEqual({})
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(
+      appPort,
+      '/catch-all/[[...rest]]',
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/catch-all/[[...rest]]',
+          'x-now-route-matches': '1=hello&catchAll=hello',
+        },
+      }
+    )
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#catch-all').text()).toBe('optional catch-all page')
+    expect(data2.params).toEqual({ rest: ['hello'] })
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+
+    const html3 = await renderViaHTTP(
+      appPort,
+      '/catch-all/[[..rest]]',
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/catch-all/[[...rest]]',
+          'x-now-route-matches': '1=hello/world&catchAll=hello/world',
+        },
+      }
+    )
+    const $3 = cheerio.load(html3)
+    const data3 = JSON.parse($3('#props').text())
+
+    expect($3('#catch-all').text()).toBe('optional catch-all page')
+    expect(data3.params).toEqual({ rest: ['hello', 'world'] })
+    expect(isNaN(data3.random)).toBe(false)
+    expect(data3.random).not.toBe(data.random)
+  })
+
+  it('should return data correctly with x-matched-path for optional catch-all route', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      `/_next/data/${buildId}/catch-all.json`,
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/catch-all/[[...rest]]',
+        },
+      }
+    )
+
+    const { pageProps: data } = await res.json()
+
+    expect(data.params).toEqual({})
+    expect(data.hello).toBe('world')
+
+    const res2 = await fetchViaHTTP(
+      appPort,
+      `/_next/data/${buildId}/catch-all/[[...rest]].json`,
+      undefined,
+      {
+        headers: {
+          'x-matched-path': `/_next/data/${buildId}/catch-all/[[...rest]].json`,
+          'x-now-route-matches': '1=hello&rest=hello',
+        },
+      }
+    )
+
+    const { pageProps: data2 } = await res2.json()
+
+    expect(data2.params).toEqual({ rest: ['hello'] })
+    expect(data2.hello).toBe('world')
+
+    const res3 = await fetchViaHTTP(
+      appPort,
+      `/_next/data/${buildId}/catch-all/[[...rest]].json`,
+      undefined,
+      {
+        headers: {
+          'x-matched-path': `/_next/data/${buildId}/catch-all/[[...rest]].json`,
+          'x-now-route-matches': '1=hello/world&rest=hello/world',
+        },
+      }
+    )
+
+    const { pageProps: data3 } = await res3.json()
+
+    expect(data3.params).toEqual({ rest: ['hello', 'world'] })
+    expect(data3.hello).toBe('world')
+  })
+
+  it('should not apply trailingSlash redirect', async () => {
+    for (const path of [
+      '/',
+      '/dynamic/another/',
+      '/dynamic/another',
+      '/fallback/first/',
+      '/fallback/first',
+      '/fallback/another/',
+      '/fallback/another',
+    ]) {
+      const res = await fetchViaHTTP(appPort, path, undefined, {
+        redirect: 'manual',
+      })
+
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('should normalize catch-all rewrite query values correctly', async () => {
+    const html = await renderViaHTTP(
+      appPort,
+      '/some-catch-all/hello/world',
+      {
+        path: 'hello/world',
+      },
+      {
+        headers: {
+          'x-matched-path': '/',
+        },
+      }
+    )
+    const $ = cheerio.load(html)
+    expect(JSON.parse($('#router').text()).query).toEqual({
+      path: ['hello', 'world'],
+    })
+  })
+
+  it('should bubble error correctly for gip page', async () => {
+    errors = []
+    const res = await fetchViaHTTP(appPort, '/errors/gip', { crash: '1' })
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('error')
+    expect(errors.length).toBe(1)
+    expect(errors[0].message).toContain('gip hit an oops')
+  })
+
+  it('should bubble error correctly for gssp page', async () => {
+    errors = []
+    const res = await fetchViaHTTP(appPort, '/errors/gssp', { crash: '1' })
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('error')
+    expect(errors.length).toBe(1)
+    expect(errors[0].message).toContain('gssp hit an oops')
+  })
+
+  it('should bubble error correctly for gsp page', async () => {
+    errors = []
+    const res = await fetchViaHTTP(appPort, '/errors/gsp/crash')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('error')
+    expect(errors.length).toBe(1)
+    expect(errors[0].message).toContain('gsp hit an oops')
+  })
+
+  it('should normalize optional values correctly for SSP page', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/optional-ssp',
+      { rest: '', another: 'value' },
+      {
+        headers: {
+          'x-matched-path': '/optional-ssp/[[...rest]]',
+        },
+      }
+    )
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    const props = JSON.parse($('#props').text())
+    expect(props.params).toEqual({})
+    expect(props.query).toEqual({ another: 'value' })
+  })
+
+  it('should normalize optional values correctly for SSG page', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/optional-ssg',
+      { rest: '', another: 'value' },
+      {
+        headers: {
+          'x-matched-path': '/optional-ssg/[[...rest]]',
+        },
+      }
+    )
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    const props = JSON.parse($('#props').text())
+    expect(props.params).toEqual({})
+  })
+
+  it('should normalize optional values correctly for API page', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/api/optional',
+      { rest: '', another: 'value' },
+      {
+        headers: {
+          'x-matched-path': '/api/optional/[[...rest]]',
+        },
+      }
+    )
+
+    const json = await res.json()
+    expect(json.query).toEqual({ another: 'value' })
+    expect(json.url).toBe('/api/optional?another=value')
+  })
+
+  it('should match the index page correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/', undefined, {
+      headers: {
+        'x-matched-path': '/index',
+      },
+      redirect: 'manual',
+    })
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    expect($('#index').text()).toBe('index page')
+  })
+
+  it('should match the root dyanmic page correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/index', undefined, {
+      headers: {
+        'x-matched-path': '/[slug]',
+      },
+      redirect: 'manual',
+    })
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    expect($('#slug-page').text()).toBe('[slug] page')
+  })
+
+  it('should handle 404s properly', async () => {
+    for (const pathname of [
+      '/_next/static/chunks/pages/index-abc123.js',
+      '/_next/static/some-file.js',
+      '/static/some-file.js',
+      '/non-existent',
+      '/404',
+    ]) {
+      const res = await fetchViaHTTP(appPort, pathname, undefined, {
+        headers: {
+          'x-matched-path': '/404',
+          redirect: 'manual',
+        },
+      })
+      expect(res.status).toBe(404)
+      expect(await res.text()).toContain('custom 404')
+    }
+  })
+})


### PR DESCRIPTION
This ensures we don't hit the `_next/static` handling in `render` for custom-servers when using minimal mode in `next-server`. Additional tests have been added to ensure we handle SSR'ing the 404 page correctly in minimal mode. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added

