### PR TITLE
Add comment to not edit in next-env file

### DIFF
--- a/packages/next/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/lib/typescript/writeAppTypeDeclarations.ts
@@ -17,6 +17,10 @@ export async function writeAppTypeDeclarations(
       os.EOL +
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + os.EOL
-        : '')
+        : '') +
+      os.EOL +
+      '// NOTE: This file should not be edited' +
+      os.EOL +
+      '// see https://nextjs.org/docs/basic-features/typescript for more information.'
   )
 }


### PR DESCRIPTION
This adds a comment to the generated `next-env.d.ts` to mention it should not be edited pointing to the documentation which contains an example of adding custom types separately. 

x-ref: https://github.com/vercel/next.js/issues/26560

## Documentation / Examples

- [x] Make sure the linting passes
