### PR TITLE
Add VS Code launch configs with `create-next-app`

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -187,6 +187,21 @@ export async function createApp({
       )
     }
 
+    // Copy VS Code launch configurations if example doesn't include one
+    const vscodeLaunchPath = path.join(root, '.vscode', 'launch.json')
+    if (!fs.existsSync(vscodeLaunchPath)) {
+      fs.mkdirSync(path.join(root, '.vscode'))
+      fs.copyFileSync(
+        path.join(
+          __dirname,
+          'templates',
+          'vscode-launch-configs',
+          `launch-${displayedCommand}.json`
+        ),
+        vscodeLaunchPath
+      )
+    }
+
     console.log('Installing packages. This might take a couple of minutes.')
     console.log()
 
@@ -288,6 +303,19 @@ export async function createApp({
         }
       },
     })
+    /**
+     * Copy appropriate VS Code launch configuration file.
+     */
+    fs.mkdirSync(path.join(root, '.vscode'))
+    fs.copyFileSync(
+      path.join(
+        __dirname,
+        'templates',
+        'vscode-launch-configs',
+        `launch-${displayedCommand}.json`
+      ),
+      path.join(root, '.vscode', 'launch.json')
+    )
   }
 
   if (tryGitInit(root)) {

--- a/packages/create-next-app/templates/vscode-launch-configs/launch-npm.json
+++ b/packages/create-next-app/templates/vscode-launch-configs/launch-npm.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev",
+      "console": "integratedTerminal",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}

--- a/packages/create-next-app/templates/vscode-launch-configs/launch-yarn.json
+++ b/packages/create-next-app/templates/vscode-launch-configs/launch-yarn.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev",
+      "console": "integratedTerminal",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Following up on #28815, I thought it'd be nice to start adding the VS Code launch configs we'll soon be recommending to users in the [Debugging](https://nextjs.org/docs/advanced-features/debugging) docs page to apps generated by `create-next-app`, to provide an easier debugging experience out-of-the-box.

I've tested these changes using the following four commands:

```bash
node {pathToRepo}/next.js/packages/create-next-app/dist/index.js
node {pathToRepo}/next.js/packages/create-next-app/dist/index.js --use-npm
node {pathToRepo}/next.js/packages/create-next-app/dist/index.js --example api-routes
node {pathToRepo}/next.js/packages/create-next-app/dist/index.js --example api-routes --use-npm
```

...and in all four cases, the correct version of `.vscode/launch.json` (in terms of containing `yarn dev` or `npm run dev`) appears in the generated app.

Would this be an appropriate and helpful addition to `create-next-app`?

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
-->

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

<!--
## Documentation / Examples

- [ ] Make sure the linting passes
-->