### PR TITLE
Fix example in "Font Optimization"

### DIFF
--- a/docs/basic-features/font-optimization.md
+++ b/docs/basic-features/font-optimization.md
@@ -17,7 +17,11 @@ By default, Next.js will automatically inline font CSS at build time, eliminatin
 
 // After
 <style data-href="https://fonts.googleapis.com/css2?family=Inter">
-  @font-face{font-family:'Inter';font-style:normal...
+  {`@font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      ...
+  }`}
 </style>
 ```
 


### PR DESCRIPTION
in this case, styles need to be passed in "styled-jsx" format, otherwise the project won't compile.

This fix will be useful for new programmers who are not familiar with next/react yet.

## Documentation / Examples

- [ X ] Make sure the linting passes
