### PR TITLE
Update github labeler with `eslint-plugin-next`

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -8,7 +8,9 @@
       "packages/react-dev-overlay/**",
       "packages/react-refresh-utils/**",
       "packages/next-codemod/**",
-      "packages/eslint-plugin-next/**"
+      "packages/eslint-plugin-next/**",
+      "packages/eslint-config-next/**",
+      "packages/next-env/**"
     ],
     "created-by: Chrome Aurora": [
       { "type": "user", "pattern": "spanicker" },

--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -7,7 +7,8 @@
       "packages/next/**",
       "packages/react-dev-overlay/**",
       "packages/react-refresh-utils/**",
-      "packages/next-codemod/**"
+      "packages/next-codemod/**",
+      "packages/eslint-plugin-next/**"
     ],
     "created-by: Chrome Aurora": [
       { "type": "user", "pattern": "spanicker" },


### PR DESCRIPTION
The `eslint-plugin-next` package should be considered a "core" package since it powers the `next lint` command
