### PR TITLE
Added webpack5 to dependencies of using-preact #26826

### DIFF
--- a/examples/using-preact/package.json
+++ b/examples/using-preact/package.json
@@ -14,7 +14,9 @@
     "preact-render-to-string": "^5.1.11",
     "react": "npm:@preact/compat",
     "react-dom": "npm:@preact/compat",
-    "react-ssr-prepass": "npm:preact-ssr-prepass@^1.1.2"
+    "react-ssr-prepass": "npm:preact-ssr-prepass@^1.1.2",
+    "webpack": "^5.4.0",
+    "webpack-cli": "^4.2.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [X] Related issues linked using fixes #26826 
- [X] Integration tests added

Added webpack5 as a dependency to the package.json of the using-preact example. Does run the StackBlitz example linked in #26826 without any errors now. Not sure whether the webpack-cli is required, can be removed if necessary! 