### PR TITLE
Add warning when `next/image` component has `style` prop

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -417,6 +417,11 @@ export default function Image({
         `Image with src "${src}" is using unsupported "ref" property. Consider using the "onLoadingComplete" property instead.`
       )
     }
+    if ('style' in rest) {
+      console.warn(
+        `Image with src "${src}" is using unsupported "style" property. Please use the "className" property instead.`
+      )
+    }
     const rand = Math.floor(Math.random() * 1000) + 100
     if (
       !unoptimized &&

--- a/test/integration/image-component/default/pages/invalid-style.js
+++ b/test/integration/image-component/default/pages/invalid-style.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import Image from 'next/image'
+import img from '../public/test.jpg'
+
+const Page = () => {
+  return (
+    <div>
+      <Image id="invalid-style" src={img} style={{ width: '100%' }} />
+    </div>
+  )
+}
+
+export default Page

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -556,6 +556,19 @@ function runTests(mode) {
         /Image with src (.*)jpg(.*) is smaller than 40x40. Consider removing(.*)/gm
       )
     })
+
+    it('should warn when style prop is used', async () => {
+      const browser = await webdriver(appPort, '/invalid-style')
+
+      const warnings = (await browser.log('browser'))
+        .map((log) => log.message)
+        .join('\n')
+      console.log({ warnings })
+      expect(await hasRedbox(browser)).toBe(false)
+      expect(warnings).toMatch(
+        /Image with src (.*)jpg(.*) is using unsupported \\"style\\" property(.*)/gm
+      )
+    })
   } else {
     //server-only tests
     it('should not create an image folder in server/chunks', async () => {

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -563,7 +563,6 @@ function runTests(mode) {
       const warnings = (await browser.log('browser'))
         .map((log) => log.message)
         .join('\n')
-      console.log({ warnings })
       expect(await hasRedbox(browser)).toBe(false)
       expect(warnings).toMatch(
         /Image with src (.*)jpg(.*) is using unsupported \\"style\\" property(.*)/gm


### PR DESCRIPTION
We've never supported the `style` prop as seen in the docs https://nextjs.org/docs/api-reference/next/image#other-props

TS users already get a build error but JS users were left in the dark.

This PR adds a warning so its clear during `next dev`.