### PR TITLE
Update error for failing to load SWC bindings

### DIFF
--- a/.github/workflows/build_native.yml
+++ b/.github/workflows/build_native.yml
@@ -95,10 +95,10 @@ jobs:
     runs-on: windows-latest
     env:
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 32
-      CARGO_PROFILE_RELEASE_LTO: "false"
+      CARGO_PROFILE_RELEASE_LTO: 'false'
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Install node x86
         run: |
           choco install nodejs-lts --x86 -y --force
@@ -123,7 +123,7 @@ jobs:
         shell: bash
         run: yarn build-native --target i686-pc-windows-msvc
         working-directory: packages/next
-      
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
@@ -160,7 +160,6 @@ jobs:
           name: next-swc-binaries
           path: packages/next/native/next-swc.*.node
 
-
   build-linux-musl:
     name: next-swc - linux-musl - node@lts
     runs-on: ubuntu-latest
@@ -187,16 +186,15 @@ jobs:
           docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
 
-      - name: "Build"
+      - name: 'Build'
         run: |
           docker run --rm -v $(pwd)/packages/next:/swc -w /swc builder sh -c "yarn build-native"
-          
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: next-swc-binaries
           path: packages/next/native/next-swc.*.node
-
 
   build-linux-aarch64:
     name: next-swc - aarch64-unknown-linux-gnu - node@14
@@ -241,7 +239,6 @@ jobs:
           name: next-swc-binaries
           path: packages/next/native/next-swc.*.node
 
-
   build-linux-aarch64-musl:
     name: next-swc - aarch64-unknown-linux-musl - node@14
     runs-on: ubuntu-18.04
@@ -282,7 +279,6 @@ jobs:
         with:
           name: next-swc-binaries
           path: packages/next/native/next-swc.*.node
-
 
   build-linux-arm7:
     name: next-swc - arm7-unknown-linux-gnu - node@14
@@ -368,12 +364,12 @@ jobs:
         id: build
         uses: vmactions/freebsd-vm@v0.1.5
         env:
-          DEBUG: "napi:*"
+          DEBUG: 'napi:*'
           RUSTUP_HOME: /usr/local/rustup
           CARGO_HOME: /usr/local/cargo
           RUSTUP_IO_THREADS: 1
         with:
-          envs: "DEBUG RUSTUP_HOME CARGO_HOME RUSTUP_IO_THREADS"
+          envs: 'DEBUG RUSTUP_HOME CARGO_HOME RUSTUP_IO_THREADS'
           usesh: true
           mem: 6000
           prepare: |
@@ -402,7 +398,7 @@ jobs:
             rm -rf target
           working-directory: packages/next
 
-      - name: "List files"
+      - name: 'List files'
         run: ls -la
 
       - name: Upload artifact
@@ -411,9 +407,8 @@ jobs:
           name: next-swc-binaries
           path: packages/next/native/next-swc.*.node
 
-      
   commit:
-    needs: 
+    needs:
       - build-native
       - build-windows-i686
       - build-windows-aarch64

--- a/errors/failed-loading-swc.md
+++ b/errors/failed-loading-swc.md
@@ -1,0 +1,31 @@
+# SWC Failed to Load
+
+#### Why This Message Occurred
+
+Next.js now uses Rust-based compiler [SWC](https://swc.rs/) to compile JavaScript/TypeScript. This new compiler is up to 17x faster than Babel when compiling individual files and up to 5x faster Fast Refresh.
+
+SWC requires a binary be downloaded that is compatible specific to your system. In some cases this binary may fail to load either from failing to download or an incompatibility with your architecture.
+
+#### Possible Ways to Fix It
+
+If SWC continues to fail to load you can opt-out by disabling `swcMinify` in your `next.config.js` or by adding a `.babelrc` to your project with the following content:
+
+```json
+{
+  "presets": ["next/babel"]
+}
+```
+
+Be sure to report the issue on [the feedback thread](https://github.com/vercel/next.js/discussions/30174) sharing the below information so we can get it fixed:
+
+- your node architecture and platform `node -e 'console.log(process.arch, process.platform)'`
+- your operating system version and CPU
+- your Next.js version `yarn next --version`
+- your package manager (`yarn` or `npm`) and version
+- your node.js version `node -v`
+- whether `@next/swc-<your-system-version>` was downloaded in `node_modules` correctly
+
+### Useful Links
+
+- [SWC Feedback Thread](https://github.com/vercel/next.js/discussions/30174)
+- [SWC Disabled Document](https://nextjs.org/docs/messages/swc-disabled)

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -9,6 +9,10 @@
           "path": "/errors/beta-middleware.md"
         },
         {
+          "title": "failed-loading-swc",
+          "path": "/errors/failed-loading-swc.md"
+        },
+        {
           "title": "deprecated-target-config",
           "path": "/errors/deprecated-target-config.md"
         },

--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -1,5 +1,6 @@
 const { loadBinding } = require('@node-rs/helper')
 const path = require('path')
+const Log = require('../output/log')
 
 /**
  * __dirname means load native addon from current dir
@@ -9,11 +10,24 @@ const path = require('path')
  * `loadBinding` helper will load `next-swc.[PLATFORM].node` from `__dirname` first
  * If failed to load addon, it will fallback to load from `next-swc-[PLATFORM]`
  */
-const bindings = loadBinding(
-  path.join(__dirname, '../../../native'),
-  'next-swc',
-  '@next/swc'
-)
+let bindings
+
+try {
+  bindings = loadBinding(
+    path.join(__dirname, '../../../native'),
+    'next-swc',
+    '@next/swc'
+  )
+} catch (err) {
+  // only log the original error message as the stack is not
+  // helpful to the user
+  console.error(err.message)
+
+  Log.error(
+    `failed to load SWC binary, see more info here: https://nextjs.org/docs/messages/failed-loading-swc`
+  )
+  process.exit(1)
+}
 
 async function transform(src, options) {
   const isModule = typeof src !== 'string'


### PR DESCRIPTION
This updates the error shown when we fail to load SWC as the error isn't very helpful for users. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
