### PR TITLE
Skip minifying middleware

### DIFF
--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -99,7 +99,7 @@ export class TerserPlugin {
 
             // don't minify _middleware as it can break in some cases
             // and doesn't provide too much of a benefit as it's server-side
-            if (/_middleware\.js$/.test(name)) {
+            if (MIDDLEWARE_ROUTE.test(name.replace(/\.js$/, ''))) {
               return false
             }
 

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -8,6 +8,7 @@ import {
 import pLimit from 'p-limit'
 import { Worker } from 'jest-worker'
 import { spans } from '../../profiling-plugin'
+import { MIDDLEWARE_ROUTE } from '../../../../../lib/constants'
 
 function getEcmaVersion(environment) {
   // ES 6th
@@ -93,6 +94,12 @@ export class TerserPlugin {
             const res = compilation.getAsset(name)
             if (!res) {
               console.log(name)
+              return false
+            }
+
+            // don't minify _middleware if swcMinify is enabled
+            // as it can break in some cases
+            if (/_middleware\.js$/.test(name) && this.options.swcMinify) {
               return false
             }
 

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -97,9 +97,9 @@ export class TerserPlugin {
               return false
             }
 
-            // don't minify _middleware if swcMinify is enabled
-            // as it can break in some cases
-            if (/_middleware\.js$/.test(name) && this.options.swcMinify) {
+            // don't minify _middleware as it can break in some cases
+            // and doesn't provide too much of a benefit as it's server-side
+            if (/_middleware\.js$/.test(name)) {
               return false
             }
 


### PR DESCRIPTION
This skips minifying middleware as it can cause issues in some cases like the below error and also isn't necessary to be minified as we don't currently minify other server pages. 

```
TypeError: (intermediate value)(intermediate value)(intermediate value)(...) is not a function
```