### PR TITLE
5MB -> 4MB body size limit

### DIFF
--- a/errors/api-routes-body-size-limit.md
+++ b/errors/api-routes-body-size-limit.md
@@ -1,12 +1,12 @@
-# API Routes Body Size Limited to 5mb
+# API Routes Body Size Limited to 4mb
 
 #### Why This Error Occurred
 
-API Routes are meant to respond quickly and are not intended to support responding with large amounts of data. The maximum size of responses is 5 MB.
+API Routes are meant to respond quickly and are not intended to support responding with large amounts of data. The maximum size of responses is 4 MB.
 
 #### Possible Ways to Fix It
 
-Limit your API Route responses to less than 5 MB. If you need to support sending large files to the client, you should consider using a dedicated media host for those assets. See link below for suggestions.
+Limit your API Route responses to less than 4 MB. If you need to support sending large files to the client, you should consider using a dedicated media host for those assets. See link below for suggestions.
 
 ### Useful Links
 

--- a/errors/api-routes-body-size-limit.md
+++ b/errors/api-routes-body-size-limit.md
@@ -1,4 +1,4 @@
-# API Routes Body Size Limited to 4mb
+# API Routes Body Size Limited to 4MB
 
 #### Why This Error Occurred
 

--- a/packages/next/server/api-utils.ts
+++ b/packages/next/server/api-utils.ts
@@ -75,9 +75,9 @@ export async function apiResolver(
         contentLength += Buffer.byteLength(args[0])
       }
 
-      if (contentLength >= 5 * 1024 * 1024) {
+      if (contentLength >= 4 * 1024 * 1024) {
         console.warn(
-          `API response for ${req.url} exceeds 5MB. This will cause the request to fail in a future version. https://nextjs.org/docs/messages/api-routes-body-size-limit`
+          `API response for ${req.url} exceeds 4MB. This will cause the request to fail in a future version. https://nextjs.org/docs/messages/api-routes-body-size-limit`
         )
       }
 

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -398,17 +398,17 @@ function runTests(dev = false) {
     expect(data).toBe('hi')
   })
 
-  it('should warn if response body is larger than 5MB', async () => {
+  it('should warn if response body is larger than 4MB', async () => {
     let res = await fetchViaHTTP(appPort, '/api/large-response')
     expect(res.ok).toBeTruthy()
     expect(stderr).toContain(
-      'API response for /api/large-response exceeds 5MB. This will cause the request to fail in a future version.'
+      'API response for /api/large-response exceeds 4MB. This will cause the request to fail in a future version.'
     )
 
     res = await fetchViaHTTP(appPort, '/api/large-chunked-response')
     expect(res.ok).toBeTruthy()
     expect(stderr).toContain(
-      'API response for /api/large-chunked-response exceeds 5MB. This will cause the request to fail in a future version.'
+      'API response for /api/large-chunked-response exceeds 4MB. This will cause the request to fail in a future version.'
     )
   })
 


### PR DESCRIPTION
This decreases the body size limit that triggers a warning from 5MB -> 4MB, which provides a little more wiggle room. Certain things like using base64 on body, headers, path, etc can cause the response to be larger than initially calculated. 

Initial PR: https://github.com/vercel/next.js/pull/26831