### PR TITLE
[typo] posts.map( posts => {} ) in examples/blog-starter-typescript

### DIFF
--- a/examples/blog-starter-typescript/pages/posts/[slug].tsx
+++ b/examples/blog-starter-typescript/pages/posts/[slug].tsx
@@ -87,10 +87,10 @@ export async function getStaticPaths() {
   const posts = getAllPosts(['slug'])
 
   return {
-    paths: posts.map((posts) => {
+    paths: posts.map((post) => {
       return {
         params: {
-          slug: posts.slug,
+          slug: post.slug,
         },
       }
     }),


### PR DESCRIPTION
In `examples/blog-starter-typescript/pages/posts/[slug].tsx`

before:
 `posts.map(posts => {})`

after:
`posts.map(post => {})`

## Documentation / Examples

- [x] Make sure the linting passes
