### PR TITLE
Add error for getStaticPaths on non-dynamic page

### DIFF
--- a/errors/non-dynamic-getstaticpaths-usage.md
+++ b/errors/non-dynamic-getstaticpaths-usage.md
@@ -1,0 +1,14 @@
+# getStaticPaths Used on Non-Dynamic Page
+
+#### Why This Error Occurred
+
+On a non-dynamic SSG page `getStaticPaths` was incorrectly exported as this can only be used on dynamic pages to return the paths to prerender.
+
+#### Possible Ways to Fix It
+
+Remove the `getStaticPaths` export on the non-dynamic page or rename the page to be a dynamic page.
+
+### Useful Links
+
+- [Dynamic Routes Documentation](https://nextjs.org/docs/routing/dynamic-routes)
+- [`getStaticPaths` Documentation](https://nextjs.org/docs/routing/dynamic-routes)

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -483,6 +483,13 @@ export async function renderToHTML(
     throw new Error(SERVER_PROPS_SSG_CONFLICT + ` ${pathname}`)
   }
 
+  if (getStaticPaths && !pageIsDynamic) {
+    throw new Error(
+      `getStaticPaths is only allowed for dynamic SSG pages and was found on '${pathname}'.` +
+        `\nRead more: https://nextjs.org/docs/messages/non-dynamic-getstaticpaths-usage`
+    )
+  }
+
   if (!!getStaticPaths && !isSSG) {
     throw new Error(
       `getStaticPaths was added without a getStaticProps in ${pathname}. Without getStaticProps, getStaticPaths does nothing`

--- a/test/integration/mixed-ssg-serverprops-error/test/index.test.js
+++ b/test/integration/mixed-ssg-serverprops-error/test/index.test.js
@@ -5,10 +5,10 @@ import { join } from 'path'
 import { nextBuild } from 'next-test-utils'
 import { SERVER_PROPS_SSG_CONFLICT } from 'next/dist/lib/constants'
 
-jest.setTimeout(1000 * 60 * 1)
+jest.setTimeout(1000 * 60 * 2)
+
 const appDir = join(__dirname, '..')
 const indexPage = join(appDir, 'pages/index.js')
-const indexPageAlt = `${indexPage}.alt`
 const indexPageBak = `${indexPage}.bak`
 
 describe('Mixed getStaticProps and getServerSideProps error', () => {
@@ -19,14 +19,53 @@ describe('Mixed getStaticProps and getServerSideProps error', () => {
 
   it('should error when exporting both getStaticPaths and getServerSideProps', async () => {
     await fs.move(indexPage, indexPageBak)
-    await fs.move(indexPageAlt, indexPage)
+    await fs.writeFile(
+      indexPage,
+      `
+      export const getStaticPaths = async () => {
+        return {
+          props: { world: 'world' }, fallback: true
+        }
+      }
 
+      export const getServerSideProps = async () => {
+        return {
+          props: { world: 'world' }
+        }
+      }
+
+      export default ({ world }) => <p>Hello {world}</p>
+    `
+    )
     const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
 
-    await fs.move(indexPage, indexPageAlt)
+    await fs.remove(indexPage)
     await fs.move(indexPageBak, indexPage)
-
     expect(code).toBe(1)
     expect(stderr).toContain(SERVER_PROPS_SSG_CONFLICT)
+  })
+
+  it('should error when exporting getStaticPaths on a non-dynamic page', async () => {
+    await fs.move(indexPage, indexPageBak)
+    await fs.writeFile(
+      indexPage,
+      `
+      export const getStaticPaths = async () => {
+        return {
+          props: { world: 'world' }, fallback: true
+        }
+      }
+
+      export default ({ world }) => <p>Hello {world}</p>
+    `
+    )
+    const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
+
+    await fs.remove(indexPage)
+    await fs.move(indexPageBak, indexPage)
+    expect(code).toBe(1)
+    expect(stderr).toContain(
+      "getStaticPaths is only allowed for dynamic SSG pages and was found on '/'."
+    )
   })
 })


### PR DESCRIPTION
Noticed in this issue the reproduction was using `getStaticPaths` on a non-dynamic page incorrectly although we don't currently show an error for this. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

x-ref: https://github.com/vercel/next.js/issues/22931