### PR TITLE
Fix Image is missing required "src" property error

### DIFF
--- a/examples/cms-wordpress/components/post-preview.js
+++ b/examples/cms-wordpress/components/post-preview.js
@@ -14,7 +14,9 @@ export default function PostPreview({
   return (
     <div>
       <div className="mb-5">
-        <CoverImage title={title} coverImage={coverImage} slug={slug} />
+        {coverImage && (
+          <CoverImage title={title} coverImage={coverImage} slug={slug} />
+        )}
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
         <Link href={`/posts/${slug}`}>


### PR DESCRIPTION
Add safety check for `CoverImage` in `/components/post-preview.js` so as to prevent error occurring in the absence of cover image for on posts listed for preview - fixes #23742.