### PR TITLE
Add module.exports to security headers documentation

### DIFF
--- a/docs/advanced-features/security-headers.md
+++ b/docs/advanced-features/security-headers.md
@@ -13,14 +13,16 @@ To improve the security of your application, you can use [`headers`](/docs/api-r
 // after learning more below.
 const securityHeaders = [];
 
-async headers() {
-  return [
-    {
-      // Apply these headers to all routes in your application.
-      source: '/(.*)',
-      headers: securityHeaders
-    }
-  ]
+module.exports = {
+  async headers() {
+    return [
+      {
+        // Apply these headers to all routes in your application.
+        source: '/(.*)',
+        headers: securityHeaders
+      }
+    ]
+  }
 }
 ```
 

--- a/docs/advanced-features/security-headers.md
+++ b/docs/advanced-features/security-headers.md
@@ -11,7 +11,7 @@ To improve the security of your application, you can use [`headers`](/docs/api-r
 
 // You can choose which headers to add to the list
 // after learning more below.
-const securityHeaders = [];
+const securityHeaders = []
 
 module.exports = {
   async headers() {
@@ -19,10 +19,10 @@ module.exports = {
       {
         // Apply these headers to all routes in your application.
         source: '/(.*)',
-        headers: securityHeaders
-      }
+        headers: securityHeaders,
+      },
     ]
-  }
+  },
 }
 ```
 


### PR DESCRIPTION
Without `module.exports`, the provided code won't work if just pasted into `next.config.js`

## Documentation / Examples

- [x] Make sure the linting passes
