### PR TITLE
Update middleware chunk handling

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -593,7 +593,8 @@ export default async function getBaseWebpackConfig(
         // and all other chunk depend on them so there is no
         // duplication that need to be pulled out.
         chunks: (chunk) =>
-          !/^(polyfills|main|pages\/_app|\/_middleware)$/.test(chunk.name),
+          !/^(polyfills|main|pages\/_app)$/.test(chunk.name) &&
+          !MIDDLEWARE_ROUTE.test(chunk.name),
         cacheGroups: {
           framework: {
             chunks: (chunk: webpack.compilation.Chunk) =>
@@ -652,6 +653,7 @@ export default async function getBaseWebpackConfig(
               chunk.name?.match(MIDDLEWARE_ROUTE),
             filename: 'server/middleware-chunks/[name].js',
             minChunks: 2,
+            enforce: true,
           },
         },
         maxInitialRequests: 25,

--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -50,6 +50,13 @@ export default class MiddlewarePlugin {
       const files = entrypoint
         .getFiles()
         .filter((file: string) => !file.endsWith('.hot-update.js'))
+        .map((file: string) =>
+          // we need to use the unminified version of the webpack runtime,
+          // remove if we do start minifying middleware chunks
+          file.startsWith('static/chunks/webpack-')
+            ? file.replace('webpack-', 'webpack-middleware-')
+            : file
+        )
 
       middlewareManifest.middleware[location] = {
         env: envPerRoute.get(entrypoint.name)!,

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -74,6 +74,8 @@ export class TerserPlugin {
     terserSpan.setAttribute('compilationName', compilation.name)
 
     return terserSpan.traceAsyncFn(async () => {
+      let webpackAsset: string
+      let hasMiddleware = false
       let numberOfAssetsForMinify = 0
       const assetsList = Object.keys(assets)
 
@@ -96,9 +98,15 @@ export class TerserPlugin {
               return false
             }
 
+            // remove below if we start minifying middleware chunks
+            if (name.startsWith('static/chunks/webpack-')) {
+              webpackAsset = name
+            }
+
             // don't minify _middleware as it can break in some cases
             // and doesn't provide too much of a benefit as it's server-side
             if (name.match(/(middleware-chunks|_middleware\.js$)/)) {
+              hasMiddleware = true
               return false
             }
 
@@ -124,6 +132,17 @@ export class TerserPlugin {
             return { name, info, inputSource: source, output, eTag }
           })
       )
+
+      if (hasMiddleware && webpackAsset) {
+        // emit a separate un-minified version of the webpack
+        // runtime for the middleware
+        const asset = compilation.getAsset(webpackAsset)
+        compilation.emitAsset(
+          webpackAsset.replace('webpack-', 'webpack-middleware-'),
+          asset.source,
+          {}
+        )
+      }
 
       const numberOfWorkers = Math.min(
         numberOfAssetsForMinify,

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -74,7 +74,7 @@ export class TerserPlugin {
     terserSpan.setAttribute('compilationName', compilation.name)
 
     return terserSpan.traceAsyncFn(async () => {
-      let webpackAsset: string
+      let webpackAsset = ''
       let hasMiddleware = false
       let numberOfAssetsForMinify = 0
       const assetsList = Object.keys(assets)

--- a/test/integration/middleware-core/test/index.test.js
+++ b/test/integration/middleware-core/test/index.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 
+import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
@@ -47,6 +48,25 @@ describe('Middleware base tests', () => {
     responseTests('/fr')
     interfaceTests()
     interfaceTests('/fr')
+
+    it('should have correct files in manifest', async () => {
+      const manifest = await fs.readJSON(
+        join(context.appDir, '.next/server/middleware-manifest.json')
+      )
+      for (const key of Object.keys(manifest.middleware)) {
+        const middleware = manifest.middleware[key]
+        expect(
+          middleware.files.some((file) => file.includes('webpack-middleware'))
+        ).toBe(true)
+        expect(
+          middleware.files.filter(
+            (file) =>
+              file.startsWith('static/chunks/') &&
+              !file.startsWith('static/chunks/webpack-middleware')
+          ).length
+        ).toBe(0)
+      }
+    })
   })
 })
 


### PR DESCRIPTION
This fixes the middleware chunks config since it previously wasn't matching middleware items correctly as the `chunk.name` is prefixed with `pages/` which it wasn't checking for and this also ensures we create a separate un-minified version of the webpack runtime to use for the middleware. 