### PR TITLE
Fix `next/image` docs version history

### DIFF
--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -14,12 +14,12 @@ description: Enable Image Optimization with the built-in Image component.
 <details>
   <summary><b>Version History</b></summary>
 
-| Version   | Changes                                                                      |
-| --------- | ---------------------------------------------------------------------------- |
-| `v11.0.0` | Added static imports for `src`. Added `placeholder` and `blurDataURL` props. |
-| `v10.0.5` | `loader` prop added.                                                         |
-| `v10.0.1` | `layout` prop added.                                                         |
-| `v10.0.0` | `next/image` introduced.                                                     |
+| Version   | Changes                                                                                           |
+| --------- | ------------------------------------------------------------------------------------------------- |
+| `v11.0.0` | `src` prop support for static import.<br/>`placeholder` prop added.<br/>`blurDataURL` prop added. |
+| `v10.0.5` | `loader` prop added.                                                                              |
+| `v10.0.1` | `layout` prop added.                                                                              |
+| `v10.0.0` | `next/image` introduced.                                                                          |
 
 </details>
 


### PR DESCRIPTION
Fixes version history in the `next/image` component [docs](
https://nextjs.org/docs/api-reference/next/image).

- [before.png](https://user-images.githubusercontent.com/229881/122237698-8874d200-ce8d-11eb-8b6b-6dad8ebfd13b.png)
- [after.png](https://user-images.githubusercontent.com/229881/122237708-8ad72c00-ce8d-11eb-891b-31f87847113c.png)
