### PR TITLE
Improve React Strict Mode documentation.

### DIFF
--- a/docs/api-reference/next.config.js/react-strict-mode.md
+++ b/docs/api-reference/next.config.js/react-strict-mode.md
@@ -6,7 +6,9 @@ description: The complete Next.js runtime is now Strict Mode-compliant, learn ho
 
 > **Suggested**: We strongly suggest you enable Strict Mode in your Next.js application to better prepare your application for the future of React.
 
-The Next.js runtime is now Strict Mode-compliant. To opt-in to Strict Mode, configure the following option in your `next.config.js`:
+React's [Strict Mode](https://reactjs.org/docs/strict-mode.html) is a development mode only feature for highlighting potential problems in an application. It helps to identify unsafe lifecycles, legacy API usage, and a number of other features.
+
+The Next.js runtime is Strict Mode-compliant. To opt-in to Strict Mode, configure the following option in your `next.config.js`:
 
 ```js
 // next.config.js
@@ -15,9 +17,7 @@ module.exports = {
 }
 ```
 
-If you or your team are not ready to use Strict Mode in your entire application, that's OK! You can incrementally migrate on a page-by-page basis [using `<React.StrictMode>`](https://reactjs.org/docs/strict-mode.html).
-
-React's Strict Mode is a development mode only feature for highlighting potential problems in an application. It helps to identify unsafe lifecycles, legacy API usage, and a number of other features.
+If you or your team are not ready to use Strict Mode in your entire application, that's OK! You can incrementally migrate on a page-by-page basis using `<React.StrictMode>`.
 
 ## Related
 


### PR DESCRIPTION
The current text linked wasn't obvious. Plus, the best description of what Strict Mode is was at the bottom of the document.