### PR TITLE
Loosen `next/image` TS types for `width` and `height`

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -84,21 +84,16 @@ function isStaticImport(src: string | StaticImport): src is StaticImport {
 
 type StringImageProps = {
   src: string
+  width?: number | string
+  height?: number | string
+  layout?: LayoutValue
 } & (
-  | { width?: never; height?: never; layout: 'fill' }
   | {
-      width: number | string
-      height: number | string
-      layout?: Exclude<LayoutValue, 'fill'>
+      placeholder?: Exclude<PlaceholderValue, 'blur'>
+      blurDataURL?: never
     }
-) &
-  (
-    | {
-        placeholder?: Exclude<PlaceholderValue, 'blur'>
-        blurDataURL?: never
-      }
-    | { placeholder: 'blur'; blurDataURL: string }
-  )
+  | { placeholder: 'blur'; blurDataURL: string }
+)
 
 type ObjectImageProps = {
   src: StaticImport
@@ -375,6 +370,11 @@ export default function Image({
     ) {
       throw new Error(
         `Image with src "${src}" has invalid "width" or "height" property. These should be numeric values.`
+      )
+    }
+    if (layout === 'fill' && (width || height)) {
+      console.warn(
+        `Image with src "${src}" and "layout='fill'" has unused properties assigned. Please remove "width" and "height".`
       )
     }
     if (!VALID_LOADING_VALUES.includes(loading)) {

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -465,10 +465,24 @@ export default function Image({
         }
       : undefined),
   }
-  if (
+  if (layout === 'fill') {
+    // <Image src="i.png" layout="fill" />
+    wrapperStyle = {
+      display: 'block',
+      overflow: 'hidden',
+
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+
+      boxSizing: 'border-box',
+      margin: 0,
+    }
+  } else if (
     typeof widthInt !== 'undefined' &&
-    typeof heightInt !== 'undefined' &&
-    layout !== 'fill'
+    typeof heightInt !== 'undefined'
   ) {
     // <Image src="i.png" width="100" height="100" />
     const quotient = heightInt / widthInt
@@ -510,25 +524,6 @@ export default function Image({
         width: widthInt,
         height: heightInt,
       }
-    }
-  } else if (
-    typeof widthInt === 'undefined' &&
-    typeof heightInt === 'undefined' &&
-    layout === 'fill'
-  ) {
-    // <Image src="i.png" layout="fill" />
-    wrapperStyle = {
-      display: 'block',
-      overflow: 'hidden',
-
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      bottom: 0,
-      right: 0,
-
-      boxSizing: 'border-box',
-      margin: 0,
     }
   } else {
     // <Image src="i.png" />

--- a/test/integration/image-component/typescript/components/image-card.tsx
+++ b/test/integration/image-component/typescript/components/image-card.tsx
@@ -10,5 +10,5 @@ type ImageCardProps = ImageProps & {
  * Example of using the `Image` component in a HOC.
  */
 export function ImageCard(props: ImageCardProps) {
-  return <Image layout="fill" {...props} />
+  return <Image {...props} layout="fill" />
 }

--- a/test/integration/image-component/typescript/components/image-card.tsx
+++ b/test/integration/image-component/typescript/components/image-card.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import Image, { ImageProps } from 'next/image'
+
+type ImageCardProps = ImageProps & {
+  id: string
+  optional?: string
+}
+
+/**
+ * Example of using the `Image` component in a HOC.
+ */
+export function ImageCard(props: ImageCardProps) {
+  return <Image layout="fill" {...props} />
+}

--- a/test/integration/image-component/typescript/pages/invalid.tsx
+++ b/test/integration/image-component/typescript/pages/invalid.tsx
@@ -6,10 +6,6 @@ const Invalid = () => {
     <div>
       <h1>Invalid TS</h1>
       <Image
-        id="no-width-or-height"
-        src="https://via.placeholder.com/500"
-      ></Image>
-      <Image
         id="no-blur-data-url"
         src="https://via.placeholder.com/500"
         width={500}

--- a/test/integration/image-component/typescript/pages/valid.tsx
+++ b/test/integration/image-component/typescript/pages/valid.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import testTall from '../public/tall.png'
 import svg from '../public/test.svg'
+import { ImageCard } from '../components/image-card'
 
 const Page = () => {
   return (
@@ -75,6 +76,14 @@ const Page = () => {
         placeholder="blur"
       />
       <Image id="object-src-with-svg" src={svg} />
+      <Image
+        id="fill-with-unused-width-height"
+        src="https://via.placeholder.com/200"
+        layout="fill"
+        width={100}
+        height={100}
+      />
+      <ImageCard id="image-card" src="https://via.placeholder.com/200" />
       <p id="stubtext">This is valid usage of the Image component</p>
     </div>
   )

--- a/test/integration/image-component/typescript/pages/valid.tsx
+++ b/test/integration/image-component/typescript/pages/valid.tsx
@@ -83,7 +83,7 @@ const Page = () => {
         width={100}
         height={100}
       />
-      <ImageCard id="image-card" src="https://via.placeholder.com/200" />
+      <ImageCard id="image-card" src="https://via.placeholder.com/300" />
       <p id="stubtext">This is valid usage of the Image component</p>
     </div>
   )

--- a/test/integration/image-component/typescript/test/index.test.js
+++ b/test/integration/image-component/typescript/test/index.test.js
@@ -73,9 +73,7 @@ describe('TypeScript Image Component', () => {
 
     it('should print error when invalid Image usage', async () => {
       await renderViaHTTP(appPort, '/invalid', {})
-      expect(output).toMatch(
-        /must use "width" and "height" properties or "layout='fill'" property/
-      )
+      expect(output).toMatch(/Error: Image/)
     })
   })
 

--- a/test/integration/image-component/typescript/test/index.test.js
+++ b/test/integration/image-component/typescript/test/index.test.js
@@ -74,6 +74,9 @@ describe('TypeScript Image Component', () => {
     it('should print error when invalid Image usage', async () => {
       await renderViaHTTP(appPort, '/invalid', {})
       expect(output).toMatch(/Error: Image/)
+      expect(output).toMatch(
+        /has "placeholder='blur'" property but is missing the "blurDataURL" property/
+      )
     })
   })
 


### PR DESCRIPTION
### Description
This changes the strict TS types to a looser implementation such that the user can always pass `width` and `height` (even when `layout=fill`) without TS errors.

### Pros vs Cons
- **Pros**: better support for wrapping `next/image` so that TS won't report false errors with `layout=fill`
- **Cons**: omitting width/height when using other `layout` will no longer show TS errors and instead fail with a runtime error

### Issues
- Fixes #26531 
- Fixes #25440 