### PR TITLE
docs: Change `_document.js` to `_document.jsx`

### DIFF
--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -6,7 +6,7 @@ description: Extend the default document markup added by Next.js.
 
 A custom `Document` is commonly used to augment your application's `<html>` and `<body>` tags. This is necessary because Next.js pages skip the definition of the surrounding document's markup.
 
-To override the default `Document`, create the file `./pages/_document.js` and extend the `Document` class as shown below:
+To override the default `Document`, create the file `./pages/_document.jsx` and extend the `Document` class as shown below:
 
 ```jsx
 import Document, { Html, Head, Main, NextScript } from 'next/document'


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR makes a small fix in the `custom-document.md` file, where `.js` is used instead of `.jsx` when referencing `_document.jsx`.

## Documentation / Examples

- [ ] Make sure the linting passes
