### PR TITLE
Add extra explanation to next/image about positioning

### DIFF
--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -102,9 +102,8 @@ When `responsive`, the image will scale the dimensions down for smaller
 viewports and scale up for larger viewports.
 
 When `fill`, the image will stretch both width and height to the dimensions of
-the parent element, provided the parent element is relative. This is usually paired with the [`objectFit`](#objectFit) property. 
+the parent element, provided the parent element is relative. This is usually paired with the [`objectFit`](#objectFit) property.
 Ensure the parent element has `position: relative` in their stylesheet.
-
 
 Try it out:
 

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -103,7 +103,7 @@ viewports and scale up for larger viewports.
 
 When `fill`, the image will stretch both width and height to the dimensions of
 the parent element, provided the parent element is relative. This is usually paired with the [`objectFit`](#objectFit) property. 
-Make sure that the parent element has `position: relative` in their stylesheet.
+Ensure the parent element has `position: relative` in their stylesheet.
 
 
 Try it out:

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -102,7 +102,9 @@ When `responsive`, the image will scale the dimensions down for smaller
 viewports and scale up for larger viewports.
 
 When `fill`, the image will stretch both width and height to the dimensions of
-the parent element, provided the parent element is relative. This is usually paired with the [`objectFit`](#objectFit) property.
+the parent element, provided the parent element is relative. This is usually paired with the [`objectFit`](#objectFit) property. 
+Make sure that the parent element has `position: relative` in their stylesheet.
+
 
 Try it out:
 


### PR DESCRIPTION
In my experience, when using next/image, a lot of devs forget about the `position: relative` when using `layout: fill`. I think it's a small and effective change to implement this one line to make it more clear.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
