### PR TITLE
Export `function prepareUrlAs`

### DIFF
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -336,7 +336,7 @@ function stripOrigin(url: string) {
   return url.startsWith(origin) ? url.substring(origin.length) : url
 }
 
-function prepareUrlAs(router: NextRouter, url: Url, as?: Url) {
+export function prepareUrlAs(router: NextRouter, url: Url, as?: Url) {
   // If url and as provided as an object representation,
   // we'll format them into the string version here.
   let [resolvedHref, resolvedAs] = resolveHref(router, url, true)


### PR DESCRIPTION
## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

---

https://github.com/vercel/next.js/blob/canary/packages/next/next-server/lib/router/router.ts#L339

It would be great if you could make the function `prepareUrlAs` here available externally.

The use cases included the following patterns.
- If the value passed to router.prefetch is a dynamic route, it needs to be converted to a string.
- When wrapping a `Link` component to create an `ActiveLink`, the comparison between the current route and `router.asPath` should be able to handle `UrlObject` as well as strings.

I hope you will consider it.

I love Next.js!