### PR TITLE
Add test for top-level _document error

### DIFF
--- a/test/acceptance/ReactRefreshLogBox.dev.test.js
+++ b/test/acceptance/ReactRefreshLogBox.dev.test.js
@@ -1279,15 +1279,15 @@ test('_app top level error shows logbox', async () => {
   )
   expect(await session.hasRedbox(true)).toBe(true)
   expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-"pages/_app.js (2:16) @ eval
+      "pages/_app.js (2:16) @ eval
 
-  1 |
-> 2 |           throw new Error(\\"test\\");
-    |                ^
-  3 |           function MyApp({ Component, pageProps }) {
-  4 |             return <Component {...pageProps} />;
-  5 |           }"
-`)
+        1 | 
+      > 2 |           throw new Error(\\"test\\");
+          |                ^
+        3 |           function MyApp({ Component, pageProps }) {
+        4 |             return <Component {...pageProps} />;
+        5 |           }"
+    `)
 
   await session.patch(
     'pages/_app.js',
@@ -1339,15 +1339,15 @@ test('_document top level error shows logbox', async () => {
   )
   expect(await session.hasRedbox(true)).toBe(true)
   expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-"pages/_document.js (4:16) @ eval
+      "pages/_document.js (4:16) @ eval
 
-  2 |           import Document, { Html, Head, Main, NextScript } from 'next/document'
-  3 |
-> 4 |           throw new Error(\\"test\\");
-    |                ^
-  5 |
-  6 |           class MyDocument extends Document {
-  7 |             static async getInitialProps(ctx) {"
+        2 |           import Document, { Html, Head, Main, NextScript } from 'next/document'
+        3 | 
+      > 4 |           throw new Error(\\"test\\");
+          |                ^
+        5 | 
+        6 |           class MyDocument extends Document {
+        7 |             static async getInitialProps(ctx) {"
 `)
 
   await session.patch(


### PR DESCRIPTION
This adds an additional test for the change in https://github.com/vercel/next.js/pull/24079 to ensure top-level errors in `_document` are also handled correctly. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
