### PR TITLE
docs(rewrites.md): update beforeFiles note

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -58,8 +58,8 @@ module.exports = {
     return {
       beforeFiles: [
         // These rewrites are checked after headers/redirects
-        // and before pages/public files which allows overriding
-        // page files
+        // and before all files including _next files which allows
+        // overriding page files
         {
           source: '/some-page',
           destination: '/somewhere-else',

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -58,8 +58,8 @@ module.exports = {
     return {
       beforeFiles: [
         // These rewrites are checked after headers/redirects
-        // and before all files including _next files which allows
-        // overriding page files
+        // and before all files including _next/public files which
+        // allows overriding page files
         {
           source: '/some-page',
           destination: '/somewhere-else',


### PR DESCRIPTION
This updates the beforeFiles rewrites note to mention the rewrites can affect `_next` files which are required for loading pages client-side. 

## Documentation / Examples

- [x] Make sure the linting passes
