### PR TITLE
fix: allow `next lint` without `eslint-config-next` installed

### DIFF
--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -198,12 +198,13 @@ async function lint(
         eslintVersion: eslintVersion,
         lintedFilesCount: results.length,
         lintFix: !!options.fix,
-        nextEslintPluginVersion: nextEslintPluginIsEnabled
-          ? require(path.join(
-              path.dirname(deps.resolved.get('eslint-config-next')!),
-              'package.json'
-            )).version
-          : null,
+        nextEslintPluginVersion:
+          nextEslintPluginIsEnabled && deps.resolved.has('eslint-config-next')
+            ? require(path.join(
+                path.dirname(deps.resolved.get('eslint-config-next')!),
+                'package.json'
+              )).version
+            : null,
         nextEslintPluginErrorsCount: formattedResult.totalNextPluginErrorCount,
         nextEslintPluginWarningsCount:
           formattedResult.totalNextPluginWarningCount,


### PR DESCRIPTION
Running `next-lint` without `eslint-config-next` installed currently does not work - error: "The "path" argument must be of type string. Received undefined". This fixes that. see https://github.com/vercel/next.js/issues/27981#issuecomment-897349249

Note, that when `@next/eslint-plugin-next` is installed, but `eslint-config-next` is not, no eslint plugin version will be reported with telemetry currently - happy to change that as well.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
