### PR TITLE
move `next/script` to `pages/_app` in script loader integration tests

### DIFF
--- a/test/integration/script-loader/pages/_app.js
+++ b/test/integration/script-loader/pages/_app.js
@@ -1,7 +1,28 @@
+import Script from 'next/script'
+
 import '../styles/styles.css'
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Script
+        id="documentAfterInteractive"
+        src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=documentAfterInteractive"
+        strategy="afterInteractive"
+      />
+      <Script
+        id="documentLazyOnload"
+        src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=documentLazyOnload"
+        strategy="lazyOnload"
+      />
+      <Script
+        id="documentBeforeInteractive"
+        src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=documentBeforeInteractive"
+        strategy="beforeInteractive"
+      />
+      <Component {...pageProps} />
+    </>
+  )
 }
 
 export default MyApp

--- a/test/integration/script-loader/pages/_document.js
+++ b/test/integration/script-loader/pages/_document.js
@@ -1,7 +1,6 @@
 import * as React from 'react'
 /// @ts-ignore
 import Document, { Main, NextScript, Head } from 'next/document'
-import Script from 'next/script'
 
 export default class MyDocument extends Document {
   constructor(props) {
@@ -20,26 +19,11 @@ export default class MyDocument extends Document {
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Voces"
           />
-          <Script
-            id="documentAfterInteractive"
-            src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=documentAfterInteractive"
-            strategy="afterInteractive"
-          ></Script>
-          <Script
-            id="documentLazyOnload"
-            src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=documentLazyOnload"
-            strategy="lazyOnload"
-          ></Script>
-          <Script
-            id="documentBeforeInteractive"
-            src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=documentBeforeInteractive"
-            strategy="beforeInteractive"
-          ></Script>
         </Head>
         <body>
           <Main />
           <NextScript />
-          <div id="text"></div>
+          <div id="text" />
         </body>
       </html>
     )


### PR DESCRIPTION
the integration tests for `next/script` currently import the `Script` component in `pages/_document.js`. [according to docs](https://nextjs.org/docs/basic-features/script#usage) however, `next/script` "should not be used in `pages/_document.js`" but in `pages/_app.js`.

this pr moves `next/script` from `pages/_document` to `pages/_app` - at least locally the `script-loader` tests still pass. @janicklas-ralph does this make sense?

this would unblock #27257

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
