### PR TITLE
Ensure rewrite does not override params from page in minimal mode

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -289,7 +289,13 @@ export function getUtils({
       // on the parsed params, this is used to signal if we need
       // to parse x-now-route-matches or not
       const isDefaultValue = Array.isArray(value)
-        ? value.every((val, idx) => val === defaultRouteMatches![key][idx])
+        ? value.some((val) => {
+            const defaultValue = defaultRouteMatches![key]
+
+            return Array.isArray(defaultValue)
+              ? defaultValue.includes(val)
+              : defaultValue === val
+          })
         : value === defaultRouteMatches![key]
 
       if (isDefaultValue || typeof value === 'undefined') {

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -815,28 +815,30 @@ export default class Server {
     }
 
     // Headers come very first
-    const headers = this.customRoutes.headers.map((r) => {
-      const headerRoute = getCustomRoute(r, 'header')
-      return {
-        match: headerRoute.match,
-        has: headerRoute.has,
-        type: headerRoute.type,
-        name: `${headerRoute.type} ${headerRoute.source} header route`,
-        fn: async (_req, res, params, _parsedUrl) => {
-          const hasParams = Object.keys(params).length > 0
+    const headers = this.minimalMode
+      ? []
+      : this.customRoutes.headers.map((r) => {
+          const headerRoute = getCustomRoute(r, 'header')
+          return {
+            match: headerRoute.match,
+            has: headerRoute.has,
+            type: headerRoute.type,
+            name: `${headerRoute.type} ${headerRoute.source} header route`,
+            fn: async (_req, res, params, _parsedUrl) => {
+              const hasParams = Object.keys(params).length > 0
 
-          for (const header of (headerRoute as Header).headers) {
-            let { key, value } = header
-            if (hasParams) {
-              key = compileNonPath(key, params)
-              value = compileNonPath(value, params)
-            }
-            res.setHeader(key, value)
-          }
-          return { finished: false }
-        },
-      } as Route
-    })
+              for (const header of (headerRoute as Header).headers) {
+                let { key, value } = header
+                if (hasParams) {
+                  key = compileNonPath(key, params)
+                  value = compileNonPath(value, params)
+                }
+                res.setHeader(key, value)
+              }
+              return { finished: false }
+            },
+          } as Route
+        })
 
     // since initial query values are decoded by querystring.parse
     // we need to re-encode them here but still allow passing through
@@ -968,12 +970,14 @@ export default class Server {
     let afterFiles: Route[] = []
     let fallback: Route[] = []
 
-    if (Array.isArray(this.customRoutes.rewrites)) {
-      afterFiles = this.customRoutes.rewrites.map(buildRewrite)
-    } else {
-      beforeFiles = this.customRoutes.rewrites.beforeFiles.map(buildRewrite)
-      afterFiles = this.customRoutes.rewrites.afterFiles.map(buildRewrite)
-      fallback = this.customRoutes.rewrites.fallback.map(buildRewrite)
+    if (!this.minimalMode) {
+      if (Array.isArray(this.customRoutes.rewrites)) {
+        afterFiles = this.customRoutes.rewrites.map(buildRewrite)
+      } else {
+        beforeFiles = this.customRoutes.rewrites.beforeFiles.map(buildRewrite)
+        afterFiles = this.customRoutes.rewrites.afterFiles.map(buildRewrite)
+        fallback = this.customRoutes.rewrites.fallback.map(buildRewrite)
+      }
     }
 
     const catchAllRoute: Route = {


### PR DESCRIPTION
This makes sure a catch-all rewrite doesn't override the params from a dynamic route in minimal mode, it also makes sure we don't attempt applying headers and rewrites un-necessarily in minimal mode. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

