### PR TITLE
Fix `next lint` no-document-import-in-page on Windows

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-document-import-in-page.js
+++ b/packages/eslint-plugin-next/lib/rules/no-document-import-in-page.js
@@ -16,7 +16,11 @@ module.exports = {
         const paths = context.getFilename().split('pages')
         const page = paths[paths.length - 1]
 
-        if (!page || page.startsWith('/_document')) {
+        if (
+          !page ||
+          page.startsWith('/_document') ||
+          page.startsWith('\\_document')
+        ) {
           return
         }
 

--- a/test/unit/eslint-plugin-next/no-document-import-in-page.test.ts
+++ b/test/unit/eslint-plugin-next/no-document-import-in-page.test.ts
@@ -29,6 +29,20 @@ ruleTester.run('no-document-import-in-page', rule, {
       filename: 'pages/_document.js',
     },
     {
+      code: `import Document from "next/document"
+
+    export default class MyDocument extends Document {
+      render() {
+        return (
+          <Html>
+          </Html>
+        );
+      }
+    }
+    `,
+      filename: 'pages\\_document.js',
+    },
+    {
       code: `import NextDocument from "next/document"
 
     export default class MyDocument extends NextDocument {
@@ -120,6 +134,20 @@ ruleTester.run('no-document-import-in-page', rule, {
       export const Test = () => <p>Test</p>
       `,
       filename: 'pages/test.js',
+      errors: [
+        {
+          message:
+            'next/document should not be imported outside of pages/_document.js. See https://nextjs.org/docs/messages/no-document-import-in-page.',
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+    {
+      code: `import Document from "next/document"
+
+      export const Test = () => <p>Test</p>
+      `,
+      filename: 'pages\\test.js',
       errors: [
         {
           message:


### PR DESCRIPTION
Fixes #28596 