### PR TITLE
Replace middleware flag with warning

### DIFF
--- a/errors/beta-middleware.md
+++ b/errors/beta-middleware.md
@@ -1,0 +1,13 @@
+# Beta Middleware Used
+
+#### Why This Error Occurred
+
+The middleware feature of Next.js is still in beta so this warning is shown to express that the feature is not yet covered by semver and can experience changes at any point.
+
+#### Possible Ways to Fix It
+
+No fix necessary.
+
+### Useful Links
+
+- [semver documentation](https://semver.org/)

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -5,6 +5,10 @@
       "heading": true,
       "routes": [
         {
+          "title": "beta-middleware",
+          "path": "/errors/beta-middleware.md"
+        },
+        {
           "title": "custom-document-image-import",
           "path": "/errors/custom-document-image-import.md"
         },

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -121,7 +121,7 @@ export function createEntrypoints(
 
     const isLikeServerless = isTargetLikeServerless(target)
 
-    if (page.match(MIDDLEWARE_ROUTE) && config.experimental.middleware) {
+    if (page.match(MIDDLEWARE_ROUTE)) {
       const loaderOpts: MiddlewareLoaderOptions = {
         absolutePagePath: pages[page],
         page,

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -284,6 +284,7 @@ export default async function build(
         )
       )
     const pageKeys = Object.keys(mappedPages)
+    const hasMiddleware = pageKeys.some((page) => MIDDLEWARE_ROUTE.test(page))
     const conflictingPublicFiles: string[] = []
     const hasCustomErrorPage: boolean =
       mappedPages['/_error'].startsWith('private-next-pages')
@@ -291,6 +292,15 @@ export default async function build(
       mappedPages['/404'] &&
         mappedPages['/404'].startsWith('private-next-pages')
     )
+
+    if (hasMiddleware) {
+      console.warn(
+        chalk.bold.yellow(`Warning: `) +
+          chalk.yellow(
+            `using beta Middleware (not covered by semver) - https://nextjs.org/docs/messages/beta-middleware`
+          )
+      )
+    }
 
     if (hasPublicDir) {
       const hasPublicUnderScoreNextDir = await fileExists(

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -284,14 +284,6 @@ export default async function build(
         )
       )
     const pageKeys = Object.keys(mappedPages)
-    const hasMiddleware = pageKeys.some((page) => MIDDLEWARE_ROUTE.test(page))
-
-    if (hasMiddleware && !config.experimental.middleware) {
-      console.warn(
-        `Warning: detected _middleware page but the "experimental.middleware" config was not enabled. Please enable it in ${config.configFileName}`
-      )
-    }
-
     const conflictingPublicFiles: string[] = []
     const hasCustomErrorPage: boolean =
       mappedPages['/_error'].startsWith('private-next-pages')
@@ -1718,26 +1710,24 @@ export default async function build(
       )
     }
 
-    if (config.experimental.middleware) {
-      const middlewareManifest: MiddlewareManifest = JSON.parse(
-        await promises.readFile(
-          path.join(distDir, SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
-          'utf8'
-        )
+    const middlewareManifest: MiddlewareManifest = JSON.parse(
+      await promises.readFile(
+        path.join(distDir, SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
+        'utf8'
       )
+    )
 
-      await promises.writeFile(
-        path.join(
-          distDir,
-          CLIENT_STATIC_FILES_PATH,
-          buildId,
-          '_middlewareManifest.js'
-        ),
-        `self.__MIDDLEWARE_MANIFEST=${devalue(
-          middlewareManifest.sortedMiddleware
-        )};self.__MIDDLEWARE_MANIFEST_CB&&self.__MIDDLEWARE_MANIFEST_CB()`
-      )
-    }
+    await promises.writeFile(
+      path.join(
+        distDir,
+        CLIENT_STATIC_FILES_PATH,
+        buildId,
+        '_middlewareManifest.js'
+      ),
+      `self.__MIDDLEWARE_MANIFEST=${devalue(
+        middlewareManifest.sortedMiddleware
+      )};self.__MIDDLEWARE_MANIFEST_CB&&self.__MIDDLEWARE_MANIFEST_CB()`
+    )
 
     const images = { ...config.images }
     const { deviceSizes, imageSizes } = images

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -946,7 +946,6 @@ export default async function getBaseWebpackConfig(
             parallel: config.experimental.cpus,
             swcMinify: config.experimental.swcMinify,
             terserOptions,
-            middlewareEnabled: config.experimental.middleware,
           }).apply(compiler)
         },
         // Minify CSS
@@ -1197,9 +1196,6 @@ export default async function getBaseWebpackConfig(
         }),
         'process.env.__NEXT_ROUTER_BASEPATH': JSON.stringify(config.basePath),
         'process.env.__NEXT_HAS_REWRITES': JSON.stringify(hasRewrites),
-        'process.env.__NEXT_HAS_MIDDLEWARE': JSON.stringify(
-          config.experimental.middleware
-        ),
         'process.env.__NEXT_I18N_SUPPORT': JSON.stringify(!!config.i18n),
         'process.env.__NEXT_I18N_DOMAINS': JSON.stringify(config.i18n?.domains),
         'process.env.__NEXT_ANALYTICS_ID': JSON.stringify(config.analyticsId),
@@ -1278,9 +1274,7 @@ export default async function getBaseWebpackConfig(
         new PagesManifestPlugin({ serverless: isLikeServerless, dev }),
       // MiddlewarePlugin should be after DefinePlugin so  NEXT_PUBLIC_*
       // replacement is done before its process.env.* handling
-      !isServer &&
-        config.experimental.middleware &&
-        new MiddlewarePlugin({ dev }),
+      !isServer && new MiddlewarePlugin({ dev }),
       isServer && new NextJsSsrImportPlugin(),
       !isServer &&
         new BuildManifestPlugin({

--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -49,20 +49,13 @@ function buildError(error, file) {
 
 export class TerserPlugin {
   constructor(options = {}) {
-    const {
-      cacheDir,
-      terserOptions = {},
-      parallel,
-      swcMinify,
-      middlewareEnabled,
-    } = options
+    const { cacheDir, terserOptions = {}, parallel, swcMinify } = options
 
     this.options = {
       swcMinify,
       cacheDir,
       parallel,
       terserOptions,
-      middlewareEnabled,
     }
   }
 
@@ -106,17 +99,15 @@ export class TerserPlugin {
             }
 
             // remove below if we start minifying middleware chunks
-            if (this.options.middlewareEnabled) {
-              if (name.startsWith('static/chunks/webpack-')) {
-                webpackAsset = name
-              }
+            if (name.startsWith('static/chunks/webpack-')) {
+              webpackAsset = name
+            }
 
-              // don't minify _middleware as it can break in some cases
-              // and doesn't provide too much of a benefit as it's server-side
-              if (name.match(/(middleware-chunks|_middleware\.js$)/)) {
-                hasMiddleware = true
-                return false
-              }
+            // don't minify _middleware as it can break in some cases
+            // and doesn't provide too much of a benefit as it's server-side
+            if (name.match(/(middleware-chunks|_middleware\.js$)/)) {
+              hasMiddleware = true
+              return false
             }
 
             const { info } = res

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -85,31 +85,27 @@ export default class PageLoader {
   }
 
   getMiddlewareList(): Promise<string[]> {
-    if (process.env.__NEXT_HAS_MIDDLEWARE) {
-      if (process.env.NODE_ENV === 'production') {
-        return getMiddlewareManifest()
-      } else {
-        if ((window as any).__DEV_MIDDLEWARE_MANIFEST) {
-          return (window as any).__DEV_MIDDLEWARE_MANIFEST
-        } else {
-          if (!this.promisedMiddlewareManifest) {
-            this.promisedMiddlewareManifest = fetch(
-              `${this.assetPrefix}/_next/static/${this.buildId}/_devMiddlewareManifest.json`
-            )
-              .then((res) => res.json())
-              .then((manifest) => {
-                ;(window as any).__DEV_MIDDLEWARE_MANIFEST = manifest
-                return manifest
-              })
-              .catch((err) => {
-                console.log(`Failed to fetch _devMiddlewareManifest`, err)
-              })
-          }
-          return this.promisedMiddlewareManifest
-        }
-      }
+    if (process.env.NODE_ENV === 'production') {
+      return getMiddlewareManifest()
     } else {
-      return Promise.resolve([])
+      if ((window as any).__DEV_MIDDLEWARE_MANIFEST) {
+        return (window as any).__DEV_MIDDLEWARE_MANIFEST
+      } else {
+        if (!this.promisedMiddlewareManifest) {
+          this.promisedMiddlewareManifest = fetch(
+            `${this.assetPrefix}/_next/static/${this.buildId}/_devMiddlewareManifest.json`
+          )
+            .then((res) => res.json())
+            .then((manifest) => {
+              ;(window as any).__DEV_MIDDLEWARE_MANIFEST = manifest
+              return manifest
+            })
+            .catch((err) => {
+              console.log(`Failed to fetch _devMiddlewareManifest`, err)
+            })
+        }
+        return this.promisedMiddlewareManifest
+      }
     }
   }
 

--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -232,31 +232,26 @@ export function getClientBuildManifest(): Promise<ClientBuildManifest> {
     markAssetError(new Error('Failed to load client build manifest'))
   )
 }
-let _getMiddlewareManifest = () => Promise.resolve([])
 
-if (process.env.__NEXT_HAS_MIDDLEWARE) {
-  _getMiddlewareManifest = async () => {
-    if (self.__MIDDLEWARE_MANIFEST) {
-      return Promise.resolve(self.__MIDDLEWARE_MANIFEST)
-    }
-
-    const onMiddlewareManifest: Promise<any> = new Promise<any>((resolve) => {
-      const cb = self.__MIDDLEWARE_MANIFEST_CB
-      self.__MIDDLEWARE_MANIFEST_CB = () => {
-        resolve(self.__MIDDLEWARE_MANIFEST!)
-        cb && cb()
-      }
-    })
-
-    return resolvePromiseWithTimeout(
-      onMiddlewareManifest,
-      MS_MAX_IDLE_DELAY,
-      markAssetError(new Error('Failed to load client middleware manifest'))
-    )
+export function getMiddlewareManifest(): Promise<any> {
+  if (self.__MIDDLEWARE_MANIFEST) {
+    return Promise.resolve(self.__MIDDLEWARE_MANIFEST)
   }
-}
 
-export const getMiddlewareManifest = _getMiddlewareManifest
+  const onMiddlewareManifest: Promise<any> = new Promise<any>((resolve) => {
+    const cb = self.__MIDDLEWARE_MANIFEST_CB
+    self.__MIDDLEWARE_MANIFEST_CB = () => {
+      resolve(self.__MIDDLEWARE_MANIFEST!)
+      cb && cb()
+    }
+  })
+
+  return resolvePromiseWithTimeout(
+    onMiddlewareManifest,
+    MS_MAX_IDLE_DELAY,
+    markAssetError(new Error('Failed to load client middleware manifest'))
+  )
+}
 
 interface RouteFiles {
   scripts: string[]

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -119,7 +119,6 @@ export type NextConfig = { [key: string]: any } & {
   staticPageGenerationTimeout?: number
   crossOrigin?: false | 'anonymous' | 'use-credentials'
   experimental?: {
-    middleware?: boolean
     swcMinify?: boolean
     swcLoader?: boolean
     cpus?: number
@@ -204,7 +203,6 @@ export const defaultConfig: NextConfig = {
   },
   staticPageGenerationTimeout: 60,
   experimental: {
-    middleware: false,
     swcLoader: false,
     swcMinify: false,
     cpus: Math.max(

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -265,12 +265,10 @@ export default class DevServer extends Server {
           routedPages.push(pageName)
         }
 
-        if (this.nextConfig.experimental.middleware) {
-          this.middleware = getSortedRoutes(routedMiddleware).map((page) => ({
-            match: getRouteMatcher(getMiddlewareRegex(page)),
-            page,
-          }))
-        }
+        this.middleware = getSortedRoutes(routedMiddleware).map((page) => ({
+          match: getRouteMatcher(getMiddlewareRegex(page)),
+          page,
+        }))
 
         try {
           // we serve a separate manifest with all pages for the client in
@@ -693,27 +691,25 @@ export default class DevServer extends Server {
       },
     })
 
-    if (this.nextConfig.experimental.middleware) {
-      fsRoutes.unshift({
-        match: route(
-          `/_next/${CLIENT_STATIC_FILES_PATH}/${this.buildId}/${DEV_MIDDLEWARE_MANIFEST}`
-        ),
-        type: 'route',
-        name: `_next/${CLIENT_STATIC_FILES_PATH}/${this.buildId}/${DEV_MIDDLEWARE_MANIFEST}`,
-        fn: async (_req, res) => {
-          res.statusCode = 200
-          res.setHeader('Content-Type', 'application/json; charset=utf-8')
-          res.end(
-            JSON.stringify(
-              this.middleware?.map((middleware) => middleware.page) || []
-            )
+    fsRoutes.unshift({
+      match: route(
+        `/_next/${CLIENT_STATIC_FILES_PATH}/${this.buildId}/${DEV_MIDDLEWARE_MANIFEST}`
+      ),
+      type: 'route',
+      name: `_next/${CLIENT_STATIC_FILES_PATH}/${this.buildId}/${DEV_MIDDLEWARE_MANIFEST}`,
+      fn: async (_req, res) => {
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json; charset=utf-8')
+        res.end(
+          JSON.stringify(
+            this.middleware?.map((middleware) => middleware.page) || []
           )
-          return {
-            finished: true,
-          }
-        },
-      })
-    }
+        )
+        return {
+          finished: true,
+        }
+      },
+    })
 
     fsRoutes.push({
       match: route('/:path*'),

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -281,7 +281,7 @@ export default class Server {
 
     if (!dev) {
       this.pagesManifest = require(pagesManifestPath)
-      if (!this.minimalMode && this.nextConfig.experimental.middleware) {
+      if (!this.minimalMode) {
         this.middlewareManifest = require(middlewareManifestPath)
       }
     }
@@ -569,9 +569,6 @@ export default class Server {
   }
 
   protected getMiddleware() {
-    if (!this.nextConfig.experimental.middleware) {
-      return []
-    }
     return Object.keys(this.middlewareManifest?.middleware || {}).map(
       (page) => ({
         match: getRouteMatcher(getMiddlewareRegex(page)),
@@ -1085,7 +1082,7 @@ export default class Server {
 
     let catchAllMiddleware: Route | undefined
 
-    if (!this.minimalMode && this.nextConfig.experimental.middleware) {
+    if (!this.minimalMode) {
       catchAllMiddleware = {
         match: route('/:path*'),
         type: 'route',

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -594,12 +594,23 @@ export default class Server {
 
   protected async ensureMiddleware(_pathname: string) {}
 
+  private middlewareBetaWarning = execOnce(() => {
+    console.warn(
+      chalk.bold.yellow(`Warning: `) +
+        chalk.yellow(
+          `using beta Middleware (not covered by semver) - https://nextjs.org/docs/messages/beta-middleware`
+        )
+    )
+  })
+
   protected async runMiddleware(params: {
     request: IncomingMessage
     response: ServerResponse
     parsedUrl: ParsedNextUrl
     parsed: UrlWithParsedQuery
   }): Promise<FetchEventResult | null> {
+    this.middlewareBetaWarning()
+
     const page: { name?: string; params?: { [key: string]: string } } = {}
     if (await this.hasPage(params.parsedUrl.pathname)) {
       page.name = params.parsedUrl.pathname

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -35,13 +35,7 @@ import { searchParamsToUrlQuery } from './utils/querystring'
 import resolveRewrites from './utils/resolve-rewrites'
 import { getRouteMatcher } from './utils/route-matcher'
 import { getRouteRegex } from './utils/route-regex'
-
-let getMiddlewareRegex: typeof import('./utils/get-middleware-regex').getMiddlewareRegex
-
-if (process.env.__NEXT_HAS_MIDDLEWARE) {
-  getMiddlewareRegex =
-    require('./utils/get-middleware-regex').getMiddlewareRegex
-}
+import { getMiddlewareRegex } from './utils/get-middleware-regex'
 
 declare global {
   interface Window {
@@ -1100,30 +1094,28 @@ export default class Router implements BaseRouter {
 
     resolvedAs = delLocale(delBasePath(resolvedAs), this.locale)
 
-    if (process.env.__NEXT_HAS_MIDDLEWARE) {
-      const effect = await this._preflightRequest({
-        as,
-        cache: process.env.NODE_ENV === 'production',
-        pages,
-        pathname,
-        query,
-      })
+    const effect = await this._preflightRequest({
+      as,
+      cache: process.env.NODE_ENV === 'production',
+      pages,
+      pathname,
+      query,
+    })
 
-      if (effect.type === 'rewrite') {
-        query = { ...query, ...effect.parsedAs.query }
-        resolvedAs = effect.asPath
-        pathname = effect.resolvedHref
-        parsed.pathname = effect.resolvedHref
-        url = formatWithValidation(parsed)
-      } else if (effect.type === 'redirect' && effect.newAs) {
-        return this.change(method, effect.newUrl, effect.newAs, options)
-      } else if (effect.type === 'redirect' && effect.destination) {
-        window.location.href = effect.destination
-        return new Promise(() => {})
-      } else if (effect.type === 'refresh') {
-        window.location.href = as
-        return new Promise(() => {})
-      }
+    if (effect.type === 'rewrite') {
+      query = { ...query, ...effect.parsedAs.query }
+      resolvedAs = effect.asPath
+      pathname = effect.resolvedHref
+      parsed.pathname = effect.resolvedHref
+      url = formatWithValidation(parsed)
+    } else if (effect.type === 'redirect' && effect.newAs) {
+      return this.change(method, effect.newUrl, effect.newAs, options)
+    } else if (effect.type === 'redirect' && effect.destination) {
+      window.location.href = effect.destination
+      return new Promise(() => {})
+    } else if (effect.type === 'refresh') {
+      window.location.href = as
+      return new Promise(() => {})
     }
 
     const route = removePathTrailingSlash(pathname)
@@ -1651,22 +1643,20 @@ export default class Router implements BaseRouter {
       return
     }
 
-    if (process.env.__NEXT_HAS_MIDDLEWARE) {
-      const effects = await this._preflightRequest({
-        as: asPath,
-        cache: true,
-        pages,
-        pathname,
-        query,
-      })
+    const effects = await this._preflightRequest({
+      as: asPath,
+      cache: true,
+      pages,
+      pathname,
+      query,
+    })
 
-      if (effects.type === 'rewrite') {
-        parsed.pathname = effects.resolvedHref
-        pathname = effects.resolvedHref
-        query = { ...query, ...effects.parsedAs.query }
-        resolvedAs = effects.asPath
-        url = formatWithValidation(parsed)
-      }
+    if (effects.type === 'rewrite') {
+      parsed.pathname = effects.resolvedHref
+      pathname = effects.resolvedHref
+      query = { ...query, ...effects.parsedAs.query }
+      resolvedAs = effects.asPath
+      url = formatWithValidation(parsed)
     }
 
     const route = removePathTrailingSlash(pathname)
@@ -1751,154 +1741,147 @@ export default class Router implements BaseRouter {
     pathname: string
     query: ParsedUrlQuery
   }): Promise<PreflightEffect> {
-    if (process.env.__NEXT_HAS_MIDDLEWARE) {
-      const cleanedAs = delLocale(
-        hasBasePath(options.as) ? delBasePath(options.as) : options.as,
-        this.locale
+    const cleanedAs = delLocale(
+      hasBasePath(options.as) ? delBasePath(options.as) : options.as,
+      this.locale
+    )
+
+    const fns: string[] = await this.pageLoader.getMiddlewareList()
+    const requiresPreflight = fns.some((middleware) => {
+      return getRouteMatcher(getMiddlewareRegex(middleware))(cleanedAs)
+    })
+
+    if (!requiresPreflight) {
+      return { type: 'next' }
+    }
+
+    const preflight = await this._getPreflightData({
+      preflightHref: options.as,
+      shouldCache: options.cache,
+    })
+
+    if (preflight.rewrite?.startsWith('/')) {
+      const parsed = parseRelativeUrl(
+        normalizeLocalePath(
+          hasBasePath(preflight.rewrite)
+            ? delBasePath(preflight.rewrite)
+            : preflight.rewrite,
+          this.locales
+        ).pathname
       )
 
-      const fns: string[] = await this.pageLoader.getMiddlewareList()
-      const requiresPreflight = fns.some((middleware) => {
-        return getRouteMatcher(getMiddlewareRegex(middleware))(cleanedAs)
-      })
+      const fsPathname = removePathTrailingSlash(parsed.pathname)
 
-      if (!requiresPreflight) {
-        return { type: 'next' }
-      }
+      let matchedPage
+      let resolvedHref
 
-      const preflight = await this._getPreflightData({
-        preflightHref: options.as,
-        shouldCache: options.cache,
-      })
+      if (options.pages.includes(fsPathname)) {
+        matchedPage = true
+        resolvedHref = fsPathname
+      } else {
+        resolvedHref = resolveDynamicRoute(fsPathname, options.pages)
 
-      if (preflight.rewrite?.startsWith('/')) {
-        const parsed = parseRelativeUrl(
-          normalizeLocalePath(
-            hasBasePath(preflight.rewrite)
-              ? delBasePath(preflight.rewrite)
-              : preflight.rewrite,
-            this.locales
-          ).pathname
-        )
-
-        const fsPathname = removePathTrailingSlash(parsed.pathname)
-
-        let matchedPage
-        let resolvedHref
-
-        if (options.pages.includes(fsPathname)) {
+        if (
+          resolvedHref !== parsed.pathname &&
+          options.pages.includes(resolvedHref)
+        ) {
           matchedPage = true
-          resolvedHref = fsPathname
-        } else {
-          resolvedHref = resolveDynamicRoute(fsPathname, options.pages)
-
-          if (
-            resolvedHref !== parsed.pathname &&
-            options.pages.includes(resolvedHref)
-          ) {
-            matchedPage = true
-          }
-        }
-
-        return {
-          type: 'rewrite',
-          asPath: parsed.pathname,
-          parsedAs: parsed,
-          matchedPage,
-          resolvedHref,
-        }
-      }
-
-      if (preflight.redirect) {
-        if (preflight.redirect.startsWith('/')) {
-          const cleanRedirect = removePathTrailingSlash(
-            normalizeLocalePath(
-              hasBasePath(preflight.redirect)
-                ? delBasePath(preflight.redirect)
-                : preflight.redirect,
-              this.locales
-            ).pathname
-          )
-
-          const { url: newUrl, as: newAs } = prepareUrlAs(
-            this,
-            cleanRedirect,
-            cleanRedirect
-          )
-
-          return {
-            type: 'redirect',
-            newUrl,
-            newAs,
-          }
-        }
-
-        return {
-          type: 'redirect',
-          destination: preflight.redirect,
-        }
-      }
-
-      if (preflight.refresh) {
-        return {
-          type: 'refresh',
         }
       }
 
       return {
-        type: 'next',
+        type: 'rewrite',
+        asPath: parsed.pathname,
+        parsedAs: parsed,
+        matchedPage,
+        resolvedHref,
       }
     }
-    return { type: 'next' }
+
+    if (preflight.redirect) {
+      if (preflight.redirect.startsWith('/')) {
+        const cleanRedirect = removePathTrailingSlash(
+          normalizeLocalePath(
+            hasBasePath(preflight.redirect)
+              ? delBasePath(preflight.redirect)
+              : preflight.redirect,
+            this.locales
+          ).pathname
+        )
+
+        const { url: newUrl, as: newAs } = prepareUrlAs(
+          this,
+          cleanRedirect,
+          cleanRedirect
+        )
+
+        return {
+          type: 'redirect',
+          newUrl,
+          newAs,
+        }
+      }
+
+      return {
+        type: 'redirect',
+        destination: preflight.redirect,
+      }
+    }
+
+    if (preflight.refresh) {
+      return {
+        type: 'refresh',
+      }
+    }
+
+    return {
+      type: 'next',
+    }
   }
 
   _getPreflightData(params: {
     preflightHref: string
     shouldCache?: boolean
   }): Promise<PreflightData> {
-    if (process.env.__NEXT_HAS_MIDDLEWARE) {
-      const { preflightHref, shouldCache = false } = params
-      const { href: cacheKey } = new URL(preflightHref, window.location.href)
+    const { preflightHref, shouldCache = false } = params
+    const { href: cacheKey } = new URL(preflightHref, window.location.href)
 
-      if (
-        process.env.NODE_ENV === 'production' &&
-        !this.isPreview &&
-        shouldCache &&
-        this.sde[cacheKey]
-      ) {
-        return Promise.resolve(this.sde[cacheKey])
-      }
-
-      return fetch(preflightHref, {
-        method: 'HEAD',
-        credentials: 'same-origin',
-        headers: { 'x-middleware-preflight': '1' },
-      })
-        .then((res) => {
-          if (!res.ok) {
-            throw new Error(`Failed to preflight request`)
-          }
-
-          return {
-            redirect: res.headers.get('Location'),
-            refresh: res.headers.has('x-middleware-refresh'),
-            rewrite: res.headers.get('x-middleware-rewrite'),
-          }
-        })
-        .then((data) => {
-          if (shouldCache) {
-            this.sde[cacheKey] = data
-          }
-
-          return data
-        })
-        .catch((err) => {
-          delete this.sde[cacheKey]
-          throw err
-        })
-    } else {
-      return {} as any
+    if (
+      process.env.NODE_ENV === 'production' &&
+      !this.isPreview &&
+      shouldCache &&
+      this.sde[cacheKey]
+    ) {
+      return Promise.resolve(this.sde[cacheKey])
     }
+
+    return fetch(preflightHref, {
+      method: 'HEAD',
+      credentials: 'same-origin',
+      headers: { 'x-middleware-preflight': '1' },
+    })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to preflight request`)
+        }
+
+        return {
+          redirect: res.headers.get('Location'),
+          refresh: res.headers.has('x-middleware-refresh'),
+          rewrite: res.headers.get('x-middleware-rewrite'),
+        }
+      })
+      .then((data) => {
+        if (shouldCache) {
+          this.sde[cacheKey] = data
+        }
+
+        return data
+      })
+      .catch((err) => {
+        delete this.sde[cacheKey]
+        throw err
+      })
   }
 
   _getStaticData(dataHref: string): Promise<object> {

--- a/test/integration/middleware-base-path/next.config.js
+++ b/test/integration/middleware-base-path/next.config.js
@@ -1,6 +1,3 @@
 module.exports = {
   basePath: '/root',
-  experimental: {
-    middleware: true,
-  },
 }

--- a/test/integration/middleware-core/next.config.js
+++ b/test/integration/middleware-core/next.config.js
@@ -3,7 +3,4 @@ module.exports = {
     locales: ['en', 'fr', 'nl'],
     defaultLocale: 'en',
   },
-  experimental: {
-    middleware: true,
-  },
 }


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/30154 this replaces the experimental flag with a warning that is shown once on usage instead. 