### PR TITLE
Fall back to fallbackSend when send is false

### DIFF
--- a/packages/next/client/performance-relayer.ts
+++ b/packages/next/client/performance-relayer.ts
@@ -63,7 +63,7 @@ function onReport(metric: Metric): void {
 
     try {
       // If send is undefined it'll throw as well. This reduces output code size.
-      send!(vitalsUrl, blob)
+      send!(vitalsUrl, blob) || fallbackSend()
     } catch (err) {
       fallbackSend()
     }


### PR DESCRIPTION
Send can result in `false` when it did not send the result so we have to fall back in that case. Shared by @timer after my PR was landed.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
