### PR TITLE
update fastify example to the latest version

### DIFF
--- a/examples/custom-server-fastify/package.json
+++ b/examples/custom-server-fastify/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "cross-env": "^7.0.2",
-    "fastify": "^2.12.1",
+    "fastify": "^3.19.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/examples/custom-server-fastify/server.js
+++ b/examples/custom-server-fastify/server.js
@@ -1,4 +1,7 @@
-const fastify = require('fastify')({ logger: { level: 'error' }, pluginTimeout: 0 })
+const fastify = require('fastify')({
+  logger: { level: 'error' },
+  pluginTimeout: 0,
+})
 const Next = require('next')
 
 const port = parseInt(process.env.PORT, 10) || 3000

--- a/examples/custom-server-fastify/server.js
+++ b/examples/custom-server-fastify/server.js
@@ -1,4 +1,4 @@
-const fastify = require('fastify')({ logger: { level: 'error' },pluginTimeout:0 }) 
+const fastify = require('fastify')({ logger: { level: 'error' }, pluginTimeout: 0 })
 const Next = require('next')
 
 const port = parseInt(process.env.PORT, 10) || 3000

--- a/examples/custom-server-fastify/server.js
+++ b/examples/custom-server-fastify/server.js
@@ -1,4 +1,4 @@
-const fastify = require('fastify')({ logger: { level: 'error' } })
+const fastify = require('fastify')({ logger: { level: 'error' },pluginTimeout:0 }) 
 const Next = require('next')
 
 const port = parseInt(process.env.PORT, 10) || 3000
@@ -12,32 +12,32 @@ fastify.register((fastify, opts, next) => {
     .then(() => {
       if (dev) {
         fastify.get('/_next/*', (req, reply) => {
-          return handle(req.req, reply.res).then(() => {
+          return handle(req.raw, reply.raw).then(() => {
             reply.sent = true
           })
         })
       }
 
       fastify.get('/a', (req, reply) => {
-        return app.render(req.req, reply.res, '/a', req.query).then(() => {
+        return app.render(req.raw, reply.raw, '/a', req.query).then(() => {
           reply.sent = true
         })
       })
 
       fastify.get('/b', (req, reply) => {
-        return app.render(req.req, reply.res, '/b', req.query).then(() => {
+        return app.render(req.raw, reply.raw, '/b', req.query).then(() => {
           reply.sent = true
         })
       })
 
       fastify.all('/*', (req, reply) => {
-        return handle(req.req, reply.res).then(() => {
+        return handle(req.raw, reply.raw).then(() => {
           reply.sent = true
         })
       })
 
       fastify.setNotFoundHandler((request, reply) => {
-        return app.render404(request.req, reply.res).then(() => {
+        return app.render404(request.raw, reply.raw).then(() => {
           reply.sent = true
         })
       })


### PR DESCRIPTION
Updated fastify to the latest version. req.req is deprecated and reply.res doesn't exist in the new version of fastify.