### PR TITLE
Make next-ssg optional

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -291,6 +291,7 @@ export default async function getBaseWebpackConfig(
           loader: 'next-swc-loader',
           options: {
             isServer,
+            pagesDir,
           },
         }
       : {

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -52,6 +52,8 @@ function getSWCOptions({ isTypeScript, isServer, development }) {
   if (isServer) {
     return {
       jsc,
+      // Disables getStaticProps/getServerSideProps tree shaking on the server compilation
+      disableNextSsg: true,
       env: {
         targets: {
           // Targets the current version of Node.js


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes


I made `next-ssg` pass optional.

`disableNextSsg` can be passed to `transform()` like `transform({disableNextSsg: true})` to disable it.

Note: I'm not sure about the test.






