### PR TITLE
Remove experimental-modern-preset option

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -41,7 +41,6 @@ type NextBabelPresetOptions = {
   'preset-react'?: any
   'class-properties'?: any
   'transform-runtime'?: any
-  'experimental-modern-preset'?: PluginItem
   'styled-jsx'?: StyledJsxBabelOptions
   'preset-typescript'?: any
 }
@@ -89,10 +88,6 @@ export default (
     (Boolean(api.caller((caller: any) => !!caller && caller.hasJsxRuntime)) &&
       options['preset-react']?.runtime !== 'classic')
 
-  const isLaxModern =
-    options['preset-env']?.targets &&
-    options['preset-env'].targets.esmodules === true
-
   const presetEnvConfig = {
     // In the test environment `modules` is often needed to be set to true, babel figures that out by itself using the `'auto'` option
     // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
@@ -122,17 +117,10 @@ export default (
     }
   }
 
-  // specify a preset to use instead of @babel/preset-env
-  const customModernPreset =
-    isLaxModern && options['experimental-modern-preset']
-
   return {
     sourceType: 'unambiguous',
     presets: [
-      customModernPreset || [
-        require('next/dist/compiled/babel/preset-env'),
-        presetEnvConfig,
-      ],
+      [require('next/dist/compiled/babel/preset-env'), presetEnvConfig],
       [
         require('next/dist/compiled/babel/preset-react'),
         {

--- a/test/unit/next-babel.unit.test.js
+++ b/test/unit/next-babel.unit.test.js
@@ -165,28 +165,6 @@ describe('next/babel', () => {
     })
   })
 
-  describe('experimental-modern-preset', () => {
-    it('should allow passing a custom Babel preset', () => {
-      const code = trim`
-        const [, b, c] = [...[1,2,3]];
-        ({a}) => a;
-      `
-      const output = babel(code, true, {
-        'preset-env': {
-          targets: {
-            esmodules: true,
-          },
-        },
-        // our modern preset is no preset at all
-        'experimental-modern-preset': () => ({}),
-      })
-
-      expect(output).toMatch(trim`
-        const[,b,c]=[...[1,2,3]];({a})=>a;
-      `)
-    })
-  })
-
   describe('respect preset-react runtime', () => {
     it('should allow forcing on automatic mode', () => {
       const code = trim`const a = ()=><a href="/">home</a>`


### PR DESCRIPTION
This option is no longer needed as the preset we wanted to try out was merged with preset-env

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
