### PR TITLE
Fix: with-passport example dependency issue

### DIFF
--- a/examples/with-passport/package.json
+++ b/examples/with-passport/package.json
@@ -14,7 +14,7 @@
     "passport-local": "1.0.0",
     "react": "latest",
     "react-dom": "latest",
-    "swr": "0.3.0",
+    "swr": "0.5.5",
     "uuid": "8.3.1"
   },
   "license": "MIT"

--- a/examples/with-passport/package.json
+++ b/examples/with-passport/package.json
@@ -14,7 +14,7 @@
     "passport-local": "1.0.0",
     "react": "latest",
     "react-dom": "latest",
-    "swr": "0.5.5",
+    "swr": "^0.5.5",
     "uuid": "8.3.1"
   },
   "license": "MIT"


### PR DESCRIPTION
fixes #24401

Simply bumping `swr` to the latest version seems to fix the issue. 🥂 

Couldn't find a consistent pattern across the examples, but most examples are flexible with swr version and use the semver caret.

Very standard use of the useSWR hook is there in the example with nothing obviously version specific.