### PR TITLE
Use named functions in layouts docs

### DIFF
--- a/docs/basic-features/layouts.md
+++ b/docs/basic-features/layouts.md
@@ -66,11 +66,13 @@ export default function Page() {
   }
 }
 
-Page.getLayout = (page) => (
-  <Layout>
-    <NestedLayout>{page}</NestedLayout>
-  </Layout>
-)
+Page.getLayout = function getLayout(page) {
+  return (
+    <Layout>
+      <NestedLayout>{page}</NestedLayout>
+    </Layout>
+  )
+}
 ```
 
 ```jsx


### PR DESCRIPTION
## Documentation / Examples
- [x] Make sure the linting passes

Fixes #27252 by using a named function rather than an arrow function. If this is the correct fix, then modifications are also needed for the `layout-component` example, but I'm just providing this one modification right now in case this fix is incorrect.