### PR TITLE
Skip processing when href is not a simple string

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/google-font-display.js
+++ b/packages/eslint-plugin-next/lib/rules/google-font-display.js
@@ -23,7 +23,7 @@ module.exports = {
         }
 
         const hrefValue = attributes.value('href')
-        const isGoogleFont = hrefValue.includes(
+        const isGoogleFont = hrefValue?.startsWith(
           'https://fonts.googleapis.com/css'
         )
 

--- a/packages/eslint-plugin-next/lib/rules/google-font-preconnect.js
+++ b/packages/eslint-plugin-next/lib/rules/google-font-preconnect.js
@@ -26,7 +26,7 @@ module.exports = {
           attributes.value('rel') !== 'preconnect'
 
         if (
-          hrefValue.includes('https://fonts.gstatic.com') &&
+          hrefValue?.startsWith('https://fonts.gstatic.com') &&
           preconnectMissing
         ) {
           context.report({

--- a/packages/eslint-plugin-next/lib/rules/no-page-custom-font.js
+++ b/packages/eslint-plugin-next/lib/rules/no-page-custom-font.js
@@ -38,7 +38,7 @@ module.exports = {
         }
 
         const hrefValue = attributes.value('href')
-        const isGoogleFont = hrefValue.includes(
+        const isGoogleFont = hrefValue?.startsWith(
           'https://fonts.googleapis.com/css'
         )
 

--- a/test/eslint-plugin-next/google-font-display.unit.test.js
+++ b/test/eslint-plugin-next/google-font-display.unit.test.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester
 
 RuleTester.setDefaultConfig({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: {
       modules: true,
@@ -20,6 +20,15 @@ ruleTester.run('google-font-display', rule, {
      export default Test = () => {
       return (
         <Head>
+          <link href={test} rel="test" />
+          <link
+            href={process.env.NEXT_PUBLIC_CANONICAL_URL}
+            rel="canonical"
+          />
+          <link
+            href={new URL("../public/favicon.ico", import.meta.url).toString()}
+            rel="icon"
+          />
           <link
             href="https://fonts.googleapis.com/css2?family=Krona+One&display=optional"
             rel="stylesheet"

--- a/test/eslint-plugin-next/google-font-preconnect.unit.test.js
+++ b/test/eslint-plugin-next/google-font-preconnect.unit.test.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester
 
 RuleTester.setDefaultConfig({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: {
       modules: true,
@@ -18,6 +18,14 @@ ruleTester.run('google-font-preconnect', rule, {
     `export const Test = () => (
         <div>
           <link rel="preconnect" href="https://fonts.gstatic.com"/>
+          <link
+            href={process.env.NEXT_PUBLIC_CANONICAL_URL}
+            rel="canonical"
+          />
+          <link
+            href={new URL("../public/favicon.ico", import.meta.url).toString()}
+            rel="icon"
+          />
         </div>
       )
     `,

--- a/test/eslint-plugin-next/no-page-custom-font.unit.test.js
+++ b/test/eslint-plugin-next/no-page-custom-font.unit.test.js
@@ -3,7 +3,7 @@ const RuleTester = require('eslint').RuleTester
 
 RuleTester.setDefaultConfig({
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
     ecmaFeatures: {
       modules: true,
@@ -25,6 +25,14 @@ ruleTester.run('no-page-custom-font', rule, {
               <link
                 href="https://fonts.googleapis.com/css2?family=Krona+One&display=swap"
                 rel="stylesheet"
+              />
+              <link
+                href={process.env.NEXT_PUBLIC_CANONICAL_URL}
+                rel="canonical"
+              />
+              <link
+                href={new URL("../public/favicon.ico", import.meta.url).toString()}
+                rel="icon"
               />
             </Head>
           </Html>


### PR DESCRIPTION
## Bug

- ~~Related issues linked using `fixes #number`~~
- [x] Integration tests added

## Describe

Throws an error if the value of the href attribute of the link element is not a simple string in multiple rules of ESLint.

```tsx
import { Html, Head } from 'next/document'

export default class MyDocument extends Document {
  render(): JSX.Element {
    return (
      <Html>
        <Head>
          <link href={new URL('../public/favicon.ico', import.meta.url).toString()} rel="icon" />
        </Head>
      </Html>
    )
  }
}
```

```console
$ eslint .

Oops! Something went wrong! :(

ESLint: 7.26.0

TypeError: Cannot read property 'includes' of undefined
Occurred while linting /home/runner/work/prj/prj/src/pages/_document.tsx:20
    at JSXOpeningElement (/home/runner/work/prj/prj/node_modules/@next/eslint-plugin-next/lib/rules/google-font-display.js:26:40)
    at /home/runner/work/prj/prj/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/home/runner/work/prj/prj/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/home/runner/work/prj/prj/node_modules/eslint/lib/linter/node-event-generator.js:256:26)
    at NodeEventGenerator.applySelectors (/home/runner/work/prj/prj/node_modules/eslint/lib/linter/node-event-generator.js:285:22)
    at NodeEventGenerator.enterNode (/home/runner/work/prj/prj/node_modules/eslint/lib/linter/node-event-generator.js:299:14)
    at CodePathAnalyzer.enterNode (/home/runner/work/prj/prj/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:711:23)
    at /home/runner/work/prj/prj/node_modules/eslint/lib/linter/linter.js:954:32
    at Array.forEach (<anonymous>)
```