### PR TITLE
Fix grammar in conflicting paths error

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1054,7 +1054,7 @@ export function detectConflictingPaths(
     })
 
     Log.error(
-      'Conflicting paths returned from getStaticPaths, paths must unique per page.\n' +
+      'Conflicting paths returned from getStaticPaths, paths must be unique per page.\n' +
         'See more info here: https://nextjs.org/docs/messages/conflicting-ssg-paths\n\n' +
         conflictingPathsOutput
     )

--- a/test/integration/conflicting-ssg-paths/test/index.test.js
+++ b/test/integration/conflicting-ssg-paths/test/index.test.js
@@ -68,7 +68,7 @@ describe('Conflicting SSG paths', () => {
     })
     const output = result.stdout + result.stderr
     expect(output).toContain(
-      'Conflicting paths returned from getStaticPaths, paths must unique per page'
+      'Conflicting paths returned from getStaticPaths, paths must be unique per page'
     )
     expect(output).toContain(
       'https://nextjs.org/docs/messages/conflicting-ssg-paths'
@@ -121,7 +121,7 @@ describe('Conflicting SSG paths', () => {
     })
     const output = result.stdout + result.stderr
     expect(output).toContain(
-      'Conflicting paths returned from getStaticPaths, paths must unique per page'
+      'Conflicting paths returned from getStaticPaths, paths must be unique per page'
     )
     expect(output).toContain(
       'https://nextjs.org/docs/messages/conflicting-ssg-paths'
@@ -175,7 +175,7 @@ describe('Conflicting SSG paths', () => {
     })
     const output = result.stdout + result.stderr
     expect(output).toContain(
-      'Conflicting paths returned from getStaticPaths, paths must unique per page'
+      'Conflicting paths returned from getStaticPaths, paths must be unique per page'
     )
     expect(output).toContain(
       'https://nextjs.org/docs/messages/conflicting-ssg-paths'


### PR DESCRIPTION
Updates `paths must unique per page` to `paths must be unique per page`.