### PR TITLE
update to webpack 5.50.0

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1446,8 +1446,6 @@ export default async function getBaseWebpackConfig(
       //  - next.config.js keys that affect compilation
       version: `${process.env.__NEXT_VERSION}|${configVars}`,
       cacheDirectory: path.join(distDir, 'cache', 'webpack'),
-      // we assume that the CI already uses cache compression
-      compression: false,
     }
 
     // Adds `next.config.js` as a buildDependency when custom webpack config is provided

--- a/packages/next/bundles/package.json
+++ b/packages/next/bundles/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "schema-utils3": "npm:schema-utils@3.0.0",
     "webpack-sources3": "npm:webpack-sources@3.2.0",
-    "webpack5": "npm:webpack@5.49.0"
+    "webpack5": "npm:webpack@5.50.0"
   },
   "resolutions": {
     "browserslist": "4.16.6",

--- a/packages/next/bundles/yarn.lock
+++ b/packages/next/bundles/yarn.lock
@@ -475,10 +475,10 @@ watchpack@^2.2.0:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.0.tgz#b16973bcf844ebcdb3afde32eda1c04d0b90f89d"
   integrity sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==
 
-"webpack5@npm:webpack@5.49.0":
-  version "5.49.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.49.0.tgz#e250362b781a9fb614ba0a97ed67c66b9c5310cd"
-  integrity sha512-XarsANVf28A7Q3KPxSnX80EkCcuOer5hTOEJWJNvbskOZ+EK3pobHarGHceyUZMxpsTHBHhlV7hiQyLZzGosYw==
+"webpack5@npm:webpack@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.50.0.tgz#5562d75902a749eb4d75131f5627eac3a3192527"
+  integrity sha512-hqxI7t/KVygs0WRv/kTgUW8Kl3YC81uyWQSo/7WUs5LsuRw0htH/fCwbVBGCuiX/t4s7qzjXFcf41O8Reiypag==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"


### PR DESCRIPTION
* performance improvements for cache serialization
* disabled cache compression by default (next.js is using webpack default again)
* support hashbang