### PR TITLE
Replace server chunk handling in outputPath with chunkFilename

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1035,15 +1035,10 @@ export default async function getBaseWebpackConfig(
       // we must set publicPath to an empty value to override the default of
       // auto which doesn't work in IE11
       publicPath: `${config.assetPrefix || ''}/_next/`,
-      path:
-        isServer && isWebpack5 && !dev
-          ? path.join(outputPath, 'chunks')
-          : outputPath,
+      path: outputPath,
       // On the server we don't use hashes
       filename: isServer
-        ? isWebpack5 && !dev
-          ? '../[name].js'
-          : '[name].js'
+        ? '[name].js'
         : `static/chunks/${isDevFallback ? 'fallback/' : ''}[name]${
             dev ? '' : isWebpack5 ? '-[contenthash]' : '-[chunkhash]'
           }.js`,
@@ -1057,7 +1052,7 @@ export default async function getBaseWebpackConfig(
         : 'static/webpack/[hash].hot-update.json',
       // This saves chunks with the name given via `import()`
       chunkFilename: isServer
-        ? '[name].js'
+        ? 'chunks/[name].js'
         : `static/chunks/${isDevFallback ? 'fallback/' : ''}${
             dev ? '[name]' : '[name].[contenthash]'
           }.js`,

--- a/packages/next/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
+++ b/packages/next/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
@@ -234,7 +234,7 @@ export class FontStylesheetGatheringPlugin {
             stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
           },
           (assets: any) => {
-            assets['../' + FONT_MANIFEST] = new sources.RawSource(
+            assets[FONT_MANIFEST] = new sources.RawSource(
               JSON.stringify(this.manifestContent, null, '  ')
             )
           }

--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -68,15 +68,8 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
           }
         }
         // don't include the entry itself in the trace
-        entryFiles.delete(
-          nodePath.join(
-            outputPath,
-            `${isWebpack5 ? '' : ''}${entrypoint.name}.js`
-          )
-        )
-        const traceOutputName = `${isWebpack5 ? '' : ''}${
-          entrypoint.name
-        }.js.nft.json`
+        entryFiles.delete(nodePath.join(outputPath, `${entrypoint.name}.js`))
+        const traceOutputName = `${entrypoint.name}.js.nft.json`
         const traceOutputPath = nodePath.dirname(
           nodePath.join(outputPath, traceOutputName)
         )

--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -71,10 +71,10 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
         entryFiles.delete(
           nodePath.join(
             outputPath,
-            `${isWebpack5 ? '../' : ''}${entrypoint.name}.js`
+            `${isWebpack5 ? '' : ''}${entrypoint.name}.js`
           )
         )
-        const traceOutputName = `${isWebpack5 ? '../' : ''}${
+        const traceOutputName = `${isWebpack5 ? '' : ''}${
           entrypoint.name
         }.js.nft.json`
         const traceOutputPath = nodePath.dirname(

--- a/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
@@ -50,7 +50,6 @@ export default class PagesManifestPlugin implements webpack.Plugin {
 
       // Write filename, replace any backslashes in path (on windows) with forwardslashes for cross-platform consistency.
       pages[pagePath] = files[files.length - 1]
-
       pages[pagePath] = pages[pagePath].replace(/\\/g, '/')
     }
 

--- a/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
@@ -51,9 +51,6 @@ export default class PagesManifestPlugin implements webpack.Plugin {
       // Write filename, replace any backslashes in path (on windows) with forwardslashes for cross-platform consistency.
       pages[pagePath] = files[files.length - 1]
 
-      if (isWebpack5 && !this.dev) {
-        pages[pagePath] = pages[pagePath].slice(3)
-      }
       pages[pagePath] = pages[pagePath].replace(/\\/g, '/')
     }
 

--- a/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/pages-manifest-plugin.ts
@@ -57,8 +57,9 @@ export default class PagesManifestPlugin implements webpack.Plugin {
       pages[pagePath] = pages[pagePath].replace(/\\/g, '/')
     }
 
-    assets[`${isWebpack5 && !this.dev ? '../' : ''}` + PAGES_MANIFEST] =
-      new sources.RawSource(JSON.stringify(pages, null, 2))
+    assets[PAGES_MANIFEST] = new sources.RawSource(
+      JSON.stringify(pages, null, 2)
+    )
   }
 
   apply(compiler: webpack.Compiler): void {


### PR DESCRIPTION
Fixes #29485 #29362

### The problem

Using `chunks` in the `output.path` directory and then using `../` to recurse up a directory for ordinary files breaks `webassemblyModuleFilename`, as it outputs into the `chunks` directory but then looks for the webpack module at the root of `server`. This renders it unable to find the file.

### The fix

Use the `chunkFilename` to handle the `chunks` subdirectory instead, and replace the relative path handlers introduced with what they had before