### PR TITLE
Prevent node inspect from causing webpack check to fail

### DIFF
--- a/packages/next/next-server/server/config-utils.ts
+++ b/packages/next/next-server/server/config-utils.ts
@@ -23,13 +23,21 @@ function reasonMessage(reason: CheckReasons) {
 export async function loadWebpackHook(phase: string, dir: string) {
   let useWebpack5 = true
   let usesRemovedFlag = false
-  const worker: any = new Worker(
+  const worker = new Worker(
     path.resolve(__dirname, './config-utils-worker.js'),
     {
       enableWorkerThreads: false,
       numWorkers: 1,
+      forkOptions: {
+        env: {
+          ...process.env,
+          NODE_OPTIONS: '',
+        },
+      },
     }
-  )
+  ) as Worker & {
+    shouldLoadWithWebpack5: typeof import('./config-utils-worker').shouldLoadWithWebpack5
+  }
   try {
     const result: CheckResult = await worker.shouldLoadWithWebpack5(phase, dir)
     if (result.reason === 'future-flag') {


### PR DESCRIPTION
This fixes a case where starting `next dev` with `NODE_OPTIONS='--inspect'` set in the environment causes the webpack version check to fail silently. This seems to only affect node 12 and not node 14 as it seems the `address already in use` error in node is only fatal in older versions. 

We might want to also override the `NODE_OPTIONS` env when starting our static check workers, export workers, and dev static paths workers. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
