### PR TITLE
add isNextDevCommand type in createServer s arguments type

### DIFF
--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -153,7 +153,9 @@ export class NextServer {
 }
 
 // This file is used for when users run `require('next')`
-function createServer(options: NextServerConstructor): NextServer {
+function createServer(
+  options: NextServerConstructor & { isNextDevCommand?: boolean }
+): NextServer {
   const standardEnv = ['production', 'development', 'test']
 
   if (options == null) {
@@ -163,7 +165,7 @@ function createServer(options: NextServerConstructor): NextServer {
   }
 
   if (
-    !(options as any).isNextDevCommand &&
+    !options.isNextDevCommand &&
     process.env.NODE_ENV &&
     !standardEnv.includes(process.env.NODE_ENV)
   ) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes

This MR allows the passing of `isNextDevCommand` in the custom server. Otherwise, you can not pass it in a typescript environment without ignoring line checking.