### PR TITLE
Throw error if res is accessed after gSSP returns

### DIFF
--- a/errors/gssp-no-mutating-res
+++ b/errors/gssp-no-mutating-res
@@ -1,0 +1,18 @@
+# Must not access ServerResponse after getServerSideProps() returns
+
+#### Why This Error Occurred
+
+`getServerSideProps()` surfaces a `ServerResponse` object through the `res` property of its `context` arg. This object is not intended to be accessed or changed after `getServerSideProps()` returns. 
+
+This is because the framework tries to optimize when items like headers or status codes are flushed to the browser. If they are changed after `getServerSideProps()` completes, we can't guarantee that the changes will work.
+
+For this reason, accessing the object after this time is disallowed.
+
+
+#### Possible Ways to Fix It
+
+You can fix this error by moving any access of the `res` object into `getServerSideProps()` itself or any functions that run before `getServerSideProps()` returns.
+
+### Useful Links
+
+- [Data Fetching Docs](https://nextjs.org/docs/basic-features/data-fetching)

--- a/errors/gssp-no-mutating-res
+++ b/errors/gssp-no-mutating-res
@@ -1,8 +1,8 @@
-# Must not access ServerResponse after getServerSideProps() returns
+# Must not access ServerResponse after getServerSideProps() resolves
 
 #### Why This Error Occurred
 
-`getServerSideProps()` surfaces a `ServerResponse` object through the `res` property of its `context` arg. This object is not intended to be accessed or changed after `getServerSideProps()` returns. 
+`getServerSideProps()` surfaces a `ServerResponse` object through the `res` property of its `context` arg. This object is not intended to be accessed or changed after `getServerSideProps()` resolves. 
 
 This is because the framework tries to optimize when items like headers or status codes are flushed to the browser. If they are changed after `getServerSideProps()` completes, we can't guarantee that the changes will work.
 

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -139,6 +139,10 @@
           "title": "gssp-mixed-not-found-redirect",
           "path": "/errors/gssp-mixed-not-found-redirect.md"
         },
+        {
+          "title": "gssp-no-mutating-res",
+          "path": "/errors/gssp-no-mutating-res.md"
+        },
         { "title": "head-build-id", "path": "/errors/head-build-id.md" },
         {
           "title": "href-interpolation-failed",

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -745,11 +745,12 @@ export async function renderToHTML(
     let canAccessRes = true
     let resOrProxy = res
     if (process.env.NODE_ENV !== 'production') {
-      resOrProxy = new Proxy(res, {
-        get: function (obj: ServerResponse, prop: string, receiver: any) {
+      resOrProxy = new Proxy<ServerResponse>(res, {
+        get: function (obj, prop, receiver) {
           if (!canAccessRes) {
             throw new Error(
-              `Must not access ServerResponse after getServerSideProps() returns! https://nextjs.org/docs/messages/gssp-no-mutating-res`
+              `You should not access 'res' after getServerSideProps resolves.` +
+                `\nRead more: https://nextjs.org/docs/messages/gssp-no-mutating-res`
             )
           }
           return Reflect.get(obj, prop, receiver)

--- a/test/integration/getserversideprops/pages/promise/mutate-res-props.js
+++ b/test/integration/getserversideprops/pages/promise/mutate-res-props.js
@@ -1,0 +1,20 @@
+export async function getServerSideProps(context) {
+  return {
+    props: (async function () {
+      // Mimic some async work, like getting data from an API
+      await new Promise((resolve) => setTimeout(resolve))
+      context.res.setHeader('test-header', 'this is a test header')
+      return {
+        text: 'res',
+      }
+    })(),
+  }
+}
+
+export default ({ text }) => {
+  return (
+    <>
+      <div>hello {text}</div>
+    </>
+  )
+}

--- a/test/integration/getserversideprops/pages/promise/mutate-res.js
+++ b/test/integration/getserversideprops/pages/promise/mutate-res.js
@@ -1,0 +1,22 @@
+let mutatedRes
+
+export async function getServerSideProps(context) {
+  mutatedRes = context.res
+  return {
+    props: (async function () {
+      return {
+        text: 'res',
+      }
+    })(),
+  }
+}
+
+export default ({ text }) => {
+  mutatedRes.setHeader('test-header', 'this is a test header')
+
+  return (
+    <>
+      <div>hello {text}</div>
+    </>
+  )
+}

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -143,6 +143,12 @@ const expectedManifestRoutes = () => [
   },
   {
     dataRouteRegex: normalizeRegEx(
+      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/promise\\/mutate-res.json$`
+    ),
+    page: '/promise/mutate-res',
+  },
+  {
+    dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/refresh.json$`
     ),
     page: '/refresh',
@@ -710,6 +716,13 @@ const runTests = (dev = false) => {
         /Error serializing `.time` returned from `getServerSideProps`/
       )
     })
+
+    it('should show error for accessing res after gssp returns', async () => {
+      const html = await renderViaHTTP(appPort, '/promise/mutate-res')
+      expect(html).toContain(
+        'Must not access ServerResponse after getServerSideProps() returns'
+      )
+    })
   } else {
     it('should not fetch data on mount', async () => {
       const browser = await webdriver(appPort, '/blog/post-100')
@@ -766,6 +779,11 @@ const runTests = (dev = false) => {
       const browser = await webdriver(appPort, '/')
       await browser.elementByCss('#non-json').click()
       await check(() => getBrowserBodyText(browser), /hello /)
+    })
+
+    it('should not show error for accessing res after gssp returns', async () => {
+      const html = await renderViaHTTP(appPort, '/promise/mutate-res')
+      expect(html).toMatch(/hello.*?res/)
     })
   }
 }

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -149,6 +149,14 @@ const expectedManifestRoutes = () => [
   },
   {
     dataRouteRegex: normalizeRegEx(
+      `^\\/_next\\/data\\/${escapeRegex(
+        buildId
+      )}\\/promise\\/mutate-res-props.json$`
+    ),
+    page: '/promise/mutate-res-props',
+  },
+  {
+    dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/refresh.json$`
     ),
     page: '/refresh',
@@ -720,7 +728,14 @@ const runTests = (dev = false) => {
     it('should show error for accessing res after gssp returns', async () => {
       const html = await renderViaHTTP(appPort, '/promise/mutate-res')
       expect(html).toContain(
-        'Must not access ServerResponse after getServerSideProps() returns'
+        `You should not access 'res' after getServerSideProps resolves`
+      )
+    })
+
+    it('should show error for accessing res through props promise after gssp returns', async () => {
+      const html = await renderViaHTTP(appPort, '/promise/mutate-res-props')
+      expect(html).toContain(
+        `You should not access 'res' after getServerSideProps resolves`
       )
     })
   } else {


### PR DESCRIPTION
Currently it's possible to access the `ServerResponse` through `context.res`
in `getServerSideProps()`. If one was to store that response and mutate
its headers or status code after gSSP returns (e.g. during rendering), it
would currently happen to work because of when headers are sent. However,
this is an anti-pattern that relies an implementation detail of the framework
and shouldn't be allowed. This will be particularly important once Next.js
starts to support basic streaming (two-part flush: routing then data) because
then the headers will be sent as soon as gSSP returns, which explicitly breaks
this pattern.

With this commit, the framework now throws an error in development mode if
the ServerResponse is accessed after gSSP returns.


## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

