### PR TITLE
Add missing await for API request

### DIFF
--- a/examples/cms-datocms/lib/api.js
+++ b/examples/cms-datocms/lib/api.js
@@ -58,7 +58,7 @@ export async function getPreviewPostBySlug(slug) {
 }
 
 export async function getAllPostsWithSlug() {
-  const data = fetchAPI(`
+  const data = await fetchAPI(`
     {
       allPosts {
         slug


### PR DESCRIPTION
`getAllPostsWithSlug` was missing an `await` on `fetchAPI`, resulting
in `data?.allPosts` always returning `undefined`. This meant SSG wasn't
aware of the paths it needed to generate.