### PR TITLE
Add config check for invalid duplicate locale domains

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -340,6 +340,19 @@ function assignDefaults(userConfig: { [key: string]: any }) {
         if (!item.defaultLocale) return true
         if (!item.domain || typeof item.domain !== 'string') return true
 
+        const defaultLocaleDuplicate = i18n.domains?.find(
+          (altItem) =>
+            altItem.defaultLocale === item.defaultLocale &&
+            altItem.domain !== item.domain
+        )
+
+        if (defaultLocaleDuplicate) {
+          console.warn(
+            `Both ${item.domain} and ${defaultLocaleDuplicate.domain} configured the defaultLocale ${item.defaultLocale} but only one can. Change one item's default locale to continue`
+          )
+          return true
+        }
+
         let hasInvalidLocale = false
 
         if (Array.isArray(item.locales)) {

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -498,4 +498,38 @@ describe('i18n Support', () => {
       runSlashTests(curCtx)
     })
   })
+
+  it('should show proper error for duplicate defaultLocales', async () => {
+    nextConfig.write(`
+      module.exports = {
+        i18n: {
+          locales: ['en', 'fr', 'nl'],
+          defaultLocale: 'en',
+          domains: [
+            {
+              domain: 'example.com',
+              defaultLocale: 'en'
+            },
+            {
+              domain: 'fr.example.com',
+              defaultLocale: 'fr',
+            },
+            {
+              domain: 'french.example.com',
+              defaultLocale: 'fr',
+            }
+          ]
+        }
+      }
+    `)
+
+    const { code, stderr } = await nextBuild(appDir, undefined, {
+      stderr: true,
+    })
+    nextConfig.restore()
+    expect(code).toBe(1)
+    expect(stderr).toContain(
+      'Both fr.example.com and french.example.com configured the defaultLocale fr but only one can'
+    )
+  })
 })


### PR DESCRIPTION
This ensures we properly show an error when users attempt configuring multiple domain items with the same `defaultLocale`. We already have an existing check ensuring multiple domain items don't share the same items in their `locale` array so this continues on that check. 

This isn't currently supported as we expect to redirect to one specific domain when a locale is detected as the preferred and if there are multiple we don't know which to redirect to. 

Closes: https://github.com/vercel/next.js/pull/22337

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

