### PR TITLE
Remove import type syntax

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -8,7 +8,7 @@ import { CompileError } from './compile-error'
 import { FatalError } from './fatal-error'
 
 import { getTypeScriptIntent } from './typescript/getTypeScriptIntent'
-import type { TypeCheckResult } from './typescript/runTypeCheck'
+import { TypeCheckResult } from './typescript/runTypeCheck'
 import { writeAppTypeDeclarations } from './typescript/writeAppTypeDeclarations'
 import { writeConfigurationDefaults } from './typescript/writeConfigurationDefaults'
 

--- a/packages/next/next-server/server/config-utils.ts
+++ b/packages/next/next-server/server/config-utils.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { Worker } from 'jest-worker'
 import * as Log from '../../build/output/log'
-import type { CheckReasons, CheckResult } from './config-utils-worker'
+import { CheckReasons, CheckResult } from './config-utils-worker'
 import { install, shouldLoadWithWebpack5 } from './config-utils-worker'
 
 export { install, shouldLoadWithWebpack5 }

--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -1,5 +1,5 @@
 import '../next-server/server/node-polyfill-fetch'
-import type {
+import {
   default as Server,
   ServerConstructor,
 } from '../next-server/server/next-server'

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -129,7 +129,7 @@ describe('Build Output', () => {
           expect(parseFloat(err404Size)).toBeCloseTo(gz ? 3.06 : 8.15, 1)
           expect(err404Size.endsWith('kB')).toBe(true)
 
-          expect(parseFloat(err404FirstLoad)).toBeCloseTo(gz ? 66.4 : 203, 1)
+          expect(parseFloat(err404FirstLoad)).toBeCloseTo(gz ? 66.5 : 203, 1)
           expect(err404FirstLoad.endsWith('kB')).toBe(true)
 
           expect(parseFloat(sharedByAll)).toBeCloseTo(gz ? 63.4 : 195, 1)


### PR DESCRIPTION
This removes `import type` syntax to prevent breaking older typescript versions

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
