### PR TITLE
Default to unenhanced head in render

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1011,7 +1011,7 @@ export async function renderToHTML(
         documentElement: (htmlProps: HtmlProps) => (
           <Document {...htmlProps} {...docProps} />
         ),
-        head: docProps.head,
+        head: docProps.head || head,
         headTags: await headTags(documentCtx),
         styles: docProps.styles,
       }


### PR DESCRIPTION
We should use the default head if we want to render externally without using Next.js. Fixes #28965

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
