### PR TITLE
Update test-pnp tests

### DIFF
--- a/scripts/test-pnp.sh
+++ b/scripts/test-pnp.sh
@@ -30,12 +30,7 @@ do
   cd "./e2e-tests/$testCase"
 
   # TODO: remove after able to load bindings with YarnPnP
-  if [ -f "next.config.js" ]; then
-    mv next.config.js next.config.bak.js
-    echo 'module.exports = { ...require("./next.config.bak.js"), experimental: { swcLoader: false } }' > next.config.js
-  else
-    echo 'module.exports = { experimental: { swcLoader: false } }' > next.config.js
-  fi
+  echo '{"presets": ["next/babel"]}' > .babelrc
 
   touch yarn.lock
   yarn set version berry


### PR DESCRIPTION
Fixes the `test-pnp` CI check failing after removing the flag we were toggling for these tests https://github.com/vercel/next.js/runs/3996538664?check_suite_focus=true