### PR TITLE
Update test workflows for mac/react

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -22,4 +22,5 @@ jobs:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install --frozen-lockfile --check-files || yarn install --frozen-lockfile --check-files
-      - run: docker run --ipc=host -e NEXT_PRIVATE_TEST_WEBPACK4_MODE=1 -e NEXT_TEST_JOB=1 -e NEXT_TELEMETRY_DISABLED=1 -v $(pwd):/next.js mcr.microsoft.com/playwright:focal /bin/bash -c 'cd /next.js && node run-tests.js test/development/acceptance/{ReactRefresh,ReactRefreshLogBox-app-doc,ReactRefreshLogBox-scss,ReactRefreshLogBox,ReactRefreshLogBoxMisc,ReactRefreshRegression,ReactRefreshRequire}.test.ts test/development/basic/*.test.ts test/integration/production/test/index.test.js'
+      - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
+      - run: node run-tests.js test/development/acceptance/{ReactRefresh,ReactRefreshLogBox-app-doc,ReactRefreshLogBox-scss,ReactRefreshLogBox,ReactRefreshLogBoxMisc,ReactRefreshRegression,ReactRefreshRequire}.test.ts test/development/basic/*.test.ts test/integration/production/test/index.test.js

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -22,6 +22,4 @@ jobs:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install --frozen-lockfile --check-files || yarn install --frozen-lockfile --check-files
-      - run: node run-tests.js test/integration/production/test/index.test.js
-      - run: node run-tests.js test/integration/basic/test/index.test.js
-      - run: node run-tests.js test/acceptance/*
+      - run: docker run --ipc=host -e NEXT_PRIVATE_TEST_WEBPACK4_MODE=1 -e NEXT_TEST_JOB=1 -e NEXT_TELEMETRY_DISABLED=1 -v $(pwd):/next.js mcr.microsoft.com/playwright:focal /bin/bash -c 'cd /next.js && node run-tests.js test/development/acceptance/{ReactRefresh,ReactRefreshLogBox-app-doc,ReactRefreshLogBox-scss,ReactRefreshLogBox,ReactRefreshLogBoxMisc,ReactRefreshRegression,ReactRefreshRequire}.test.ts test/development/basic/*.test.ts test/integration/production/test/index.test.js'

--- a/.github/workflows/test_react_experimental.yml
+++ b/.github/workflows/test_react_experimental.yml
@@ -17,6 +17,8 @@ jobs:
 
       - run: yarn upgrade react@experimental react-dom@experimental -W --dev
 
+      - run: node run-tests.js --timings --write-timings -g 1/1
+
       - uses: actions/cache@v2
         id: cache-build
         with:

--- a/.github/workflows/test_react_experimental.yml
+++ b/.github/workflows/test_react_experimental.yml
@@ -6,50 +6,45 @@ on:
 name: Test react@experimental
 
 jobs:
-  # build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - run: yarn install --frozen-lockfile --check-files
-  #       env:
-  #         NEXT_TELEMETRY_DISABLED: 1
+      - run: yarn install --frozen-lockfile --check-files
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
 
-  #     - run: yarn upgrade react@next react-dom@next -W --dev
+      - run: yarn upgrade react@experimental react-dom@experimental -W --dev
 
-  #     - uses: actions/cache@v2
-  #       id: cache-build
-  #       with:
-  #         path: ./*
-  #         key: ${{ github.sha }}
+      - uses: actions/cache@v2
+        id: cache-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-react-experimental
 
   testAll:
     name: Test All
     runs-on: ubuntu-latest
-    # needs: build
+    needs: build
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      HEADLESS: true
-      NEXT_PRIVATE_SKIP_SIZE_TESTS: true
       NEXT_PRIVATE_REACT_ROOT: 1
+      NEXT_PRIVATE_SKIP_SIZE_TESTS: true
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5, 6]
     steps:
-      # - uses: actions/cache@v2
-      #   id: restore-build
-      #   with:
-      #     path: ./*
-      #     key: ${{ github.sha }}
-
-      - uses: actions/checkout@v2
-
-      - run: yarn install --frozen-lockfile --check-files
-
-      - run: yarn upgrade react@experimental react-dom@experimental -W --dev
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-react-experimental
 
       # TODO: remove after we fix watchpack watching too much
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-      - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3
+      - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
+
+      - run: node run-tests.js --timings -g ${{ matrix.group }}/6

--- a/.github/workflows/test_react_next.yml
+++ b/.github/workflows/test_react_next.yml
@@ -17,6 +17,8 @@ jobs:
 
       - run: yarn upgrade react@next react-dom@next -W --dev
 
+      - run: node run-tests.js --timings --write-timings -g 1/1
+
       - uses: actions/cache@v2
         id: cache-build
         with:

--- a/.github/workflows/test_react_next.yml
+++ b/.github/workflows/test_react_next.yml
@@ -6,50 +6,45 @@ on:
 name: Test react@next
 
 jobs:
-  # build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - run: yarn install --frozen-lockfile --check-files
-  #       env:
-  #         NEXT_TELEMETRY_DISABLED: 1
+      - run: yarn install --frozen-lockfile --check-files
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
 
-  #     - run: yarn upgrade react@next react-dom@next -W --dev
+      - run: yarn upgrade react@next react-dom@next -W --dev
 
-  #     - uses: actions/cache@v2
-  #       id: cache-build
-  #       with:
-  #         path: ./*
-  #         key: ${{ github.sha }}
+      - uses: actions/cache@v2
+        id: cache-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-react-next
 
   testAll:
     name: Test All
     runs-on: ubuntu-latest
-    # needs: build
+    needs: build
     env:
       NEXT_TELEMETRY_DISABLED: 1
-      HEADLESS: true
-      NEXT_PRIVATE_SKIP_SIZE_TESTS: true
       NEXT_PRIVATE_REACT_ROOT: 1
+      NEXT_PRIVATE_SKIP_SIZE_TESTS: true
     strategy:
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5, 6]
     steps:
-      # - uses: actions/cache@v2
-      #   id: restore-build
-      #   with:
-      #     path: ./*
-      #     key: ${{ github.sha }}
-
-      - uses: actions/checkout@v2
-
-      - run: yarn install --frozen-lockfile --check-files
-
-      - run: yarn upgrade react@next react-dom@next -W --dev
+      - uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-react-next
 
       # TODO: remove after we fix watchpack watching too much
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-      - run: node run-tests.js --timings -g ${{ matrix.group }}/6 -c 3
+      - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
+
+      - run: node run-tests.js --timings -g ${{ matrix.group }}/6


### PR DESCRIPTION
This updates the macOS and react@{next,experimental} workflows to setup playwright correctly and also optimizes the react workflows a bit to re-use the same build across tests instead of re-building each time. 