### PR TITLE
Fix basePath: false not being honored for client-side redirect

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1126,13 +1126,16 @@ export default class Router implements BaseRouter {
 
       // handle redirect on client-transition
       if ((__N_SSG || __N_SSP) && props) {
-        if ((props as any).pageProps && (props as any).pageProps.__N_REDIRECT) {
-          const destination = (props as any).pageProps.__N_REDIRECT
+        if (props.pageProps && props.pageProps.__N_REDIRECT) {
+          const destination = props.pageProps.__N_REDIRECT
 
           // check if destination is internal (resolves to a page) and attempt
           // client-navigation if it is falling back to hard navigation if
           // it's not
-          if (destination.startsWith('/')) {
+          if (
+            destination.startsWith('/') &&
+            props.pageProps.__N_REDIRECT_BASE_PATH !== false
+          ) {
             const parsedHref = parseRelativeUrl(destination)
             parsedHref.pathname = resolveDynamicRoute(
               parsedHref.pathname,

--- a/test/integration/config-promise-error/next.config.js
+++ b/test/integration/config-promise-error/next.config.js
@@ -1,5 +1,0 @@
-module.exports = (phase, { isServer }) => {
-  return new Promise((resolve) => {
-    resolve({ target: 'serverless' })
-  })
-}

--- a/test/integration/config-promise-error/test/index.test.js
+++ b/test/integration/config-promise-error/test/index.test.js
@@ -7,7 +7,7 @@ import { nextBuild } from 'next-test-utils'
 const appDir = join(__dirname, '..')
 
 describe('Promise in next config', () => {
-  afterAll(() => fs.remove(join(appDir, 'next.config.js')))
+  afterEach(() => fs.remove(join(appDir, 'next.config.js')))
 
   it('should throw error when a promise is return on config', async () => {
     fs.writeFile(
@@ -21,9 +21,12 @@ describe('Promise in next config', () => {
     `
     )
 
-    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
+    const { stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
 
-    expect(stderr).toMatch(
+    expect(stderr + stdout).toMatch(
       /Error: > Promise returned in next config\. https:\/\//
     )
   })
@@ -32,7 +35,6 @@ describe('Promise in next config', () => {
     fs.writeFile(
       join(appDir, 'next.config.js'),
       `
-      setTimeout(() => process.exit(0), 2 * 1000)
       module.exports = (phase, { isServer }) => {
         return {
           webpack: async (config) => {
@@ -43,7 +45,12 @@ describe('Promise in next config', () => {
     `
     )
 
-    const { stderr } = await nextBuild(appDir, undefined, { stderr: true })
-    expect(stderr).toMatch(/> Promise returned in next config\. https:\/\//)
+    const { stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).toMatch(
+      /> Promise returned in next config\. https:\/\//
+    )
   })
 })

--- a/test/integration/gssp-redirect-base-path/test/index.test.js
+++ b/test/integration/gssp-redirect-base-path/test/index.test.js
@@ -51,9 +51,18 @@ const runTests = (isDev) => {
     )
     expect(res.status).toBe(307)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const parsedUrl = url.parse(res.headers.get('location'))
+    expect(parsedUrl.pathname).toBe(`/404`)
 
-    expect(pathname).toBe(`/404`)
+    const browser = await webdriver(appPort, `${basePath}`)
+    await browser.eval(`next.router.push('/gssp-blog/redirect-1-no-basepath-')`)
+    await check(
+      () => browser.eval('document.documentElement.innerHTML'),
+      /oops not found/
+    )
+
+    const parsedUrl2 = url.parse(await browser.eval('window.location.href'))
+    expect(parsedUrl2.pathname).toBe('/404')
   })
 
   it('should apply permanent redirect when visited directly for GSSP page', async () => {


### PR DESCRIPTION
This ensures we don't automatically prefix the redirect with the configured `basePath` with `basePath: false` is set for a getStaticProps/getServerSideProps redirect on the client. This also fixes a flakey test in `test/integration/config-promise-error`

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/28425