### PR TITLE
Add experimental CRA transform to docs

### DIFF
--- a/docs/advanced-features/codemods.md
+++ b/docs/advanced-features/codemods.md
@@ -17,6 +17,14 @@ Codemods are transformations that run on your codebase programmatically. This al
 - `--dry` Do a dry-run, no code will be edited
 - `--print` Prints the changed output for comparison
 
+## Next.js 11
+
+### `cra-to-next` (experimental)
+
+Migrates a Create React App project to Next.js; creating a pages directory and necessary config to match behavior. Client-side only rendering is leveraged initially to prevent breaking compatibility due to `window` usage during SSR and can be enabled seamlessly to allow gradual adoption of Next.js specific features.
+
+Please share any feedback related to this transform [in this discussion](https://github.com/vercel/next.js/discussions/25858).
+
 ## Next.js 10
 
 ### `add-missing-react-import`


### PR DESCRIPTION
This mentions the experimental create react app transform to the codemods doc including the feedback link while it is experimental. 

## Documentation / Examples

- [x] Make sure the linting passes
