### PR TITLE
Ensure all package.json files are traced correctly

### DIFF
--- a/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/constants/package.json
+++ b/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/constants/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "constants",
+  "main": "../dist/constants"
+}

--- a/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/dist/constants.js
+++ b/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/dist/constants.js
@@ -1,0 +1,1 @@
+console.log('hi from constants')

--- a/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/dist/index.js
+++ b/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/dist/index.js
@@ -1,0 +1,1 @@
+console.log('hi from index')

--- a/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/package.json
+++ b/test/integration/build-trace-extra-entries/app/node_modules/nested-structure/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "nested-structure",
+  "main": "./dist/index.js"
+}

--- a/test/integration/build-trace-extra-entries/app/pages/another.js
+++ b/test/integration/build-trace-extra-entries/app/pages/another.js
@@ -1,0 +1,11 @@
+import 'nested-structure/constants'
+
+export default function Page() {
+  return <p>another page</p>
+}
+
+export function getStaticProps() {
+  return {
+    props: {},
+  }
+}

--- a/test/integration/build-trace-extra-entries/test/index.test.js
+++ b/test/integration/build-trace-extra-entries/test/index.test.js
@@ -10,7 +10,10 @@ describe('build trace with extra entries', () => {
   it('should build and trace correctly', async () => {
     const result = await nextBuild(appDir, undefined, {
       cwd: appDir,
+      stderr: true,
+      stdout: true,
     })
+    console.log(result)
     expect(result.code).toBe(0)
 
     const appTrace = await fs.readJSON(
@@ -18,6 +21,9 @@ describe('build trace with extra entries', () => {
     )
     const indexTrace = await fs.readJSON(
       join(appDir, '.next/server/pages/index.js.nft.json')
+    )
+    const anotherTrace = await fs.readJSON(
+      join(appDir, '.next/server/pages/another.js.nft.json')
     )
 
     expect(appTrace.files.some((file) => file.endsWith('hello.json'))).toBe(
@@ -28,6 +34,22 @@ describe('build trace with extra entries', () => {
     ).toBeFalsy()
     expect(
       indexTrace.files.some((file) => file.includes('some-cms/index.js'))
+    ).toBe(true)
+
+    expect(
+      anotherTrace.files.some((file) =>
+        file.includes('nested-structure/constants/package.json')
+      )
+    ).toBe(true)
+    expect(
+      anotherTrace.files.some((file) =>
+        file.includes('nested-structure/package.json')
+      )
+    ).toBe(true)
+    expect(
+      anotherTrace.files.some((file) =>
+        file.includes('nested-structure/dist/constants.js')
+      )
     ).toBe(true)
   })
 })


### PR DESCRIPTION
This fixes cases where not all `package.json`s were being added to the traces correctly while using webpack's resolving with the `outputFileTracing`. The specific case notice while testing has been added as an integration test to ensure it is working as expected. 