### PR TITLE
Add error page path for next-script-for-ga

### DIFF
--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -270,6 +270,10 @@
           "path": "/errors/next-image-unconfigured-host.md"
         },
         {
+          "title": "next-script-for-ga",
+          "path": "/errors/next-script-for-ga.md"
+        },
+        {
           "title": "next-start-serverless",
           "path": "/errors/next-start-serverless.md"
         },


### PR DESCRIPTION

## Documentation / Examples

- [x] Make sure the linting passes

**My console**

> src/pages/_document.tsx#L14
> Use the `next/script` component for loading third party scripts. See: https://nextjs.org/docs/messages/next-script-for-ga

https://nextjs.org/docs/messages/next-script-for-ga is 404 now.
