### PR TITLE
Prevent TypeError during client side navigation

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -766,7 +766,7 @@ function doRender(input: RenderRouteInfo): Promise<any> {
 
       // Force browser to recompute layout, which should prevent a flash of
       // unstyled content:
-      getComputedStyle(document.body, 'height')
+      getComputedStyle(document.body)
     }
 
     if (input.scroll) {


### PR DESCRIPTION
In the recent Firefox Canary Versions after each client side navigation a TypeError is thrown, which can be replicated on the next.js site aswell. `TypeError: Window.getComputedStyle: 'height' is not a valid pseudo-element` This only happens in production mode, which makes is hard to attach a traceback, but I think I've tracked down the cause:

It happens because instead of passing a pseudo element selector as second to `getComputedStyle` the string `height` is passed. According to the [MDN `getComputedStyle` docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) this is supposed to throw a TypeError.

> TypeError: If the passed object is not an Element or the pseudoElt is not a valid pseudo-element selector or is ::part() or ::slotted().

If the comment is right and the purpose of this line is to trigger layout, it should also happen without the second argument.

Line was added in: https://github.com/vercel/next.js/pull/16318