### PR TITLE
docs: Fix minor mistype

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ We recommend creating a new Next.js app using `create-next-app`, which sets up e
 ```bash
 npx create-next-app
 # or
-yarn create next-app
+yarn create-next-app
 ```
 
 If you want to start with a TypeScript project you can use the `--typescript` flag:
@@ -32,7 +32,7 @@ If you want to start with a TypeScript project you can use the `--typescript` fl
 ```bash
 npx create-next-app --typescript
 # or
-yarn create next-app --typescript
+yarn create-next-app --typescript
 ```
 
 After the installation is complete, follow the instructions to start the development server. Try editing `pages/index.js` and see the result on your browser.


### PR DESCRIPTION
You forgot to put dash at `create next-app`, it supposed to be `create-next-app`.