### PR TITLE
Fix strapi links

### DIFF
--- a/examples/cms-strapi/README.md
+++ b/examples/cms-strapi/README.md
@@ -179,7 +179,7 @@ You should now be able to see the draft post. To exit the preview mode, you can 
 
 ### Step 10. Deploy Strapi
 
-To deploy to production, you must first deploy your Strapi app. The Strapi app for our demo at https://next-blog-strapi.vercel.app/ is deployed to Heroku ([here’s the documentation](https://strapi.io/documentation/v3.x/deployment/heroku.html)) and uses Cloudinary for image hosting ([see this file](https://github.com/strapi/strapi-starter-next-blog/blob/master/backend/extensions/upload/config/settings.js)).
+To deploy to production, you must first deploy your Strapi app. The Strapi app for our demo at https://next-blog-strapi.vercel.app/ is deployed to Heroku ([here’s the documentation](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.html)) and uses Cloudinary for image hosting ([see this file](https://github.com/strapi/strapi-starter-next-blog/blob/23b184781a3f219ad472f6a2c3a3d239a3d16513/backend/extensions/upload/config/settings.js)).
 
 ### Step 11. Deploy on Vercel
 


### PR DESCRIPTION
Fix broken links on the `cms-strapi` example.

- [x] https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.html
- [x] https://github.com/strapi/strapi-starter-next-blog/blob/23b184781a3f219ad472f6a2c3a3d239a3d16513/backend/extensions/upload/config/settings.js

## Documentation / Examples

- [x] Make sure the linting passes
