### PR TITLE
Remove log from failing to parse source map

### DIFF
--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -118,7 +118,6 @@ export async function getNotFoundError(
       message
     )
   } catch (err) {
-    console.log('Failed to parse source map:', err)
     // Don't fail on failure to resolve sourcemaps
     return input
   }


### PR DESCRIPTION
This removes the log when we fail to parse the source maps in the `wellknown-errors-plugin` since this log isn't really actionable by users and clutters the error output. 

x-ref: https://github.com/vercel/next.js/issues/27783#issuecomment-915654054