### PR TITLE
Fix root global jsx style

### DIFF
--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -25,11 +25,11 @@ export const store = createStore<OutputState>({
 let lastStore: OutputState = { appUrl: null, bindAddr: null, bootstrap: true }
 function hasStoreChanged(nextStore: OutputState) {
   if (
-    ([
-      ...new Set([...Object.keys(lastStore), ...Object.keys(nextStore)]),
-    ] as Array<keyof OutputState>).every((key) =>
-      Object.is(lastStore[key], nextStore[key])
-    )
+    (
+      [
+        ...new Set([...Object.keys(lastStore), ...Object.keys(nextStore)]),
+      ] as Array<keyof OutputState>
+    ).every((key) => Object.is(lastStore[key], nextStore[key]))
   ) {
     return false
   }

--- a/packages/next/build/swc/tests/fixture/styled-jsx/global/output.js
+++ b/packages/next/build/swc/tests/fixture/styled-jsx/global/output.js
@@ -3,5 +3,5 @@ const Test = ()=><div className={"jsx-d47d6adadf14e957"}>
     <_JSXStyle id={"d47d6adadf14e957"}>{"body {color:red}\n:hover {color:red;\ndisplay:-webkit-box;\ndisplay:-webkit-flex;\ndisplay:-ms-flexbox;\ndisplay:flex;\n-webkit-animation:foo 1s ease-out;\nanimation:foo 1s ease-out}\ndiv a {display:none}\n[data-test] >div {color:red}"}</_JSXStyle>
   </div>
 ;
-const Test2 = ()=><style global jsx>{"p { color: red }"}</style>
+const Test2 = ()=><_JSXStyle id={"94239b6d6b42c9b5"}>{"p {color:red}"}</_JSXStyle>
 ;

--- a/packages/next/build/swc/tests/fixture/styled-jsx/mixed-global-scoped/output.js
+++ b/packages/next/build/swc/tests/fixture/styled-jsx/mixed-global-scoped/output.js
@@ -1,5 +1,5 @@
 import _JSXStyle from "styled-jsx/style";
-const Test = ()=><style global jsx>{"p { color: red }"}</style>
+const Test = ()=><_JSXStyle id={"94239b6d6b42c9b5"}>{"p {color:red}"}</_JSXStyle>
 ;
 export default (()=><div className={"jsx-3822e6e1fb9fa41a"}>
     <p className={"jsx-3822e6e1fb9fa41a"}>test</p>

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -716,7 +716,8 @@ export default async function getBaseWebpackConfig(
         return `commonjs ${request}`
       }
 
-      const notExternalModules = /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|constants|dynamic)$)|string-hash$)/
+      const notExternalModules =
+        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|constants|dynamic)$)|string-hash$)/
       if (notExternalModules.test(request)) {
         return
       }
@@ -773,9 +774,10 @@ export default async function getBaseWebpackConfig(
       // Makes sure dist/shared and dist/server are not bundled
       // we need to process shared `router/router` and `dynamic`,
       // so that the DefinePlugin can inject process.env values
-      const isNextExternal = /next[/\\]dist[/\\](shared|server)[/\\](?!lib[/\\](router[/\\]router|dynamic))/.test(
-        res
-      )
+      const isNextExternal =
+        /next[/\\]dist[/\\](shared|server)[/\\](?!lib[/\\](router[/\\]router|dynamic))/.test(
+          res
+        )
 
       if (isNextExternal) {
         // Generate Next.js external import
@@ -1352,11 +1354,10 @@ export default async function getBaseWebpackConfig(
         !dev &&
         isServer &&
         (function () {
-          const {
-            FontStylesheetGatheringPlugin,
-          } = require('./webpack/plugins/font-stylesheet-gathering-plugin') as {
-            FontStylesheetGatheringPlugin: typeof import('./webpack/plugins/font-stylesheet-gathering-plugin').FontStylesheetGatheringPlugin
-          }
+          const { FontStylesheetGatheringPlugin } =
+            require('./webpack/plugins/font-stylesheet-gathering-plugin') as {
+              FontStylesheetGatheringPlugin: typeof import('./webpack/plugins/font-stylesheet-gathering-plugin').FontStylesheetGatheringPlugin
+            }
           return new FontStylesheetGatheringPlugin({
             isLikeServerless,
           })
@@ -1374,7 +1375,7 @@ export default async function getBaseWebpackConfig(
             minimized: true,
           },
         }),
-    ].filter((Boolean as any) as ExcludesFalse),
+    ].filter(Boolean as any as ExcludesFalse),
   }
 
   // Support tsconfig and jsconfig baseUrl
@@ -1423,9 +1424,10 @@ export default async function getBaseWebpackConfig(
     // This restores the webpack defaults
     webpack5Config.snapshot = {}
     if (process.versions.pnp === '3') {
-      const match = /^(.+?)[\\/]cache[\\/]jest-worker-npm-[^\\/]+\.zip[\\/]node_modules[\\/]/.exec(
-        require.resolve('jest-worker')
-      )
+      const match =
+        /^(.+?)[\\/]cache[\\/]jest-worker-npm-[^\\/]+\.zip[\\/]node_modules[\\/]/.exec(
+          require.resolve('jest-worker')
+        )
       if (match) {
         webpack5Config.snapshot.managedPaths = [
           path.resolve(match[1], 'unplugged'),
@@ -1440,16 +1442,18 @@ export default async function getBaseWebpackConfig(
       }
     }
     if (process.versions.pnp === '1') {
-      const match = /^(.+?[\\/]v4)[\\/]npm-jest-worker-[^\\/]+-[\da-f]{40}[\\/]node_modules[\\/]/.exec(
-        require.resolve('jest-worker')
-      )
+      const match =
+        /^(.+?[\\/]v4)[\\/]npm-jest-worker-[^\\/]+-[\da-f]{40}[\\/]node_modules[\\/]/.exec(
+          require.resolve('jest-worker')
+        )
       if (match) {
         webpack5Config.snapshot.immutablePaths = [match[1]]
       }
     } else if (process.versions.pnp === '3') {
-      const match = /^(.+?)[\\/]jest-worker-npm-[^\\/]+\.zip[\\/]node_modules[\\/]/.exec(
-        require.resolve('jest-worker')
-      )
+      const match =
+        /^(.+?)[\\/]jest-worker-npm-[^\\/]+\.zip[\\/]node_modules[\\/]/.exec(
+          require.resolve('jest-worker')
+        )
       if (match) {
         webpack5Config.snapshot.immutablePaths = [match[1]]
       }
@@ -1510,15 +1514,12 @@ export default async function getBaseWebpackConfig(
     webpack5Config.cache = cache
 
     if (process.env.NEXT_WEBPACK_LOGGING) {
-      const logInfra = process.env.NEXT_WEBPACK_LOGGING.includes(
-        'infrastructure'
-      )
-      const logProfileClient = process.env.NEXT_WEBPACK_LOGGING.includes(
-        'profile-client'
-      )
-      const logProfileServer = process.env.NEXT_WEBPACK_LOGGING.includes(
-        'profile-server'
-      )
+      const logInfra =
+        process.env.NEXT_WEBPACK_LOGGING.includes('infrastructure')
+      const logProfileClient =
+        process.env.NEXT_WEBPACK_LOGGING.includes('profile-client')
+      const logProfileServer =
+        process.env.NEXT_WEBPACK_LOGGING.includes('profile-server')
       const logDefault = !logInfra && !logProfileClient && !logProfileServer
 
       if (logDefault || logInfra) {
@@ -1546,7 +1547,8 @@ export default async function getBaseWebpackConfig(
       }
 
       if ((logProfileClient && !isServer) || (logProfileServer && isServer)) {
-        const ProgressPlugin = (webpack.ProgressPlugin as unknown) as typeof webpack5.ProgressPlugin
+        const ProgressPlugin =
+          webpack.ProgressPlugin as unknown as typeof webpack5.ProgressPlugin
         webpack5Config.plugins!.push(
           new ProgressPlugin({
             profile: true,
@@ -1769,9 +1771,10 @@ export default async function getBaseWebpackConfig(
     }
     if (webpackConfig.optimization?.minimizer?.length) {
       // Disable CSS Minifier
-      webpackConfig.optimization.minimizer = webpackConfig.optimization.minimizer.filter(
-        (e) => (e as any).__next_css_remove !== true
-      )
+      webpackConfig.optimization.minimizer =
+        webpackConfig.optimization.minimizer.filter(
+          (e) => (e as any).__next_css_remove !== true
+        )
     }
   } else if (!config.future.strictPostcssConfiguration) {
     await __overrideCssConfiguration(dir, !dev, webpackConfig)
@@ -1811,93 +1814,94 @@ export default async function getBaseWebpackConfig(
 
   // Patch `@zeit/next-sass`, `@zeit/next-less`, `@zeit/next-stylus` for compatibility
   if (webpackConfig.module && Array.isArray(webpackConfig.module.rules)) {
-    ;[].forEach.call(webpackConfig.module.rules, function (
-      rule: webpack.RuleSetRule
-    ) {
-      if (!(rule.test instanceof RegExp && Array.isArray(rule.use))) {
-        return
-      }
-
-      const isSass =
-        rule.test.source === '\\.scss$' || rule.test.source === '\\.sass$'
-      const isLess = rule.test.source === '\\.less$'
-      const isCss = rule.test.source === '\\.css$'
-      const isStylus = rule.test.source === '\\.styl$'
-
-      // Check if the rule we're iterating over applies to Sass, Less, or CSS
-      if (!(isSass || isLess || isCss || isStylus)) {
-        return
-      }
-
-      ;[].forEach.call(rule.use, function (use: webpack.RuleSetUseItem) {
-        if (
-          !(
-            use &&
-            typeof use === 'object' &&
-            // Identify use statements only pertaining to `css-loader`
-            (use.loader === 'css-loader' ||
-              use.loader === 'css-loader/locals') &&
-            use.options &&
-            typeof use.options === 'object' &&
-            // The `minimize` property is a good heuristic that we need to
-            // perform this hack. The `minimize` property was only valid on
-            // old `css-loader` versions. Custom setups (that aren't next-sass,
-            // next-less or next-stylus) likely have the newer version.
-            // We still handle this gracefully below.
-            (Object.prototype.hasOwnProperty.call(use.options, 'minimize') ||
-              Object.prototype.hasOwnProperty.call(
-                use.options,
-                'exportOnlyLocals'
-              ))
-          )
-        ) {
+    ;[].forEach.call(
+      webpackConfig.module.rules,
+      function (rule: webpack.RuleSetRule) {
+        if (!(rule.test instanceof RegExp && Array.isArray(rule.use))) {
           return
         }
 
-        // Try to monkey patch within a try-catch. We shouldn't fail the build
-        // if we cannot pull this off.
-        // The user may not even be using the `next-sass` or `next-less` or
-        // `next-stylus` plugins.
-        // If it does work, great!
-        try {
-          // Resolve the version of `@zeit/next-css` as depended on by the Sass,
-          // Less or Stylus plugin.
-          const correctNextCss = require.resolve('@zeit/next-css', {
-            paths: [
-              isCss
-                ? // Resolve `@zeit/next-css` from the base directory
-                  dir
-                : // Else, resolve it from the specific plugins
-                  require.resolve(
-                    isSass
-                      ? '@zeit/next-sass'
-                      : isLess
-                      ? '@zeit/next-less'
-                      : isStylus
-                      ? '@zeit/next-stylus'
-                      : 'next'
-                  ),
-            ],
-          })
+        const isSass =
+          rule.test.source === '\\.scss$' || rule.test.source === '\\.sass$'
+        const isLess = rule.test.source === '\\.less$'
+        const isCss = rule.test.source === '\\.css$'
+        const isStylus = rule.test.source === '\\.styl$'
 
-          // If we found `@zeit/next-css` ...
-          if (correctNextCss) {
-            // ... resolve the version of `css-loader` shipped with that
-            // package instead of whichever was hoisted highest in your
-            // `node_modules` tree.
-            const correctCssLoader = require.resolve(use.loader, {
-              paths: [correctNextCss],
-            })
-            if (correctCssLoader) {
-              // We saved the user from a failed build!
-              use.loader = correctCssLoader
-            }
-          }
-        } catch (_) {
-          // The error is not required to be handled.
+        // Check if the rule we're iterating over applies to Sass, Less, or CSS
+        if (!(isSass || isLess || isCss || isStylus)) {
+          return
         }
-      })
-    })
+
+        ;[].forEach.call(rule.use, function (use: webpack.RuleSetUseItem) {
+          if (
+            !(
+              use &&
+              typeof use === 'object' &&
+              // Identify use statements only pertaining to `css-loader`
+              (use.loader === 'css-loader' ||
+                use.loader === 'css-loader/locals') &&
+              use.options &&
+              typeof use.options === 'object' &&
+              // The `minimize` property is a good heuristic that we need to
+              // perform this hack. The `minimize` property was only valid on
+              // old `css-loader` versions. Custom setups (that aren't next-sass,
+              // next-less or next-stylus) likely have the newer version.
+              // We still handle this gracefully below.
+              (Object.prototype.hasOwnProperty.call(use.options, 'minimize') ||
+                Object.prototype.hasOwnProperty.call(
+                  use.options,
+                  'exportOnlyLocals'
+                ))
+            )
+          ) {
+            return
+          }
+
+          // Try to monkey patch within a try-catch. We shouldn't fail the build
+          // if we cannot pull this off.
+          // The user may not even be using the `next-sass` or `next-less` or
+          // `next-stylus` plugins.
+          // If it does work, great!
+          try {
+            // Resolve the version of `@zeit/next-css` as depended on by the Sass,
+            // Less or Stylus plugin.
+            const correctNextCss = require.resolve('@zeit/next-css', {
+              paths: [
+                isCss
+                  ? // Resolve `@zeit/next-css` from the base directory
+                    dir
+                  : // Else, resolve it from the specific plugins
+                    require.resolve(
+                      isSass
+                        ? '@zeit/next-sass'
+                        : isLess
+                        ? '@zeit/next-less'
+                        : isStylus
+                        ? '@zeit/next-stylus'
+                        : 'next'
+                    ),
+              ],
+            })
+
+            // If we found `@zeit/next-css` ...
+            if (correctNextCss) {
+              // ... resolve the version of `css-loader` shipped with that
+              // package instead of whichever was hoisted highest in your
+              // `node_modules` tree.
+              const correctCssLoader = require.resolve(use.loader, {
+                paths: [correctNextCss],
+              })
+              if (correctCssLoader) {
+                // We saved the user from a failed build!
+                use.loader = correctCssLoader
+              }
+            }
+          } catch (_) {
+            // The error is not required to be handled.
+          }
+        })
+      }
+    )
   }
 
   // Backwards compat for `main.js` entry key

--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -110,9 +110,8 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
     compilation.hooks.finishModules.tapAsync(
       PLUGIN_NAME,
       async (_stats: any, callback: any) => {
-        const finishModulesSpan = traceEntrypointsPluginSpan.traceChild(
-          'finish-modules'
-        )
+        const finishModulesSpan =
+          traceEntrypointsPluginSpan.traceChild('finish-modules')
         await finishModulesSpan
           .traceAsyncFn(async () => {
             // we create entry -> module maps so that we can
@@ -169,14 +168,13 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
 
               try {
                 return await new Promise((resolve, reject) => {
-                  ;(compilation.inputFileSystem
-                    .readFile as typeof import('fs').readFile)(
-                    path,
-                    (err, data) => {
-                      if (err) return reject(err)
-                      resolve(data)
-                    }
-                  )
+                  ;(
+                    compilation.inputFileSystem
+                      .readFile as typeof import('fs').readFile
+                  )(path, (err, data) => {
+                    if (err) return reject(err)
+                    resolve(data)
+                  })
                 })
               } catch (e) {
                 if (
@@ -191,14 +189,13 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
             const readlink = async (path: string): Promise<string | null> => {
               try {
                 return await new Promise((resolve, reject) => {
-                  ;(compilation.inputFileSystem
-                    .readlink as typeof import('fs').readlink)(
-                    path,
-                    (err, link) => {
-                      if (err) return reject(err)
-                      resolve(link)
-                    }
-                  )
+                  ;(
+                    compilation.inputFileSystem
+                      .readlink as typeof import('fs').readlink
+                  )(path, (err, link) => {
+                    if (err) return reject(err)
+                    resolve(link)
+                  })
                 })
               } catch (e) {
                 if (
@@ -217,8 +214,9 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
             ): Promise<import('fs').Stats | null> => {
               try {
                 return await new Promise((resolve, reject) => {
-                  ;(compilation.inputFileSystem
-                    .stat as typeof import('fs').stat)(path, (err, stats) => {
+                  ;(
+                    compilation.inputFileSystem.stat as typeof import('fs').stat
+                  )(path, (err, stats) => {
                     if (err) return reject(err)
                     resolve(stats)
                   })

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -210,9 +210,8 @@ export default class HotReloader {
       parsedPageBundleUrl: UrlObject
     ): Promise<{ finished?: true }> => {
       const { pathname } = parsedPageBundleUrl
-      const params: { path: string[] } | null = matchNextPageBundleRequest(
-        pathname
-      )
+      const params: { path: string[] } | null =
+        matchNextPageBundleRequest(pathname)
       if (!params) {
         return {}
       }
@@ -457,25 +456,24 @@ export default class HotReloader {
     const prevClientPageHashes = new Map<string, string>()
     const prevServerPageHashes = new Map<string, string>()
 
-    const trackPageChanges = (
-      pageHashMap: Map<string, string>,
-      changedItems: Set<string>
-    ) => (stats: webpack.compilation.Compilation) => {
-      stats.entrypoints.forEach((entry, key) => {
-        if (key.startsWith('pages/')) {
-          entry.chunks.forEach((chunk: any) => {
-            if (chunk.id === key) {
-              const prevHash = pageHashMap.get(key)
+    const trackPageChanges =
+      (pageHashMap: Map<string, string>, changedItems: Set<string>) =>
+      (stats: webpack.compilation.Compilation) => {
+        stats.entrypoints.forEach((entry, key) => {
+          if (key.startsWith('pages/')) {
+            entry.chunks.forEach((chunk: any) => {
+              if (chunk.id === key) {
+                const prevHash = pageHashMap.get(key)
 
-              if (prevHash && prevHash !== chunk.hash) {
-                changedItems.add(key)
+                if (prevHash && prevHash !== chunk.hash) {
+                  changedItems.add(key)
+                }
+                pageHashMap.set(key, chunk.hash)
               }
-              pageHashMap.set(key, chunk.hash)
-            }
-          })
-        }
-      })
-    }
+            })
+          }
+        })
+      }
 
     multiCompiler.compilers[0].hooks.emit.tap(
       'NextjsHotReloaderForClient',


### PR DESCRIPTION
This fixes an issue where global `styled-jsx` elements at the root of a component were not being transformed.

Example:
```
const Test2 = ()=><style global jsx>{"p { color: red }"}</style>
````