### PR TITLE
Add eslint config options to `NextConfig` type

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -22,8 +22,17 @@ export interface DomainLocale {
   locales?: string[]
 }
 
+export interface ESLintConfig {
+  /** Only run ESLint on these directories during production builds (`next build`). */
+  dirs?: string[]
+  /** Do not run ESLint during production builds (`next build`). */
+  ignoreDuringBuilds?: boolean
+}
+
 export type NextConfig = { [key: string]: any } & {
   i18n?: I18NConfig | null
+
+  eslint?: ESLintConfig
 
   headers?: () => Promise<Header[]>
   rewrites?: () => Promise<


### PR DESCRIPTION
This adds missing eslint config options to the public `NextConfig` type.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
