### PR TITLE
Fix falsy values not being returned in post fields

### DIFF
--- a/examples/blog-starter-typescript/lib/api.ts
+++ b/examples/blog-starter-typescript/lib/api.ts
@@ -29,7 +29,7 @@ export function getPostBySlug(slug: string, fields: string[] = []) {
       items[field] = content
     }
 
-    if (data[field]) {
+    if (typeof data[field] !== 'undefined') {
       items[field] = data[field]
     }
   })

--- a/examples/blog-starter/lib/api.js
+++ b/examples/blog-starter/lib/api.js
@@ -25,7 +25,7 @@ export function getPostBySlug(slug, fields = []) {
       items[field] = content
     }
 
-    if (data[field]) {
+    if (typeof data[field] !== 'undefined') {
       items[field] = data[field]
     }
   })

--- a/examples/blog-with-comment/lib/getPost.js
+++ b/examples/blog-with-comment/lib/getPost.js
@@ -25,7 +25,7 @@ export function getPostBySlug(slug, fields = []) {
       items[field] = content
     }
 
-    if (data[field]) {
+    if (typeof data[field] !== 'undefined') {
       items[field] = data[field]
     }
   })


### PR DESCRIPTION
I imported a bunch of old markdown posts to the blog-starter example but some of the post metadata was not returned by the API in the example code.

For example, having `published: false` in post metadata was not returned in the item fields.

The problem was in check:
```
if (data[field]) {
  items[field] = data[field]
}
```
This rejects all falsy values in addition to fields that are not set. Checking only for `undefined` should fix this issue.

I didn't find existing integration tests for the blog example nor an issue describing this problem.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
