### PR TITLE
Replace regex lexer with minimal regex for named groups

### DIFF
--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -6,10 +6,6 @@ import {
   PERMANENT_REDIRECT_STATUS,
   TEMPORARY_REDIRECT_STATUS,
 } from '../next-server/lib/constants'
-// @ts-ignore
-import Lexer from 'next/dist/compiled/regexr-lexer/lexer'
-// @ts-ignore
-import lexerProfiles from 'next/dist/compiled/regexr-lexer/profiles'
 
 export type RouteHas =
   | {
@@ -52,6 +48,7 @@ export type Redirect = {
 
 export const allowedStatusCodes = new Set([301, 302, 303, 307, 308])
 const allowedHasTypes = new Set(['header', 'cookie', 'query', 'host'])
+const namedGroupsRegex = /\(\?<([a-zA-Z][a-zA-Z0-9]*)>/g
 
 export function getRedirectStatus(route: {
   statusCode?: number
@@ -330,14 +327,11 @@ function checkCustomRoutes(
         }
 
         if (hasItem.value) {
-          const matcher = new RegExp(`^${hasItem.value}$`)
-          const lexer = new Lexer()
-          lexer.profile = lexerProfiles.js
-          lexer.parse(`/${matcher.source}/`)
-
-          Object.keys(lexer.namedGroups).forEach((groupKey) => {
-            hasSegments.add(groupKey)
-          })
+          for (const match of hasItem.value.matchAll(namedGroupsRegex)) {
+            if (match[1]) {
+              hasSegments.add(match[1])
+            }
+          }
 
           if (hasItem.type === 'host') {
             hasSegments.add('host')

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -229,7 +229,6 @@
     "postcss-preset-env": "6.7.0",
     "postcss-scss": "3.0.5",
     "recast": "0.18.5",
-    "regexr": "https://github.com/ijjk/regexr-lexer.git#3bcf3d1c4bc6dd9239c47acb1fb7b419823f8337",
     "resolve-url-loader": "3.1.2",
     "sass-loader": "10.0.5",
     "schema-utils": "2.7.1",

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const notifier = require('node-notifier')
-const { relative, basename, resolve, join, dirname } = require('path')
+const { relative, basename, resolve } = require('path')
 const { Module } = require('module')
 
 // Note:
@@ -687,20 +687,9 @@ export async function path_to_regexp(task, opts) {
     .target('dist/compiled/path-to-regexp')
 }
 
-export async function copy_regexr_lexer(task, opts) {
-  await task
-    .source(
-      join(
-        relative(__dirname, dirname(require.resolve('regexr/package.json'))),
-        'lexer-dist/**/*'
-      )
-    )
-    .target('dist/compiled/regexr-lexer')
-}
-
 export async function precompile(task, opts) {
   await task.parallel(
-    ['browser_polyfills', 'path_to_regexp', 'copy_ncced', 'copy_regexr_lexer'],
+    ['browser_polyfills', 'path_to_regexp', 'copy_ncced'],
     opts
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13957,10 +13957,6 @@ regexpu-core@^4.7.1:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
-"regexr@https://github.com/ijjk/regexr-lexer.git#3bcf3d1c4bc6dd9239c47acb1fb7b419823f8337":
-  version "3.8.0"
-  resolved "https://github.com/ijjk/regexr-lexer.git#3bcf3d1c4bc6dd9239c47acb1fb7b419823f8337"
-
 registry-auth-token@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"


### PR DESCRIPTION
This removes the regex lexer in favor of a minimal regex to gather the named groups which we can expand on to handle edge cases as we catch them. Existing integration tests should cover this change so no additional ones have been added. 

Closes: https://github.com/vercel/next.js/issues/24599

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
