### PR TITLE
Update next-env note in docs

### DIFF
--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -53,7 +53,7 @@ npm run dev
 
 You're now ready to start converting files from `.js` to `.tsx` and leveraging the benefits of TypeScript!.
 
-> A file named `next-env.d.ts` will be created in the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. **You cannot remove it**, however, you can edit it (but you don't need to).
+> A file named `next-env.d.ts` will be created in the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. **You cannot remove it**, and it should not be edited as it can change at any time.
 
 > TypeScript `strict` mode is turned off by default. When you feel comfortable with TypeScript, it's recommended to turn it on in your `tsconfig.json`.
 


### PR DESCRIPTION
This ensures we don't recommend editing the `next-env` file since we need to be able to tweak it to accept future types we add in Next.js


## Documentation / Examples

- [x] Make sure the linting passes

Closes: https://github.com/vercel/next.js/issues/26533