### PR TITLE
Fix resolving href with query and matching as

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -829,7 +829,9 @@ export default class Router implements BaseRouter {
       return false
     }
     const shouldResolveHref =
-      url === as || (options as any)._h || (options as any)._shouldResolveHref
+      (options as any)._h ||
+      (options as any)._shouldResolveHref ||
+      pathNoQueryHash(url) === pathNoQueryHash(as)
 
     // for static pages with query params in the URL we delay
     // marking the router ready until after the query is updated

--- a/test/integration/dynamic-routing/pages/index.js
+++ b/test/integration/dynamic-routing/pages/index.js
@@ -26,6 +26,10 @@ const Page = () => {
         <a id="view-post-1-hash-1-href-only">View post 1 (hash only href)</a>
       </Link>
       <br />
+      <Link href="/post-1?hidden=value" as="/post-1">
+        <a id="view-post-1-hidden-query">View post 1 (href query)</a>
+      </Link>
+      <br />
       <Link
         href={{
           hash: 'my-hash',

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -368,6 +368,23 @@ function runTests(dev) {
     }
   })
 
+  it('should navigate to a dynamic page with href with differing query and as correctly', async () => {
+    let browser
+    try {
+      browser = await webdriver(appPort, '/')
+      await browser.eval('window.beforeNav = 1')
+      await browser.elementByCss('#view-post-1-hidden-query').click()
+      await browser.waitForElementByCss('#asdf')
+
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+
+      const text = await browser.elementByCss('#asdf').text()
+      expect(text).toMatch(/this is.*?post-1/i)
+    } finally {
+      if (browser) await browser.close()
+    }
+  })
+
   it('should navigate to a dynamic page successfully no as', async () => {
     let browser
     try {


### PR DESCRIPTION
This ensures we attempt resolving the `href` if the href pathname matches the as pathname so that client-transitions still succeed correctly when using hidden href query params.  

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/26169
Fixes: https://github.com/vercel/next.js/issues/26508