### PR TITLE
Remove period for ESLint `passHref` docs link.

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/link-passhref.js
+++ b/packages/eslint-plugin-next/lib/rules/link-passhref.js
@@ -54,7 +54,7 @@ module.exports = {
               attributes.value('passHref') !== true
                 ? 'must be set to true'
                 : 'is missing'
-            }. See https://nextjs.org/docs/messages/link-passhref.`,
+            }. See https://nextjs.org/docs/messages/link-passhref`,
           })
         }
       },

--- a/test/eslint-plugin-next/link-passhref.unit.test.js
+++ b/test/eslint-plugin-next/link-passhref.unit.test.js
@@ -53,7 +53,7 @@ ruleTester.run('link-passhref', rule, {
       errors: [
         {
           message:
-            'passHref is missing. See https://nextjs.org/docs/messages/link-passhref.',
+            'passHref is missing. See https://nextjs.org/docs/messages/link-passhref',
           type: 'JSXOpeningElement',
         },
       ],
@@ -70,7 +70,7 @@ ruleTester.run('link-passhref', rule, {
       errors: [
         {
           message:
-            'passHref must be set to true. See https://nextjs.org/docs/messages/link-passhref.',
+            'passHref must be set to true. See https://nextjs.org/docs/messages/link-passhref',
           type: 'JSXOpeningElement',
         },
       ],


### PR DESCRIPTION
Due to the period at the end of this sentence, when clicking on the link it would 404. This PR simply removes the period from the message.
