### PR TITLE
(examples/with-urql): fixes graphql server url

### DIFF
--- a/examples/with-urql/README.md
+++ b/examples/with-urql/README.md
@@ -2,6 +2,12 @@
 
 Use [urql](https://github.com/FormidableLabs/urql) with Next.js using SSG.
 
+## Preview
+
+Preview the example live on [StackBlitz](http://stackblitz.com/):
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-urql)
+
 ## Deploy your own
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):

--- a/examples/with-urql/graphql/client.js
+++ b/examples/with-urql/graphql/client.js
@@ -1,5 +1,5 @@
 import { createClient } from 'urql'
 
 export const client = createClient({
-  url: 'https://graphql-pokemon.vercel.app/',
+  url: 'https://graphql-pokemon2.vercel.app/',
 })


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes

As mentioned in #25854 `with-urql` doesn't work. After investigation, I've found that Pokémon GraphQL server located at `https://graphql-pokemon.vercel.app` is down.
After some research I came across its repository and this [pull request](https://github.com/lucasbento/graphql-pokemon/pull/14). That pull request provides new URL `https://graphql-pokemon2.vercel.app` which seems to work.

I don't know the status of this server, maybe @leerob can confirm this PR is ok.