### PR TITLE
Add relationship between issuer and module to traces

### DIFF
--- a/packages/next/build/compiler.ts
+++ b/packages/next/build/compiler.ts
@@ -1,4 +1,5 @@
 import { webpack } from 'next/dist/compiled/webpack/webpack'
+import { Span } from '../telemetry/trace'
 
 export type CompilerResult = {
   errors: string[]
@@ -35,16 +36,16 @@ function closeCompiler(compiler: webpack.Compiler | webpack.MultiCompiler) {
 }
 
 export function runCompiler(
-  config: webpack.Configuration | webpack.Configuration[]
+  config: webpack.Configuration,
+  { runWebpackSpan }: { runWebpackSpan: Span }
 ): Promise<CompilerResult> {
   return new Promise((resolve, reject) => {
     const compiler = webpack(config)
-    compiler.run(
-      (
-        err: Error,
-        statsOrMultiStats: { stats: webpack.Stats[] } | webpack.Stats
-      ) => {
-        closeCompiler(compiler).then(() => {
+    compiler.run((err: Error, stats: webpack.Stats) => {
+      const webpackCloseSpan = runWebpackSpan.traceChild('webpack-close')
+      webpackCloseSpan
+        .traceAsyncFn(() => closeCompiler(compiler))
+        .then(() => {
           if (err) {
             const reason = err?.toString()
             if (reason) {
@@ -53,21 +54,11 @@ export function runCompiler(
             return reject(err)
           }
 
-          if ('stats' in statsOrMultiStats) {
-            const result: CompilerResult = statsOrMultiStats.stats.reduce(
-              generateStats,
-              { errors: [], warnings: [] }
-            )
-            return resolve(result)
-          }
-
-          const result = generateStats(
-            { errors: [], warnings: [] },
-            statsOrMultiStats
-          )
+          const result = webpackCloseSpan
+            .traceChild('webpack-generate-error-stats')
+            .traceFn(() => generateStats({ errors: [], warnings: [] }, stats))
           return resolve(result)
         })
-      }
-    )
+    })
   })
 }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -570,7 +570,7 @@ export default async function build(
     let result: CompilerResult = { warnings: [], errors: [] }
     // We run client and server compilation separately to optimize for memory usage
     await runWebpackSpan.traceAsyncFn(async () => {
-      const clientResult = await runCompiler(clientConfig)
+      const clientResult = await runCompiler(clientConfig, { runWebpackSpan })
       // Fail build if clientResult contains errors
       if (clientResult.errors.length > 0) {
         result = {
@@ -578,7 +578,7 @@ export default async function build(
           errors: [...clientResult.errors],
         }
       } else {
-        const serverResult = await runCompiler(configs[1])
+        const serverResult = await runCompiler(configs[1], { runWebpackSpan })
         result = {
           warnings: [...clientResult.warnings, ...serverResult.warnings],
           errors: [...clientResult.errors, ...serverResult.errors],

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -860,6 +860,7 @@ export default async function getBaseWebpackConfig(
   const emacsLockfilePattern = '**/.#*'
 
   let webpackConfig: webpack.Configuration = {
+    parallelism: Number(process.env.NEXT_WEBPACK_PARALLELISM) || undefined,
     externals: !isServer
       ? // make sure importing "next" is handled gracefully for client
         // bundles in case a user imported types and it wasn't removed

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1310,7 +1310,7 @@ export default async function getBaseWebpackConfig(
         new BuildStatsPlugin({
           distDir,
         }),
-      process.env.TRACE_TARGET && new ProfilingPlugin({ runWebpackSpan }),
+      new ProfilingPlugin({ runWebpackSpan }),
       config.optimizeFonts &&
         !dev &&
         isServer &&

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1310,7 +1310,7 @@ export default async function getBaseWebpackConfig(
         new BuildStatsPlugin({
           distDir,
         }),
-      new ProfilingPlugin({ runWebpackSpan }),
+      process.env.TRACE_TARGET && new ProfilingPlugin({ runWebpackSpan }),
       config.optimizeFonts &&
         !dev &&
         isServer &&

--- a/packages/next/build/webpack/plugins/profiling-plugin.ts
+++ b/packages/next/build/webpack/plugins/profiling-plugin.ts
@@ -101,7 +101,7 @@ export class ProfilingPlugin {
           return module.userRequest.split('.').pop()
         })()
 
-        const issuerModule = compilation.moduleGraph.getIssuer(module)
+        const issuerModule = compilation?.moduleGraph?.getIssuer(module)
 
         const span = trace(
           `build-module${moduleType ? `-${moduleType}` : ''}`,

--- a/packages/next/build/webpack/plugins/profiling-plugin.ts
+++ b/packages/next/build/webpack/plugins/profiling-plugin.ts
@@ -101,9 +101,11 @@ export class ProfilingPlugin {
           return module.userRequest.split('.').pop()
         })()
 
+        const issuerModule = compilation.moduleGraph.getIssuer(module)
+
         const span = trace(
           `build-module${moduleType ? `-${moduleType}` : ''}`,
-          compilerSpan.id
+          issuerModule ? spans.get(issuerModule)?.id : compilerSpan.id
         )
         span.setAttribute('name', module.userRequest)
         spans.set(module, span)


### PR DESCRIPTION
Sets the parent span for module traces to the module that caused this current module to compile, this makes tracing why a module was compiled much simpler. Also added `NEXT_WEBPACK_PARALLELISM` to allow for better traces of individual modules, this should only be used in combination with tracing. Also added `webpack-close` which fills the time that was not traced previous.

New trace chart from Jaeger, previously this would be flat:

<img width="397" alt="Screen Shot 2021-08-17 at 12 21 44" src="https://user-images.githubusercontent.com/6324199/129709424-7895b8f3-856b-4dc5-ad63-c0116a8e8cc7.png">


<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
