### PR TITLE
Correct header going off top of screen for narrow displays

### DIFF
--- a/packages/create-next-app/templates/typescript/styles/Home.module.css
+++ b/packages/create-next-app/templates/typescript/styles/Home.module.css
@@ -3,7 +3,6 @@
   padding: 0 0.5rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
   height: 100vh;
 }


### PR DESCRIPTION
Correct header going off top of page for narrow displays.

This was bothering me so I figured I would raise a PR. Not sure if this has some unintended consequences.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
