### PR TITLE
Prevent timeout when loading routes in development

### DIFF
--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -164,13 +164,15 @@ function resolvePromiseWithTimeout<T>(
       resolve(r)
     }).catch(reject)
 
-    requestIdleCallback(() =>
-      setTimeout(() => {
-        if (!cancelled) {
-          reject(err)
-        }
-      }, ms)
-    )
+    if (process.env.NODE_ENV !== 'development') {
+      requestIdleCallback(() =>
+        setTimeout(() => {
+          if (!cancelled) {
+            reject(err)
+          }
+        }, ms)
+      )
+    }
   })
 }
 


### PR DESCRIPTION
@Timer The new route loader (https://github.com/vercel/next.js/pull/19006) will timeout loading routes after 3.8s [`MS_MAX_IDLE_DELAY`](https://github.com/vercel/next.js/blob/canary/packages/next/client/route-loader.ts#L6-L10), but this can easily happen when running dev on a large app.

Fixes https://github.com/vercel/next.js/issues/25675

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
