### PR TITLE
Ensure blurDataURL is correct in dev with basePath

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1157,6 +1157,7 @@ export default async function getBaseWebpackConfig(
                 options: {
                   isServer,
                   isDev: dev,
+                  basePath: config.basePath,
                   assetPrefix: config.assetPrefix,
                 },
               },

--- a/packages/next/build/webpack/loaders/next-image-loader.js
+++ b/packages/next/build/webpack/loaders/next-image-loader.js
@@ -9,7 +9,8 @@ const VALID_BLUR_EXT = ['jpeg', 'png', 'webp']
 function nextImageLoader(content) {
   const imageLoaderSpan = this.currentTraceSpan.traceChild('next-image-loader')
   return imageLoaderSpan.traceAsyncFn(async () => {
-    const { isServer, isDev, assetPrefix } = loaderUtils.getOptions(this)
+    const { isServer, isDev, assetPrefix, basePath } =
+      loaderUtils.getOptions(this)
     const context = this.rootContext
     const opts = { context, content }
     const interpolatedName = loaderUtils.interpolateName(
@@ -31,7 +32,7 @@ function nextImageLoader(content) {
     if (VALID_BLUR_EXT.includes(extension)) {
       if (isDev) {
         const prefix = 'http://localhost'
-        const url = new URL('/_next/image', prefix)
+        const url = new URL(`${basePath || ''}/_next/image`, prefix)
         url.searchParams.set('url', outputPath)
         url.searchParams.set('w', BLUR_IMG_SIZE)
         url.searchParams.set('q', BLUR_QUALITY)


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/29307 this ensures the `blurDataURL` is correctly prefixed with the `basePath` in development since we use the `_next/image` endpoint to generate the placeholder in dev mode. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/29289#issuecomment-927758204
