### PR TITLE
Update bundle analyzer readme

### DIFF
--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -5,14 +5,16 @@ Use `webpack-bundle-analyzer` in your Next.js project
 ## Installation
 
 ```
-npm install -D @next/bundle-analyzer
+npm install @next/bundle-analyzer
 ```
 
 or
 
 ```
-yarn add --dev @next/bundle-analyzer
+yarn add @next/bundle-analyzer
 ```
+
+Note: if installing as a `devDependency` make sure to wrap the require in a `process.env` check as `next.config.js` is loaded during `next start` as well.
 
 ### Usage with environment variables
 


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/27463 this adds a note about installing as `devDependency` instead of changing the default install command as the plugin being a `devDependency` might cause issues unless wrapped in a `process.env` check. 


## Documentation / Examples

- [x] Make sure the linting passes
