### PR TITLE
Update release stats job name

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -253,7 +253,7 @@ jobs:
 
       - run: ./scripts/publish-release.sh
 
-  prStats:
+  releaseStats:
     name: Release Stats
     runs-on: ubuntu-latest
     needs: [publishRelease]


### PR DESCRIPTION
This renames the release stats job name to clarify it is not the same job used for PR stats which is located in a separate workflow. 
