### PR TITLE
Fix external check for non-local next import

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -176,6 +176,7 @@ const WEBPACK_RESOLVE_OPTIONS = {
   // Otherwise combined ESM+CJS packages will never be external
   // as resolving mismatch would lead to opt-out from being external.
   dependencyType: 'commonjs',
+  symlinks: true,
 }
 
 const NODE_RESOLVE_OPTIONS = {
@@ -738,12 +739,14 @@ export default async function getBaseWebpackConfig(
     if (baseRes !== res) {
       return
     }
+    const isNextExternal = res.match(/next[/\\]dist[/\\]next-server[/\\]/)
 
     // Default pages have to be transpiled
     if (
-      res.match(/[/\\]next[/\\]dist[/\\]/) ||
-      // This is the @babel/plugin-transform-runtime "helpers: true" option
-      res.match(/node_modules[/\\]@babel[/\\]runtime[/\\]/)
+      !isNextExternal &&
+      (res.match(/[/\\]next[/\\]dist[/\\]/) ||
+        // This is the @babel/plugin-transform-runtime "helpers: true" option
+        res.match(/node_modules[/\\]@babel[/\\]runtime[/\\]/))
     ) {
       return
     }
@@ -758,7 +761,7 @@ export default async function getBaseWebpackConfig(
 
     // Anything else that is standard JavaScript within `node_modules`
     // can be externalized.
-    if (/node_modules[/\\].*\.c?js$/.test(res)) {
+    if (isNextExternal || /node_modules[/\\].*\.c?js$/.test(res)) {
       return `commonjs ${request}`
     }
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -739,14 +739,20 @@ export default async function getBaseWebpackConfig(
     if (baseRes !== res) {
       return
     }
-    const isNextExternal = res.match(/next[/\\]dist[/\\]next-server[/\\]/)
+
+    if (
+      res.match(
+        /next[/\\]dist[/\\]next-server[/\\](?!lib[/\\]router[/\\]router)/
+      )
+    ) {
+      return `commonjs ${request}`
+    }
 
     // Default pages have to be transpiled
     if (
-      !isNextExternal &&
-      (res.match(/[/\\]next[/\\]dist[/\\]/) ||
-        // This is the @babel/plugin-transform-runtime "helpers: true" option
-        res.match(/node_modules[/\\]@babel[/\\]runtime[/\\]/))
+      res.match(/[/\\]next[/\\]dist[/\\]/) ||
+      // This is the @babel/plugin-transform-runtime "helpers: true" option
+      res.match(/node_modules[/\\]@babel[/\\]runtime[/\\]/)
     ) {
       return
     }
@@ -761,7 +767,7 @@ export default async function getBaseWebpackConfig(
 
     // Anything else that is standard JavaScript within `node_modules`
     // can be externalized.
-    if (isNextExternal || /node_modules[/\\].*\.c?js$/.test(res)) {
+    if (/node_modules[/\\].*\.c?js$/.test(res)) {
       return `commonjs ${request}`
     }
 

--- a/test/integration/getserversideprops/pages/index.js
+++ b/test/integration/getserversideprops/pages/index.js
@@ -1,6 +1,41 @@
 import Link from 'next/link'
+import ReactDOM from 'react-dom/server'
+import { RouterContext } from 'next/dist/next-server/lib/router-context'
+import { useRouter } from 'next/router'
 
-export async function getServerSideProps({ req }) {
+function RouterComp(props) {
+  const router = useRouter()
+
+  if (!router) {
+    throw new Error('router is missing!')
+  }
+
+  return (
+    <>
+      <p>props {JSON.stringify(props)}</p>
+      <p>router: {JSON.stringify(router)}</p>
+    </>
+  )
+}
+
+export async function getServerSideProps({ req, query, preview }) {
+  // this ensures the same router context is used by the useRouter hook
+  // no matter where it is imported
+  console.log(
+    ReactDOM.renderToString(
+      <RouterContext.Provider
+        value={{
+          query,
+          pathname: '/',
+          asPath: req.url,
+          isPreview: preview,
+        }}
+      >
+        <p>hello world</p>
+        <RouterComp hello={'world'} />
+      </RouterContext.Provider>
+    )
+  )
   return {
     props: {
       url: req.url,


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/24603 ensuring we maintain the previous behavior to correctly externalize non-local `next/dist/next-server` imports, an added test case has been added to ensure we prevent regressing on this behavior. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

Fixes: https://github.com/vercel/next.js/issues/25303
