### PR TITLE
Ensure dev server side errors are correct

### DIFF
--- a/packages/next/client/dev/on-demand-entries-client.js
+++ b/packages/next/client/dev/on-demand-entries-client.js
@@ -9,7 +9,11 @@ export default async ({ assetPrefix }) => {
     )
   })
 
-  setupPing(assetPrefix, () => Router.pathname, currentPage)
+  setupPing(
+    assetPrefix,
+    () => Router.query.__NEXT_PAGE || Router.pathname,
+    currentPage
+  )
 
   // prevent HMR connection from being closed when running tests
   if (!process.env.__NEXT_TEST_MODE) {

--- a/packages/next/client/dev/on-demand-entries-utils.js
+++ b/packages/next/client/dev/on-demand-entries-utils.js
@@ -29,7 +29,10 @@ export function setupPing(assetPrefix, pathnameFn, retry) {
     if (event.data.indexOf('{') === -1) return
     try {
       const payload = JSON.parse(event.data)
-      if (payload.invalid) {
+      // don't attempt fetching the page if we're already showing
+      // the dev overlay as this can cause the error to be triggered
+      // repeatedly
+      if (payload.invalid && !self.__NEXT_DATA__.err) {
         // Payload can be invalid even if the page does not exist.
         // So, we need to make sure it exists before reloading.
         fetch(location.href, {

--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -59,6 +59,12 @@ initNext({ webpackHMR })
       } else if (event.data.indexOf('serverOnlyChanges') !== -1) {
         const { pages } = JSON.parse(event.data)
 
+        // Make sure to reload when the dev-overlay is showing for an
+        // API route
+        if (pages.includes(router.query.__NEXT_PAGE)) {
+          return window.location.reload()
+        }
+
         if (!router.clc && pages.includes(router.pathname)) {
           console.log('Refreshing page data due to server-side change')
 

--- a/packages/next/server/api-utils.ts
+++ b/packages/next/server/api-utils.ts
@@ -25,7 +25,9 @@ export async function apiResolver(
   query: any,
   resolverModule: any,
   apiContext: __ApiPreviewProps,
-  propagateError: boolean
+  propagateError: boolean,
+  dev?: boolean,
+  page?: string
 ): Promise<void> {
   const apiReq = req as NextApiRequest
   const apiRes = res as NextApiResponse
@@ -117,6 +119,13 @@ export async function apiResolver(
     if (err instanceof ApiError) {
       sendError(apiRes, err.statusCode, err.message)
     } else {
+      if (dev) {
+        if (err) {
+          err.page = page
+        }
+        throw err
+      }
+
       console.error(err)
       if (propagateError) {
         throw err

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -134,7 +134,7 @@ export default class HotReloader {
   private webpackHotMiddleware: (NextHandleFunction & any) | null
   private config: NextConfigComplete
   private stats: webpack.Stats | null
-  private serverStats: webpack.Stats | null
+  public serverStats: webpack.Stats | null
   private clientError: Error | null = null
   private serverError: Error | null = null
   private serverPrevDocumentHash: string | null

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -334,10 +334,12 @@ export default class DevServer extends Server {
     setGlobal('telemetry', telemetry)
 
     process.on('unhandledRejection', (reason) => {
-      this.logErrorWithOriginalStack(reason).catch(() => {})
+      this.logErrorWithOriginalStack(reason, 'unhandledRejection').catch(
+        () => {}
+      )
     })
     process.on('uncaughtException', (err) => {
-      this.logErrorWithOriginalStack(err).catch(() => {})
+      this.logErrorWithOriginalStack(err, 'uncaughtException').catch(() => {})
     })
   }
 

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -455,11 +455,13 @@ export default class DevServer extends Server {
             )
 
             const source = await getSourceById(
-              !!frame.file?.startsWith('file:'),
+              !!frame.file?.startsWith(sep) ||
+                !!frame.file?.startsWith('file:'),
               moduleId,
               compilation,
               this.hotReloader!.isWebpack5
             )
+
             const originalFrame = await createOriginalStackFrame({
               line: frame.lineNumber!,
               column: frame.column,

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1067,7 +1067,7 @@ export default class Server {
    * @param res http response
    * @param pathname path of request
    */
-  protected async handleApiRequest(
+  private async handleApiRequest(
     req: IncomingMessage,
     res: ServerResponse,
     pathname: string,

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -487,7 +487,7 @@ export default class Server {
     try {
       return await this.run(req, res, parsedUrl)
     } catch (err) {
-      if (this.minimalMode) {
+      if (this.minimalMode || this.renderOpts.dev) {
         throw err
       }
       this.logError(err)
@@ -1067,7 +1067,7 @@ export default class Server {
    * @param res http response
    * @param pathname path of request
    */
-  private async handleApiRequest(
+  protected async handleApiRequest(
     req: IncomingMessage,
     res: ServerResponse,
     pathname: string,
@@ -1125,7 +1125,9 @@ export default class Server {
       query,
       pageModule,
       this.renderOpts.previewProps,
-      this.minimalMode
+      this.minimalMode,
+      this.renderOpts.dev,
+      page
     )
     return true
   }
@@ -1857,6 +1859,7 @@ export default class Server {
     ctx: RequestContext
   ): Promise<ResponsePayload | null> {
     const { res, query, pathname } = ctx
+    let page = pathname
     const bubbleNoFallback = !!query._nextBubbleNoFallback
     delete query._nextBubbleNoFallback
 
@@ -1888,6 +1891,7 @@ export default class Server {
           )
           if (dynamicRouteResult) {
             try {
+              page = dynamicRoute.page
               return await this.renderToResponseWithComponents(
                 {
                   ...ctx,
@@ -1929,7 +1933,10 @@ export default class Server {
       )
 
       if (!isWrappedError) {
-        if (this.minimalMode) {
+        if (this.minimalMode || this.renderOpts.dev) {
+          if (err) {
+            err.page = page
+          }
           throw err
         }
         this.logError(err)

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -405,6 +405,7 @@ export async function renderToHTML(
     buildManifest,
     fontManifest,
     reactLoadableManifest,
+    ErrorDebug,
     getStaticProps,
     getStaticPaths,
     getServerSideProps,
@@ -1055,6 +1056,15 @@ export async function renderToHTML(
   const renderPage: RenderPage = (
     options: ComponentsEnhancer = {}
   ): RenderPageResult | Promise<RenderPageResult> => {
+    if (ctx.err && ErrorDebug) {
+      const htmlOrPromise = renderToString(<ErrorDebug error={ctx.err} />)
+      return typeof htmlOrPromise === 'string'
+        ? { html: htmlOrPromise, head }
+        : htmlOrPromise.then((html) => ({
+            html,
+            head,
+          }))
+    }
     if (dev && (props.router || props.Component)) {
       throw new Error(
         `'router' and 'Component' can not be returned in getInitialProps from _app.js https://nextjs.org/docs/messages/cant-override-next-props`

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -405,7 +405,6 @@ export async function renderToHTML(
     buildManifest,
     fontManifest,
     reactLoadableManifest,
-    ErrorDebug,
     getStaticProps,
     getStaticPaths,
     getServerSideProps,
@@ -941,10 +940,7 @@ export async function renderToHTML(
       ;(renderOpts as any).pageData = props
     }
   } catch (dataFetchError) {
-    if (isDataReq || !dev || !dataFetchError) throw dataFetchError
-    ctx.err = dataFetchError
-    renderOpts.err = dataFetchError
-    console.error(dataFetchError)
+    throw dataFetchError
   }
 
   if (
@@ -1059,16 +1055,6 @@ export async function renderToHTML(
   const renderPage: RenderPage = (
     options: ComponentsEnhancer = {}
   ): RenderPageResult | Promise<RenderPageResult> => {
-    if (ctx.err && ErrorDebug) {
-      const htmlOrPromise = renderToString(<ErrorDebug error={ctx.err} />)
-      return typeof htmlOrPromise === 'string'
-        ? { html: htmlOrPromise, head }
-        : htmlOrPromise.then((html) => ({
-            html,
-            head,
-          }))
-    }
-
     if (dev && (props.router || props.Component)) {
       throw new Error(
         `'router' and 'Component' can not be returned in getInitialProps from _app.js https://nextjs.org/docs/messages/cant-override-next-props`

--- a/packages/react-dev-overlay/src/middleware.ts
+++ b/packages/react-dev-overlay/src/middleware.ts
@@ -177,52 +177,50 @@ export async function createOriginalStackFrame({
   }
 }
 
-function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
-  async function getSourceById(
-    isServerSide: boolean,
-    isFile: boolean,
-    id: string
-  ): Promise<Source> {
-    if (isFile) {
-      const fileContent: string | null = await fs
-        .readFile(id, 'utf-8')
-        .catch(() => null)
+export async function getSourceById(
+  isFile: boolean,
+  id: string,
+  compilation: any,
+  isWebpack5: boolean
+): Promise<Source> {
+  if (isFile) {
+    const fileContent: string | null = await fs
+      .readFile(id, 'utf-8')
+      .catch(() => null)
 
-      if (fileContent == null) {
-        return null
-      }
-
-      const map = getRawSourceMap(fileContent)
-      if (map == null) {
-        return null
-      }
-
-      return {
-        map() {
-          return map
-        },
-      }
+    if (fileContent == null) {
+      return null
     }
 
-    try {
-      const compilation = isServerSide
-        ? options.serverStats()?.compilation
-        : options.stats()?.compilation
-      if (compilation == null) {
-        return null
-      }
-
-      const module = [...compilation.modules].find(
-        (searchModule) =>
-          getModuleId(compilation, searchModule, options.isWebpack5) === id
-      )
-      return getModuleSource(compilation, module, options.isWebpack5)
-    } catch (err) {
-      console.error(`Failed to lookup module by ID ("${id}"):`, err)
+    const map = getRawSourceMap(fileContent)
+    if (map == null) {
       return null
+    }
+
+    return {
+      map() {
+        return map
+      },
     }
   }
 
+  try {
+    if (compilation == null) {
+      return null
+    }
+
+    const module = [...compilation.modules].find(
+      (searchModule) =>
+        getModuleId(compilation, searchModule, isWebpack5) === id
+    )
+    return getModuleSource(compilation, module, isWebpack5)
+  } catch (err) {
+    console.error(`Failed to lookup module by ID ("${id}"):`, err)
+    return null
+  }
+}
+
+function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
   return async function (
     req: IncomingMessage,
     res: ServerResponse,
@@ -254,10 +252,15 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
 
       let source: Source
       try {
+        const compilation = isServerSide
+          ? options.serverStats()?.compilation
+          : options.stats()?.compilation
+
         source = await getSourceById(
-          isServerSide,
           frame.file.startsWith('file:'),
-          moduleId
+          moduleId,
+          compilation,
+          !!options.isWebpack5
         )
       } catch (err) {
         console.log('Failed to get source map:', err)

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -109,14 +109,24 @@ function runTests(dev = false) {
     const res = await fetchViaHTTP(appPort, '/api/user-error', null, {})
     const text = await res.text()
     expect(res.status).toBe(500)
-    expect(text).toBe('Internal Server Error')
+
+    if (dev) {
+      expect(text).toContain('User error')
+    } else {
+      expect(text).toBe('Internal Server Error')
+    }
   })
 
   it('should throw Internal Server Error (async)', async () => {
     const res = await fetchViaHTTP(appPort, '/api/user-error-async', null, {})
     const text = await res.text()
     expect(res.status).toBe(500)
-    expect(text).toBe('Internal Server Error')
+
+    if (dev) {
+      expect(text).toContain('User error')
+    } else {
+      expect(text).toBe('Internal Server Error')
+    }
   })
 
   it('should parse JSON body', async () => {

--- a/test/integration/server-side-dev-errors/pages/api/blog/[slug].js
+++ b/test/integration/server-side-dev-errors/pages/api/blog/[slug].js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ slug: req.query.slug })
+}

--- a/test/integration/server-side-dev-errors/pages/api/hello.js
+++ b/test/integration/server-side-dev-errors/pages/api/hello.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ hello: 'world' })
+}

--- a/test/integration/server-side-dev-errors/pages/blog/[slug].js
+++ b/test/integration/server-side-dev-errors/pages/blog/[slug].js
@@ -1,0 +1,9 @@
+export default function Page() {
+  return <p>dynamic getServerSideProps page</p>
+}
+
+export async function getServerSideProps() {
+  return {
+    props: {},
+  }
+}

--- a/test/integration/server-side-dev-errors/pages/gsp.js
+++ b/test/integration/server-side-dev-errors/pages/gsp.js
@@ -1,0 +1,9 @@
+export default function Page() {
+  return <p>getStaticProps page</p>
+}
+
+export async function getStaticProps() {
+  return {
+    props: {},
+  }
+}

--- a/test/integration/server-side-dev-errors/pages/gssp.js
+++ b/test/integration/server-side-dev-errors/pages/gssp.js
@@ -1,0 +1,9 @@
+export default function Page() {
+  return <p>getServerSideProps page</p>
+}
+
+export async function getServerSideProps() {
+  return {
+    props: {},
+  }
+}

--- a/test/integration/server-side-dev-errors/pages/uncaught-exception.js
+++ b/test/integration/server-side-dev-errors/pages/uncaught-exception.js
@@ -1,0 +1,12 @@
+export default function Page() {
+  return <p>getServerSideProps page</p>
+}
+
+export async function getServerSideProps() {
+  setTimeout(() => {
+    throw new Error('catch this exception')
+  }, 10)
+  return {
+    props: {},
+  }
+}

--- a/test/integration/server-side-dev-errors/pages/uncaught-rejection.js
+++ b/test/integration/server-side-dev-errors/pages/uncaught-rejection.js
@@ -1,0 +1,12 @@
+export default function Page() {
+  return <p>getServerSideProps page</p>
+}
+
+export async function getServerSideProps() {
+  setTimeout(() => {
+    Promise.reject(new Error('catch this rejection'))
+  }, 10)
+  return {
+    props: {},
+  }
+}

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -1,0 +1,201 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import webdriver from 'next-webdriver'
+import {
+  killApp,
+  findPort,
+  launchApp,
+  check,
+  hasRedbox,
+  getRedboxSource,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const appDir = join(__dirname, '../')
+const gspPage = join(appDir, 'pages/gsp.js')
+const gsspPage = join(appDir, 'pages/gssp.js')
+const dynamicGsspPage = join(appDir, 'pages/blog/[slug].js')
+const apiPage = join(appDir, 'pages/api/hello.js')
+const dynamicApiPage = join(appDir, 'pages/api/blog/[slug].js')
+
+let stderr = ''
+let appPort
+let app
+
+describe('server-side dev errors', () => {
+  beforeAll(async () => {
+    appPort = await findPort()
+    app = await launchApp(appDir, appPort, {
+      onStderr(msg) {
+        stderr += msg
+      },
+      env: {
+        __NEXT_TEST_WITH_DEVTOOL: 1,
+      },
+    })
+  })
+  afterAll(() => killApp(app))
+
+  it('should show server-side error for gsp page correctly', async () => {
+    const content = await fs.readFile(gspPage, 'utf8')
+
+    try {
+      const stderrIdx = stderr.length
+      await fs.writeFile(
+        gspPage,
+        content.replace('return {', 'missingVar;return {')
+      )
+      const browser = await webdriver(appPort, '/gsp')
+
+      await check(async () => {
+        const err = stderr.substr(stderrIdx)
+
+        return err.includes('pages/gsp.js') &&
+          err.includes('6:2') &&
+          err.includes('getStaticProps') &&
+          err.includes('missingVar')
+          ? 'success'
+          : err
+      }, 'success')
+
+      expect(await hasRedbox(browser, true)).toBe(true)
+
+      expect(await getRedboxSource(browser)).toContain('missingVar')
+      await fs.writeFile(gspPage, content)
+      await hasRedbox(browser, false)
+    } finally {
+      await fs.writeFile(gspPage, content)
+    }
+  })
+
+  it('should show server-side error for gssp page correctly', async () => {
+    const content = await fs.readFile(gsspPage, 'utf8')
+
+    try {
+      const stderrIdx = stderr.length
+      await fs.writeFile(
+        gsspPage,
+        content.replace('return {', 'missingVar;return {')
+      )
+      const browser = await webdriver(appPort, '/gssp')
+
+      await check(async () => {
+        const err = stderr.substr(stderrIdx)
+
+        return err.includes('pages/gssp.js') &&
+          err.includes('6:2') &&
+          err.includes('getServerSideProps') &&
+          err.includes('missingVar')
+          ? 'success'
+          : err
+      }, 'success')
+
+      expect(await hasRedbox(browser, true)).toBe(true)
+
+      expect(await getRedboxSource(browser)).toContain('missingVar')
+      await fs.writeFile(gsspPage, content)
+      await hasRedbox(browser, false)
+    } finally {
+      await fs.writeFile(gsspPage, content)
+    }
+  })
+
+  it('should show server-side error for dynamic gssp page correctly', async () => {
+    const content = await fs.readFile(dynamicGsspPage, 'utf8')
+
+    try {
+      const stderrIdx = stderr.length
+      await fs.writeFile(
+        dynamicGsspPage,
+        content.replace('return {', 'missingVar;return {')
+      )
+      const browser = await webdriver(appPort, '/blog/first')
+
+      await check(async () => {
+        const err = stderr.substr(stderrIdx)
+
+        return err.includes('pages/blog/[slug].js') &&
+          err.includes('6:2') &&
+          err.includes('getServerSideProps') &&
+          err.includes('missingVar')
+          ? 'success'
+          : err
+      }, 'success')
+
+      expect(await hasRedbox(browser, true)).toBe(true)
+
+      expect(await getRedboxSource(browser)).toContain('missingVar')
+      await fs.writeFile(dynamicGsspPage, content)
+      await hasRedbox(browser, false)
+    } finally {
+      await fs.writeFile(dynamicGsspPage, content)
+    }
+  })
+
+  it('should show server-side error for api route correctly', async () => {
+    const content = await fs.readFile(apiPage, 'utf8')
+
+    try {
+      const stderrIdx = stderr.length
+      await fs.writeFile(
+        apiPage,
+        content.replace('res.status', 'missingVar;res.status')
+      )
+      const browser = await webdriver(appPort, '/api/hello')
+
+      await check(async () => {
+        const err = stderr.substr(stderrIdx)
+
+        return err.includes('pages/api/hello.js') &&
+          err.includes('2:2') &&
+          err.includes('default') &&
+          err.includes('missingVar')
+          ? 'success'
+          : err
+      }, 'success')
+
+      expect(await hasRedbox(browser, true)).toBe(true)
+
+      expect(await getRedboxSource(browser)).toContain('missingVar')
+      await fs.writeFile(apiPage, content)
+      await hasRedbox(browser, false)
+    } finally {
+      await fs.writeFile(apiPage, content)
+    }
+  })
+
+  it('should show server-side error for dynamic api route correctly', async () => {
+    const content = await fs.readFile(dynamicApiPage, 'utf8')
+
+    try {
+      const stderrIdx = stderr.length
+      await fs.writeFile(
+        dynamicApiPage,
+        content.replace('res.status', 'missingVar;res.status')
+      )
+      const browser = await webdriver(appPort, '/api/blog/first')
+
+      await check(async () => {
+        const err = stderr.substr(stderrIdx)
+
+        return err.includes('pages/api/blog/[slug].js') &&
+          err.includes('2:2') &&
+          err.includes('default') &&
+          err.includes('missingVar')
+          ? 'success'
+          : err
+      }, 'success')
+
+      expect(await hasRedbox(browser, true)).toBe(true)
+
+      expect(await getRedboxSource(browser)).toContain('missingVar')
+      await fs.writeFile(dynamicApiPage, content)
+      await hasRedbox(browser, false)
+    } finally {
+      await fs.writeFile(dynamicApiPage, content)
+    }
+  })
+})

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -198,4 +198,36 @@ describe('server-side dev errors', () => {
       await fs.writeFile(dynamicApiPage, content)
     }
   })
+
+  it('should show server-side error for uncaught rejection correctly', async () => {
+    const stderrIdx = stderr.length
+    await webdriver(appPort, '/uncaught-rejection')
+
+    await check(async () => {
+      const err = stderr.substr(stderrIdx)
+
+      return err.includes('pages/uncaught-rejection.js') &&
+        err.includes('7:19') &&
+        err.includes('getServerSideProps') &&
+        err.includes('catch this rejection')
+        ? 'success'
+        : err
+    }, 'success')
+  })
+
+  it('should show server-side error for uncaught exception correctly', async () => {
+    const stderrIdx = stderr.length
+    await webdriver(appPort, '/uncaught-exception')
+
+    await check(async () => {
+      const err = stderr.substr(stderrIdx)
+
+      return err.includes('pages/uncaught-exception.js') &&
+        err.includes('7:10') &&
+        err.includes('getServerSideProps') &&
+        err.includes('catch this exception')
+        ? 'success'
+        : err
+    }, 'success')
+  })
 })


### PR DESCRIPTION
This updates server-side errors shown in the terminal to resolve the stack trace and show accurate line/columns and related source code similar to how we do in the dev overlay. This also updates to trigger the dev overlay when an error occurred in an API route and dismisses the overlay after the error as been fixed. 

Examples:

<details>

<summary>before: `getServerSideProps` error</summary>

<img width="962" alt="Screen Shot 2021-08-25 at 23 16 40" src="https://user-images.githubusercontent.com/22380829/130899904-4e47b200-7846-4f90-af3f-e5c5eb82e18e.png">

</details>

<details>

<summary>after: `getServerSideProps` error</summary>

<img width="962" alt="Screen Shot 2021-08-25 at 21 49 35" src="https://user-images.githubusercontent.com/22380829/130899938-96e53427-b237-4b22-8cff-3d2ce19c4057.png">

</details>

<details>

<summary>before: API route error</summary>

<img width="962" alt="Screen Shot 2021-08-25 at 23 16 01" src="https://user-images.githubusercontent.com/22380829/130899967-eee4de86-86c1-43f3-b81f-c0b30bab3ef3.png">

</details>

<details>

<summary>after: API route error</summary>

<img width="962" alt="Screen Shot 2021-08-25 at 21 47 01" src="https://user-images.githubusercontent.com/22380829/130899996-747168a8-1b9a-4276-9b57-5d763968934c.png">

<img width="1286" alt="Screen Shot 2021-08-25 at 20 46 58" src="https://user-images.githubusercontent.com/22380829/130900006-430675ad-39e6-4547-bff8-5ddbc97138bb.png">

</details>

<details>

<summary>before: uncaught rejection/exception</summary>

<img width="962" alt="Screen Shot 2021-08-26 at 09 27 58" src="https://user-images.githubusercontent.com/22380829/130982272-cef31185-6b14-4605-ba2c-3571bd61cdfc.png">

</details>

<details>

<summary>after: uncaught rejection/exception</summary>

<img width="962" alt="Screen Shot 2021-08-26 at 09 27 22" src="https://user-images.githubusercontent.com/22380829/130982343-2493dd94-ed48-4b34-9034-efea5e7fa09f.png">

</details>

Fixes: https://github.com/vercel/next.js/issues/26711
Fixes: https://github.com/vercel/next.js/issues/21904
