### PR TITLE
Add `@next/crawler-utils` package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -26,3 +26,4 @@ packages/create-next-app/templates/**
 test/integration/eslint/**
 test-timings.json
 packages/next/build/swc/tests/fixture/**
+packages/next-crawler-utils/*

--- a/packages/next-crawler-utils/build.ts
+++ b/packages/next-crawler-utils/build.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import crawlers from 'crawler-user-agents'
+
+const license = readFileSync(
+  join(dirname(require.resolve('crawler-user-agents')), 'LICENSE')
+).toString()
+const pattern = crawlers.map((crawler) => crawler.pattern).join('|')
+
+process.stdout.write(
+  `
+  /*
+  ${license}
+  */
+  export const CRAWLER_PATTERN = /${pattern}/`
+)

--- a/packages/next-crawler-utils/package.json
+++ b/packages/next-crawler-utils/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@next/crawler-utils",
+  "version": "11.1.3-canary.9",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": {
+    "url": "vercel/next.js",
+    "directory": "packages/next-crawler-utils"
+  },
+  "files": [
+    "dist/index.d.ts",
+    "dist/index.js"
+  ],
+  "scripts": {
+    "prerelease": "rimraf ./dist/",
+    "release": "tsc -d -p tsconfig.json --outDir ./dist --declaration false && node dist/build.js > dist/index.ts && tsc -d dist/index.ts",
+    "prepublish": "yarn release"
+  },
+  "devDependencies": {
+    "crawler-user-agents": "1.0.84",
+    "rimraf": "3.0.0"
+  }
+}

--- a/packages/next-crawler-utils/tsconfig.json
+++ b/packages/next-crawler-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2015",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "preserveWatchOutput": true
+  }
+}

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@babel/runtime": "7.15.3",
     "@hapi/accept": "5.0.2",
+    "@next/crawler-utils": "11.1.3-canary.9",
     "@next/env": "11.1.3-canary.9",
     "@next/polyfill-module": "11.1.3-canary.9",
     "@next/react-dev-overlay": "11.1.3-canary.9",

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -2,6 +2,7 @@ import compression from 'next/dist/compiled/compression'
 import fs from 'fs'
 import chalk from 'chalk'
 import { IncomingMessage, ServerResponse } from 'http'
+import { CRAWLER_PATTERN } from '@next/crawler-utils'
 import Proxy from 'next/dist/compiled/http-proxy'
 import { join, relative, resolve, sep } from 'path'
 import {
@@ -1250,12 +1251,14 @@ export default class Server {
       query: ParsedUrlQuery
     }
   ): Promise<void> {
+    const userAgent = partialContext.req.headers['user-agent']
     const ctx = {
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
-        // TODO: Determine when dynamic HTML is allowed
-        supportsDynamicHTML: false,
+        supportsDynamicHTML: userAgent
+          ? !CRAWLER_PATTERN.test(userAgent)
+          : false,
       },
     } as const
     const payload = await fn(ctx)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7688,6 +7688,11 @@ cpy@7.3.0:
     globby "^9.2.0"
     nested-error-stacks "^2.1.0"
 
+crawler-user-agents@1.0.84:
+  version "1.0.84"
+  resolved "https://registry.yarnpkg.com/crawler-user-agents/-/crawler-user-agents-1.0.84.tgz#b225dca5d7a67d280678e945c96e77badc58656f"
+  integrity sha512-EeYQmI3c++XPMKb60p1zpFuLNrM/K/2ElhX/vN9KjTYc6r00QDSfX/NU6BXY79yUYUwG259DMC8NFrxpuureZQ==
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"


### PR DESCRIPTION
Adds a `@next/crawler-utils` package, which exports a `RegExp` pattern of crawler user agents. The pattern is generated by running a script at build time to import `crawler-user-agents` and concatenate the patterns. The generated document also shares the `LICENSE`.

This is essentially just a hand built `ncc`. Running `ncc` on the `crawler-user-agents` isn't sufficient as it contains a lot of other extraneous data that we don't want to bundle with Next.js.

---

We use this package to prevent crawlers from receiving dynamic HTML. 