### PR TITLE
Parallelize `requirePage` when loading components

### DIFF
--- a/packages/next/server/load-components.ts
+++ b/packages/next/server/load-components.ts
@@ -92,18 +92,20 @@ export async function loadComponents(
     } as LoadComponentsReturnType
   }
 
-  const DocumentMod = await requirePage('/_document', distDir, serverless)
-  const AppMod = await requirePage('/_app', distDir, serverless)
-  const ComponentMod = await requirePage(pathname, distDir, serverless)
+  const [DocumentMod, AppMod, ComponentMod] = await Promise.all([
+    requirePage('/_document', distDir, serverless),
+    requirePage('/_app', distDir, serverless),
+    requirePage(pathname, distDir, serverless),
+  ])
 
-  const [buildManifest, reactLoadableManifest, Component, Document, App] =
-    await Promise.all([
-      require(join(distDir, BUILD_MANIFEST)),
-      require(join(distDir, REACT_LOADABLE_MANIFEST)),
-      interopDefault(ComponentMod),
-      interopDefault(DocumentMod),
-      interopDefault(AppMod),
-    ])
+  const [buildManifest, reactLoadableManifest] = await Promise.all([
+    require(join(distDir, BUILD_MANIFEST)),
+    require(join(distDir, REACT_LOADABLE_MANIFEST)),
+  ])
+
+  const Component = interopDefault(ComponentMod)
+  const Document = interopDefault(DocumentMod)
+  const App = interopDefault(AppMod)
 
   const { getServerSideProps, getStaticProps, getStaticPaths } = ComponentMod
 


### PR DESCRIPTION
We can potentially speed it up a little bit by using `Promise.all` here. This was raised by @devknoll in https://github.com/vercel/next.js/pull/29470#pullrequestreview-766039044.