### PR TITLE
Fix CORS issue in GraphQL example that prevented Apollo Studio from working

### DIFF
--- a/examples/api-routes-graphql/pages/api/graphql.js
+++ b/examples/api-routes-graphql/pages/api/graphql.js
@@ -22,15 +22,19 @@ const apolloServer = new ApolloServer({ typeDefs, resolvers })
 const startServer = apolloServer.start()
 
 export default async function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    res.end()
-    return false
-  }
   res.setHeader('Access-Control-Allow-Credentials', 'true')
   res.setHeader(
     'Access-Control-Allow-Origin',
     'https://studio.apollographql.com'
   )
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Origin, X-Requested-With, Content-Type, Accept'
+  )
+  if (req.method === 'OPTIONS') {
+    res.end()
+    return false
+  }
 
   await startServer
   await apolloServer.createHandler({


### PR DESCRIPTION
Update example so Apollo Studio works properly 