### PR TITLE
Increase stats action install timeout

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -102,7 +102,9 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       logger(`Running initial build for ${dir}`)
       if (!actionInfo.skipClone) {
         let buildCommand = `cd ${dir}${
-          !statsConfig.skipInitialInstall ? ' && yarn install' : ''
+          !statsConfig.skipInitialInstall
+            ? ' && yarn install --network-timeout 1000000'
+            : ''
         }`
 
         if (statsConfig.initialBuildCommand) {


### PR DESCRIPTION
This updates the PR stats action to add the `--network-timeout 1000000` flag when doing initial `yarn` installation to hopefully prevent the random `yarn` failures while it's running. Thanks @styfle for the tip! 
