### PR TITLE
Update concurrent tests and enable experimental streaming

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -76,7 +76,7 @@ import { sendRenderResult, setRevalidateHeaders } from './send-payload'
 import { serveStatic } from './serve-static'
 import { IncrementalCache } from './incremental-cache'
 import { execOnce } from '../shared/lib/utils'
-import { isBlockedPage, CRAWLER_PATTERN } from './utils'
+import { isBlockedPage, isBot } from './utils'
 import RenderResult from './render-result'
 import { loadEnvConfig } from '@next/env'
 import './node-polyfill-fetch'
@@ -1256,7 +1256,7 @@ export default class Server {
       renderOpts: {
         ...this.renderOpts,
         supportsDynamicHTML: userAgent
-          ? !CRAWLER_PATTERN.test(userAgent)
+          ? !isBot(userAgent)
           : false,
       },
     } as const

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1255,9 +1255,7 @@ export default class Server {
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
-        supportsDynamicHTML: userAgent
-          ? !isBot(userAgent)
-          : false,
+        supportsDynamicHTML: userAgent ? !isBot(userAgent) : false,
       },
     } as const
     const payload = await fn(ctx)

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1254,8 +1254,8 @@ export default class Server {
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
-        // TODO: Determine when dynamic HTML is allowed
-        supportsDynamicHTML: false,
+        // TODO: Disable dynamic HTML support for crawlers.
+        supportsDynamicHTML: true,
       },
     } as const
     const payload = await fn(ctx)

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -76,7 +76,7 @@ import { sendRenderResult, setRevalidateHeaders } from './send-payload'
 import { serveStatic } from './serve-static'
 import { IncrementalCache } from './incremental-cache'
 import { execOnce } from '../shared/lib/utils'
-import { isBlockedPage } from './utils'
+import { isBlockedPage, CRAWLER_PATTERN } from './utils'
 import RenderResult from './render-result'
 import { loadEnvConfig } from '@next/env'
 import './node-polyfill-fetch'
@@ -1250,12 +1250,14 @@ export default class Server {
       query: ParsedUrlQuery
     }
   ): Promise<void> {
+    const userAgent = partialContext.req.headers['user-agent']
     const ctx = {
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
-        // TODO: Disable dynamic HTML support for crawlers.
-        supportsDynamicHTML: true,
+        supportsDynamicHTML: userAgent
+          ? !CRAWLER_PATTERN.test(userAgent)
+          : false,
       },
     } as const
     const payload = await fn(ctx)

--- a/packages/next/server/utils.ts
+++ b/packages/next/server/utils.ts
@@ -15,5 +15,6 @@ export function cleanAmpPath(pathname: string): string {
   return pathname
 }
 
-export const CRAWLER_PATTERN =
-  /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/
+export function isBot(userAgent: string): boolean {
+  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i.test(userAgent)
+}

--- a/packages/next/server/utils.ts
+++ b/packages/next/server/utils.ts
@@ -14,3 +14,6 @@ export function cleanAmpPath(pathname: string): string {
   pathname = pathname.replace(/\?$/, '')
   return pathname
 }
+
+export const CRAWLER_PATTERN =
+  /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/

--- a/packages/next/server/utils.ts
+++ b/packages/next/server/utils.ts
@@ -16,5 +16,7 @@ export function cleanAmpPath(pathname: string): string {
 }
 
 export function isBot(userAgent: string): boolean {
-  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i.test(userAgent)
+  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i.test(
+    userAgent
+  )
 }

--- a/test/integration/react-18/app/components/hello.js
+++ b/test/integration/react-18/app/components/hello.js
@@ -9,5 +9,29 @@ export default function Hello({ name, thrown = false }) {
     thrown
   )
 
-  return <p>hello {ReactDOM.version}</p>
+  const [hydrated, setHydrated] = React.useState(() => false)
+  React.useEffect(() => {
+    if (!hydrated) {
+      setHydrated(true)
+    }
+  }, [hydrated])
+
+  const serverRendered = React.useMemo(() => {
+    if (typeof window === 'undefined') {
+      return true
+    }
+    const elem = document.getElementById('server-rendered')
+    if (elem) {
+      return elem.innerText === 'true'
+    }
+    return false
+  }, [])
+
+  return (
+    <p>
+      hello {ReactDOM.version}
+      <span id="server-rendered">{serverRendered.toString()}</span>
+      {hydrated ? <span id="hydrated">{hydrated.toString()}</span> : null}
+    </p>
+  )
 }

--- a/test/integration/react-18/app/pages/ssr.js
+++ b/test/integration/react-18/app/pages/ssr.js
@@ -1,0 +1,8 @@
+export default function SSR() {
+  return 'hello'
+}
+
+export function getServerSideProps() {
+  // Prevent static optimization
+  return { props: {} }
+}

--- a/test/integration/react-18/test/concurrent.js
+++ b/test/integration/react-18/test/concurrent.js
@@ -1,47 +1,64 @@
 /* eslint-env jest */
 
 import webdriver from 'next-webdriver'
-import cheerio from 'cheerio'
 import { check } from 'next-test-utils'
 
-export default (context, render) => {
-  async function get$(path, query) {
-    const html = await render(path, query)
-    return cheerio.load(html)
-  }
-
-  it('should resolve suspense modules on server side if suspense', async () => {
-    const $ = await get$('/suspense/no-preload')
-    const nextData = JSON.parse($('#__NEXT_DATA__').text())
-    const content = $('#__next').text()
-    expect(content).toBe('barfoo')
-    expect(nextData.dynamicIds).toBeUndefined()
-  })
-
-  it('should resolve suspense on server side if not suspended on server', async () => {
-    const $ = await get$('/suspense/no-thrown')
-    const html = $('body').html()
-    // there might be html comments between text, test hello only
-    expect(html).toContain('hello')
-    expect(JSON.parse($('#__NEXT_DATA__').text()).dynamicIds).toBeUndefined()
-  })
-
-  it('should resolve suspense on server side if suspended on server', async () => {
-    const $ = await get$('/suspense/thrown')
-    const html = $('body').html()
-    expect(html).toContain('hello')
-    expect(JSON.parse($('#__NEXT_DATA__').text()).dynamicIds).toBeUndefined()
-  })
-
-  it('should hydrate suspenses on client side if suspended on server', async () => {
+export default (context, _render) => {
+  async function withBrowser(path, cb) {
     let browser
     try {
-      browser = await webdriver(context.appPort, '/suspense/thrown')
-      await check(() => browser.elementByCss('body').text(), /hello/)
+      browser = await webdriver(context.appPort, path, false)
+      await cb(browser)
     } finally {
       if (browser) {
         await browser.close()
       }
     }
+  }
+
+  it('should resolve suspense modules on server side if suspense', async () => {
+    await withBrowser('/suspense/no-preload', async (browser) => {
+      await check(() => browser.waitForElementByCss('#__next').text(), /barfoo/)
+      await check(
+        () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
+        /undefined/
+      )
+    })
+  })
+
+  it('should resolve suspense on server side if not suspended on server', async () => {
+    await withBrowser('/suspense/no-thrown', async (browser) => {
+      await check(
+        () => browser.waitForElementByCss('#server-rendered').text(),
+        /true/
+      )
+      await check(
+        () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
+        /undefined/
+      )
+    })
+  })
+
+  it('should resolve suspense on server side if suspended on server', async () => {
+    await withBrowser('/suspense/thrown', async (browser) => {
+      await check(
+        () => browser.waitForElementByCss('#server-rendered').text(),
+        /true/
+      )
+      await check(
+        () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
+        /undefined/
+      )
+    })
+  })
+
+  it('should hydrate suspenses on client side if suspended on server', async () => {
+    await withBrowser('/suspense/thrown', async (browser) => {
+      await check(() => browser.waitForElementByCss('#hydrated').text(), /true/)
+      await check(
+        () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
+        /undefined/
+      )
+    })
   })
 }


### PR DESCRIPTION
Updates the React 18 concurrent tests to support streaming, by using webdriver (instead of cheerio) to support dynamic updates, and being more explicit about SSR vs. hydrated content.

Also enables streaming support by setting `supportsDynamicHTML: true` in `pipe(...)` for non-bot user agents.