### PR TITLE
docs: updated minimum Node.js version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ If you have questions about anything related to Next.js, you're always welcome t
 
 #### System Requirements
 
-- [Node.js 10.13](https://nodejs.org/) or later
+- [Node.js 12.0](https://nodejs.org/) or later
 - MacOS, Windows (including WSL), and Linux are supported
 
 ## Setup


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes


According to new requirements in `package.json` minimum Node.js version for now is 12.0