### PR TITLE
EcmaScript Modules for the client build

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -581,7 +581,7 @@ export async function getJsPageSizeInKb(
     computedManifestData ||
     (await computeFromManifest(buildManifest, distPath, gzipSize))
 
-  const fnFilterJs = (entry: string) => entry.endsWith('.js')
+  const fnFilterJs = (entry: string) => /\.m?js$/.test(entry)
 
   const pageFiles = (
     buildManifest.pages[denormalizePagePath(page)] || []

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1013,9 +1013,9 @@ export default async function getBaseWebpackConfig(
           : '[name].js'
         : `static/chunks/${isDevFallback ? 'fallback/' : ''}[name]${
             dev ? '' : isWebpack5 ? '-[contenthash]' : '-[chunkhash]'
-          }.js`,
+          }.mjs`,
       library: isServer ? undefined : '_N_E',
-      libraryTarget: isServer ? 'commonjs2' : 'assign',
+      libraryTarget: isServer ? 'commonjs2' : 'global',
       hotUpdateChunkFilename: isWebpack5
         ? 'static/webpack/[id].[fullhash].hot-update.js'
         : 'static/webpack/[id].[hash].hot-update.js',
@@ -1027,7 +1027,7 @@ export default async function getBaseWebpackConfig(
         ? '[name].js'
         : `static/chunks/${isDevFallback ? 'fallback/' : ''}${
             dev ? '[name]' : '[name].[contenthash]'
-          }.js`,
+          }.mjs`,
       strictModuleExceptionHandling: true,
       crossOriginLoading: crossOrigin,
       futureEmitAssets: !dev,
@@ -1341,6 +1341,13 @@ export default async function getBaseWebpackConfig(
   if (isWebpack5) {
     // futureEmitAssets is on by default in webpack 5
     delete webpackConfig.output?.futureEmitAssets
+
+    if (!isServer) {
+      // @ts-ignore experiments exists
+      webpackConfig.experiments = {
+        outputModule: true,
+      }
+    }
 
     if (isServer && dev) {
       // Enable building of client compilation before server compilation in development

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -73,7 +73,7 @@ function getEntrypointFiles(entrypoint: any): string[] {
       ?.getFiles()
       .filter((file: string) => {
         // We don't want to include `.hot-update.js` files into the initial page
-        return /(?<!\.hot-update)\.(js|css)($|\?)/.test(file)
+        return /(?<!\.hot-update)\.(m?js|css)($|\?)/.test(file)
       })
       .map((file: string) => file.replace(/\\/g, '/')) ?? []
   )
@@ -183,14 +183,14 @@ export default class BuildManifestPlugin {
         // as a dependency for the app. If the flag is false, the file won't be
         // downloaded by the client.
         assetMap.lowPriorityFiles.push(
-          `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`
+          `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.mjs`
         )
         // Add the runtime ssg manifest file as a lazy-loaded file dependency.
         // We also stub this file out for development mode (when it is not
         // generated).
         const srcEmptySsgManifest = `self.__SSG_MANIFEST=new Set;self.__SSG_MANIFEST_CB&&self.__SSG_MANIFEST_CB()`
 
-        const ssgManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_ssgManifest.js`
+        const ssgManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_ssgManifest.mjs`
         assetMap.lowPriorityFiles.push(ssgManifestPath)
         assets[ssgManifestPath] = new sources.RawSource(srcEmptySsgManifest)
       }
@@ -211,7 +211,7 @@ export default class BuildManifestPlugin {
       )
 
       if (!this.isDevFallback) {
-        const clientManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`
+        const clientManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.mjs`
 
         assets[clientManifestPath] = new sources.RawSource(
           `self.__BUILD_MANIFEST = ${generateClientManifest(

--- a/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -68,7 +68,7 @@ export class NextJsRequireCacheHotReloader implements webpack.Plugin {
         entries.forEach((page) => {
           const outputPath = path.join(
             compilation.outputOptions.path,
-            page + '.js'
+            page + '.mjs'
           )
           deleteCache(outputPath)
         })

--- a/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
@@ -35,7 +35,7 @@ export default class PagesManifestPlugin implements webpack.Plugin {
         .getFiles()
         .filter(
           (file: string) =>
-            !file.includes('webpack-runtime') && file.endsWith('.js')
+            !file.includes('webpack-runtime') && /\.m?js$/.test(file)
         )
 
       if (!isWebpack5 && files.length > 1) {

--- a/packages/next/build/webpack/plugins/react-loadable-plugin.ts
+++ b/packages/next/build/webpack/plugins/react-loadable-plugin.ts
@@ -130,10 +130,7 @@ function buildManifest(
           for (const chunk of (chunkGroup as any)
             .chunks as webpack.compilation.Chunk[]) {
             chunk.files.forEach((file: string) => {
-              if (
-                (file.endsWith('.js') || file.endsWith('.css')) &&
-                file.match(/^static\/(chunks|css)\//)
-              ) {
+              if (/^static\/(chunks|css)\/.*\.(m?js|css)$/.test(file)) {
                 files.add(file)
               }
             })

--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -236,7 +236,7 @@ function getFilesForRoute(
       scripts: [
         assetPrefix +
           '/_next/static/chunks/pages' +
-          encodeURI(getAssetPathFromRoute(route, '.js')),
+          encodeURI(getAssetPathFromRoute(route, '.mjs')),
       ],
       // Styles are handled by `style-loader` in development:
       css: [],
@@ -250,7 +250,7 @@ function getFilesForRoute(
       (entry) => assetPrefix + '/_next/' + encodeURI(entry)
     )
     return {
-      scripts: allFiles.filter((v) => v.endsWith('.js')),
+      scripts: allFiles.filter((v) => /\.m?js$/.test(v)),
       css: allFiles.filter((v) => v.endsWith('.css')),
     }
   })

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -83,7 +83,7 @@ function addCorsSupport(req: IncomingMessage, res: ServerResponse) {
 }
 
 const matchNextPageBundleRequest = route(
-  '/_next/static/chunks/pages/:path*.js(\\.map|)'
+  '/_next/static/chunks/pages/:path*.(mjs|js)(\\.map|)'
 )
 
 // Recursively look up the issuer till it ends up at the root

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -307,10 +307,10 @@ describe('AMP Usage', () => {
           )
       ).toEqual([
         '__NEXT_DATA__',
-        '/_next/static/chunks/react-refresh.js',
-        '/_next/static/chunks/polyfills.js',
-        '/_next/static/chunks/webpack.js',
-        '/_next/static/chunks/amp.js',
+        '/_next/static/chunks/react-refresh.mjs',
+        '/_next/static/chunks/polyfills.mjs',
+        '/_next/static/chunks/webpack.mjs',
+        '/_next/static/chunks/amp.mjs',
       ])
     })
 

--- a/test/integration/app-document-import-order/test/index.test.js
+++ b/test/integration/app-document-import-order/test/index.test.js
@@ -57,7 +57,7 @@ describe('Root components import order', () => {
     const html = await res.text()
     const $ = cheerio.load(html)
 
-    const requiredByRegex = /^\/_next\/static\/chunks\/(requiredBy\w*).*\.js/
+    const requiredByRegex = /^\/_next\/static\/chunks\/(requiredBy\w*).*\.m?js/
     const chunks = Array.from($('head').contents())
       .filter(
         (child) =>

--- a/test/integration/basepath/test/index.test.js
+++ b/test/integration/basepath/test/index.test.js
@@ -473,13 +473,13 @@ const runTests = (dev = false) => {
           `[].slice.call(document.querySelectorAll("link[rel=prefetch]")).map((e) => new URL(e.href).pathname)`
         )
         expect(prefetches).toContainEqual(
-          expect.stringMatching(/\/gsp-[^./]+\.js/)
+          expect.stringMatching(/\/gsp-[^./]+\.m?js/)
         )
         expect(prefetches).toContainEqual(
-          expect.stringMatching(/\/gssp-[^./]+\.js/)
+          expect.stringMatching(/\/gssp-[^./]+\.m?js/)
         )
         expect(prefetches).toContainEqual(
-          expect.stringMatching(/\/other-page-[^./]+\.js/)
+          expect.stringMatching(/\/other-page-[^./]+\.m?js/)
         )
         return 'yes'
       }, 'yes')

--- a/test/integration/basic/test/dynamic.js
+++ b/test/integration/basic/test/dynamic.js
@@ -144,7 +144,7 @@ export default (context, render) => {
       it('should render the correct filename', async () => {
         const $ = await get$('/dynamic/chunkfilename')
         expect($('body').text()).toMatch(/test chunkfilename/)
-        expect($('html').html()).toMatch(/hello-world\.js/)
+        expect($('html').html()).toMatch(/hello-world\.m?js/)
       })
 
       it('should render the component on client side', async () => {
@@ -192,8 +192,8 @@ export default (context, render) => {
       it('should only include the rendered module script tag', async () => {
         const $ = await get$('/dynamic/multiple-modules')
         const html = $('html').html()
-        expect(html).toMatch(/hello1\.js/)
-        expect(html).not.toMatch(/hello2\.js/)
+        expect(html).toMatch(/hello1\.m?js/)
+        expect(html).not.toMatch(/hello2\.m?js/)
       })
 
       it('should only load the rendered module in the browser', async () => {
@@ -206,8 +206,8 @@ export default (context, render) => {
           const html = await browser
             .elementByCss('html')
             .getAttribute('innerHTML')
-          expect(html).toMatch(/hello1\.js/)
-          expect(html).not.toMatch(/hello2\.js/)
+          expect(html).toMatch(/hello1\.m?js/)
+          expect(html).not.toMatch(/hello2\.m?js/)
         } finally {
           if (browser) {
             await browser.close()
@@ -219,8 +219,8 @@ export default (context, render) => {
         const $ = await get$('/dynamic/multiple-modules')
         const html = $('html').html()
         try {
-          expect(html.match(/chunks[\\/]hello1\.js/g).length).toBe(1)
-          expect(html).not.toMatch(/hello2\.js/)
+          expect(html.match(/chunks[\\/]hello1\.m?js/g).length).toBe(1)
+          expect(html).not.toMatch(/hello2\.m?js/)
         } catch (err) {
           console.error(html)
           throw err

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -45,9 +45,9 @@ describe('Build Output', () => {
 
           expect(stdout).toMatch(/\/ (.* )?\d{1,} B/)
           expect(stdout).toMatch(/\+ First Load JS shared by all [ 0-9.]* kB/)
-          expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.js [ 0-9.]* kB/)
+          expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.m?js [ 0-9.]* kB/)
           expect(stdout).toMatch(
-            / chunks\/framework\.[0-9a-z]{6}\.js [ 0-9. ]* kB/
+            / chunks\/framework\.[0-9a-z]{6}\.m?js [ 0-9. ]* kB/
           )
 
           expect(stdout).not.toContain(' /_document')
@@ -96,10 +96,10 @@ describe('Build Output', () => {
           const err404FirstLoad = parsePageFirstLoad('/404')
 
           const sharedByAll = parseSharedSize('shared by all')
-          const _appSize = parseSharedSize('_app\\..*?\\.js')
-          const webpackSize = parseSharedSize('webpack\\..*?\\.js')
-          const mainSize = parseSharedSize('main\\..*?\\.js')
-          const frameworkSize = parseSharedSize('framework\\..*?\\.js')
+          const _appSize = parseSharedSize('_app\\..*?\\.m?js')
+          const webpackSize = parseSharedSize('webpack\\..*?\\.m?js')
+          const mainSize = parseSharedSize('main\\..*?\\.m?js')
+          const frameworkSize = parseSharedSize('framework\\..*?\\.m?js')
 
           for (const size of [
             indexSize,
@@ -206,9 +206,9 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/ (.* )?\d{1,} B/)
       expect(stdout).toMatch(/\/_app (.* )?\d{1,} B/)
       expect(stdout).toMatch(/\+ First Load JS shared by all \s*[0-9.]+ kB/)
-      expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.js \s*[0-9.]+ kB/)
+      expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.m?js \s*[0-9.]+ kB/)
       expect(stdout).toMatch(
-        / chunks\/framework\.[0-9a-z]{6}\.js \s*[0-9.]+ kB/
+        / chunks\/framework\.[0-9a-z]{6}\.m?js \s*[0-9.]+ kB/
       )
 
       expect(stdout).not.toContain(' /_document')
@@ -236,9 +236,9 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/amp (.* )?AMP/)
       expect(stdout).toMatch(/\/hybrid (.* )?[0-9.]+ B/)
       expect(stdout).toMatch(/\+ First Load JS shared by all \s*[0-9.]+ kB/)
-      expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.js \s*[0-9.]+ kB/)
+      expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.m?js \s*[0-9.]+ kB/)
       expect(stdout).toMatch(
-        / chunks\/framework\.[0-9a-z]{6}\.js \s*[0-9.]+ kB/
+        / chunks\/framework\.[0-9a-z]{6}\.m?js \s*[0-9.]+ kB/
       )
 
       expect(stdout).not.toContain(' /_document')
@@ -264,8 +264,10 @@ describe('Build Output', () => {
       expect(stdout).toMatch(/\/ (.* )?\d{1,} B/)
       expect(stdout).toMatch(/λ \/404 (.* )?\d{1,} B/)
       expect(stdout).toMatch(/\+ First Load JS shared by all [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.js [ 0-9.]* kB/)
-      expect(stdout).toMatch(/ chunks\/framework\.[0-9a-z]{6}\.js [ 0-9. ]* kB/)
+      expect(stdout).toMatch(/ chunks\/main\.[0-9a-z]{6}\.m?js [ 0-9.]* kB/)
+      expect(stdout).toMatch(
+        / chunks\/framework\.[0-9a-z]{6}\.m?js [ 0-9. ]* kB/
+      )
 
       expect(stdout).not.toContain(' /_document')
       expect(stdout).not.toContain(' /_app')

--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -24,7 +24,7 @@ export default function (render, fetch, ctx) {
       const $ = await get$('/')
       $('script[src]').each((_index, element) => {
         const parsedUrl = url.parse($(element).attr('src'))
-        if (!parsedUrl.pathname.endsWith('.js')) {
+        if (!/\.m?js$/.test(parsedUrl.pathname)) {
           throw new Error(
             `Page includes script that is not a javascript file ${parsedUrl.pathname}`
           )

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -1686,7 +1686,7 @@ describe('CSS Support', () => {
           appDir,
           '.next/static/',
           buildId,
-          '_buildManifest.js'
+          '_buildManifest.mjs'
         )
         if (!(await pathExists(fileName))) {
           throw new Error('Missing build manifest')

--- a/test/integration/custom-routes-catchall/test/index.test.js
+++ b/test/integration/custom-routes-catchall/test/index.test.js
@@ -28,7 +28,7 @@ const runTests = () => {
     const bundlePath = await join(
       '/docs/_next/static/',
       buildId,
-      '_buildManifest.js'
+      '_buildManifest.mjs'
     )
     const data = await renderViaHTTP(appPort, bundlePath)
     expect(data).toContain('/hello')

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -571,7 +571,7 @@ const runTests = (isDev = false) => {
     await renderViaHTTP(appPort, '/hello')
     const data = await renderViaHTTP(
       appPort,
-      `/hidden/_next/static/${buildId}/_buildManifest.js`
+      `/hidden/_next/static/${buildId}/_buildManifest.mjs`
     )
     expect(data).toContain('/hello')
   })

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -353,7 +353,7 @@ describe('Prefetching Links in viewport', () => {
 
   it('should correctly omit pre-generated dynamic pages from SSG manifest', async () => {
     const content = await readFile(
-      join(appDir, '.next', 'static', 'test-build', '_ssgManifest.js'),
+      join(appDir, '.next', 'static', 'test-build', '_ssgManifest.mjs'),
       'utf8'
     )
 

--- a/test/integration/production-browser-sourcemaps/test/index.test.js
+++ b/test/integration/production-browser-sourcemaps/test/index.test.js
@@ -17,7 +17,7 @@ function runTests() {
       /.*/
     )
     const jsFiles = browserFiles.filter(
-      (file) => file.endsWith('.js') && file.includes('/pages/')
+      (file) => /\.m?js$/.test(file) && file.includes('/pages/')
     )
 
     jsFiles.forEach((file) => {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -344,7 +344,7 @@ describe('Production Usage', () => {
     it('should set correct Cache-Control header for static 404s', async () => {
       // this is to fix where 404 headers are set to 'public, max-age=31536000, immutable'
       const res = await fetch(
-        `http://localhost:${appPort}/_next//static/common/bad-static.js`
+        `http://localhost:${appPort}/_next//static/common/bad-static.mjs`
       )
 
       expect(res.status).toBe(404)
@@ -753,14 +753,14 @@ describe('Production Usage', () => {
     const url = `http://localhost:${appPort}`
     await fetch(`${url}/stateless`) // make sure the stateless page is built
     const clientSideJsRes = await fetch(
-      `${url}/_next/development/static/development/pages/stateless.js`
+      `${url}/_next/development/static/development/pages/stateless.mjs`
     )
     expect(clientSideJsRes.status).toBe(404)
     const clientSideJsBody = await clientSideJsRes.text()
     expect(clientSideJsBody).toMatch(/404/)
 
     const serverSideJsRes = await fetch(
-      `${url}/_next/development/server/static/development/pages/stateless.js`
+      `${url}/_next/development/server/static/development/pages/stateless.mjs`
     )
     expect(serverSideJsRes.status).toBe(404)
     const serverSideJsBody = await serverSideJsRes.text()
@@ -799,7 +799,7 @@ describe('Production Usage', () => {
     for (const page of pages) {
       const file = getPageFileFromPagesManifest(appDir, page)
 
-      expect(file.endsWith('.js')).toBe(true)
+      expect(file).toMatch(/\.m?js$/)
     }
   })
 

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -32,6 +32,7 @@ module.exports = (context) => {
       const pathsToCheck = [
         `/_next/${buildId}/page/../../../info`,
         `/_next/${buildId}/page/../../../info.js`,
+        `/_next/${buildId}/page/../../../info.mjs`,
         `/_next/${buildId}/page/../../../info.json`,
         `/_next/:buildId/webpack/chunks/../../../info.json`,
         `/_next/:buildId/webpack/../../../info.json`,

--- a/test/integration/relay-analytics-disabled/test/index.test.js
+++ b/test/integration/relay-analytics-disabled/test/index.test.js
@@ -54,8 +54,8 @@ describe('Analytics relayer (disabled)', () => {
   it('Does not include the code', async () => {
     const pageFiles = [
       ...new Set([
-        ...buildManifest.pages['/'].filter((file) => file.endsWith('.js')),
-        ...buildManifest.pages['/_app'].filter((file) => file.endsWith('.js')),
+        ...buildManifest.pages['/'].filter((file) => /\.m?js$/.test(file)),
+        ...buildManifest.pages['/_app'].filter((file) => /\.m?js$/.test(file)),
       ]),
     ]
 

--- a/test/integration/required-server-files-ssr-404/test/index.test.js
+++ b/test/integration/required-server-files-ssr-404/test/index.test.js
@@ -538,9 +538,9 @@ describe('Required Server Files', () => {
 
   it('should handle 404s properly', async () => {
     for (const pathname of [
-      '/_next/static/chunks/pages/index-abc123.js',
-      '/_next/static/some-file.js',
-      '/static/some-file.js',
+      '/_next/static/chunks/pages/index-abc123.mjs',
+      '/_next/static/some-file.mjs',
+      '/static/some-file.mjs',
       '/non-existent',
       '/404',
     ]) {

--- a/test/integration/serverless-trace/test/index.test.js
+++ b/test/integration/serverless-trace/test/index.test.js
@@ -132,7 +132,7 @@ describe('Serverless Trace', () => {
     for (const page of pages) {
       const file = getPageFileFromPagesManifest(appDir, page)
 
-      expect(file.endsWith('.js')).toBe(true)
+      expect(file).toMatch(/\.m?js$/)
     }
   })
   it('should reply on API request successfully', async () => {

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -201,7 +201,7 @@ describe('Serverless', () => {
     for (const page of pages) {
       const file = getPageFileFromPagesManifest(appDir, page)
 
-      expect(file.endsWith('.js')).toBe(true)
+      expect(file).toMatch(/\.m?js$/)
     }
   })
 

--- a/test/integration/typeof-window-replace/test/index.test.js
+++ b/test/integration/typeof-window-replace/test/index.test.js
@@ -25,7 +25,7 @@ describe('typeof window replace', () => {
 
   it('Replaces `typeof window` with object for client code', async () => {
     const pageFile = buildManifest.pages['/'].find(
-      (file) => file.endsWith('.js') && file.includes('pages/index')
+      (file) => /\.m?js$/.test(file) && file.includes('pages/index')
     )
 
     const content = await fs.readFile(
@@ -48,7 +48,7 @@ describe('typeof window replace', () => {
 
   it('Does not replace `typeof window` for `node_modules` code', async () => {
     const pageFile = buildManifest.pages['/'].find(
-      (file) => file.endsWith('.js') && file.includes('pages/index')
+      (file) => /\.m?js$/.test(file) && file.includes('pages/index')
     )
 
     const content = await fs.readFile(

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -577,7 +577,7 @@ export function getPageFileFromBuildManifest(dir, page) {
 
   const pageFile = pageFiles.find(
     (file) =>
-      file.endsWith('.js') &&
+      /\.m?js$/.test(file) &&
       file.includes(`pages${page === '' ? '/index' : page}`)
   )
   if (!pageFile) {


### PR DESCRIPTION
This add ESM support for the client build.

TODOs:

- [ ] for testing purposes it's currently enabled by default -> disable it by default
- [ ] `experimental.esm: "client"`
- [ ] add tests

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
