### PR TITLE
Fix eslint loading on Windows

### DIFF
--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -101,7 +101,7 @@ async function lint(
       return null
     }
 
-    const mod = await import(deps.resolved.get('eslint')!)
+    const mod = await Promise.resolve(require(deps.resolved.get('eslint')!))
 
     const { ESLint } = mod
     let eslintVersion = ESLint?.version ?? mod?.CLIEngine?.version


### PR DESCRIPTION
This fixes the failing Azure tests from `import` being used to load `eslint` with an absolute path: 

```sh
error - ESLint: Only file and data URLs are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```