### PR TITLE
Add isDevfallback to cache name to create a separate cache for the fallback compiler

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1514,6 +1514,11 @@ export default async function getBaseWebpackConfig(
     isCraCompat: config.experimental.craCompat,
   })
 
+  // @ts-ignore Cache exists
+  webpackConfig.cache.name = `${webpackConfig.name}-${webpackConfig.mode}${
+    isDevFallback ? '-fallback' : ''
+  }`
+
   let originalDevtool = webpackConfig.devtool
   if (typeof config.webpack === 'function') {
     webpackConfig = config.webpack(webpackConfig, {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -316,6 +316,7 @@ export default async function getBaseWebpackConfig(
           options: {
             isServer,
             pagesDir,
+            hasReactRefresh,
           },
         }
       : {

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -39,6 +39,7 @@ function getSWCOptions({
   isPageFile,
   pagesDir,
   isNextDist,
+  hasReactRefresh,
   isCommonJS,
 }) {
   const jsc = {
@@ -56,7 +57,7 @@ function getSWCOptions({
         throwIfNamespace: true,
         development: development,
         useBuiltins: true,
-        refresh: development && !isServer,
+        refresh: hasReactRefresh,
       },
       optimizer: {
         simplify: false,
@@ -122,7 +123,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
 
   let loaderOptions = getOptions(this) || {}
 
-  const { isServer, pagesDir } = loaderOptions
+  const { isServer, pagesDir, hasReactRefresh } = loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
 
   const isNextDist = nextDistPath.test(filename)
@@ -136,6 +137,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
     development: this.mode === 'development',
     isNextDist,
     isCommonJS,
+    hasReactRefresh,
   })
 
   const programmaticOptions = {


### PR DESCRIPTION
- Use hasReactRefresh to enable fast refresh in swc
- Add isDevfallback to cache name to create a separate cache for the fallback compiler

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
