### PR TITLE
Next swc publish flow (redo)

### DIFF
--- a/.github/workflows/build_native.yml
+++ b/.github/workflows/build_native.yml
@@ -1,154 +1,82 @@
-on:
-  workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - 'packages/next/build/swc/**'
+on: workflow_dispatch
 
 name: Build next-swc native binaries
 
 jobs:
-  build:
+  build-native:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-latest]
+        description: [default]
+        include:
+          - os: ubuntu-18.04
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            description: m1
 
-    name: stable - ${{ matrix.os }} - node@14
+    name: next-swc - ${{ matrix.os }} - ${{ matrix.target }} - node@14
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
-
       - name: Setup node
         uses: actions/setup-node@v2
         with:
           node-version: 14
           check-latest: true
-
       - name: Install
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           profile: minimal
-
+          toolchain: nightly-2021-03-25
+          target: ${{ matrix.target }}
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
           key: stable-${{ matrix.os }}-node@14-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
           key: stable-${{ matrix.os }}-node@14-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache NPM dependencies
-        uses: actions/cache@v1
+      - name: Cache native binary
+        id: binary-cache
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: npm-cache-${{ matrix.os }}-node@14-${{ hashFiles('yarn.lock') }}
-
-      - name: 'Install dependencies'
-        run: yarn install --frozen-lockfile --registry https://registry.npmjs.org --network-timeout 300000
-
+          path: packages/next/native/**
+          key: next-swc-nightly-2021-03-25-${{ matrix.target }}-${{ hashFiles('packages/next/build/swc/**') }}
       - name: 'Build'
-        run: yarn --cwd packages/next build-native
+        if: steps.binary-cache.outputs.cache-hit != true
+        run: yarn build-native --target ${{ matrix.target }}
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
-
+        working-directory: packages/next
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: next-swc-binaries
-          path: packages/next/native
-
+          path: packages/next/native/next-swc.*.node
       - name: Clear the cargo caches
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean
           cargo-cache
-
-  build-apple-silicon:
-    name: stable - aarch64-apple-darwin - node@14
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-          toolchain: nightly-2021-03-25
-          target: aarch64-apple-darwin
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --registry https://registry.npmjs.org --network-timeout 300000
-
-      - name: Cross build aarch64
-        run: yarn --cwd packages/next build-native --target aarch64-apple-darwin
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: next-swc-binaries
-          path: packages/next/native
-
-      - name: Clear the cargo caches
-        run: |
-          cargo install cargo-cache --no-default-features --features ci-autoclean
-          cargo-cache
-
   commit:
-    needs: [build, build-apple-silicon]
+    needs: build-native
     runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
-        if: ${{ github.event_name  == 'workflow_dispatch' }}
       - uses: actions/download-artifact@v2
         with:
           name: next-swc-binaries
           path: packages/next/native
-        if: ${{ github.event_name  == 'workflow_dispatch' }}
       - uses: EndBug/add-and-commit@v7
         with:
           add: 'packages/next/native --force'
           message: 'Build next-swc binaries'
-        if: ${{ github.event_name  == 'workflow_dispatch' }}
-
-  check:
-    needs: [build, build-apple-silicon]
-    runs-on: ubuntu-18.04
-
-    steps:
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name  == 'pull_request' }}
-      - uses: actions/download-artifact@v2
-        with:
-          name: next-swc-binaries
-          path: packages/next/native
-        if: ${{ github.event_name  == 'pull_request' }}
-      - run: git diff --exit-code
-        if: ${{ github.event_name  == 'pull_request' }}
-
-  test:
-    runs-on: ubuntu-18.04
-
-    steps:
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name  == 'pull_request' }}
-      - name: Install
-        if: ${{ github.event_name  == 'pull_request' }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2021-03-25
-          profile: minimal
-      - run: cd packages/next/build/swc && cargo test
-        if: ${{ github.event_name  == 'pull_request' }}

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -328,7 +328,7 @@ jobs:
           path: packages/next/native/**
           key: next-swc-nightly-2021-03-25-${{ matrix.target }}-${{ hashFiles('packages/next/build/swc/**') }}
       - name: 'Build'
-        if: steps.binary-cache.outputs.cache-hit != true
+        if: steps.binary-cache.outputs.cache-hit != 'true'
         run: yarn build-native --target ${{ matrix.target }}
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches: [canary]
+    tags: [v*]
   pull_request:
     types: [opened, synchronize]
 
@@ -46,7 +47,7 @@ jobs:
   checkPrecompiled:
     name: Check Pre-compiled
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, build-native]
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
@@ -56,6 +57,10 @@ jobs:
         with:
           path: ./*
           key: ${{ github.sha }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: next-swc-binaries
+          path: packages/next/native
       - run: ./scripts/check-pre-compiled.sh
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
@@ -240,9 +245,10 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
   publishRelease:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: Potentially publish release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, build-native]
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
@@ -251,7 +257,11 @@ jobs:
         with:
           path: ./*
           key: ${{ github.sha }}
-
+      - uses: actions/download-artifact@v2
+        with:
+          name: next-swc-binaries
+          path: packages/next/native
+      - run: ./scripts/prepublish-native.js
       - run: ./scripts/publish-release.sh
 
   releaseStats:
@@ -268,3 +278,80 @@ jobs:
       - uses: ./.github/actions/next-stats-action
         env:
           PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
+
+  build-native:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest, windows-latest]
+        description: [default]
+        include:
+          - os: ubuntu-18.04
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            description: m1
+
+    name: next-swc - ${{ matrix.os }} - ${{ matrix.target }} - node@14
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          check-latest: true
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2021-03-25
+          target: ${{ matrix.target }}
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: stable-${{ matrix.os }}-node@14-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: stable-${{ matrix.os }}-node@14-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache native binary
+        id: binary-cache
+        uses: actions/cache@v2
+        with:
+          path: packages/next/native/**
+          key: next-swc-nightly-2021-03-25-${{ matrix.target }}-${{ hashFiles('packages/next/build/swc/**') }}
+      - name: 'Build'
+        if: steps.binary-cache.outputs.cache-hit != true
+        run: yarn build-native --target ${{ matrix.target }}
+        env:
+          MACOSX_DEPLOYMENT_TARGET: '10.13'
+        working-directory: packages/next
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: next-swc-binaries
+          path: packages/next/native/next-swc.*.node
+      - name: Clear the cargo caches
+        run: |
+          cargo install cargo-cache --no-default-features --features ci-autoclean
+          cargo-cache
+
+  test-native:
+    name: Unit Test Native Code
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2021-03-25
+          profile: minimal
+      - run: cd packages/next/build/swc && cargo test

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -60,7 +60,11 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: next-swc-binaries
-          path: packages/next/native
+          path: packages/next/build/swc/dist
+      # Only check linux build for now, mac builds can sometimes be different even with the same code
+      - run: |
+          mv ./packages/next/build/swc/dist/next-swc.linux-x64-gnu.node \
+            ./packages/next/native/next-swc.linux-x64-gnu.node
       - run: ./scripts/check-pre-compiled.sh
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
@@ -260,8 +264,8 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: next-swc-binaries
-          path: packages/next/native
-      - run: ./scripts/prepublish-native.js
+          path: packages/next/build/swc/dist
+      - run: ./scripts/publish-native.js $GITHUB_REF
       - run: ./scripts/publish-release.sh
 
   releaseStats:
@@ -325,7 +329,7 @@ jobs:
         id: binary-cache
         uses: actions/cache@v2
         with:
-          path: packages/next/native/**
+          path: packages/next/native/next-swc.*.node
           key: next-swc-nightly-2021-03-25-${{ matrix.target }}-${{ hashFiles('packages/next/build/swc/**') }}
       - name: 'Build'
         if: steps.binary-cache.outputs.cache-hit != 'true'

--- a/packages/next/build/swc/npm/.gitignore
+++ b/packages/next/build/swc/npm/.gitignore
@@ -1,0 +1,1 @@
+next-swc.*.node

--- a/packages/next/build/swc/npm/next-swc-darwin-arm64/README.md
+++ b/packages/next/build/swc/npm/next-swc-darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `next-swc-darwin-arm64`
+
+This is the **aarch64-apple-darwin** binary for `next-swc`

--- a/packages/next/build/swc/npm/next-swc-darwin-arm64/package.json
+++ b/packages/next/build/swc/npm/next-swc-darwin-arm64/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "next-swc-darwin-arm64",
+  "version": "0.0.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "next-swc.darwin-arm64.node",
+  "files": [
+    "next-swc.darwin-arm64.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/packages/next/build/swc/npm/next-swc-darwin-x64/README.md
+++ b/packages/next/build/swc/npm/next-swc-darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `next-swc-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `next-swc`

--- a/packages/next/build/swc/npm/next-swc-darwin-x64/package.json
+++ b/packages/next/build/swc/npm/next-swc-darwin-x64/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "next-swc-darwin-x64",
+  "version": "0.0.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "next-swc.darwin-x64.node",
+  "files": [
+    "next-swc.darwin-x64.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/packages/next/build/swc/npm/next-swc-linux-x64-gnu/README.md
+++ b/packages/next/build/swc/npm/next-swc-linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `next-swc-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `next-swc`

--- a/packages/next/build/swc/npm/next-swc-linux-x64-gnu/package.json
+++ b/packages/next/build/swc/npm/next-swc-linux-x64-gnu/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "next-swc-linux-x64-gnu",
+  "version": "0.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "next-swc.linux-x64-gnu.node",
+  "files": [
+    "next-swc.linux-x64-gnu.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/packages/next/build/swc/npm/next-swc-win32-x64-msvc/README.md
+++ b/packages/next/build/swc/npm/next-swc-win32-x64-msvc/README.md
@@ -1,0 +1,3 @@
+# `next-swc-win32-x64-msvc`
+
+This is the **x86_64-pc-windows-msvc** binary for `next-swc`

--- a/packages/next/build/swc/npm/next-swc-win32-x64-msvc/package.json
+++ b/packages/next/build/swc/npm/next-swc-win32-x64-msvc/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "next-swc-win32-x64-msvc",
+  "version": "0.0.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "next-swc.win32-x64-msvc.node",
+  "files": [
+    "next-swc.win32-x64-msvc.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -54,7 +54,7 @@
     "types": "tsc --declaration --emitDeclarationOnly --declarationDir dist",
     "typescript": "tsc --noEmit --declaration",
     "ncc-compiled": "ncc cache clean && taskr ncc",
-    "build-native": "npx -p @napi-rs/cli napi build --platform --release --cargo-cwd build/swc native"
+    "build-native": "npx -p @napi-rs/cli@1.2.1 napi build --platform --release --cargo-cwd build/swc native"
   },
   "taskr": {
     "requires": [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -54,7 +54,7 @@
     "types": "tsc --declaration --emitDeclarationOnly --declarationDir dist",
     "typescript": "tsc --noEmit --declaration",
     "ncc-compiled": "ncc cache clean && taskr ncc",
-    "build-native": "napi build --platform --release --cargo-cwd build/swc native"
+    "build-native": "npx -p @napi-rs/cli napi build --platform --release --cargo-cwd build/swc native"
   },
   "taskr": {
     "requires": [

--- a/scripts/prepublish-native.js
+++ b/scripts/prepublish-native.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const path = require('path')
+const { readFile, readdir, writeFile } = require('fs/promises')
+const { copy } = require('fs-extra')
+
+const cwd = process.cwd()
+
+;(async function () {
+  let version = JSON.parse(await readFile(path.join(cwd, 'lerna.json'))).version
+
+  // Copy binaries to package folders, update version, and copy package folders to packages directory
+  let nativePackagesDir = path.join(cwd, 'packages/next/build/swc/npm')
+  let nativePackages = await readdir(nativePackagesDir)
+  for (let nativePackage of nativePackages) {
+    let binaryName = `next-swc.${nativePackage.substr(9)}.node`
+    await copy(
+      path.join(cwd, 'packages/next/native', binaryName),
+      path.join(nativePackagesDir, nativePackage, binaryName)
+    )
+    let pkg = JSON.parse(
+      await readFile(
+        path.join(nativePackagesDir, nativePackage, 'package.json')
+      )
+    )
+    pkg.version = version
+    await writeFile(
+      path.join(nativePackagesDir, nativePackage, 'package.json'),
+      JSON.stringify(pkg, null, 2)
+    )
+  }
+  await copy(
+    path.join(cwd, 'packages/next/build/swc/npm'),
+    path.join(cwd, 'packages')
+  )
+
+  // Update optional dependencies versions
+  let nextPkg = JSON.parse(
+    await readFile(path.join(cwd, 'packages/next/package.json'))
+  )
+  for (let name of nativePackages) {
+    let optionalDependencies = nextPkg.optionalDependencies || {}
+    optionalDependencies[name] = version
+    nextPkg.optionalDependencies = optionalDependencies
+  }
+  await writeFile(
+    path.join(path.join(cwd, 'packages/next/package.json')),
+    JSON.stringify(nextPkg, null, 2)
+  )
+})()

--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -9,65 +9,71 @@ const exec = util.promisify(require('child_process').exec)
 const cwd = process.cwd()
 
 ;(async function () {
-  let version = JSON.parse(await readFile(path.join(cwd, 'lerna.json'))).version
-  let gitref = process.argv.slice(2)[0]
+  try {
+    let version = JSON.parse(await readFile(path.join(cwd, 'lerna.json')))
+      .version
+    let gitref = process.argv.slice(2)[0]
 
-  // Copy binaries to package folders, update version, and publish
-  let nativePackagesDir = path.join(cwd, 'packages/next/build/swc/npm')
-  let nativePackages = await readdir(nativePackagesDir)
-  let publishPromises = []
-  for (let nativePackage of nativePackages) {
-    if (nativePackage === '.gitignore') {
-      continue
+    // Copy binaries to package folders, update version, and publish
+    let nativePackagesDir = path.join(cwd, 'packages/next/build/swc/npm')
+    let nativePackages = await readdir(nativePackagesDir)
+    let publishPromises = []
+    for (let nativePackage of nativePackages) {
+      if (nativePackage === '.gitignore') {
+        continue
+      }
+      let binaryName = `next-swc.${nativePackage.substr(9)}.node`
+      await copy(
+        path.join(cwd, 'packages/next/build/swc/dist', binaryName),
+        path.join(nativePackagesDir, nativePackage, binaryName)
+      )
+      let pkg = JSON.parse(
+        await readFile(
+          path.join(nativePackagesDir, nativePackage, 'package.json')
+        )
+      )
+      pkg.version = version
+      await writeFile(
+        path.join(nativePackagesDir, nativePackage, 'package.json'),
+        JSON.stringify(pkg, null, 2)
+      )
+      publishPromises.push(
+        exec(
+          `npm publish ${path.join(nativePackagesDir, nativePackage)}${
+            gitref.contains('canary') ? ' --tag canary' : ''
+          }`
+        )
+      )
+      // lerna publish in next step will fail if git status is not clean
+      publishPromises.push(
+        exec(
+          `git update-index --skip-worktree ${path.join(
+            nativePackagesDir,
+            nativePackage,
+            'package.json'
+          )}`
+        )
+      )
     }
-    let binaryName = `next-swc.${nativePackage.substr(9)}.node`
-    await copy(
-      path.join(cwd, 'packages/next/build/swc/dist', binaryName),
-      path.join(nativePackagesDir, nativePackage, binaryName)
+    await Promise.all(publishPromises)
+
+    // Update optional dependencies versions
+    let nextPkg = JSON.parse(
+      await readFile(path.join(cwd, 'packages/next/package.json'))
     )
-    let pkg = JSON.parse(
-      await readFile(
-        path.join(nativePackagesDir, nativePackage, 'package.json')
-      )
-    )
-    pkg.version = version
+    for (let name of nativePackages) {
+      let optionalDependencies = nextPkg.optionalDependencies || {}
+      optionalDependencies[name] = version
+      nextPkg.optionalDependencies = optionalDependencies
+    }
     await writeFile(
-      path.join(nativePackagesDir, nativePackage, 'package.json'),
-      JSON.stringify(pkg, null, 2)
-    )
-    publishPromises.push(
-      exec(
-        `npm publish ${path.join(nativePackagesDir, nativePackage)}${
-          gitref.contains('canary') ? ' --tag canary' : ''
-        }`
-      )
+      path.join(path.join(cwd, 'packages/next/package.json')),
+      JSON.stringify(nextPkg, null, 2)
     )
     // lerna publish in next step will fail if git status is not clean
-    publishPromises.push(
-      exec(
-        `git update-index --skip-worktree ${path.join(
-          nativePackagesDir,
-          nativePackage,
-          'package.json'
-        )}`
-      )
-    )
+    await exec('git update-index --skip-worktree packages/next/package.json')
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
   }
-  await Promise.all(publishPromises)
-
-  // Update optional dependencies versions
-  let nextPkg = JSON.parse(
-    await readFile(path.join(cwd, 'packages/next/package.json'))
-  )
-  for (let name of nativePackages) {
-    let optionalDependencies = nextPkg.optionalDependencies || {}
-    optionalDependencies[name] = version
-    nextPkg.optionalDependencies = optionalDependencies
-  }
-  await writeFile(
-    path.join(path.join(cwd, 'packages/next/package.json')),
-    JSON.stringify(nextPkg, null, 2)
-  )
-  // lerna publish in next step will fail if git status is not clean
-  await exec('git update-index --skip-worktree packages/next/package.json')
 })()

--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -3,8 +3,7 @@
 const path = require('path')
 const { readFile, readdir, writeFile } = require('fs/promises')
 const { copy } = require('fs-extra')
-const util = require('util')
-const exec = util.promisify(require('child_process').exec)
+const { execSync } = require('child_process')
 
 const cwd = process.cwd()
 
@@ -17,7 +16,6 @@ const cwd = process.cwd()
     // Copy binaries to package folders, update version, and publish
     let nativePackagesDir = path.join(cwd, 'packages/next/build/swc/npm')
     let nativePackages = await readdir(nativePackagesDir)
-    let publishPromises = []
     for (let nativePackage of nativePackages) {
       if (nativePackage === '.gitignore') {
         continue
@@ -37,25 +35,20 @@ const cwd = process.cwd()
         path.join(nativePackagesDir, nativePackage, 'package.json'),
         JSON.stringify(pkg, null, 2)
       )
-      publishPromises.push(
-        exec(
-          `npm publish ${path.join(nativePackagesDir, nativePackage)}${
-            gitref.contains('canary') ? ' --tag canary' : ''
-          }`
-        )
+      execSync(
+        `npm publish ${path.join(nativePackagesDir, nativePackage)}${
+          gitref.contains('canary') ? ' --tag canary' : ''
+        }`
       )
       // lerna publish in next step will fail if git status is not clean
-      publishPromises.push(
-        exec(
-          `git update-index --skip-worktree ${path.join(
-            nativePackagesDir,
-            nativePackage,
-            'package.json'
-          )}`
-        )
+      execSync(
+        `git update-index --skip-worktree ${path.join(
+          nativePackagesDir,
+          nativePackage,
+          'package.json'
+        )}`
       )
     }
-    await Promise.all(publishPromises)
 
     // Update optional dependencies versions
     let nextPkg = JSON.parse(
@@ -71,7 +64,7 @@ const cwd = process.cwd()
       JSON.stringify(nextPkg, null, 2)
     )
     // lerna publish in next step will fail if git status is not clean
-    await exec('git update-index --skip-worktree packages/next/package.json')
+    execSync('git update-index --skip-worktree packages/next/package.json')
   } catch (err) {
     console.error(err)
     process.exit(1)


### PR DESCRIPTION
This fixes some issues that slipped through in the [last PR](https://github.com/vercel/next.js/pull/27932)

The main issue was that `lerna publish` will fail if there are any changes that have not been committed. To resolve this I added a `.gitignore` file to ignore the built binaries that are moved into the package and used `git update-index --skip-worktree` on the package jsons that need to be updated with new versions. The native packages are also being published on their own instead of through `lerna publish`.

Another issue is that the `checkPrecompiled` job was sometimes failing unexpectedly because the binaries were changing even when the code and rust toolchain stayed the same. I've only seen this happen with windows and more frequently mac builds, so I changed it to only check the linux build for now while I investigate.
