### PR TITLE
Optimize vanilla Emotion example

### DIFF
--- a/examples/with-emotion-vanilla/pages/_document.js
+++ b/examples/with-emotion-vanilla/pages/_document.js
@@ -3,9 +3,17 @@ import * as React from 'react'
 import { renderStatic } from '../shared/renderer'
 export default class AppDocument extends Document {
   static async getInitialProps(ctx) {
-    const page = await ctx.renderPage()
-    const { css, ids } = await renderStatic(page.html)
+    const originalRenderPage = ctx.renderPage
+    let page
+
+    ctx.renderPage = () => {
+      page = originalRenderPage()
+      return page
+    }
+
     const initialProps = await Document.getInitialProps(ctx)
+    const { css, ids } = await renderStatic(page.html)
+
     return {
       ...initialProps,
       styles: (


### PR DESCRIPTION
If I understand correctly `Document.getInitialProps(ctx)` is calling `ctx.renderPage` under the hood. If that understanding is correct then the version before my changes was calling `ctx.renderPage` twice (once explicitly and one within `Document.getInitialProps(ctx)` call). Therefore the proposed change is a perf improvement.