### PR TITLE
Add note for exportPathMap query and prerender pages

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -175,7 +175,7 @@ jobs:
           key: ${{ github.sha }}
 
       - run: xvfb-run node run-tests.js test/integration/{fallback-modules,link-ref,production,basic,async-modules,font-optimization,ssr-ctx}/test/index.test.js test/acceptance/*.test.js
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
   testLegacyReact:
     name: React 16 + Webpack 4 (Basic, Production, Acceptance)

--- a/docs/api-reference/next.config.js/exportPathMap.md
+++ b/docs/api-reference/next.config.js/exportPathMap.md
@@ -40,6 +40,8 @@ module.exports = {
 }
 ```
 
+Note: the `query` field in `exportPathMap` can not be used with [automatically statically optimized pages](/docs/advanced-features/automatic-static-optimization) or [`getStaticProps` pages](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation) as they are rendered to HTML files at build-time and additional query information can not be provided during `next export`.
+
 The pages will then be exported as HTML files, for example, `/about` will become `/about.html`.
 
 `exportPathMap` is an `async` function that receives 2 arguments: the first one is `defaultPathMap`, which is the default map used by Next.js. The second argument is an object with:


### PR DESCRIPTION
This makes sure to mention the `query` field in `exportPathMap` can not currently be used with prerendered pages since we also show an error for this. 

## Documentation / Examples

- [x] Make sure the linting passes

x-ref: https://github.com/vercel/next.js/issues/24242