### PR TITLE
Add warning for older TypeScript versions

### DIFF
--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -4,8 +4,10 @@ import {
   hasNecessaryDependencies,
   NecessaryDependencies,
 } from './has-necessary-dependencies'
+import semver from 'next/dist/compiled/semver'
 import { CompileError } from './compile-error'
 import { FatalError } from './fatal-error'
+import * as log from '../build/output/log'
 
 import { getTypeScriptIntent } from './typescript/getTypeScriptIntent'
 import { TypeCheckResult } from './typescript/runTypeCheck'
@@ -37,6 +39,12 @@ export async function verifyTypeScriptSetup(
 
     // Load TypeScript after we're sure it exists:
     const ts = (await import(deps.resolved)) as typeof import('typescript')
+
+    if (semver.lt(ts.version, '4.3.2')) {
+      log.warn(
+        `Minimum recommended TypeScript version is v4.3.2, older versions can potentially be incompatible with Next.js. Detected: ${ts.version}`
+      )
+    }
 
     // Reconfigure (or create) the user's `tsconfig.json` for them:
     await writeConfigurationDefaults(ts, tsConfigPath, firstTimeSetup)

--- a/test/integration/typescript-version-warning/app/node_modules/typescript/index.js
+++ b/test/integration/typescript-version-warning/app/node_modules/typescript/index.js
@@ -1,0 +1,5 @@
+const mod = require('../../../../../../node_modules/typescript')
+
+mod.version = '3.8.3'
+
+module.exports = mod

--- a/test/integration/typescript-version-warning/app/node_modules/typescript/package.json
+++ b/test/integration/typescript-version-warning/app/node_modules/typescript/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "typescript",
+  "version": "3.8.3",
+  "main": "./index.js"
+}

--- a/test/integration/typescript-version-warning/app/pages/index.tsx
+++ b/test/integration/typescript-version-warning/app/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page(props) {
+  return <p>hello world</p>
+}

--- a/test/integration/typescript-version-warning/app/tsconfig.json
+++ b/test/integration/typescript-version-warning/app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/test/integration/typescript-version-warning/test/index.test.js
+++ b/test/integration/typescript-version-warning/test/index.test.js
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild, findPort, launchApp, killApp } from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../app')
+
+describe('Minimum TypeScript Warning', () => {
+  it('should show warning during next build with old version', async () => {
+    const res = await nextBuild(appDir, [], {
+      stderr: true,
+      stdout: true,
+    })
+    expect(res.stdout + res.stderr).toContain(
+      'Minimum recommended TypeScript version is'
+    )
+  })
+
+  it('should show warning during next dev with old version', async () => {
+    let output = ''
+
+    const handleOutput = (msg) => {
+      output += msg
+    }
+    const app = await launchApp(appDir, await findPort(), {
+      onStdout: handleOutput,
+      onStderr: handleOutput,
+    })
+    await killApp(app)
+
+    expect(output).toContain('Minimum recommended TypeScript version is')
+  })
+
+  it('should not show warning during next build with new version', async () => {
+    await fs.rename(
+      join(appDir, 'node_modules/typescript'),
+      join(appDir, 'node_modules/typescript-back')
+    )
+    const res = await nextBuild(appDir, [], {
+      stderr: true,
+      stdout: true,
+    })
+    await fs.rename(
+      join(appDir, 'node_modules/typescript-back'),
+      join(appDir, 'node_modules/typescript')
+    )
+    expect(res.stdout + res.stderr).toContain(
+      'Minimum recommended TypeScript version is'
+    )
+  })
+
+  it('should not show warning during next dev with new version', async () => {
+    let output = ''
+
+    const handleOutput = (msg) => {
+      output += msg
+    }
+    await fs.rename(
+      join(appDir, 'node_modules/typescript'),
+      join(appDir, 'node_modules/typescript-back')
+    )
+    const app = await launchApp(appDir, await findPort(), {
+      onStdout: handleOutput,
+      onStderr: handleOutput,
+    })
+    await killApp(app)
+    await fs.rename(
+      join(appDir, 'node_modules/typescript-back'),
+      join(appDir, 'node_modules/typescript')
+    )
+
+    expect(output).toContain('Minimum recommended TypeScript version is')
+  })
+})


### PR DESCRIPTION
This adds a warning when older TypeScript versions are used as there can be incompatibilities with newer types used in Next.js and older versions aren't compatible with incremental type checking

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
