### PR TITLE
Changed `getInitialProps` to `getStaticProps`

### DIFF
--- a/docs/advanced-features/automatic-static-optimization.md
+++ b/docs/advanced-features/automatic-static-optimization.md
@@ -4,7 +4,7 @@ description: Next.js automatically optimizes your app to be static HTML whenever
 
 # Automatic Static Optimization
 
-Next.js automatically determines that a page is static (can be prerendered) if it has no blocking data requirements. This determination is made by the absence of `getServerSideProps` and `getInitialProps` in the page.
+Next.js automatically determines that a page is static (can be prerendered) if it has no blocking data requirements. This determination is made by the absence of `getServerSideProps` and `getStaticProps` in the page.
 
 This feature allows Next.js to emit hybrid applications that contain **both server-rendered and statically generated pages**.
 


### PR DESCRIPTION
Just changed `getInitialProps` to `getStaticProps` in the **Automatic Static Optimization** doc page.

Link to doc: [Automatic Static Optimization](https://nextjs.org/docs/advanced-features/automatic-static-optimization)
