### PR TITLE
Fix "env" key in babelrc with new Babel mode

### DIFF
--- a/packages/next/build/babel/loader/types.d.ts
+++ b/packages/next/build/babel/loader/types.d.ts
@@ -11,7 +11,6 @@ export interface NextBabelLoaderOptions {
   isServer: boolean
   development: boolean
   pagesDir: string
-  presets: any[]
   sourceMaps?: any[]
   overrides: any
   caller: any

--- a/test/integration/babel-custom/fixtures/babel-env/.babelrc
+++ b/test/integration/babel-custom/fixtures/babel-env/.babelrc
@@ -1,0 +1,22 @@
+{
+  "env": {
+    "development": {
+      "presets": ["next/babel"]
+    },
+    "production": {
+      "presets": ["next/babel"]
+    },
+    "test": {
+      "presets": [
+        [
+          "next/babel",
+          {
+            "preset-env": {
+              "modules": "commonjs"
+            }
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/test/integration/babel-custom/fixtures/babel-env/pages/index.js
+++ b/test/integration/babel-custom/fixtures/babel-env/pages/index.js
@@ -1,0 +1,1 @@
+export default () => <h1>Hello World</h1>

--- a/test/integration/babel-custom/test/index.test.js
+++ b/test/integration/babel-custom/test/index.test.js
@@ -6,6 +6,10 @@ import { nextBuild } from 'next-test-utils'
 jest.setTimeout(1000 * 60 * 5)
 
 describe('Babel', () => {
+  it('should allow setting babelrc env', async () => {
+    await nextBuild(join(__dirname, '../fixtures/babel-env'))
+  })
+
   it('should allow setting targets.browsers', async () => {
     await nextBuild(join(__dirname, '../fixtures/targets-browsers'))
   })


### PR DESCRIPTION
Fixes an issue where "env" would be ignored and would crash if there was no top level "presets". Also found that webpack did not invalidate the cache on changes to the babel config, so I also fixed that.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
