### PR TITLE
Revert server split chunks config

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -822,17 +822,7 @@ export default async function getBaseWebpackConfig(
       ...(isWebpack5 ? { emitOnErrors: !dev } : { noEmitOnErrors: dev }),
       checkWasmTypes: false,
       nodeEnv: false,
-      splitChunks: isServer
-        ? isWebpack5
-          ? {
-              // allow to split entrypoints
-              chunks: 'all',
-              // size of files is not so relevant for server build
-              // we want to prefer deduplication to load less code
-              minSize: 1000,
-            }
-          : false
-        : splitChunksConfig,
+      splitChunks: isServer ? false : splitChunksConfig,
       runtimeChunk: isServer
         ? isWebpack5 && !isLikeServerless
           ? { name: 'webpack-runtime' }


### PR DESCRIPTION
This reverts the server splits chunks config in https://github.com/vercel/next.js/pull/25035 to fix server chunks being output outside of the `.next/server/chunks` directory causing tracing to fail when deployed

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
