### PR TITLE
Enhance `next dev` performance with placeholder=blur

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1034,6 +1034,8 @@ export default async function getBaseWebpackConfig(
                 dependency: { not: ['url'] },
                 options: {
                   isServer,
+                  isDev: dev,
+                  configImageSizes: config.images.imageSizes,
                 },
               },
             ]

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1035,7 +1035,7 @@ export default async function getBaseWebpackConfig(
                 options: {
                   isServer,
                   isDev: dev,
-                  configImageSizes: config.images.imageSizes,
+                  assetPrefix: config.assetPrefix,
                 },
               },
             ]

--- a/packages/next/build/webpack/loaders/next-image-loader.js
+++ b/packages/next/build/webpack/loaders/next-image-loader.js
@@ -9,7 +9,7 @@ const VALID_BLUR_EXT = ['jpeg', 'png', 'webp']
 function nextImageLoader(content) {
   const imageLoaderSpan = this.currentTraceSpan.traceChild('next-image-loader')
   return imageLoaderSpan.traceAsyncFn(async () => {
-    const { isServer, isDev } = loaderUtils.getOptions(this)
+    const { isServer, isDev, assetPrefix } = loaderUtils.getOptions(this)
     const context = this.rootContext
     const opts = { context, content }
     const interpolatedName = loaderUtils.interpolateName(
@@ -31,7 +31,7 @@ function nextImageLoader(content) {
     if (isDev) {
       const prefix = 'http://localhost'
       const url = new URL('/_next/image', prefix)
-      url.searchParams.set('url', outputPath)
+      url.searchParams.set('url', assetPrefix + outputPath)
       url.searchParams.set('w', BLUR_IMG_SIZE)
       url.searchParams.set('q', BLUR_QUALITY)
       blurDataURL = url.href.slice(prefix.length)

--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -26,7 +26,7 @@ const CACHE_VERSION = 3
 const MODERN_TYPES = [/* AVIF, */ WEBP]
 const ANIMATABLE_TYPES = [WEBP, PNG, GIF]
 const VECTOR_TYPES = [SVG]
-
+const BLUR_IMG_SIZE = 8 // should match `next-image-loader`
 const inflightRequests = new Map<string, Promise<undefined>>()
 
 export async function imageOptimizer(
@@ -124,6 +124,10 @@ export async function imageOptimizer(
   }
 
   const sizes = [...deviceSizes, ...imageSizes]
+
+  if (isDev) {
+    sizes.push(BLUR_IMG_SIZE)
+  }
 
   if (!sizes.includes(width)) {
     res.statusCode = 400

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -934,7 +934,6 @@ describe('Image Optimizer', () => {
   })
 
   describe('dev support for dynamic blur placeholder', () => {
-    const size = 8
     beforeAll(async () => {
       const json = JSON.stringify({
         images: {
@@ -952,6 +951,12 @@ describe('Image Optimizer', () => {
       await fs.remove(imagesDir)
     })
 
-    runTests({ w: size, isDev: true })
+    it('should support width 8 per BLUR_IMG_SIZE with next dev', async () => {
+      const query = { url: '/test.png', w: 8, q: 70 }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await fetchViaHTTP(appPort, '/_next/image', query, opts)
+      expect(res.status).toBe(200)
+      await expectWidth(res, 8)
+    })
   })
 })

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -932,4 +932,26 @@ describe('Image Optimizer', () => {
       await expectWidth(res, 64)
     })
   })
+
+  describe('dev support for dynamic blur placeholder', () => {
+    const size = 8
+    beforeAll(async () => {
+      const json = JSON.stringify({
+        images: {
+          deviceSizes: [largeSize],
+          imageSizes: [],
+        },
+      })
+      nextConfig.replace('{ /* replaceme */ }', json)
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort)
+    })
+    afterAll(async () => {
+      await killApp(app)
+      nextConfig.restore()
+      await fs.remove(imagesDir)
+    })
+
+    runTests({ w: size, isDev: true })
+  })
 })


### PR DESCRIPTION
This PR changes the implementation of `placeholder=blur` when using `next dev` so that it lazy loads on-demand.

This will improve the developer experience for web apps with many blurred images.