### PR TITLE
Update eslint-config-next rule for api routes

### DIFF
--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -49,9 +49,12 @@ module.exports = {
     {
       files: ['**/pages/api/**/*.[jt]s'],
       rules: {
-        'import/no-anonymous-default-export': ['warn', {'allowArrowFunction': true}]
-      }
-    }
+        'import/no-anonymous-default-export': [
+          'warn',
+          { allowArrowFunction: true },
+        ],
+      },
+    },
   ],
   settings: {
     react: {

--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -46,6 +46,12 @@ module.exports = {
         warnOnUnsupportedTypeScriptVersion: true,
       },
     },
+    {
+      files: ['**/pages/api/**/*.[jt]s'],
+      rules: {
+        'import/no-anonymous-default-export': ['warn', {'allowArrowFunction': true}]
+      }
+    }
   ],
   settings: {
     react: {


### PR DESCRIPTION
Allow `import/no-anonymous-default-export' for arrow functions only in `\*\*/pages/api/**/*.[jt]s`.

Was as conservative as possible in only removing the warning in arrow functions in api routes. Everywhere else will still warn!

As the default anonymous export still seems to be the suggested way to write api route handlers, the status quo basically forces every next.js user using the new `eslint-config-next` to either live with the eslint warning underlines (which, who can do that?! Amirite) or manually disable them for every project.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
