### PR TITLE
fix: Respect TransitionOptions.scroll when replacing a hash

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -944,7 +944,7 @@ export default class Router implements BaseRouter {
       Router.events.emit('hashChangeStart', as, routeProps)
       // TODO: do we need the resolved href when only a hash change?
       this.changeState(method, url, as, options)
-      this.scrollToHash(cleanedAs)
+      this.scrollToHash(cleanedAs, options)
       this.notify(this.components[this.route], null)
       Router.events.emit('hashChangeComplete', as, routeProps)
       return true
@@ -1453,7 +1453,10 @@ export default class Router implements BaseRouter {
     return oldHash !== newHash
   }
 
-  scrollToHash(as: string): void {
+  scrollToHash(as: string, options: TransitionOptions = {}): void {
+    // Prevents forced scroll TransitionOptions.scroll is deliberately set to false
+    if (!options.scroll) return;
+
     const [, hash] = as.split('#')
     // Scroll to top if the hash is just `#` with no value or `#top`
     // To mirror browsers

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1453,7 +1453,7 @@ export default class Router implements BaseRouter {
     return oldHash !== newHash
   }
 
-  scrollToHash(as: string, options: TransitionOptions = {}): void {
+  scrollToHash(as: string, options: TransitionOptions): void {
     // Prevents forced scroll TransitionOptions.scroll is deliberately set to false
     if (!options.scroll) return;
 

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1455,7 +1455,7 @@ export default class Router implements BaseRouter {
 
   scrollToHash(as: string, options: TransitionOptions): void {
     // Prevents forced scroll TransitionOptions.scroll is deliberately set to false
-    if (!options.scroll) return;
+    if (!options.scroll) return
 
     const [, hash] = as.split('#')
     // Scroll to top if the hash is just `#` with no value or `#top`


### PR DESCRIPTION
In some scenarios it's nice to have the option to replace a hash in the url without enforcing a scroll. The TransitionsOptions already allow you to set the scroll option as false, but currently the `scrollToHash` method doesn't respect it.

[Related discussion #13804](https://github.com/vercel/next.js/discussions/13804)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
