### PR TITLE
update webpack

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -250,7 +250,7 @@
     "webpack-sources1": "npm:webpack-sources@1.4.3",
     "webpack-sources3": "npm:webpack-sources@3.2.0",
     "webpack4": "npm:webpack@4.44.1",
-    "webpack5": "npm:webpack@5.58.2",
+    "webpack5": "npm:webpack@5.59.0",
     "ws": "8.2.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19717,10 +19717,10 @@ webpack-sources@^3.2.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-"webpack5@npm:webpack@5.58.2":
-  version "5.58.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.58.2.tgz#6b4af12fc9bd5cbedc00dc0a2fc2b9592db16b44"
-  integrity sha512-3S6e9Vo1W2ijk4F4PPWRIu6D/uGgqaPmqw+av3W3jLDujuNkdxX5h5c+RQ6GkjVR+WwIPOfgY8av+j5j4tMqJw==
+"webpack5@npm:webpack@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.59.0.tgz#a5038fc0d4d9350ee528e7e1e0282080c63efcf5"
+  integrity sha512-2HiFHKnWIb/cBfOfgssQn8XIRvntISXiz//F1q1+hKMs+uzC1zlVCJZEP7XqI1wzrDyc/ZdB4G+MYtz5biJxCA==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"


### PR DESCRIPTION
https://github.com/webpack/webpack/releases/tag/v5.59.0

We need:
* experiments.buildHttp improvements for the new experimental flag
* managedPaths improvements from the monorepo improvements
* module build hooks for tracing