### PR TITLE
Ensure we only ignore .git cache for check-precompiled

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -53,9 +53,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
   lint:
@@ -65,9 +63,7 @@ jobs:
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
       - run: ./scripts/check-manifests.js
       - run: yarn lint
@@ -129,9 +125,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       - run: node run-tests.js --type unit
@@ -155,9 +149,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
@@ -193,9 +185,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
@@ -235,9 +225,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
@@ -263,9 +251,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       # TODO: remove after we fix watchpack watching too much
@@ -289,9 +275,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       - run: bash ./scripts/test-pnp.sh
@@ -333,9 +317,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
@@ -356,9 +338,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
       - run: npx playwright install-deps && npx playwright install firefox
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
@@ -385,9 +365,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       # TODO: use macos runner so that we can use playwright to test against
@@ -419,9 +397,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
 
       - run: '[[ -z "$BROWSERSTACK_ACCESS_KEY" ]] && echo "Skipping for PR" || npm i -g browserstack-local@1.4.0'
@@ -445,9 +421,7 @@ jobs:
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
       - uses: actions/download-artifact@v2
         with:
@@ -465,9 +439,7 @@ jobs:
       - uses: actions/cache@v2
         id: restore-build
         with:
-          path: |
-            ./*
-            !./.git
+          path: ./*
           key: ${{ github.sha }}
       - run: ./scripts/release-stats.sh
       - uses: ./.github/actions/next-stats-action


### PR DESCRIPTION
This should fix https://github.com/vercel/next.js/runs/3667473066 failing from `.git` not being downloaded from the cache as expected. 