### PR TITLE
Trim large test output to not exceed limit

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -236,7 +236,24 @@ async function main() {
         children.delete(child)
         if (code) {
           if (isFinalRun) {
-            outputChunks.forEach((chunk) => process.stdout.write(chunk))
+            // limit out to last 64kb so that we don't
+            // run out of log room in CI
+            let trimmedOutputSize = 0
+            const trimmedOutputLimit = 64 * 1024
+            const trimmedOutput = []
+
+            for (let i = outputChunks.length; i >= 0; i--) {
+              const chunk = outputChunks[i]
+              if (!chunk) continue
+
+              trimmedOutputSize += chunk.byteLength || chunk.length
+              trimmedOutput.splice(0, 0, chunk)
+
+              if (trimmedOutputSize > trimmedOutputLimit) {
+                break
+              }
+            }
+            trimmedOutput.forEach((chunk) => process.stdout.write(chunk))
           }
           reject(new Error(`failed with code: ${code}`))
         }

--- a/run-tests.js
+++ b/run-tests.js
@@ -247,7 +247,7 @@ async function main() {
               if (!chunk) continue
 
               trimmedOutputSize += chunk.byteLength || chunk.length
-              trimmedOutput.splice(0, 0, chunk)
+              trimmedOutput.unshift(chunk)
 
               if (trimmedOutputSize > trimmedOutputLimit) {
                 break


### PR DESCRIPTION
This ensures we trim test output that will exceed the amount that can be shown in GitHub actions so that we can still see which tests failed instead of un-helpful test logs. 