### PR TITLE
Fixed no-img-element documentation snippet.

### DIFF
--- a/errors/no-img-element.md
+++ b/errors/no-img-element.md
@@ -9,7 +9,7 @@ An HTML `<img>` element was used to display an image. For better performance and
 Import and use the `<Image />` component:
 
 ```jsx
-import { Image } from 'next/image'
+import Image from 'next/image'
 
 function Home() {
   return (


### PR DESCRIPTION
Module "next/image" has no exported member 'Image'.
It must be `import Image from "next/image"`

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Documentation added
- [x] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [x] Make sure the linting passes
