### PR TITLE
[ESLint] Adds --max-warnings flag to `next lint`

### DIFF
--- a/packages/next/cli/next-lint.ts
+++ b/packages/next/cli/next-lint.ts
@@ -55,6 +55,7 @@ const nextLint: cliCommand = (argv) => {
     '--ignore-path': String,
     '--no-ignore': Boolean,
     '--quiet': Boolean,
+    '--max-warnings': Number,
     '--no-inline-config': Boolean,
     '--report-unused-disable-directives': String,
     '--cache': Boolean,
@@ -108,6 +109,7 @@ const nextLint: cliCommand = (argv) => {
 
         Handling warnings:
           --quiet                        Report errors only - default: false
+          --max-warnings Int             Number of warnings to trigger nonzero exit code - default: -1
 
         Inline configuration comments:
           --no-inline-config             Prevent comments from changing config or rules
@@ -143,8 +145,16 @@ const nextLint: cliCommand = (argv) => {
   )
 
   const reportErrorsOnly = Boolean(args['--quiet'])
+  const maxWarnings = args['--max-warnings'] ?? -1
 
-  runLintCheck(baseDir, lintDirs, false, eslintOptions(args), reportErrorsOnly)
+  runLintCheck(
+    baseDir,
+    lintDirs,
+    false,
+    eslintOptions(args),
+    reportErrorsOnly,
+    maxWarnings
+  )
     .then(async (lintResults) => {
       const lintOutput =
         typeof lintResults === 'string' ? lintResults : lintResults?.output

--- a/test/integration/eslint/max-warnings/.eslintrc
+++ b/test/integration/eslint/max-warnings/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "next",
+  "root": true,
+  "rules": {
+    "@next/next/no-html-link-for-pages": 0,
+    "@next/next/no-sync-scripts": 1
+  }
+}

--- a/test/integration/eslint/max-warnings/pages/about.js
+++ b/test/integration/eslint/max-warnings/pages/about.js
@@ -1,0 +1,8 @@
+const About = () => (
+  <div>
+    <p>About</p>
+    <script src="https://example.com" />
+  </div>
+)
+
+export default About

--- a/test/integration/eslint/max-warnings/pages/index.js
+++ b/test/integration/eslint/max-warnings/pages/index.js
@@ -1,0 +1,8 @@
+const Home = () => (
+  <div>
+    <p>Home</p>
+    <script src="https://example.com" />
+  </div>
+)
+
+export default Home

--- a/test/integration/eslint/test/index.test.js
+++ b/test/integration/eslint/test/index.test.js
@@ -12,6 +12,7 @@ const dirIgnoreDuringBuilds = join(__dirname, '../ignore-during-builds')
 const dirCustomDirectories = join(__dirname, '../custom-directories')
 const dirConfigInPackageJson = join(__dirname, '../config-in-package-json')
 const dirInvalidEslintVersion = join(__dirname, '../invalid-eslint-version')
+const dirMaxWarnings = join(__dirname, '../max-warnings')
 
 describe('ESLint', () => {
   describe('Next Build', () => {
@@ -185,6 +186,44 @@ describe('ESLint', () => {
         'Error: Comments inside children section of tag should be placed inside braces'
       )
       expect(output).not.toContain(
+        'Warning: External synchronous scripts are forbidden'
+      )
+    })
+
+    test('max warnings flag errors when warnings exceed threshold', async () => {
+      const { stdout, stderr } = await nextLint(
+        dirMaxWarnings,
+        ['--max-warnings', 1],
+        {
+          stdout: true,
+          stderr: true,
+        }
+      )
+
+      expect(stderr).not.toEqual('')
+      expect(stderr).toContain(
+        'Warning: External synchronous scripts are forbidden'
+      )
+      expect(stdout).not.toContain(
+        'Warning: External synchronous scripts are forbidden'
+      )
+    })
+
+    test('max warnings flag does not error when warnings do not exceed threshold', async () => {
+      const { stdout, stderr } = await nextLint(
+        dirMaxWarnings,
+        ['--max-warnings', 2],
+        {
+          stdout: true,
+          stderr: true,
+        }
+      )
+
+      expect(stderr).toEqual('')
+      expect(stderr).not.toContain(
+        'Warning: External synchronous scripts are forbidden'
+      )
+      expect(stdout).toContain(
         'Warning: External synchronous scripts are forbidden'
       )
     })


### PR DESCRIPTION
Adds `--max-warnings` flag to `next lint` to enable setting of a maximum warning threshold.

Fixes #26671