### PR TITLE
[middleware] Enable body for requests

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -103,6 +103,7 @@ import { getMiddlewareInfo } from './require'
 import { parseUrl as simpleParseUrl } from '../shared/lib/router/utils/parse-url'
 import { MIDDLEWARE_ROUTE } from '../lib/constants'
 import { NextResponse } from './web/spec-extension/response'
+import { setReadableStream } from './web/node-request'
 import { run } from './web/sandbox'
 import type { FetchEventResult } from './web/types'
 import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'
@@ -331,6 +332,8 @@ export default class Server {
     res: ServerResponse,
     parsedUrl?: UrlWithParsedQuery
   ): Promise<void> {
+    req = setReadableStream(req)
+
     const urlParts = (req.url || '').split('?')
     const urlNoQuery = urlParts[0]
 
@@ -658,6 +661,7 @@ export default class Server {
           request: {
             headers: params.request.headers,
             method: params.request.method || 'GET',
+            body: (params.request as any).__readable || null,
             nextConfig: {
               basePath: this.nextConfig.basePath,
               i18n: this.nextConfig.i18n,

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -16,6 +16,7 @@ export async function adapter(params: {
 
   const event = new NextFetchEvent(
     new NextRequest(url, {
+      body: params.request.body || null,
       geo: params.request.geo,
       headers: fromNodeHeaders(params.request.headers),
       ip: params.request.ip,

--- a/packages/next/server/web/node-request.ts
+++ b/packages/next/server/web/node-request.ts
@@ -1,0 +1,100 @@
+import type { IncomingMessage as NodeIncomingMessage } from 'http'
+import { ReadableStream } from 'next/dist/compiled/web-streams-polyfill'
+import { PassThrough } from 'stream'
+
+class IncomingMessage extends PassThrough implements NodeIncomingMessage {
+  #original: NodeIncomingMessage
+
+  constructor(original: NodeIncomingMessage) {
+    super()
+    this.#original = original
+  }
+
+  get httpVersion() {
+    return this.#original.httpVersion
+  }
+
+  get httpVersionMajor() {
+    return this.#original.httpVersionMajor
+  }
+
+  get httpVersionMinor() {
+    return this.#original.httpVersionMinor
+  }
+
+  get complete() {
+    return this.#original.complete
+  }
+
+  get connection() {
+    return this.#original.connection
+  }
+
+  get socket() {
+    return this.#original.socket
+  }
+
+  get headers() {
+    return this.#original.headers
+  }
+
+  get rawHeaders() {
+    return this.#original.rawHeaders
+  }
+
+  get trailers() {
+    return this.#original.trailers
+  }
+
+  get rawTrailers() {
+    return this.#original.rawTrailers
+  }
+
+  setTimeout(msecs: number, callback?: () => void) {
+    this.#original.setTimeout(msecs, callback)
+    return this
+  }
+
+  get method() {
+    return this.#original.method
+  }
+
+  get url() {
+    return this.#original.url
+  }
+
+  get statusCode() {
+    return this.#original.statusCode
+  }
+
+  get statusMessage() {
+    return this.#original.statusMessage
+  }
+
+  destroy(error?: Error) {
+    this.#original.destroy(error)
+  }
+}
+
+export function setReadableStream(original: NodeIncomingMessage) {
+  if (!original.method || !['POST', 'PUT', 'PATCH'].includes(original.method)) {
+    return original
+  }
+
+  const request = new IncomingMessage(original)
+  const passthrough = new PassThrough()
+
+  original.pipe(request)
+  original.pipe(passthrough)
+  ;(request as any).__readable = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of passthrough) {
+        controller.enqueue(chunk)
+      }
+
+      controller.close()
+    },
+  })
+
+  return request
+}

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -59,13 +59,12 @@ export async function run(params: {
       crypto: new polyfills.Crypto(),
       fetch: (input: RequestInfo, init: RequestInit = {}) => {
         const url = getFetchURL(input, params.request.headers)
-        init.headers = getFetchHeaders(params.name, init)
         if (isRequestLike(input)) {
           return fetch(url, {
             ...init,
             headers: {
               ...Object.fromEntries(input.headers),
-              ...Object.fromEntries(init.headers),
+              ...Object.fromEntries(getFetchHeaders(params.name, init)),
             },
           })
         }

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -187,7 +187,7 @@ function getFetchHeaders(middleware: string, init: RequestInit) {
   const prevsub = headers.get(`x-middleware-subrequest`) || ''
   const value = prevsub.split(':').concat(middleware).join(':')
   headers.set(`x-middleware-subrequest`, value)
-  headers.set(`user-agent`, `Next.JS Middleware`)
+  headers.set(`user-agent`, `Next.js Middleware`)
   return headers
 }
 

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -1,4 +1,4 @@
-import type { RequestData, FetchEventResult } from '../types'
+import type { RequestData, FetchEventResult, NodeHeaders } from '../types'
 import { Blob, File, FormData } from 'next/dist/compiled/formdata-node'
 import { dirname } from 'path'
 import { ReadableStream } from 'next/dist/compiled/web-streams-polyfill'
@@ -57,7 +57,20 @@ export async function run(params: {
       },
       Crypto: polyfills.Crypto,
       crypto: new polyfills.Crypto(),
-      fetch,
+      fetch: (input: RequestInfo, init: RequestInit = {}) => {
+        const url = getFetchURL(input, params.request.headers)
+        init.headers = getFetchHeaders(params.name, init)
+        if (isRequestLike(input)) {
+          return fetch(url, {
+            ...init,
+            headers: {
+              ...Object.fromEntries(input.headers),
+              ...Object.fromEntries(init.headers),
+            },
+          })
+        }
+        return fetch(url, init)
+      },
       File,
       FormData,
       process: { env: { ...process.env } },
@@ -167,4 +180,27 @@ function sandboxRequire(referrer: string, specifier: string) {
   }
   module.loaded = true
   return module.exports
+}
+
+function getFetchHeaders(middleware: string, init: RequestInit) {
+  const headers = new Headers(init.headers ?? {})
+  const prevsub = headers.get(`x-middleware-subrequest`) || ''
+  const value = prevsub.split(':').concat(middleware).join(':')
+  headers.set(`x-middleware-subrequest`, value)
+  headers.set(`user-agent`, `Next.JS Middleware`)
+  return headers
+}
+
+function getFetchURL(input: RequestInfo, headers: NodeHeaders = {}): string {
+  const initurl = isRequestLike(input) ? input.url : input
+  if (initurl.startsWith('/')) {
+    const host = headers.host?.toString()
+    const localhost = host === 'localhost' || host?.startsWith('localhost:')
+    return `${localhost ? 'http' : 'https'}://${host}${initurl}`
+  }
+  return initurl
+}
+
+function isRequestLike(obj: unknown): obj is Request {
+  return Boolean(obj && typeof obj === 'object' && 'url' in obj)
 }

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -194,7 +194,7 @@ function getFetchURL(input: RequestInfo, headers: NodeHeaders = {}): string {
   const initurl = isRequestLike(input) ? input.url : input
   if (initurl.startsWith('/')) {
     const host = headers.host?.toString()
-    const localhost = host === 'localhost' || host?.startsWith('localhost:')
+    const localhost = host === '127.0.0.1' || host === 'localhost' || host?.startsWith('localhost:')
     return `${localhost ? 'http' : 'https'}://${host}${initurl}`
   }
   return initurl

--- a/packages/next/server/web/types.ts
+++ b/packages/next/server/web/types.ts
@@ -5,6 +5,7 @@ export interface NodeHeaders {
 }
 
 export interface RequestData {
+  body?: ReadableStream | null
   geo?: {
     city?: string
     country?: string


### PR DESCRIPTION
This PR brings some improvements to the Middleware.

- Allows to skip sub-requests for next invocations when doing `fetch(event.request)` from a Middleware.
- Enables passing the request body to the middleware. For this we include we replace the `IncomingRequest` with a `PassThrough` that simulates the original request in order to read the body more than once.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
