### PR TITLE
Include Cloudflare as an Image loader

### DIFF
--- a/docs/basic-features/image-optimization.md
+++ b/docs/basic-features/image-optimization.md
@@ -120,6 +120,7 @@ The following Image Optimization cloud providers are included:
 - [Imgix](https://www.imgix.com): `loader: 'imgix'`
 - [Cloudinary](https://cloudinary.com): `loader: 'cloudinary'`
 - [Akamai](https://www.akamai.com): `loader: 'akamai'`
+- [Cloudflare](https://developers.cloudflare.com/image-resizing/): `loader: 'cloudflare'`
 - Custom: `loader: 'custom'` use a custom cloud provider by implementing the [`loader`](/docs/api-reference/next/image.md#loader) prop on the `next/image` component
 - Default: Works automatically with `next dev`, `next start`, or a custom server
 

--- a/errors/invalid-images-config.md
+++ b/errors/invalid-images-config.md
@@ -18,7 +18,7 @@ module.exports = {
     // limit of 50 domains values
     domains: [],
     path: '/_next/image',
-    // loader can be 'default', 'imgix', 'cloudinary', 'akamai', or 'custom'
+    // loader can be 'default', 'imgix', 'cloudinary', 'akamai', 'cloudflare', or 'custom'
     loader: 'default',
     // disable static imports for image files
     disableStaticImages: false,

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -36,6 +36,7 @@ const loaders = new Map<
   ['imgix', imgixLoader],
   ['cloudinary', cloudinaryLoader],
   ['akamai', akamaiLoader],
+  ['cloudflare', cloudflareLoader],
   ['custom', customLoader],
 ])
 
@@ -688,6 +689,20 @@ function imgixLoader({
 
 function akamaiLoader({ root, src, width }: DefaultImageLoaderProps): string {
   return `${root}${normalizeSrc(src)}?imwidth=${width}`
+}
+
+function cloudflareLoader({
+  root = '',
+  src,
+  width,
+  quality,
+}: DefaultImageLoaderProps): string {
+  const params = [`width=${width}`]
+  if (quality) {
+    params.push(`quality=${quality}`)
+  }
+  const paramsString = params.join(',')
+  return `${root}/cdn-cgi/image/${paramsString}/${normalizeSrc(src)}`
 }
 
 function cloudinaryLoader({

--- a/packages/next/server/image-config.ts
+++ b/packages/next/server/image-config.ts
@@ -3,6 +3,7 @@ export const VALID_LOADERS = [
   'imgix',
   'cloudinary',
   'akamai',
+  'cloudflare',
   'custom',
 ] as const
 

--- a/test/integration/image-optimizer/test/index.test.js
+++ b/test/integration/image-optimizer/test/index.test.js
@@ -858,7 +858,7 @@ describe('Image Optimizer', () => {
       await nextConfig.restore()
 
       expect(stderr).toContain(
-        'Specified images.loader should be one of (default, imgix, cloudinary, akamai, custom), received invalid value (notreal)'
+        'Specified images.loader should be one of (default, imgix, cloudinary, akamai, cloudflare, custom), received invalid value (notreal)'
       )
     })
 


### PR DESCRIPTION
This PR adds [Cloudflare's Image resizing service](https://developers.cloudflare.com/image-resizing/) as a loader for next's Image component. it simply copies the integration as specified in https://developers.cloudflare.com/image-resizing/integration-with-frameworks#nextjs and inlines it here.

It's not clear to me how to add tests for this, and I was hoping to get some guidance for the same if I needed to. What have I missed? Leaving all the checkboxes unchecked as I figure that out, but figured I'd open the PR to start a conversation. Please and thank you! 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes
