### PR TITLE
Update docs for Prerender Error message

### DIFF
--- a/errors/prerender-error.md
+++ b/errors/prerender-error.md
@@ -7,7 +7,8 @@ While prerendering a page an error occurred. This can occur for many reasons fro
 #### Possible Ways to Fix It
 
 - Make sure to move any non-pages out of the `pages` folder
-- Check for any code that assumes a prop is available even when it might not be. e.g., have default data for all dynamic pages' props.
+- Check for any code that assumes a prop is available, even when it might not be
+- Set default values for all dynamic pages' props (avoid `undefined`, use `null` instead so it can be serialized)
 - Check for any out of date modules that you might be relying on
 - Make sure your component handles `fallback` if it is enabled in `getStaticPaths`. [Fallback docs](https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required)
 - Make sure you are not trying to export (`next export`) pages that have server-side rendering enabled [(getServerSideProps)](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering)


### PR DESCRIPTION
Update docs to mention `undefined` doesn't work, use `null` instead