### PR TITLE
Wrap last return statement in `else` to fix tree shaking

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -103,9 +103,9 @@ export function getDomainLocale(
       }${locale === detectedDomain.defaultLocale ? '' : `/${locale}`}${path}`
     }
     return false
+  } else {
+    return false
   }
-
-  return false
 }
 
 export function addLocale(


### PR DESCRIPTION
## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

fixes #27744


