### PR TITLE
Fix forward slash encoding while interpolating

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -249,14 +249,17 @@ export function getUtils({
         let paramValue: string
 
         if (Array.isArray(params[param])) {
-          paramValue = (params[param] as string[]).join('/')
+          paramValue = (params[param] as string[])
+            .map((v) => v && encodeURIComponent(v))
+            .join('/')
         } else {
-          paramValue = params[param] as string
+          paramValue =
+            params[param] && encodeURIComponent(params[param] as string)
         }
 
         pathname =
           pathname.substr(0, paramIdx) +
-          encodeURI(paramValue || '') +
+          (paramValue || '') +
           pathname.substr(paramIdx + builtParam.length)
       }
     }

--- a/test/integration/required-server-files/test/index.test.js
+++ b/test/integration/required-server-files/test/index.test.js
@@ -516,6 +516,28 @@ describe('Required Server Files', () => {
     expect(props.params).toEqual({})
   })
 
+  it('should normalize optional values correctly for SSG page with encoded slash', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/optional-ssg/[[...rest]]',
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/optional-ssg/[[...rest]]',
+          'x-now-route-matches':
+            '1=en%2Fes%2Fhello%252Fworld&rest=en%2Fes%2Fhello%252Fworld',
+        },
+      }
+    )
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    const props = JSON.parse($('#props').text())
+    expect(props.params).toEqual({
+      rest: ['en', 'es', 'hello/world'],
+    })
+  })
+
   it('should normalize optional values correctly for API page', async () => {
     const res = await fetchViaHTTP(
       appPort,


### PR DESCRIPTION
This ensures we encode `/` to `%2F` properly while interpolating dynamic route params into a path since previously we were using `encodeURI` on the resulting string which doesn't encode `/` since it is a valid path value.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/24775