### PR TITLE
Undo sourcemap change 

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -6,27 +6,17 @@ const path = require('path')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const transform = require('@swc/core').transform
 
-// SWC doesn't allow setting `sourceFileName` yet so we have to manually edit the sourcemap to the correct input file path
-function updateSourceMapSources(map, sourceFileName) {
-  map.sources = [sourceFileName]
-  return map
-}
-
 module.exports = function (task) {
   // eslint-disable-next-line require-yield
   task.plugin('swc', {}, function* (
     file,
     serverOrClient,
-    { stripExtension } = {}
+    { stripExtension, dev } = {}
   ) {
     // Don't compile .d.ts
     if (file.base.endsWith('.d.ts')) return
 
     const isClient = serverOrClient === 'client'
-
-    const filePath = path.join(file.dir, file.base)
-    const fullFilePath = path.join(__dirname, filePath)
-    const distFilePath = path.dirname(path.join(__dirname, 'dist', filePath))
 
     const swcClientOptions = {
       module: {
@@ -118,14 +108,7 @@ module.exports = function (task) {
       this._.files.push({
         base: map,
         dir: file.dir,
-        data: Buffer.from(
-          JSON.stringify(
-            updateSourceMapSources(
-              JSON.parse(output.map),
-              path.relative(distFilePath, fullFilePath)
-            )
-          )
-        ),
+        data: Buffer.from(output.map),
       })
     }
 


### PR DESCRIPTION
This undoes the change from https://github.com/vercel/next.js/pull/27623 since it appears to be breaking source maps from changing the sources field in the generated source map to a relative path causing it to break jest's source map handling as can be seen in the `test-unit` CI job [here](https://github.com/vercel/next.js/runs/3214076727). 

This reverts commit f9ebc7772f7cffe1c3f01a8caad791fbf2e9803c.

