### PR TITLE
integrate fallback app and error into client compiler

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -229,7 +229,6 @@ export default async function getBaseWebpackConfig(
     reactProductionProfiling = false,
     entrypoints,
     rewrites,
-    isDevFallback = false,
     runWebpackSpan,
   }: {
     buildId: string
@@ -241,7 +240,6 @@ export default async function getBaseWebpackConfig(
     reactProductionProfiling?: boolean
     entrypoints: webpack5.EntryObject
     rewrites: CustomRoutes['rewrites']
-    isDevFallback?: boolean
     runWebpackSpan: Span
   }
 ): Promise<webpack.Configuration> {
@@ -889,7 +887,7 @@ export default async function getBaseWebpackConfig(
         ],
     optimization: {
       // @ts-ignore: TODO remove ts-ignore when webpack 4 is removed
-      emitOnErrors: !dev,
+      emitOnErrors: true,
       checkWasmTypes: false,
       nodeEnv: false,
       splitChunks: isServer
@@ -971,9 +969,7 @@ export default async function getBaseWebpackConfig(
         ? !dev
           ? '../[name].js'
           : '[name].js'
-        : `static/chunks/${isDevFallback ? 'fallback/' : ''}[name]${
-            dev ? '' : '-[contenthash]'
-          }.js`,
+        : `static/chunks/[name]${dev ? '' : '-[contenthash]'}.js`,
       library: isServer ? undefined : '_N_E',
       libraryTarget: isServer ? 'commonjs2' : 'assign',
       hotUpdateChunkFilename: 'static/webpack/[id].[fullhash].hot-update.js',
@@ -982,9 +978,7 @@ export default async function getBaseWebpackConfig(
       // This saves chunks with the name given via `import()`
       chunkFilename: isServer
         ? '[name].js'
-        : `static/chunks/${isDevFallback ? 'fallback/' : ''}${
-            dev ? '[name]' : '[name].[contenthash]'
-          }.js`,
+        : `static/chunks/${dev ? '[name]' : '[name].[contenthash]'}.js`,
       strictModuleExceptionHandling: true,
       crossOriginLoading: crossOrigin,
       webassemblyModuleFilename: 'static/wasm/[modulehash].wasm',
@@ -1243,7 +1237,6 @@ export default async function getBaseWebpackConfig(
         new BuildManifestPlugin({
           buildId,
           rewrites,
-          isDevFallback,
         }),
       new ProfilingPlugin({ runWebpackSpan }),
       config.optimizeFonts &&

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -92,15 +92,12 @@ const processRoute = (r: Rewrite) => {
 export default class BuildManifestPlugin {
   private buildId: string
   private rewrites: CustomRoutes['rewrites']
-  private isDevFallback: boolean
 
   constructor(options: {
     buildId: string
     rewrites: CustomRoutes['rewrites']
-    isDevFallback?: boolean
   }) {
     this.buildId = options.buildId
-    this.isDevFallback = !!options.isDevFallback
     this.rewrites = {
       beforeFiles: [],
       afterFiles: [],
@@ -189,50 +186,42 @@ export default class BuildManifestPlugin {
         assetMap.pages[pagePath] = [...new Set([...mainFiles, ...filesForPage])]
       }
 
-      if (!this.isDevFallback) {
-        // Add the runtime build manifest file (generated later in this file)
-        // as a dependency for the app. If the flag is false, the file won't be
-        // downloaded by the client.
-        assetMap.lowPriorityFiles.push(
-          `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`
-        )
-        // Add the runtime ssg manifest file as a lazy-loaded file dependency.
-        // We also stub this file out for development mode (when it is not
-        // generated).
-        const srcEmptySsgManifest = `self.__SSG_MANIFEST=new Set;self.__SSG_MANIFEST_CB&&self.__SSG_MANIFEST_CB()`
+      // Add the runtime build manifest file (generated later in this file)
+      // as a dependency for the app. If the flag is false, the file won't be
+      // downloaded by the client.
+      assetMap.lowPriorityFiles.push(
+        `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`
+      )
+      // Add the runtime ssg manifest file as a lazy-loaded file dependency.
+      // We also stub this file out for development mode (when it is not
+      // generated).
+      const srcEmptySsgManifest = `self.__SSG_MANIFEST=new Set;self.__SSG_MANIFEST_CB&&self.__SSG_MANIFEST_CB()`
 
-        const ssgManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_ssgManifest.js`
-        assetMap.lowPriorityFiles.push(ssgManifestPath)
-        assets[ssgManifestPath] = new sources.RawSource(srcEmptySsgManifest)
-      }
+      const ssgManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_ssgManifest.js`
+      assetMap.lowPriorityFiles.push(ssgManifestPath)
+      assets[ssgManifestPath] = new sources.RawSource(srcEmptySsgManifest)
 
       assetMap.pages = Object.keys(assetMap.pages)
         .sort()
         // eslint-disable-next-line
         .reduce((a, c) => ((a[c] = assetMap.pages[c]), a), {} as any)
 
-      let buildManifestName = BUILD_MANIFEST
-
-      if (this.isDevFallback) {
-        buildManifestName = `fallback-${BUILD_MANIFEST}`
-      }
+      const buildManifestName = BUILD_MANIFEST
 
       assets[buildManifestName] = new sources.RawSource(
         JSON.stringify(assetMap, null, 2)
       )
 
-      if (!this.isDevFallback) {
-        const clientManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`
+      const clientManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`
 
-        assets[clientManifestPath] = new sources.RawSource(
-          `self.__BUILD_MANIFEST = ${generateClientManifest(
-            compiler,
-            compilation,
-            assetMap,
-            this.rewrites
-          )};self.__BUILD_MANIFEST_CB && self.__BUILD_MANIFEST_CB()`
-        )
-      }
+      assets[clientManifestPath] = new sources.RawSource(
+        `self.__BUILD_MANIFEST = ${generateClientManifest(
+          compiler,
+          compilation,
+          assetMap,
+          this.rewrites
+        )};self.__BUILD_MANIFEST_CB && self.__BUILD_MANIFEST_CB()`
+      )
 
       return assets
     })

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -754,10 +754,11 @@ export default class DevServer extends Server {
   }
 
   protected async getFallbackErrorComponents(): Promise<LoadComponentsReturnType | null> {
-    await this.hotReloader!.buildFallbackError()
     // Build the error page to ensure the fallback is built too.
-    // TODO: See if this can be moved into hotReloader or removed.
-    await this.hotReloader!.ensurePage('/_error')
+    await Promise.all([
+      this.hotReloader!.ensurePage('/_fallback/_app', true),
+      this.hotReloader!.ensurePage('/_fallback/_error', true),
+    ])
     return await loadDefaultErrorComponents(this.distDir)
   }
 

--- a/packages/next/server/load-components.ts
+++ b/packages/next/server/load-components.ts
@@ -43,12 +43,23 @@ export async function loadDefaultErrorComponents(distDir: string) {
   const ComponentMod = require('next/dist/pages/_error')
   const Component = interopDefault(ComponentMod)
 
+  const buildManifest: BuildManifest = require(join(distDir, BUILD_MANIFEST))
+
+  const fallbackBuildManifest = {
+    ...buildManifest,
+    lowPriorityFiles: [],
+    pages: {
+      '/_app': buildManifest.pages['/_fallback/_app'],
+      '/_error': buildManifest.pages['/_fallback/_error'],
+    },
+  }
+
   return {
     App,
     Document,
     Component,
     pageConfig: {},
-    buildManifest: require(join(distDir, `fallback-${BUILD_MANIFEST}`)),
+    buildManifest: fallbackBuildManifest,
     reactLoadableManifest: {},
     ComponentMod,
   }


### PR DESCRIPTION
refactoring that gets rid of isDevFallback and the 3rd compiler

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes
