### PR TITLE
Render as a concatenation of streams

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1182,8 +1182,9 @@ export async function renderToHTML(
       ? async (html: string) => {
           html = await optimizeAmp(html, renderOpts.ampOptimizerConfig)
           if (!renderOpts.ampSkipValidation && renderOpts.ampValidator) {
-            return await renderOpts.ampValidator(html, pathname)
+            await renderOpts.ampValidator(html, pathname)
           }
+          return html
         }
       : null,
     process.env.__NEXT_OPTIMIZE_FONTS || process.env.__NEXT_OPTIMIZE_IMAGES

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1178,6 +1178,14 @@ export async function renderToHTML(
   )
 
   const postProcessors: Array<((html: string) => Promise<string>) | null> = [
+    inAmpMode
+      ? async (html: string) => {
+          html = await optimizeAmp(html, renderOpts.ampOptimizerConfig)
+          if (!renderOpts.ampSkipValidation && renderOpts.ampValidator) {
+            return await renderOpts.ampValidator(html, pathname)
+          }
+        }
+      : null,
     process.env.__NEXT_OPTIMIZE_FONTS || process.env.__NEXT_OPTIMIZE_IMAGES
       ? async (html: string) => {
           return await postProcess(


### PR DESCRIPTION
Return the `RenderResult` as a concatenation of streams, rather than a concatenation of strings. 