### PR TITLE
Move default quality config setting to next.config.js

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -80,6 +80,7 @@ const {
   loader: configLoader,
   path: configPath,
   domains: configDomains,
+  quality: configQuality,
 } =
   ((process.env.__NEXT_IMAGE_OPTS as any) as ImageConfig) || imageConfigDefault
 // sort smallest to largest
@@ -585,5 +586,5 @@ function defaultLoader({
     }
   }
 
-  return `${root}?url=${encodeURIComponent(src)}&w=${width}&q=${quality || 75}`
+  return `${root}?url=${encodeURIComponent(src)}&w=${width}&q=${quality || configQuality || imageConfigDefault.quality}`
 }

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -532,7 +532,7 @@ function cloudinaryLoader({
   quality,
 }: DefaultImageLoaderProps): string {
   // Demo: https://res.cloudinary.com/demo/image/upload/w_300,c_limit,q_auto/turtles.jpg
-  const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
+  const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || configQuality || 'auto')]
   let paramsString = params.join(',') + '/'
   return `${root}${paramsString}${normalizeSrc(src)}`
 }

--- a/packages/next/next-server/server/image-config.ts
+++ b/packages/next/next-server/server/image-config.ts
@@ -13,6 +13,7 @@ export type ImageConfig = {
   loader: LoaderValue
   path: string
   domains?: string[]
+  quality?: number | string
 }
 
 export const imageConfigDefault: ImageConfig = {
@@ -21,4 +22,5 @@ export const imageConfigDefault: ImageConfig = {
   path: '/_next/image',
   loader: 'default',
   domains: [],
+  quality: 75,
 }


### PR DESCRIPTION
## Feature

- [x] Implements an existing feature request or [RFC](https://github.com/vercel/next.js/discussions/16832). Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using fixes #24596
- [ ] Integration tests added
- [ ] Documentation added
- [ ]  Telemetry added. In case of a feature if it's used or not.

### Motivation

Using Next version `10.2.0` we're not able to set a default `quality` for all instances of `<Image />` component.

We can either set it explicitly directly on the component `<Image quality={95} {...props} />` or inherit the default value `75`

### Loaders

The default quality (int) is applied to the following loaders

- [x] default
- [x] cloudinary
- [ ] imgix (quality is sent only when it is provided explicitly)
- [ ] akamai (no quality parameter)


## Example

To define the default image quality in `next.config.js` under the `images` key next to the other image configs

```ts
// next.config.js

module.exports = {
  images: {
    domains: [],
    quality: 95,
  },
}
```



