### PR TITLE
fix: replace usage of `fromEntries` in browser bundled `resolve-rewrites.ts`

### DIFF
--- a/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
@@ -43,12 +43,13 @@ export default function resolveRewrites(
           headers: {
             host: document.location.hostname,
           },
-          cookies: Object.fromEntries(
-            document.cookie.split('; ').map((item) => {
+          cookies: document.cookie
+            .split('; ')
+            .reduce<Record<string, string>>((acc, item) => {
               const [key, ...value] = item.split('=')
-              return [key, value.join('=')]
-            })
-          ),
+              acc[key] = value.join('=')
+              return acc
+            }, {}),
         } as any,
         rewrite.has,
         parsedAs.query


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added

Fixes #25207

Currently rewritten routes that use a `has` condition throw an `Object.fromEntries is not a function` error in older browsers.

## Documentation / Examples

- [x] Make sure the linting passes

## Solution

As mentioned in issue #25207, looks like last year the team decided not to include the `fromEntries` polyfill https://github.com/vercel/next.js/pull/15772#discussion_r463957221.

As such, we should avoid using non-polyfilled methods in core next.js code bundled in the browser.

This PR's changes should result in the same object being returned, without using `fromEntries`.