### PR TITLE
Fix minor typo in index.test.js

### DIFF
--- a/test/integration/app-document/test/index.test.js
+++ b/test/integration/app-document/test/index.test.js
@@ -9,7 +9,7 @@ import {
   killApp,
 } from 'next-test-utils'
 
-// test suits
+// test suites
 import rendering from './rendering'
 import client from './client'
 import csp from './csp'


### PR DESCRIPTION
Fix minor typo:

suits -> suites
