### PR TITLE
Add jsdoc types to docs snippets

### DIFF
--- a/docs/api-reference/next.config.js/introduction.md
+++ b/docs/api-reference/next.config.js/introduction.md
@@ -11,18 +11,27 @@ For custom advanced behavior of Next.js, you can create a `next.config.js` in th
 Take a look at the following `next.config.js` example:
 
 ```js
-module.exports = {
+/**
+ * @type {import('next').NextConfig}
+ */
+const config = {
   /* config options here */
 }
+
+module.exports = config
 ```
 
 You can also use a function:
 
 ```js
 module.exports = (phase, { defaultConfig }) => {
-  return {
+  /**
+   * @type {import('next').NextConfig}
+   */
+  const config = {
     /* config options here */
   }
+  return config
 }
 ```
 

--- a/docs/api-reference/next.config.js/introduction.md
+++ b/docs/api-reference/next.config.js/introduction.md
@@ -14,11 +14,11 @@ Take a look at the following `next.config.js` example:
 /**
  * @type {import('next').NextConfig}
  */
-const config = {
+const nextConfig = {
   /* config options here */
 }
 
-module.exports = config
+module.exports = nextConfig
 ```
 
 You can also use a function:
@@ -28,10 +28,10 @@ module.exports = (phase, { defaultConfig }) => {
   /**
    * @type {import('next').NextConfig}
    */
-  const config = {
+  const nextConfig = {
     /* config options here */
   }
-  return config
+  return nextConfig
 }
 ```
 


### PR DESCRIPTION
This PR adds the JSDoc types so that VS Code and other tools can use autocompletion when editing `next.config.js`