### PR TITLE
fix example with-next-less Cannot find module "webpack/lib/node/NodeTemplatePlugin"

### DIFF
--- a/examples/with-next-less/package.json
+++ b/examples/with-next-less/package.json
@@ -8,9 +8,11 @@
   "dependencies": {
     "@zeit/next-less": "^1.0.1",
     "less": "^3.0.4",
-    "next": "latest",
+    "next": "10.0.6",
+    "next-compose-plugins": "^2.2.1",
     "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react-dom": "^16.7.0",
+    "webpack": "^4.46.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
fix: `Error: Cannot find module 'webpack/lib/node/NodeTemplatePlugin'`

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- fix example with-next-less  Cannot find module "webpack/lib/node/NodeTemplatePlugin"


