### PR TITLE
Disable split chunks in webpack 5 in dev mode

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -835,7 +835,7 @@ export default async function getBaseWebpackConfig(
       checkWasmTypes: false,
       nodeEnv: false,
       splitChunks: isServer
-        ? isWebpack5
+        ? isWebpack5 && !dev
           ? ({
               filename: '[name].js',
               // allow to split entrypoints


### PR DESCRIPTION
Using split chunks can cause a chunks hash to unexpectedly change in development which can cause it to trigger a page reload unexpectedly since we detect changes for `_document` based on the chunk hash. This disables split chunks for webpack 5 in dev mode until we update handling to check for changes in a different way. 

x-ref:  https://github.com/vercel/next.js/issues/25434

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
