### PR TITLE
[ESLint] Adds `--quiet` flag, TypeScript resolver and bug fixes

### DIFF
--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -58,6 +58,9 @@ module.exports = {
       [require.resolve('eslint-import-resolver-node')]: {
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
+      [require.resolve('eslint-import-resolver-typescript')]: {
+        alwaysTryTypes: true,
+      },
     },
   },
 }

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -13,6 +13,7 @@
     "@rushstack/eslint-patch": "^1.0.6",
     "@typescript-eslint/parser": "^4.20.0",
     "eslint-import-resolver-node": "^0.3.4",
+    "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.23.1",

--- a/packages/eslint-plugin-next/lib/rules/link-passhref.js
+++ b/packages/eslint-plugin-next/lib/rules/link-passhref.js
@@ -44,9 +44,7 @@ module.exports = {
 
         const hasAnchorChild = children.some(
           (attr) =>
-            attr.type === 'JSXElement' &&
-            attr.openingElement.name.name === 'a' &&
-            attr.closingElement.name.name === 'a'
+            attr.type === 'JSXElement' && attr.openingElement.name.name === 'a'
         )
 
         if (!hasAnchorChild && !hasPassHref) {

--- a/packages/next/cli/next-lint.ts
+++ b/packages/next/cli/next-lint.ts
@@ -28,7 +28,6 @@ const eslintOptions = (args: arg.Spec) => ({
     args['--report-unused-disable-directives'] || null,
   cache: args['--cache'] ?? false,
   cacheLocation: args['--cache-location'] || '.eslintcache',
-  cacheStrategy: args['--cache-strategy'] || 'metadata',
   errorOnUnmatchedPattern: !Boolean(args['--no-error-on-unmatched-pattern']),
 })
 
@@ -55,11 +54,11 @@ const nextLint: cliCommand = (argv) => {
     '--fix-type': [String],
     '--ignore-path': String,
     '--no-ignore': Boolean,
+    '--quiet': Boolean,
     '--no-inline-config': Boolean,
     '--report-unused-disable-directives': String,
     '--cache': Boolean,
     '--cache-location': String,
-    '--cache-strategy': String,
     '--no-error-on-unmatched-pattern': Boolean,
 
     // Aliases
@@ -107,6 +106,9 @@ const nextLint: cliCommand = (argv) => {
           --ignore-path path::String     Specify path of ignore file
           --no-ignore                    Disable use of ignore files and patterns
 
+        Handling warnings:
+          --quiet                        Report errors only - default: false
+
         Inline configuration comments:
           --no-inline-config             Prevent comments from changing config or rules
           --report-unused-disable-directives  Adds reported errors for unused eslint-disable directives ("error" | "warn" | "off")
@@ -114,7 +116,6 @@ const nextLint: cliCommand = (argv) => {
         Caching:
           --cache                        Only check changed files - default: false
           --cache-location path::String  Path to the cache file or directory - default: .eslintcache
-          --cache-strategy String        Strategy to use for detecting changed files - either: metadata or content - default: metadata
         
         Miscellaneous:
           --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched - default: false
@@ -140,7 +141,10 @@ const nextLint: cliCommand = (argv) => {
     },
     []
   )
-  runLintCheck(baseDir, lintDirs, false, eslintOptions(args))
+
+  const reportErrorsOnly = Boolean(args['--quiet'])
+
+  runLintCheck(baseDir, lintDirs, false, eslintOptions(args), reportErrorsOnly)
     .then(async (lintResults) => {
       const lintOutput =
         typeof lintResults === 'string' ? lintResults : lintResults?.output

--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -28,7 +28,8 @@ async function lint(
   lintDirs: string[],
   eslintrcFile: string | null,
   pkgJsonPath: string | null,
-  eslintOptions: any = null
+  eslintOptions: any = null,
+  reportErrorsOnly: boolean = false
 ): Promise<
   | string
   | null
@@ -59,7 +60,6 @@ async function lint(
       'error'
     )} - ESLint class not found. Please upgrade to ESLint version 7 or later`
   }
-
   let options: any = {
     useEslintrc: true,
     baseConfig: {},
@@ -110,8 +110,9 @@ async function lint(
   }
   const lintStart = process.hrtime()
 
-  const results = await eslint.lintFiles(lintDirs)
+  let results = await eslint.lintFiles(lintDirs)
   if (options.fix) await ESLint.outputFixes(results)
+  if (reportErrorsOnly) results = await ESLint.getErrorResults(results) // Only return errors if --quiet flag is used
 
   const formattedResult = formatResults(baseDir, results)
   const lintEnd = process.hrtime(lintStart)
@@ -141,7 +142,8 @@ export async function runLintCheck(
   baseDir: string,
   lintDirs: string[],
   lintDuringBuild: boolean = false,
-  eslintOptions: any = null
+  eslintOptions: any = null,
+  reportErrorsOnly: boolean = false
 ): ReturnType<typeof lint> {
   try {
     // Find user's .eslintrc file
@@ -202,7 +204,8 @@ export async function runLintCheck(
       lintDirs,
       eslintrcFile,
       pkgJsonPath,
-      eslintOptions
+      eslintOptions,
+      reportErrorsOnly
     )
   } catch (err) {
     throw err

--- a/test/integration/eslint/custom-config/.eslintrc
+++ b/test/integration/eslint/custom-config/.eslintrc
@@ -3,6 +3,6 @@
   "root": true,
   "rules": {
     "@next/next/no-html-link-for-pages": 0,
-    "@next/next/no-sync-scripts": 2
+    "@next/next/no-sync-scripts": 1
   }
 }

--- a/test/integration/eslint/custom-config/pages/index.js
+++ b/test/integration/eslint/custom-config/pages/index.js
@@ -1,6 +1,7 @@
 const Home = () => (
   <div>
     <p>Home</p>
+    <script src="https://example.com" />
     /* Badly formatted comment */
   </div>
 )

--- a/test/integration/eslint/test/index.test.js
+++ b/test/integration/eslint/test/index.test.js
@@ -42,6 +42,9 @@ describe('ESLint', () => {
 
       const output = stdout + stderr
       expect(output).toContain(
+        'Warning: External synchronous scripts are forbidden'
+      )
+      expect(output).toContain(
         'Error: Comments inside children section of tag should be placed inside braces'
       )
     })
@@ -75,7 +78,7 @@ describe('ESLint', () => {
       )
     })
 
-    test.only('invalid eslint version', async () => {
+    test('invalid eslint version', async () => {
       const { stdout, stderr } = await nextBuild(dirInvalidEslintVersion, [], {
         stdout: true,
         stderr: true,
@@ -115,6 +118,9 @@ describe('ESLint', () => {
       })
 
       const output = stdout + stderr
+      expect(output).toContain(
+        'Warning: External synchronous scripts are forbidden'
+      )
       expect(output).toContain(
         'Error: Comments inside children section of tag should be placed inside braces'
       )
@@ -166,6 +172,21 @@ describe('ESLint', () => {
           await fs.move(`${eslintrcFile}.original`, eslintrcFile)
         }
       }
+    })
+
+    test('quiet flag suppresses warnings and only reports errors', async () => {
+      const { stdout, stderr } = await nextLint(dirCustomConfig, ['--quiet'], {
+        stdout: true,
+        stderr: true,
+      })
+
+      const output = stdout + stderr
+      expect(output).toContain(
+        'Error: Comments inside children section of tag should be placed inside braces'
+      )
+      expect(output).not.toContain(
+        'Warning: External synchronous scripts are forbidden'
+      )
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7008,6 +7008,17 @@ eslint-import-resolver-node@^0.3.4:
     debug "^2.6.9"
     resolve "^1.13.1"
 
+eslint-import-resolver-typescript@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz#ec1e7063ebe807f0362a7320543aaed6fe1100e1"
+  integrity sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==
+  dependencies:
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
+
 eslint-module-utils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"


### PR DESCRIPTION
Feature additions:

- #26179: Supports `--quiet` flag in `next lint` to only report errors and suppress warnings
- #25920: Adds `eslint-import-resolver-typescript` to ESLint config to support absolute TS paths

Bug Fixes:

- #26227. Removes the `cacheStrategy` option as it's not supported in versions of ESLint < 7.21.0
- #26206. Updates `link-passhref` ESLint rule to support self-enclosed anchor tags