### PR TITLE
Fixed typo and error when using Auth0 service;

### DIFF
--- a/examples/blog-with-comment/README.md
+++ b/examples/blog-with-comment/README.md
@@ -46,7 +46,7 @@ Go to the [Upstash Console](https://console.upstash.com/) and create a new datab
      to `https://myapp.com/` when deploying your application.
    - **Allowed Logout URLs**: Should be set to `http://localhost:3000/` when testing locally or typically
      to `https://myapp.com/` when deploying your application.
-   - **Allowed Web Origins**: Should be set to `http://localhost:3000` when testing locally or typically 
+   - **Allowed Web Origins**: Should be set to `http://localhost:3000` when testing locally or typically
      to `https://myapp.com/` when deploying your application.
 4. Save the settings.
 

--- a/examples/blog-with-comment/README.md
+++ b/examples/blog-with-comment/README.md
@@ -46,13 +46,15 @@ Go to the [Upstash Console](https://console.upstash.com/) and create a new datab
      to `https://myapp.com/` when deploying your application.
    - **Allowed Logout URLs**: Should be set to `http://localhost:3000/` when testing locally or typically
      to `https://myapp.com/` when deploying your application.
+   - **Allowed Web Origins**: Should be set to `http://localhost:3000` when testing locally or typically 
+     to `https://myapp.com/` when deploying your application.
 4. Save the settings.
 
 #### Auth0 environment
 
 - `NEXT_PUBLIC_AUTH0_DOMAIN`: Can be found in the Auth0 dashboard under `settings`.
 - `NEXT_PUBLIC_AUTH0_CLIENT_ID`: Can be found in the Auth0 dashboard under `settings`.
-- `NEXT_PUBLIC_AUTH0_ADMIN_EMAIL`: This is the email of the admin user which you use while singing in Auth0. Admin is able to delete any comment.
+- `NEXT_PUBLIC_AUTH0_ADMIN_EMAIL`: This is the email of the admin user which you use while signing in Auth0. Admin is able to delete any comment.
 
 ## Deploy Your Local Project
 


### PR DESCRIPTION
`Allowed Web Origin` on Auth0 is now required to be set to `http://localhost:3000`

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes
