### PR TITLE
Fix default static /500 with i18n

### DIFF
--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -197,7 +197,7 @@ export default async function exportPage({
         ...headerMocks,
       } as unknown as ServerResponse
 
-      if (path === '/500' && page === '/_error') {
+      if (updatedPath === '/500' && page === '/_error') {
         res.statusCode = 500
       }
 

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -76,6 +76,17 @@ describe('i18n Support', () => {
     })
 
     runTests(ctx)
+
+    it('should have pre-rendered /500 correctly', async () => {
+      for (const locale of locales) {
+        const content = await fs.readFile(
+          join(appDir, '.next/server/pages/', locale, '500.html'),
+          'utf8'
+        )
+        expect(content).toContain('500')
+        expect(content).toMatch(/internal server error/i)
+      }
+    })
   })
 
   describe('serverless mode', () => {


### PR DESCRIPTION
This ensures we generate the default static `/500` page with the correct status code when i18n is enabled since currently we're rendering the default `404` page content instead. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/25574