### PR TITLE
Ensure manifests check has correct exit code on fail

### DIFF
--- a/errors/gssp-no-mutating-res.md
+++ b/errors/gssp-no-mutating-res.md
@@ -2,12 +2,11 @@
 
 #### Why This Error Occurred
 
-`getServerSideProps()` surfaces a `ServerResponse` object through the `res` property of its `context` arg. This object is not intended to be accessed or changed after `getServerSideProps()` resolves. 
+`getServerSideProps()` surfaces a `ServerResponse` object through the `res` property of its `context` arg. This object is not intended to be accessed or changed after `getServerSideProps()` resolves.
 
 This is because the framework tries to optimize when items like headers or status codes are flushed to the browser. If they are changed after `getServerSideProps()` completes, we can't guarantee that the changes will work.
 
 For this reason, accessing the object after this time is disallowed.
-
 
 #### Possible Ways to Fix It
 

--- a/scripts/check-manifests.js
+++ b/scripts/check-manifests.js
@@ -64,4 +64,7 @@ async function main() {
 
 main()
   .then(() => console.log('success'))
-  .catch(console.error)
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })


### PR DESCRIPTION
Noticed this check was logging an error but was being marked as pass due to the exit code not being updated on exit so I fixed the exit status on error and updated the failing path. 