### PR TITLE
Omit un-necessary stack trace from invalid routes

### DIFF
--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -174,10 +174,11 @@ function checkCustomRoutes(
   type: RouteType
 ): void {
   if (!Array.isArray(routes)) {
-    throw new Error(
+    console.error(
       `${type}s must return an array, received ${typeof routes}.\n` +
         `See here for more info: https://nextjs.org/docs/messages/routes-must-be-array`
     )
+    process.exit(1)
   }
 
   let numInvalidRoutes = 0
@@ -456,8 +457,8 @@ function checkCustomRoutes(
       )
     }
     console.error()
-
-    throw new Error(`Invalid ${type}${numInvalidRoutes === 1 ? '' : 's'} found`)
+    console.error(`Invalid ${type}${numInvalidRoutes === 1 ? '' : 's'} found`)
+    process.exit(1)
   }
 }
 

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -175,7 +175,7 @@ function checkCustomRoutes(
 ): void {
   if (!Array.isArray(routes)) {
     console.error(
-      `${type}s must return an array, received ${typeof routes}.\n` +
+      `Error: ${type}s must return an array, received ${typeof routes}.\n` +
         `See here for more info: https://nextjs.org/docs/messages/routes-must-be-array`
     )
     process.exit(1)
@@ -457,7 +457,9 @@ function checkCustomRoutes(
       )
     }
     console.error()
-    console.error(`Invalid ${type}${numInvalidRoutes === 1 ? '' : 's'} found`)
+    console.error(
+      `Error: Invalid ${type}${numInvalidRoutes === 1 ? '' : 's'} found`
+    )
     process.exit(1)
   }
 }


### PR DESCRIPTION
This removes the extra stack trace from throwing an error instead of logging and then exiting since the stack trace doesn't provide any additional information that is helpful for debugging in this case. 

<details>

<summary>Before screenshot</summary>

![image](https://user-images.githubusercontent.com/22380829/115301794-4f3b1280-a127-11eb-8a0d-0797efb8fc9f.png)


</details>

<details>

<summary>After screenshot</summary>

<img width="962" alt="Screen Shot 2021-04-19 at 3 53 45 PM" src="https://user-images.githubusercontent.com/22380829/115301901-6ed23b00-a127-11eb-83f9-e3f4cf0ed8fe.png">


</details>