### PR TITLE
[ESLint] Don't warn when using <img> with an SVG source

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-img-element.js
+++ b/packages/eslint-plugin-next/lib/rules/no-img-element.js
@@ -1,3 +1,5 @@
+const NodeAttributes = require('../utils/nodeAttributes.js')
+
 module.exports = {
   meta: {
     docs: {
@@ -16,6 +18,11 @@ module.exports = {
         }
 
         if (node.attributes.length === 0) {
+          return
+        }
+        
+        const attributes = new NodeAttributes(node)
+        if (attributes.has('src') && attributes.value('src').endsWith('.svg')) {
           return
         }
 


### PR DESCRIPTION
Unless there a benefit that I am not aware of for using `<Image>` with SVG files, I feel this is one less rule to ignore inline in my code.
Pinging @housseindjirdeh since you are the ESLint guy around here 😁