### PR TITLE
add missing catch in serve-static.ts (#23140)

### DIFF
--- a/packages/next/server/serve-static.ts
+++ b/packages/next/server/serve-static.ts
@@ -7,16 +7,20 @@ export function serveStatic(
   path: string
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    send(req, path)
-      .on('directory', () => {
-        // We don't allow directories to be read.
-        const err: any = new Error('No directory access')
-        err.code = 'ENOENT'
-        reject(err)
-      })
-      .on('error', reject)
-      .pipe(res)
-      .on('finish', resolve)
+    try {
+      send(req, path)
+        .on('directory', () => {
+          // We don't allow directories to be read.
+          const err: any = new Error('No directory access')
+          err.code = 'ENOENT'
+          reject(err)
+        })
+        .on('error', reject)
+        .pipe(res)
+        .on('finish', resolve)
+    } catch(e) {
+      reject(e)
+    }
   })
 }
 


### PR DESCRIPTION
Seems to fix `e.removeHeader()` unhandled promise rejection exit issues people reported: #23140, #19309

## Bug

- [x] Related issues linked using `fixes #number`
