### PR TITLE
[ESLint] Update default `.eslintrc` file created to have `.json` format

### DIFF
--- a/packages/next/lib/eslint/writeDefaultConfig.ts
+++ b/packages/next/lib/eslint/writeDefaultConfig.ts
@@ -70,14 +70,14 @@ export async function writeDefaultConfig(
     }
   } else {
     await fs.writeFile(
-      '.eslintrc',
+      '.eslintrc.json',
       CommentJson.stringify(defaultConfig, null, 2) + os.EOL
     )
 
     console.log(
       chalk.green(
         `We created the ${chalk.bold(
-          '.eslintrc'
+          '.eslintrc.json'
         )} file for you and included the base Next.js ESLint configuration.`
       )
     )


### PR DESCRIPTION
Fixs #26857. Update default `.eslintrc` file created to have `.json` format (`.eslintrc` without a file format is **not** on the list of supported [configuration file formats](https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats))