### PR TITLE
Fix routing in examples/custom-server-express

### DIFF
--- a/examples/custom-server-express/README.md
+++ b/examples/custom-server-express/README.md
@@ -4,7 +4,9 @@ Most of the time the default Next.js server will be enough but there are times y
 
 Because the Next.js server is just a node.js module you can combine it with any other part of the node.js ecosystem. In this case we are using express to build a custom router on top of Next.
 
-This example demonstrates a server that serves the component living in `pages/a.js` when the route `/b` is requested and `pages/b.js` when the route `/a` is accessed. This is obviously a non-standard routing strategy. You can see how this custom routing is being made inside `server.js`.
+This example demonstrates a server that serves the component living in `pages/apple.js` when the route `/a` is requested and `pages/b.js` when the route `/b` is accessed. The first of these two is obviously a non-standard routing strategy. You can see how this custom routing is being made inside `server.js`.
+
+Since we have a `pages/apple.js` file, Next.js would serve this file on the `/apple` route as well which would make the same component available on two different routes. This is why file-system routing is disabled in `next.config.js`.
 
 ## How to use
 

--- a/examples/custom-server-express/next.config.js
+++ b/examples/custom-server-express/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  /**
+   * Disable /apple route
+   * https://nextjs.org/docs/advanced-features/custom-server#disabling-file-system-routing
+   */
+  useFileSystemPublicRoutes: false,
+}

--- a/examples/custom-server-express/package.json
+++ b/examples/custom-server-express/package.json
@@ -2,7 +2,7 @@
   "name": "custom-server-express",
   "version": "1.0.0",
   "scripts": {
-    "dev": "node server.js",
+    "dev": "nodemon server.js",
     "build": "next build",
     "start": "cross-env NODE_ENV=production node server.js"
   },
@@ -10,6 +10,7 @@
     "cross-env": "^7.0.2",
     "express": "^4.17.1",
     "next": "latest",
+    "nodemon": "^2.0.7",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/examples/custom-server-express/pages/a.js
+++ b/examples/custom-server-express/pages/a.js
@@ -1,3 +1,0 @@
-export default function A() {
-  return <div>a</div>
-}

--- a/examples/custom-server-express/pages/apple.js
+++ b/examples/custom-server-express/pages/apple.js
@@ -1,0 +1,3 @@
+export default function Apple() {
+  return <div>apple</div>
+}

--- a/examples/custom-server-express/pages/index.js
+++ b/examples/custom-server-express/pages/index.js
@@ -4,12 +4,12 @@ export default function Home() {
   return (
     <ul>
       <li>
-        <Link href="/b" as="/a">
+        <Link href="/a">
           <a>a</a>
         </Link>
       </li>
       <li>
-        <Link href="/a" as="/b">
+        <Link href="/b">
           <a>b</a>
         </Link>
       </li>

--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -9,8 +9,12 @@ const handle = app.getRequestHandler()
 app.prepare().then(() => {
   const server = express()
 
+  server.get('/', (req, res) => {
+    return app.render(req, res, '/', req.query)
+  })
+
   server.get('/a', (req, res) => {
-    return app.render(req, res, '/a', req.query)
+    return app.render(req, res, '/apple', req.query)
   })
 
   server.get('/b', (req, res) => {


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes

## Problem

The existing [custom-server-express example](https://github.com/vercel/next.js/tree/canary/examples/custom-server-express) has problems:

- The README contains outdated information. The routing strategy explained was switched in #6382
- On running the application, clicking on "a" returns "b" even after the change in #6382 This is because path decorators are used in [pages/index.js](https://github.com/vercel/next.js/blob/canary/examples/custom-server-express/pages/index.js) which seem to override the routing defined in `server.js`.
- The development server doesn't refresh on file changes (tested on macOS Big Sur). Took me a while to realize the server needs to be restarted for every file change.

## Solution

- Removed path decorators from `pages/index.js`. That's a different concept and probably is more confusing than relevant in a minimal custom server example.
- Changed routes so that one demonstrates a non-standard strategy and other one shows the standard way. This still gets the point across without making routes look like typos which lead to #6382
- Disabled file-system routing with docs link and demonstration of why doing that would make sense in a custom server.
- Changed development server to use `nodemon` instead of `node` so the server restarts on all file changes automatically.
- Updated README with explanation of important parts