### PR TITLE
Provide Next.js postcss version to cssnano-simple

### DIFF
--- a/packages/next/build/webpack/plugins/css-minimizer-plugin.ts
+++ b/packages/next/build/webpack/plugins/css-minimizer-plugin.ts
@@ -48,7 +48,7 @@ export class CssMinimizerPlugin {
       input = asset.source()
     }
 
-    return postcss([cssnanoSimple])
+    return postcss([cssnanoSimple({}, postcss)])
       .process(input, postcssOptions)
       .then((res) => {
         if (res.map) {

--- a/packages/next/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
+++ b/packages/next/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
@@ -18,11 +18,14 @@ import {
 
 function minifyCss(css: string): Promise<string> {
   return postcss([
-    minifier({
-      excludeAll: true,
-      discardComments: true,
-      normalizeWhitespace: { exclude: false },
-    }),
+    minifier(
+      {
+        excludeAll: true,
+        discardComments: true,
+        normalizeWhitespace: { exclude: false },
+      },
+      postcss
+    ),
   ])
     .process(css, { from: undefined })
     .then((res) => res.css)

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -79,7 +79,7 @@
     "chokidar": "3.5.1",
     "constants-browserify": "1.0.0",
     "crypto-browserify": "3.12.0",
-    "cssnano-simple": "2.0.0",
+    "cssnano-simple": "2.1.0",
     "domain-browser": "4.19.0",
     "encoding": "0.1.13",
     "etag": "1.8.1",

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -3,8 +3,7 @@ declare module 'next/dist/compiled/babel/plugin-transform-modules-commonjs'
 declare module 'next/dist/compiled/babel/plugin-syntax-jsx'
 declare module 'browserslist'
 declare module 'cssnano-simple' {
-  import { OldPlugin } from 'postcss'
-  const cssnanoSimple: OldPlugin<{}>
+  const cssnanoSimple: any
   export = cssnanoSimple
 }
 declare module 'styled-jsx/server'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7284,10 +7284,10 @@ cssnano-simple@1.2.1:
     cssnano-preset-simple "1.2.1"
     postcss "^7.0.32"
 
-cssnano-simple@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cssnano-simple/-/cssnano-simple-2.0.0.tgz#930d9dcd8ba105c5a62ce719cb00854da58b5c05"
-  integrity sha512-0G3TXaFxlh/szPEG/o3VcmCwl0N3E60XNb9YZZijew5eIs6fLjJuOPxQd9yEBaX2p/YfJtt49i4vYi38iH6/6w==
+cssnano-simple@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cssnano-simple/-/cssnano-simple-2.1.0.tgz#747a110ceff616ba2e883e2cb64666f0a87acd8b"
+  integrity sha512-iFisFT39FT1YCw7ydvvRH4Yq0ftVBQGfGXuKv8TJ9WOzmPXaw7MZbxBzFQoeJUVCp+fGf6tvwaQqSigw4tvn7w==
   dependencies:
     cssnano-preset-simple "^2.0.0"
 


### PR DESCRIPTION
This ensures the correct version of postcss is always used even when npm does not resolve peerdeps correctly.

Depends on https://github.com/Timer/cssnano-simple/pull/16

Fixes #24882

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
