### PR TITLE
reload the page to show 404 when receiving `invalid` event from on-demand-entries

### DIFF
--- a/packages/next/client/dev/on-demand-entries-utils.js
+++ b/packages/next/client/dev/on-demand-entries-utils.js
@@ -33,13 +33,24 @@ export function setupPing(assetPrefix, pathnameFn, retry) {
       // the dev overlay as this can cause the error to be triggered
       // repeatedly
       if (payload.invalid && !self.__NEXT_DATA__.err) {
-        // Payload can be invalid even if the page does not exist.
-        // So, we need to make sure it exists before reloading.
+        // Payload can be invalid even if the page does exist.
+        // So, we check if it can be created.
         fetch(location.href, {
           credentials: 'same-origin',
         }).then((pageRes) => {
           if (pageRes.status === 200) {
+            // Page exists now, reload
             location.reload()
+          } else {
+            // Page doesn't exist
+            if (
+              self.__NEXT_DATA__.page === currentPage &&
+              currentPage !== '/_error'
+            ) {
+              // We are still on the page,
+              // reload to show 404 error page
+              location.reload()
+            }
           }
         })
       }


### PR DESCRIPTION
This fixes a race-condition when changes happens exactly during page load when the EventSource is not yet fully connected. It already causes some flaky tests.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
