### PR TITLE
(examples/with-webassembly) fixed for webpack 5

### DIFF
--- a/examples/with-webassembly/next.config.js
+++ b/examples/with-webassembly/next.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   webpack(config) {
     config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'
+
+    // Since Webpack 5 doesn't enable WebAssembly by default, we should do it manually
+    config.experiments = { asyncWebAssembly: true }
+
     return config
   },
 }


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes

Fixes #26436

As mention in #25854 `with-webassembly` example doesn't work anymore after switching to webpack 5.
This PR adds webpack experimental configuration.
