### PR TITLE
feat: bump styled-components version on examples

### DIFF
--- a/examples/with-grommet/package.json
+++ b/examples/with-grommet/package.json
@@ -11,7 +11,7 @@
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "styled-components": "^4.0.0"
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
     "babel-plugin-styled-components": "^1.8.0"

--- a/examples/with-orbit-components/package.json
+++ b/examples/with-orbit-components/package.json
@@ -11,7 +11,7 @@
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "styled-components": "^4.0.0"
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
     "@kiwicom/babel-plugin-orbit-components": "latest",

--- a/examples/with-rebass/package.json
+++ b/examples/with-rebass/package.json
@@ -13,7 +13,7 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "rebass": "^4.0.7",
-    "styled-components": "^2.1.1"
+    "styled-components": "^5.3.0"
   },
   "license": "MIT"
 }

--- a/examples/with-rebass/package.json
+++ b/examples/with-rebass/package.json
@@ -6,14 +6,16 @@
     "start": "next start"
   },
   "dependencies": {
-    "babel-plugin-styled-components": "^1.1.7",
-    "babel-plugin-transform-object-assign": "^6.22.0",
-    "babel-plugin-transform-object-set-prototype-of-to-assign": "^6.22.0",
     "next": "latest",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "rebass": "^4.0.7",
     "styled-components": "^5.3.0"
+  },
+  "devDependencies": {
+    "babel-plugin-styled-components": "^1.1.7",
+    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-object-set-prototype-of-to-assign": "^6.22.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Hey guys! 
Some time ago I used the `with-grommet` example to start a project and I ran into some issues because of the styled-components version. I tried to use some new features and it didn't work as I expected, then I noticed the styled-component version was the `v4`. When I bumped the version it started to work. I am bumping all the styled-components versions on examples because some people may run into the same issue.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [x] Make sure the linting passes
