### PR TITLE
Load Babel config from "package.json"

### DIFF
--- a/packages/next/build/babel/loader/get-config.ts
+++ b/packages/next/build/babel/loader/get-config.ts
@@ -138,8 +138,16 @@ function getPlugins(
   ].filter(Boolean)
 }
 
+const isPackageJsonFile = /package\.json$/
 const isJsonFile = /\.(json|babelrc)$/
 const isJsFile = /\.js$/
+
+function parseJsonFile(filePath: string) {
+  const rawContent = readFileSync(filePath, 'utf8')
+  const parsedContent = JSON5.parse(rawContent)
+
+  return parsedContent
+}
 
 /**
  * While this function does block execution while reading from disk, it
@@ -148,9 +156,10 @@ const isJsFile = /\.js$/
  * be generated during compilation.
  */
 function getCustomBabelConfig(configFilePath: string) {
-  if (isJsonFile.exec(configFilePath)) {
-    const babelConfigRaw = readFileSync(configFilePath, 'utf8')
-    return JSON5.parse(babelConfigRaw)
+  if (isPackageJsonFile.exec(configFilePath)) {
+    return parseJsonFile(configFilePath).babel
+  } else if (isJsonFile.exec(configFilePath)) {
+    return parseJsonFile(configFilePath)
   } else if (isJsFile.exec(configFilePath)) {
     return require(configFilePath)
   }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -302,6 +302,15 @@ export default async function getBaseWebpackConfig(
     }
   }
 
+  // Check whether `package.json#babel` is defined or not and use `package.json`
+  // as the config file if it is, mimicking Babel's original behavior who also
+  // looks there first.
+  // https://github.com/babel/babel/blob/v7.15.8/packages/babel-core/src/config/files/configuration.ts#L101
+  const packageJsonPath = path.join(dir, 'package.json')
+  const usingPackageJson = parseJsonFile(packageJsonPath).babel
+    ? packageJsonPath
+    : undefined
+
   const babelConfigFile = await [
     '.babelrc',
     '.babelrc.json',
@@ -318,7 +327,7 @@ export default async function getBaseWebpackConfig(
       (await memo) ||
       ((await fileExists(configFilePath)) ? configFilePath : undefined)
     )
-  }, Promise.resolve(undefined))
+  }, Promise.resolve(usingPackageJson))
 
   const distDir = path.join(dir, config.distDir)
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -307,9 +307,10 @@ export default async function getBaseWebpackConfig(
   // looks there first.
   // https://github.com/babel/babel/blob/v7.15.8/packages/babel-core/src/config/files/configuration.ts#L101
   const packageJsonPath = path.join(dir, 'package.json')
-  const usingPackageJson = parseJsonFile(packageJsonPath).babel
-    ? packageJsonPath
-    : undefined
+  const usingPackageJson =
+    (await fileExists(packageJsonPath)) && parseJsonFile(packageJsonPath)?.babel
+      ? packageJsonPath
+      : undefined
 
   const babelConfigFile = await [
     '.babelrc',


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Fixes #26334 

As mentioned in the linked issue, Babel also accepts custom configuration options to be defined in the `package.json` file, under the `babel` key, and, in fact, it gives precedence to that configuration source.
This PR mimics Babel's behavior, by checking first if the `package.json#babel` is defined and using that if it is.

**Babel docs:** https://babeljs.io/docs/en/config-files
**Babel source code:** 
* `findPackageData`: https://github.com/babel/babel/blob/672a58660f0b15691c44582f1f3fdcdac0fa0d2f/packages/babel-core/src/config/files/package.ts#L14
* `findRelativeConfig`: https://github.com/babel/babel/blob/672a58660f0b15691c44582f1f3fdcdac0fa0d2f/packages/babel-core/src/config/files/configuration.ts#L56
* `loadOneConfig`: https://github.com/babel/babel/blob/672a58660f0b15691c44582f1f3fdcdac0fa0d2f/packages/babel-core/src/config/files/configuration.ts#L100


## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
