### PR TITLE
docs: Add link to Cypress GitHub Actions Guide to Testing docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,6 +130,7 @@ You will have noticed that running Cypress so far has opened an interactive brow
 You can learn more about Cypress and Continuous Integration from these resources:
 
 - [Cypress Continuous Integration Docs](https://docs.cypress.io/guides/continuous-integration/introduction)
+- [Cypress GitHub Actions Guide](https://on.cypress.io/github-actions)
 - [Official Cypress Github Action](https://github.com/cypress-io/github-action)
 
 ## Jest and React Testing Library


### PR DESCRIPTION
@leerob 

This pull request points to our [Cypress GitHub Actions Guide](https://on.cypress.io/github-actions) in the Cypress Documentation site.  It contains a guided walkthrough of using GitHub Actions with Cypress in text and our [recently released videos](https://on.cypress.io/ci-gha-playlist) in context. 

## Documentation / Examples

- [x] Make sure the linting passes
