### PR TITLE
(docs) Add `permanent` property in redirect object

### DIFF
--- a/docs/api-reference/next.config.js/redirects.md
+++ b/docs/api-reference/next.config.js/redirects.md
@@ -208,6 +208,7 @@ module.exports = {
             value: 'example.com',
           },
         ],
+        permanent: false,
         destination: '/another-page',
       },
     ]


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

I found that an example for a redirect rule in the documentation doesn't have the required property `permanent`. I noticed this because I tried to use that same rule but building fails with the following message:

```
`permanent` is not set to `true` or `false` for route {"source":"/:path((?!another-page$).*)","has":[{"type":"host","value":"example.com"}],"destination":"/another-page"}


Error: Invalid redirect found
```

My PR simply adds the missing `permanent` property as false to be consistent with the rest.

## Documentation / Examples

- [x] Make sure the linting passes
