### PR TITLE
Continue: fix typo in breakpoint config

### DIFF
--- a/examples/with-stitches/stitches.config.js
+++ b/examples/with-stitches/stitches.config.js
@@ -67,7 +67,7 @@ export const { css, styled, global, getCssString } = createCss({
     }),
   },
   media: {
-    bp1: '@media (min-width: 520px)',
-    bp2: '@media (min-width: 900px)',
+    bp1: '(min-width: 520px)',
+    bp2: '(min-width: 900px)',
   },
 })


### PR DESCRIPTION
This copies over the example fix from https://github.com/vercel/next.js/pull/25806 since we can't land the PR from a deleted fork/branch it seems. 


## Documentation / Examples

- [x] Make sure the linting passes
