### PR TITLE
Fix for with-clerk example

### DIFF
--- a/examples/with-clerk/package.json
+++ b/examples/with-clerk/package.json
@@ -1,7 +1,6 @@
 {
   "name": "with-clerk",
   "scripts": {
-    "predev": "([[ -d .vercel ]] || vercel link) && vercel env pull .env.local",
     "dev": "next dev",
     "build": "next build",
     "start": "next start"
@@ -12,9 +11,6 @@
     "next": "10.0.9",
     "react": "17.0.1",
     "react-dom": "17.0.1"
-  },
-  "devDependencies": {
-    "vercel": "^21.3.3"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [x] Make sure the linting passes

The predev npm script assumes that vercel cli is installed. It's better for the example to run without it.