### PR TITLE
Fix ie11 has rewrite test

### DIFF
--- a/test/integration/rewrites-has-condition/pages/index.js
+++ b/test/integration/rewrites-has-condition/pages/index.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function Page(props) {
+  return (
+    <>
+      <p id="index">index page</p>
+      <Link href="/rewrite-simple">
+        <a id="to-simple">to /rewrite-simple</a>
+      </Link>
+      <br />
+
+      <Link href="/rewrite-with-has?hasQuery=true">
+        <a id="to-has-rewrite">to /rewrite-with-has?hasQuery=true</a>
+      </Link>
+      <br />
+    </>
+  )
+}

--- a/test/integration/rewrites-has-condition/test/index.test.js
+++ b/test/integration/rewrites-has-condition/test/index.test.js
@@ -18,33 +18,32 @@ let appPort
 let app
 
 const runTests = () => {
-  it('should load page rewrite without browser errors', async () => {
-    const browser = await webdriver(appPort, '/rewrite-simple')
+  it('should navigate to a simple rewrite without error', async () => {
+    const browser = await webdriver(appPort, '/')
+    await browser.eval('window.beforeNav = 1')
 
-    expect(await browser.waitForElementByCss('#another').text()).toBe(
-      'another page'
-    )
-
-    const browserLogs = await browser.log('browser')
-    const errorLogs = browserLogs.filter((log) => {
-      return log.level.name === 'SEVERE' && log.message.includes('Error:')
-    })
-    expect(errorLogs).toEqual([])
+    await browser
+      .elementByCss('#to-simple')
+      .click()
+      .waitForElementByCss('#another')
+    expect(await browser.elementByCss('#pathname').text()).toBe('/another')
+    expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({})
+    expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
-  // Regression test for https://github.com/vercel/next.js/issues/25207
-  it('should load page rewrite, with "has" condition, without browser errors', async () => {
-    const browser = await webdriver(appPort, '/rewrite-with-has?hasQuery=123')
+  it('should navigate to a has rewrite without error', async () => {
+    const browser = await webdriver(appPort, '/')
+    await browser.eval('window.beforeNav = 1')
 
-    expect(await browser.waitForElementByCss('#another').text()).toBe(
-      'another page'
-    )
-
-    const browserLogs = await browser.log('browser')
-    const errorLogs = browserLogs.filter((log) => {
-      return log.level.name === 'SEVERE' && log.message.includes('Error:')
+    await browser
+      .elementByCss('#to-has-rewrite')
+      .click()
+      .waitForElementByCss('#another')
+    expect(await browser.elementByCss('#pathname').text()).toBe('/another')
+    expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
+      hasQuery: 'true',
     })
-    expect(errorLogs).toEqual([])
+    expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 }
 


### PR DESCRIPTION
This updates the `rewrites-has-condition` tests to not rely on the `browser.log` method since it's not available with ie11

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
