### PR TITLE
Add missing `removeHeader()` function to image optimizer mock res

### DIFF
--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -259,6 +259,9 @@ export async function imageOptimizer(
         mockRes.getHeaderNames = () => Object.keys(mockHeaders)
         mockRes.setHeader = (name: string, value: string | string[]) =>
           (mockHeaders[name.toLowerCase()] = value)
+        mockRes.removeHeader = (name: string) => {
+          delete mockHeaders[name.toLowerCase()]
+        }
         mockRes._implicitHeader = () => {}
         mockRes.connection = res.connection
         mockRes.finished = false


### PR DESCRIPTION
- Related to #27724 
- Related to #19309 
- Related to #23140 