### PR TITLE
allow incremental type checking to use caching

### DIFF
--- a/packages/next/lib/typescript/runTypeCheck.ts
+++ b/packages/next/lib/typescript/runTypeCheck.ts
@@ -43,11 +43,13 @@ export async function runTypeCheck(
     noEmit: true,
   }
 
-  let program: import('typescript').Program
+  let program:
+    | import('typescript').Program
+    | import('typescript').BuilderProgram
   let incremental = false
   if (options.incremental && cacheDir) {
     incremental = true
-    const builderProgram = ts.createIncrementalProgram({
+    program = ts.createIncrementalProgram({
       rootNames: effectiveConfiguration.fileNames,
       options: {
         ...options,
@@ -55,7 +57,6 @@ export async function runTypeCheck(
         tsBuildInfoFile: path.join(cacheDir, '.tsbuildinfo'),
       },
     })
-    program = builderProgram.getProgram()
   } else {
     program = ts.createProgram(effectiveConfiguration.fileNames, options)
   }
@@ -73,7 +74,7 @@ export async function runTypeCheck(
   //
   const regexIgnoredFile = /[\\/]__(?:tests|mocks)__[\\/]|(?<=[\\/.])(?:spec|test)\.[^\\/]+$/
   const allDiagnostics = ts
-    .getPreEmitDiagnostics(program)
+    .getPreEmitDiagnostics(program as import('typescript').Program)
     .concat(result.diagnostics)
     .filter((d) => !(d.file && regexIgnoredFile.test(d.file.fileName)))
 


### PR DESCRIPTION
emit must be called on build program to leverage caching

While the the current way of calling incremental typescript seem to work, it actually doesn't use caching correct. A difference is only notice-able on larger code bases...
