### PR TITLE
Skip SSR 'require' modification for chunks without a name

### DIFF
--- a/packages/next/build/webpack/plugins/nextjs-ssr-import.ts
+++ b/packages/next/build/webpack/plugins/nextjs-ssr-import.ts
@@ -9,6 +9,13 @@ export default class NextJsSsrImportPlugin {
       compilation.mainTemplate.hooks.requireEnsure.tap(
         'NextJsSSRImport',
         (code: string, chunk: any) => {
+          // If we're on a chunk without a name, skip it. It's likely a dynamic import
+          // that will be handled by Webpack, i.e. a WASM module.
+          // See https://github.com/vercel/next.js/issues/22581
+          if (!chunk.name) {
+            return; 
+          }
+          
           // Update to load chunks from our custom chunks directory
           const outputPath = resolve('/')
           const pagePath = join('/', dirname(chunk.name))


### PR DESCRIPTION
This skips 'require' normalization for chunks without a name, which was throwing errors when used with WASM imports.  Fixes #22581.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Documentation / Examples

- [x] Make sure the linting passes
