### PR TITLE
chore(test): add use case for i18n with external rewrite

### DIFF
--- a/test/integration/custom-routes-i18n-incremental-adoption/next.config.js
+++ b/test/integration/custom-routes-i18n-incremental-adoption/next.config.js
@@ -1,0 +1,21 @@
+const destination = 'http://localhost:__EXTERNAL_PORT__'
+
+module.exports = {
+  i18n: {
+    // localeDetection: false,
+    locales: ['nl-NL', 'nl-BE', 'nl', 'fr-BE', 'fr', 'en'],
+    defaultLocale: 'en',
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/:path*',
+        destination: '/:path*',
+      },
+      {
+        source: '/:path*',
+        destination: `${destination}/:path*`,
+      },
+    ]
+  },
+}

--- a/test/integration/custom-routes-i18n-incremental-adoption/pages/index.js
+++ b/test/integration/custom-routes-i18n-incremental-adoption/pages/index.js
@@ -1,0 +1,3 @@
+const Index = () => <h1>Index</h1>
+
+export default Index

--- a/test/integration/custom-routes-i18n-incremental-adoption/test/index.test.js
+++ b/test/integration/custom-routes-i18n-incremental-adoption/test/index.test.js
@@ -1,0 +1,84 @@
+/* eslint-env jest */
+
+import http from 'http'
+import { join } from 'path'
+import cheerio from 'cheerio'
+import {
+  launchApp,
+  killApp,
+  findPort,
+  nextBuild,
+  nextStart,
+  File,
+  fetchViaHTTP,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '..')
+const nextConfig = new File(join(appDir, 'next.config.js'))
+let server
+let externalPort
+let appPort
+let app
+
+const runTests = () => {
+  it('should rewrite correctly', async () => {
+    for (const [path, dest] of [
+      ['/path-1', '/path-1'],
+      ['/en/path-1', '/en/path-1'],
+      ['/fr/path-1', '/fr/path-1'],
+    ]) {
+      const res = await fetchViaHTTP(appPort, path, undefined, {
+        redirect: 'manual',
+      })
+
+      expect(res.status).toBe(200)
+      const $ = cheerio.load(await res.text())
+      expect(JSON.parse($('#data').text())).toEqual({
+        url: dest,
+      })
+    }
+  })
+}
+
+describe('Custom routes i18n incremental adoption', () => {
+  beforeAll(async () => {
+    externalPort = await findPort()
+    server = http.createServer((req, res) => {
+      res.statusCode = 200
+      res.end(
+        `<p id='data'>${JSON.stringify({
+          url: req.url,
+        })}</p>`
+      )
+    })
+    await new Promise((res, rej) => {
+      server.listen(externalPort, (err) => (err ? rej(err) : res()))
+    })
+    nextConfig.replace(/__EXTERNAL_PORT__/g, '' + externalPort)
+  })
+  afterAll(async () => {
+    server.close()
+    nextConfig.restore()
+  })
+
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+    runTests(true)
+  })
+
+  describe('production mode', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+      appPort = await findPort()
+      app = await nextStart(appDir, appPort)
+    })
+    afterAll(() => killApp(app))
+    runTests()
+  })
+})


### PR DESCRIPTION
Didn't find a use case for incremental adoption with i18n.

https://nextjs.org/blog/incremental-adoption

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
