### PR TITLE
Ensure server split chunks are nested in chunks dir

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -824,13 +824,14 @@ export default async function getBaseWebpackConfig(
       nodeEnv: false,
       splitChunks: isServer
         ? isWebpack5
-          ? {
+          ? ({
+              filename: `${dev ? '[name]' : '[name].[contenthash]'}.js`,
               // allow to split entrypoints
               chunks: 'all',
               // size of files is not so relevant for server build
               // we want to prefer deduplication to load less code
               minSize: 1000,
-            }
+            } as any)
           : false
         : splitChunksConfig,
       runtimeChunk: isServer


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/25035 this ensures the split chunks are nested in the `.next/server/chunks` directory which ensures tracing succeeds successfully when deployed. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
