### PR TITLE
Update polling env var for tests in CI

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           fetch-depth: 25
 
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js --timings --write-timings -g 1/1
@@ -61,6 +65,10 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - uses: actions/cache@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
@@ -115,6 +123,11 @@ jobs:
         group: [1, 2, 3, 4, 5, 6]
     steps:
       - run: echo ${{needs.build.outputs.docsChange}}
+
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - uses: actions/cache@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
@@ -191,6 +204,10 @@ jobs:
       NEXT_PRIVATE_TEST_WEBPACK4_MODE: 1
 
     steps:
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - uses: actions/cache@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
@@ -231,6 +248,10 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - uses: actions/cache@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
@@ -253,6 +274,10 @@ jobs:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
     steps:
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - uses: actions/cache@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
@@ -270,6 +295,10 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - uses: actions/cache@v2
         id: restore-build
         with:
@@ -318,6 +347,17 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+        if: ${{ matrix.os == "ubuntu-18.04" }}
+      - name: tune windows network
+        run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
+        if: ${{ matrix.os == "windows-latest" }}
+      - name: tune mac network
+        run: sudo sysctl -w net.link.generic.system.hwcksum_tx=0 && sudo sysctl -w net.link.generic.system.hwcksum_rx=0
+        if: ${{ matrix.os == "macos-latest" }}
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 25

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -350,13 +350,13 @@ jobs:
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
-        if: ${{ matrix.os == "ubuntu-18.04" }}
+        if: ${{ matrix.os == 'ubuntu-18.04' }}
       - name: tune windows network
         run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
-        if: ${{ matrix.os == "windows-latest" }}
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: tune mac network
         run: sudo sysctl -w net.link.generic.system.hwcksum_tx=0 && sudo sysctl -w net.link.generic.system.hwcksum_rx=0
-        if: ${{ matrix.os == "macos-latest" }}
+        if: ${{ matrix.os == 'macos-latest' }}
 
       - uses: actions/checkout@v2
         with:

--- a/run-tests.js
+++ b/run-tests.js
@@ -216,6 +216,7 @@ async function main() {
                   // reliable polling method.
                   CHOKIDAR_USEPOLLING: 'true',
                   CHOKIDAR_INTERVAL: 500,
+                  WATCHPACK_POLLING: 'true',
                 }
               : {}),
           },

--- a/run-tests.js
+++ b/run-tests.js
@@ -216,7 +216,7 @@ async function main() {
                   // reliable polling method.
                   CHOKIDAR_USEPOLLING: 'true',
                   CHOKIDAR_INTERVAL: 500,
-                  WATCHPACK_POLLING: 'true',
+                  WATCHPACK_POLLING: 500,
                 }
               : {}),
           },

--- a/run-tests.js
+++ b/run-tests.js
@@ -257,7 +257,7 @@ async function main() {
     for (let i = 0; i < NUM_RETRIES + 1; i++) {
       try {
         console.log(`Starting ${test} retry ${i}/${NUM_RETRIES}`)
-        const time = await runTest(test, true)
+        const time = await runTest(test, i > 0)
         timings.push({
           file: test,
           time,
@@ -306,7 +306,7 @@ async function main() {
       for (let i = 0; i < NUM_RETRIES + 1; i++) {
         try {
           console.log(`Starting ${test} retry ${i}/${NUM_RETRIES}`)
-          const time = await runTest(test, true)
+          const time = await runTest(test, i > 0)
           timings.push({
             file: test,
             time,

--- a/run-tests.js
+++ b/run-tests.js
@@ -257,7 +257,7 @@ async function main() {
     for (let i = 0; i < NUM_RETRIES + 1; i++) {
       try {
         console.log(`Starting ${test} retry ${i}/${NUM_RETRIES}`)
-        const time = await runTest(test, i > 0)
+        const time = await runTest(test, true)
         timings.push({
           file: test,
           time,
@@ -306,7 +306,7 @@ async function main() {
       for (let i = 0; i < NUM_RETRIES + 1; i++) {
         try {
           console.log(`Starting ${test} retry ${i}/${NUM_RETRIES}`)
-          const time = await runTest(test, i > 0)
+          const time = await runTest(test, true)
           timings.push({
             file: test,
             time,


### PR DESCRIPTION
This updates to set the [watchpack polling env variable](https://github.com/webpack/watchpack/blob/c651129195d84cc80e547a45be38861b5bbada1a/lib/DirectoryWatcher.js#L18) when running tests in CI since it is used instead of chokidar with webpack 5

This also applies the suggestion from https://github.com/actions/virtual-environments/issues/1187 to disable tcp/udp offloading to hopefully help with the network flakiness we've seen