### PR TITLE
include image types in `create-next-app` next-env.d.ts

### DIFF
--- a/packages/create-next-app/templates/typescript/next-env.d.ts
+++ b/packages/create-next-app/templates/typescript/next-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
Previous TypeScript template in `create-next-app` only had the following in `next-env.d.ts`
```ts
/// <reference types="next" />
/// <reference types="next/types/global" />
```

New `next-env.d.ts` has this:
```ts
/// <reference types="next" />
/// <reference types="next/types/global" />
/// <reference types="next/image-types/global" />
```

Next.js automatically adds the `image-types` reference, but it won't be included in the initial commit. 
## Documentation / Examples

- [x] Make sure the linting passes
