### PR TITLE
Update max-age in HSTS sample

### DIFF
--- a/docs/advanced-features/security-headers.md
+++ b/docs/advanced-features/security-headers.md
@@ -48,7 +48,7 @@ If you're deploying to [Vercel](https://vercel.com/docs/edge-network/headers#str
 ```jsx
 {
   key: 'Strict-Transport-Security',
-  value: 'max-age=31536000; includeSubDomains; preload'
+  value: 'max-age=63072000; includeSubDomains; preload'
 }
 ```
 


### PR DESCRIPTION
The previous paragraph mentions a max-age of 2 years, so the number of seconds should match.

## Documentation / Examples

- [x] Make sure the linting passes
