### PR TITLE
Fix occasional test failures

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -20,6 +20,8 @@ const UNIT_TEST_EXT = '.unit.test.js'
 const DEV_TEST_EXT = '.dev.test.js'
 const PROD_TEST_EXT = '.prod.test.js'
 
+const NON_CONCURRENT_TESTS = ['test/integration/basic/test/index.test.js']
+
 // which types we have configured to run separate
 const configuredTestTypes = [UNIT_TEST_EXT]
 
@@ -216,6 +218,61 @@ async function main() {
         resolve(new Date().getTime() - start)
       })
     })
+
+  const nonConcurrentTestNames = []
+
+  testNames = testNames.filter((testName) => {
+    if (NON_CONCURRENT_TESTS.includes(testName)) {
+      nonConcurrentTestNames.push(testName)
+      return false
+    }
+    return true
+  })
+
+  // run non-concurrent test names separately and before
+  // concurrent ones
+  for (const test of nonConcurrentTestNames) {
+    let passed = false
+
+    for (let i = 0; i < NUM_RETRIES + 1; i++) {
+      try {
+        const time = await runTest(test, i > 0)
+        timings.push({
+          file: test,
+          time,
+        })
+        passed = true
+        break
+      } catch (err) {
+        if (i < NUM_RETRIES) {
+          try {
+            const testDir = path.dirname(path.join(__dirname, test))
+            console.log('Cleaning test files at', testDir)
+            await exec(`git clean -fdx "${testDir}"`)
+            await exec(`git checkout "${testDir}"`)
+          } catch (err) {}
+        }
+      }
+    }
+    if (!passed) {
+      console.error(`${test} failed to pass within ${NUM_RETRIES} retries`)
+      children.forEach((child) => child.kill())
+
+      if (isTestJob) {
+        try {
+          const testsOutput = await fs.readFile(`${test}${RESULTS_EXT}`, 'utf8')
+          console.log(
+            `--test output start--`,
+            testsOutput,
+            `--test output end--`
+          )
+        } catch (err) {
+          console.log(`Failed to load test output`, err)
+        }
+      }
+      process.exit(1)
+    }
+  }
 
   await Promise.all(
     testNames.map(async (test) => {

--- a/test/integration/rewrite-with-browser-history/test/index.test.js
+++ b/test/integration/rewrite-with-browser-history/test/index.test.js
@@ -30,7 +30,7 @@ const runTests = () => {
       .click()
       .waitForElementByCss('#index')
 
-    await browser.back()
+    await browser.back().waitForElementByCss('#another')
 
     expect(await browser.elementByCss('#another').text()).toBe('another page')
 


### PR DESCRIPTION
This separates out the basic test suite into a non-concurrent group since it seems to fail when run concurrently with other tests at the same time, this also fixes another test item that has been flaking recently from us not waiting for the page to transition completely before a check.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
