### PR TITLE
Increase PR stats repo build timeout

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -110,7 +110,9 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
         if (statsConfig.initialBuildCommand) {
           buildCommand += ` && ${statsConfig.initialBuildCommand}`
         }
-        await exec(buildCommand)
+        // allow 5 minutes node_modules install + building all packages
+        // in case of noisy environment slowing down initial repo build
+        await exec(buildCommand, false, { timeout: 5 * 60 * 1000 })
       }
 
       logger(`Linking packages in ${dir}`)


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/27308 this increases the `exec` timeout to allow more time for the repo to install/build since it can sometimes take longer in GitHub actions. 