### PR TITLE
[24798] Fix client-side header rewrites

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -74,6 +74,7 @@ const {
   locales,
   domainLocales,
   isPreview,
+  headers,
 } = data
 
 let { defaultLocale } = data
@@ -397,6 +398,7 @@ export default async (opts: { webpackHMR?: any } = {}) => {
     defaultLocale,
     domainLocales,
     isPreview,
+    headers,
   })
 
   const renderCtx: RenderRouteInfo = {

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -502,6 +502,7 @@ export default class Router implements BaseRouter {
   route: string
   pathname: string
   query: ParsedUrlQuery
+  headers?: Record<string, string>
   asPath: string
   basePath: string
 
@@ -554,6 +555,7 @@ export default class Router implements BaseRouter {
       defaultLocale,
       domainLocales,
       isPreview,
+      headers,
     }: {
       subscription: Subscription
       initialProps: any
@@ -568,6 +570,7 @@ export default class Router implements BaseRouter {
       defaultLocale?: string
       domainLocales?: DomainLocales
       isPreview?: boolean
+      headers?: Record<string, string>
     }
   ) {
     // represents the current component key
@@ -603,6 +606,7 @@ export default class Router implements BaseRouter {
     this.pageLoader = pageLoader
     this.pathname = pathname
     this.query = query
+    this.headers = headers
     // if auto prerendered and dynamic route wait to update asPath
     // until after mount to prevent hydration mismatch
     const autoExportDynamic =

--- a/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
@@ -19,7 +19,8 @@ export default function resolveRewrites(
   },
   query: ParsedUrlQuery,
   resolveHref: (path: string) => string,
-  locales?: string[]
+  locales?: string[],
+  headers?: Record<string, string>
 ): {
   matchedPage: boolean
   parsedAs: ReturnType<typeof parseRelativeUrl>
@@ -41,6 +42,7 @@ export default function resolveRewrites(
       const hasParams = matchHas(
         {
           headers: {
+            ...(headers || {}),
             host: document.location.hostname,
           },
           cookies: Object.fromEntries(

--- a/packages/next/next-server/lib/utils.ts
+++ b/packages/next/next-server/lib/utils.ts
@@ -105,6 +105,7 @@ export type NEXT_DATA = {
   domainLocales?: DomainLocales
   scriptLoader?: any[]
   isPreview?: boolean
+  headers?: Record<string, string>
 }
 
 /**

--- a/packages/next/next-server/server/render.tsx
+++ b/packages/next/next-server/server/render.tsx
@@ -190,6 +190,7 @@ export type RenderOptsPartial = {
   locales?: string[]
   defaultLocale?: string
   domainLocales?: DomainLocales
+  headers?: Record<string, string>
 }
 
 export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial
@@ -234,6 +235,7 @@ function renderDocument(
     defaultLocale,
     domainLocales,
     isPreview,
+    headers,
   }: RenderOpts & {
     props: any
     docComponentsRendered: DocumentProps['docComponentsRendered']
@@ -258,6 +260,7 @@ function renderDocument(
     scriptLoader: any
     isPreview?: boolean
     autoExport?: boolean
+    headers?: Record<string, string>
   }
 ): string {
   return (
@@ -288,6 +291,7 @@ function renderDocument(
             defaultLocale,
             domainLocales,
             isPreview,
+            headers,
           },
           buildManifest,
           docComponentsRendered,
@@ -1079,6 +1083,7 @@ export async function renderToHTML(
     isPreview: isPreview === true ? true : undefined,
     autoExport: isAutoExport === true ? true : undefined,
     nextExport: nextExport === true ? true : undefined,
+    headers: renderOpts.headers,
   })
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/next/next-server/server/router.ts
+++ b/packages/next/next-server/server/router.ts
@@ -62,6 +62,7 @@ export default class Router {
   dynamicRoutes: DynamicRoutes
   useFileSystemPublicRoutes: boolean
   locales: string[]
+  clientHeaders: string[]
 
   constructor({
     basePath = '',
@@ -78,6 +79,7 @@ export default class Router {
     pageChecker,
     useFileSystemPublicRoutes,
     locales = [],
+    clientHeaders = [],
   }: {
     basePath: string
     headers: Route[]
@@ -93,6 +95,7 @@ export default class Router {
     pageChecker: PageChecker
     useFileSystemPublicRoutes: boolean
     locales: string[]
+    clientHeaders: string[]
   }) {
     this.basePath = basePath
     this.headers = headers
@@ -104,6 +107,7 @@ export default class Router {
     this.dynamicRoutes = dynamicRoutes
     this.useFileSystemPublicRoutes = useFileSystemPublicRoutes
     this.locales = locales
+    this.clientHeaders = clientHeaders
   }
 
   setDynamicRoutes(routes: DynamicRoutes = []) {


### PR DESCRIPTION
## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added

fixes #24798 

## Description

This PR adds the headers to client-side routing. Before "server routing" and "client routing" were similar in the way they get the rewrites, but they were different in the way they use request headers to decide the rewrites. On the client, we only use the `.host` header which we get from the `document`, and on the server, we just use all the available headers.

I expected the headers to also be taken into account on the client-side, either by sending the rewrites that were activated from the server, or the client having them available in its own router, just like it has all the rewrites available in `window.__BUILD_MANIFEST`. Sadly neither was true and the header for the initial request was not used for any of the subsequent requests.

We could argue that only the first request to the server should do rewrites based on the header, but I think that it's more straightforward to account for the headers that were in the initial request and reuse them throughout the client-side journey.

The real-world use-case that we have for this is as follows:

- We have a proxy server that proxies all requests to the same next.js server
- We append an `x-brand` to requests going to the next.js server
- The next.js server checks the rewrites for this `brand` and replies with the correct page
- On the client side a user navigates to another page with the client router and loses all the rewrites sent back by the server

Let me know what y'all think, if this is something you agree with I'd gladly also write some integration tests for this.