### PR TITLE
Fix for `next-script-for-ga` ESLint rule crashing when a method is used in dangerouslySetInnerHTML

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/next-script-for-ga.js
+++ b/packages/eslint-plugin-next/lib/rules/next-script-for-ga.js
@@ -52,8 +52,8 @@ module.exports = {
         // https://developers.google.com/analytics/devguides/collection/analyticsjs#the_google_analytics_tag
         // https://developers.google.com/tag-manager/quickstart
         if (
-          attributes.has('dangerouslySetInnerHTML') &&
-          attributes.value('dangerouslySetInnerHTML')[0]
+          attributes.value('dangerouslySetInnerHTML') &&
+          attributes.value('dangerouslySetInnerHTML').length > 0
         ) {
           const htmlContent =
             attributes.value('dangerouslySetInnerHTML')[0].value.quasis &&

--- a/test/unit/eslint-plugin-next/next-script-for-ga.test.ts
+++ b/test/unit/eslint-plugin-next/next-script-for-ga.test.ts
@@ -207,5 +207,35 @@ ruleTester.run('sync-scripts', rule, {
         },
       ],
     },
+    {
+      code: `
+        export class Blah extends Head {
+          createGoogleAnalyticsMarkup() {
+            return {
+              __html: \`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'UA-148481588-2');\`,
+            };
+          }
+
+          render() {
+            return (
+              <div>
+                <h1>Hello title</h1>
+                <script dangerouslySetInnerHTML={this.createGoogleAnalyticsMarkup()} />
+                <script async src='https://www.google-analytics.com/analytics.js'></script>
+              </div>
+            );
+          }
+      }`,
+      errors: [
+        {
+          message: ERROR_MSG,
+          type: 'JSXOpeningElement',
+        },
+      ],
+    },
   ],
 })


### PR DESCRIPTION
Fixes #28635

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`
