### PR TITLE
type custom, for redirect and rewrite has

### DIFF
--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -129,9 +129,10 @@ To only match a redirect when header, cookie, or query values also match the `ha
 
 `has` items have the following fields:
 
-- `type`: `String` - must be either `header`, `cookie`, `host`, or `query`.
+- `type`: `String` - must be either `header`, `cookie`, `host`, `query`, or `custom`.
 - `key`: `String` - the key from the selected type to match against.
 - `value`: `String` or `undefined` - the value to check for, if undefined any value will match. A regex like string can be used to capture a specific part of the value, e.g. if the value `first-(?<paramName>.*)` is used for `first-second` then `second` will be usable in the destination with `:paramName`.
+- `check`: `Function` - when the `type` is `custom`, `check` is a function that accepts `req` and returns `false` when it should not redirect, `true` when it should redirect, or a parameters object, with parameters to be used in the redirection.
 
 ```js
 module.exports = {
@@ -194,6 +195,18 @@ module.exports = {
           {
             type: 'host',
             value: 'example.com',
+          },
+        ],
+        destination: '/another-page',
+      },
+      // if a custom check matches (the cookie foo should be equal to the query parameter foo),
+      // this redirect will be applied
+      {
+        source: '/some-page',
+        has: [
+          {
+            type: 'custom',
+            check: req => req.cookies.foo === req.query.foo
           },
         ],
         destination: '/another-page',

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -222,9 +222,10 @@ To only match a rewrite when header, cookie, or query values also match the `has
 
 `has` items have the following fields:
 
-- `type`: `String` - must be either `header`, `cookie`, `host`, or `query`.
+- `type`: `String` - must be either `header`, `cookie`, `host`, `query`, or `custom`.
 - `key`: `String` - the key from the selected type to match against.
 - `value`: `String` or `undefined` - the value to check for, if undefined any value will match. A regex like string can be used to capture a specific part of the value, e.g. if the value `first-(?<paramName>.*)` is used for `first-second` then `second` will be usable in the destination with `:paramName`.
+- `check`: `Function` - when the `type` is `custom`, `check` is a function that accepts `req` and returns `false` when it should not rewrite, `true` when it should redirect, or a parameters object, with parameters to be used in the redirection.
 
 ```js
 module.exports = {
@@ -284,6 +285,18 @@ module.exports = {
           {
             type: 'host',
             value: 'example.com',
+          },
+        ],
+        destination: '/another-page',
+      },
+      // if a custom check matches (the cookie foo should be equal to the query parameter foo),
+      // this redirect will be applied
+      {
+        source: '/some-page',
+        has: [
+          {
+            type: 'custom',
+            check: (req) => req.cookies.foo === req.query.foo,
           },
         ],
         destination: '/another-page',

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { IncomingMessage } from 'http'
 import { parse as parseUrl } from 'url'
 import { NextConfig } from '../server/config'
 import * as pathToRegexp from 'next/dist/compiled/path-to-regexp'
@@ -13,11 +14,19 @@ export type RouteHas =
       type: 'header' | 'query' | 'cookie'
       key: string
       value?: string
+      match?: undefined
     }
   | {
       type: 'host'
       key?: undefined
       value: string
+      match?: undefined
+    }
+  | {
+      type: 'custom'
+      key?: undefined
+      value?: undefined
+      match: (req: IncomingMessage) => boolean | { [param: string]: any }
     }
 
 export type Rewrite = {

--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -14,19 +14,19 @@ export type RouteHas =
       type: 'header' | 'query' | 'cookie'
       key: string
       value?: string
-      match?: undefined
+      check?: undefined
     }
   | {
       type: 'host'
       key?: undefined
       value: string
-      match?: undefined
+      check?: undefined
     }
   | {
       type: 'custom'
       key?: undefined
       value?: undefined
-      match: (req: IncomingMessage) => boolean | { [param: string]: any }
+      check: (req: IncomingMessage) => boolean | { [param: string]: any }
     }
 
 export type Rewrite = {

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -72,18 +72,22 @@ export function matchHas(
         break
       }
       case 'custom': {
-        if (typeof hasItem.match !== 'function') {
+        if (typeof hasItem.check !== 'function') {
           return false
         }
-        const result = hasItem.match(req)
-
-        if (!result) {
+        try {
+          const result = hasItem.check(req)
+          if (!result) {
+            return false
+          }
+          if (typeof result === 'object') {
+            Object.assign(params, result)
+          }
+          return true
+        } catch (e) {
+          console.error(e)
           return false
         }
-        if (typeof result === 'object') {
-          Object.assign(params, result)
-        }
-        return true
       }
       default: {
         break

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -71,6 +71,20 @@ export function matchHas(
         value = hostname
         break
       }
+      case 'custom': {
+        if (typeof hasItem.match !== 'function') {
+          return false
+        }
+        const result = hasItem.match(req)
+
+        if (!result) {
+          return false
+        }
+        if (typeof result === 'object') {
+          Object.assign(params, result)
+        }
+        return true
+      }
       default: {
         break
       }


### PR DESCRIPTION
## Feature

It's a secondary request in this discussion: https://github.com/vercel/next.js/discussions/25931

And it's related with this PR https://github.com/vercel/next.js/pull/27103

The "has not" would be simple, it only redirects on absence.

If the developer wants to redirect when the value is not equal, he can use the custom check.

Also the custom check makes it possible to write conditional redirections for any scenario, like regular expressions, or 

