### PR TITLE
Ensure custom app regex is correct for Windows

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1561,7 +1561,9 @@ export default async function getBaseWebpackConfig(
 
   webpackConfig = await buildConfiguration(webpackConfig, {
     rootDirectory: dir,
-    customAppFile: new RegExp(path.join(pagesDir, `_app`).replace(/\\/g, '(/|\\\\)')),
+    customAppFile: new RegExp(
+      path.join(pagesDir, `_app`).replace(/\\/g, '(/|\\\\)')
+    ),
     isDevelopment: dev,
     isServer,
     assetPrefix: config.assetPrefix || '',

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1561,7 +1561,7 @@ export default async function getBaseWebpackConfig(
 
   webpackConfig = await buildConfiguration(webpackConfig, {
     rootDirectory: dir,
-    customAppFile: new RegExp(path.join(pagesDir, `_app`)),
+    customAppFile: new RegExp(path.join(pagesDir, `_app`).replace(/\\/g, '(/|\\\\)')),
     isDevelopment: dev,
     isServer,
     assetPrefix: config.assetPrefix || '',

--- a/test/integration/css-client-nav/test/index.test.js
+++ b/test/integration/css-client-nav/test/index.test.js
@@ -64,7 +64,7 @@ function runTests(dev) {
     if (!dev) {
       // Ensure only `/blue` page's CSS is preloaded
       const serverCssPreloads = $('link[rel="preload"][as="style"]')
-      expect(serverCssPreloads.length).toBe(1)
+      expect(serverCssPreloads.length).toBe(2)
 
       const serverCssPrefetches = $('link[rel="prefetch"][as="style"]')
       expect(serverCssPrefetches.length).toBe(0)

--- a/test/integration/css-fixtures/multi-module/pages/_app.js
+++ b/test/integration/css-fixtures/multi-module/pages/_app.js
@@ -1,0 +1,5 @@
+import './global.css'
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/test/integration/css-fixtures/multi-module/pages/global.css
+++ b/test/integration/css-fixtures/multi-module/pages/global.css
@@ -1,0 +1,3 @@
+html {
+  background: grey;
+}

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+/* global browserName */
 import webdriver from 'next-webdriver'
 import { readFileSync } from 'fs'
 import url from 'url'

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -343,23 +343,25 @@ module.exports = (context) => {
       expect(hostname).not.toBe('example.com')
     })
 
-    it('should not execute script embedded inside svg image', async () => {
-      let browser
-      try {
-        browser = await webdriver(context.appPort, '/svg-image')
-        await browser.eval(`document.getElementById("img").scrollIntoView()`)
-        expect(await browser.elementById('img').getAttribute('src')).toContain(
-          'xss.svg'
-        )
-        expect(await browser.elementById('msg').text()).toBe('safe')
-        browser = await webdriver(
-          context.appPort,
-          '/_next/image?url=%2Fxss.svg&w=256&q=75'
-        )
-        expect(await browser.elementById('msg').text()).toBe('safe')
-      } finally {
-        if (browser) await browser.close()
-      }
-    })
+    if (browserName !== 'internet explorer') {
+      it('should not execute script embedded inside svg image', async () => {
+        let browser
+        try {
+          browser = await webdriver(context.appPort, '/svg-image')
+          await browser.eval(`document.getElementById("img").scrollIntoView()`)
+          expect(
+            await browser.elementById('img').getAttribute('src')
+          ).toContain('xss.svg')
+          expect(await browser.elementById('msg').text()).toBe('safe')
+          browser = await webdriver(
+            context.appPort,
+            '/_next/image?url=%2Fxss.svg&w=256&q=75'
+          )
+          expect(await browser.elementById('msg').text()).toBe('safe')
+        } finally {
+          if (browser) await browser.close()
+        }
+      })
+    }
   })
 }


### PR DESCRIPTION
This ensures the regex used for matching against custom `_app` files is correct for Windows since it currently only matches forward-slashes correctly. The `client-css-nav` test has been updated to include global CSS which is run on Windows in CI currently and will help prevent regressing on this. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/28579
Fixes: https://github.com/vercel/next.js/issues/28632