### PR TITLE
Include stylesheets with initial routes

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -382,7 +382,7 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
     pageLoader,
     App: CachedApp,
     Component: CachedComponent,
-    styleSheets: styleSheets!,
+    styleSheets,
     wrapApp,
     err: initialErr,
     isFallback: Boolean(isFallback),
@@ -408,7 +408,7 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
     App: CachedApp,
     initial: true,
     Component: CachedComponent,
-    styleSheets: styleSheets!,
+    styleSheets,
     props: hydrateProps,
     err: initialErr,
   }

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -271,7 +271,6 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
   }
 
   let initialErr = hydrateErr
-  let styleSheets: StyleSheetTuple[]
 
   try {
     const appEntrypoint = await pageLoader.routeLoader.whenEntrypoint('/_app')
@@ -320,12 +319,11 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
       // error, so we need to skip waiting for the entrypoint.
       process.env.NODE_ENV === 'development' && hydrateErr
         ? { error: hydrateErr }
-        : await pageLoader.loadPage(page)
+        : await pageLoader.routeLoader.whenEntrypoint(page)
     if ('error' in pageEntrypoint) {
       throw pageEntrypoint.error
     }
-    CachedComponent = pageEntrypoint.page
-    styleSheets = pageEntrypoint.styleSheets
+    CachedComponent = pageEntrypoint.component
 
     if (process.env.NODE_ENV !== 'production') {
       const { isValidElementType } = require('react-is')
@@ -378,6 +376,7 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
     await window.__NEXT_PRELOADREADY(dynamicIds)
   }
 
+  const styleSheets: StyleSheetTuple[] = []
   router = createRouter(page, query, asPath, {
     initialProps: hydrateProps,
     pageLoader,

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -271,6 +271,7 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
   }
 
   let initialErr = hydrateErr
+  let styleSheets: StyleSheetTuple[]
 
   try {
     const appEntrypoint = await pageLoader.routeLoader.whenEntrypoint('/_app')
@@ -319,11 +320,12 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
       // error, so we need to skip waiting for the entrypoint.
       process.env.NODE_ENV === 'development' && hydrateErr
         ? { error: hydrateErr }
-        : await pageLoader.routeLoader.whenEntrypoint(page)
+        : await pageLoader.loadPage(page)
     if ('error' in pageEntrypoint) {
       throw pageEntrypoint.error
     }
-    CachedComponent = pageEntrypoint.component
+    CachedComponent = pageEntrypoint.page
+    styleSheets = pageEntrypoint.styleSheets
 
     if (process.env.NODE_ENV !== 'production') {
       const { isValidElementType } = require('react-is')
@@ -381,6 +383,7 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
     pageLoader,
     App: CachedApp,
     Component: CachedComponent,
+    styleSheets: styleSheets!,
     wrapApp,
     err: initialErr,
     isFallback: Boolean(isFallback),
@@ -406,6 +409,7 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
     App: CachedApp,
     initial: true,
     Component: CachedComponent,
+    styleSheets: styleSheets!,
     props: hydrateProps,
     err: initialErr,
   }

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -435,11 +435,7 @@ export type PrefetchOptions = {
   locale?: string | false
 }
 
-export type PrivateRouteInfo =
-  | (CompletePrivateRouteInfo & { initial: true })
-  | CompletePrivateRouteInfo
-
-export type CompletePrivateRouteInfo = {
+export type PrivateRouteInfo = {
   Component: ComponentType
   styleSheets: StyleSheetTuple[]
   __N_SSG?: boolean
@@ -447,9 +443,10 @@ export type CompletePrivateRouteInfo = {
   props?: Record<string, any>
   err?: Error
   error?: any
+  initial?: true
 }
 
-export type AppProps = Pick<CompletePrivateRouteInfo, 'Component' | 'err'> & {
+export type AppProps = Pick<PrivateRouteInfo, 'Component' | 'err'> & {
   router: Router
 } & Record<string, any>
 export type AppComponent = ComponentType<AppProps>
@@ -1290,7 +1287,7 @@ export default class Router implements BaseRouter {
     as: string,
     routeProps: RouteProperties,
     loadErrorFail?: boolean
-  ): Promise<CompletePrivateRouteInfo> {
+  ): Promise<PrivateRouteInfo> {
     if (err.cancelled) {
       // bubble up cancellation errors
       throw err
@@ -1326,7 +1323,7 @@ export default class Router implements BaseRouter {
         ))
       }
 
-      const routeInfo: CompletePrivateRouteInfo = {
+      const routeInfo: PrivateRouteInfo = {
         props,
         Component,
         styleSheets,
@@ -1375,7 +1372,7 @@ export default class Router implements BaseRouter {
         return existingRouteInfo
       }
 
-      let cachedRouteInfo: CompletePrivateRouteInfo | undefined = undefined
+      let cachedRouteInfo: PrivateRouteInfo | undefined = undefined
       // can only use non-initial route info
       // cannot reuse route info in development since it can change after HMR
       if (
@@ -1385,7 +1382,7 @@ export default class Router implements BaseRouter {
       ) {
         cachedRouteInfo = existingRouteInfo
       }
-      const routeInfo: CompletePrivateRouteInfo =
+      const routeInfo: PrivateRouteInfo =
         cachedRouteInfo ||
         (await this.fetchComponent(route).then((res) => ({
           Component: res.page,
@@ -1416,7 +1413,7 @@ export default class Router implements BaseRouter {
         )
       }
 
-      const props = await this._getData<CompletePrivateRouteInfo>(() =>
+      const props = await this._getData<PrivateRouteInfo>(() =>
         __N_SSG
           ? this._getStaticData(dataHref!)
           : __N_SSP

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -436,7 +436,7 @@ export type PrefetchOptions = {
 }
 
 export type PrivateRouteInfo =
-  | (Omit<CompletePrivateRouteInfo, 'styleSheets'> & { initial: true })
+  | (CompletePrivateRouteInfo & { initial: true })
   | CompletePrivateRouteInfo
 
 export type CompletePrivateRouteInfo = {
@@ -574,6 +574,7 @@ export default class Router implements BaseRouter {
       App,
       wrapApp,
       Component,
+      styleSheets,
       err,
       subscription,
       isFallback,
@@ -587,6 +588,7 @@ export default class Router implements BaseRouter {
       initialProps: any
       pageLoader: any
       Component: ComponentType
+      styleSheets: StyleSheetTuple[]
       App: AppComponent
       wrapApp: (WrapAppComponent: AppComponent) => any
       err?: Error
@@ -609,6 +611,7 @@ export default class Router implements BaseRouter {
     if (pathname !== '/_error') {
       this.components[this.route] = {
         Component,
+        styleSheets,
         initial: true,
         props: initialProps,
         err,


### PR DESCRIPTION
We don't include `styleSheets` on the initial routes because we expect them to be included in the HTML. However, that's an implementation detail (and we already have other mechanisms in place to avoid setting them when rendering the initial route), so we should just always include them for simplicity.

This is also useful for a refactor I'm working on to separate data fetching from the router for Server Components.