### PR TITLE
Export Router interfaces

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -42,23 +42,23 @@ declare global {
   }
 }
 
-interface RouteProperties {
+export interface RouteProperties {
   shallow: boolean
 }
 
-interface TransitionOptions {
+export interface TransitionOptions {
   shallow?: boolean
   locale?: string | false
   scroll?: boolean
 }
 
-interface NextHistoryState {
+export interface NextHistoryState {
   url: string
   as: string
   options: TransitionOptions
 }
 
-type HistoryState =
+export type HistoryState =
   | null
   | { __N: false }
   | ({ __N: true; idx: number } & NextHistoryState)


### PR DESCRIPTION
Semantic error TS4058: Return type of exported function has or is using name 'TransitionOptions' from external module "/node_modules/next/dist/shared/lib/router/router" but cannot be named.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
