### PR TITLE
Make next.config.js keys optional

### DIFF
--- a/packages/next/next-server/server/config-shared.ts
+++ b/packages/next/next-server/server/config-shared.ts
@@ -57,12 +57,12 @@ export type NextConfig = { [key: string]: any } & {
       validator?: string
       skipValidation?: boolean
     }
-    turboMode: boolean
+    turboMode?: boolean
     eslint?: boolean
-    reactRoot: boolean
-    enableBlurryPlaceholder: boolean
-    disableOptimizedLoading: boolean
-    gzipSize: boolean
+    reactRoot?: boolean
+    enableBlurryPlaceholder?: boolean
+    disableOptimizedLoading?: boolean
+    gzipSize?: boolean
   }
 }
 

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -157,7 +157,7 @@ export default class Server {
     images: string
     fontManifest: FontManifest
     optimizeImages: boolean
-    disableOptimizedLoading: boolean
+    disableOptimizedLoading?: boolean
     optimizeCss: any
     locale?: string
     locales?: string[]
@@ -219,7 +219,7 @@ export default class Server {
       optimizeImages: !!this.nextConfig.experimental.optimizeImages,
       optimizeCss: this.nextConfig.experimental.optimizeCss,
       disableOptimizedLoading: this.nextConfig.experimental
-        .disableOptimizedLoading,
+        ?.disableOptimizedLoading,
       domainLocales: this.nextConfig.i18n?.domains,
       distDir: this.distDir,
     }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -219,7 +219,7 @@ export default class Server {
       optimizeImages: !!this.nextConfig.experimental.optimizeImages,
       optimizeCss: this.nextConfig.experimental.optimizeCss,
       disableOptimizedLoading: this.nextConfig.experimental
-        ?.disableOptimizedLoading,
+        .disableOptimizedLoading,
       domainLocales: this.nextConfig.i18n?.domains,
       distDir: this.distDir,
     }


### PR DESCRIPTION
## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Description

These values should be optional and not required on the `NextConfig` type.