### PR TITLE
Docs: next/script with inline code needs "id"

### DIFF
--- a/docs/basic-features/script.md
+++ b/docs/basic-features/script.md
@@ -145,6 +145,10 @@ import Script from 'next/script'
 />
 ```
 
+> **Note:**
+>
+> - `next/script` components with inline content require an `id` attribute to be defined to track and optimize the script.
+
 ### Forwarding Attributes
 
 ```js


### PR DESCRIPTION
If a next/script tag with inline content does not have an "id" attribute then eslint-plugin-next gives a warning. This should be mentioned in the docs for next/script.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [X] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [X] Make sure the linting passes
