### PR TITLE
chore: add missing dependencies to `with-jest` example

### DIFF
--- a/examples/with-jest/__tests__/__snapshots__/snapshot.js.snap
+++ b/examples/with-jest/__tests__/__snapshots__/snapshot.js.snap
@@ -8,7 +8,7 @@ exports[`renders homepage unchanged 1`] = `
     <h1
       className="title"
     >
-      Welcome to 
+      Welcome to
       <a
         href="https://nextjs.org"
       >
@@ -18,7 +18,7 @@ exports[`renders homepage unchanged 1`] = `
     <p
       className="description"
     >
-      Get started by editing 
+      Get started by editing
       <code>
         pages/index.js
       </code>

--- a/examples/with-jest/__tests__/__snapshots__/snapshot.js.snap
+++ b/examples/with-jest/__tests__/__snapshots__/snapshot.js.snap
@@ -8,7 +8,7 @@ exports[`renders homepage unchanged 1`] = `
     <h1
       className="title"
     >
-      Welcome to
+      Welcome to 
       <a
         href="https://nextjs.org"
       >
@@ -18,7 +18,7 @@ exports[`renders homepage unchanged 1`] = `
     <p
       className="description"
     >
-      Get started by editing
+      Get started by editing 
       <code>
         pages/index.js
       </code>

--- a/examples/with-jest/jest.config.js
+++ b/examples/with-jest/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
   transform: {
-    '^.+\\.(js|jsx|ts|tsx)$': '<rootDir>/node_modules/babel-jest',
+    '^.+\\.(js|jsx|ts|tsx)$': require.resolve('babel-jest'),
     '^.+\\.css$': '<rootDir>/config/jest/cssTransform.js',
   },
   transformIgnorePatterns: [
@@ -15,6 +15,6 @@ module.exports = {
     '^.+\\.module\\.(css|sass|scss)$',
   ],
   moduleNameMapper: {
-    '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
+    '^.+\\.module\\.(css|sass|scss)$': require.resolve('identity-obj-proxy'),
   },
 }

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -14,6 +14,8 @@
     "react-dom": "16.12.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.13.8",
+    "@babel/runtime": "^7.13.17",
     "@testing-library/jest-dom": "^5.1.0",
     "@testing-library/react": "^9.4.0",
     "babel-jest": "^25.1.0",


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes

Added missing dependencies to the `with-jest` example

Closes https://github.com/vercel/next.js/issues/23413