### PR TITLE
Ensure we dont attempt minifying middleware-chunks

### DIFF
--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -8,7 +8,6 @@ import {
 import pLimit from 'p-limit'
 import { Worker } from 'jest-worker'
 import { spans } from '../../profiling-plugin'
-import { MIDDLEWARE_ROUTE } from '../../../../../lib/constants'
 
 function getEcmaVersion(environment) {
   // ES 6th
@@ -99,7 +98,7 @@ export class TerserPlugin {
 
             // don't minify _middleware as it can break in some cases
             // and doesn't provide too much of a benefit as it's server-side
-            if (MIDDLEWARE_ROUTE.test(name.replace(/\.js$/, ''))) {
+            if (name.match(/(middleware-chunks|_middleware\.js$)/)) {
               return false
             }
 


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/30122 this ensures we don't minify the accompanying `middleware-chunks` either. 