### PR TITLE
Tests: Execute development-logs tests.

### DIFF
--- a/test/integration/basic/test/index.test.js
+++ b/test/integration/basic/test/index.test.js
@@ -10,6 +10,7 @@ import dynamic from './dynamic'
 import processEnv from './process-env'
 import publicFolder from './public-folder'
 import security from './security'
+import developmentLogs from './development-logs'
 
 const context = {}
 jest.setTimeout(1000 * 60 * 5)
@@ -29,4 +30,5 @@ describe('Basic Features', () => {
   processEnv(context)
   publicFolder(context)
   security(context)
+  developmentLogs(context)
 })


### PR DESCRIPTION
The tests to assert development logs when using Link are being ignored.
After adding them to integration/basic they execute correctly as can be seen in the log below:

```
Development Logs
      ✓ should warn when prefetch is true (1345 ms)
      ✓ should not warn when prefetch is false (879 ms)
      ✓ should not warn when prefetch is not specified (834 ms)

Test Suites: 1 skipped, 1 passed, 1 of 2 total
Tests:       88 skipped, 3 passed, 91 total
```

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
