### PR TITLE
Add warning for large number of routes

### DIFF
--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -414,6 +414,10 @@
         {
           "title": "import-esm-externals",
           "path": "/errors/import-esm-externals.md"
+        },
+        {
+          "title": "max-custom-routes-reached",
+          "path": "max-custom-routes-reached.md"
         }
       ]
     }

--- a/errors/max-custom-routes-reached.md
+++ b/errors/max-custom-routes-reached.md
@@ -1,0 +1,17 @@
+# Max Custom Routes Reached
+
+#### Why This Error Occurred
+
+The number of combined routes from `headers`, `redirects`, and `rewrites` exceeds 1024. This can impact the performance of requests since for each request all of these routes can potentially need to be checked.
+
+#### Possible Ways to Fix It
+
+- Leverage dynamic routes inside of the `pages` folder to reduce the number of rewrites needed
+- Combine headers routes into dynamic matches e.g. `/first-header-route` `/second-header-route` -> `/(first-header-route$|second-header-route$)`
+
+### Useful Links
+
+- [Dynamic Routes documentation](https://nextjs.org/docs/routing/dynamic-routes)
+- [Rewrites documentation](https://nextjs.org/docs/api-reference/next.config.js/rewrites)
+- [Redirects documentation](https://nextjs.org/docs/api-reference/next.config.js/redirects)
+- [Headers documentation](https://nextjs.org/docs/api-reference/next.config.js/headers)

--- a/errors/max-custom-routes-reached.md
+++ b/errors/max-custom-routes-reached.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-The number of combined routes from `headers`, `redirects`, and `rewrites` exceeds 1024. This can impact performance because each request will iterate over all routes to check for a match in the worst case.
+The number of combined routes from `headers`, `redirects`, and `rewrites` exceeds 1000. This can impact performance because each request will iterate over all routes to check for a match in the worst case.
 
 #### Possible Ways to Fix It
 

--- a/errors/max-custom-routes-reached.md
+++ b/errors/max-custom-routes-reached.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-The number of combined routes from `headers`, `redirects`, and `rewrites` exceeds 1024. This can impact the performance of requests since for each request all of these routes can potentially need to be checked.
+The number of combined routes from `headers`, `redirects`, and `rewrites` exceeds 1024. This can impact performance because each request will iterate over all routes to check for a match in the worst case.
 
 #### Possible Ways to Fix It
 

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -1,4 +1,5 @@
 import { parse as parseUrl } from 'url'
+import * as Log from '../build/output/log'
 import { NextConfig } from '../server/config'
 import * as pathToRegexp from 'next/dist/compiled/path-to-regexp'
 import escapeStringRegexp from 'next/dist/compiled/escape-string-regexp'
@@ -666,6 +667,23 @@ export default async function loadCustomRoutes(
         internal: true,
       } as Redirect)
     }
+  }
+
+  const totalRewrites =
+    rewrites.beforeFiles.length +
+    rewrites.afterFiles.length +
+    rewrites.fallback.length
+
+  const totalRoutes = headers.length + redirects.length + totalRewrites
+
+  if (totalRoutes > 1024) {
+    console.warn(
+      `Warning total number of custom routes exceeds 1024, this can reduce performance. Route counts:\n` +
+        `headers: ${headers.length}\n` +
+        `rewrites: ${totalRewrites}\n` +
+        `redirects: ${redirects.length}\n` +
+        `See more info: https://nextjs.org/docs/messages/max-custom-routes-reached`
+    )
   }
 
   return {

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import { parse as parseUrl } from 'url'
 import { NextConfig } from '../server/config'
 import * as pathToRegexp from 'next/dist/compiled/path-to-regexp'
@@ -621,6 +622,24 @@ export default async function loadCustomRoutes(
     loadRedirects(config),
   ])
 
+  const totalRewrites =
+    rewrites.beforeFiles.length +
+    rewrites.afterFiles.length +
+    rewrites.fallback.length
+
+  const totalRoutes = headers.length + redirects.length + totalRewrites
+
+  if (totalRoutes > 1000) {
+    console.warn(
+      chalk.bold.yellow(`Warning: `) +
+        `total number of custom routes exceeds 1000, this can reduce performance. Route counts:\n` +
+        `headers: ${headers.length}\n` +
+        `rewrites: ${totalRewrites}\n` +
+        `redirects: ${redirects.length}\n` +
+        `See more info: https://nextjs.org/docs/messages/max-custom-routes-reached`
+    )
+  }
+
   if (config.trailingSlash) {
     redirects.unshift(
       {
@@ -666,23 +685,6 @@ export default async function loadCustomRoutes(
         internal: true,
       } as Redirect)
     }
-  }
-
-  const totalRewrites =
-    rewrites.beforeFiles.length +
-    rewrites.afterFiles.length +
-    rewrites.fallback.length
-
-  const totalRoutes = headers.length + redirects.length + totalRewrites
-
-  if (totalRoutes > 1024) {
-    console.warn(
-      `Warning total number of custom routes exceeds 1024, this can reduce performance. Route counts:\n` +
-        `headers: ${headers.length}\n` +
-        `rewrites: ${totalRewrites}\n` +
-        `redirects: ${redirects.length}\n` +
-        `See more info: https://nextjs.org/docs/messages/max-custom-routes-reached`
-    )
   }
 
   return {

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -1,5 +1,4 @@
 import { parse as parseUrl } from 'url'
-import * as Log from '../build/output/log'
 import { NextConfig } from '../server/config'
 import * as pathToRegexp from 'next/dist/compiled/path-to-regexp'
 import escapeStringRegexp from 'next/dist/compiled/escape-string-regexp'


### PR DESCRIPTION
This adds a warning when more than 1000 routes are added since it can have performance impacts and includes a document that we can add suggestions to reduce the number of routes being added. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
