### PR TITLE
Update client error to show link in console

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -457,6 +457,10 @@ export function renderError(renderErrorProps: RenderErrorProps): Promise<any> {
 
   // Make sure we log the error to the console, otherwise users can't track down issues.
   console.error(err)
+  console.error(
+    `A client-side exception has occurred, see here for more info: https://nextjs.org/docs/messages/client-side-exception-occurred`
+  )
+
   return pageLoader
     .loadPage('/_error')
     .then(({ page: ErrorComponent, styleSheets }) => {

--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -57,11 +57,8 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
                 title
               ) : (
                 <>
-                  Application error: a client-side exception has occurred (
-                  <a href="https://nextjs.org/docs/messages/client-side-exception-occurred">
-                    developer guidance
-                  </a>
-                  )
+                  Application error: a client-side exception has occurred (see
+                  the console for more information)
                 </>
               )}
               .

--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -58,7 +58,7 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
               ) : (
                 <>
                   Application error: a client-side exception has occurred (see
-                  the console for more information)
+                  the browser console for more information)
                 </>
               )}
               .

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -1509,7 +1509,7 @@ describe('CSS Support', () => {
           await browser.waitForElementByCss('#link-other').click()
           await check(
             () => browser.eval(`document.body.innerText`),
-            'Application error: a client-side exception has occurred (see the console for more information).',
+            'Application error: a client-side exception has occurred (see the browser console for more information).',
             true
           )
 

--- a/test/integration/css/test/index.test.js
+++ b/test/integration/css/test/index.test.js
@@ -1509,7 +1509,7 @@ describe('CSS Support', () => {
           await browser.waitForElementByCss('#link-other').click()
           await check(
             () => browser.eval(`document.body.innerText`),
-            'Application error: a client-side exception has occurred (developer guidance).',
+            'Application error: a client-side exception has occurred (see the console for more information).',
             true
           )
 

--- a/test/integration/no-page-props/test/index.test.js
+++ b/test/integration/no-page-props/test/index.test.js
@@ -39,7 +39,7 @@ const runTests = () => {
   it('should load 404 page correctly', async () => {
     const browser = await webdriver(appPort, '/non-existent')
     expect(await browser.elementByCss('h2').text()).toBe(
-      'Application error: a client-side exception has occurred (developer guidance).'
+      'Application error: a client-side exception has occurred (see the console for more information).'
     )
     expect(await browser.eval('window.uncaughtErrors')).toEqual([])
   })
@@ -74,7 +74,7 @@ const runTests = () => {
     await browser.waitForElementByCss('h2')
     expect(await browser.eval('window.beforeNav')).toBe(null)
     expect(await browser.elementByCss('h2').text()).toBe(
-      'Application error: a client-side exception has occurred (developer guidance).'
+      'Application error: a client-side exception has occurred (see the console for more information).'
     )
     expect(await browser.eval('window.uncaughtErrors')).toEqual([])
   })

--- a/test/integration/no-page-props/test/index.test.js
+++ b/test/integration/no-page-props/test/index.test.js
@@ -39,7 +39,7 @@ const runTests = () => {
   it('should load 404 page correctly', async () => {
     const browser = await webdriver(appPort, '/non-existent')
     expect(await browser.elementByCss('h2').text()).toBe(
-      'Application error: a client-side exception has occurred (see the console for more information).'
+      'Application error: a client-side exception has occurred (see the browser console for more information).'
     )
     expect(await browser.eval('window.uncaughtErrors')).toEqual([])
   })
@@ -74,7 +74,7 @@ const runTests = () => {
     await browser.waitForElementByCss('h2')
     expect(await browser.eval('window.beforeNav')).toBe(null)
     expect(await browser.elementByCss('h2').text()).toBe(
-      'Application error: a client-side exception has occurred (see the console for more information).'
+      'Application error: a client-side exception has occurred (see the browser console for more information).'
     )
     expect(await browser.eval('window.uncaughtErrors')).toEqual([])
   })


### PR DESCRIPTION
This updates our default client-side error to show the developer info link in the console to help prevent users from confusing it with a debug link for the application itself. 

