### PR TITLE
Add missing import in CSS docs

### DIFF
--- a/docs/basic-features/built-in-css-support.md
+++ b/docs/basic-features/built-in-css-support.md
@@ -72,6 +72,7 @@ For importing CSS required by a third party component, you can do so in your com
 // components/ExampleDialog.js
 import { useState } from 'react'
 import { Dialog } from '@reach/dialog'
+import VisuallyHidden from '@reach/visually-hidden'
 import '@reach/dialog/styles.css'
 
 function ExampleDialog(props) {


### PR DESCRIPTION
This is a one-line commit, which adds the missing import for VisuallyHidden component, from Reach UI, to the CSS documentation in the Dialog component example.
