### PR TITLE
Update removeHash handling for stats-app

### DIFF
--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -67,7 +67,7 @@ async function runConfigs(
         const results = await glob(rename.srcGlob, { cwd: statsAppDir })
         for (const result of results) {
           let dest = rename.removeHash
-            ? result.replace(/(\.|-)[0-9a-f]{20}(\.|-)/g, '$1HASH$2')
+            ? result.replace(/(\.|-)[0-9a-f]{16}(\.|-)/g, '$1HASH$2')
             : rename.dest
           if (result === dest) continue
           await fs.move(


### PR DESCRIPTION
This updates the `removeHash` handling for the `stats-app` for the new hash length being used. 

x-ref: https://github.com/vercel/next.js/pull/30095