### PR TITLE
Exclude webpack externals from webpack bundles

### DIFF
--- a/packages/next/compiled/webpack/bundle4.js
+++ b/packages/next/compiled/webpack/bundle4.js
@@ -130918,7 +130918,7 @@ module.exports = function () {
     ModuleFilenameHelpers: __webpack_require__(71474),
     GraphHelpers: __webpack_require__(32973),
     Module: __webpack_require__(75993),
-    NormalModule: __webpack_require__(14738),
+    NormalModule: __webpack_require__(25963),
     Dependency: __webpack_require__(57282),
     LibraryTemplatePlugin: __webpack_require__(65237),
     SingleEntryPlugin: __webpack_require__(19070),
@@ -131085,14 +131085,6 @@ module.exports = require("next/dist/compiled/terser");;
 
 "use strict";
 module.exports = require("next/dist/compiled/webpack-sources");;
-
-/***/ }),
-
-/***/ 14738:
-/***/ (function(module) {
-
-"use strict";
-module.exports = require("next/dist/compiled/webpack/NormalModule");;
 
 /***/ }),
 

--- a/packages/next/compiled/webpack/bundle4.js
+++ b/packages/next/compiled/webpack/bundle4.js
@@ -130918,7 +130918,7 @@ module.exports = function () {
     ModuleFilenameHelpers: __webpack_require__(71474),
     GraphHelpers: __webpack_require__(32973),
     Module: __webpack_require__(75993),
-    NormalModule: __webpack_require__(25963),
+    NormalModule: __webpack_require__(14738),
     Dependency: __webpack_require__(57282),
     LibraryTemplatePlugin: __webpack_require__(65237),
     SingleEntryPlugin: __webpack_require__(19070),
@@ -131085,6 +131085,14 @@ module.exports = require("next/dist/compiled/terser");;
 
 "use strict";
 module.exports = require("next/dist/compiled/webpack-sources");;
+
+/***/ }),
+
+/***/ 14738:
+/***/ (function(module) {
+
+"use strict";
+module.exports = require("next/dist/compiled/webpack/NormalModule");;
 
 /***/ }),
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -781,12 +781,18 @@ export async function ncc_mini_css_extract_plugin(task, opts) {
 
 // eslint-disable-next-line camelcase
 export async function ncc_webpack_bundle4(task, opts) {
+  const bundleExternals = {
+    ...externals,
+  }
+  for (const pkg of Object.keys(webpackBundlePackages)) {
+    delete bundleExternals[pkg]
+  }
   await task
     .source(opts.src || 'bundles/webpack/bundle4.js')
     .ncc({
       packageName: 'webpack',
       bundleName: 'webpack',
-      externals,
+      externals: bundleExternals,
       minify: false,
       target: 'es5',
     })
@@ -795,6 +801,12 @@ export async function ncc_webpack_bundle4(task, opts) {
 
 // eslint-disable-next-line camelcase
 export async function ncc_webpack_bundle5(task, opts) {
+  const bundleExternals = {
+    ...externals,
+  }
+  for (const pkg of Object.keys(webpackBundlePackages)) {
+    delete bundleExternals[pkg]
+  }
   await task
     .source(opts.src || 'bundles/webpack/bundle5.js')
     .ncc({
@@ -804,7 +816,7 @@ export async function ncc_webpack_bundle5(task, opts) {
         if (path.endsWith('.runtime.js')) return `'./${basename(path)}'`
       },
       externals: {
-        ...externals,
+        ...bundleExternals,
         'schema-utils': 'next/dist/compiled/schema-utils3',
         'webpack-sources': 'next/dist/compiled/webpack-sources3',
       },


### PR DESCRIPTION
Fixes `Pre-compiled check` failures by excluding webpack externals from the webpack bundles.