### PR TITLE
show partial compiled message and correct module count

### DIFF
--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -96,7 +96,7 @@ store.subscribe((state) => {
     startTime = 0
 
     timeMessage =
-      time > 2000 ? ` in ${Math.round(time / 100) / 10} s` : ` in ${time} ms`
+      time > 2000 ? ` in ${Math.round(time / 100) / 10}s` : ` in ${time} ms`
   }
 
   let modulesMessage = ''

--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -14,6 +14,7 @@ export type OutputState =
       | {
           loading: false
           typeChecking: boolean
+          partial: 'client' | 'server' | undefined
           modules: number
           errors: string[] | null
           warnings: string[] | null
@@ -103,6 +104,11 @@ store.subscribe((state) => {
     modulesMessage = ` (${state.modules} modules)`
   }
 
+  let partialMessage = ''
+  if (state.partial) {
+    partialMessage = ` ${state.partial}`
+  }
+
   if (state.warnings) {
     Log.warn(state.warnings.join('\n\n'))
     // Ensure traces are flushed after each compile in development mode
@@ -112,12 +118,14 @@ store.subscribe((state) => {
 
   if (state.typeChecking) {
     Log.info(
-      `bundled successfully${timeMessage}${modulesMessage}, waiting for typecheck results...`
+      `bundled${partialMessage} successfully${timeMessage}${modulesMessage}, waiting for typecheck results...`
     )
     return
   }
 
-  Log.event(`compiled successfully${timeMessage}${modulesMessage}`)
+  Log.event(
+    `compiled${partialMessage} successfully${timeMessage}${modulesMessage}`
+  )
   // Ensure traces are flushed after each compile in development mode
   flushAllTraces()
 })


### PR DESCRIPTION
```
event - compiled successfully in 4.1s (1597 modules)
event - compiled client successfully in 271 ms (1076 modules)
```

instead of

```
event - compiled successfully in 4.1 s (1597 modules)
event - compiled successfully in 271 ms (1708 modules)
```

* spacing for seconds
* module count only counts modules from compilers that were running
* add a note to message when only one compiler had something to do