### PR TITLE
Suggest `getStaticProps` for authentication

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -15,7 +15,7 @@ The first step to identifying which authentication pattern you need is understan
 
 ### Authenticating Statically Generated Pages
 
-Next.js automatically determines that a page is static if there are no blocking data requirements. This means the absence of [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering) and `getInitialProps` in the page. Instead, your page can render a loading state from the server, followed by fetching the user client-side.
+Next.js automatically determines that a page is static if there are no blocking data requirements. This means the absence of [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering) and [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) in the page. Instead, your page can render a loading state from the server, followed by fetching the user client-side.
 
 One advantage of this pattern is it allows pages to be served from a global CDN and preloaded using [`next/link`](/docs/api-reference/next/link.md). In practice, this results in a faster TTI ([Time to Interactive](https://web.dev/interactive/)).
 


### PR DESCRIPTION
- Suggest `getStaticProps` instead of `getInitialProps` to get authentication data to be consistent across docs
- Also linked to the `getStaticProps` page

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [ ] Make sure the linting passes
