### PR TITLE
Change pure functions to functions

### DIFF
--- a/docs/api-routes/api-middlewares.md
+++ b/docs/api-routes/api-middlewares.md
@@ -119,7 +119,7 @@ export default handler
 
 ## Extending the `req`/`res` objects with TypeScript
 
-For better type-safety, it is not recommended to extend the `req` and `res` objects. Instead, use pure functions to work with them:
+For better type-safety, it is not recommended to extend the `req` and `res` objects. Instead, use functions to work with them:
 
 ```ts
 // utils/cookies.ts


### PR DESCRIPTION
The right terminology should be used so we don't learn new developers wrong facts.

Using pure function here is plain wrong, the definition of a pure functions is as follows:

> The function return values are identical for identical arguments. The function application has no side effects. 

What you have here both have side effects, the calls to `res.setXXX`, and it isn't identical for identical arguments since you have `Date.now()`.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
