### PR TITLE
Fix: with-tailwindcss-emotion example type error

### DIFF
--- a/examples/with-tailwindcss-emotion/package.json
+++ b/examples/with-tailwindcss-emotion/package.json
@@ -19,7 +19,7 @@
     "autoprefixer": "^10.2.6",
     "next": "latest",
     "postcss": "^8.3.5",
-    "tailwindcss": "^2.2.4",
+    "tailwindcss": "~2.1.4",
     "xwind": "0.8.0"
   },
   "license": "MIT"

--- a/examples/with-tailwindcss-emotion/tailwind.config.js
+++ b/examples/with-tailwindcss-emotion/tailwind.config.js
@@ -1,7 +1,6 @@
 const colors = require('tailwindcss/colors')
 
 module.exports = {
-  mode: 'jit',
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
This is a fix to work around the error that is occurring `with-tailwindcss-emotion`.
I found that the error occurs starting from `tailwindcss` 2.2.0.

fixes #26337

## Bug

- [x] Related issues linked using `fixes #number`
