### PR TITLE
Re-add strip-ansi babel include

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -287,6 +287,7 @@ export default async function getBaseWebpackConfig(
     /next[\\/]dist[\\/]next-server[\\/]lib/,
     /next[\\/]dist[\\/]client/,
     /next[\\/]dist[\\/]pages/,
+    /[\\/](strip-ansi|ansi-regex)[\\/]/,
   ]
 
   // Support for NODE_PATH


### PR DESCRIPTION
This re-adds the strip-ansi babel include regex from https://github.com/vercel/next.js/pull/25101 since it seems to be needed still for the ie11 dev tests that are currently failing 

x-ref: https://github.com/vercel/next.js/pull/25101/files

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
