### PR TITLE
Update dependencies of all CMS examples.

### DIFF
--- a/examples/cms-agilitycms/components/avatar.js
+++ b/examples/cms-agilitycms/components/avatar.js
@@ -1,11 +1,16 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={picture.url}
-        className="w-12 h-12 rounded-full mr-4"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={picture.url}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-agilitycms/components/cover-image.js
+++ b/examples/cms-agilitycms/components/cover-image.js
@@ -1,4 +1,3 @@
-//import { Image } from 'react-datocms'
 import Image from '../lib/components/image'
 import cn from 'classnames'
 import Link from 'next/link'
@@ -17,7 +16,7 @@ export default function CoverImage({ title, responsiveImage, slug }) {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link href="/[...slug]" as={`/posts/${slug}`}>
+        <Link href={`/posts/${slug}`}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-agilitycms/components/hero-post.js
+++ b/examples/cms-agilitycms/components/hero-post.js
@@ -23,7 +23,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link href="/[...slug]" as={`/posts/${slug}`}>
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-agilitycms/components/post-preview.js
+++ b/examples/cms-agilitycms/components/post-preview.js
@@ -21,7 +21,7 @@ export default function PostPreview({
         />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link href="/[...slug]" as={`/posts/${slug}`}>
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-agilitycms/lib/components/image.js
+++ b/examples/cms-agilitycms/lib/components/image.js
@@ -1,39 +1,5 @@
 import React, { useCallback, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
-//  type ResponsiveImageType = {
-//   aspectRatio: number;
-//   base64?: string | null;
-//   height?: number | null;
-//   width: number;
-//   sizes?: string | null;
-//   src?: string | null;
-//   srcSet?: string | null;
-//   webpSrcSet?: string | null;
-//   bgColor?: string | null;
-//   alt?: string | null;
-//   title?: string | null;
-// };
-
-// type ImagePropTypes = {
-//   data: ResponsiveImageType;
-//   className?: string;
-//   pictureClassName?: string;
-//   fadeInDuration?: number;
-//   intersectionTreshold?: number;
-//   intersectionMargin?: string;
-//   lazyLoad?: boolean;
-//   style?: React.CSSProperties;
-//   pictureStyle?: React.CSSProperties;
-//   explicitWidth?: boolean;
-// };
-
-// type State = {
-//   lazyLoad: boolean;
-//   isSsr: boolean;
-//   isIntersectionObserverAvailable: boolean;
-//   inView: boolean;
-//   loaded: boolean;
-// };
 
 const imageAddStrategy = ({
   lazyLoad,

--- a/examples/cms-agilitycms/package.json
+++ b/examples/cms-agilitycms/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@agility/content-fetch": "^0.8.1",
-    "classnames": "2.2.6",
-    "date-fns": "2.10.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "latest",
     "react": "^17.0.2",
@@ -20,9 +20,9 @@
     "remark-html": "10.0.0"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^2.1.0",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.2.0"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-agilitycms/postcss.config.js
+++ b/examples/cms-agilitycms/postcss.config.js
@@ -1,19 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    process.env.NODE_ENV === 'production'
-      ? [
-          '@fullhuman/postcss-purgecss',
-          {
-            content: [
-              './pages/**/*.{js,jsx,ts,tsx}',
-              './components/**/*.{js,jsx,ts,tsx}',
-            ],
-            defaultExtractor: (content) =>
-              content.match(/[\w-/:]+(?<!:)/g) || [],
-          },
-        ]
-      : undefined,
-    'postcss-preset-env',
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-agilitycms/tailwind.config.js
+++ b/examples/cms-agilitycms/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -29,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-buttercms/components/avatar.js
+++ b/examples/cms-buttercms/components/avatar.js
@@ -1,11 +1,16 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={picture}
-        className="w-12 h-12 rounded-full mr-4 grayscale"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={picture}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-buttercms/components/cover-image.js
+++ b/examples/cms-buttercms/components/cover-image.js
@@ -1,16 +1,28 @@
+import Image from 'next/image'
 import Link from 'next/link'
+import cn from 'classnames'
 
 export default function CoverImage({ title, url, slug }) {
+  const image = (
+    <Image
+      width={2000}
+      height={1000}
+      alt={`Cover Image for ${title}`}
+      className={cn('shadow-small', {
+        'hover:shadow-medium transition-shadow duration-200': slug,
+      })}
+      src={url}
+    />
+  )
+
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
-          <a aria-label={title}>
-            <img src={url} alt={title} />
-          </a>
+        <Link href={`/posts/${slug}`}>
+          <a aria-label={title}>{image}</a>
         </Link>
       ) : (
-        <img src={url} alt={title} />
+        image
       )}
     </div>
   )

--- a/examples/cms-buttercms/components/hero-post.js
+++ b/examples/cms-buttercms/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-buttercms/components/post-preview.js
+++ b/examples/cms-buttercms/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} url={coverImage} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-buttercms/package.json
+++ b/examples/cms-buttercms/package.json
@@ -7,18 +7,17 @@
     "start": "next start"
   },
   "dependencies": {
-    "buttercms": "1.2.2",
-    "classnames": "2.2.6",
-    "date-fns": "2.14.0",
-    "isomorphic-unfetch": "3.0.0",
+    "buttercms": "1.2.7",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "4.2.1",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.4.6"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-buttercms/postcss.config.js
+++ b/examples/cms-buttercms/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-buttercms/tailwind.config.js
+++ b/examples/cms-buttercms/tailwind.config.js
@@ -1,11 +1,9 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
-      fontFamily: {
-        sans:
-          '-apple-system, "Helvetica Neue", "Segoe UI", Roboto, Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
-      },
       colors: {
         'accent-1': '#FAFAFA',
         'accent-2': '#EAEAEA',
@@ -34,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-contentful/README.md
+++ b/examples/cms-contentful/README.md
@@ -8,9 +8,9 @@ This example showcases Next.js's [Static Generation](https://nextjs.org/docs/bas
 
 ## Deploy your own
 
-Once you have access to [the environment variables you'll need](#step-5-set-up-environment-variables), deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
+Using the Deploy Button below, you'll deploy the Next.js project as well as connect it to your Contentful space using the Vercel Contentful Integration.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/cms-contentful&project-name=cms-contentful&repository-name=cms-contentful&env=CONTENTFUL_SPACE_ID,CONTENTFUL_ACCESS_TOKEN,CONTENTFUL_PREVIEW_ACCESS_TOKEN,CONTENTFUL_PREVIEW_SECRET&envDescription=Required%20to%20connect%20the%20app%20with%20Contentful&envLink=https://vercel.link/cms-contentful-env)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Ftree%2Fcanary%2Fexamples%2Fcms-contentful&project-name=nextjs-contentful-blog&repository-name=nextjs-contentful-blog&demo-title=Next.js+Blog&demo-description=Static+blog+with+multiple+authors+using+Preview+Mode&demo-url=https%3A%2F%2Fnext-blog-contentful.vercel.app%2F&demo-image=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Fv1625705016%2Ffront%2Fexamples%2FCleanShot_2021-07-07_at_19.43.15_2x.png&integration-ids=oac_aZtAZpDfT1lX3zrnWy7KT9VA&env=CONTENTFUL_PREVIEW_SECRET&envDescription=Any%20URL%20friendly%20value%20to%20secure%20Preview%20Mode)
 
 ### Related examples
 
@@ -237,4 +237,6 @@ To deploy your local project to Vercel, push it to GitHub/GitLab/Bitbucket and [
 
 Alternatively, you can deploy using our template by clicking on the Deploy button below.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/cms-contentful&project-name=cms-contentful&repository-name=cms-contentful&env=CONTENTFUL_SPACE_ID,CONTENTFUL_ACCESS_TOKEN,CONTENTFUL_PREVIEW_ACCESS_TOKEN,CONTENTFUL_PREVIEW_SECRET&envDescription=Required%20to%20connect%20the%20app%20with%20Contentful&envLink=https://vercel.link/cms-contentful-env)
+This will deploy the Next.js project as well as connect it to your Contentful space using the Vercel Contentful Integration. If you are using Preview Mode, make sure to add `CONTENTFUL_PREVIEW_SECRET` as an [Environment Variable](https://vercel.com/docs/environment-variables) as well.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Ftree%2Fcanary%2Fexamples%2Fcms-contentful&project-name=nextjs-contentful-blog&repository-name=nextjs-contentful-blog&demo-title=Next.js+Blog&demo-description=Static+blog+with+multiple+authors+using+Preview+Mode&demo-url=https%3A%2F%2Fnext-blog-contentful.vercel.app%2F&demo-image=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Fv1625705016%2Ffront%2Fexamples%2FCleanShot_2021-07-07_at_19.43.15_2x.png&integration-ids=oac_aZtAZpDfT1lX3zrnWy7KT9VA&env=CONTENTFUL_PREVIEW_SECRET&envDescription=Any%20URL%20friendly%20value%20to%20secure%20Preview%20Mode)

--- a/examples/cms-contentful/components/avatar.js
+++ b/examples/cms-contentful/components/avatar.js
@@ -5,7 +5,7 @@ export default function Avatar({ name, picture }) {
     <div className="flex items-center">
       <div className="w-12 h-12 relative mr-4">
         <Image
-          src={picture}
+          src={picture.url}
           layout="fill"
           className="rounded-full"
           alt={name}

--- a/examples/cms-contentful/components/avatar.js
+++ b/examples/cms-contentful/components/avatar.js
@@ -1,11 +1,16 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={picture.url}
-        className="w-12 h-12 rounded-full mr-4"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={picture}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-contentful/components/cover-image.js
+++ b/examples/cms-contentful/components/cover-image.js
@@ -1,20 +1,24 @@
-import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
+import cn from 'classnames'
 
 export default function CoverImage({ title, url, slug }) {
   const image = (
-    <img
-      src={url}
+    <Image
+      width={2000}
+      height={1000}
       alt={`Cover Image for ${title}`}
       className={cn('shadow-small', {
         'hover:shadow-medium transition-shadow duration-200': slug,
       })}
+      src={url}
     />
   )
+
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-contentful/components/post-preview.js
+++ b/examples/cms-contentful/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage title={title} slug={slug} url={coverImage.url} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-contentful/package.json
+++ b/examples/cms-contentful/package.json
@@ -9,17 +9,17 @@
   },
   "dependencies": {
     "@contentful/rich-text-react-renderer": "14.1.1",
-    "classnames": "2.2.6",
-    "date-fns": "2.14.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^2.3.0",
+    "autoprefixer": "10.2.6",
     "contentful-import": "^7.8.7",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.5.1"
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-contentful/postcss.config.js
+++ b/examples/cms-contentful/postcss.config.js
@@ -1,19 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    process.env.NODE_ENV === 'production'
-      ? [
-          '@fullhuman/postcss-purgecss',
-          {
-            content: [
-              './pages/**/*.{js,jsx,ts,tsx}',
-              './components/**/*.{js,jsx,ts,tsx}',
-            ],
-            defaultExtractor: (content) =>
-              content.match(/[\w-/:]+(?<!:)/g) || [],
-          },
-        ]
-      : undefined,
-    'postcss-preset-env',
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-contentful/tailwind.config.js
+++ b/examples/cms-contentful/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './components/**/*.css'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-cosmic/components/avatar.js
+++ b/examples/cms-cosmic/components/avatar.js
@@ -1,13 +1,18 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      {picture && (
-        <img
-          src={`${picture}?auto=format,compress,enhance&w=100&h=100`}
-          className="w-12 h-12 rounded-full mr-4"
-          alt={name}
-        />
-      )}
+      <div className="w-12 h-12 relative mr-4">
+        {picture && (
+          <Image
+            src={`${picture}?auto=format,compress,enhance&w=100&h=100`}
+            layout="fill"
+            className="rounded-full"
+            alt={name}
+          />
+        )}
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-cosmic/components/cover-image.js
+++ b/examples/cms-cosmic/components/cover-image.js
@@ -24,7 +24,7 @@ export default function CoverImage({ title, url, slug }) {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-cosmic/components/hero-post.js
+++ b/examples/cms-cosmic/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-cosmic/components/post-preview.js
+++ b/examples/cms-cosmic/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} url={coverImage.imgix_url} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-cosmic/package.json
+++ b/examples/cms-cosmic/package.json
@@ -7,22 +7,22 @@
     "start": "next start"
   },
   "dependencies": {
-    "classnames": "2.2.6",
+    "classnames": "2.3.1",
     "cosmicjs": "^3.2.43",
-    "date-fns": "2.14.0",
+    "date-fns": "2.22.1",
     "lazysizes": "^5.2.1-rc2",
     "next": "latest",
     "react": "^17.0.2",
-    "react-datocms": "1.2.4",
+    "react-datocms": "1.6.3",
     "react-dom": "^17.0.2",
     "react-imgix": "^9.0.2",
     "remark": "12.0.0",
     "remark-html": "11.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "4.2.1",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.4.6"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-cosmic/postcss.config.js
+++ b/examples/cms-cosmic/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-cosmic/tailwind.config.js
+++ b/examples/cms-cosmic/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-datocms/components/avatar.js
+++ b/examples/cms-datocms/components/avatar.js
@@ -1,11 +1,16 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={picture.url}
-        className="w-12 h-12 rounded-full mr-4"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={picture.url}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-datocms/components/cover-image.js
+++ b/examples/cms-datocms/components/cover-image.js
@@ -17,7 +17,7 @@ export default function CoverImage({ title, responsiveImage, slug }) {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-datocms/components/hero-post.js
+++ b/examples/cms-datocms/components/hero-post.js
@@ -23,7 +23,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-datocms/components/post-preview.js
+++ b/examples/cms-datocms/components/post-preview.js
@@ -21,7 +21,7 @@ export default function PostPreview({
         />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-datocms/package.json
+++ b/examples/cms-datocms/package.json
@@ -7,19 +7,19 @@
     "start": "next start"
   },
   "dependencies": {
-    "classnames": "2.2.6",
-    "date-fns": "2.14.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
     "react": "^17.0.2",
-    "react-datocms": "1.2.4",
+    "react-datocms": "1.6.3",
     "react-dom": "^17.0.2",
     "remark": "12.0.0",
     "remark-html": "11.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "4.2.1",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.4.6"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-datocms/postcss.config.js
+++ b/examples/cms-datocms/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-datocms/tailwind.config.js
+++ b/examples/cms-datocms/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-drupal/package.json
+++ b/examples/cms-drupal/package.json
@@ -8,18 +8,16 @@
   },
   "dependencies": {
     "classnames": "2.3.1",
-    "date-fns": "2.21.3",
+    "date-fns": "2.22.1",
     "next": "latest",
     "next-drupal": "latest",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "autoprefixer": "10.2.5",
-    "postcss": "8.2.15",
-    "postcss-flexbugs-fixes": "5.0.2",
-    "postcss-preset-env": "6.7.0",
-    "tailwindcss": "2.1.2"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-drupal/postcss.config.js
+++ b/examples/cms-drupal/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-drupal/tailwind.config.js
+++ b/examples/cms-drupal/tailwind.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   mode: 'jit',
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -31,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-ghost/components/avatar.js
+++ b/examples/cms-ghost/components/avatar.js
@@ -1,13 +1,18 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      {picture && (
-        <img
-          src={`${picture}?auto=format,compress,enhance&w=100&h=100`}
-          className="w-12 h-12 rounded-full mr-4"
-          alt={name}
-        />
-      )}
+      <div className="w-12 h-12 relative mr-4">
+        {picture && (
+          <Image
+            src={`${picture}?auto=format,compress,enhance&w=100&h=100`}
+            layout="fill"
+            className="rounded-full"
+            alt={name}
+          />
+        )}
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-ghost/components/hero-post.js
+++ b/examples/cms-ghost/components/hero-post.js
@@ -25,7 +25,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-ghost/package.json
+++ b/examples/cms-ghost/package.json
@@ -8,18 +8,17 @@
   },
   "dependencies": {
     "@tryghost/content-api": "^1.4.13",
-    "classnames": "2.2.6",
-    "date-fns": "2.16.1",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "lazysizes": "^5.3.0",
     "next": "latest",
-    "postcss": "^8.2.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "^5.0.2",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^2.0.2"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-ghost/postcss.config.js
+++ b/examples/cms-ghost/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-ghost/tailwind.config.js
+++ b/examples/cms-ghost/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-graphcms/components/hero-post.js
+++ b/examples/cms-graphcms/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="mb-20 md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl leading-tight lg:text-6xl">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-graphcms/components/post-preview.js
+++ b/examples/cms-graphcms/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} url={coverImage.url} />
       </div>
       <h3 className="mb-3 text-3xl leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-graphcms/package.json
+++ b/examples/cms-graphcms/package.json
@@ -7,18 +7,16 @@
     "start": "next start"
   },
   "dependencies": {
-    "autoprefixer": "10.1.0",
-    "classnames": "2.2.6",
-    "date-fns": "2.10.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
-    "postcss": "8.2.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "^5.0.2",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "2.0.2"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-graphcms/postcss.config.js
+++ b/examples/cms-graphcms/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-graphcms/tailwind.config.js
+++ b/examples/cms-graphcms/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-kontent/components/avatar.js
+++ b/examples/cms-kontent/components/avatar.js
@@ -1,7 +1,16 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img src={picture} className="w-12 h-12 rounded-full mr-4" alt={name} />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={picture}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-kontent/components/cover-image.js
+++ b/examples/cms-kontent/components/cover-image.js
@@ -1,20 +1,23 @@
 import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
 
 export default function CoverImage({ title, src, slug }) {
   const image = (
-    <img
-      src={src}
+    <Image
+      width={2000}
+      height={1000}
       alt={`Cover Image for ${title}`}
+      src={src}
       className={cn('shadow-small', {
         'hover:shadow-medium transition-shadow duration-200': slug,
       })}
     />
   )
   return (
-    <div className="-mx-5 sm:mx-0">
+    <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={slug}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-kontent/components/hero-post.js
+++ b/examples/cms-kontent/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-kontent/components/post-preview.js
+++ b/examples/cms-kontent/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} src={coverImage} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-kontent/package.json
+++ b/examples/cms-kontent/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@kentico/kontent-delivery": "^9.2.0",
-    "classnames": "2.2.6",
-    "date-fns": "2.10.0",
-    "gray-matter": "4.0.2",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
+    "gray-matter": "4.0.3",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -19,9 +19,9 @@
     "rxjs": "^6.6.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "^4.2.1",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.7.3"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-kontent/postcss.config.js
+++ b/examples/cms-kontent/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-kontent/tailwind.config.js
+++ b/examples/cms-kontent/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-prepr/components/cover-image.js
+++ b/examples/cms-prepr/components/cover-image.js
@@ -18,7 +18,7 @@ export default function CoverImage({ title, url, slug }) {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-prepr/components/hero-post.js
+++ b/examples/cms-prepr/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="mb-20 md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl leading-tight lg:text-6xl">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-prepr/components/post-preview.js
+++ b/examples/cms-prepr/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} url={coverImage} />
       </div>
       <h3 className="mb-3 text-3xl leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-prepr/package.json
+++ b/examples/cms-prepr/package.json
@@ -8,18 +8,16 @@
   },
   "dependencies": {
     "@preprio/nodejs-sdk": "^1.1.0",
-    "autoprefixer": "10.1.0",
-    "classnames": "2.2.6",
-    "date-fns": "2.10.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
-    "postcss": "8.2.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "^5.0.2",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "2.0.2"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-prepr/postcss.config.js
+++ b/examples/cms-prepr/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-prepr/tailwind.config.js
+++ b/examples/cms-prepr/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-prismic/components/avatar.js
+++ b/examples/cms-prismic/components/avatar.js
@@ -1,11 +1,16 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={picture.url}
-        className="w-12 h-12 rounded-full mr-4"
-        alt={name[0].text}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={picture}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-prismic/components/avatar.js
+++ b/examples/cms-prismic/components/avatar.js
@@ -5,10 +5,10 @@ export default function Avatar({ name, picture }) {
     <div className="flex items-center">
       <div className="w-12 h-12 relative mr-4">
         <Image
-          src={picture}
+          src={picture.url}
           layout="fill"
           className="rounded-full"
-          alt={name}
+          alt={name[0].text}
         />
       </div>
       <div className="text-xl font-bold">{name}</div>

--- a/examples/cms-prismic/components/cover-image.js
+++ b/examples/cms-prismic/components/cover-image.js
@@ -1,20 +1,24 @@
-import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
+import cn from 'classnames'
 
 export default function CoverImage({ title, url, slug }) {
   const image = (
-    <img
-      src={url}
+    <Image
+      width={2000}
+      height={1000}
       alt={`Cover Image for ${title}`}
       className={cn('shadow-small', {
         'hover:shadow-medium transition-shadow duration-200': slug,
       })}
+      src={url}
     />
   )
+
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-prismic/components/hero-post.js
+++ b/examples/cms-prismic/components/hero-post.js
@@ -24,7 +24,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">
                 <RichText render={title} />
               </a>

--- a/examples/cms-prismic/components/post-preview.js
+++ b/examples/cms-prismic/components/post-preview.js
@@ -22,7 +22,7 @@ export default function PostPreview({
         />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">
             <RichText render={title} />
           </a>

--- a/examples/cms-prismic/package.json
+++ b/examples/cms-prismic/package.json
@@ -7,18 +7,18 @@
     "start": "next start"
   },
   "dependencies": {
-    "classnames": "2.2.6",
-    "date-fns": "2.10.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
-    "prismic-javascript": "3.0.1",
-    "prismic-reactjs": "1.3.1",
+    "prismic-javascript": "3.0.2",
+    "prismic-reactjs": "1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^2.1.0",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.2.0"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-prismic/postcss.config.js
+++ b/examples/cms-prismic/postcss.config.js
@@ -1,19 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    process.env.NODE_ENV === 'production'
-      ? [
-          '@fullhuman/postcss-purgecss',
-          {
-            content: [
-              './pages/**/*.{js,jsx,ts,tsx}',
-              './components/**/*.{js,jsx,ts,tsx}',
-            ],
-            defaultExtractor: (content) =>
-              content.match(/[\w-/:]+(?<!:)/g) || [],
-          },
-        ]
-      : undefined,
-    'postcss-preset-env',
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-prismic/tailwind.config.js
+++ b/examples/cms-prismic/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -29,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-sanity/components/avatar.js
+++ b/examples/cms-sanity/components/avatar.js
@@ -1,13 +1,17 @@
+import Image from 'next/image'
 import { urlForImage } from '../lib/sanity'
 
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={urlForImage(picture).height(96).width(96).fit('crop').url()}
-        className="w-12 h-12 rounded-full mr-4"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={urlForImage(picture).height(96).width(96).fit('crop').url()}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-sanity/components/cover-image.js
+++ b/examples/cms-sanity/components/cover-image.js
@@ -1,17 +1,18 @@
 import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
 import { urlForImage } from '../lib/sanity'
 
 export default function CoverImage({ title, slug, image: source }) {
   const image = source ? (
-    <img
+    <Image
       width={2000}
       height={1000}
       alt={`Cover Image for ${title}`}
+      src={urlForImage(source).height(1000).width(2000).url()}
       className={cn('shadow-small', {
         'hover:shadow-medium transition-shadow duration-200': slug,
       })}
-      src={urlForImage(source).height(1000).width(2000).url()}
     />
   ) : (
     <div style={{ paddingTop: '50%', backgroundColor: '#ddd' }} />
@@ -20,7 +21,7 @@ export default function CoverImage({ title, slug, image: source }) {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={slug}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-sanity/components/hero-post.js
+++ b/examples/cms-sanity/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-sanity/components/post-preview.js
+++ b/examples/cms-sanity/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} image={coverImage} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-sanity/package.json
+++ b/examples/cms-sanity/package.json
@@ -8,17 +8,17 @@
   },
   "dependencies": {
     "@sanity/block-content-to-react": "2.0.7",
-    "classnames": "2.2.6",
-    "date-fns": "2.10.0",
-    "next-sanity": "0.1.5",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
+    "next-sanity": "0.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^2.1.0",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.2.0"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-sanity/postcss.config.js
+++ b/examples/cms-sanity/postcss.config.js
@@ -1,21 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    ...(process.env.NODE_ENV === 'production'
-      ? [
-          [
-            '@fullhuman/postcss-purgecss',
-            {
-              content: [
-                './pages/**/*.{js,jsx,ts,tsx}',
-                './components/**/*.{js,jsx,ts,tsx}',
-              ],
-              defaultExtractor: (content) =>
-                content.match(/[\w-/:]+(?<!:)/g) || [],
-            },
-          ],
-        ]
-      : []),
-    'postcss-preset-env',
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-sanity/tailwind.config.js
+++ b/examples/cms-sanity/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -29,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-storyblok/components/avatar.js
+++ b/examples/cms-storyblok/components/avatar.js
@@ -5,7 +5,7 @@ export default function Avatar({ name, picture }) {
     <div className="flex items-center">
       <div className="w-12 h-12 relative mr-4">
         <Image
-          src={picture}
+          src={picture.filename}
           layout="fill"
           className="rounded-full"
           alt={name}

--- a/examples/cms-storyblok/components/avatar.js
+++ b/examples/cms-storyblok/components/avatar.js
@@ -1,11 +1,16 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={picture.filename}
-        className="w-12 h-12 rounded-full mr-4 grayscale"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={picture}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-storyblok/components/cover-image.js
+++ b/examples/cms-storyblok/components/cover-image.js
@@ -1,16 +1,27 @@
+import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
 
 export default function CoverImage({ title, url, slug }) {
+  const image = (
+    <Image
+      width={2000}
+      height={1000}
+      alt={`Cover Image for ${title}`}
+      src={url}
+      className={cn('shadow-small', {
+        'hover:shadow-medium transition-shadow duration-200': slug,
+      })}
+    />
+  )
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
-          <a aria-label={title}>
-            <img src={url} alt={title} />
-          </a>
+        <Link href={slug}>
+          <a aria-label={title}>{image}</a>
         </Link>
       ) : (
-        <img src={url} alt={title} />
+        image
       )}
     </div>
   )

--- a/examples/cms-storyblok/components/hero-post.js
+++ b/examples/cms-storyblok/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-storyblok/components/post-preview.js
+++ b/examples/cms-storyblok/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} url={coverImage} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-storyblok/package.json
+++ b/examples/cms-storyblok/package.json
@@ -7,8 +7,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "classnames": "2.2.6",
-    "date-fns": "2.14.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -17,9 +17,9 @@
     "storyblok-js-client": "2.5.0"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "4.2.1",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.4.6"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-storyblok/postcss.config.js
+++ b/examples/cms-storyblok/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-storyblok/tailwind.config.js
+++ b/examples/cms-storyblok/tailwind.config.js
@@ -1,11 +1,9 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
-      fontFamily: {
-        sans:
-          '-apple-system, "Helvetica Neue", "Segoe UI", Roboto, Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
-      },
       colors: {
         'accent-1': '#FAFAFA',
         'accent-2': '#EAEAEA',
@@ -34,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-strapi/components/avatar.js
+++ b/examples/cms-strapi/components/avatar.js
@@ -1,15 +1,20 @@
+import Image from 'next/image'
+
 export default function Avatar({ name, picture }) {
   const url = picture.url ?? picture[0].url
 
   return (
     <div className="flex items-center">
-      <img
-        src={`${
-          url.startsWith('/') ? process.env.NEXT_PUBLIC_STRAPI_API_URL : ''
-        }${url}`}
-        className="w-12 h-12 rounded-full mr-4 grayscale"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={`${
+            url.startsWith('/') ? process.env.NEXT_PUBLIC_STRAPI_API_URL : ''
+          }${url}`}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-strapi/components/cover-image.js
+++ b/examples/cms-strapi/components/cover-image.js
@@ -1,19 +1,31 @@
+import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
 
 export default function CoverImage({ title, url, slug }) {
   const imageUrl = `${
     url.startsWith('/') ? process.env.NEXT_PUBLIC_STRAPI_API_URL : ''
   }${url}`
+
+  const image = (
+    <Image
+      width={2000}
+      height={1000}
+      alt={`Cover Image for ${title}`}
+      src={imageUrl}
+      className={cn('shadow-small', {
+        'hover:shadow-medium transition-shadow duration-200': slug,
+      })}
+    />
+  )
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
-          <a aria-label={title}>
-            <img src={imageUrl} alt={title} />
-          </a>
+        <Link href={slug}>
+          <a aria-label={title}>{image}</a>
         </Link>
       ) : (
-        <img src={imageUrl} alt={title} />
+        image
       )}
     </div>
   )

--- a/examples/cms-strapi/components/hero-post.js
+++ b/examples/cms-strapi/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-strapi/components/post-preview.js
+++ b/examples/cms-strapi/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} url={coverImage.url} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-strapi/package.json
+++ b/examples/cms-strapi/package.json
@@ -7,9 +7,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "classnames": "2.2.6",
-    "date-fns": "2.14.0",
-    "isomorphic-unfetch": "3.0.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -17,9 +16,9 @@
     "remark-html": "11.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "4.2.1",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.4.6"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-strapi/postcss.config.js
+++ b/examples/cms-strapi/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-strapi/tailwind.config.js
+++ b/examples/cms-strapi/tailwind.config.js
@@ -1,11 +1,9 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
-      fontFamily: {
-        sans:
-          '-apple-system, "Helvetica Neue", "Segoe UI", Roboto, Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
-      },
       colors: {
         'accent-1': '#FAFAFA',
         'accent-2': '#EAEAEA',
@@ -34,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-takeshape/components/avatar.js
+++ b/examples/cms-takeshape/components/avatar.js
@@ -1,19 +1,23 @@
+import Image from 'next/image'
 import { getImageUrl } from 'takeshape-routing'
 
 export default function Avatar({ name, picture }) {
   return (
     <div className="flex items-center">
-      <img
-        src={getImageUrl(picture.path, {
-          fm: 'jpg',
-          fit: 'crop',
-          w: 100,
-          h: 100,
-          sat: -100,
-        })}
-        className="w-12 h-12 rounded-full mr-4"
-        alt={name}
-      />
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={getImageUrl(picture.path, {
+            fm: 'jpg',
+            fit: 'crop',
+            w: 100,
+            h: 100,
+            sat: -100,
+          })}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
       <div className="text-xl font-bold">{name}</div>
     </div>
   )

--- a/examples/cms-takeshape/components/cover-image.js
+++ b/examples/cms-takeshape/components/cover-image.js
@@ -1,10 +1,14 @@
 import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
 import { getImageUrl } from 'takeshape-routing'
 
 export default function CoverImage({ title, coverImage, slug }) {
   const image = (
-    <img
+    <Image
+      width={2000}
+      height={1000}
+      alt={`Cover Image for ${title}`}
       src={getImageUrl(coverImage.path, {
         fm: 'jpg',
         fit: 'crop',
@@ -19,7 +23,7 @@ export default function CoverImage({ title, coverImage, slug }) {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={slug}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-takeshape/components/hero-post.js
+++ b/examples/cms-takeshape/components/hero-post.js
@@ -19,7 +19,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a className="hover:underline">{title}</a>
             </Link>
           </h3>

--- a/examples/cms-takeshape/components/post-preview.js
+++ b/examples/cms-takeshape/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage slug={slug} title={title} coverImage={coverImage} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a className="hover:underline">{title}</a>
         </Link>
       </h3>

--- a/examples/cms-takeshape/package.json
+++ b/examples/cms-takeshape/package.json
@@ -7,8 +7,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "classnames": "2.2.6",
-    "date-fns": "2.10.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -17,9 +17,9 @@
     "takeshape-routing": "4.86.0"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^2.1.0",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.2.0"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-takeshape/postcss.config.js
+++ b/examples/cms-takeshape/postcss.config.js
@@ -1,19 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    process.env.NODE_ENV === 'production'
-      ? [
-          '@fullhuman/postcss-purgecss',
-          {
-            content: [
-              './pages/**/*.{js,jsx,ts,tsx}',
-              './components/**/*.{js,jsx,ts,tsx}',
-            ],
-            defaultExtractor: (content) =>
-              content.match(/[\w-/:]+(?<!:)/g) || [],
-          },
-        ]
-      : undefined,
-    'postcss-preset-env',
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-takeshape/tailwind.config.js
+++ b/examples/cms-takeshape/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -29,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/cms-wordpress/components/avatar.js
+++ b/examples/cms-wordpress/components/avatar.js
@@ -1,3 +1,5 @@
+import Image from 'next/image'
+
 export default function Avatar({ author }) {
   const name = author
     ? author.firstName && author.lastName
@@ -6,17 +8,16 @@ export default function Avatar({ author }) {
     : null
 
   return (
-    <>
-      {author && (
-        <div className="flex items-center">
-          <img
-            src={author.avatar.url}
-            className="w-12 h-12 rounded-full mr-4"
-            alt={name}
-          />
-          <div className="text-xl font-bold">{name}</div>
-        </div>
-      )}
-    </>
+    <div className="flex items-center">
+      <div className="w-12 h-12 relative mr-4">
+        <Image
+          src={author.avatar.url}
+          layout="fill"
+          className="rounded-full"
+          alt={name}
+        />
+      </div>
+      <div className="text-xl font-bold">{name}</div>
+    </div>
   )
 }

--- a/examples/cms-wordpress/components/cover-image.js
+++ b/examples/cms-wordpress/components/cover-image.js
@@ -1,9 +1,13 @@
 import cn from 'classnames'
+import Image from 'next/image'
 import Link from 'next/link'
 
 export default function CoverImage({ title, coverImage, slug }) {
   const image = (
-    <img
+    <Image
+      width={2000}
+      height={1000}
+      alt={`Cover Image for ${title}`}
       src={coverImage?.sourceUrl}
       className={cn('shadow-small', {
         'hover:shadow-medium transition-shadow duration-200': slug,
@@ -13,7 +17,7 @@ export default function CoverImage({ title, coverImage, slug }) {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={slug}>
           <a aria-label={title}>{image}</a>
         </Link>
       ) : (

--- a/examples/cms-wordpress/components/hero-post.js
+++ b/examples/cms-wordpress/components/hero-post.js
@@ -21,7 +21,7 @@ export default function HeroPost({
       <div className="md:grid md:grid-cols-2 md:col-gap-16 lg:col-gap-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-6xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
+            <Link href={`/posts/${slug}`}>
               <a
                 className="hover:underline"
                 dangerouslySetInnerHTML={{ __html: title }}

--- a/examples/cms-wordpress/components/post-preview.js
+++ b/examples/cms-wordpress/components/post-preview.js
@@ -17,7 +17,7 @@ export default function PostPreview({
         <CoverImage title={title} coverImage={coverImage} slug={slug} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
+        <Link href={`/posts/${slug}`}>
           <a
             className="hover:underline"
             dangerouslySetInnerHTML={{ __html: title }}

--- a/examples/cms-wordpress/package.json
+++ b/examples/cms-wordpress/package.json
@@ -7,16 +7,16 @@
     "start": "next start"
   },
   "dependencies": {
-    "classnames": "2.2.6",
-    "date-fns": "2.14.0",
+    "classnames": "2.3.1",
+    "date-fns": "2.22.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "postcss-flexbugs-fixes": "4.2.1",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.4.6"
+    "autoprefixer": "10.2.6",
+    "postcss": "8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/cms-wordpress/postcss.config.js
+++ b/examples/cms-wordpress/postcss.config.js
@@ -1,18 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    'postcss-flexbugs-fixes',
-    [
-      'postcss-preset-env',
-      {
-        autoprefixer: {
-          flexbox: 'no-2009',
-        },
-        stage: 3,
-        features: {
-          'custom-properties': false,
-        },
-      },
-    ],
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/cms-wordpress/tailwind.config.js
+++ b/examples/cms-wordpress/tailwind.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  purge: ['./components/**/*.js', './pages/**/*.js'],
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {
@@ -30,4 +32,8 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
 }

--- a/examples/with-userbase/components/layout/index.js
+++ b/examples/with-userbase/components/layout/index.js
@@ -1,5 +1,6 @@
 import Nav from '../nav'
-function Layout({ user, setUser, children }) {
+
+export default function Layout({ user, setUser, children }) {
   return (
     <div className="container mx-auto">
       <Nav user={user} setUser={setUser} />
@@ -7,5 +8,3 @@ function Layout({ user, setUser, children }) {
     </div>
   )
 }
-
-export default Layout

--- a/examples/with-userbase/package.json
+++ b/examples/with-userbase/package.json
@@ -7,15 +7,15 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^9.2.0",
+    "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "userbase-js": "^1.3.0"
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "^1.3.0",
-    "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^1.1.4"
+    "autoprefixer": "^10.2.6",
+    "postcss": "^8.3.5",
+    "tailwindcss": "^2.2.4"
   },
   "license": "MIT"
 }

--- a/examples/with-userbase/postcss.config.js
+++ b/examples/with-userbase/postcss.config.js
@@ -1,21 +1,8 @@
+// If you want to use other PostCSS plugins, see the following:
+// https://tailwindcss.com/docs/using-with-preprocessors
 module.exports = {
-  plugins: [
-    'tailwindcss',
-    ...(process.env.NODE_ENV === 'production'
-      ? [
-          [
-            '@fullhuman/postcss-purgecss',
-            {
-              content: [
-                './pages/**/*.{js,jsx,ts,tsx}',
-                './components/**/*.{js,jsx,ts,tsx}',
-              ],
-              defaultExtractor: (content) =>
-                content.match(/[\w-/:]+(?<!:)/g) || [],
-            },
-          ],
-        ]
-      : []),
-    'postcss-preset-env',
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/examples/with-userbase/tailwind.config.js
+++ b/examples/with-userbase/tailwind.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  mode: 'jit',
+  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {},
+  },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
- Ensures all CMS examples are using `next/image`
- Remove `as` from `next/link` in examples as it's no longer needed
- Remove outdated Tailwind configurations
- Use Tailwind JIT for all CMS examples
- Update as many dependencies as possible (no major version bumps)
- Adds Vercel Contentful Integration to the README Deploy Button 