### PR TITLE
Fix HMR when custom _app or _document is removed

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -478,7 +478,7 @@ export default async function getBaseWebpackConfig(
       next: NEXT_PROJECT_ROOT,
 
       // fallback to default _app when custom is removed
-      ...(dev && customAppFileExt
+      ...(dev && customAppFileExt && isWebpack5
         ? {
             [`${PAGES_DIR_ALIAS}/_app${customAppFileExt}`]: [
               path.join(pagesDir, `_app${customAppFileExt}`),
@@ -488,7 +488,7 @@ export default async function getBaseWebpackConfig(
         : {}),
 
       // fallback to default _document when custom is removed
-      ...(dev && customDocumentFileExt
+      ...(dev && customDocumentFileExt && isWebpack5
         ? {
             [`${PAGES_DIR_ALIAS}/_document${customDocumentFileExt}`]: [
               path.join(pagesDir, `_document${customDocumentFileExt}`),

--- a/test/integration/app-document-remove-hmr/pages/_app.js
+++ b/test/integration/app-document-remove-hmr/pages/_app.js
@@ -1,0 +1,8 @@
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <p>custom _app</p>
+      <Component {...pageProps} />
+    </>
+  )
+}

--- a/test/integration/app-document-remove-hmr/pages/_document.js
+++ b/test/integration/app-document-remove-hmr/pages/_document.js
@@ -1,0 +1,23 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <p>custom _document</p>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/test/integration/app-document-remove-hmr/pages/index.js
+++ b/test/integration/app-document-remove-hmr/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>index page</p>
+}

--- a/test/integration/app-document-remove-hmr/test/index.test.js
+++ b/test/integration/app-document-remove-hmr/test/index.test.js
@@ -1,0 +1,128 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import webdriver from 'next-webdriver'
+import { killApp, findPort, launchApp, check } from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../')
+const appPage = join(appDir, 'pages/_app.js')
+const indexPage = join(appDir, 'pages/index.js')
+const documentPage = join(appDir, 'pages/_document.js')
+
+let appPort
+let app
+
+describe('_app removal HMR', () => {
+  beforeAll(async () => {
+    appPort = await findPort()
+    app = await launchApp(appDir, appPort)
+  })
+  afterAll(() => killApp(app))
+
+  it('should HMR when _app is removed', async () => {
+    let indexContent = await fs.readFile(indexPage)
+    try {
+      const browser = await webdriver(appPort, '/')
+
+      const html = await browser.eval('document.documentElement.innerHTML')
+      expect(html).toContain('custom _app')
+
+      await fs.rename(appPage, appPage + '.bak')
+
+      await check(async () => {
+        const html = await browser.eval('document.documentElement.innerHTML')
+        return html.includes('index page') && !html.includes('custom _app')
+          ? 'success'
+          : html
+      }, 'success')
+
+      await fs.writeFile(
+        indexPage,
+        `
+        export default function Page() {
+          return <p>index page updated</p>
+        }
+      `
+      )
+
+      await check(async () => {
+        const html = await browser.eval('document.documentElement.innerHTML')
+        return html.indexOf('index page updated') &&
+          !html.includes('custom _app')
+          ? 'success'
+          : html
+      }, 'success')
+
+      await fs.rename(appPage + '.bak', appPage)
+
+      await check(async () => {
+        const html = await browser.eval('document.documentElement.innerHTML')
+        return html.includes('index page updated') &&
+          html.includes('custom _app')
+          ? 'success'
+          : html
+      }, 'success')
+    } finally {
+      await fs.writeFile(indexPage, indexContent)
+
+      if (await fs.pathExists(appPage + '.bak')) {
+        await fs.rename(appPage + '.bak', appPage)
+      }
+    }
+  })
+
+  it('should HMR when _document is removed', async () => {
+    let indexContent = await fs.readFile(indexPage)
+    try {
+      const browser = await webdriver(appPort, '/')
+
+      const html = await browser.eval('document.documentElement.innerHTML')
+      expect(html).toContain('custom _document')
+
+      await fs.rename(documentPage, documentPage + '.bak')
+
+      await check(async () => {
+        const html = await browser.eval('document.documentElement.innerHTML')
+        return html.includes('index page') && !html.includes('custom _document')
+          ? 'success'
+          : html
+      }, 'success')
+
+      await fs.writeFile(
+        indexPage,
+        `
+        export default function Page() {
+          return <p>index page updated</p>
+        }
+      `
+      )
+
+      await check(async () => {
+        const html = await browser.eval('document.documentElement.innerHTML')
+        return html.indexOf('index page updated') &&
+          !html.includes('custom _document')
+          ? 'success'
+          : html
+      }, 'success')
+
+      await fs.rename(documentPage + '.bak', documentPage)
+
+      await check(async () => {
+        const html = await browser.eval('document.documentElement.innerHTML')
+        return html.includes('index page updated') &&
+          html.includes('custom _document')
+          ? 'success'
+          : html
+      }, 'success')
+    } finally {
+      await fs.writeFile(indexPage, indexContent)
+
+      if (await fs.pathExists(documentPage + '.bak')) {
+        await fs.rename(documentPage + '.bak', documentPage)
+      }
+    }
+  })
+})


### PR DESCRIPTION
This adds the fallback webpack alias handling to handle a custom `_app` or `_document` being removed in development gracefully. 
 
## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/27888