### PR TITLE
Set default webpack publicPath value to override auto

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -909,6 +909,9 @@ export default async function getBaseWebpackConfig(
             },
           }
         : {}),
+      // we must set publicPath to an empty value to override the default of
+      // auto which doesn't work in IE11
+      publicPath: '',
       path:
         isServer && isWebpack5 && !dev
           ? path.join(outputPath, 'chunks')

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -123,16 +123,16 @@ describe('Build Output', () => {
           )
           expect(indexSize.endsWith('B')).toBe(true)
 
-          expect(parseFloat(indexFirstLoad)).toBeCloseTo(gz ? 63.6 : 195, 1)
+          expect(parseFloat(indexFirstLoad)).toBeCloseTo(gz ? 63.4 : 195, 1)
           expect(indexFirstLoad.endsWith('kB')).toBe(true)
 
           expect(parseFloat(err404Size)).toBeCloseTo(gz ? 3.06 : 8.15, 1)
           expect(err404Size.endsWith('kB')).toBe(true)
 
-          expect(parseFloat(err404FirstLoad)).toBeCloseTo(gz ? 66.45 : 203, 1)
+          expect(parseFloat(err404FirstLoad)).toBeCloseTo(gz ? 66.3 : 202, 1)
           expect(err404FirstLoad.endsWith('kB')).toBe(true)
 
-          expect(parseFloat(sharedByAll)).toBeCloseTo(gz ? 63.4 : 195, 1)
+          expect(parseFloat(sharedByAll)).toBeCloseTo(gz ? 63.2 : 194, 1)
           expect(sharedByAll.endsWith('kB')).toBe(true)
 
           const appSizeValue = _appSize.endsWith('kB')
@@ -144,7 +144,7 @@ describe('Build Output', () => {
           const webpackSizeValue = webpackSize.endsWith('kB')
             ? parseFloat(webpackSize)
             : parseFloat(webpackSize) / 1000
-          expect(webpackSizeValue).toBeCloseTo(gz ? 0.95 : 1.81, 2)
+          expect(webpackSizeValue).toBeCloseTo(gz ? 0.76 : 1.45, 2)
           expect(webpackSize.endsWith('kB') || webpackSize.endsWith(' B')).toBe(
             true
           )

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 /* global browserName */
 import cheerio from 'cheerio'
-import { existsSync } from 'fs'
+import fs, { existsSync } from 'fs-extra'
+import globOriginal from 'glob'
 import {
   nextServer,
   renderViaHTTP,
@@ -24,6 +25,10 @@ import { join } from 'path'
 import dynamicImportTests from './dynamic'
 import processEnv from './process-env'
 import security from './security'
+import { promisify } from 'util'
+
+const glob = promisify(globOriginal)
+
 const appDir = join(__dirname, '../')
 let appPort
 let server
@@ -62,6 +67,23 @@ describe('Production Usage', () => {
     expect(output).toContain('Generating static pages (37/37)')
     // we should only have 4 segments and the initial message logged out
     expect(output.match(/Generating static pages/g).length).toBe(5)
+  })
+
+  it('should not contain currentScript usage for publicPath', async () => {
+    const globResult = await glob('webpack-*.js', {
+      cwd: join(appDir, '.next/static/chunks'),
+    })
+
+    if (!globResult || globResult.length !== 1) {
+      throw new Error('could not find webpack-hash.js chunk')
+    }
+
+    const content = await fs.readFile(
+      join(appDir, '.next/static/chunks', globResult[0]),
+      'utf8'
+    )
+
+    expect(content).not.toContain('.currentScript')
   })
 
   describe('With basic usage', () => {


### PR DESCRIPTION
This ensures `publicPath` is set to an empty value since the default in webpack 5 is `auto` which isn't supported in IE11

Fixes: https://github.com/vercel/next.js/issues/25441

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
