### PR TITLE
Remove duplicate type for StaticImageData

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -57,13 +57,6 @@ type OnLoadingComplete = (result: {
 
 type ImgElementStyle = NonNullable<JSX.IntrinsicElements['img']['style']>
 
-interface StaticImageData {
-  src: string
-  height: number
-  width: number
-  blurDataURL?: string
-}
-
 interface StaticRequire {
   default: StaticImageData
 }


### PR DESCRIPTION
Follow up to #27916 

This interface was defined twice so I removed the private one and kept the global/public one.

https://github.com/vercel/next.js/blob/eb871d30915d668dd9ba897d4d04ced207ce2e6d/packages/next/image-types/global.d.ts#L4-L9

https://github.com/vercel/next.js/blob/b881d65c1289aada030fdbe0b5b70ebf98bcb54c/packages/next/client/image.tsx#L60-L65