### PR TITLE
bugfix (config): fix typo in breakpoint config

### DIFF
--- a/examples/with-stitches/stitches.config.js
+++ b/examples/with-stitches/stitches.config.js
@@ -67,7 +67,7 @@ export const { css, styled, global, getCssString } = createCss({
     }),
   },
   media: {
-    bp1: '@media (min-width: 520px)',
-    bp2: '@media (min-width: 900px)',
+    bp1: '(min-width: 520px)',
+    bp2: '(min-width: 900px)',
   },
 })


### PR DESCRIPTION
Media query breakpoint string should not contain `@media `, as per example:
https://stitches.dev/docs/breakpoints

## Documentation / Examples

The media breakpoints should change variant styles in the example, but because the config is written incorrectly, no media breakpoints are generated in CSS. No bug or error is given by stitches, but that does not seem to be a Next.js issue.

`bp1: '@media (min-width: 520px)'` should be ` bp1: '(min-width: 520px)'`


- [x] Make sure the linting passes
