### PR TITLE
fix: image placeholder type

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -74,14 +74,10 @@ export type ImageProps = Omit<
         height: number | string
         layout?: Exclude<LayoutValue, 'fill'>
       }
-  ) &
-  (
-    | {
-        placeholder?: Exclude<PlaceholderValue, 'blur'>
-        blurDataURL?: never
-      }
-    | { placeholder: 'blur'; blurDataURL: string }
-  )
+  ) & {
+    placeholder?: PlaceholderValue
+    blurDataURL?: string
+  }
 
 const {
   deviceSizes: configDeviceSizes,


### PR DESCRIPTION
## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added

closes https://github.com/vercel/next.js/issues/25344 / `Types of property 'placeholder' are incompatible`