### PR TITLE
Ensure default params are detected after rewrite

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -280,7 +280,7 @@ export function getUtils({
 
   function normalizeDynamicRouteParams(params: ParsedUrlQuery) {
     let hasValidParams = true
-    if (!defaultRouteRegex) return { params, hasValidParams }
+    if (!defaultRouteRegex) return { params, hasValidParams: false }
 
     params = Object.keys(defaultRouteRegex.groups).reduce((prev, key) => {
       let value: string | string[] | undefined = params[key]
@@ -288,15 +288,15 @@ export function getUtils({
       // if the value matches the default value we can't rely
       // on the parsed params, this is used to signal if we need
       // to parse x-now-route-matches or not
-      const isDefaultValue = Array.isArray(value)
-        ? value.some((val) => {
-            const defaultValue = defaultRouteMatches![key]
+      const defaultValue = defaultRouteMatches![key]
 
-            return Array.isArray(defaultValue)
-              ? defaultValue.includes(val)
-              : defaultValue === val
+      const isDefaultValue = Array.isArray(defaultValue)
+        ? defaultValue.some((defaultVal) => {
+            return Array.isArray(value)
+              ? value.some((val) => val.includes(defaultVal))
+              : value?.includes(defaultVal)
           })
-        : value === defaultRouteMatches![key]
+        : value?.includes(defaultValue as string)
 
       if (isDefaultValue || typeof value === 'undefined') {
         hasValidParams = false

--- a/test/integration/required-server-files/test/index.test.js
+++ b/test/integration/required-server-files/test/index.test.js
@@ -216,6 +216,20 @@ describe('Required Server Files', () => {
     expect($2('#slug').text()).toBe('second')
     expect(isNaN(data2.random)).toBe(false)
     expect(data2.random).not.toBe(data.random)
+
+    const html3 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
+      headers: {
+        'x-matched-path': '/dynamic/[slug]?slug=%5Bslug%5D.json',
+        'x-now-route-matches': '1=second&slug=second',
+      },
+    })
+    const $3 = cheerio.load(html3)
+    const data3 = JSON.parse($3('#props').text())
+
+    expect($3('#dynamic').text()).toBe('dynamic page')
+    expect($3('#slug').text()).toBe('second')
+    expect(isNaN(data3.random)).toBe(false)
+    expect(data3.random).not.toBe(data.random)
   })
 
   it('should render fallback page correctly with x-matched-path and routes-matches', async () => {


### PR DESCRIPTION
This ensures we detect default param values in minimal mode even if there's a slight difference from a rewrite taking place. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
