### PR TITLE
Fix TS type conflict for `<img>` tag

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -627,6 +627,7 @@ export default function Image({
           data-nimg={layout}
           style={imgStyle}
           className={className}
+          // @ts-ignore - TODO: upgrade to `@types/react@17`
           loading={loading || 'lazy'}
         />
       </noscript>

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -40,11 +40,6 @@ declare module 'react' {
   interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
     nonce?: string
   }
-
-  // <img loading="lazy"> support
-  interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
-    loading?: 'auto' | 'eager' | 'lazy'
-  }
 }
 
 export type Redirect =


### PR DESCRIPTION
This type was added in PR #28269 but doesn't need to be public and was causing conflicts with `@types/react@17`.

We currently use `@types/react@16` so ideally we should upgrade to `@types/react@17` and then remove the `ts-ignore`.

Fixes #28647 