### PR TITLE
fix: migrate with-stitches example to be compat with stitches@1.0.0

### DIFF
--- a/examples/with-stitches/pages/_document.jsx
+++ b/examples/with-stitches/pages/_document.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
-import { getCssString } from '../stitches.config'
+import { getCssText } from '../stitches.config'
 
 export default class Document extends NextDocument {
   render() {
@@ -9,7 +9,7 @@ export default class Document extends NextDocument {
         <Head>
           <style
             id="stitches"
-            dangerouslySetInnerHTML={{ __html: getCssString() }}
+            dangerouslySetInnerHTML={{ __html: getCssText() }}
           />
         </Head>
         <body>

--- a/examples/with-stitches/stitches.config.js
+++ b/examples/with-stitches/stitches.config.js
@@ -1,6 +1,6 @@
-import { createCss } from '@stitches/react'
+import { createStitches } from '@stitches/react'
 
-export const { css, styled, global, getCssString } = createCss({
+export const { css, styled, globalCss, getCssText } = createStitches({
   theme: {
     colors: {
       hiContrast: 'hsl(206,10%,5%)',


### PR DESCRIPTION
This updates the exports coming from stitches/react@1.0.0

## Documentation / Examples

- [x] Make sure the linting passes
