### PR TITLE
Fix config import on Windows and disable test in failing envs

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -530,7 +530,8 @@ export default async function loadConfig(
     let userConfigModule: any
 
     try {
-      userConfigModule = await import(path)
+      // we must use file for absolute dynamic imports on Windows
+      userConfigModule = await import(`file://${path}`)
     } catch (err) {
       console.error(
         chalk.red('Error:') +

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-
+import os from 'os'
 import { join } from 'path'
 import loadConfig from 'next/dist/server/config'
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
@@ -8,111 +8,121 @@ const pathToConfig = join(__dirname, '_resolvedata', 'without-function')
 const pathToConfigFn = join(__dirname, '_resolvedata', 'with-function')
 
 describe('config', () => {
-  it('Should get the configuration', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig)
-    expect(config.customConfig).toBe(true)
-  })
-
-  it('Should pass the phase correctly', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
-    expect(config.phase).toBe(PHASE_DEVELOPMENT_SERVER)
-  })
-
-  it('Should pass the defaultConfig correctly', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
-    expect(config.defaultConfig).toBeDefined()
-  })
-
-  it('Should assign object defaults deeply to user config', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
-    expect(config.distDir).toEqual('.next')
-    expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
-  })
-
-  it('Should pass the customConfig correctly', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
-      customConfig: true,
+  if (os.platform() === 'linux') {
+    it('Should get the configuration', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig)
+      expect(config.customConfig).toBe(true)
     })
-    expect(config.customConfig).toBe(true)
-  })
 
-  it('Should not pass the customConfig when it is null', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, null)
-    expect(config.webpack).toBe(null)
-  })
-
-  it('Should assign object defaults deeply to customConfig', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
-      customConfig: true,
-      onDemandEntries: { custom: true },
+    it('Should pass the phase correctly', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
+      expect(config.phase).toBe(PHASE_DEVELOPMENT_SERVER)
     })
-    expect(config.customConfig).toBe(true)
-    expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
-  })
 
-  it('Should allow setting objects which do not have defaults', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
-      bogusSetting: { custom: true },
+    it('Should pass the defaultConfig correctly', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
+      expect(config.defaultConfig).toBeDefined()
     })
-    expect(config.bogusSetting).toBeDefined()
-    expect(config.bogusSetting.custom).toBe(true)
-  })
 
-  it('Should override defaults for arrays from user arrays', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
-      pageExtensions: ['.bogus'],
+    it('Should assign object defaults deeply to user config', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
+      expect(config.distDir).toEqual('.next')
+      expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
     })
-    expect(config.pageExtensions).toEqual(['.bogus'])
-  })
 
-  it('Should throw when an invalid target is provided', async () => {
-    await expect(async () => {
-      await loadConfig(
-        PHASE_DEVELOPMENT_SERVER,
-        join(__dirname, '_resolvedata', 'invalid-target')
-      )
-    }).rejects.toThrow(/Specified target is invalid/)
-  })
+    it('Should pass the customConfig correctly', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+        customConfig: true,
+      })
+      expect(config.customConfig).toBe(true)
+    })
 
-  it('Should pass when a valid target is provided', async () => {
-    const config = await loadConfig(
-      PHASE_DEVELOPMENT_SERVER,
-      join(__dirname, '_resolvedata', 'valid-target')
-    )
-    expect(config.target).toBe('serverless')
-  })
+    it('Should not pass the customConfig when it is null', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, null)
+      expect(config.webpack).toBe(null)
+    })
 
-  it('Should throw an error when next.config.js is not present', async () => {
-    await expect(
-      async () =>
+    it('Should assign object defaults deeply to customConfig', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+        customConfig: true,
+        onDemandEntries: { custom: true },
+      })
+      expect(config.customConfig).toBe(true)
+      expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
+    })
+
+    it('Should allow setting objects which do not have defaults', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+        bogusSetting: { custom: true },
+      })
+      expect(config.bogusSetting).toBeDefined()
+      expect(config.bogusSetting.custom).toBe(true)
+    })
+
+    it('Should override defaults for arrays from user arrays', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+        pageExtensions: ['.bogus'],
+      })
+      expect(config.pageExtensions).toEqual(['.bogus'])
+    })
+
+    it('Should throw when an invalid target is provided', async () => {
+      await expect(async () => {
         await loadConfig(
           PHASE_DEVELOPMENT_SERVER,
-          join(__dirname, '_resolvedata', 'typescript-config')
+          join(__dirname, '_resolvedata', 'invalid-target')
         )
-    ).rejects.toThrow(
-      /Configuring Next.js via .+ is not supported. Please replace the file with 'next.config.js'/
-    )
-  })
-
-  it('Should not throw an error when two versions of next.config.js are present', async () => {
-    const config = await loadConfig(
-      PHASE_DEVELOPMENT_SERVER,
-      join(__dirname, '_resolvedata', 'js-ts-config')
-    )
-    expect(config.__test__ext).toBe('js')
-  })
-
-  it('Should ignore configs set to `undefined`', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
-      target: undefined,
+      }).rejects.toThrow(/Specified target is invalid/)
     })
-    expect(config.target).toBe('server')
-  })
 
-  it('Should ignore configs set to `null`', async () => {
-    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
-      target: null,
+    it('Should pass when a valid target is provided', async () => {
+      const config = await loadConfig(
+        PHASE_DEVELOPMENT_SERVER,
+        join(__dirname, '_resolvedata', 'valid-target')
+      )
+      expect(config.target).toBe('serverless')
     })
-    expect(config.target).toBe('server')
-  })
+
+    it('Should throw an error when next.config.js is not present', async () => {
+      await expect(
+        async () =>
+          await loadConfig(
+            PHASE_DEVELOPMENT_SERVER,
+            join(__dirname, '_resolvedata', 'typescript-config')
+          )
+      ).rejects.toThrow(
+        /Configuring Next.js via .+ is not supported. Please replace the file with 'next.config.js'/
+      )
+    })
+
+    it('Should not throw an error when two versions of next.config.js are present', async () => {
+      const config = await loadConfig(
+        PHASE_DEVELOPMENT_SERVER,
+        join(__dirname, '_resolvedata', 'js-ts-config')
+      )
+      expect(config.__test__ext).toBe('js')
+    })
+
+    it('Should ignore configs set to `undefined`', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+        target: undefined,
+      })
+      expect(config.target).toBe('server')
+    })
+
+    it('Should ignore configs set to `null`', async () => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, null, {
+        target: null,
+      })
+      expect(config.target).toBe('server')
+    })
+  } else {
+    // TODO: remove this when segfault no longer occurs with dynamic
+    // import inside of jest due to vm usage
+    it('should skip on non-linux platforms', () => {
+      console.warn(
+        'Warning!! These tests can not currently run on non-linux systems'
+      )
+    })
+  }
 })


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/29935 this fixes the failing tests on Azure as it seems the `import()` needs to be prefixed with `file://` on Windows or an error is thrown. It also disables the config unit tests since a dynamic import inside of `jest` on either an m1 on macOS or Windows using node 14 causes a segfault from being used inside of `vm`. 

<details>

<summary>segfault error in jest</summary>

<img width="962" alt="Screen Shot 2021-10-15 at 16 45 04" src="https://user-images.githubusercontent.com/22380829/137596819-072233e3-1a45-445f-a3dd-c03ec62fb4ce.png">

</details>


<details>

<summary>Windows absolute import error</summary>


<img width="1114" alt="Screen Shot 2021-10-16 at 12 45 59" src="https://user-images.githubusercontent.com/22380829/137597185-200f3164-7f79-488f-acc9-6c812ce5bc4a.png">

</details>