### PR TITLE
Fix eslint version check for older versions

### DIFF
--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -42,7 +42,7 @@ async function lint(
   const mod = await import(deps.resolved.get('eslint')!)
 
   const { ESLint } = mod
-  let eslintVersion = ESLint.version
+  let eslintVersion = ESLint?.version
 
   if (!ESLint) {
     eslintVersion = mod?.CLIEngine?.version

--- a/test/integration/eslint/invalid-eslint-version/.eslintrc
+++ b/test/integration/eslint/invalid-eslint-version/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "next",
+  "root": true
+}

--- a/test/integration/eslint/invalid-eslint-version/node_modules/eslint/index.js
+++ b/test/integration/eslint/invalid-eslint-version/node_modules/eslint/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/integration/eslint/invalid-eslint-version/node_modules/eslint/lib/api.js
+++ b/test/integration/eslint/invalid-eslint-version/node_modules/eslint/lib/api.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/integration/eslint/invalid-eslint-version/node_modules/eslint/package.json
+++ b/test/integration/eslint/invalid-eslint-version/node_modules/eslint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint",
+  "main": "./index.js",
+  "version": "6.0.1"
+}

--- a/test/integration/eslint/invalid-eslint-version/pages/index.js
+++ b/test/integration/eslint/invalid-eslint-version/pages/index.js
@@ -1,0 +1,8 @@
+const Home = () => (
+  <div>
+    <p>Home</p>
+    /* Badly formatted comment */
+  </div>
+)
+
+export default Home

--- a/test/integration/eslint/test/index.test.js
+++ b/test/integration/eslint/test/index.test.js
@@ -11,6 +11,7 @@ const dirCustomConfig = join(__dirname, '../custom-config')
 const dirIgnoreDuringBuilds = join(__dirname, '../ignore-during-builds')
 const dirCustomDirectories = join(__dirname, '../custom-directories')
 const dirConfigInPackageJson = join(__dirname, '../config-in-package-json')
+const dirInvalidEslintVersion = join(__dirname, '../invalid-eslint-version')
 
 describe('ESLint', () => {
   describe('Next Build', () => {
@@ -71,6 +72,18 @@ describe('ESLint', () => {
       )
       expect(output).toContain(
         'Warning: External synchronous scripts are forbidden'
+      )
+    })
+
+    test.only('invalid eslint version', async () => {
+      const { stdout, stderr } = await nextBuild(dirInvalidEslintVersion, [], {
+        stdout: true,
+        stderr: true,
+      })
+
+      const output = stdout + stderr
+      expect(output).toContain(
+        'Your project has an older version of ESLint installed'
       )
     })
   })


### PR DESCRIPTION
This ensures we don't fail to access the version on older versions of eslint and adds a test case to ensure this is working as expected. 

Fixes: https://github.com/vercel/next.js/issues/26126


## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
