### PR TITLE
Remove <link> tag rendered invalid by font-optimisation

### DIFF
--- a/packages/next/shared/lib/post-process.ts
+++ b/packages/next/shared/lib/post-process.ts
@@ -25,6 +25,12 @@ type middlewareSignature = {
   condition: ((options: postProcessOptions) => boolean) | null
 }
 
+type fontDefinition = {
+  url: string
+  nonce: string | undefined
+  element: HTMLElement
+}
+
 const middlewareRegistry: Array<middlewareSignature> = []
 
 function registerPostProcessor(
@@ -74,7 +80,7 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
     if (!options.getFontDefinition) {
       return
     }
-    const fontDefinitions: (string | undefined)[][] = []
+    const fontDefinitions: fontDefinition[] = []
     // collecting all the requested font definitions
     originalDom
       .querySelectorAll('link')
@@ -92,7 +98,7 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
         const nonce = element.getAttribute('nonce')
 
         if (url) {
-          fontDefinitions.push([url, nonce])
+          fontDefinitions.push({ url, nonce, element })
         }
       })
 
@@ -100,7 +106,7 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
   }
   mutate = async (
     markup: string,
-    fontDefinitions: string[][],
+    fontDefinitions: fontDefinition[],
     options: renderOptions
   ) => {
     let result = markup
@@ -111,7 +117,7 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
     }
 
     fontDefinitions.forEach((fontDef) => {
-      const [url, nonce] = fontDef
+      const { url, nonce, element } = fontDef
       const fallBackLinkTag = `<link rel="stylesheet" href="${url}"/>`
       if (
         result.indexOf(`<style data-href="${url}">`) > -1 ||
@@ -134,6 +140,8 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
           '</head>',
           `<style data-href="${url}"${nonceStr}>${fontContent}</style></head>`
         )
+
+        result = result.replace(element.outerHTML, '')
 
         const provider = OPTIMIZED_FONT_PROVIDERS.find((p) =>
           url.startsWith(p.url)

--- a/packages/next/shared/lib/post-process.ts
+++ b/packages/next/shared/lib/post-process.ts
@@ -141,6 +141,7 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
           `<style data-href="${url}"${nonceStr}>${fontContent}</style></head>`
         )
 
+        // Remove the invalid link tags from the resultant HTML.
         result = result.replace(element.outerHTML, '')
 
         const provider = OPTIMIZED_FONT_PROVIDERS.find((p) =>

--- a/test/integration/font-optimization/test/index.test.js
+++ b/test/integration/font-optimization/test/index.test.js
@@ -96,12 +96,10 @@ describe('Font Optimization', () => {
           const link = $(
             `link[rel="stylesheet"][data-href="${staticHeadFont}"]`
           )
-          const nonce = link.attr('nonce')
           const style = $(`style[data-href="${staticHeadFont}"]`)
           const styleNonce = style.attr('nonce')
 
-          expect(link).toBeDefined()
-          expect(nonce).toBe('VmVyY2Vs')
+          expect(link).toBeUndefined()
           expect(styleNonce).toBe('VmVyY2Vs')
         })
 
@@ -111,9 +109,7 @@ describe('Font Optimization', () => {
 
           const $ = cheerio.load(html)
 
-          expect($(`link[data-href="${withFont}"]`).attr().rel).toBe(
-            'stylesheet'
-          )
+          expect($(`link[data-href="${withFont}"]`)).toBeUndefined()
 
           expect(html).toMatch(withFontPattern)
 
@@ -121,7 +117,6 @@ describe('Font Optimization', () => {
 
           const $2 = cheerio.load(htmlWithoutFont)
 
-          expect($2(`link[data-href="${withFont}"]`).attr()).toBeUndefined()
           expect(htmlWithoutFont).not.toMatch(withFontPattern)
         })
 
@@ -131,7 +126,7 @@ describe('Font Optimization', () => {
           expect(await fsExists(builtPage('font-manifest.json'))).toBe(true)
           expect(
             $(`link[rel=stylesheet][data-href="${staticFont}"]`).length
-          ).toBe(1)
+          ).toBe(0)
           expect(html).toMatch(staticPattern)
         })
 
@@ -141,7 +136,7 @@ describe('Font Optimization', () => {
           expect(await fsExists(builtPage('font-manifest.json'))).toBe(true)
           expect(
             $(`link[rel=stylesheet][data-href="${staticHeadFont}"]`).length
-          ).toBe(1)
+          ).toBe(0)
           expect(html).toMatch(staticHeadPattern)
         })
 
@@ -151,7 +146,7 @@ describe('Font Optimization', () => {
           expect(await fsExists(builtPage('font-manifest.json'))).toBe(true)
           expect(
             $(`link[rel=stylesheet][data-href="${starsFont}"]`).length
-          ).toBe(1)
+          ).toBe(0)
           expect(html).toMatch(starsPattern)
         })
 


### PR DESCRIPTION
[BUG/#27160] Remove `<link>` tag from resultant HTML which is rendered invalid when font-optimization is enabled.

Fixes #27160

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`
