### PR TITLE
Ensure generateBuildId is not required in config type

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -45,7 +45,7 @@ export type NextConfig = { [key: string]: any } & {
   cleanDistDir?: boolean
   assetPrefix?: string
   useFileSystemPublicRoutes?: boolean
-  generateBuildId: () => string | null
+  generateBuildId?: () => string | null
   generateEtags?: boolean
   pageExtensions?: string[]
   compress?: boolean


### PR DESCRIPTION
This ensures none of the top-level config fields are required as this type is public and can be used for type checking now. 

Fixes: https://github.com/vercel/next.js/issues/27428

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
