### PR TITLE
Run acceptance tests non-concurrently

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -20,7 +20,13 @@ const UNIT_TEST_EXT = '.unit.test.js'
 const DEV_TEST_EXT = '.dev.test.js'
 const PROD_TEST_EXT = '.prod.test.js'
 
-const NON_CONCURRENT_TESTS = ['test/integration/basic/test/index.test.js']
+const NON_CONCURRENT_TESTS = [
+  'test/integration/basic/test/index.test.js',
+  'test/acceptance/ReactRefresh.dev.test.js',
+  'test/acceptance/ReactRefreshLogBox.dev.test.js',
+  'test/acceptance/ReactRefreshRegression.dev.test.js',
+  'test/acceptance/ReactRefreshRequire.dev.test.js',
+]
 
 // which types we have configured to run separate
 const configuredTestTypes = [UNIT_TEST_EXT]


### PR DESCRIPTION
This adds the acceptance tests to the non-concurrent tests to help reduce the number of filesystem watch events being listened to at once to help make these tests more stable

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
