### PR TITLE
Update stats-config for release stats

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -45,6 +45,10 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       await checkoutRef(actionInfo.prRef, diffRepoDir)
     }
 
+    if (actionInfo.isRelease) {
+      process.env.STATS_IS_RELEASE = 'true'
+    }
+
     // load stats config from allowed locations
     const { statsConfig, relativeStatsAppDir } = loadStatsConfig()
 

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -135,7 +135,10 @@ module.exports = {
               generateBuildId: () => 'BUILD_ID',
               experimental: {
                 swcLoader: true,
-                swcMinify: true,
+                swcMinify: ${
+                  // TODO: remove after stable release > 11.1.2
+                  process.env.STATS_IS_RELEASE ? 'false' : 'true'
+                },
               },
               webpack(config) {
                 config.optimization.minimize = false
@@ -159,7 +162,10 @@ module.exports = {
             module.exports = {
               experimental: {
                 swcLoader: true,
-                swcMinify: true
+                swcMinify: ${
+                  // TODO: remove after stable release > 11.1.2
+                  process.env.STATS_IS_RELEASE ? 'false' : 'true'
+                },
               },
               generateBuildId: () => 'BUILD_ID'
             }


### PR DESCRIPTION
Currently the release stats fails to compare against the last stable since it attempts using `swcMinify` which has a fix in the latest version that wasn't available in the last stable so it fails. This temporarily disables using `swcMinify` for release stats until the next stable release. 