### PR TITLE
Add native binaries to npm package

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -10,6 +10,7 @@
   "types": "types/index.d.ts",
   "files": [
     "dist",
+    "native",
     "app.js",
     "app.d.ts",
     "babel.js",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

swc doesn't work because native binaries aren't included in next's npm package.

## Bug

- ~~Related issues linked using `fixes #number`~~
- ~~Integration tests added~~
- ~~Errors have helpful link attached, see `contributing.md`~~
