### PR TITLE
Fix GSP redirect cache error

### DIFF
--- a/packages/next/next-server/server/incremental-cache.ts
+++ b/packages/next/next-server/server/incremental-cache.ts
@@ -194,7 +194,11 @@ export class IncrementalCache {
 
     // TODO: This option needs to cease to exist unless it stops mutating the
     // `next build` output's manifest.
-    if (this.incrementalOptions.flushToDisk && !data.isNotFound) {
+    if (
+      this.incrementalOptions.flushToDisk &&
+      !data.isNotFound &&
+      !data.isRedirect
+    ) {
       try {
         const seedPath = this.getSeedPath(pathname, 'html')
         await promises.mkdir(path.dirname(seedPath), { recursive: true })

--- a/test/integration/gssp-redirect/pages/gsp-blog-blocking/[post].js
+++ b/test/integration/gssp-redirect/pages/gsp-blog-blocking/[post].js
@@ -81,6 +81,6 @@ export const getStaticProps = ({ params }) => {
 export const getStaticPaths = () => {
   return {
     paths: ['first', 'second'].map((post) => ({ params: { post } })),
-    fallback: true,
+    fallback: 'blocking',
   }
 }

--- a/test/integration/gssp-redirect/test/index.test.js
+++ b/test/integration/gssp-redirect/test/index.test.js
@@ -110,6 +110,111 @@ const runTests = (isDev) => {
     expect(pathname).toBe('/gsp-blog/redirect-dest-_gsp-blog_first')
   })
 
+  it('should apply redirect when fallback blocking GSP page is visited directly (internal dynamic)', async () => {
+    const browser = await webdriver(
+      appPort,
+      '/gsp-blog-blocking/redirect-dest-_gsp-blog_first',
+      true,
+      true
+    )
+
+    await browser.waitForElementByCss('#gsp')
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props).toEqual({
+      params: {
+        post: 'first',
+      },
+    })
+    const initialHref = await browser.eval(() => window.initialHref)
+    const { pathname } = url.parse(initialHref)
+    expect(pathname).toBe('/gsp-blog/first')
+  })
+
+  it('should apply redirect when fallback blocking GSP page is visited directly (internal dynamic) second visit', async () => {
+    const browser = await webdriver(
+      appPort,
+      '/gsp-blog-blocking/redirect-dest-_gsp-blog_first',
+      true,
+      true
+    )
+
+    await browser.waitForElementByCss('#gsp')
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props).toEqual({
+      params: {
+        post: 'first',
+      },
+    })
+    const initialHref = await browser.eval(() => window.initialHref)
+    const { pathname } = url.parse(initialHref)
+    expect(pathname).toBe('/gsp-blog/first')
+  })
+
+  it('should apply redirect when fallback blocking GSP page is visited directly (internal dynamic) with revalidate', async () => {
+    const browser = await webdriver(
+      appPort,
+      '/gsp-blog-blocking/redirect-revalidate-dest-_gsp-blog_first',
+      true,
+      true
+    )
+
+    await browser.waitForElementByCss('#gsp')
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props).toEqual({
+      params: {
+        post: 'first',
+      },
+    })
+    const initialHref = await browser.eval(() => window.initialHref)
+    const { pathname } = url.parse(initialHref)
+    expect(pathname).toBe('/gsp-blog/first')
+  })
+
+  it('should apply redirect when fallback blocking GSP page is visited directly (internal dynamic) with revalidate second visit', async () => {
+    const browser = await webdriver(
+      appPort,
+      '/gsp-blog-blocking/redirect-revalidate-dest-_gsp-blog_first',
+      true,
+      true
+    )
+
+    await browser.waitForElementByCss('#gsp')
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props).toEqual({
+      params: {
+        post: 'first',
+      },
+    })
+    const initialHref = await browser.eval(() => window.initialHref)
+    const { pathname } = url.parse(initialHref)
+    expect(pathname).toBe('/gsp-blog/first')
+  })
+
+  it('should apply redirect when fallback blocking GSP page is visited directly (internal dynamic) with revalidate', async () => {
+    const browser = await webdriver(
+      appPort,
+      '/gsp-blog-blocking/redirect-revalidate-dest-_gsp-blog_first',
+      true,
+      true
+    )
+
+    await browser.waitForElementByCss('#gsp')
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props).toEqual({
+      params: {
+        post: 'first',
+      },
+    })
+    const initialHref = await browser.eval(() => window.initialHref)
+    const { pathname } = url.parse(initialHref)
+    expect(pathname).toBe('/gsp-blog/first')
+  })
+
   if (!isDev) {
     it('should apply redirect when fallback GSP page is visited directly (internal dynamic) 2nd visit', async () => {
       const browser = await webdriver(
@@ -435,15 +540,28 @@ describe('GS(S)P Redirect Support', () => {
   })
 
   describe('production mode', () => {
+    let output = ''
+
     beforeAll(async () => {
       await fs.remove(join(appDir, '.next'))
       await nextBuild(appDir)
       appPort = await findPort()
-      app = await nextStart(appDir, appPort)
+      app = await nextStart(appDir, appPort, {
+        onStdout(msg) {
+          output += msg
+        },
+        onStderr(msg) {
+          output += msg
+        },
+      })
     })
     afterAll(() => killApp(app))
 
     runTests()
+
+    it('should not have errors in output', async () => {
+      expect(output).not.toContain('Failed to update prerender files')
+    })
   })
 
   describe('serverless mode', () => {

--- a/test/integration/gssp-redirect/test/index.test.js
+++ b/test/integration/gssp-redirect/test/index.test.js
@@ -194,27 +194,6 @@ const runTests = (isDev) => {
     expect(pathname).toBe('/gsp-blog/first')
   })
 
-  it('should apply redirect when fallback blocking GSP page is visited directly (internal dynamic) with revalidate', async () => {
-    const browser = await webdriver(
-      appPort,
-      '/gsp-blog-blocking/redirect-revalidate-dest-_gsp-blog_first',
-      true,
-      true
-    )
-
-    await browser.waitForElementByCss('#gsp')
-
-    const props = JSON.parse(await browser.elementByCss('#props').text())
-    expect(props).toEqual({
-      params: {
-        post: 'first',
-      },
-    })
-    const initialHref = await browser.eval(() => window.initialHref)
-    const { pathname } = url.parse(initialHref)
-    expect(pathname).toBe('/gsp-blog/first')
-  })
-
   if (!isDev) {
     it('should apply redirect when fallback GSP page is visited directly (internal dynamic) 2nd visit', async () => {
       const browser = await webdriver(


### PR DESCRIPTION
This makes sure we don't attempt flushing cache info to disk for `getStaticProps` `redirect` items with `revalidate`

Fixes: https://github.com/vercel/next.js/issues/20816

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added

