### PR TITLE
Updating redirect

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -152,7 +152,7 @@ export type GetServerSidePropsContext<
 
 export type GetServerSidePropsResult<P> =
   | { props: P }
-  | { redirect: Redirect }
+  | { redirect?: Redirect }
   | { notFound: true }
 
 export type GetServerSideProps<


### PR DESCRIPTION
Marking `redirect` in `GetServerSideProps` as optional, as per guidance in https://nextjs.org/docs/basic-features/data-fetching.