### PR TITLE
Add missing `typescript` property to `NextConfig`

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -176,7 +176,7 @@ export default async function build(
       telemetry.record(events)
     )
 
-    const ignoreTypeScriptErrors = Boolean(config.typescript?.ignoreBuildErrors)
+    const ignoreTypeScriptErrors = Boolean(config.typescript.ignoreBuildErrors)
     const typeCheckStart = process.hrtime()
     const typeCheckingSpinner = createSpinner({
       prefixText: `${Log.prefixes.info} ${
@@ -216,7 +216,7 @@ export default async function build(
       typeCheckingSpinner.stopAndPersist()
     }
 
-    const ignoreESLint = Boolean(config.eslint?.ignoreDuringBuilds)
+    const ignoreESLint = Boolean(config.eslint.ignoreDuringBuilds)
     const eslintCacheDir = path.join(cacheDir, 'eslint/')
     if (!ignoreESLint && runLint) {
       await nextBuildSpan

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -29,10 +29,16 @@ export interface ESLintConfig {
   ignoreDuringBuilds?: boolean
 }
 
+export interface TypeScriptConfig {
+  /** Do not run TypeScript during production builds (`next build`). */
+  ignoreBuildErrors?: boolean
+}
+
 export type NextConfig = { [key: string]: any } & {
   i18n?: I18NConfig | null
 
   eslint?: ESLintConfig
+  typescript?: TypeScriptConfig
 
   headers?: () => Promise<Header[]>
   rewrites?: () => Promise<
@@ -139,6 +145,12 @@ export const defaultConfig: NextConfig = {
   env: {},
   webpack: null,
   webpackDevMiddleware: null,
+  eslint: {
+    ignoreDuringBuilds: false,
+  },
+  typescript: {
+    ignoreBuildErrors: false,
+  },
   distDir: '.next',
   cleanDistDir: true,
   assetPrefix: '',


### PR DESCRIPTION
This is similar to https://github.com/vercel/next.js/pull/27126 , https://github.com/vercel/next.js/pull/27446 and https://github.com/vercel/next.js/pull/27974

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes
