### PR TITLE
fix(next/image): trigger onLoad once image is fully loaded

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -256,6 +256,7 @@ export default function Image({
   loader = defaultImageLoader,
   placeholder = 'empty',
   blurDataURL,
+  onLoad,
   ...all
 }: ImageProps) {
   let rest: Partial<ImageProps> = all
@@ -502,6 +503,7 @@ export default function Image({
             })}
             src={src}
             decoding="async"
+            onLoad={onLoad}
             sizes={sizes}
             style={imgStyle}
             className={className}
@@ -513,6 +515,7 @@ export default function Image({
         {...imgAttributes}
         decoding="async"
         className={className}
+        onLoad={isVisible ? onLoad : undefined}
         ref={(element) => {
           setRef(element)
           removePlaceholder(element, placeholder)

--- a/test/integration/image-component/default/pages/on-load.js
+++ b/test/integration/image-component/default/pages/on-load.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Image from 'next/image'
+
+const Page = () => {
+  const [isLoaded, setIsLoaded] = React.useState(false)
+
+  return (
+    <div>
+      <p>Home Page</p>
+      <div style={{ height: '2000px' }}></div>
+      <Image
+        id="lazy-image"
+        src="/test.jpg"
+        width="400"
+        height="400"
+        data-loaded={isLoaded}
+        onLoad={() => setIsLoaded(true)}
+      ></Image>
+      <p id="stubtext">This is the index page</p>
+    </div>
+  )
+}
+
+export default Page

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -523,6 +523,43 @@ function runTests(mode) {
     }
   })
 
+  it('should trigger onLoad when image have loaded', async () => {
+    let browser
+    try {
+      browser = await webdriver(appPort, '/on-load')
+
+      const id = 'lazy-image'
+
+      expect(await getSrc(browser, id)).not.toBe(
+        '/_next/image?url=%2Ftest.jpg&w=828&q=75'
+      )
+      expect(await browser.elementById(id).getAttribute('data-loaded')).toBe(
+        'false'
+      )
+
+      let viewportHeight = await browser.eval(`window.innerHeight`)
+      let topOfMidImage = await browser.eval(
+        `document.getElementById('${id}').parentElement.offsetTop`
+      )
+      let buffer = 150
+      await browser.eval(
+        `window.scrollTo(0, ${topOfMidImage - (viewportHeight + buffer)})`
+      )
+
+      await check(() => {
+        return getSrc(browser, id)
+      }, '/_next/image?url=%2Ftest.jpg&w=828&q=75')
+
+      expect(await browser.elementById(id).getAttribute('data-loaded')).toBe(
+        'true'
+      )
+    } finally {
+      if (browser) {
+        await browser.close()
+      }
+    }
+  })
+
   // Tests that use the `unsized` attribute:
   if (mode !== 'dev') {
     it('should correctly rotate image', async () => {


### PR DESCRIPTION
This is related to #24754. Not sure this is the right way to address this issue, but I would be happy to discuss about it.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
