### PR TITLE
Fix eslint config next/core-web-vitals

### DIFF
--- a/packages/eslint-config-next/core-web-vitals.js
+++ b/packages/eslint-config-next/core-web-vitals.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['.', 'plugin:@next/next/core-web-vitals'].map(require.resolve),
+  extends: [require.resolve('.'), 'plugin:@next/next/core-web-vitals'],
 }

--- a/test/integration/eslint/config-core-web-vitals/.eslintrc
+++ b/test/integration/eslint/config-core-web-vitals/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "next/core-web-vitals",
+  "root": true
+}

--- a/test/integration/eslint/config-core-web-vitals/pages/index.js
+++ b/test/integration/eslint/config-core-web-vitals/pages/index.js
@@ -1,0 +1,9 @@
+const Home = () => (
+  <div>
+    <p>Home</p>
+    <script src="https://example.com" />
+    <img src="https://example.com/image.png" />
+  </div>
+)
+
+export default Home

--- a/test/integration/eslint/test/index.test.js
+++ b/test/integration/eslint/test/index.test.js
@@ -8,6 +8,7 @@ jest.setTimeout(1000 * 60 * 2)
 
 const dirFirstTimeSetup = join(__dirname, '../first-time-setup')
 const dirCustomConfig = join(__dirname, '../custom-config')
+const dirWebVitalsConfig = join(__dirname, '../config-core-web-vitals')
 const dirPluginRecommendedConfig = join(
   __dirname,
   '../plugin-recommended-config'
@@ -164,6 +165,21 @@ describe('ESLint', () => {
       )
       expect(output).toContain(
         'Error: Comments inside children section of tag should be placed inside braces'
+      )
+    })
+
+    test('shows warnings and errors with next/core-web-vitals config', async () => {
+      const { stdout, stderr } = await nextLint(dirWebVitalsConfig, [], {
+        stdout: true,
+        stderr: true,
+      })
+
+      const output = stdout + stderr
+      expect(output).toContain(
+        "Warning: Do not use <img>. Use Image from 'next/image' instead."
+      )
+      expect(output).toContain(
+        'Error: External synchronous scripts are forbidden'
       )
     })
 


### PR DESCRIPTION
fixes what i messed up in #27363. cf. https://github.com/vercel/next.js/pull/27363#issuecomment-888495697

also added an integration test for extending from `next/core-web-vitals` eslint config

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
