### PR TITLE
Drop react-is dependency in styled-components example

### DIFF
--- a/examples/with-styled-components/package.json
+++ b/examples/with-styled-components/package.json
@@ -9,7 +9,6 @@
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-is": "^17.0.2",
     "styled-components": "^5.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
`react-is` dependency was [dropped](https://github.com/styled-components/styled-components/commit/8165cbe994f6f749236244f6f7017c2f0b9afcfe) as part of `styled-components@v5`.

(I don't know which checkbox to check)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
