### PR TITLE
Update has query encoding when used in path

### DIFF
--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -30,16 +30,6 @@ export function matchHas(
   query: Params
 ): false | Params {
   const params: Params = {}
-  let initialQueryValues: string[] = []
-
-  if (typeof window === 'undefined') {
-    initialQueryValues = Object.values((req as any).__NEXT_INIT_QUERY)
-  }
-  if (typeof window !== 'undefined') {
-    initialQueryValues = Array.from(
-      new URLSearchParams(location.search).values()
-    )
-  }
 
   const allMatch = has.every((hasItem) => {
     let value: undefined | string

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -56,12 +56,7 @@ export function matchHas(
         break
       }
       case 'query': {
-        // preserve initial encoding of query values
         value = query[key!]
-
-        if (initialQueryValues.includes(value || '')) {
-          value = encodeURIComponent(value!)
-        }
         break
       }
       case 'host': {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -198,7 +198,7 @@ module.exports = {
               key: 'post',
             },
           ],
-          destination: '/blog/:post',
+          destination: '/blog-catchall/:post',
         },
         {
           source: '/blog/about',

--- a/test/integration/custom-routes/pages/blog-catchall/[...slug].js
+++ b/test/integration/custom-routes/pages/blog-catchall/[...slug].js
@@ -1,0 +1,18 @@
+export const getStaticProps = ({ params }) => {
+  return {
+    props: {
+      params,
+    },
+  }
+}
+
+export const getStaticPaths = () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}
+
+export default function Page(props) {
+  return <p id="props">{JSON.stringify(props)}</p>
+}

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -7,6 +7,7 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
+import escapeRegex from 'escape-string-regexp'
 import {
   launchApp,
   killApp,
@@ -43,15 +44,19 @@ const runTests = (isDev = false) => {
     for (const expected of [
       {
         post: 'first',
+        slug: ['first'],
       },
       {
         post: 'hello%20world',
+        slug: ['hello world'],
       },
       {
         post: 'hello/world',
+        slug: ['hello', 'world'],
       },
       {
         post: 'hello%2fworld',
+        slug: ['hello', 'world'],
       },
     ]) {
       const { status = 200, post } = expected
@@ -68,8 +73,10 @@ const runTests = (isDev = false) => {
 
       if (status === 200) {
         const $ = cheerio.load(await res.text())
-        expect(JSON.parse($('#query').text())).toEqual({
-          post: decodeURIComponent(post),
+        expect(JSON.parse($('#props').text())).toEqual({
+          params: {
+            slug: expected.slug,
+          },
         })
       }
     }
@@ -1107,12 +1114,30 @@ const runTests = (isDev = false) => {
       ]) {
         route.regex = normalizeRegEx(route.regex)
       }
+      for (const route of manifest.dataRoutes) {
+        route.dataRouteRegex = normalizeRegEx(route.dataRouteRegex)
+      }
 
       expect(manifest).toEqual({
         version: 3,
         pages404: true,
         basePath: '',
-        dataRoutes: [],
+        dataRoutes: [
+          {
+            dataRouteRegex: normalizeRegEx(
+              `^/_next/data/${escapeRegex(
+                buildId
+              )}/blog\\-catchall/(.+?)\\.json$`
+            ),
+            namedDataRouteRegex: `^/_next/data/${escapeRegex(
+              buildId
+            )}/blog\\-catchall/(?<slug>.+?)\\.json$`,
+            page: '/blog-catchall/[...slug]',
+            routeKeys: {
+              slug: 'slug',
+            },
+          },
+        ],
         redirects: [
           {
             destination: '/:path+',
@@ -1817,7 +1842,7 @@ const runTests = (isDev = false) => {
               source: '/has-rewrite-7',
             },
             {
-              destination: '/blog/:post',
+              destination: '/blog-catchall/:post',
               has: [
                 {
                   key: 'post',
@@ -1866,6 +1891,14 @@ const runTests = (isDev = false) => {
             regex: normalizeRegEx('^\\/blog\\/([^\\/]+?)(?:\\/)?$'),
             routeKeys: {
               post: 'post',
+            },
+          },
+          {
+            namedRegex: '^/blog\\-catchall/(?<slug>.+?)(?:/)?$',
+            page: '/blog-catchall/[...slug]',
+            regex: normalizeRegEx('^\\/blog\\-catchall\\/(.+?)(?:\\/)?$'),
+            routeKeys: {
+              slug: 'slug',
             },
           },
         ],


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/26963 which after discussion changes to interpolate the decoded variant of the value into the path. 

x-ref: https://github.com/vercel/next.js/issues/24775

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

