### PR TITLE
Update the with-graphql-react example

### DIFF
--- a/examples/with-graphql-react/README.md
+++ b/examples/with-graphql-react/README.md
@@ -1,6 +1,13 @@
 # Next.js example with [`graphql-react`](https://github.com/jaydenseric/graphql-react)
 
-[`graphql-react`](https://github.com/jaydenseric/graphql-react) is a [GraphQL](https://graphql.org) client for [React](https://reactjs.org) using modern [context](https://reactjs.org/docs/context) and [hooks](https://reactjs.org/docs/hooks-intro) APIs that is lightweight (&lt; 3 KB [size limited](https://github.com/ai/size-limit)) but powerful; the first [Relay](https://facebook.github.io/relay) and [Apollo](https://apollographql.com/docs/react) alternative with server side rendering.
+[`graphql-react`](https://github.com/jaydenseric/graphql-react) is a [GraphQL](https://graphql.org) client for [React](https://reactjs.org) using modern [context](https://reactjs.org/docs/context) and [hooks](https://reactjs.org/docs/hooks-intro) APIs that is lightweight (< 4 kB) but powerful; the first [Relay](https://relay.dev) and [Apollo](https://apollographql.com/docs/react) alternative with server side rendering. It can also be used to custom load, cache and server side render any data, even from non-GraphQL sources.
+
+This example demonstrates:
+
+- Polyfilling [required globals](https://github.com/jaydenseric/graphql-react#support) missing in Node.js.
+- Loading and rendering GraphQL data in pages.
+- Using Next.js [dynamic route](https://nextjs.org/docs/routing/dynamic-routes) parameters in GraphQL query variables.
+- Using [`next-server-context`](https://github.com/jaydenseric/next-server-context) to set a HTTP response status code (e.g. 404) for the server side rendered page according to GraphQL query results.
 
 ## Deploy your own
 
@@ -19,8 +26,3 @@ yarn create next-app --example with-graphql-react with-graphql-react-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
-
-## Notes
-
-- In `pages/_app.js` a [custom `App` component](https://github.com/vercel/next.js#custom-app) is decorated with the [`withGraphQLApp`](https://github.com/jaydenseric/next-graphql-react/#function-withgraphqlapp) [higher-order component](https://reactjs.org/docs/higher-order-components) from [`next-graphql-react`](https://github.com/jaydenseric/next-graphql-react), generating a `graphql` prop that populates the [`GraphQLProvider`](https://github.com/jaydenseric/graphql-react#function-graphqlprovider) component from [`graphql-react`](https://github.com/jaydenseric/graphql-react).
-- In `pages/index.js` the [`useGraphQL`](https://github.com/jaydenseric/graphql-react#function-usegraphql) React hook from [`graphql-react`](https://github.com/jaydenseric/graphql-react) is used to query the [GraphQL Pokémon API](https://github.com/lucasbento/graphql-pokemon) and show a picture of Pikachu.

--- a/examples/with-graphql-react/components/ErrorMessage.js
+++ b/examples/with-graphql-react/components/ErrorMessage.js
@@ -1,0 +1,14 @@
+import Head from 'next/head'
+
+export default function ErrorMessage({ title, description }) {
+  return (
+    <article>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+      </Head>
+      <h1>{title}</h1>
+      <p>{description}</p>
+    </article>
+  )
+}

--- a/examples/with-graphql-react/components/ErrorMessageLoading.js
+++ b/examples/with-graphql-react/components/ErrorMessageLoading.js
@@ -1,0 +1,10 @@
+import useServerContext from 'next-server-context/public/useServerContext.js'
+import ErrorMessage from './ErrorMessage'
+
+export default function ErrorLoading() {
+  const serverContext = useServerContext()
+
+  if (serverContext) serverContext.response.statusCode = 500
+
+  return <ErrorMessage title="Error loading" description="Unable to load." />
+}

--- a/examples/with-graphql-react/components/ErrorMessageMissing.js
+++ b/examples/with-graphql-react/components/ErrorMessageMissing.js
@@ -1,0 +1,10 @@
+import useServerContext from 'next-server-context/public/useServerContext.js'
+import ErrorMessage from './ErrorMessage'
+
+export default function ErrorMissing() {
+  const serverContext = useServerContext()
+
+  if (serverContext) serverContext.response.statusCode = 404
+
+  return <ErrorMessage title="Error 404" description="Something is missing." />
+}

--- a/examples/with-graphql-react/components/PageCache.js
+++ b/examples/with-graphql-react/components/PageCache.js
@@ -1,0 +1,14 @@
+import ErrorMessageLoading from './ErrorMessageLoading'
+
+export default function PageCache({
+  cacheValue: { errors, data } = {},
+  renderData,
+}) {
+  return errors ? (
+    <ErrorMessageLoading />
+  ) : data ? (
+    renderData(data)
+  ) : (
+    <p>Loading…</p>
+  )
+}

--- a/examples/with-graphql-react/hooks/useLoadCountriesApi.js
+++ b/examples/with-graphql-react/hooks/useLoadCountriesApi.js
@@ -1,0 +1,20 @@
+import useLoadGraphQL from 'graphql-react/public/useLoadGraphQL.js'
+import { useCallback } from 'react'
+
+export default function useLoadCountriesApi() {
+  const loadGraphQL = useLoadGraphQL()
+
+  return useCallback(
+    (cacheKey, graphqlOperation) => {
+      return loadGraphQL(cacheKey, 'https://countries.trevorblades.com', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(graphqlOperation),
+      })
+    },
+    [loadGraphQL]
+  )
+}

--- a/examples/with-graphql-react/node-polyfills.js
+++ b/examples/with-graphql-react/node-polyfills.js
@@ -1,0 +1,21 @@
+if (typeof window === 'undefined') {
+  if (!('performance' in global))
+    global.performance = require('perf_hooks').performance
+
+  if (!('EventTarget' in global))
+    global.EventTarget =
+      require('events').EventTarget || require('event-target-shim').EventTarget
+
+  if (!('Event' in global))
+    global.Event = require('events').Event || require('event-target-shim').Event
+
+  if (!('CustomEvent' in global))
+    global.CustomEvent = class CustomEvent extends Event {
+      constructor(eventName, { detail, ...eventOptions } = {}) {
+        super(eventName, eventOptions)
+        this.detail = detail
+      }
+    }
+
+  require('abort-controller/polyfill')
+}

--- a/examples/with-graphql-react/package.json
+++ b/examples/with-graphql-react/package.json
@@ -2,10 +2,16 @@
   "name": "with-graphql-react",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": "^12.20 || >= 14.13"
+  },
   "dependencies": {
-    "graphql-react": "^11.0.1",
+    "abort-controller": "^3.0.0",
+    "event-target-shim": "^6.0.2",
+    "graphql-react": "^15.0.0",
     "next": "latest",
-    "next-graphql-react": "^8.0.0",
+    "next-graphql-react": "^11.0.0",
+    "next-server-context": "^3.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/with-graphql-react/pages/_app.js
+++ b/examples/with-graphql-react/pages/_app.js
@@ -1,10 +1,6 @@
-import { GraphQLProvider } from 'graphql-react'
-import { withGraphQLApp } from 'next-graphql-react'
+import '../node-polyfills'
+import withGraphQLReact from 'next-graphql-react/public/withGraphQLReact.js'
+import withServerContext from 'next-server-context/public/withServerContext.js'
+import App from 'next/app'
 
-const App = ({ Component, pageProps, graphql }) => (
-  <GraphQLProvider graphql={graphql}>
-    <Component {...pageProps} />
-  </GraphQLProvider>
-)
-
-export default withGraphQLApp(App)
+export default withGraphQLReact(withServerContext(App))

--- a/examples/with-graphql-react/pages/countries/[countryCode].js
+++ b/examples/with-graphql-react/pages/countries/[countryCode].js
@@ -1,0 +1,81 @@
+import useAutoLoad from 'graphql-react/public/useAutoLoad.js'
+import useCacheEntry from 'graphql-react/public/useCacheEntry.js'
+import useWaterfallLoad from 'graphql-react/public/useWaterfallLoad.js'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { useCallback } from 'react'
+import ErrorMessageMissing from '../../components/ErrorMessageMissing'
+import PageCache from '../../components/PageCache'
+import useLoadCountriesApi from '../../hooks/useLoadCountriesApi'
+
+const query = /* GraphQL */ `
+  query($countryCode: ID!) {
+    country(code: $countryCode) {
+      name
+      emoji
+      capital
+    }
+  }
+`
+
+export default function CountryPage() {
+  const {
+    query: { countryCode },
+  } = useRouter()
+  const cacheKey = `CountryPage-${countryCode}`
+  const cacheValue = useCacheEntry(cacheKey)
+  const loadCountriesApi = useLoadCountriesApi()
+  const load = useCallback(
+    () =>
+      loadCountriesApi(cacheKey, {
+        query,
+        variables: {
+          countryCode,
+        },
+      }),
+    [cacheKey, countryCode, loadCountriesApi]
+  )
+
+  useAutoLoad(cacheKey, load)
+
+  const isWaterfallLoading = useWaterfallLoad(cacheKey, load)
+
+  return isWaterfallLoading ? null : (
+    <>
+      <Head>
+        <title>Country</title>
+      </Head>
+      <PageCache
+        cacheValue={cacheValue}
+        renderData={(data) =>
+          data.country ? (
+            <article>
+              <Head>
+                <title>{data.country.name}</title>
+                <meta
+                  name="description"
+                  content={`Information about the country ${data.country.name}.`}
+                />
+              </Head>
+              <h1>{data.country.name}</h1>
+              <table>
+                <tbody>
+                  <tr>
+                    <th scope="row">Flag</th>
+                    <td>{data.country.emoji}</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Capital</th>
+                    <td>{data.country.capital}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </article>
+          ) : (
+            <ErrorMessageMissing />
+          )
+        }
+      />
+    </>
+  )
+}

--- a/examples/with-graphql-react/pages/index.js
+++ b/examples/with-graphql-react/pages/index.js
@@ -1,30 +1,60 @@
-import { useGraphQL } from 'graphql-react'
+import useAutoLoad from 'graphql-react/public/useAutoLoad.js'
+import useCacheEntry from 'graphql-react/public/useCacheEntry.js'
+import useWaterfallLoad from 'graphql-react/public/useWaterfallLoad.js'
+import Head from 'next/head'
+import Link from 'next/link'
+import { useCallback } from 'react'
+import PageCache from '../components/PageCache'
+import useLoadCountriesApi from '../hooks/useLoadCountriesApi'
+
+const cacheKey = 'IndexPage'
+const query = /* GraphQL */ `
+  {
+    countries {
+      code
+      name
+    }
+  }
+`
 
 export default function IndexPage() {
-  const { loading, cacheValue: { data } = {} } = useGraphQL({
-    fetchOptionsOverride(options) {
-      options.url = 'https://graphql-pokemon.vercel.app'
-    },
-    operation: {
-      query: /* GraphQL */ `
-        {
-          pokemon(name: "Pikachu") {
-            name
-            image
-          }
-        }
-      `,
-    },
-    loadOnMount: true,
-    loadOnReload: true,
-    loadOnReset: true,
-  })
+  const cacheValue = useCacheEntry(cacheKey)
+  const loadCountriesApi = useLoadCountriesApi()
+  const load = useCallback(
+    () =>
+      loadCountriesApi(cacheKey, {
+        query,
+      }),
+    [loadCountriesApi]
+  )
 
-  return data ? (
-    <img src={data.pokemon.image} alt={data.pokemon.name} />
-  ) : loading ? (
-    <p>Loading…</p>
-  ) : (
-    <p>Error!</p>
+  useAutoLoad(cacheKey, load)
+
+  const isWaterfallLoading = useWaterfallLoad(cacheKey, load)
+
+  return isWaterfallLoading ? null : (
+    <>
+      <Head>
+        <title>Countries</title>
+        <meta name="description" content="Countries of the world." />
+      </Head>
+      <PageCache
+        cacheValue={cacheValue}
+        renderData={(data) => (
+          <article>
+            <h1>Countries</h1>
+            <ul>
+              {data.countries.map(({ code, name }) => (
+                <li key={code}>
+                  <Link href={`/countries/${code}`}>
+                    <a>{name}</a>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </article>
+        )}
+      />
+    </>
   )
 }


### PR DESCRIPTION
- Completely new example for [`graphql-react`](https://github.com/jaydenseric/graphql-react) v15 and [`next-graphql-react`](https://github.com/jaydenseric/next-graphql-react) v11, that:
  - Uses the [Countries GraphQL API](https://github.com/trevorblades/countries) instead of the [GraphQL Pokémon API](https://github.com/lucasbento/graphql-pokemon) that has had significant outages.
  - Demonstrates using Next.js [dynamic route](https://nextjs.org/docs/routing/dynamic-routes) parameters in GraphQL query variables.
  - Demonstrates using [`next-server-context`](https://github.com/jaydenseric/next-server-context) to set a HTTP response status code (e.g. 404) for the server side rendered page according to GraphQL query results.
- Added a package `engines` field.
- Tweaked the maximum [`graphql-react`](https://github.com/jaydenseric/graphql-react) bundle size mentioned in the readme. The slightly larger maximum reflects measurement changes (KB vs kB, [webpack](https://webpack.js.org) vs [esbuild](https://esbuild.github.io), etc.) and extras exported in the new API; the more composable new API is actually more bundle efficient.
- Updated the [Relay](https://relay.dev) link URL in the readme.