### PR TITLE
Update to latest TypeScript version and de-dupe versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "tailwindcss": "1.1.3",
     "taskr": "1.1.0",
     "tree-kill": "1.2.2",
-    "typescript": "4.3.0-beta",
+    "typescript": "4.3.4",
     "wait-port": "0.2.2",
     "web-streams-polyfill": "2.1.1",
     "webpack-bundle-analyzer": "4.3.0",

--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -43,7 +43,7 @@
     "prompts": "2.1.0",
     "rimraf": "3.0.0",
     "tar": "4.4.10",
-    "typescript": "3.8.3",
+    "typescript": "4.3.4",
     "update-check": "1.5.4",
     "validate-npm-package-name": "3.0.0"
   },

--- a/packages/next/build/babel/plugins/no-anonymous-default-export.ts
+++ b/packages/next/build/babel/plugins/no-anonymous-default-export.ts
@@ -18,7 +18,7 @@ export default function NoAnonymousDefaultExport({
     return { visitor: {} }
   }
 
-  const warn = onWarning!
+  const warn: any = onWarning
   return {
     visitor: {
       ExportDefaultDeclaration(path) {

--- a/packages/next/build/babel/plugins/optimize-hook-destructuring.ts
+++ b/packages/next/build/babel/plugins/optimize-hook-destructuring.ts
@@ -43,7 +43,7 @@ export default function ({
         const specifier = (binding.path.parent as BabelTypes.ImportDeclaration)
           .source.value
         // not a match
-        if (!libs.some((lib) => lib === specifier)) return
+        if (!libs.some((lib: any) => lib === specifier)) return
       }
 
       // only match function calls with names that look like a hook

--- a/packages/next/build/compiler.ts
+++ b/packages/next/build/compiler.ts
@@ -24,7 +24,7 @@ function generateStats(
 // Webpack 5 requires the compiler to be closed (to save caches)
 // Webpack 4 does not have this close method so in order to be backwards compatible we check if it exists
 function closeCompiler(compiler: webpack.Compiler | webpack.MultiCompiler) {
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     if ('close' in compiler) {
       // @ts-ignore Close only exists on the compiler in webpack 5
       return compiler.close((err: any) => (err ? reject(err) : resolve()))

--- a/packages/next/client/performance-relayer.ts
+++ b/packages/next/client/performance-relayer.ts
@@ -36,9 +36,9 @@ function onReport(metric: Metric): void {
       value: metric.value.toString(),
       speed:
         'connection' in navigator &&
-        navigator['connection'] &&
-        'effectiveType' in navigator['connection']
-          ? (navigator['connection']['effectiveType'] as string)
+        (navigator as any)['connection'] &&
+        'effectiveType' in (navigator as any)['connection']
+          ? ((navigator as any)['connection']['effectiveType'] as string)
           : '',
     }
 

--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -93,7 +93,7 @@ function prefetchViaDom(
   as: string,
   link?: HTMLLinkElement
 ): Promise<any> {
-  return new Promise((res, rej) => {
+  return new Promise<void>((res, rej) => {
     if (document.querySelector(`link[rel="prefetch"][href^="${href}"]`)) {
       return res()
     }
@@ -104,7 +104,7 @@ function prefetchViaDom(
     if (as) link!.as = as
     link!.rel = `prefetch`
     link!.crossOrigin = process.env.__NEXT_CROSS_ORIGIN!
-    link!.onload = res
+    link!.onload = res as any
     link!.onerror = rej
 
     // `href` should always be last:

--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -45,7 +45,7 @@ const loadScript = (props: Props): void => {
 
   const el = document.createElement('script')
 
-  const loadPromise = new Promise((resolve, reject) => {
+  const loadPromise = new Promise<void>((resolve, reject) => {
     el.addEventListener('load', function () {
       resolve()
       if (onLoad) {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -239,7 +239,7 @@
     "taskr": "1.1.0",
     "terser": "5.5.1",
     "text-table": "0.2.0",
-    "typescript": "3.8.3",
+    "typescript": "4.3.4",
     "unistore": "3.4.1",
     "web-vitals": "0.2.4",
     "webpack": "4.44.1",

--- a/packages/next/server/on-demand-entry-handler.ts
+++ b/packages/next/server/on-demand-entry-handler.ts
@@ -175,7 +175,7 @@ export default function onDemandEntryHandler(
 
       page = posix.normalize(pageUrl)
 
-      return new Promise((resolve, reject) => {
+      return new Promise<void>((resolve, reject) => {
         // Makes sure the page that is being kept in on-demand-entries matches the webpack output
         const normalizedPage = normalizePathSep(page)
         const entryInfo = entries[normalizedPage]

--- a/test/integration/typescript-version-warning/test/index.test.js
+++ b/test/integration/typescript-version-warning/test/index.test.js
@@ -6,6 +6,7 @@ import { nextBuild, findPort, launchApp, killApp } from 'next-test-utils'
 jest.setTimeout(1000 * 60 * 2)
 
 const appDir = join(__dirname, '../app')
+const tsFile = join(appDir, 'node_modules/typescript/index.js')
 
 describe('Minimum TypeScript Warning', () => {
   it('should show warning during next build with old version', async () => {
@@ -34,19 +35,15 @@ describe('Minimum TypeScript Warning', () => {
   })
 
   it('should not show warning during next build with new version', async () => {
-    await fs.rename(
-      join(appDir, 'node_modules/typescript'),
-      join(appDir, 'node_modules/typescript-back')
-    )
+    const content = await fs.readFile(tsFile, 'utf8')
+    await fs.writeFile(tsFile, content.replace('3.8.3', '4.3.4'))
     const res = await nextBuild(appDir, [], {
       stderr: true,
       stdout: true,
     })
-    await fs.rename(
-      join(appDir, 'node_modules/typescript-back'),
-      join(appDir, 'node_modules/typescript')
-    )
-    expect(res.stdout + res.stderr).toContain(
+    await fs.writeFile(tsFile, content)
+
+    expect(res.stdout + res.stderr).not.toContain(
       'Minimum recommended TypeScript version is'
     )
   })
@@ -57,20 +54,15 @@ describe('Minimum TypeScript Warning', () => {
     const handleOutput = (msg) => {
       output += msg
     }
-    await fs.rename(
-      join(appDir, 'node_modules/typescript'),
-      join(appDir, 'node_modules/typescript-back')
-    )
+    const content = await fs.readFile(tsFile, 'utf8')
+    await fs.writeFile(tsFile, content.replace('3.8.3', '4.3.4'))
     const app = await launchApp(appDir, await findPort(), {
       onStdout: handleOutput,
       onStderr: handleOutput,
     })
+    await fs.writeFile(tsFile, content)
     await killApp(app)
-    await fs.rename(
-      join(appDir, 'node_modules/typescript-back'),
-      join(appDir, 'node_modules/typescript')
-    )
 
-    expect(output).toContain('Minimum recommended TypeScript version is')
+    expect(output).not.toContain('Minimum recommended TypeScript version is')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -16443,14 +16443,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-
-typescript@4.3.0-beta:
-  version "4.3.0-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.0-beta.tgz#8098e7be29032f09827e94b8e3a6befc9ff70c77"
-  integrity sha512-bl3wxSVL6gWLQFa466Vm5Vk3z0BNx+QxWhb9wFiYEHm6H8oqFd8Wo3XjgCVxAa5yiSFFKgo/ngBpXdIwqo5o0A==
+typescript@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
 typescript@^4.1.3:
   version "4.1.3"


### PR DESCRIPTION
This updates to the latest TypeScript version and de-dupes the version used between the monorepo for testing and the version used in `packages/next`. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
