### PR TITLE
Indicate attaching debugger (vs launching)

### DIFF
--- a/docs/advanced-features/debugging.md
+++ b/docs/advanced-features/debugging.md
@@ -55,7 +55,7 @@ Create a file named `.vscode/launch.json` at the root of your project with this 
     {
       "type": "node",
       "request": "attach",
-      "name": "Launch Program",
+      "name": "Attach to application",
       "skipFiles": ["<node_internals>/**"],
       "port": 9229
     }


### PR DESCRIPTION
**Documentation change only.** The prior configuration name indicating that it launched the application. Really, it just attaches to an already running application, which the new name indicates.