### PR TITLE
WIP: Fix example with-relay-modern

### DIFF
--- a/examples/with-relay-modern/package.json
+++ b/examples/with-relay-modern/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "babel-plugin-relay": "^12.0.0",
-    "graphql-cli": "^4.1.0",
+    "graphql-cli": "^3.0.14",
     "relay-compiler": "^12.0.0"
   }
 }

--- a/examples/with-relay-modern/package.json
+++ b/examples/with-relay-modern/package.json
@@ -8,15 +8,15 @@
     "schema": "graphql get-schema -e dev"
   },
   "dependencies": {
-    "graphql": "^14.6.0",
+    "graphql": "^15.6.0",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-relay": "^9.0.0"
+    "react-relay": "^12.0.0"
   },
   "devDependencies": {
-    "babel-plugin-relay": "^9.0.0",
-    "graphql-cli": "^3.0.14",
-    "relay-compiler": "^9.0.0"
+    "babel-plugin-relay": "^12.0.0",
+    "graphql-cli": "^4.1.0",
+    "relay-compiler": "^12.0.0"
   }
 }

--- a/examples/with-relay-modern/pages/index.js
+++ b/examples/with-relay-modern/pages/index.js
@@ -15,7 +15,7 @@ const Index = ({ viewer }) => (
 
 export async function getStaticProps() {
   const environment = initEnvironment()
-  const queryProps = await fetchQuery(environment, indexPageQuery)
+  const queryProps = await fetchQuery(environment, indexPageQuery).toPromise()
   const initialRecords = environment.getStore().getSource().toJSON()
 
   return {


### PR DESCRIPTION
- [x] `npm install` fails - dependencies are outdated
- [x] Migrate to new Relay API
- [ ] The sample GraphQL API endpoint used in the example is not working anymore: https://github.com/prisma-labs/nextjs-graphql-api-examples/issues/1
- [ ] Make sure the linting passes

