### PR TITLE
Fix host segment replacing for custom routes

### DIFF
--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -389,6 +389,17 @@ module.exports = {
         destination: '/somewhere',
         permanent: false,
       },
+      {
+        source: '/has-redirect-6',
+        has: [
+          {
+            type: 'host',
+            value: '(?<subdomain>.*)-test.example.com',
+          },
+        ],
+        destination: 'https://:subdomain.example.com/some-path/end?a=b',
+        permanent: false,
+      },
     ]
   },
 


### PR DESCRIPTION
This fixes segments inside of the host of the destination failing to parse with url.parse due to the unexpected colon by escaping the colon for segments and then unescaping them after we have parsed the URL.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

x-ref: https://github.com/vercel/vercel/pull/6713

