### PR TITLE
Update `publish-canary` script to include checkout

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -155,3 +155,7 @@ yarn create next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
 ````
+
+## Publishing
+
+Repo maintainers can use `yarn publish-canary` to publish a new version of all packages to npm.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "types": "lerna run types --stream",
     "typescript": "lerna run typescript",
     "prepublish": "lerna run prepublish",
-    "publish-canary": "lerna version prerelease --preid canary --force-publish && release --pre --skip-questions",
+    "publish-canary": "git checkout canary && git pull && lerna version prerelease --preid canary --force-publish && release --pre --skip-questions",
     "publish-stable": "lerna version --force-publish",
     "lint-staged": "lint-staged",
     "next-with-deps": "./scripts/next-with-deps.sh",


### PR DESCRIPTION
This updates the publishing instructions to make it easier for new Next.js team members