### PR TITLE
Add locale switcher to i18n-routing example

### DIFF
--- a/examples/i18n-routing/components/locale-switcher.js
+++ b/examples/i18n-routing/components/locale-switcher.js
@@ -1,5 +1,5 @@
-import { useRouter } from 'next/router'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 export default function LocaleSwitcher() {
   const router = useRouter()

--- a/examples/i18n-routing/components/locale-switcher.js
+++ b/examples/i18n-routing/components/locale-switcher.js
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+
+export default function LocaleSwitcher() {
+  const router = useRouter()
+  const { locales, locale: activeLocale } = router
+  const otherLocales = locales.filter((locale) => locale !== activeLocale)
+
+  return (
+    <div>
+      <p>Locale switcher:</p>
+      <ul>
+        {otherLocales.map((locale) => {
+          const { pathname, query } = router
+          return (
+            <li key={locale}>
+              <Link href={{ pathname, query }} locale={locale}>
+                <a>{locale}</a>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/examples/i18n-routing/components/locale-switcher.js
+++ b/examples/i18n-routing/components/locale-switcher.js
@@ -11,10 +11,10 @@ export default function LocaleSwitcher() {
       <p>Locale switcher:</p>
       <ul>
         {otherLocales.map((locale) => {
-          const { pathname, query } = router
+          const { pathname, query, asPath } = router
           return (
             <li key={locale}>
-              <Link href={{ pathname, query }} locale={locale}>
+              <Link href={{ pathname, query }} as={asPath} locale={locale}>
                 <a>{locale}</a>
               </Link>
             </li>

--- a/examples/i18n-routing/pages/gsp/[slug].js
+++ b/examples/i18n-routing/pages/gsp/[slug].js
@@ -1,5 +1,6 @@
-import Link from 'next/link'
+import LocaleSwitcher from '../../components/locale-switcher'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 
 export default function GspPage(props) {
   const router = useRouter()
@@ -16,6 +17,9 @@ export default function GspPage(props) {
       <p>Current locale: {props.locale}</p>
       <p>Default locale: {defaultLocale}</p>
       <p>Configured locales: {JSON.stringify(props.locales)}</p>
+
+      <LocaleSwitcher />
+      <br />
 
       <Link href="/gsp">
         <a>To getStaticProps page</a>

--- a/examples/i18n-routing/pages/gsp/[slug].js
+++ b/examples/i18n-routing/pages/gsp/[slug].js
@@ -1,6 +1,6 @@
-import LocaleSwitcher from '../../components/locale-switcher'
-import { useRouter } from 'next/router'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
+import LocaleSwitcher from '../../components/locale-switcher'
 
 export default function GspPage(props) {
   const router = useRouter()
@@ -19,7 +19,6 @@ export default function GspPage(props) {
       <p>Configured locales: {JSON.stringify(props.locales)}</p>
 
       <LocaleSwitcher />
-      <br />
 
       <Link href="/gsp">
         <a>To getStaticProps page</a>

--- a/examples/i18n-routing/pages/gsp/index.js
+++ b/examples/i18n-routing/pages/gsp/index.js
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import LocaleSwitcher from '../../components/locale-switcher'
 
 export default function GspPage(props) {
   const router = useRouter()
@@ -11,6 +12,8 @@ export default function GspPage(props) {
       <p>Current locale: {props.locale}</p>
       <p>Default locale: {defaultLocale}</p>
       <p>Configured locales: {JSON.stringify(props.locales)}</p>
+
+      <LocaleSwitcher />
 
       <Link href="/gsp/first">
         <a>To dynamic getStaticProps page</a>

--- a/examples/i18n-routing/pages/gssp.js
+++ b/examples/i18n-routing/pages/gssp.js
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import LocaleSwitcher from '../components/locale-switcher'
 
 export default function GsspPage(props) {
   const router = useRouter()
@@ -11,6 +12,8 @@ export default function GsspPage(props) {
       <p>Current locale: {props.locale}</p>
       <p>Default locale: {defaultLocale}</p>
       <p>Configured locales: {JSON.stringify(props.locales)}</p>
+
+      <LocaleSwitcher />
 
       <Link href="/gsp">
         <a>To getStaticProps page</a>

--- a/examples/i18n-routing/pages/index.js
+++ b/examples/i18n-routing/pages/index.js
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import LocaleSwitcher from '../components/locale-switcher'
 
 export default function IndexPage(props) {
   const router = useRouter()
@@ -11,6 +12,8 @@ export default function IndexPage(props) {
       <p>Current locale: {locale}</p>
       <p>Default locale: {defaultLocale}</p>
       <p>Configured locales: {JSON.stringify(locales)}</p>
+
+      <LocaleSwitcher />
 
       <Link href="/gsp">
         <a>To getStaticProps page</a>


### PR DESCRIPTION
Adds a local switcher component to the `i18n-routing` example to demonstrate how to switch between locales using `next/link` for dynamic `getStaticProps` pages.

## Documentation / Examples

- [x] Make sure the linting passes

