### PR TITLE
fix(docs): Clarify contribution docs about linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ Choose the right checklist for the change that you're making:
 
 ## Documentation / Examples
 
-- [ ] Make sure the linting passes
+- [ ] Make sure the linting passes by running `yarn lint`

--- a/contributing.md
+++ b/contributing.md
@@ -72,7 +72,7 @@ If you would like to run the tests in headless mode (with the browser windows hi
 yarn testheadless
 ```
 
-Running a specific test suite inside of the `test/integration` directory:
+Running a specific test suite (e.g. `production`) inside of the `test/integration` directory:
 
 ```sh
 yarn testonly --testPathPattern "production"
@@ -84,7 +84,21 @@ Running one test in the `production` test suite:
 yarn testonly --testPathPattern "production" -t "should allow etag header support"
 ```
 
-### Running the integration apps
+### Linting
+
+To check the formatting of your code:
+
+```sh
+yarn lint
+```
+
+If you get errors, you can fix them with:
+
+```sh
+yarn lint-fix
+```
+
+### Running the example apps
 
 Running examples can be done with:
 


### PR DESCRIPTION
While making my first PR to this repo recently, I came across this instruction:

- [x] Make sure the linting passes

and while I was _guessing_ that `yarn lint` would do it, I wanted to confirm, so I headed over to `CONTRIBUTING.md` and searched for "lint," but found nothing. So I checked out `package.json`, found out what I needed to know, linted, pushed, and was on my way.

Not that hard. But why not make it easier?  :-)

This PR includes two main changes:

- The instruction above is amended with the command to do the linting
- There is a "Linting" section added to `CONTRIBUTING.md`

While I was in the latter document, I noticed two other things which I thought could potentially be clearer and fixed those, too:

- In the testing section, when talking about testing a particular suite of tests, the example suite is `"production"`. Since that word is so overloaded, I added an "e.g." to make it clear that it's just an example test suite name and doesn't have any other special meaning.
- In the section about testing against the examples, I changed the title to use "examples," since that's how they're talked about everywhere else that I've seen, both in the docs and in the repo.

(These latter two I don't feel strongly about, and are admittedly out of scope for this PR, so if you want me to revert them, I can, as they're really just drive-bys.)
