### PR TITLE
Use `Log.warn()` instead of `console.warn()` in next-server

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -295,11 +295,8 @@ export default async function build(
     )
 
     if (hasMiddleware) {
-      console.warn(
-        chalk.bold.yellow(`Warning: `) +
-          chalk.yellow(
-            `using beta Middleware (not covered by semver) - https://nextjs.org/docs/messages/beta-middleware`
-          )
+      Log.warn(
+        `using beta Middleware (not covered by semver) - https://nextjs.org/docs/messages/beta-middleware`
       )
     }
 

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -595,11 +595,8 @@ export default class Server {
   protected async ensureMiddleware(_pathname: string) {}
 
   private middlewareBetaWarning = execOnce(() => {
-    console.warn(
-      chalk.bold.yellow(`Warning: `) +
-        chalk.yellow(
-          `using beta Middleware (not covered by semver) - https://nextjs.org/docs/messages/beta-middleware`
-        )
+    Log.warn(
+      `Middleware beta is not covered by semver - https://nextjs.org/docs/messages/beta-middleware`
     )
   })
 
@@ -2300,11 +2297,8 @@ export default class Server {
   }
 
   private customErrorNo404Warn = execOnce(() => {
-    console.warn(
-      chalk.bold.yellow(`Warning: `) +
-        chalk.yellow(
-          `You have added a custom /_error page without a custom /404 page. This prevents the 404 page from being auto statically optimized.\nSee here for info: https://nextjs.org/docs/messages/custom-error-no-custom-404`
-        )
+    Log.warn(
+      `You have added a custom /_error page without a custom /404 page. This prevents the 404 page from being auto statically optimized.\nSee here for info: https://nextjs.org/docs/messages/custom-error-no-custom-404`
     )
   })
 

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1,6 +1,5 @@
 import compression from 'next/dist/compiled/compression'
 import fs from 'fs'
-import chalk from 'chalk'
 import { IncomingMessage, ServerResponse } from 'http'
 import Proxy from 'next/dist/compiled/http-proxy'
 import { join, relative, resolve, sep } from 'path'
@@ -596,7 +595,7 @@ export default class Server {
 
   private middlewareBetaWarning = execOnce(() => {
     Log.warn(
-      `Middleware beta is not covered by semver - https://nextjs.org/docs/messages/beta-middleware`
+      `using beta Middleware (not covered by semver) - https://nextjs.org/docs/messages/beta-middleware`
     )
   })
 

--- a/test/integration/middleware-core/test/index.test.js
+++ b/test/integration/middleware-core/test/index.test.js
@@ -17,8 +17,7 @@ jest.setTimeout(1000 * 60 * 2)
 const context = {}
 context.appDir = join(__dirname, '../')
 
-const middlewareWarning =
-  'Warning: using beta Middleware (not covered by semver)'
+const middlewareWarning = 'using beta Middleware (not covered by semver)'
 
 describe('Middleware base tests', () => {
   describe('dev mode', () => {


### PR DESCRIPTION
Let's make these warnings consistent with the others