### PR TITLE
Add type annotation for NextConfig to CNA typescript template

### DIFF
--- a/packages/create-next-app/templates/typescript/next.config.js
+++ b/packages/create-next-app/templates/typescript/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
 }


### PR DESCRIPTION
This adds a type annotation for the `NextConfig` type to `next.config.js` in the `create-next-app` typescript template.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
