### PR TITLE
Disable strictExportPresence when webpack 5 is enabled

### DIFF
--- a/packages/next/build/webpack/config/blocks/base.ts
+++ b/packages/next/build/webpack/config/blocks/base.ts
@@ -1,6 +1,6 @@
 import isWslBoolean from 'next/dist/compiled/is-wsl'
 import curry from 'next/dist/compiled/lodash.curry'
-import { webpack } from 'next/dist/compiled/webpack/webpack'
+import { webpack, isWebpack5 } from 'next/dist/compiled/webpack/webpack'
 import { ConfigurationContext } from '../utils'
 
 const isWindows = process.platform === 'win32' || isWslBoolean
@@ -46,7 +46,9 @@ export const base = curry(function base(
   if (!config.module) {
     config.module = { rules: [] }
   }
-  config.module.strictExportPresence = true
+
+  // TODO: add codemod for "Should not import the named export" with JSON files
+  config.module.strictExportPresence = !isWebpack5
 
   return config
 })


### PR DESCRIPTION
Solves an issue some users ran into where enabling webpack 5 highlighted a wrong JSON import where named exports were used for JSON data.

> Should not import the named export 'myValue' (imported as 'myValue') from default-exporting module (only default export is available soon)

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
