### PR TITLE
support new env var "DOT_ENV" for specifying the .env file that should be loaded

### DIFF
--- a/packages/next-env/index.ts
+++ b/packages/next-env/index.ts
@@ -77,8 +77,11 @@ export function loadEnvConfig(
   // environment values e.g. \$ENV_FILE_KEY
   if (combinedEnv) return { combinedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
 
-  const isTest = process.env.NODE_ENV === 'test'
-  const mode = isTest ? 'test' : dev ? 'development' : 'production'
+  let mode = process.env.DOT_ENV
+  if (!mode) {
+    const isTest = process.env.NODE_ENV === 'test'
+    mode = isTest ? 'test' : dev ? 'development' : 'production'
+  }  
   const dotenvFiles = [
     `.env.${mode}.local`,
     // Don't include `.env.local` for `test` environment


### PR DESCRIPTION
attempts to partially solve https://github.com/vercel/next.js/issues/19046 (.env file loading), implements [RFC](https://github.com/vercel/next.js/discussions/25764)

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
