### PR TITLE
Rename next/image `dangerously-unoptimized` to `custom` and warn when applicable

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -121,7 +121,8 @@ The following Image Optimization cloud providers are included:
 - [Imgix](https://www.imgix.com): `loader: 'imgix'`
 - [Cloudinary](https://cloudinary.com): `loader: 'cloudinary'`
 - [Akamai](https://www.akamai.com): `loader: 'akamai'`
-- dangerously-unoptimized: uses image directly from `src` prop without optimization (only needed with `next export` or when the built-in `_next/image` optimizer can not be leveraged) `loader: 'dangerously-unoptimized'`
+- Custom: `loader: 'custom'` use a custom cloud provider by implementing the [`loader`](/docs/api-reference/next/image.md#loader) prop on the `next/image` component
+- Dangerously Unoptimized: `loader: 'dangerously-unoptimized'` uses image directly from `src` prop without optimization
 - Default: Works automatically with `next dev`, `next start`, or a custom server
 
 If you need a different provider, you can use the [`loader`](/docs/api-reference/next/image.md#loader) prop with `next/image`.

--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -122,7 +122,6 @@ The following Image Optimization cloud providers are included:
 - [Cloudinary](https://cloudinary.com): `loader: 'cloudinary'`
 - [Akamai](https://www.akamai.com): `loader: 'akamai'`
 - Custom: `loader: 'custom'` use a custom cloud provider by implementing the [`loader`](/docs/api-reference/next/image.md#loader) prop on the `next/image` component
-- Dangerously Unoptimized: `loader: 'dangerously-unoptimized'` uses image directly from `src` prop without optimization
 - Default: Works automatically with `next dev`, `next start`, or a custom server
 
 If you need a different provider, you can use the [`loader`](/docs/api-reference/next/image.md#loader) prop with `next/image`.

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -250,11 +250,11 @@
           "path": "/errors/next-head-count-missing.md"
         },
         {
-          "title": "next-image-missing-loader.md",
+          "title": "next-image-missing-loader",
           "path": "/errors/next-image-missing-loader.md"
         },
         {
-          "title": "next-image-missing-loader-width.md",
+          "title": "next-image-missing-loader-width",
           "path": "/errors/next-image-missing-loader-width.md"
         },
         {

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -250,6 +250,14 @@
           "path": "/errors/next-head-count-missing.md"
         },
         {
+          "title": "next-image-missing-loader.md",
+          "path": "/errors/next-image-missing-loader.md"
+        },
+        {
+          "title": "next-image-missing-loader-width.md",
+          "path": "/errors/next-image-missing-loader-width.md"
+        },
+        {
           "title": "next-image-unconfigured-host",
           "path": "/errors/next-image-unconfigured-host.md"
         },

--- a/errors/next-image-missing-loader-width.md
+++ b/errors/next-image-missing-loader-width.md
@@ -1,0 +1,17 @@
+# Missing `width` in the URL Returned by the Loader Prop on `next/image`
+
+#### Why This Error Occurred
+
+The [`loader`](https://nextjs.org/docs/api-reference/next/image#loader) prop on the `next/image` component allows you to override the built-in URL resolution with a custom implementation in order to support any 3rd party cloud provider that can perform Image Optimization.
+
+This error occurred because the provided `loader()` function did not use `width` in the returned URL string. This means that the image will likely not be resized and therefore degrade performance.
+
+#### Possible Ways to Fix It
+
+- Ensure your Image Optimization provider can resize images. Then use the `width` parameter from the [`loader()`](https://nextjs.org/docs/api-reference/next/image#loader) function to construct the correct URL string.
+- Add the [`unoptimized`](https://nextjs.org/docs/api-reference/next/image#unoptimized) prop.
+
+### Useful Links
+
+- [Image Optimization Documentation](https://nextjs.org/docs/basic-features/image-optimization)
+- [`next/image` Documentation](https://nextjs.org/docs/api-reference/next/image)

--- a/errors/next-image-missing-loader.md
+++ b/errors/next-image-missing-loader.md
@@ -1,0 +1,15 @@
+# Missing `loader` Prop on `next/image`
+
+#### Why This Error Occurred
+
+When using the `next/image` component with [`loader="custom"`](https://nextjs.org/docs/basic-features/image-optimization#loader) in `next.config.js`, you must provide the [`loader`](https://nextjs.org/docs/api-reference/next/image#loader) prop to the component with your custom implementation.
+
+#### Possible Ways to Fix It
+
+- Add the [`loader`](https://nextjs.org/docs/api-reference/next/image#loader) prop to all usages of the `next/image` component.
+- Change the [`loader`](https://nextjs.org/docs/basic-features/image-optimization#loader) configuration in `next.config.js`.
+
+### Useful Links
+
+- [Image Optimization Documentation](https://nextjs.org/docs/basic-features/image-optimization)
+- [`next/image` Documentation](https://nextjs.org/docs/api-reference/next/image)

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -404,6 +404,13 @@ export default function Image({
         `Image with src "${src}" is using unsupported "ref" property. Consider using the "onLoadingComplete" property instead.`
       )
     }
+    const rand = Math.floor(Math.random() * 1000) + 100
+    const url = loader({ src, width: rand, quality: 75 })
+    if (!url.includes(rand.toString()) && !unoptimized) {
+      console.warn(
+        `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.`
+      )
+    }
   }
   let isLazy =
     !priority && (loading === 'lazy' || typeof loading === 'undefined')

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -421,7 +421,8 @@ export default function Image({
       !loader({ src, width: rand, quality: 75 }).includes(rand.toString())
     ) {
       console.warn(
-        `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.`
+        `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.` +
+          `\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader-width`
       )
     }
   }
@@ -678,7 +679,10 @@ function cloudinaryLoader({
 }
 
 function customLoader({ src }: DefaultImageLoaderProps): string {
-  throw new Error(`Image with src "${src}" is missing "loader" prop.`)
+  throw new Error(
+    `Image with src "${src}" is missing "loader" prop.` +
+      `\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader`
+  )
 }
 
 function defaultLoader({

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -37,7 +37,6 @@ const loaders = new Map<
   ['cloudinary', cloudinaryLoader],
   ['akamai', akamaiLoader],
   ['custom', customLoader],
-  ['dangerously-unoptimized', unoptimizedLoader],
 ])
 
 const VALID_LAYOUT_VALUES = [
@@ -666,10 +665,6 @@ function cloudinaryLoader({
   const params = ['f_auto', 'c_limit', 'w_' + width, 'q_' + (quality || 'auto')]
   let paramsString = params.join(',') + '/'
   return `${root}${paramsString}${normalizeSrc(src)}`
-}
-
-function unoptimizedLoader({ src }: DefaultImageLoaderProps): string {
-  return src
 }
 
 function customLoader(_: DefaultImageLoaderProps): string {

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -338,6 +338,17 @@ export default function Image({
   const heightInt = getInt(height)
   const qualityInt = getInt(quality)
 
+  let isLazy =
+    !priority && (loading === 'lazy' || typeof loading === 'undefined')
+  if (src.startsWith('data:')) {
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+    unoptimized = true
+    isLazy = false
+  }
+  if (typeof window !== 'undefined' && loadedImageURLs.has(src)) {
+    isLazy = false
+  }
+
   if (process.env.NODE_ENV !== 'production') {
     if (!src) {
       throw new Error(
@@ -405,22 +416,14 @@ export default function Image({
       )
     }
     const rand = Math.floor(Math.random() * 1000) + 100
-    const url = loader({ src, width: rand, quality: 75 })
-    if (!url.includes(rand.toString()) && !unoptimized) {
+    if (
+      !unoptimized &&
+      !loader({ src, width: rand, quality: 75 }).includes(rand.toString())
+    ) {
       console.warn(
         `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.`
       )
     }
-  }
-  let isLazy =
-    !priority && (loading === 'lazy' || typeof loading === 'undefined')
-  if (src && src.startsWith('data:')) {
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
-    unoptimized = true
-    isLazy = false
-  }
-  if (src && typeof window !== 'undefined' && loadedImageURLs.has(src)) {
-    isLazy = false
   }
 
   const [setRef, isIntersected] = useIntersection<HTMLImageElement>({

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -32,10 +32,11 @@ const loaders = new Map<
   LoaderValue,
   (props: DefaultImageLoaderProps) => string
 >([
+  ['default', defaultLoader],
   ['imgix', imgixLoader],
   ['cloudinary', cloudinaryLoader],
   ['akamai', akamaiLoader],
-  ['default', defaultLoader],
+  ['custom', customLoader],
   ['dangerously-unoptimized', unoptimizedLoader],
 ])
 
@@ -626,8 +627,6 @@ export default function Image({
   )
 }
 
-//BUILT IN LOADERS
-
 function normalizeSrc(src: string): string {
   return src[0] === '/' ? src.slice(1) : src
 }
@@ -671,6 +670,10 @@ function cloudinaryLoader({
 
 function unoptimizedLoader({ src }: DefaultImageLoaderProps): string {
   return src
+}
+
+function customLoader(_: DefaultImageLoaderProps): string {
+  throw new Error('Expected `loader` prop on `next/image` component')
 }
 
 function defaultLoader({

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -667,8 +667,8 @@ function cloudinaryLoader({
   return `${root}${paramsString}${normalizeSrc(src)}`
 }
 
-function customLoader(_: DefaultImageLoaderProps): string {
-  throw new Error('Expected `loader` prop on `next/image` component')
+function customLoader({ src }: DefaultImageLoaderProps): string {
+  throw new Error(`Image with src "${src}" is missing "loader" prop.`)
 }
 
 function defaultLoader({

--- a/packages/next/server/image-config.ts
+++ b/packages/next/server/image-config.ts
@@ -4,6 +4,7 @@ export const VALID_LOADERS = [
   'cloudinary',
   'akamai',
   'dangerously-unoptimized',
+  'custom',
 ] as const
 
 export type LoaderValue = typeof VALID_LOADERS[number]

--- a/packages/next/server/image-config.ts
+++ b/packages/next/server/image-config.ts
@@ -3,8 +3,8 @@ export const VALID_LOADERS = [
   'imgix',
   'cloudinary',
   'akamai',
-  'dangerously-unoptimized',
   'custom',
+  'dangerously-unoptimized',
 ] as const
 
 export type LoaderValue = typeof VALID_LOADERS[number]

--- a/packages/next/server/image-config.ts
+++ b/packages/next/server/image-config.ts
@@ -4,7 +4,6 @@ export const VALID_LOADERS = [
   'cloudinary',
   'akamai',
   'custom',
-  'dangerously-unoptimized',
 ] as const
 
 export type LoaderValue = typeof VALID_LOADERS[number]

--- a/test/integration/export-image-loader/pages/index.js
+++ b/test/integration/export-image-loader/pages/index.js
@@ -1,8 +1,10 @@
 import Image from 'next/image'
 
+const loader = undefined
+
 export default () => (
   <div>
     <p>Should succeed during export</p>
-    <Image alt="icon" src="/i.png" width="10" height="10" />
+    <Image alt="icon" src="/i.png" width="10" height="10" loader={loader} />
   </div>
 )

--- a/test/integration/export-image-loader/test/index.test.js
+++ b/test/integration/export-image-loader/test/index.test.js
@@ -45,39 +45,6 @@ describe('Export with cloudinary loader next/image component', () => {
   })
 })
 
-describe('Export with dangerously-unoptimized loader next/image component', () => {
-  beforeAll(async () => {
-    await nextConfig.replace(
-      '{ /* replaceme */ }',
-      JSON.stringify({
-        images: {
-          loader: 'dangerously-unoptimized',
-        },
-      })
-    )
-  })
-  it('should build successfully', async () => {
-    await fs.remove(join(appDir, '.next'))
-    const { code } = await nextBuild(appDir)
-    if (code !== 0) throw new Error(`build failed with status ${code}`)
-  })
-
-  it('should export successfully', async () => {
-    const { code } = await nextExport(appDir, { outdir })
-    if (code !== 0) throw new Error(`export failed with status ${code}`)
-  })
-
-  it('should contain img element with same src in html output', async () => {
-    const html = await fs.readFile(join(outdir, 'index.html'))
-    const $ = cheerio.load(html)
-    expect($('img[alt="icon"]').attr('src')).toBe('/i.png')
-  })
-
-  afterAll(async () => {
-    await nextConfig.restore()
-  })
-})
-
 describe('Export with custom loader next/image component', () => {
   beforeAll(async () => {
     await nextConfig.replace(

--- a/test/integration/export-image-loader/test/index.test.js
+++ b/test/integration/export-image-loader/test/index.test.js
@@ -90,7 +90,7 @@ describe('Export with custom loader next/image component', () => {
     )
     await pagesIndexJs.replace(
       'loader = undefined',
-      '({src}) => "custom-" + src '
+      'loader = ({src}) => "/custom" + src'
     )
   })
   it('should build successfully', async () => {
@@ -107,7 +107,7 @@ describe('Export with custom loader next/image component', () => {
   it('should contain img element with same src in html output', async () => {
     const html = await fs.readFile(join(outdir, 'index.html'))
     const $ = cheerio.load(html)
-    expect($('img[alt="icon"]').attr('src')).toBe('/custom-i.png')
+    expect($('img[alt="icon"]').attr('src')).toBe('/custom/i.png')
   })
 
   afterAll(async () => {

--- a/test/integration/export-image-loader/test/index.test.js
+++ b/test/integration/export-image-loader/test/index.test.js
@@ -9,6 +9,7 @@ jest.setTimeout(1000 * 60 * 5)
 const appDir = join(__dirname, '../')
 const outdir = join(appDir, 'out')
 const nextConfig = new File(join(appDir, 'next.config.js'))
+const pagesIndexJs = new File(join(appDir, 'pages', 'index.js'))
 
 describe('Export with cloudinary loader next/image component', () => {
   beforeAll(async () => {
@@ -74,5 +75,43 @@ describe('Export with dangerously-unoptimized loader next/image component', () =
 
   afterAll(async () => {
     await nextConfig.restore()
+  })
+})
+
+describe('Export with custom loader next/image component', () => {
+  beforeAll(async () => {
+    await nextConfig.replace(
+      '{ /* replaceme */ }',
+      JSON.stringify({
+        images: {
+          loader: 'custom',
+        },
+      })
+    )
+    await pagesIndexJs.replace(
+      'loader = undefined',
+      '({src}) => "custom-" + src '
+    )
+  })
+  it('should build successfully', async () => {
+    await fs.remove(join(appDir, '.next'))
+    const { code } = await nextBuild(appDir)
+    if (code !== 0) throw new Error(`build failed with status ${code}`)
+  })
+
+  it('should export successfully', async () => {
+    const { code } = await nextExport(appDir, { outdir })
+    if (code !== 0) throw new Error(`export failed with status ${code}`)
+  })
+
+  it('should contain img element with same src in html output', async () => {
+    const html = await fs.readFile(join(outdir, 'index.html'))
+    const $ = cheerio.load(html)
+    expect($('img[alt="icon"]').attr('src')).toBe('/custom-i.png')
+  })
+
+  afterAll(async () => {
+    await nextConfig.restore()
+    await pagesIndexJs.restore()
   })
 })

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -757,8 +757,8 @@ describe('Image Optimizer', () => {
       await renderViaHTTP(appPort, '/', {})
       await killApp(app).catch(() => {})
       await nextConfig.restore()
-      expect(output).toContain(
-        'Error: Expected `loader` prop on `next/image` component'
+      expect(output).toMatch(
+        /Error: Image with src "(.+)" is missing "loader" prop/
       )
     })
   })

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -730,7 +730,7 @@ describe('Image Optimizer', () => {
       await nextConfig.restore()
 
       expect(stderr).toContain(
-        'Specified images.loader should be one of (default, imgix, cloudinary, akamai, dangerously-unoptimized), received invalid value (notreal)'
+        'Specified images.loader should be one of (default, imgix, cloudinary, akamai, custom, dangerously-unoptimized), received invalid value (notreal)'
       )
     })
   })

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -9,6 +9,7 @@ import {
   launchApp,
   nextBuild,
   nextStart,
+  renderViaHTTP,
   waitFor,
 } from 'next-test-utils'
 import isAnimated from 'next/dist/compiled/is-animated'
@@ -731,6 +732,33 @@ describe('Image Optimizer', () => {
 
       expect(stderr).toContain(
         'Specified images.loader should be one of (default, imgix, cloudinary, akamai, custom, dangerously-unoptimized), received invalid value (notreal)'
+      )
+    })
+
+    it('should error when loader=custom but loader prop is undefined', async () => {
+      await nextConfig.replace(
+        '{ /* replaceme */ }',
+        JSON.stringify({
+          images: {
+            loader: 'custom',
+          },
+        })
+      )
+      let output = ''
+      const appPort = await findPort()
+      app = await launchApp(appDir, appPort, {
+        onStderr(msg) {
+          output += msg || ''
+        },
+        onStdout(msg) {
+          output += msg || ''
+        },
+      })
+      await renderViaHTTP(appPort, '/', {})
+      await killApp(app).catch(() => {})
+      await nextConfig.restore()
+      expect(output).toContain(
+        'Error: Expected `loader` prop on `next/image` component'
       )
     })
   })

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -731,7 +731,7 @@ describe('Image Optimizer', () => {
       await nextConfig.restore()
 
       expect(stderr).toContain(
-        'Specified images.loader should be one of (default, imgix, cloudinary, akamai, custom, dangerously-unoptimized), received invalid value (notreal)'
+        'Specified images.loader should be one of (default, imgix, cloudinary, akamai, custom), received invalid value (notreal)'
       )
     })
 


### PR DESCRIPTION
Since we are no longer accepting new built-in loaders, users may wish to use a different cloud provider.

So this PR renames `dangerously-unoptimized` to `custom` to handle this case as well as the intention of `next export`.

If the user doesn't add a `loader` prop, we throw an error.
If the user adds a `loader` prop but it doesn't return the width, we print a warning.

- Follow up to #26847 
- Fixes #21079 
- Fixes #19612 
- Related to #26850 