### PR TITLE
Document full routes order in rewrites doc

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -89,6 +89,15 @@ module.exports = {
 
 Note: rewrites in `beforeFiles` do not check the filesystem/dynamic routes immediately after matching a source, they continue until all `beforeFiles` have been checked.
 
+The order Next.js routes are checked is:
+
+1. [headers](/docs/api-reference/next.config.js/headers.md) are checked/applied
+2. [redirects](/docs/api-reference/next.config.js/redirects.md) are checked/applied
+3. `beforeFiles` rewrites are checked/applied
+4. static files from the [public directory](https://nextjs.org/docs/basic-features/static-file-serving), `_next/static` files, and non-dynamic pages are checked/served
+5. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
+6. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked.
+
 ## Rewrite parameters
 
 When using parameters in a rewrite the parameters will be passed in the query by default when none of the parameters are used in the `destination`.

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -91,10 +91,10 @@ Note: rewrites in `beforeFiles` do not check the filesystem/dynamic routes immed
 
 The order Next.js routes are checked is:
 
-1. [headers](/docs/api-reference/next.config.js/headers.md) are checked/applied
-2. [redirects](/docs/api-reference/next.config.js/redirects.md) are checked/applied
+1. [headers](/docs/api-reference/next.config.js/headers) are checked/applied
+2. [redirects](/docs/api-reference/next.config.js/redirects) are checked/applied
 3. `beforeFiles` rewrites are checked/applied
-4. static files from the [public directory](https://nextjs.org/docs/basic-features/static-file-serving), `_next/static` files, and non-dynamic pages are checked/served
+4. static files from the [public directory](/docs/basic-features/static-file-serving), `_next/static` files, and non-dynamic pages are checked/served
 5. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
 6. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked.
 


### PR DESCRIPTION
This expands on https://github.com/vercel/next.js/pull/27211 and lists the full routes order used in Next.js to allow more exact matching when leveraging the different rewrite priorities. 

## Documentation / Examples

- [x] Make sure the linting passes
