### PR TITLE
fix pageKey and compiling output for on-demand-entries

### DIFF
--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -170,21 +170,25 @@ export default function onDemandEntryHandler(
         throw pageNotFoundError(normalizedPagePath)
       }
 
-      let pageUrl = page.replace(/\\/g, '/')
+      let bundlePath: string
+      let absolutePagePath: string
+      if (pagePath.startsWith('next/dist/pages/')) {
+        bundlePath = page
+        absolutePagePath = require.resolve(pagePath)
+      } else {
+        let pageUrl = pagePath.replace(/\\/g, '/')
 
-      pageUrl = `${pageUrl[0] !== '/' ? '/' : ''}${pageUrl
-        .replace(new RegExp(`\\.+(?:${pageExtensions.join('|')})$`), '')
-        .replace(/\/index$/, '')}`
+        pageUrl = `${pageUrl[0] !== '/' ? '/' : ''}${pageUrl
+          .replace(new RegExp(`\\.+(?:${pageExtensions.join('|')})$`), '')
+          .replace(/\/index$/, '')}`
 
-      pageUrl = pageUrl === '' ? '/' : pageUrl
+        pageUrl = pageUrl === '' ? '/' : pageUrl
+        const bundleFile = normalizePagePath(pageUrl)
+        bundlePath = posix.join('pages', bundleFile)
+        absolutePagePath = join(pagesDir, pagePath)
+        page = posix.normalize(pageUrl)
+      }
 
-      const bundleFile = normalizePagePath(pageUrl)
-      const bundlePath = posix.join('pages', bundleFile)
-      const absolutePagePath = pagePath.startsWith('next/dist/pages')
-        ? require.resolve(pagePath)
-        : join(pagesDir, pagePath)
-
-      page = posix.normalize(pageUrl)
       const normalizedPage = normalizePathSep(page)
 
       const isMiddleware = normalizedPage.match(MIDDLEWARE_ROUTE)
@@ -194,7 +198,7 @@ export default function onDemandEntryHandler(
       const addPageEntry = (type: 'client' | 'server') => {
         return new Promise<void>((resolve, reject) => {
           // Makes sure the page that is being kept in on-demand-entries matches the webpack output
-          const pageKey = `${type}${normalizedPage}`
+          const pageKey = `${type}${page}`
           const entryInfo = entries[pageKey]
 
           if (entryInfo) {

--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -170,7 +170,7 @@ export default function onDemandEntryHandler(
         throw pageNotFoundError(normalizedPagePath)
       }
 
-      let pageUrl = pagePath.replace(/\\/g, '/')
+      let pageUrl = page.replace(/\\/g, '/')
 
       pageUrl = `${pageUrl[0] !== '/' ? '/' : ''}${pageUrl
         .replace(new RegExp(`\\.+(?:${pageExtensions.join('|')})$`), '')

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -33,6 +33,7 @@ describe('basic HMR', () => {
         const newContactPagePath = join('pages', 'hmr', '_contact.js')
         let browser
         try {
+          const start = next.cliOutput.length
           browser = await webdriver(next.appPort, '/hmr/contact')
           const text = await browser.elementByCss('p').text()
           expect(text).toBe('This is the contact page.')
@@ -53,6 +54,12 @@ describe('basic HMR', () => {
             () => getBrowserBodyText(browser),
             /This is the contact page/
           )
+
+          expect(next.cliOutput.slice(start)).toContain('compiling...')
+          expect(next.cliOutput.slice(start)).toContain(
+            'compiling /hmr/contact...'
+          )
+          expect(next.cliOutput).toContain('compiling /_error...')
         } finally {
           if (browser) {
             await browser.close()
@@ -297,6 +304,7 @@ describe('basic HMR', () => {
       const newPage = join('pages', 'hmr', 'new-page.js')
 
       try {
+        const start = next.cliOutput.length
         browser = await webdriver(next.appPort, '/hmr/new-page')
 
         expect(await browser.elementByCss('body').text()).toMatch(
@@ -317,6 +325,11 @@ describe('basic HMR', () => {
           () => getBrowserBodyText(browser),
           /This page could not be found/
         )
+
+        expect(next.cliOutput.slice(start)).toContain(
+          'compiling /hmr/new-page...'
+        )
+        expect(next.cliOutput.slice(start)).toContain('compiling /_error...')
       } catch (err) {
         await next.deleteFile(newPage)
         throw err
@@ -332,6 +345,7 @@ describe('basic HMR', () => {
       const aboutPage = join('pages', 'hmr', 'about2.js')
       const aboutContent = await next.readFile(aboutPage)
       try {
+        const start = next.cliOutput.length
         browser = await webdriver(next.appPort, '/hmr/about2')
         await check(() => getBrowserBodyText(browser), /This is the about page/)
 
@@ -345,6 +359,10 @@ describe('basic HMR', () => {
         await next.patchFile(aboutPage, aboutContent)
 
         await check(() => getBrowserBodyText(browser), /This is the about page/)
+        expect(next.cliOutput.slice(start)).toContain(
+          'compiling /hmr/about2...'
+        )
+        expect(next.cliOutput).toContain('compiling /_error...')
       } catch (err) {
         await next.patchFile(aboutPage, aboutContent)
         if (browser) {


### PR DESCRIPTION
shows `compiling /_error...` instead of `compiling /next/dist/pages/_error...`