### PR TITLE
docs(config intro): Fix github link hash

### DIFF
--- a/docs/api-reference/next.config.js/introduction.md
+++ b/docs/api-reference/next.config.js/introduction.md
@@ -44,7 +44,7 @@ module.exports = (phase, { defaultConfig }) => {
 }
 ```
 
-The commented lines are the place where you can put the configs allowed by `next.config.js`, which are defined [here](https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/config-shared.ts#L33).
+The commented lines are the place where you can put the configs allowed by `next.config.js`, which are defined [here](https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/config-shared.ts#L68).
 
 However, none of the configs are required, and it's not necessary to understand what each config does. Instead, search for the features you need to enable or modify in this section and they will show you what to do.
 


### PR DESCRIPTION
Doc page: https://nextjs.org/docs/api-reference/next.config.js/introduction

[`config-sahred.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/config-shared.ts) file has been updated and the link here now is pointing to the random line!
