### PR TITLE
Update `yarn next` script with `--enable-source-maps`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "publish-canary": "lerna version prerelease --preid canary --force-publish && release --pre --skip-questions",
     "publish-stable": "lerna version --force-publish",
     "lint-staged": "lint-staged",
-    "next": "node --trace-deprecation packages/next/dist/bin/next",
+    "next": "node --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
     "debug": "node --inspect packages/next/dist/bin/next"
   },
   "pre-commit": "lint-staged",


### PR DESCRIPTION
This will allow for easier development. For example, when running `yarn next dev examples/basic-css` and an internal is error is thrown, you'll see the TS source file in the stack trace instead of the JS dist file.

