### PR TITLE
feat(package.json): add contributor-friendly lifecycle scripts

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -12,7 +12,20 @@ Read about our [Commitment to Open Source](https://vercel.com/oss).
 
 > You may need to run `yarn types` again if your types get outdated.
 
-To contribute to [our examples](examples), take a look at the [“Adding examples” section](#adding-examples).
+To contribute to [our examples](examples), take a look at the [“Adding examples”
+section](#adding-examples).
+
+## Building
+
+You can build the project, including all type definitions, with:
+
+```bash
+yarn build
+# - or -
+yarn prepublish
+```
+
+If you need to clean the project for any reason, use `yarn clean`.
 
 ## Adding warning/error descriptions
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "packages/*"
   ],
   "scripts": {
+    "clean": "yarn lerna clean -y && yarn lerna bootstrap && yarn lerna exec 'rm -rf ./dist'",
+    "build": "yarn prepublish",
     "lerna": "lerna",
     "dev": "lerna run dev --stream --parallel",
     "dev2": "while true; do yarn --check-files && yarn dev; done",


### PR DESCRIPTION
## Feature

I was struggling to get my local dev build working as a local package.json override, and types do not seem to be generated by `yarn dev`, so I had to figure out a cohesive way to build the project start-to-finish (and also clean the project).

Building the project and all types ended up just being `yarn prepublish`, here aliased as `yarn build`, and I added a `yarn clean` script. These two together should make it very difficult for any contributor to be confused how to generate a final build including all type declarations.

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

https://github.com/ctjlewis/next.js/blob/b2a888c14405d7978dc612fc4c66db208038736f/contributing.md#building
