### PR TITLE
Changed the condition to show 'experimental warning'

### DIFF
--- a/packages/next/next-server/server/config.ts
+++ b/packages/next/next-server/server/config.ts
@@ -59,7 +59,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       if (
         key === 'experimental' &&
         value !== undefined &&
-        value !== defaultConfig[key]
+        Object.keys(value).length
       ) {
         experimentalWarning()
       }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #25498`
- [ ] Integration tests added

Added a check to see if 'experimental' object has any items in it or not. And depending on that the experimentalWarning is shown