### PR TITLE
Avoid fs write `next-env.d.ts` on read-only filesystems

### DIFF
--- a/packages/next/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/lib/typescript/writeAppTypeDeclarations.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import os from 'os'
 import path from 'path'
+import { fileExists } from '../file-exists'
 
 export async function writeAppTypeDeclarations(
   baseDir: string,
@@ -24,7 +25,10 @@ export async function writeAppTypeDeclarations(
     os.EOL
 
   // Avoids a write for read-only filesystems
-  if ((await fs.readFile(appTypeDeclarations, 'utf8')) === content) {
+  if (
+    (await fileExists(appTypeDeclarations)) &&
+    (await fs.readFile(appTypeDeclarations, 'utf8')) === content
+  ) {
     return
   }
 

--- a/packages/next/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/lib/typescript/writeAppTypeDeclarations.ts
@@ -9,19 +9,24 @@ export async function writeAppTypeDeclarations(
   // Reference `next` types
   const appTypeDeclarations = path.join(baseDir, 'next-env.d.ts')
 
-  await fs.writeFile(
-    appTypeDeclarations,
+  const content =
     '/// <reference types="next" />' +
-      os.EOL +
-      '/// <reference types="next/types/global" />' +
-      os.EOL +
-      (imageImportsEnabled
-        ? '/// <reference types="next/image-types/global" />' + os.EOL
-        : '') +
-      os.EOL +
-      '// NOTE: This file should not be edited' +
-      os.EOL +
-      '// see https://nextjs.org/docs/basic-features/typescript for more information.' +
-      os.EOL
-  )
+    os.EOL +
+    '/// <reference types="next/types/global" />' +
+    os.EOL +
+    (imageImportsEnabled
+      ? '/// <reference types="next/image-types/global" />' + os.EOL
+      : '') +
+    os.EOL +
+    '// NOTE: This file should not be edited' +
+    os.EOL +
+    '// see https://nextjs.org/docs/basic-features/typescript for more information.' +
+    os.EOL
+
+  // Avoids a write for read-only filesystems
+  if ((await fs.readFile(appTypeDeclarations, 'utf8')) === content) {
+    return
+  }
+
+  await fs.writeFile(appTypeDeclarations, content)
 }

--- a/test/integration/typescript-app-type-declarations/next-env.d.ts
+++ b/test/integration/typescript-app-type-declarations/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/test/integration/typescript-app-type-declarations/pages/index.tsx
+++ b/test/integration/typescript-app-type-declarations/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <div />
+}

--- a/test/integration/typescript-app-type-declarations/test/index.test.js
+++ b/test/integration/typescript-app-type-declarations/test/index.test.js
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import { findPort, launchApp, killApp } from 'next-test-utils'
+import { promises as fs } from 'fs'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '..')
+const appTypeDeclarations = join(appDir, 'next-env.d.ts')
+
+describe('TypeScript App Type Declarations', () => {
+  it('should write a new next-env.d.ts if none exist', async () => {
+    const prevContent = await fs.readFile(appTypeDeclarations, 'utf8')
+    try {
+      await fs.unlink(appTypeDeclarations)
+      const appPort = await findPort()
+      let app
+      try {
+        app = await launchApp(appDir, appPort, {})
+        const content = await fs.readFile(appTypeDeclarations, 'utf8')
+        expect(content).toEqual(prevContent)
+      } finally {
+        await killApp(app)
+      }
+    } finally {
+      await fs.writeFile(appTypeDeclarations, prevContent)
+    }
+  })
+
+  it('should overwrite next-env.d.ts if an incorrect one exists', async () => {
+    const prevContent = await fs.readFile(appTypeDeclarations, 'utf8')
+    try {
+      await fs.writeFile(appTypeDeclarations, prevContent + 'modification')
+      const appPort = await findPort()
+      let app
+      try {
+        app = await launchApp(appDir, appPort, {})
+        const content = await fs.readFile(appTypeDeclarations, 'utf8')
+        expect(content).toEqual(prevContent)
+      } finally {
+        await killApp(app)
+      }
+    } finally {
+      await fs.writeFile(appTypeDeclarations, prevContent)
+    }
+  })
+
+  it('should not touch an existing correct next-env.d.ts', async () => {
+    const prevStat = await fs.stat(appTypeDeclarations)
+    const appPort = await findPort()
+    let app
+    try {
+      app = await launchApp(appDir, appPort, {})
+      const stat = await fs.stat(appTypeDeclarations)
+      expect(stat.mtime).toEqual(prevStat.mtime)
+    } finally {
+      await killApp(app)
+    }
+  })
+})

--- a/test/integration/typescript-app-type-declarations/tsconfig.json
+++ b/test/integration/typescript-app-type-declarations/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "module": "esnext",
+    "jsx": "preserve",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "components", "pages"]
+}


### PR DESCRIPTION
Next.js currently writes the TS type declarations on startup, regardless of the existing content of the file. This is good for ensuring the file content stays consistent. However, if the file content is already correct, this will perform an unnessecary write.

When running Next in read-only filesystems (such as the Bazel sandbox) this can cause the build to fail even if the content of the type declaration file is already correct.

This fixes this by only writing the contents of the file if the current contents don't match.

## Test Plan

Added an integration test for the general behavior of writing `next-env.d.ts`.