### PR TITLE
Take project references into account when running type check

### DIFF
--- a/packages/next/lib/typescript/runTypeCheck.ts
+++ b/packages/next/lib/typescript/runTypeCheck.ts
@@ -56,9 +56,14 @@ export async function runTypeCheck(
         incremental: true,
         tsBuildInfoFile: path.join(cacheDir, '.tsbuildinfo'),
       },
+      projectReferences: effectiveConfiguration.projectReferences,
     })
   } else {
-    program = ts.createProgram(effectiveConfiguration.fileNames, options)
+    program = ts.createProgram({
+      rootNames: effectiveConfiguration.fileNames,
+      options,
+      projectReferences: effectiveConfiguration.projectReferences,
+    })
   }
   const result = program.emit()
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR adds support for project references. Right now, if a user builds a project that has references pointing outside of `rootDir`, type checking fails with the following error:

`Type error: File '<filename>' is not under 'rootDir' '<rootDir>'. 'rootDir' is expected to contain all source files.`

There wasn't an existing issue to link this PR to, and I haven't added any tests, but since the fix is pretty trivial, I hoped that it can be accepted as is.

Here's `CreateProgramOptions` declaration for the reference:
https://github.com/microsoft/TypeScript/blob/391f9ffb85896e25aa7edd0e25abcbf2ae808cab/lib/typescript.d.ts#L2984-L2991

Thank you!

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
