### PR TITLE
Ignore no-anonymous-default-export babel plugin for node_modules

### DIFF
--- a/packages/next/build/babel/plugins/no-anonymous-default-export.ts
+++ b/packages/next/build/babel/plugins/no-anonymous-default-export.ts
@@ -21,9 +21,11 @@ export default function NoAnonymousDefaultExport({
   const warn: any = onWarning
   return {
     visitor: {
-      ExportDefaultDeclaration(path) {
-        const def = path.node.declaration
+      ExportDefaultDeclaration(path, state) {
+        const filename = state.file.opts.filename
+        if (filename.includes('/node_modules/')) return
 
+        const def = path.node.declaration
         if (
           !(
             def.type === 'ArrowFunctionExpression' ||

--- a/test/unit/babel-plugin-no-anonymous-default-export.unit.test.js
+++ b/test/unit/babel-plugin-no-anonymous-default-export.unit.test.js
@@ -1,0 +1,65 @@
+/* eslint-env jest */
+import { transform } from '@babel/core'
+
+const trim = (s) => s.join('\n').trim().replace(/^\s+/gm, '')
+
+const mockOnWarning = jest.fn()
+
+// avoid generating __source annotations in JSX during testing:
+const plugin = require('next/dist/build/babel/plugins/no-anonymous-default-export')
+
+const babel = (code, esm = true, pluginOptions = {}) =>
+  transform(code, {
+    filename: 'noop.js',
+    presets: [['@babel/preset-react', { development: true, pragma: '__jsx' }]],
+    plugins: [[plugin, pluginOptions]],
+    babelrc: false,
+    configFile: false,
+    sourceType: 'module',
+    compact: true,
+    caller: {
+      name: 'tests',
+      supportsStaticESM: esm,
+      onWarning: mockOnWarning,
+    },
+  }).code
+
+describe('babel plugin (no-anonymous-default-export)', () => {
+  beforeEach(() => {
+    mockOnWarning.mockReset()
+  })
+
+  describe('ArrowFunctionExpression', () => {
+    it('should trigger on a default export anonymous arrow function', () => {
+      babel(trim`
+        export default () => 'hello'
+      `)
+      expect(mockOnWarning).toHaveBeenCalled()
+    })
+
+    it('should not trigger on a named default export arrow function', () => {
+      babel(trim`
+        const func = () => 'hello'
+        export default func
+      `)
+      expect(mockOnWarning).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('FunctionDeclaration', () => {
+    it('should trigger on a default export anonymous function', () => {
+      babel(trim`
+        export default function() { return 'hello' }
+      `)
+      expect(mockOnWarning).toHaveBeenCalled()
+    })
+
+    it('should not trigger on a named default export function', () => {
+      babel(trim`
+        function named() { return 'hello' }
+        export default named
+      `)
+      expect(mockOnWarning).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Hello! 
For issue [15696](https://github.com/vercel/next.js/issues/15696) I'd like to submit this pull request.
As discussed in the issue I am preventing the warnings for any node_modules.

I am unclear of if this would be a bug, fix, or feature. I would declare this a linting improvement 😅 . I also haven't found tests for your babel plugins, nor documentation. Let me now if I've just been blind or if I should improve this PR in any way.