### PR TITLE
Fix fallback: false triggering 404 before rewrites

### DIFF
--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -997,8 +997,11 @@ export default class Server {
             parsedUrl.query.__nextLocale = localePathResult.detectedLocale
           }
         }
+        const bubbleNoFallback = !!query._nextBubbleNoFallback
 
         if (pathname === '/api' || pathname.startsWith('/api/')) {
+          delete query._nextBubbleNoFallback
+
           const handled = await this.handleApiRequest(
             req as NextApiRequest,
             res as NextApiResponse,
@@ -1009,7 +1012,6 @@ export default class Server {
             return { finished: true }
           }
         }
-        const bubbleNoFallback = !!query._nextBubbleNoFallback
 
         try {
           await this.render(req, res, pathname, query, parsedUrl)

--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -171,17 +171,17 @@ export default class Router {
 
       // Matched a page or dynamic route so render it using catchAllRoute
       if (matchedPage) {
-        checkParsedUrl.pathname = fsPathname
-
         const pageParams = this.catchAllRoute.match(checkParsedUrl.pathname)
+        checkParsedUrl.pathname = fsPathname
+        checkParsedUrl.query._nextBubbleNoFallback = '1'
 
-        await this.catchAllRoute.fn(
+        const result = await this.catchAllRoute.fn(
           req,
           res,
           pageParams as Params,
           checkParsedUrl
         )
-        return true
+        return result.finished
       }
     }
 

--- a/test/integration/fallback-false-rewrite/next.config.js
+++ b/test/integration/fallback-false-rewrite/next.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  rewrites() {
+    return {
+      fallback: [
+        {
+          source: '/:path*',
+          destination: '/another',
+        },
+      ],
+    }
+  },
+}

--- a/test/integration/fallback-false-rewrite/pages/[slug].js
+++ b/test/integration/fallback-false-rewrite/pages/[slug].js
@@ -1,0 +1,31 @@
+import { useRouter } from 'next/router'
+
+export const getStaticProps = () => {
+  return {
+    props: {
+      world: 'world',
+    },
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: ['/first', '/second'],
+    fallback: false,
+  }
+}
+
+export default function Page({ world }) {
+  const router = useRouter()
+
+  if (router.isFallback) {
+    throw new Error('should not have fallback')
+  }
+
+  return (
+    <>
+      <p id="slug">hello {world}</p>
+      <p id="query">{JSON.stringify(router.query)}</p>
+    </>
+  )
+}

--- a/test/integration/fallback-false-rewrite/pages/another.js
+++ b/test/integration/fallback-false-rewrite/pages/another.js
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+
+export const getServerSideProps = () => {
+  return {
+    props: {},
+  }
+}
+
+export default function Page() {
+  return (
+    <>
+      <p id="another">another</p>
+      <p id="query">{JSON.stringify(useRouter().query)}</p>
+    </>
+  )
+}

--- a/test/integration/fallback-false-rewrite/test/index.test.js
+++ b/test/integration/fallback-false-rewrite/test/index.test.js
@@ -1,0 +1,119 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import cheerio from 'cheerio'
+import webdriver from 'next-webdriver'
+import {
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  launchApp,
+  fetchViaHTTP,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../')
+let appPort
+let app
+
+const runTests = () => {
+  it('should rewrite correctly for path at same level as fallback: false SSR', async () => {
+    const res = await fetchViaHTTP(appPort, '/hello', undefined, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(200)
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+
+    expect($('#another').text()).toBe('another')
+    expect(JSON.parse($('#query').text())).toEqual({
+      path: ['hello'],
+    })
+  })
+
+  it('should rewrite correctly for path above fallback: false SSR', async () => {
+    const res = await fetchViaHTTP(appPort, '/hello/world', undefined, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(200)
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+
+    expect($('#another').text()).toBe('another')
+    expect(JSON.parse($('#query').text())).toEqual({
+      path: ['hello', 'world'],
+    })
+  })
+
+  it('should rewrite correctly for path at same level as fallback: false client', async () => {
+    const browser = await webdriver(appPort, '/hello')
+
+    expect(await browser.elementByCss('#another').text()).toBe('another')
+    expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
+      path: ['hello'],
+    })
+  })
+
+  it('should rewrite correctly for path above fallback: false client', async () => {
+    const browser = await webdriver(appPort, '/hello/world')
+
+    expect(await browser.elementByCss('#another').text()).toBe('another')
+    expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
+      path: ['hello', 'world'],
+    })
+  })
+
+  it('should not rewrite for path from fallback: false SSR', async () => {
+    const res = await fetchViaHTTP(appPort, '/first', undefined, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(200)
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+
+    expect($('#slug').text()).toContain('hello')
+    expect(JSON.parse($('#query').text())).toEqual({
+      slug: 'first',
+    })
+  })
+
+  it('should not rewrite for path from fallback: false client', async () => {
+    const browser = await webdriver(appPort, '/second')
+
+    expect(await browser.elementByCss('#slug').text()).toContain('hello')
+    expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
+      slug: 'second',
+    })
+  })
+}
+
+describe('fallback: false rewrite', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      await fs.remove(join(appDir, '.next'))
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await fs.remove(join(appDir, '.next'))
+      await nextBuild(appDir, [])
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+
+    runTests()
+  })
+})


### PR DESCRIPTION
This fixes dynamic pages with `fallback: false` that don't have a matching path causing a 404 before rewrites are checked unexpectedly. This ensures we treat `fallback: false` pages as a match only if they also have a matching static path so that fallback rewrites can be triggered correctly. An additional test suite as been added to ensure this is working as expected. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added

