### PR TITLE
[ESLint] Adds `--format` flag to `next lint`

### DIFF
--- a/packages/next/cli/next-lint.ts
+++ b/packages/next/cli/next-lint.ts
@@ -63,9 +63,11 @@ const nextLint: cliCommand = (argv) => {
     '--cache': Boolean,
     '--cache-location': String,
     '--error-on-unmatched-pattern': Boolean,
+    '--format': String,
 
     // Aliases
     '-c': '--config',
+    '-f': '--format',
   }
 
   let args: arg.Result<arg.Spec>
@@ -112,6 +114,9 @@ const nextLint: cliCommand = (argv) => {
         Handling warnings:
           --quiet                        Report errors only - default: false
           --max-warnings Int             Number of warnings to trigger nonzero exit code - default: -1
+        
+        Output:
+          -f, --format String            Use a specific output format - default: Next.js custom formatter
 
         Inline configuration comments:
           --no-inline-config             Prevent comments from changing config or rules
@@ -148,6 +153,7 @@ const nextLint: cliCommand = (argv) => {
 
   const reportErrorsOnly = Boolean(args['--quiet'])
   const maxWarnings = args['--max-warnings'] ?? -1
+  const formatter = args['--format'] || null
 
   runLintCheck(
     baseDir,
@@ -155,7 +161,8 @@ const nextLint: cliCommand = (argv) => {
     false,
     eslintOptions(args),
     reportErrorsOnly,
-    maxWarnings
+    maxWarnings,
+    formatter
   )
     .then(async (lintResults) => {
       const lintOutput =

--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -30,7 +30,8 @@ async function lint(
   pkgJsonPath: string | null,
   eslintOptions: any = null,
   reportErrorsOnly: boolean = false,
-  maxWarnings: number = -1
+  maxWarnings: number = -1,
+  formatter: string | null = null
 ): Promise<
   | string
   | null
@@ -111,12 +112,18 @@ async function lint(
     }
   }
   const lintStart = process.hrtime()
-
   let results = await eslint.lintFiles(lintDirs)
+  let selectedFormatter = null
+
   if (options.fix) await ESLint.outputFixes(results)
   if (reportErrorsOnly) results = await ESLint.getErrorResults(results) // Only return errors if --quiet flag is used
 
-  const formattedResult = formatResults(baseDir, results)
+  if (formatter) selectedFormatter = await eslint.loadFormatter(formatter)
+  const formattedResult = formatResults(
+    baseDir,
+    results,
+    selectedFormatter?.format
+  )
   const lintEnd = process.hrtime(lintStart)
   const totalWarnings = results.reduce(
     (sum: number, file: LintResult) => sum + file.warningCount,
@@ -152,7 +159,8 @@ export async function runLintCheck(
   lintDuringBuild: boolean = false,
   eslintOptions: any = null,
   reportErrorsOnly: boolean = false,
-  maxWarnings: number = -1
+  maxWarnings: number = -1,
+  formatter: string | null = null
 ): ReturnType<typeof lint> {
   try {
     // Find user's .eslintrc file
@@ -215,7 +223,8 @@ export async function runLintCheck(
       pkgJsonPath,
       eslintOptions,
       reportErrorsOnly,
-      maxWarnings
+      maxWarnings,
+      formatter
     )
   } catch (err) {
     throw err

--- a/test/integration/eslint/test/index.test.js
+++ b/test/integration/eslint/test/index.test.js
@@ -259,5 +259,23 @@ describe('ESLint', () => {
         'Warning: External synchronous scripts are forbidden'
       )
     })
+
+    test('format flag supports additional user-defined formats', async () => {
+      const { stdout, stderr } = await nextLint(
+        dirMaxWarnings,
+        ['-f', 'codeframe'],
+        {
+          stdout: true,
+          stderr: true,
+        }
+      )
+
+      const output = stdout + stderr
+      expect(output).toContain(
+        'warning: External synchronous scripts are forbidden'
+      )
+      expect(stdout).toContain('<script src="https://example.com" />')
+      expect(stdout).toContain('2 warnings found')
+    })
   })
 })


### PR DESCRIPTION
Adds `--format` support to `next lint` to allow defining of additional formatters. Fixes #26387.