### PR TITLE
Remove experimental note for has routes

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -173,8 +173,6 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-Note: this feature is still experimental and not covered by semver and is to be used at your own risk until it is made stable.
-
 To only apply a header when either header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the header to be applied.
 
 `has` items have the following fields:

--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -117,8 +117,6 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-Note: this feature is still experimental and not covered by semver and is to be used at your own risk until it is made stable.
-
 To only match a redirect when header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the redirect to be applied.
 
 `has` items have the following fields:

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -197,8 +197,6 @@ module.exports = {
 
 ## Header, Cookie, and Query Matching
 
-Note: this feature is still experimental and not covered by semver and is to be used at your own risk until it is made stable.
-
 To only match a rewrite when header, cookie, or query values also match the `has` field can be used. Both the `source` and all `has` items must match for the rewrite to be applied.
 
 `has` items have the following fields:

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -6,8 +6,6 @@ import {
   PERMANENT_REDIRECT_STATUS,
   TEMPORARY_REDIRECT_STATUS,
 } from '../next-server/lib/constants'
-import { execOnce } from '../next-server/lib/utils'
-import * as Log from '../build/output/log'
 // @ts-ignore
 import Lexer from 'next/dist/compiled/regexr-lexer/lexer'
 // @ts-ignore
@@ -163,12 +161,6 @@ function tryParsePath(route: string, handleUrl?: boolean): ParseAttemptResult {
 
 export type RouteType = 'rewrite' | 'redirect' | 'header'
 
-const experimentalHasWarn = execOnce(() => {
-  Log.warn(
-    `'has' route field support is still experimental and not covered by semver, use at your own risk.`
-  )
-})
-
 function checkCustomRoutes(
   routes: Redirect[] | Header[] | Rewrite[],
   type: RouteType
@@ -245,7 +237,6 @@ function checkCustomRoutes(
       invalidParts.push('`has` must be undefined or valid has object')
       hadInvalidHas = true
     } else if (route.has) {
-      experimentalHasWarn()
       const invalidHasItems = []
 
       for (const hasItem of route.has) {

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -1783,8 +1783,8 @@ describe('Custom routes', () => {
       )
     })
 
-    it('should show warning for experimental has usage', async () => {
-      expect(stderr).toContain(
+    it('should not show warning for experimental has usage', async () => {
+      expect(stderr).not.toContain(
         "'has' route field support is still experimental and not covered by semver, use at your own risk."
       )
     })


### PR DESCRIPTION
This removes the warnings/notes for the `has` custom-routes feature being experimental

## Documentation / Examples

- [x] Make sure the linting passes
