### PR TITLE
fix: next dynamic with jest

### DIFF
--- a/packages/next/next-server/lib/loadable.js
+++ b/packages/next/next-server/lib/loadable.js
@@ -94,7 +94,8 @@ function createLoadableComponent(loadFn, options) {
   if (
     !initialized &&
     typeof window !== 'undefined' &&
-    typeof opts.webpack === 'function'
+    typeof opts.webpack === 'function' &&
+    typeof require.resolveWeak === 'function'
   ) {
     const moduleIds = opts.webpack()
     READY_INITIALIZERS.push((ids) => {

--- a/test/unit/fixtures/stub-components/hello.js
+++ b/test/unit/fixtures/stub-components/hello.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Hello() {
+  return <div>hello</div>
+}

--- a/test/unit/next-dynamic.test.js
+++ b/test/unit/next-dynamic.test.js
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { act, render } from '@testing-library/react'
+import dynamic from 'next/dynamic'
+
+describe('next/dynamic', () => {
+  it('test link with unmount', () => {
+    const App = dynamic(() => import('./fixtures/stub-components/hello'))
+    act(() => {
+      const { unmount } = render(<App />)
+      unmount()
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Fixes #19862

Avoid executing `webpack` property on `loadableGenerated` of loadable component compiled from `next/dynamic` when `require.resolveWeak` is unavailable due to jest runtime missing `require.resolveWeak`.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] unit tests added

