### PR TITLE
let loaders automatically infer source map setting

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/loaders/global.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/global.ts
@@ -27,7 +27,6 @@ export function getGlobalCssLoader(
     loader: require.resolve('next/dist/compiled/css-loader'),
     options: {
       importLoaders: 1 + preProcessors.length,
-      sourceMap: true,
       // Next.js controls CSS Modules eligibility:
       modules: false,
       url: cssFileResolve,
@@ -41,7 +40,6 @@ export function getGlobalCssLoader(
     loader: require.resolve('next/dist/compiled/postcss-loader'),
     options: {
       postcssOptions: { plugins: postCssPlugins, config: false },
-      sourceMap: true,
     },
   })
 

--- a/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
@@ -28,7 +28,6 @@ export function getCssModuleLoader(
     loader: require.resolve('next/dist/compiled/css-loader'),
     options: {
       importLoaders: 1 + preProcessors.length,
-      sourceMap: true,
       // Use CJS mode for backwards compatibility:
       esModule: false,
       url: cssFileResolve,
@@ -57,7 +56,6 @@ export function getCssModuleLoader(
     loader: require.resolve('next/dist/compiled/postcss-loader'),
     options: {
       postcssOptions: { plugins: postCssPlugins, config: false },
-      sourceMap: true,
     },
   })
 


### PR DESCRIPTION
These loaders automatically use the global source map setting when this option is omitted