### PR TITLE
Add support for dynamic HTML

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1332,11 +1332,7 @@ function multiplexResult(result: RenderResult): RenderResult {
   result({
     next(chunk) {
       chunks.push(chunk)
-      subscribers.forEach((subscriber) => {
-        try {
-          subscriber.next(chunk)
-        } catch {}
-      })
+      subscribers.forEach((subscriber) => subscriber.next(chunk))
     },
     error(error) {
       if (!streamResult) {

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1360,7 +1360,7 @@ function multiplexResult(result: RenderResult): RenderResult {
           cleanup()
           try {
             innerSubscriber.complete()
-          } catch (err) {}
+          } catch {}
         }
       },
       error(err) {
@@ -1368,7 +1368,7 @@ function multiplexResult(result: RenderResult): RenderResult {
           cleanup()
           try {
             innerSubscriber.error(err)
-          } catch (err) {}
+          } catch {}
         }
       },
     }

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1374,18 +1374,29 @@ function multiplexResult(result: RenderResult): RenderResult {
         if (completed) {
           return
         }
-        subscriber.next(chunk)
+        try {
+          subscriber.next(chunk)
+        } catch (err) {
+          if (!completed) {
+            completed = true
+            try {
+              subscriber.error(err)
+            } catch {}
+          }
+        }
       }
 
       if (!completed) {
         if (!streamResult) {
           subscribers.add(subscriber)
         } else {
-          if (streamResult.kind === 'FAILED') {
-            subscriber.error(streamResult.error)
-          } else {
-            subscriber.complete()
-          }
+          try {
+            if (streamResult.kind === 'FAILED') {
+              subscriber.error(streamResult.error)
+            } else {
+              subscriber.complete()
+            }
+          } catch {}
         }
       }
     })

--- a/packages/next/server/utils.ts
+++ b/packages/next/server/utils.ts
@@ -21,7 +21,6 @@ export type Observer<T> = {
   error(error: Error): void
   complete(): void
 }
-// TODO: Consider just using an actual Observable here
 export type RenderResult = (observer: Observer<string>) => Disposable
 
 export function resultFromChunks(chunks: string[]): RenderResult {

--- a/packages/next/server/utils.ts
+++ b/packages/next/server/utils.ts
@@ -16,12 +16,13 @@ export function cleanAmpPath(pathname: string): string {
 }
 
 export type Disposable = () => void
-// TODO: Consider just using an actual Observable here
-export type RenderResult = (observer: {
-  next(chunk: string): void
+export type Observer<T> = {
+  next(chunk: T): void
   error(error: Error): void
   complete(): void
-}) => Disposable
+}
+// TODO: Consider just using an actual Observable here
+export type RenderResult = (observer: Observer<string>) => Disposable
 
 export function resultFromChunks(chunks: string[]): RenderResult {
   return ({ next, complete, error }) => {


### PR DESCRIPTION
Implements `renderToString` in terms of a new `renderToStream`. The former is used for legacy documents that generate the body HTML as part of `getInitialProps`. The latter will be used directly in #27794 when streaming dynamic HTML.

Since we're exposing an actual streaming response for dynamic HTML (instead of buffering with `resultFromChunks`), we use `multiplexResult` to buffer and multiplex the underlying result to multiple subscribers.