### PR TITLE
Assume a recent `react@experimental` if `reactRoot` is set

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -233,10 +233,11 @@ export default async function getBaseWebpackConfig(
   const reactVersion = await getPackageVersion({ cwd: dir, name: 'react' })
   const hasReactRefresh: boolean = dev && !isServer
   const hasJsxRuntime: boolean =
-    Boolean(reactVersion) &&
-    // 17.0.0-rc.0 had a breaking change not compatible with Next.js, but was
-    // fixed in rc.1.
-    semver.gte(reactVersion!, '17.0.0-rc.1')
+    config.experimental.reactRoot ||
+    (Boolean(reactVersion) &&
+      // 17.0.0-rc.0 had a breaking change not compatible with Next.js, but was
+      // fixed in rc.1.
+      semver.gte(reactVersion!, '17.0.0-rc.1'))
 
   const babelConfigFile = await [
     '.babelrc',

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -508,11 +508,7 @@ function renderReactElement(
   const reactEl = fn(shouldHydrate ? markHydrateComplete : markRenderComplete)
   if (process.env.__NEXT_REACT_ROOT) {
     if (!reactRoot) {
-      const createRootName =
-        typeof (ReactDOM as any).unstable_createRoot === 'function'
-          ? 'unstable_createRoot'
-          : 'createRoot'
-      reactRoot = (ReactDOM as any)[createRootName](domEl, {
+      reactRoot = (ReactDOM as any).createRoot(domEl, {
         hydrate: shouldHydrate,
       })
     }


### PR DESCRIPTION
Since `createRoot` stabilized in the experimental channel, we should assume you're using it. We should also assume that if you're using it, the React version is greater than `17.0.0-rc.1` for the purposes of using the new JSX runtime.