### PR TITLE
Update resolve options for nft

### DIFF
--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -9,6 +9,7 @@ import {
   isWebpack5,
   sources,
 } from 'next/dist/compiled/webpack/webpack'
+import { NODE_RESOLVE_OPTIONS } from '../../webpack-config'
 
 const PLUGIN_NAME = 'TraceEntryPointsPlugin'
 const TRACE_IGNORES = [
@@ -352,7 +353,12 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
               )
             }
           )
-          const resolver = compilation.resolverFactory.get('normal')
+          let resolver = compilation.resolverFactory.get('normal')
+
+          resolver = resolver.withOptions({
+            ...NODE_RESOLVE_OPTIONS,
+            extensions: undefined,
+          })
 
           const doResolve = async (
             request: string,


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/29473 after additional testing it seems we need to ensure the `main` field is used when tracing packages during builds so that `module` isn't being used unexpectedly. 

