### PR TITLE
(examples/image-component): fix placeholder href

### DIFF
--- a/examples/image-component/pages/index.js
+++ b/examples/image-component/pages/index.js
@@ -69,7 +69,7 @@ const Index = () => (
         placeholder effect while that image loads.
       </p>
       <p>
-        <Link href="/background">
+        <Link href="/placeholder">
           <a>See an example of the blurry placeholder.</a>
         </Link>
       </p>


### PR DESCRIPTION
The href was linking to a page with an Image that didn't use `placeholder="blur"`