### PR TITLE
RouteHas.value accepts boolean and  false means should not be pressent

### DIFF
--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -131,7 +131,7 @@ To only match a redirect when header, cookie, or query values also match the `ha
 
 - `type`: `String` - must be either `header`, `cookie`, `host`, or `query`.
 - `key`: `String` - the key from the selected type to match against.
-- `value`: `String` or `undefined` - the value to check for, if undefined any value will match. A regex like string can be used to capture a specific part of the value, e.g. if the value `first-(?<paramName>.*)` is used for `first-second` then `second` will be usable in the destination with `:paramName`.
+- `value`: `String`, `undefined` or `false` - the value to check for, if undefined any value will match, if false the cookie or query parameter should not be present. A regex like string can be used to capture a specific part of the value, e.g. if the value `first-(?<paramName>.*)` is used for `first-second` then `second` will be usable in the destination with `:paramName`.
 
 ```js
 module.exports = {

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -224,7 +224,7 @@ To only match a rewrite when header, cookie, or query values also match the `has
 
 - `type`: `String` - must be either `header`, `cookie`, `host`, or `query`.
 - `key`: `String` - the key from the selected type to match against.
-- `value`: `String` or `undefined` - the value to check for, if undefined any value will match. A regex like string can be used to capture a specific part of the value, e.g. if the value `first-(?<paramName>.*)` is used for `first-second` then `second` will be usable in the destination with `:paramName`.
+- `value`: `String`, `undefined` or `false` - the value to check for, if undefined any value will match, if false the cookie or query parameter should not be present.. A regex like string can be used to capture a specific part of the value, e.g. if the value `first-(?<paramName>.*)` is used for `first-second` then `second` will be usable in the destination with `:paramName`.
 
 ```js
 module.exports = {

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -12,7 +12,7 @@ export type RouteHas =
   | {
       type: 'header' | 'query' | 'cookie'
       key: string
-      value?: string
+      value?: string | boolean
     }
   | {
       type: 'host'
@@ -264,6 +264,7 @@ function checkCustomRoutes(
         }
         if (
           typeof hasItem.value !== 'undefined' &&
+          typeof hasItem.value !== 'boolean' &&
           typeof hasItem.value !== 'string'
         ) {
           invalidHasParts.push(`invalid value "${hasItem.value}"`)

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -344,7 +344,7 @@ function checkCustomRoutes(
           hasSegments.add(hasItem.key)
         }
 
-        if (hasItem.value) {
+        if (typeof hasItem.value === 'string') {
           for (const match of hasItem.value.matchAll(namedGroupsRegex)) {
             if (match[1]) {
               hasSegments.add(match[1])

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -76,7 +76,9 @@ export function matchHas(
       }
     }
 
-    if (!hasItem.value && value) {
+    if (hasItem.value === false && value === undefined) {
+      return true
+    } else if (!hasItem.value && value) {
       params[getSafeParamName(key!)] = value
       return true
     } else if (value) {


### PR DESCRIPTION

It implements this feature request, that has not been accepted.
https://github.com/vercel/next.js/discussions/25931

```
module.exports = {
  async redirects() {
    return [
      // if the cookie `authorized` is **not** pressent
      // this redirect will be applied
      {
        source: '/users/:path*',
        has: [
          {
            type: 'cookie',
            key: 'authorized',
            value: false,
          },
        ],
        permanent: false,
        destination: '/login',
      },
    ]
  },
}
```