### PR TITLE
Fix SWC unit test

### DIFF
--- a/packages/next/build/swc/tests/fixture/styled-jsx/tpl-placeholder-1/output.js
+++ b/packages/next/build/swc/tests/fixture/styled-jsx/tpl-placeholder-1/output.js
@@ -9,7 +9,6 @@ export default class {
                 ]
             ]
         ])}>
-
           <p className={_JSXStyle.dynamic([
             [
                 "8b268cf2c0a3f89b",
@@ -18,11 +17,9 @@ export default class {
                 ]
             ]
         ])}>test</p>
-
           <_JSXStyle id={"8b268cf2c0a3f89b"} dynamic={[
             inputSize ? "height: calc(2 * var(--a)) !important;" : ""
         ]}>{`@media only screen {a.__jsx-style-dynamic-selector {${inputSize ? "height: calc(2 * var(--a)) !important;" : ""} }}`}</_JSXStyle>
-
         </div>;
     }
-};
+}


### PR DESCRIPTION
This fixes the expected output failing slightly from whitespace/`;` for one of the SWC unit tests. 

x-ref: https://github.com/vercel/next.js/runs/3733995930?check_suite_focus=true