### PR TITLE
fix: hydration warning in with-mobx-state-tree-typescript example

### DIFF
--- a/examples/with-mobx-state-tree-typescript/components/SampleComponent.tsx
+++ b/examples/with-mobx-state-tree-typescript/components/SampleComponent.tsx
@@ -11,7 +11,7 @@ interface IOwnProps {
 }
 
 const SampleComponent: React.FC<IOwnProps> = observer((props) => {
-  const { lastUpdate, light, start, stop } = useStore('')
+  const { lastUpdate, light, start, stop } = useStore(props.store)
 
   useEffect(() => {
     start()

--- a/examples/with-mobx-state-tree-typescript/next-env.d.ts
+++ b/examples/with-mobx-state-tree-typescript/next-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />

--- a/examples/with-mobx-state-tree-typescript/pages/ssg.tsx
+++ b/examples/with-mobx-state-tree-typescript/pages/ssg.tsx
@@ -2,8 +2,8 @@ import { getSnapshot } from 'mobx-state-tree'
 import SampleComponent from '../components/SampleComponent'
 import { initializeStore } from '../store'
 
-export default function Ssg() {
-  return <SampleComponent title={'SSG Page'} linkTo="/" />
+export default function Ssg({ initialState }) {
+  return <SampleComponent title={'SSG Page'} linkTo="/" store={initialState} />
 }
 
 // If you build and start the app, the date returned here will have the same

--- a/examples/with-mobx-state-tree-typescript/pages/ssr.tsx
+++ b/examples/with-mobx-state-tree-typescript/pages/ssr.tsx
@@ -2,8 +2,8 @@ import { getSnapshot } from 'mobx-state-tree'
 import SampleComponent from '../components/SampleComponent'
 import { initializeStore } from '../store'
 
-export default function Ssr() {
-  return <SampleComponent title={'SSR Page'} linkTo="/" />
+export default function Ssr({ initialState }) {
+  return <SampleComponent title={'SSR Page'} linkTo="/" store={initialState} />
 }
 
 // The date returned here will be different for every request that hits the page,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number` fixes https://github.com/vercel/next.js/issues/27290
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes
