### PR TITLE
Ensure API route errors are propagated in minimal mode

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1179,7 +1179,7 @@ export default class Server {
       query,
       pageModule,
       this.renderOpts.previewProps,
-      false
+      this.minimalMode
     )
     return true
   }

--- a/test/integration/required-server-files/pages/api/error.js
+++ b/test/integration/required-server-files/pages/api/error.js
@@ -1,0 +1,3 @@
+export default async function handler(req, res) {
+  throw new Error('some error from /api/error')
+}

--- a/test/integration/required-server-files/test/index.test.js
+++ b/test/integration/required-server-files/test/index.test.js
@@ -470,6 +470,15 @@ describe('Required Server Files', () => {
     expect(errors[0].message).toContain('gsp hit an oops')
   })
 
+  it('should bubble error correctly for API page', async () => {
+    errors = []
+    const res = await fetchViaHTTP(appPort, '/api/error')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('error')
+    expect(errors.length).toBe(1)
+    expect(errors[0].message).toContain('some error from /api/error')
+  })
+
   it('should normalize optional values correctly for SSP page', async () => {
     const res = await fetchViaHTTP(
       appPort,


### PR DESCRIPTION
This ensures when an error occurs in an API route while using minimal mode the error is bubbled so it can be handled at the top-level 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

