### PR TITLE
Add note about beforeFiles continuing

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -87,6 +87,8 @@ module.exports = {
 }
 ```
 
+Note: rewrites in `beforeFiles` do not check the filesystem/dynamic routes immediately after matching a source, they continue until all `beforeFiles` have been checked.
+
 ## Rewrite parameters
 
 When using parameters in a rewrite the parameters will be passed in the query by default when none of the parameters are used in the `destination`.


### PR DESCRIPTION
This adds a note explaining that `beforeFiles` continue instead of checking the filesystem/dynamic routes immediately like they do in `afterFiles` and `fallback`. 

## Documentation / Examples

- [x] Make sure the linting passes

Closes: https://github.com/vercel/next.js/issues/26795