### PR TITLE
Update typescript.md

### DIFF
--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -152,7 +152,7 @@ The `next.config.js` file must be a JavaScript file as it does not get parsed by
 // @ts-check
 
 /**
- * @type {import('next').NextConfig}
+ * @type import('next/dist/next-server/server/config').NextConfig}
  **/
 const nextConfig = {
   /* config options here */


### PR DESCRIPTION
next v11.0.1

Error:
```
Namespace '"/***/node_modules/next/types/index"' has no exported member 'NextConfig'
```
It also is available here.
```
@type import('next/dist/next-server/server/config-shared').NextConfig
```
