### PR TITLE
Fix with-docker example fails to load image

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -1,5 +1,6 @@
 # Install dependencies only when needed
-FROM node:alpine AS deps
+FROM node:14-alpine AS deps
+ AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -7,14 +8,14 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
-FROM node:alpine AS builder
+FROM node:14-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build
 
 # Production image, copy all the files and run next
-FROM node:alpine AS runner
+FROM node:14-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
node version should be 14, otherwise, next/image fails to load static file images located in public dir
detail: https://stackoverflow.com/questions/67641673/next-js-app-running-inside-a-docker-container-fails-to-load-static-file-images

## Documentation / Examples

- [ ] Make sure the linting passes
