### PR TITLE
feat(create-react-app): TypeScript can emit ES2015 instead of ES5

### DIFF
--- a/packages/create-next-app/templates/typescript/tsconfig.json
+++ b/packages/create-next-app/templates/typescript/tsconfig.json
@@ -1,18 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "moduleResolution": "node",
+    // Allow all features in input.
+    "module": "esnext",
+    // Emit ES2015 over ES5 for smaller bundles.
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "preserve",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve"
+    "isolatedModules": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Feature
It seems appropriate to feed Webpack ES2015 over ES5 for smaller/faster bundles. This involves changing TypeScript's `target` field to `es2015` instead of `es5`.

Also rearranged the template tsconfig to be more organized.

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes
