### PR TITLE
Update postcss version in examples

### DIFF
--- a/examples/cms-ghost/package.json
+++ b/examples/cms-ghost/package.json
@@ -12,7 +12,7 @@
     "date-fns": "2.16.1",
     "lazysizes": "^5.3.0",
     "next": "latest",
-    "postcss": "^8.2.4",
+    "postcss": "^8.2.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/cms-graphcms/package.json
+++ b/examples/cms-graphcms/package.json
@@ -11,7 +11,7 @@
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
     "next": "latest",
-    "postcss": "8.2.2",
+    "postcss": "8.2.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/cms-prepr/package.json
+++ b/examples/cms-prepr/package.json
@@ -12,7 +12,7 @@
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
     "next": "latest",
-    "postcss": "8.2.2",
+    "postcss": "8.2.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
Updating postcss version in some examples to fix vulnerability in previous versions.
Updated to 8.2.15.