### PR TITLE
avoid using absolute paths in import/require

### DIFF
--- a/packages/next/build/webpack/loaders/next-client-pages-loader.ts
+++ b/packages/next/build/webpack/loaders/next-client-pages-loader.ts
@@ -18,14 +18,17 @@ function nextClientPagesLoader(this: any) {
 
     pagesLoaderSpan.setAttribute('absolutePagePath', absolutePagePath)
 
-    const stringifiedAbsolutePagePath = JSON.stringify(absolutePagePath)
+    const stringifiedPagePath = loaderUtils.stringifyRequest(
+      this,
+      absolutePagePath
+    )
     const stringifiedPage = JSON.stringify(page)
 
     return `
     (window.__NEXT_P = window.__NEXT_P || []).push([
       ${stringifiedPage},
       function () {
-        return require(${stringifiedAbsolutePagePath});
+        return require(${stringifiedPagePath});
       }
     ]);
   `

--- a/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
@@ -1,5 +1,6 @@
 import devalue from 'next/dist/compiled/devalue'
 import escapeRegexp from 'next/dist/compiled/escape-string-regexp'
+import loaderUtils from 'next/dist/compiled/loader-utils'
 import { join } from 'path'
 import { parse } from 'querystring'
 import { webpack } from 'next/dist/compiled/webpack/webpack'
@@ -112,7 +113,10 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
         }
 
         const apiHandler = getApiHandler({
-          pageModule: require("${absolutePagePath}"),
+          pageModule: require(${loaderUtils.stringifyRequest(
+            this,
+            absolutePagePath
+          )}),
           rewrites: combinedRewrites,
           i18n: ${i18n || 'undefined'},
           page: "${page}",
@@ -137,12 +141,21 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
       }
       import { getPageHandler } from 'next/dist/build/webpack/loaders/next-serverless-loader/page-handler'
 
-      const documentModule = require("${absoluteDocumentPath}")
+      const documentModule = require(${loaderUtils.stringifyRequest(
+        this,
+        absoluteDocumentPath
+      )})
 
-      const appMod = require('${absoluteAppPath}')
+      const appMod = require(${loaderUtils.stringifyRequest(
+        this,
+        absoluteAppPath
+      )})
       let App = appMod.default || appMod.then && appMod.then(mod => mod.default);
 
-      const compMod = require('${absolutePagePath}')
+      const compMod = require(${loaderUtils.stringifyRequest(
+        this,
+        absolutePagePath
+      )})
 
       const Component = compMod.default || compMod.then && compMod.then(mod => mod.default)
       export default Component
@@ -175,9 +188,14 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
         pageConfig: config,
         appModule: App,
         documentModule: documentModule,
-        errorModule: require("${absoluteErrorPath}"),
+        errorModule: require(${loaderUtils.stringifyRequest(
+          this,
+          absoluteErrorPath
+        )}),
         notFoundModule: ${
-          absolute404Path ? `require("${absolute404Path}")` : undefined
+          absolute404Path
+            ? `require(${loaderUtils.stringifyRequest(this, absolute404Path)})`
+            : undefined
         },
         pageGetStaticProps: getStaticProps,
         pageGetStaticPaths: getStaticPaths,


### PR DESCRIPTION
Using absolute paths leads to unnecessary watched paths and tested paths for resolving