### PR TITLE
Pin create-next-app to eslint@v7

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -230,7 +230,7 @@ export async function createApp({
     /**
      * Default devDependencies.
      */
-    const devDependencies = ['eslint', 'eslint-config-next']
+    const devDependencies = ['eslint@7', 'eslint-config-next']
     /**
      * TypeScript projects will have type definitions and other devDependencies.
      */


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/29770

## Description

Pins `eslint` to `v7`. This avoids issues with `v8` from both [changes to the public api](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#the-lib-entrypoint-has-been-removed) and [lack of support from rushstack](https://github.com/microsoft/rushstack/issues/2890). See https://github.com/vercel/next.js/issues/29770#issuecomment-940636627 for slightly more detail. 

Local testing showed output of next app correctly pinned to `v7`. 

<img width="495" alt="Screen Shot 2021-10-12 at 12 31 56 AM" src="https://user-images.githubusercontent.com/29002354/136892312-1571718c-882b-4235-98f4-c1b8d4c72d26.png">


### Bug Checklist

- [X] Related issues linked using `fixes #number`
- [ ] Integration tests added
   - Happy to add an integration test for pinning to v7 if we'd like, will need to be updated / removed when v8 is supported. 
- [ ] Errors have helpful link attached, see `contributing.md`
	- No errors to add links for


