### PR TITLE
Add delay to placeholder removal

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -261,6 +261,8 @@ function defaultImageLoader(loaderProps: ImageLoaderProps) {
 
 // See https://stackoverflow.com/q/39777833/266535 for why we use this ref
 // handler instead of the img's onLoad attribute.
+// 1500ms delay in removing placeholder is to prevent flash of white between
+// image load and image render.
 function removePlaceholder(
   element: HTMLImageElement | null,
   placeholder: PlaceholderValue
@@ -270,11 +272,15 @@ function removePlaceholder(
       // If the real image fails to load, this will still remove the placeholder.
       // This is the desired behavior for now, and will be revisited when error
       // handling is worked on for the image component itself.
-      element.style.backgroundImage = 'none'
+      setTimeout(() => {
+        element.style.backgroundImage = 'none'
+      }, 1500)
     } else {
       element.onload = () => {
         if (!element.src.startsWith('data:')) {
-          element.style.backgroundImage = 'none'
+          setTimeout(() => {
+            element.style.backgroundImage = 'none'
+          }, 1500)
         }
       }
     }

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -607,14 +607,15 @@ describe('Image Component Tests', () => {
       let browser
       try {
         browser = await webdriver(appPort, '/blurry-placeholder')
-        await waitFor(1550)
-        expect(
-          await getComputedStyle(
-            browser,
-            'blurry-placeholder',
-            'background-image'
-          )
-        ).toBe('none')
+        await check(
+          async () =>
+            await getComputedStyle(
+              browser,
+              'blurry-placeholder',
+              'background-image'
+            ),
+          'none'
+        )
         expect(
           await getComputedStyle(
             browser,
@@ -627,13 +628,15 @@ describe('Image Component Tests', () => {
 
         await browser.eval('document.getElementById("spacer").remove()')
 
-        expect(
-          await getComputedStyle(
-            browser,
-            'blurry-placeholder-with-lazy',
-            'background-image'
-          )
-        ).toBe('none')
+        await check(
+          async () =>
+            await getComputedStyle(
+              browser,
+              'blurry-placeholder-with-lazy',
+              'background-image'
+            ),
+          'none'
+        )
       } finally {
         if (browser) {
           await browser.close()

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -607,7 +607,7 @@ describe('Image Component Tests', () => {
       let browser
       try {
         browser = await webdriver(appPort, '/blurry-placeholder')
-
+        await waitFor(1550)
         expect(
           await getComputedStyle(
             browser,

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -16,7 +16,7 @@ import {
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
-jest.setTimeout(1000 * 60)
+jest.setTimeout(1000 * 80)
 
 const appDir = join(__dirname, '../')
 


### PR DESCRIPTION
This PR introduces a delay of 1500 ms between the image ref callback and removing the blurry placeholder background. Previously, the background was getting removed after the image had loaded but before it was rendered, causing an ugly flash of white as the image appeared.
There shouldn't be any downside to this delay--the blurry placeholder is covered entirely by the image and therefore not visible after the image is rendered.