### PR TITLE
Fix trace when initial file is also child

### DIFF
--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -327,7 +327,11 @@ export class TraceEntryPointsPlugin implements webpack.Plugin {
                 for (const file of fileList!) {
                   const reason = reasons!.get(file)
 
-                  if (!reason || reason.type === 'initial' || !reason.parents) {
+                  if (
+                    !reason ||
+                    !reason.parents ||
+                    (reason.type === 'initial' && reason.parents.size === 0)
+                  ) {
                     continue
                   }
                   propagateToParents(reason.parents, file)

--- a/test/integration/production/pages/client-error.js
+++ b/test/integration/production/pages/client-error.js
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+import Error from 'next/error'
+
+export default function Page(props) {
+  return (
+    <>
+      <Error title="something went wrong (on purpose)" />
+      <Link href="/">
+        <a>to home</a>
+      </Link>
+    </>
+  )
+}

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -80,6 +80,22 @@ describe('Production Usage', () => {
         notTests: [/node_modules\/react\/cjs\/react\.development\.js/],
       },
       {
+        page: '/client-error',
+        tests: [
+          /webpack-runtime\.js/,
+          /chunks\/.*?\.js/,
+          /node_modules\/react\/index\.js/,
+          /node_modules\/react\/package\.json/,
+          /node_modules\/react\/cjs\/react\.production\.min\.js/,
+          /next\/link\.js/,
+          /next\/dist\/client\/link\.js/,
+          /next\/dist\/shared\/lib\/router\/utils\/resolve-rewrites\.js/,
+          /next\/dist\/pages\/_error\.js/,
+          /next\/error\.js/,
+        ],
+        notTests: [/node_modules\/react\/cjs\/react\.development\.js/],
+      },
+      {
         page: '/dynamic',
         tests: [
           /webpack-runtime\.js/,
@@ -110,6 +126,8 @@ describe('Production Usage', () => {
         notTests: [
           /node_modules\/react\/cjs\/react\.development\.js/,
           /node_modules\/nanoid\/index\.cjs/,
+          /next\/dist\/pages\/_error\.js/,
+          /next\/error\.js/,
         ],
       },
       {

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -58,7 +58,7 @@ describe('Production Usage', () => {
   })
 
   it('should contain generated page count in output', async () => {
-    const pageCount = 39
+    const pageCount = 40
     expect(output).toContain(`Generating static pages (0/${pageCount})`)
     expect(output).toContain(
       `Generating static pages (${pageCount}/${pageCount})`


### PR DESCRIPTION
This fixes a case where the trace omits initial files even when they are also imported in a file. Additional checks have been added to ensure this case is working properly. 