### PR TITLE
Fix delay between blur image and high res image

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -261,32 +261,27 @@ function defaultImageLoader(loaderProps: ImageLoaderProps) {
 
 // See https://stackoverflow.com/q/39777833/266535 for why we use this ref
 // handler instead of the img's onLoad attribute.
-// 1500ms delay in removing placeholder is to prevent flash of white between
-// image load and image render.
 function removePlaceholder(
   element: HTMLImageElement | null,
   placeholder: PlaceholderValue
 ) {
   if (placeholder === 'blur' && element) {
-    if (element.complete && !element.src.startsWith('data:')) {
+    const handleLoad = () => {
+      if (!element.src.startsWith('data:')) {
+        ;(element.decode() || Promise.resolve()).then(() => {
+          element.style.filter = 'none'
+          element.style.backgroundSize = 'none'
+          element.style.backgroundImage = 'none'
+        })
+      }
+    }
+    if (element.complete) {
       // If the real image fails to load, this will still remove the placeholder.
       // This is the desired behavior for now, and will be revisited when error
       // handling is worked on for the image component itself.
-      setTimeout(() => {
-        element.style.filter = 'none'
-        element.style.backgroundSize = 'none'
-        element.style.backgroundImage = 'none'
-      }, 1500)
+      handleLoad()
     } else {
-      element.onload = () => {
-        if (!element.src.startsWith('data:')) {
-          setTimeout(() => {
-            element.style.filter = 'none'
-            element.style.backgroundSize = 'none'
-            element.style.backgroundImage = 'none'
-          }, 1500)
-        }
-      }
+      element.onload = handleLoad
     }
   }
 }

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -268,7 +268,7 @@ function removePlaceholder(
   if (placeholder === 'blur' && element) {
     const handleLoad = () => {
       if (!element.src.startsWith('data:')) {
-        (element.decode || Promise.resolve)().then(() => {
+        ;(element.decode || Promise.resolve)().then(() => {
           element.style.filter = 'none'
           element.style.backgroundSize = 'none'
           element.style.backgroundImage = 'none'

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -268,7 +268,7 @@ function removePlaceholder(
   if (placeholder === 'blur' && element) {
     const handleLoad = () => {
       if (!element.src.startsWith('data:')) {
-        ;(element.decode() || Promise.resolve()).then(() => {
+        (element.decode || Promise.resolve)().then(() => {
           element.style.filter = 'none'
           element.style.backgroundSize = 'none'
           element.style.backgroundImage = 'none'

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -262,26 +262,27 @@ function defaultImageLoader(loaderProps: ImageLoaderProps) {
 // See https://stackoverflow.com/q/39777833/266535 for why we use this ref
 // handler instead of the img's onLoad attribute.
 function removePlaceholder(
-  element: HTMLImageElement | null,
+  img: HTMLImageElement | null,
   placeholder: PlaceholderValue
 ) {
-  if (placeholder === 'blur' && element) {
+  if (placeholder === 'blur' && img) {
     const handleLoad = () => {
-      if (!element.src.startsWith('data:')) {
-        ;(element.decode || Promise.resolve)().then(() => {
-          element.style.filter = 'none'
-          element.style.backgroundSize = 'none'
-          element.style.backgroundImage = 'none'
+      if (!img.src.startsWith('data:')) {
+        const p = 'decode' in img ? img.decode() : Promise.resolve()
+        p.then(() => {
+          img.style.filter = 'none'
+          img.style.backgroundSize = 'none'
+          img.style.backgroundImage = 'none'
         })
       }
     }
-    if (element.complete) {
+    if (img.complete) {
       // If the real image fails to load, this will still remove the placeholder.
       // This is the desired behavior for now, and will be revisited when error
       // handling is worked on for the image component itself.
       handleLoad()
     } else {
-      element.onload = handleLoad
+      img.onload = handleLoad
     }
   }
 }


### PR DESCRIPTION
Previously, we had an arbitrary delay of 1500ms but instead we can wait until decoding is complete.

Thanks to @kripod: https://github.com/vercel/next.js/pull/25916#issuecomment-858311201