### PR TITLE
Ensure history navigates correctly with dynamic routes + basePath

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -1522,7 +1522,7 @@ export default class Router implements BaseRouter {
         // if this directly matches a page we need to update the href to
         // allow the correct page chunk to be loaded
         pathname = rewritesResult.resolvedHref
-        parsed.pathname = addBasePath(pathname)
+        parsed.pathname = pathname
         url = formatWithValidation(parsed)
       }
     } else {
@@ -1530,7 +1530,7 @@ export default class Router implements BaseRouter {
 
       if (parsed.pathname !== pathname) {
         pathname = parsed.pathname
-        parsed.pathname = addBasePath(pathname)
+        parsed.pathname = pathname
         url = formatWithValidation(parsed)
       }
     }

--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -993,7 +993,7 @@ export default class Router implements BaseRouter {
           // if this directly matches a page we need to update the href to
           // allow the correct page chunk to be loaded
           pathname = rewritesResult.resolvedHref
-          parsed.pathname = pathname
+          parsed.pathname = addBasePath(pathname)
           url = formatWithValidation(parsed)
         }
       } else {
@@ -1001,6 +1001,7 @@ export default class Router implements BaseRouter {
 
         if (parsed.pathname !== pathname) {
           pathname = parsed.pathname
+          parsed.pathname = addBasePath(pathname)
           url = formatWithValidation(parsed)
         }
       }
@@ -1521,7 +1522,7 @@ export default class Router implements BaseRouter {
         // if this directly matches a page we need to update the href to
         // allow the correct page chunk to be loaded
         pathname = rewritesResult.resolvedHref
-        parsed.pathname = pathname
+        parsed.pathname = addBasePath(pathname)
         url = formatWithValidation(parsed)
       }
     } else {
@@ -1529,6 +1530,7 @@ export default class Router implements BaseRouter {
 
       if (parsed.pathname !== pathname) {
         pathname = parsed.pathname
+        parsed.pathname = addBasePath(pathname)
         url = formatWithValidation(parsed)
       }
     }

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -54,6 +54,32 @@ afterAll(async () => {
 })
 
 const runTests = (dev = false) => {
+  it('should navigate back correctly to a dynamic route', async () => {
+    const browser = await webdriver(appPort, `${basePath}`)
+
+    expect(await browser.elementByCss('#index-page').text()).toContain(
+      'index page'
+    )
+
+    await browser.eval('window.beforeNav = 1')
+
+    await browser.eval('window.next.router.push("/catchall/first")')
+    await check(() => browser.elementByCss('p').text(), /first/)
+    expect(await browser.eval('window.beforeNav')).toBe(1)
+
+    await browser.eval('window.next.router.push("/catchall/second")')
+    await check(() => browser.elementByCss('p').text(), /second/)
+    expect(await browser.eval('window.beforeNav')).toBe(1)
+
+    await browser.eval('window.next.router.back()')
+    await check(() => browser.elementByCss('p').text(), /first/)
+    expect(await browser.eval('window.beforeNav')).toBe(1)
+
+    await browser.eval('window.history.forward()')
+    await check(() => browser.elementByCss('p').text(), /second/)
+    expect(await browser.eval('window.beforeNav')).toBe(1)
+  })
+
   if (dev) {
     describe('Hot Module Reloading', () => {
       describe('delete a page and add it back', () => {


### PR DESCRIPTION
This ensures the `basePath` is correctly re-added to the `url` after resolving a dynamic route since the `url` stored in history is expected to already contain the `basePath`, an additional test has been added to ensure this is working correctly back/forward through history

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

Fixes: https://github.com/vercel/next.js/issues/25285
