### PR TITLE
Update gSSP type to support props as a promise

### DIFF
--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -160,7 +160,7 @@ export type GetServerSidePropsContext<
 }
 
 export type GetServerSidePropsResult<P> =
-  | { props: P }
+  | { props: P | Promise<P> }
   | { redirect: Redirect }
   | { notFound: true }
 

--- a/test/integration/typescript/pages/ssr/promise.tsx
+++ b/test/integration/typescript/pages/ssr/promise.tsx
@@ -1,0 +1,19 @@
+import { GetServerSideProps } from 'next'
+
+type Props = {
+  data: string
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  context
+) => {
+  return {
+    props: (async function () {
+      return { data: 'some data' }
+    })(),
+  }
+}
+
+export default function Page({ data }: Props) {
+  return <h1> {data} </h1>
+}


### PR DESCRIPTION
In a previous PR, `getServerSideProps` was altered to support returning
`props` as a promise. This change updates the TS types to permit promises
as well, so you can write type `GetServerSideProps<Props>` instead of
`GetServerSideProps<Promise<Props>>`. e.g.:

```typescript
type Props = {
  data: string
}

export const getServerSideProps: GetServerSideProps<Props> = async (
  context
) => {
  return {
    props: (async function () {
      return { data: 'some data' }
    })(),
  }
}
```

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

