### PR TITLE
Replace CSS tag with JS import

### DIFF
--- a/examples/with-loading/pages/_app.js
+++ b/examples/with-loading/pages/_app.js
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
 import Link from 'next/link'
-import Head from 'next/head'
 import { useRouter } from 'next/router'
 import NProgress from 'nprogress'
+import '../public/nprogress.css'
 
 export default function App({ Component, pageProps }) {
   const router = useRouter()
@@ -29,10 +29,6 @@ export default function App({ Component, pageProps }) {
 
   return (
     <>
-      <Head>
-        {/* Import CSS for nprogress */}
-        <link rel="stylesheet" type="text/css" href="/nprogress.css" />
-      </Head>
       <nav>
         <style jsx>{`
           a {


### PR DESCRIPTION
Replaces `<link />` tag import with JS import to fix ESLint warning: https://nextjs.org/docs/messages/no-css-tags