### PR TITLE
Add initial test trace outputs

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -175,7 +175,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: dist-without-markdown
+          name: test-trace
+          retention-days: 2
           path: |
             test/traces
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -171,6 +171,13 @@ jobs:
         name: Run test/e2e (dev)
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
+      - name: Upload test trace
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-without-markdown
+          path: |
+            test/traces
+
   testProd:
     name: Test Production
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -172,6 +172,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
       - name: Upload test trace
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: dist-without-markdown
@@ -529,7 +530,6 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
         working-directory: packages/next
       - name: Upload artifact
-        if: always()
         uses: actions/upload-artifact@v2.2.4
         with:
           name: next-swc-binaries

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -529,6 +529,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
         working-directory: packages/next
       - name: Upload artifact
+        if: always()
         uses: actions/upload-artifact@v2.2.4
         with:
           name: next-swc-binaries

--- a/packages/next/build/swc/tests/full/example/output.js
+++ b/packages/next/build/swc/tests/full/example/output.js
@@ -1,36 +1,36 @@
 import a from "other";
-function _arrayWithHoles(b) {
-    if (Array.isArray(b)) return b;
+function _arrayWithHoles(a) {
+    if (Array.isArray(a)) return a;
 }
-function _classCallCheck(c, d) {
-    if (!(c instanceof d)) throw new TypeError("Cannot call a class as a function");
+function _classCallCheck(a, b) {
+    if (!(a instanceof b)) throw new TypeError("Cannot call a class as a function");
 }
-function _iterableToArrayLimit(b, e) {
-    var f = [], g = !0, h = !1, i = void 0;
+function _iterableToArrayLimit(a, b) {
+    var c = [], d = !0, e = !1, f = void 0;
     try {
-        for(var j, k = b[Symbol.iterator](); !(g = (j = k.next()).done) && (f.push(j.value), !e || f.length !== e); g = !0);
-    } catch (l) {
-        h = !0, i = l;
+        for(var g, h = a[Symbol.iterator](); !(d = (g = h.next()).done) && (c.push(g.value), !b || c.length !== b); d = !0);
+    } catch (a) {
+        e = !0, f = a;
     } finally{
         try {
-            g || null == k.return || k.return();
+            d || null == h.return || h.return();
         } finally{
-            if (h) throw i;
+            if (e) throw f;
         }
     }
-    return f;
+    return c;
 }
 function _nonIterableRest() {
     throw new TypeError("Invalid attempt to destructure non-iterable instance");
 }
-function _slicedToArray(b, e) {
-    return _arrayWithHoles(b) || _iterableToArrayLimit(b, e) || _nonIterableRest();
+function _slicedToArray(a, b) {
+    return _arrayWithHoles(a) || _iterableToArrayLimit(a, b) || _nonIterableRest();
 }
 var foo = _slicedToArray(a, 1)[0], Foo = function() {
     "use strict";
     _classCallCheck(this, Foo);
 };
 export var __N_SSG = !0;
-export default function Home() {
+export default function a() {
     return React.createElement("div", null);
 };

--- a/run-tests.js
+++ b/run-tests.js
@@ -298,9 +298,17 @@ async function main() {
             }
             trimmedOutput.forEach((chunk) => process.stdout.write(chunk))
           }
-          reject(new Error(`failed with code: ${code}`))
+          return reject(new Error(`failed with code: ${code}`))
         }
-        await fs.remove(path.join(__dirname, 'test/traces')).catch(() => {})
+        await fs
+          .remove(
+            path.join(
+              __dirname,
+              'test/traces',
+              path.relative(__dirname, test).replace(/\//g, '-')
+            )
+          )
+          .catch(() => {})
         resolve(new Date().getTime() - start)
       })
     })

--- a/run-tests.js
+++ b/run-tests.js
@@ -298,38 +298,9 @@ async function main() {
             }
             trimmedOutput.forEach((chunk) => process.stdout.write(chunk))
           }
-          try {
-            const isolatedTestDir =
-              process.env.NEXT_TEST_DIR || (await fs.realpath(os.tmpdir()))
-            const traceFile = await glob('next-(install|test)-*/.next/trace', {
-              cwd: isolatedTestDir,
-              dot: true,
-            })
-
-            if (traceFile.length > 0) {
-              await fs.copy(
-                path.join(isolatedTestDir, traceFile.pop()),
-                path.join(
-                  __dirname,
-                  'test/traces',
-                  `${path.basename(test)}-next-trace`
-                )
-              )
-            }
-          } catch (err) {
-            console.error('failed to copy .next/trace')
-          }
           reject(new Error(`failed with code: ${code}`))
         }
-        await fs
-          .remove(
-            path.join(
-              __dirname,
-              'test/traces',
-              `playwright-trace-${path.basename(test)}.zip`
-            )
-          )
-          .catch(() => {})
+        await fs.remove(path.join(__dirname, 'test/traces')).catch(() => {})
         resolve(new Date().getTime() - start)
       })
     })

--- a/run-tests.js
+++ b/run-tests.js
@@ -305,7 +305,9 @@ async function main() {
             path.join(
               __dirname,
               'test/traces',
-              path.relative(__dirname, test).replace(/\//g, '-')
+              path
+                .relative(path.join(__dirname, 'test'), test)
+                .replace(/\//g, '-')
             )
           )
           .catch(() => {})

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -636,8 +636,6 @@ describe('basic HMR', () => {
         browser = await webdriver(next.appPort, '/hmr')
         await browser.elementByCss('#error-in-gip-link').click()
 
-        throw new Error('test error')
-
         expect(await hasRedbox(browser)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
           " 1 of 1 unhandled error

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -636,6 +636,8 @@ describe('basic HMR', () => {
         browser = await webdriver(next.appPort, '/hmr')
         await browser.elementByCss('#error-in-gip-link').click()
 
+        throw new Error('test error')
+
         expect(await hasRedbox(browser)).toBe(true)
         expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
           " 1 of 1 unhandled error

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -56,7 +56,7 @@ class Playwright extends BrowserInterface {
         `${path
           .relative(path.join(__dirname, '../../'), process.env.TEST_FILE_PATH)
           .replace(/\//g, '-')}`,
-        `playwright-${encodeURIComponent(url)}.zip`
+        `playwright-${encodeURIComponent(url)}-${Date.now()}.zip`
       )
 
       await fs.remove(traceOutputPath)

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -53,6 +53,9 @@ class Playwright extends BrowserInterface {
       const traceDir = path.join(__dirname, '../../traces')
       const traceOutputPath = path.join(
         traceDir,
+        `${path
+          .relative(path.join(__dirname, '../../'), process.env.TEST_FILE_PATH)
+          .replace(/\//g, '-')}`,
         `playwright-${encodeURIComponent(url)}.zip`
       )
 

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -61,7 +61,7 @@ class Playwright extends BrowserInterface {
         .stop({
           path: traceOutputPath,
         })
-        .catch(console.error)
+        .catch((err) => console.error('failed to write playwright trace', err))
     }
 
     // clean-up existing pages

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -8,6 +8,8 @@ import { NextStartInstance } from './next-modes/next-start'
 const testFile = module.parent.filename
 const testsFolder = path.join(__dirname, '..')
 
+process.env.TEST_FILE_PATH = testFile
+
 let testMode = process.env.NEXT_TEST_MODE
 
 if (!testFile.match(/\.test\.(js|tsx?)/)) {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -166,8 +166,14 @@ export class NextInstance {
           path.join(this.testDir, '.next/trace'),
           path.join(
             __dirname,
-            'test/traces',
-            `${path.basename(process.env.TEST_FILE_PATH)}-next-trace`
+            '../../traces',
+            `${path
+              .relative(
+                path.join(__dirname, '../../'),
+                process.env.TEST_FILE_PATH
+              )
+              .replace(/\//g, '-')}`,
+            `next-trace`
           )
         )
         .catch(() => {})

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -160,6 +160,17 @@ export class NextInstance {
     this.emit('destroy', [])
     await this.stop()
 
+    if (process.env.TRACE_PLAYWRIGHT) {
+      await fs.copy(
+        path.join(this.testDir, '.next/trace'),
+        path.join(
+          __dirname,
+          'test/traces',
+          `${path.basename(process.env.TEST_FILE_PATH)}-next-trace`
+        )
+      )
+    }
+
     if (!process.env.NEXT_TEST_SKIP_CLEANUP) {
       await fs.remove(this.testDir)
     }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -161,14 +161,16 @@ export class NextInstance {
     await this.stop()
 
     if (process.env.TRACE_PLAYWRIGHT) {
-      await fs.copy(
-        path.join(this.testDir, '.next/trace'),
-        path.join(
-          __dirname,
-          'test/traces',
-          `${path.basename(process.env.TEST_FILE_PATH)}-next-trace`
+      await fs
+        .copy(
+          path.join(this.testDir, '.next/trace'),
+          path.join(
+            __dirname,
+            'test/traces',
+            `${path.basename(process.env.TEST_FILE_PATH)}-next-trace`
+          )
         )
-      )
+        .catch(() => {})
     }
 
     if (!process.env.NEXT_TEST_SKIP_CLEANUP) {

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -2,6 +2,10 @@ import { getFullUrl } from 'next-test-utils'
 import os from 'os'
 import { BrowserInterface } from './browsers/base'
 
+if (!process.env.TEST_FILE_PATH) {
+  process.env.TEST_FILE_PATH = module.parent.filename
+}
+
 let deviceIP: string
 const isBrowserStack = !!process.env.BROWSERSTACK
 ;(global as any).browserName = process.env.BROWSER_NAME || 'chrome'


### PR DESCRIPTION
This adds uploading test traces from `playwright` and `.next/trace` when a test fails to allow investigating flakes that aren't able to be reproduced easily. This also updates the `swc` test for the new expected output. 

The playwright traces can be viewed with `yarn playwright show-trace ./path/to-playwright-trace.zip` and the `next-trace` file can viewed with `jaegar` or `./scripts/trace-to-tree.mjs`.   