### PR TITLE
make client and server independent for on-demand-entries

### DIFF
--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -38,6 +38,8 @@ function hasStoreChanged(nextStore: OutputState) {
   return true
 }
 
+let startTime = 0
+
 store.subscribe((state) => {
   if (!hasStoreChanged(state)) {
     return
@@ -52,6 +54,7 @@ store.subscribe((state) => {
 
   if (state.loading) {
     Log.wait('compiling...')
+    if (startTime === 0) startTime = Date.now()
     return
   }
 
@@ -77,6 +80,15 @@ store.subscribe((state) => {
     return
   }
 
+  let timeMessage = ''
+  if (startTime) {
+    const time = Date.now() - startTime
+    startTime = 0
+
+    timeMessage =
+      time > 2000 ? ` in ${Math.round(time / 100) / 10} s` : ` in ${time} ms`
+  }
+
   if (state.warnings) {
     Log.warn(state.warnings.join('\n\n'))
     // Ensure traces are flushed after each compile in development mode
@@ -85,11 +97,13 @@ store.subscribe((state) => {
   }
 
   if (state.typeChecking) {
-    Log.info('bundled successfully, waiting for typecheck results...')
+    Log.info(
+      `bundled successfully${timeMessage}, waiting for typecheck results...`
+    )
     return
   }
 
-  Log.event('compiled successfully')
+  Log.event(`compiled successfully${timeMessage}`)
   // Ensure traces are flushed after each compile in development mode
   flushAllTraces()
 })

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1414,11 +1414,6 @@ export default async function getBaseWebpackConfig(
       },
     }
 
-    if (isServer && dev) {
-      // Enable building of client compilation before server compilation in development
-      webpack5Config.dependencies = ['client']
-    }
-
     if (dev) {
       // @ts-ignore unsafeCache exists
       webpack5Config.module.unsafeCache = (module) =>

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -230,7 +230,7 @@ export default class HotReloader {
 
       if (page === '/_error' || BLOCKED_PAGES.indexOf(page) === -1) {
         try {
-          await this.ensurePage(page)
+          await this.ensurePage(page, true)
         } catch (error) {
           await renderScriptError(
             pageBundleRes,
@@ -403,30 +403,31 @@ export default class HotReloader {
         const isClientCompilation = config.name === 'client'
 
         await Promise.all(
-          Object.keys(entries).map(async (page) => {
+          Object.keys(entries).map(async (pageKey) => {
+            const isClientKey = pageKey.startsWith('client')
+            if (isClientKey !== isClientCompilation) return
+            const page = pageKey.slice(
+              isClientKey ? 'client'.length : 'server'.length
+            )
             if (isClientCompilation && page.match(API_ROUTE)) {
               return
             }
-            const { serverBundlePath, clientBundlePath, absolutePagePath } =
-              entries[page]
+            const { bundlePath, absolutePagePath } = entries[pageKey]
             const pageExists = await isWriteable(absolutePagePath)
             if (!pageExists) {
               // page was removed
-              delete entries[page]
+              delete entries[pageKey]
               return
             }
 
-            entries[page].status = BUILDING
+            entries[pageKey].status = BUILDING
             const pageLoaderOpts: ClientPagesLoaderOptions = {
               page,
               absolutePagePath,
             }
 
-            const name = isClientCompilation
-              ? clientBundlePath
-              : serverBundlePath
-            entrypoints[name] = finalizeEntrypoint(
-              name,
+            entrypoints[bundlePath] = finalizeEntrypoint(
+              bundlePath,
               isClientCompilation
                 ? `next-client-pages-loader?${stringify(pageLoaderOpts)}!`
                 : absolutePagePath,
@@ -439,6 +440,10 @@ export default class HotReloader {
         return entrypoints
       }
     }
+
+    // Enable building of client compilation before server compilation in development
+    // @ts-ignore webpack 5
+    configs.parallelism = 1
 
     const multiCompiler = webpack(configs)
 
@@ -682,15 +687,18 @@ export default class HotReloader {
     )
   }
 
-  public async ensurePage(page: string) {
+  public async ensurePage(page: string, clientOnly: boolean = false) {
     // Make sure we don't re-build or dispose prebuilt pages
     if (page !== '/_error' && BLOCKED_PAGES.indexOf(page) !== -1) {
       return
     }
-    if (this.serverError || this.clientError) {
-      return Promise.reject(this.serverError || this.clientError)
+    const error = clientOnly
+      ? this.clientError
+      : this.serverError || this.clientError
+    if (error) {
+      return Promise.reject(error)
     }
-    return this.onDemandEntries.ensurePage(page)
+    return this.onDemandEntries.ensurePage(page, clientOnly)
   }
 }
 

--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -15,8 +15,7 @@ export const BUILT = Symbol('built')
 
 export let entries: {
   [page: string]: {
-    serverBundlePath: string
-    clientBundlePath: string
+    bundlePath: string
     absolutePagePath: string
     status?: typeof ADDED | typeof BUILDING | typeof BUILT
     lastActiveTime?: number
@@ -41,7 +40,7 @@ export default function onDemandEntryHandler(
   const { compilers } = multiCompiler
   const invalidator = new Invalidator(watcher, multiCompiler)
 
-  let lastAccessPages = ['']
+  let lastClientAccessPages = ['']
   let doneCallbacks: EventEmitter | null = new EventEmitter()
 
   for (const compiler of compilers) {
@@ -53,12 +52,15 @@ export default function onDemandEntryHandler(
     )
   }
 
-  function getPagePathsFromEntrypoints(entrypoints: any): string[] {
+  function getPagePathsFromEntrypoints(
+    type: string,
+    entrypoints: any
+  ): string[] {
     const pagePaths = []
     for (const entrypoint of entrypoints.values()) {
       const page = getRouteFromEntrypoint(entrypoint.name)
       if (page) {
-        pagePaths.push(page)
+        pagePaths.push(`${type}${page}`)
       }
     }
 
@@ -70,10 +72,16 @@ export default function onDemandEntryHandler(
       return invalidator.doneBuilding()
     }
     const [clientStats, serverStats] = multiStats.stats
-    const pagePaths = new Set([
-      ...getPagePathsFromEntrypoints(clientStats.compilation.entrypoints),
-      ...getPagePathsFromEntrypoints(serverStats.compilation.entrypoints),
-    ])
+    const pagePaths = [
+      ...getPagePathsFromEntrypoints(
+        'client',
+        clientStats.compilation.entrypoints
+      ),
+      ...getPagePathsFromEntrypoints(
+        'server',
+        serverStats.compilation.entrypoints
+      ),
+    ]
 
     for (const page of pagePaths) {
       const entry = entries[page]
@@ -86,7 +94,6 @@ export default function onDemandEntryHandler(
       }
 
       entry.status = BUILT
-      entry.lastActiveTime = Date.now()
       doneCallbacks!.emit(page)
     }
 
@@ -94,14 +101,15 @@ export default function onDemandEntryHandler(
   })
 
   const disposeHandler = setInterval(function () {
-    disposeInactiveEntries(watcher, lastAccessPages, maxInactiveAge)
+    disposeInactiveEntries(watcher, lastClientAccessPages, maxInactiveAge)
   }, 5000)
 
   disposeHandler.unref()
 
   function handlePing(pg: string) {
     const page = normalizePathSep(pg)
-    const entryInfo = entries[page]
+    const pageKey = `client${page}`
+    const entryInfo = entries[pageKey]
     let toSend
 
     // If there's no entry, it may have been invalidated and needs to be re-built.
@@ -121,12 +129,12 @@ export default function onDemandEntryHandler(
     if (entryInfo.status !== BUILT) return
 
     // If there's an entryInfo
-    if (!lastAccessPages.includes(page)) {
-      lastAccessPages.unshift(page)
+    if (!lastClientAccessPages.includes(pageKey)) {
+      lastClientAccessPages.unshift(pageKey)
 
       // Maintain the buffer max length
-      if (lastAccessPages.length > pagesBufferLength) {
-        lastAccessPages.pop()
+      if (lastClientAccessPages.length > pagesBufferLength) {
+        lastClientAccessPages.pop()
       }
     }
     entryInfo.lastActiveTime = Date.now()
@@ -134,7 +142,7 @@ export default function onDemandEntryHandler(
   }
 
   return {
-    async ensurePage(page: string) {
+    async ensurePage(page: string, clientOnly: boolean) {
       let normalizedPagePath: string
       try {
         normalizedPagePath = normalizePagePath(page)
@@ -167,48 +175,63 @@ export default function onDemandEntryHandler(
       pageUrl = pageUrl === '' ? '/' : pageUrl
 
       const bundleFile = normalizePagePath(pageUrl)
-      const serverBundlePath = posix.join('pages', bundleFile)
-      const clientBundlePath = posix.join('pages', bundleFile)
+      const bundlePath = posix.join('pages', bundleFile)
       const absolutePagePath = pagePath.startsWith('next/dist/pages')
         ? require.resolve(pagePath)
         : join(pagesDir, pagePath)
 
       page = posix.normalize(pageUrl)
+      const normalizedPage = normalizePathSep(page)
 
-      return new Promise<void>((resolve, reject) => {
-        // Makes sure the page that is being kept in on-demand-entries matches the webpack output
-        const normalizedPage = normalizePathSep(page)
-        const entryInfo = entries[normalizedPage]
+      let entriesChanged = false
+      const addPageEntry = (type: 'client' | 'server') => {
+        return new Promise<void>((resolve, reject) => {
+          // Makes sure the page that is being kept in on-demand-entries matches the webpack output
+          const pageKey = `${type}${normalizedPage}`
+          const entryInfo = entries[pageKey]
 
-        if (entryInfo) {
-          if (entryInfo.status === BUILT) {
+          if (entryInfo) {
+            entryInfo.lastActiveTime = Date.now()
+            if (entryInfo.status === BUILT) {
+              resolve()
+              return
+            }
+
+            doneCallbacks!.once(pageKey, handleCallback)
+            return
+          }
+
+          entriesChanged = true
+
+          entries[pageKey] = {
+            bundlePath,
+            absolutePagePath,
+            status: ADDED,
+            lastActiveTime: Date.now(),
+          }
+          doneCallbacks!.once(pageKey, handleCallback)
+
+          function handleCallback(err: Error) {
+            if (err) return reject(err)
             resolve()
-            return
           }
+        })
+      }
 
-          if (entryInfo.status === BUILDING) {
-            doneCallbacks!.once(normalizedPage, handleCallback)
-            return
-          }
-        }
+      const promise = clientOnly
+        ? addPageEntry('client')
+        : Promise.all([addPageEntry('client'), addPageEntry('server')])
 
-        Log.event(`build page: ${normalizedPage}`)
-
-        entries[normalizedPage] = {
-          serverBundlePath,
-          clientBundlePath,
-          absolutePagePath,
-          status: ADDED,
-        }
-        doneCallbacks!.once(normalizedPage, handleCallback)
-
+      if (entriesChanged) {
+        Log.event(
+          clientOnly
+            ? `build page: ${normalizedPage} (client only)`
+            : `build page: ${normalizedPage}`
+        )
         invalidator.invalidate()
+      }
 
-        function handleCallback(err: Error) {
-          if (err) return reject(err)
-          resolve()
-        }
-      })
+      return promise
     },
 
     middleware(req: IncomingMessage, res: ServerResponse, next: Function) {
@@ -234,8 +257,8 @@ export default function onDemandEntryHandler(
 }
 
 function disposeInactiveEntries(
-  watcher: any,
-  lastAccessPages: any,
+  _watcher: any,
+  lastClientAccessPages: any,
   maxInactiveAge: number
 ) {
   const disposingPages: any = []
@@ -250,7 +273,7 @@ function disposeInactiveEntries(
     // We should not build the last accessed page even we didn't get any pings
     // Sometimes, it's possible our XHR ping to wait before completing other requests.
     // In that case, we should not dispose the current viewing page
-    if (lastAccessPages.includes(page)) return
+    if (lastClientAccessPages.includes(page)) return
 
     if (lastActiveTime && Date.now() - lastActiveTime > maxInactiveAge) {
       disposingPages.push(page)
@@ -262,7 +285,7 @@ function disposeInactiveEntries(
       delete entries[page]
     })
     // disposing inactive page(s)
-    watcher.invalidate()
+    // watcher.invalidate()
   }
 }
 


### PR DESCRIPTION
allow to dispose server while client is making changes
allow to dispose other entries while making changes
avoid recompiling when disposing entries

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
