### PR TITLE
Add some missing fields to the NextConfig type

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -9,7 +9,7 @@ import { warn } from './output/log'
 import { ClientPagesLoaderOptions } from './webpack/loaders/next-client-pages-loader'
 import { ServerlessLoaderQuery } from './webpack/loaders/next-serverless-loader'
 import { LoadedEnvFiles } from '@next/env'
-import { NextConfig } from '../server/config'
+import { NextConfigComplete } from '../server/config-shared'
 
 type PagesMapping = {
   [page: string]: string
@@ -72,7 +72,7 @@ export function createEntrypoints(
   target: 'server' | 'serverless' | 'experimental-serverless-trace',
   buildId: string,
   previewMode: __ApiPreviewProps,
-  config: NextConfig,
+  config: NextConfigComplete,
   loadedEnvFiles: LoadedEnvFiles
 ): Entrypoints {
   const client: WebpackEntrypoints = {}
@@ -90,9 +90,9 @@ export function createEntrypoints(
     distDir: DOT_NEXT_ALIAS,
     buildId,
     assetPrefix: config.assetPrefix,
-    generateEtags: config.generateEtags,
+    generateEtags: config.generateEtags ? 'true' : '',
     poweredByHeader: config.poweredByHeader,
-    canonicalBase: config.amp.canonicalBase,
+    canonicalBase: config.amp.canonicalBase || '',
     basePath: config.basePath,
     runtimeConfig: hasRuntimeConfig
       ? JSON.stringify({

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -52,10 +52,7 @@ import {
   isDynamicRoute,
 } from '../shared/lib/router/utils'
 import { __ApiPreviewProps } from '../server/api-utils'
-import loadConfig, {
-  isTargetLikeServerless,
-  NextConfig,
-} from '../server/config'
+import loadConfig, { isTargetLikeServerless } from '../server/config'
 import { BuildManifest } from '../server/get-page-files'
 import '../server/node-polyfill-fetch'
 import { normalizePagePath } from '../server/normalize-page-path'
@@ -91,6 +88,7 @@ import { PagesManifest } from './webpack/plugins/pages-manifest-plugin'
 import { writeBuildId } from './write-build-id'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { isWebpack5 } from 'next/dist/compiled/webpack/webpack'
+import { NextConfigComplete } from '../server/config-shared'
 
 const staticCheckWorker = require.resolve('./utils')
 
@@ -130,7 +128,7 @@ export default async function build(
       .traceChild('load-dotenv')
       .traceFn(() => loadEnvConfig(dir, false, Log))
 
-    const config: NextConfig = await nextBuildSpan
+    const config: NextConfigComplete = await nextBuildSpan
       .traceChild('load-next-config')
       .traceAsyncFn(() => loadConfig(PHASE_PRODUCTION_BUILD, dir, conf))
     const { target } = config
@@ -1527,7 +1525,7 @@ export default async function build(
 
     const images = { ...config.images }
     const { deviceSizes, imageSizes } = images
-    images.sizes = [...deviceSizes, ...imageSizes]
+    ;(images as any).sizes = [...deviceSizes, ...imageSizes]
 
     await promises.writeFile(
       path.join(distDir, IMAGES_MANIFEST),

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -27,7 +27,7 @@ import {
   SERVER_DIRECTORY,
 } from '../shared/lib/constants'
 import { execOnce } from '../shared/lib/utils'
-import { NextConfig } from '../server/config'
+import { NextConfigComplete } from '../server/config-shared'
 import { findPageFile } from '../server/lib/find-page-file'
 import { WebpackEntrypoints } from './entries'
 import * as Log from './output/log'
@@ -228,7 +228,7 @@ export default async function getBaseWebpackConfig(
     isDevFallback = false,
   }: {
     buildId: string
-    config: NextConfig
+    config: NextConfigComplete
     dev?: boolean
     isServer?: boolean
     pagesDir: string

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -29,10 +29,8 @@ import {
   SERVERLESS_DIRECTORY,
   SERVER_DIRECTORY,
 } from '../shared/lib/constants'
-import loadConfig, {
-  isTargetLikeServerless,
-  NextConfig,
-} from '../server/config'
+import loadConfig, { isTargetLikeServerless } from '../server/config'
+import { NextConfigComplete } from '../server/config-shared'
 import { eventCliSession } from '../telemetry/events'
 import { hasNextSupport } from '../telemetry/ci-info'
 import { Telemetry } from '../telemetry/storage'
@@ -136,7 +134,7 @@ interface ExportOptions {
 export default async function exportApp(
   dir: string,
   options: ExportOptions,
-  configuration?: NextConfig
+  configuration?: NextConfigComplete
 ): Promise<void> {
   const nextExportSpan = trace('next-export')
 

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 import { Header, Redirect, Rewrite } from '../lib/load-custom-routes'
-import { imageConfigDefault } from './image-config'
+import { ImageConfig, imageConfigDefault } from './image-config'
 
 export type DomainLocales = Array<{
   http?: true
@@ -9,8 +9,13 @@ export type DomainLocales = Array<{
   defaultLocale: string
 }>
 
+type NoOptionals<T> = {
+  [P in keyof T]-?: T[P]
+}
+
+export type NextConfigComplete = NoOptionals<NextConfig>
+
 export type NextConfig = { [key: string]: any } & {
-  cleanDistDir?: boolean
   i18n?: {
     locales: string[]
     defaultLocale: string
@@ -28,9 +33,35 @@ export type NextConfig = { [key: string]: any } & {
       }
   >
   redirects?: () => Promise<Redirect[]>
-  trailingSlash?: boolean
+
   webpack5?: false
   excludeDefaultMomentLocales?: boolean
+
+  trailingSlash?: boolean
+  env?: { [key: string]: string }
+  distDir?: string
+  cleanDistDir?: boolean
+  assetPrefix?: string
+  useFileSystemPublicRoutes?: boolean
+  generateBuildId: () => string | null
+  generateEtags?: boolean
+  pageExtensions?: string[]
+  compress?: boolean
+  images?: ImageConfig
+  devIndicators?: {
+    buildActivity?: boolean
+  }
+  onDemandEntries?: {
+    maxInactiveAge?: number
+    pagesBufferLength?: number
+  }
+  amp?: {
+    canonicalBase?: string
+  }
+  basePath?: string
+  sassOptions?: { [key: string]: any }
+  productionBrowserSourceMaps?: boolean
+  optimizeFonts?: boolean
 
   future: {
     /**
@@ -67,7 +98,7 @@ export type NextConfig = { [key: string]: any } & {
 }
 
 export const defaultConfig: NextConfig = {
-  env: [],
+  env: {},
   webpack: null,
   webpackDevMiddleware: null,
   distDir: '.next',
@@ -99,6 +130,12 @@ export const defaultConfig: NextConfig = {
   i18n: null,
   productionBrowserSourceMaps: false,
   optimizeFonts: true,
+  webpack5:
+    Number(process.env.NEXT_PRIVATE_TEST_WEBPACK4_MODE) > 0 ? false : undefined,
+  excludeDefaultMomentLocales: true,
+  serverRuntimeConfig: {},
+  publicRuntimeConfig: {},
+  reactStrictMode: false,
   experimental: {
     cpus: Math.max(
       1,
@@ -121,15 +158,9 @@ export const defaultConfig: NextConfig = {
     craCompat: false,
     esmExternals: false,
   },
-  webpack5:
-    Number(process.env.NEXT_PRIVATE_TEST_WEBPACK4_MODE) > 0 ? false : undefined,
-  excludeDefaultMomentLocales: true,
   future: {
     strictPostcssConfiguration: false,
   },
-  serverRuntimeConfig: {},
-  publicRuntimeConfig: {},
-  reactStrictMode: false,
 }
 
 export function normalizeConfig(phase: string, config: any) {

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -5,7 +5,11 @@ import * as Log from '../build/output/log'
 import { hasNextSupport } from '../telemetry/ci-info'
 import { CONFIG_FILE, PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
 import { execOnce } from '../shared/lib/utils'
-import { defaultConfig, normalizeConfig } from './config-shared'
+import {
+  defaultConfig,
+  NextConfigComplete,
+  normalizeConfig,
+} from './config-shared'
 import { loadWebpackHook } from './config-utils'
 import { ImageConfig, imageConfigDefault, VALID_LOADERS } from './image-config'
 import { loadEnvConfig } from '@next/env'
@@ -168,7 +172,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
         result.assetPrefix = result.basePath
       }
 
-      if (result.amp.canonicalBase === '') {
+      if (result.amp?.canonicalBase === '') {
         result.amp.canonicalBase = result.basePath
       }
     }
@@ -410,12 +414,15 @@ export default async function loadConfig(
   phase: string,
   dir: string,
   customConfig?: object | null
-) {
+): Promise<NextConfigComplete> {
   await loadEnvConfig(dir, phase === PHASE_DEVELOPMENT_SERVER, Log)
   await loadWebpackHook(phase, dir)
 
   if (customConfig) {
-    return assignDefaults({ configOrigin: 'server', ...customConfig })
+    return assignDefaults({
+      configOrigin: 'server',
+      ...customConfig,
+    }) as NextConfigComplete
   }
 
   const path = await findUp(CONFIG_FILE, { cwd: dir })
@@ -459,7 +466,7 @@ export default async function loadConfig(
       configOrigin: CONFIG_FILE,
       configFile: path,
       ...userConfig,
-    })
+    }) as NextConfigComplete
   } else {
     const configBaseName = basename(CONFIG_FILE, extname(CONFIG_FILE))
     const nonJsPath = findUp.sync(
@@ -480,7 +487,7 @@ export default async function loadConfig(
     }
   }
 
-  return defaultConfig
+  return defaultConfig as NextConfigComplete
 }
 
 export function isTargetLikeServerless(target: string) {

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -24,7 +24,7 @@ import { isWriteable } from '../../build/is-writeable'
 import { ClientPagesLoaderOptions } from '../../build/webpack/loaders/next-client-pages-loader'
 import { stringify } from 'querystring'
 import { difference } from '../../build/utils'
-import { NextConfig } from '../config'
+import { NextConfigComplete } from '../config-shared'
 import { CustomRoutes } from '../../lib/load-custom-routes'
 import { DecodeError } from '../../shared/lib/utils'
 
@@ -131,7 +131,7 @@ export default class HotReloader {
   private middlewares: any[]
   private pagesDir: string
   private webpackHotMiddleware: (NextHandleFunction & any) | null
-  private config: NextConfig
+  private config: NextConfigComplete
   private stats: webpack.Stats | null
   private serverStats: webpack.Stats | null
   private clientError: Error | null = null
@@ -154,7 +154,7 @@ export default class HotReloader {
       previewProps,
       rewrites,
     }: {
-      config: NextConfig
+      config: NextConfigComplete
       pagesDir: string
       buildId: string
       previewProps: __ApiPreviewProps

--- a/packages/next/server/image-config.ts
+++ b/packages/next/server/image-config.ts
@@ -14,7 +14,7 @@ export type ImageConfig = {
   loader: LoaderValue
   path: string
   domains?: string[]
-  disableStaticImages: boolean
+  disableStaticImages?: boolean
 }
 
 export const imageConfigDefault: ImageConfig = {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -96,6 +96,7 @@ import ResponseCache, {
   ResponseCacheEntry,
   ResponseCacheValue,
 } from './response-cache'
+import { NextConfigComplete } from './config-shared'
 
 const getCustomRouteMatcher = pathMatch(true)
 
@@ -135,7 +136,7 @@ export type ServerConstructor = {
 export default class Server {
   protected dir: string
   protected quiet: boolean
-  protected nextConfig: NextConfig
+  protected nextConfig: NextConfigComplete
   protected distDir: string
   protected pagesDir?: string
   protected publicDir: string
@@ -187,7 +188,8 @@ export default class Server {
     this.quiet = quiet
     loadEnvConfig(this.dir, dev, Log)
 
-    this.nextConfig = conf
+    this.nextConfig = conf as NextConfigComplete
+
     this.distDir = join(this.dir, this.nextConfig.distDir)
     this.publicDir = join(this.dir, CLIENT_PUBLIC_FILES_PATH)
     this.hasStaticDir = !minimalMode && fs.existsSync(join(this.dir, 'static'))
@@ -207,7 +209,7 @@ export default class Server {
 
     this.renderOpts = {
       poweredByHeader: this.nextConfig.poweredByHeader,
-      canonicalBase: this.nextConfig.amp.canonicalBase,
+      canonicalBase: this.nextConfig.amp.canonicalBase || '',
       buildId: this.buildId,
       generateEtags,
       previewProps: this.getPreviewProps(),


### PR DESCRIPTION
This adds some missing fields to the `NextConfig` type we expose under `next` and also adds a `NextConfigComplete` internal type that allows us to not treat all fields as optional like you would when using the type in `next.config.js`. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
