### PR TITLE
Add helpful error for link with multiple children

### DIFF
--- a/errors/link-multiple-children.md
+++ b/errors/link-multiple-children.md
@@ -1,0 +1,36 @@
+# Multiple children were passed to <Link>
+
+#### Why This Error Occurred
+
+In your application code multiple children were passed to `next/link` but only one child is supported:
+
+For example:
+
+```js
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <Link href="/about">
+      <a>To About</a>
+      <a>Second To About</a>
+    </Link>
+  )
+}
+```
+
+#### Possible Ways to Fix It
+
+Make sure only one child is used when using `<Link>`:
+
+```js
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <Link href="/about">
+      <a>To About</a>
+    </Link>
+  )
+}
+```

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -229,7 +229,21 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
   }
 
   // This will return the first child, if multiple are provided it will throw an error
-  const child: any = Children.only(children)
+  let child: any
+  if (process.env.NODE_ENV === 'development') {
+    try {
+      child = Children.only(children)
+    } catch (err) {
+      throw new Error(
+        `Multiple children were passed to <Link> with \`href\` of \`${props.href}\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children` +
+          (typeof window !== 'undefined'
+            ? "\nOpen your browser's console to view the Component stack trace."
+            : '')
+      )
+    }
+  } else {
+    child = Children.only(children)
+  }
   const childRef: any = child && typeof child === 'object' && child.ref
 
   const [setIntersectionRef, isVisible] = useIntersection({

--- a/packages/next/next-server/server/config-utils.ts
+++ b/packages/next/next-server/server/config-utils.ts
@@ -3,6 +3,7 @@ import { Worker } from 'jest-worker'
 import * as Log from '../../build/output/log'
 import { CheckReasons, CheckResult } from './config-utils-worker'
 import { install, shouldLoadWithWebpack5 } from './config-utils-worker'
+import { PHASE_PRODUCTION_SERVER } from '../lib/constants'
 
 export { install, shouldLoadWithWebpack5 }
 
@@ -36,11 +37,15 @@ export async function loadWebpackHook(phase: string, dir: string) {
   )
   try {
     const result: CheckResult = await worker.shouldLoadWithWebpack5(phase, dir)
-    Log.info(
-      `Using webpack ${result.enabled ? '5' : '4'}. Reason: ${reasonMessage(
-        result.reason
-      )} https://nextjs.org/docs/messages/webpack5`
-    )
+    // Don't log which webpack version is being used when booting production server as it's not used after build
+    if (phase !== PHASE_PRODUCTION_SERVER) {
+      Log.info(
+        `Using webpack ${result.enabled ? '5' : '4'}. Reason: ${reasonMessage(
+          result.reason
+        )} https://nextjs.org/docs/messages/webpack5`
+      )
+    }
+
     useWebpack5 = Boolean(result.enabled)
   } catch {
     // If this errors, it likely will do so again upon boot, so we just swallow

--- a/packages/next/next-server/server/config-utils.ts
+++ b/packages/next/next-server/server/config-utils.ts
@@ -3,7 +3,6 @@ import { Worker } from 'jest-worker'
 import * as Log from '../../build/output/log'
 import { CheckReasons, CheckResult } from './config-utils-worker'
 import { install, shouldLoadWithWebpack5 } from './config-utils-worker'
-import { PHASE_PRODUCTION_SERVER } from '../lib/constants'
 
 export { install, shouldLoadWithWebpack5 }
 
@@ -37,15 +36,11 @@ export async function loadWebpackHook(phase: string, dir: string) {
   )
   try {
     const result: CheckResult = await worker.shouldLoadWithWebpack5(phase, dir)
-    // Don't log which webpack version is being used when booting production server as it's not used after build
-    if (phase !== PHASE_PRODUCTION_SERVER) {
-      Log.info(
-        `Using webpack ${result.enabled ? '5' : '4'}. Reason: ${reasonMessage(
-          result.reason
-        )} https://nextjs.org/docs/messages/webpack5`
-      )
-    }
-
+    Log.info(
+      `Using webpack ${result.enabled ? '5' : '4'}. Reason: ${reasonMessage(
+        result.reason
+      )} https://nextjs.org/docs/messages/webpack5`
+    )
     useWebpack5 = Boolean(result.enabled)
   } catch {
     // If this errors, it likely will do so again upon boot, so we just swallow

--- a/test/acceptance/ReactRefreshLogBox.dev.test.js
+++ b/test/acceptance/ReactRefreshLogBox.dev.test.js
@@ -1099,6 +1099,34 @@ test('logbox: anchors links in error messages', async () => {
   await cleanup()
 })
 
+test('<Link> with multiple children', async () => {
+  const [session, cleanup] = await sandbox()
+
+  console.log({ SANDBOX: session.sandboxDirectory })
+  await session.patch(
+    'index.js',
+    `
+      import Link from 'next/link'
+
+      export default function Index() {
+        return (
+          <Link href="/">
+            <p>One</p>
+            <p>Two</p>
+          </Link>
+        )
+      }
+    `
+  )
+
+  expect(await session.hasRedbox(true)).toBe(true)
+  expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+    `"Error: Multiple children were passed to <Link> with \`href\` of \`/\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children"`
+  )
+
+  await cleanup()
+})
+
 test('<Link> component props errors', async () => {
   const [session, cleanup] = await sandbox()
 


### PR DESCRIPTION
Makes sure a helpful error is shown for `<Link>` with multiple children

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
