### PR TITLE
Add note about adding additional types

### DIFF
--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -53,7 +53,7 @@ npm run dev
 
 You're now ready to start converting files from `.js` to `.tsx` and leveraging the benefits of TypeScript!.
 
-> A file named `next-env.d.ts` will be created in the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. **You cannot remove it**, and it should not be edited as it can change at any time.
+> A file named `next-env.d.ts` will be created in the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. **You cannot remove it or edit it** as it can change at any time.
 
 > TypeScript `strict` mode is turned off by default. When you feel comfortable with TypeScript, it's recommended to turn it on in your `tsconfig.json`.
 

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -57,6 +57,8 @@ You're now ready to start converting files from `.js` to `.tsx` and leveraging t
 
 > TypeScript `strict` mode is turned off by default. When you feel comfortable with TypeScript, it's recommended to turn it on in your `tsconfig.json`.
 
+> Additional types can be added to your project separate of `next-env.d.ts` by adding a separate file e.g. `additional.d.ts` and then adding it to the `include` config in your `tsconfig.json`
+
 By default, Next.js will do type checking as part of `next build`. We recommend using code editor type checking during development.
 
 If you want to silence the error reports, refer to the documentation for [Ignoring TypeScript errors](/docs/api-reference/next.config.js/ignoring-typescript-errors.md).

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -57,7 +57,7 @@ You're now ready to start converting files from `.js` to `.tsx` and leveraging t
 
 > TypeScript `strict` mode is turned off by default. When you feel comfortable with TypeScript, it's recommended to turn it on in your `tsconfig.json`.
 
-> Additional types can be added to your project separate of `next-env.d.ts` by adding a separate file e.g. `additional.d.ts` and then adding it to the `include` config in your `tsconfig.json`
+> Instead of editing `next-env.d.ts`, you can include additional types by adding a new file e.g. `additional.d.ts` and then referencing it in the [`include`](https://www.typescriptlang.org/tsconfig#include) array in your `tsconfig.json`.
 
 By default, Next.js will do type checking as part of `next build`. We recommend using code editor type checking during development.
 


### PR DESCRIPTION
This adds a note mentioning how additional types can be added to prevent users from trying to edit `next-env.d.ts`


## Documentation / Examples

- [x] Make sure the linting passes

x-ref: https://github.com/vercel/next.js/pull/26485#issuecomment-867091407
