### PR TITLE
Update typescript version

### DIFF
--- a/examples/with-expo-typescript/package.json
+++ b/examples/with-expo-typescript/package.json
@@ -28,6 +28,6 @@
     "@types/react-dom": "16.9.8",
     "@types/react-native": "0.62.10",
     "babel-preset-expo": "~8.1.0",
-    "typescript": "4.0"
+    "typescript": "4.4.4"
   }
 }


### PR DESCRIPTION
Resolves  message using `yarn dev` 

```
warn  - Minimum recommended TypeScript version is v4.3.2, older versions can potentially be incompatible with Next.js. Detected: 4.0.8
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
