### PR TITLE
(next/script): Omit src for children and dangerouslySetInnerHTML props

### DIFF
--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -83,6 +83,10 @@ const loadScript = (props: Props): void => {
       continue
     }
 
+    if ((dangerouslySetInnerHTML || children) && k === 'src') {
+      continue
+    }
+
     const attr = DOMAttributeNames[k] || k.toLowerCase()
     el.setAttribute(attr, value)
   }


### PR DESCRIPTION
When using `next/script` with `children` prop or `dangerouslySetInnerHTML` together with `beforeInteractive` strategy. The DOM element is created with `src="(unknown)"` which prevents from executing the inline script.

This PR adds an explicit condition to omit `src` field in those cases.

Fixes: https://github.com/vercel/next.js/issues/26343, https://github.com/vercel/next.js/issues/26240