### PR TITLE
Fix incorrect example in headers and rewrites docs

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -166,13 +166,17 @@ The following characters `(`, `)`, `{`, `}`, `:`, `*`, `+`, `?` are used for reg
 
 ```js
 module.exports = {
-  async redirects() {
+  async headers() {
     return [
       {
         // this will match `/english(default)/something` being requested
         source: '/english\\(default\\)/:slug',
-        destination: '/en-us/:slug',
-        permanent: false,
+        headers: [
+          {
+            key: 'x-header',
+            value: 'value',
+          },
+        ],
       },
     ]
   },

--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -203,13 +203,12 @@ The following characters `(`, `)`, `{`, `}`, `:`, `*`, `+`, `?` are used for reg
 
 ```js
 module.exports = {
-  async redirects() {
+  async rewrites() {
     return [
       {
         // this will match `/english(default)/something` being requested
         source: '/english\\(default\\)/:slug',
         destination: '/en-us/:slug',
-        permanent: false,
       },
     ]
   },


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/issues/22660#issuecomment-890400273

## Documentation / Examples

- [x] Make sure the linting passes
