### PR TITLE
Invalidate webpack cache when swc options are enabled/disabled

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1497,6 +1497,8 @@ export default async function getBaseWebpackConfig(
       hasRewrites,
       reactRoot: config.experimental.reactRoot,
       concurrentFeatures: config.experimental.concurrentFeatures,
+      swcMinify: config.experimental.swcMinify,
+      swcLoader: config.experimental.swcLoader,
     })
 
     const cache: any = {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Ensures webpack caching is invalidated when switching between SWC on/off.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
