### PR TITLE
Bump babel target to Node.js 12

### DIFF
--- a/packages/next/taskfile-babel.js
+++ b/packages/next/taskfile-babel.js
@@ -55,12 +55,6 @@ const babelServerOpts = {
           node: '12.0',
         },
         loose: true,
-        // This is handled by the Next.js webpack config that will run next/babel over the same code.
-        exclude: [
-          'transform-typeof-symbol',
-          'transform-async-to-generator',
-          'transform-spread',
-        ],
       },
     ],
   ],

--- a/packages/next/taskfile-babel.js
+++ b/packages/next/taskfile-babel.js
@@ -52,7 +52,7 @@ const babelServerOpts = {
       {
         modules: 'commonjs',
         targets: {
-          node: '8.3',
+          node: '12.0',
         },
         loose: true,
         // This is handled by the Next.js webpack config that will run next/babel over the same code.


### PR DESCRIPTION
Next.js 11 supports Node.js 12 and newer. This PR updates babel to reflect this.

Follow up to PR #25761 