### PR TITLE
Add new example for Adeira SX Design

### DIFF
--- a/examples/with-sx-design/.gitignore
+++ b/examples/with-sx-design/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/with-sx-design/README.md
+++ b/examples/with-sx-design/README.md
@@ -1,0 +1,27 @@
+# Next.js + SX Design example
+
+This example shows how to use [SX Design](https://github.com/adeira/sx-design) with Next.js.
+
+## Preview
+
+Preview the example live on [StackBlitz](http://stackblitz.com/):
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-sx-design)
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-sx-design&project-name=with-sx-design&repository-name=with-sx-design)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-sx-design with-sx-design-app
+# or
+yarn create next-app --example with-sx-design with-sx-design-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-sx-design/package.json
+++ b/examples/with-sx-design/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@adeira/sx": "^0.28.0",
+    "@adeira/sx-design": "^0.18.0"
+  }
+}

--- a/examples/with-sx-design/pages/_app.css
+++ b/examples/with-sx-design/pages/_app.css
@@ -1,0 +1,6 @@
+html,
+body {
+  direction: ltr;
+  margin: 0;
+  padding: 0;
+}

--- a/examples/with-sx-design/pages/_app.js
+++ b/examples/with-sx-design/pages/_app.js
@@ -1,0 +1,13 @@
+import { ErrorBoundary, SxDesignProvider } from '@adeira/sx-design'
+
+import './_app.css'
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <SxDesignProvider locale="en-US" theme="system">
+      <ErrorBoundary>
+        <Component {...pageProps} />
+      </ErrorBoundary>
+    </SxDesignProvider>
+  )
+}

--- a/examples/with-sx-design/pages/index.js
+++ b/examples/with-sx-design/pages/index.js
@@ -1,0 +1,62 @@
+import sx from '@adeira/sx'
+import { LayoutBlock, Link, Text, Note } from '@adeira/sx-design'
+import Head from 'next/head'
+
+export default function Home() {
+  return (
+    <div className={styles('container')}>
+      <Head>
+        <title>SX Design Example</title>
+        <meta name="description" content="SX Design Example" />
+      </Head>
+
+      <main className={styles('main')}>
+        <LayoutBlock spacing="large">
+          <Text size={48}>
+            Welcome to{' '}
+            <Link href="https://github.com/adeira/sx-design" target="_blank">
+              SX Design
+            </Link>{' '}
+            example!
+          </Text>
+
+          <Note tint="warning">
+            Try to change to light/dark mode in your computer settings. SX
+            Design will automatically adapt!
+          </Note>
+
+          <Text size={24} weight={200}>
+            Get started by editing{' '}
+            <code className={styles('code')}>
+              examples/with-sx-design/pages/index.js
+            </code>
+          </Text>
+        </LayoutBlock>
+      </main>
+    </div>
+  )
+}
+
+const styles = sx.create({
+  container: {
+    minHeight: '100vh',
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: 'rgba(var(--sx-foreground))',
+    backgroundColor: 'rgba(var(--sx-background))',
+  },
+  main: {
+    textAlign: 'center',
+  },
+  code: {
+    background: 'rgba(var(--sx-accent-3))',
+    borderRadius: 'var(--sx-radius)',
+    padding: '0.5rem',
+    fontSize: '.8em',
+    fontFamily:
+      'Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace',
+  },
+})


### PR DESCRIPTION
This PR adds a new minimal example for Adeira [SX Design](https://github.com/adeira/sx-design). It showcases basic components as well as automatic dark mode styles:

<img width="867" alt="Screen Shot 2021-08-14 at 21 06 24" src="https://user-images.githubusercontent.com/978368/129464699-7bd8373a-2aec-4495-b3c0-0aa15a24917b.png">

See: https://github.com/adeira/sx-design

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes
