### PR TITLE
remove opentelemetry/api

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -68,7 +68,6 @@
     "@next/polyfill-module": "10.2.4-canary.7",
     "@next/react-dev-overlay": "10.2.4-canary.7",
     "@next/react-refresh-utils": "10.2.4-canary.7",
-    "@opentelemetry/api": "0.14.0",
     "assert": "2.0.0",
     "ast-types": "0.13.2",
     "browserify-zlib": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,18 +2595,6 @@
     "@octokit/openapi-types" "^4.0.2"
     "@types/node" ">= 8"
 
-"@opentelemetry/api@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-0.14.0.tgz#4e17d8d2f1da72b19374efa7b6526aa001267cae"
-  integrity sha512-L7RMuZr5LzMmZiQSQDy9O1jo0q+DaLy6XpYJfIGfYSfoJA5qzYwUP3sP1uMIQ549DvxAgM3ng85EaPTM/hUHwQ==
-  dependencies:
-    "@opentelemetry/context-base" "^0.14.0"
-
-"@opentelemetry/context-base@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
-  integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
-
 "@polka/url@^1.0.0-next.9":
   version "1.0.0-next.11"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"


### PR DESCRIPTION
## Bug

Resolves the issue #21861 by simply removing the opentelemetry/api dependency, which does not appear to be required since #22713 was implemented.  

Identified the same issue where implementing opentelemetry with the latest libraries causes conflicts with the api version included in nextjs.

No tests or code updated, as library was otherwise unused.
Please let me know if it's appropriate to remove and there's not some other reason it's included that I could not see