### PR TITLE
Ensure trailingSlash is correct for index with query

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -80,11 +80,15 @@ function buildCancellationError() {
 }
 
 function addPathPrefix(path: string, prefix?: string) {
-  return prefix && path.startsWith('/')
-    ? path === '/'
-      ? normalizePathTrailingSlash(prefix)
-      : `${prefix}${pathNoQueryHash(path) === '/' ? path.substring(1) : path}`
-    : path
+  if (!path.startsWith('/') || !prefix) {
+    return path
+  }
+  const pathname = pathNoQueryHash(path)
+
+  return (
+    normalizePathTrailingSlash(`${prefix}${pathname}`) +
+    path.substr(pathname.length)
+  )
 }
 
 export function getDomainLocale(

--- a/test/e2e/basepath-trailing-slash.test.ts
+++ b/test/e2e/basepath-trailing-slash.test.ts
@@ -1,0 +1,100 @@
+import { join } from 'path'
+import webdriver from 'next-webdriver'
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { hasRedbox } from 'next-test-utils'
+
+describe('basePath + trailingSlash', () => {
+  let next: NextInstance
+  const basePath = '/docs'
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        pages: new FileRef(join(__dirname, 'basepath/pages')),
+        public: new FileRef(join(__dirname, 'basepath/public')),
+        external: new FileRef(join(__dirname, 'basepath/external')),
+      },
+      nextConfig: {
+        trailingSlash: true,
+        basePath,
+        onDemandEntries: {
+          // Make sure entries are not getting disposed.
+          maxInactiveAge: 1000 * 60 * 60,
+        },
+      },
+    })
+  })
+  afterAll(() => next.destroy())
+
+  const runTests = (dev = false) => {
+    it('should allow URL query strings without refresh', async () => {
+      const browser = await webdriver(next.url, `${basePath}/hello/?query=true`)
+      try {
+        await browser.eval('window.itdidnotrefresh = "hello"')
+        await new Promise((resolve, reject) => {
+          // Timeout of EventSource created in setupPing()
+          // (on-demand-entries-utils.js) is 5000 ms (see #13132, #13560)
+          setTimeout(resolve, dev ? 10000 : 1000)
+        })
+        expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
+
+        const pathname = await browser.elementByCss('#pathname').text()
+        expect(pathname).toBe('/hello')
+        expect(await browser.eval('window.location.pathname')).toBe(
+          `${basePath}/hello/`
+        )
+        expect(await browser.eval('window.location.search')).toBe('?query=true')
+
+        if (dev) {
+          expect(await hasRedbox(browser, false)).toBe(false)
+        }
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should allow URL query strings on index without refresh', async () => {
+      const browser = await webdriver(next.url, `${basePath}/?query=true`)
+      try {
+        await browser.eval('window.itdidnotrefresh = "hello"')
+        await new Promise((resolve, reject) => {
+          // Timeout of EventSource created in setupPing()
+          // (on-demand-entries-utils.js) is 5000 ms (see #13132, #13560)
+          setTimeout(resolve, dev ? 10000 : 1000)
+        })
+        expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
+
+        const pathname = await browser.elementByCss('#pathname').text()
+        expect(pathname).toBe('/')
+        expect(await browser.eval('window.location.pathname')).toBe(
+          basePath + '/'
+        )
+        expect(await browser.eval('window.location.search')).toBe('?query=true')
+
+        if (dev) {
+          expect(await hasRedbox(browser, false)).toBe(false)
+        }
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should correctly replace state when same asPath but different url', async () => {
+      const browser = await webdriver(next.url, `${basePath}/`)
+      try {
+        await browser.elementByCss('#hello-link').click()
+        await browser.waitForElementByCss('#something-else-link')
+        await browser.elementByCss('#something-else-link').click()
+        await browser.waitForElementByCss('#something-else-page')
+        await browser.back()
+        await browser.waitForElementByCss('#index-page')
+        await browser.forward()
+        await browser.waitForElementByCss('#something-else-page')
+      } finally {
+        await browser.close()
+      }
+    })
+  }
+  runTests((global as any).isDev)
+})

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -13,7 +13,7 @@ import {
   waitFor,
 } from 'next-test-utils'
 
-describe('should set-up next', () => {
+describe('basePath', () => {
   let next: NextInstance
   const basePath = '/docs'
 
@@ -784,7 +784,7 @@ describe('should set-up next', () => {
         await new Promise((resolve, reject) => {
           // Timeout of EventSource created in setupPing()
           // (on-demand-entries-utils.js) is 5000 ms (see #13132, #13560)
-          setTimeout(resolve, 10000)
+          setTimeout(resolve, dev ? 10000 : 1000)
         })
         expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
 
@@ -810,7 +810,7 @@ describe('should set-up next', () => {
         await new Promise((resolve, reject) => {
           // Timeout of EventSource created in setupPing()
           // (on-demand-entries-utils.js) is 5000 ms (see #13132, #13560)
-          setTimeout(resolve, 10000)
+          setTimeout(resolve, dev ? 10000 : 1000)
         })
         expect(await browser.eval('window.itdidnotrefresh')).toBe('hello')
 

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -25,7 +25,7 @@ const testModeFromFile = testFolderModes.find((mode) =>
 if (testModeFromFile === 'e2e') {
   const validE2EModes = ['dev', 'start', 'deploy']
 
-  if (!process.env.NEXT_TEST_JOB) {
+  if (!process.env.NEXT_TEST_JOB && !testMode) {
     console.warn('Warn: no NEXT_TEST_MODE set, using default of start')
     testMode = 'start'
   }


### PR DESCRIPTION
This ensures we don't remove the trailingSlash unexpectedly when updating the query on the client for the index path with `basePath` enabled. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/27873
Closes: https://github.com/vercel/next.js/pull/28935