### PR TITLE
Update beforeFiles rewrites to continue

### DIFF
--- a/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/next-server/lib/router/utils/resolve-rewrites.ts
@@ -101,19 +101,16 @@ export default function resolveRewrites(
   let finished = false
 
   for (let i = 0; i < rewrites.beforeFiles.length; i++) {
-    const rewrite = rewrites.beforeFiles[i]
-
-    if (handleRewrite(rewrite)) {
-      finished = true
-      break
-    }
+    // we don't end after match in beforeFiles to allow
+    // continuing through all beforeFiles rewrites
+    handleRewrite(rewrites.beforeFiles[i])
   }
+  matchedPage = pages.includes(fsPathname)
 
-  if (!pages.includes(fsPathname)) {
+  if (!matchedPage) {
     if (!finished) {
       for (let i = 0; i < rewrites.afterFiles.length; i++) {
-        const rewrite = rewrites.afterFiles[i]
-        if (handleRewrite(rewrite)) {
+        if (handleRewrite(rewrites.afterFiles[i])) {
           finished = true
           break
         }
@@ -129,8 +126,7 @@ export default function resolveRewrites(
 
     if (!finished) {
       for (let i = 0; i < rewrites.fallback.length; i++) {
-        const rewrite = rewrites.fallback[i]
-        if (handleRewrite(rewrite)) {
+        if (handleRewrite(rewrites.fallback[i])) {
           finished = true
           break
         }

--- a/packages/next/next-server/server/next-server.ts
+++ b/packages/next/next-server/server/next-server.ts
@@ -902,11 +902,11 @@ export default class Server {
           } as Route
         })
 
-    const buildRewrite = (rewrite: Rewrite) => {
+    const buildRewrite = (rewrite: Rewrite, check = true) => {
       const rewriteRoute = getCustomRoute(rewrite, 'rewrite')
       return {
         ...rewriteRoute,
-        check: true,
+        check,
         type: rewriteRoute.type,
         name: `Rewrite route ${rewriteRoute.source}`,
         match: rewriteRoute.match,
@@ -975,11 +975,17 @@ export default class Server {
 
     if (!this.minimalMode) {
       if (Array.isArray(this.customRoutes.rewrites)) {
-        afterFiles = this.customRoutes.rewrites.map(buildRewrite)
+        afterFiles = this.customRoutes.rewrites.map((r) => buildRewrite(r))
       } else {
-        beforeFiles = this.customRoutes.rewrites.beforeFiles.map(buildRewrite)
-        afterFiles = this.customRoutes.rewrites.afterFiles.map(buildRewrite)
-        fallback = this.customRoutes.rewrites.fallback.map(buildRewrite)
+        beforeFiles = this.customRoutes.rewrites.beforeFiles.map((r) =>
+          buildRewrite(r, false)
+        )
+        afterFiles = this.customRoutes.rewrites.afterFiles.map((r) =>
+          buildRewrite(r)
+        )
+        fallback = this.customRoutes.rewrites.fallback.map((r) =>
+          buildRewrite(r)
+        )
       }
     }
 

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -190,6 +190,10 @@ module.exports = {
           ],
           destination: '/with-params?idk=:idk',
         },
+        {
+          source: '/blog/about',
+          destination: '/hello',
+        },
       ],
       beforeFiles: [
         {
@@ -201,6 +205,10 @@ module.exports = {
             },
           ],
           destination: '/with-params?overridden=1',
+        },
+        {
+          source: '/old-blog/:path*',
+          destination: '/blog/:path*',
         },
       ],
     }

--- a/test/integration/custom-routes/pages/nav.js
+++ b/test/integration/custom-routes/pages/nav.js
@@ -32,5 +32,13 @@ export default () => (
       <a id="to-rewritten-dynamic">to rewritten dynamic</a>
     </Link>
     <br />
+    <Link href="/hello?overrideMe=1">
+      <a id="to-overridden">to /hello?overrideMe=1</a>
+    </Link>
+    <br />
+    <Link href="/old-blog/about">
+      <a id="to-old-blog">to /old-blog/post-1</a>
+    </Link>
+    <br />
   </>
 )


### PR DESCRIPTION
This updates beforeFiles rewrites to continue instead of matching a public file/page immediately after a match, this allows all beforeFiles routes to be checked before matching the filesystem.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
