### PR TITLE
Add trace url on bootup

### DIFF
--- a/packages/next/build/webpack/plugins/profiling-plugin.ts
+++ b/packages/next/build/webpack/plugins/profiling-plugin.ts
@@ -86,7 +86,8 @@ export class ProfilingPlugin {
       this.traceHookPair(
         'webpack-compilation',
         compiler.hooks.beforeCompile,
-        compiler.hooks.afterCompile
+        compiler.hooks.afterCompile,
+        () => ({ name: compiler.name })
       )
     }
 

--- a/packages/next/build/webpack/plugins/profiling-plugin.ts
+++ b/packages/next/build/webpack/plugins/profiling-plugin.ts
@@ -76,7 +76,8 @@ export class ProfilingPlugin {
       this.traceHookPair(
         'webpack-invalidated',
         compiler.hooks.invalid,
-        compiler.hooks.done
+        compiler.hooks.done,
+        () => ({ name: compiler.name })
       )
     }
   }

--- a/packages/next/telemetry/trace/report/to-telemetry.ts
+++ b/packages/next/telemetry/trace/report/to-telemetry.ts
@@ -1,13 +1,13 @@
 import { traceGlobals } from '../shared'
 
-const TRACE_EVENT_WHITELIST = new Map(
+const TRACE_EVENT_ACCESSLIST = new Map(
   Object.entries({
     'webpack-invalidated': 'WEBPACK_INVALIDATED',
   })
 )
 
 const reportToTelemetry = (spanName: string, duration: number) => {
-  const eventName = TRACE_EVENT_WHITELIST.get(spanName)
+  const eventName = TRACE_EVENT_ACCESSLIST.get(spanName)
   if (!eventName) {
     return
   }

--- a/packages/next/telemetry/trace/report/to-zipkin.ts
+++ b/packages/next/telemetry/trace/report/to-zipkin.ts
@@ -1,17 +1,16 @@
 import { randomBytes } from 'crypto'
 import fetch from 'node-fetch'
+import * as Log from '../../../build/output/log'
 
 let traceId = process.env.TRACE_ID
-if (!traceId) {
-  traceId = process.env.TRACE_ID = randomBytes(8).toString('hex')
-}
 
 const localEndpoint = {
-  serviceName: 'zipkin-query',
+  serviceName: 'nextjs',
   ipv4: '127.0.0.1',
   port: 9411,
 }
-const zipkinUrl = `http://${localEndpoint.ipv4}:${localEndpoint.port}/api/v2/spans`
+const zipkinUrl = `http://${localEndpoint.ipv4}:${localEndpoint.port}`
+const zipkinAPI = `${zipkinUrl}/api/v2/spans`
 
 const reportToLocalHost = (
   name: string,
@@ -21,6 +20,12 @@ const reportToLocalHost = (
   parentId?: string,
   attrs?: Object
 ) => {
+  if (!traceId) {
+    traceId = process.env.TRACE_ID = randomBytes(8).toString('hex')
+    Log.info(
+      `Zipkin trace will be available on ${zipkinUrl}/zipkin/traces/${traceId}`
+    )
+  }
   const body = [
     {
       traceId,
@@ -35,11 +40,11 @@ const reportToLocalHost = (
   ]
 
   // We intentionally do not block on I/O here.
-  fetch(zipkinUrl, {
+  fetch(zipkinAPI, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
-  }).catch(() => {})
+  }).catch(console.log)
 }
 
 export default reportToLocalHost


### PR DESCRIPTION
Adds a link to open the trace in zipkin:

<img width="729" alt="Screen Shot 2021-06-25 at 12 35 45" src="https://user-images.githubusercontent.com/6324199/123412548-fb7af880-d5b1-11eb-95a1-ce96bb9f535c.png">


<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Documentation / Examples

- [ ] Make sure the linting passes
