### PR TITLE
Update windows tests to use node 12

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ pr:
 variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
   NEXT_TELEMETRY_DISABLED: '1'
-  node_version: ^10.10.0
+  node_version: ^12.0.0
 
 stages:
   - stage: Build


### PR DESCRIPTION
Since node v10 is now officially EOL this updates our windows tests to use v12 instead
