### PR TITLE
docs: remove `this` usage from function component

### DIFF
--- a/docs/basic-features/script.md
+++ b/docs/basic-features/script.md
@@ -118,7 +118,7 @@ export default function Home() {
         id="stripe-js"
         src="https://js.stripe.com/v3/"
         onLoad={() => {
-          this.setState({ stripe: window.Stripe('pk_test_12345') })
+          setState({ stripe: window.Stripe('pk_test_12345') })
         }}
       />
     </>

--- a/docs/basic-features/script.md
+++ b/docs/basic-features/script.md
@@ -109,16 +109,19 @@ export default function Home() {
 ### Executing Code After Loading (`onLoad`)
 
 ```js
+import { useState } from 'react'
 import Script from 'next/script'
 
 export default function Home() {
+  const [stripe, setStripe] = useState(null)
+
   return (
     <>
       <Script
         id="stripe-js"
         src="https://js.stripe.com/v3/"
         onLoad={() => {
-          setState({ stripe: window.Stripe('pk_test_12345') })
+          setStripe({ stripe: window.Stripe('pk_test_12345') })
         }}
       />
     </>


### PR DESCRIPTION
Fix a small error in the `next/script` docs.

Let me know if you'd like a `useState` for the sake of a complete example.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
