### PR TITLE
Fix default server host value causing issues on Windows

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -77,7 +77,7 @@ const nextDev: cliCommand = (argv) => {
   // We do not set a default host value here to prevent breaking
   // some set-ups that rely on listening on other interfaces
   const host = args['--hostname']
-  const ipPort = `${!host ? 'localhost' : host}:${port}`
+  const ipPort = `${host || 'localhost'}:${port}`
   const appUrl = `http://${ipPort}`
 
   startServer({ dir, dev: true, isNextDevCommand: true }, port, host)

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -73,12 +73,16 @@ const nextDev: cliCommand = (argv) => {
 
   const port =
     args['--port'] || (process.env.PORT && parseInt(process.env.PORT)) || 3000
-  const host = args['--hostname'] || '0.0.0.0'
-  const appUrl = `http://${host === '0.0.0.0' ? 'localhost' : host}:${port}`
+
+  // We do not set a default host value here to prevent breaking
+  // some set-ups that rely on listening on other interfaces
+  const host = args['--hostname']
+  const ipPort = `${!host ? 'localhost' : host}:${port}`
+  const appUrl = `http://${ipPort}`
 
   startServer({ dir, dev: true, isNextDevCommand: true }, port, host)
     .then(async (app) => {
-      startedDevelopmentServer(appUrl, `${host}:${port}`)
+      startedDevelopmentServer(appUrl, ipPort)
       // Start preflight after server is listening and ignore errors:
       preflight().catch(() => {})
       // Finalize server bootup:

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -77,12 +77,13 @@ const nextDev: cliCommand = (argv) => {
   // We do not set a default host value here to prevent breaking
   // some set-ups that rely on listening on other interfaces
   const host = args['--hostname']
-  const ipPort = `${host || 'localhost'}:${port}`
-  const appUrl = `http://${ipPort}`
+  const appUrl = `http://${
+    !host || host === '0.0.0.0' ? 'localhost' : host
+  }:${port}`
 
   startServer({ dir, dev: true, isNextDevCommand: true }, port, host)
     .then(async (app) => {
-      startedDevelopmentServer(appUrl, ipPort)
+      startedDevelopmentServer(appUrl, `${host || '0.0.0.0'}:${port}`)
       // Start preflight after server is listening and ignore errors:
       preflight().catch(() => {})
       // Finalize server bootup:


### PR DESCRIPTION
This fixes a case where the HMR connection for fast refresh would fail to connect on Windows due to a change being made to the default host being listened to. Previously we didn't set a default for the `host` value when calling `server.listen` which allowed the default listening behavior to be used although in https://github.com/vercel/next.js/pull/20409 a default of `0.0.0.0` was added which causes conflicts for some set-ups mainly on Windows it seems. 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added (N/A)
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/27298
Fixes: https://github.com/vercel/next.js/issues/27254
Fixes: https://github.com/vercel/next.js/issues/4456#issuecomment
Fixes: https://github.com/vercel/next.js/pull/20409#issuecomment-849933092
x-ref: https://github.com/vercel/next.js/pull/20409