### PR TITLE
Fix html validation for Image component sizer

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -588,7 +588,6 @@ export default function Image({
               }}
               alt=""
               aria-hidden={true}
-              role="presentation"
               src={`data:image/svg+xml;base64,${toBase64(sizerSvg)}`}
             />
           ) : null}


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute#deciding_between_aria-hiddentrue_rolepresentation_and_rolenone):


- `aria-hidden="true"` will remove the entire element from the accessibility API. 
- `role="presentation"` will remove the semantic meaning of an element while still exposing it to assistive technology. 

We don't need both so we'll keep `aria-hidden="true"` since the element is used for sizing, not content that should be read.

Fixes #27163 