### PR TITLE
fix: handle Promise.reject case of Sentry.flush in with-sentry example

### DIFF
--- a/examples/with-sentry/pages/_error.js
+++ b/examples/with-sentry/pages/_error.js
@@ -39,21 +39,22 @@ MyError.getInitialProps = async ({ res, err, asPath }) => {
 
   if (err) {
     Sentry.captureException(err)
+  } else {
+    // If this point is reached, getInitialProps was called without any
+    // information about what the error might be. This is unexpected and may
+    // indicate a bug introduced in Next.js, so record it in Sentry
+    Sentry.captureException(
+      new Error(`_error.js getInitialProps missing data at path: ${asPath}`)
+    )
+  }
 
+  try {
     // Flushing before returning is necessary if deploying to Vercel, see
     // https://vercel.com/docs/platform/limits#streaming-responses
     await Sentry.flush(2000)
-
-    return errorInitialProps
+  } catch (err) {
+    console.log(err)
   }
-
-  // If this point is reached, getInitialProps was called without any
-  // information about what the error might be. This is unexpected and may
-  // indicate a bug introduced in Next.js, so record it in Sentry
-  Sentry.captureException(
-    new Error(`_error.js getInitialProps missing data at path: ${asPath}`)
-  )
-  await Sentry.flush(2000)
 
   return errorInitialProps
 }

--- a/examples/with-sentry/pages/_error.js
+++ b/examples/with-sentry/pages/_error.js
@@ -53,7 +53,7 @@ MyError.getInitialProps = async ({ res, err, asPath }) => {
     // https://vercel.com/docs/platform/limits#streaming-responses
     await Sentry.flush(2000)
   } catch (err) {
-    console.log(err)
+    // no-empty
   }
 
   return errorInitialProps

--- a/examples/with-sentry/pages/api/test4.js
+++ b/examples/with-sentry/pages/api/test4.js
@@ -5,11 +5,16 @@ async function handler(req, res) {
     throw new Error('API Test 4')
   } catch (error) {
     Sentry.captureException(error)
+
+    try {
+      // Flushing before returning is necessary if deploying to Vercel, see
+      // https://vercel.com/docs/platform/limits#streaming-responses
+      await Sentry.flush(2000)
+    } catch (err) {
+      console.log(err)
+    }
   }
 
-  // Flushing before returning is necessary if deploying to Vercel, see
-  // https://vercel.com/docs/platform/limits#streaming-responses
-  await Sentry.flush(2000)
   res.status(200).json({ name: 'John Doe' })
 }
 

--- a/examples/with-sentry/pages/api/test4.js
+++ b/examples/with-sentry/pages/api/test4.js
@@ -11,7 +11,7 @@ async function handler(req, res) {
       // https://vercel.com/docs/platform/limits#streaming-responses
       await Sentry.flush(2000)
     } catch (err) {
-      console.log(err)
+      // no-empty
     }
   }
 

--- a/examples/with-sentry/pages/ssr/test4.js
+++ b/examples/with-sentry/pages/ssr/test4.js
@@ -8,9 +8,13 @@ export async function getServerSideProps() {
   } catch (error) {
     Sentry.captureException(error)
 
-    // Flushing before returning is necessary if deploying to Vercel, see
-    // https://vercel.com/docs/platform/limits#streaming-responses
-    await Sentry.flush(2000)
+    try {
+      // Flushing before returning is necessary if deploying to Vercel, see
+      // https://vercel.com/docs/platform/limits#streaming-responses
+      await Sentry.flush(2000)
+    } catch (err) {
+      console.log(err)
+    }
   }
 
   return { props: {} }

--- a/examples/with-sentry/pages/ssr/test4.js
+++ b/examples/with-sentry/pages/ssr/test4.js
@@ -13,7 +13,7 @@ export async function getServerSideProps() {
       // https://vercel.com/docs/platform/limits#streaming-responses
       await Sentry.flush(2000)
     } catch (err) {
-      console.log(err)
+      // no-empty
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Note

It took me hours to figure out why I was getting an "Internal Server Error" when I added Sentry to our Next-Vercel setup based on "with-sentry".

I prepared examples in my demo repo here: https://github.com/natterstefan/next-with-sentry/pull/2 with one deployment with and one without the `try/catch`.

The `with-sentry` example [does not handle the case when `Sentry.flush` returns a rejected Promise](https://github.com/vercel/next.js/blob/9ab916ac99eb200a478c8d5ffe94b6ec9c0a315b/examples/with-sentry/pages/api/test4.js#L12). I was not aware of that as well until I read https://github.com/getsentry/sentry-javascript/issues/3691#issuecomment-868380487.

In my opinion, one problem lies in the description of `Sentry.flush`:

> If you provide a timeout and the queue takes longer to drain the promise returns false
> ([src](https://github.com/getsentry/sentry-javascript/blob/a732ae830b613f0227330b93038695ad678ed591/packages/node/src/sdk.ts#L153))

I did not think of handling `Promise.reject` when I read the docs of `Sentry.flush`. 😅 That took some time to figure that out.

The maintainers of `@sentry/nextjs` use `try/catch` as well -> https://github.com/getsentry/sentry-javascript/commit/6c1b4bd71b463cbecc30144bd0931f96ec87da2d.

---

FTR: So this fixes the example, **but** it does not fix the issue why `Sentry.flush` throws an error/rejects. 🤔

_Edit:_ There are comments mentioning the issue with `Sentry.flush`: https://github.com/getsentry/sentry-javascript/issues/3643#issuecomment-869093890, and https://github.com/getsentry/sentry-javascript/issues/3746. Let's see if they handle it ([announced here](https://github.com/getsentry/sentry-javascript/issues/3643#issuecomment-869836001)) or not.

## Documentation / Examples

- [x] Make sure the linting passes
