### PR TITLE
Increase windows test timeout

### DIFF
--- a/test/jest-setup-after-env.ts
+++ b/test/jest-setup-after-env.ts
@@ -1,3 +1,5 @@
+import os from 'os'
+
 // A default max-timeout of 90 seconds is allowed
 // per test we should aim to bring this down though
-jest.setTimeout(90 * 1000)
+jest.setTimeout(os.platform() === 'win32' ? 120 * 1000 : 90 * 1000)

--- a/test/jest-setup-after-env.ts
+++ b/test/jest-setup-after-env.ts
@@ -2,4 +2,4 @@ import os from 'os'
 
 // A default max-timeout of 90 seconds is allowed
 // per test we should aim to bring this down though
-jest.setTimeout(os.platform() === 'win32' ? 120 * 1000 : 90 * 1000)
+jest.setTimeout(os.platform() === 'win32' ? 240 * 1000 : 90 * 1000)


### PR DESCRIPTION
This increases the default timeout length for tests running on Windows as they are currently timing out in Azure. 