### PR TITLE
New Middleware API signature

### DIFF
--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -475,9 +475,6 @@ export default class DevServer extends Server {
   }): Promise<FetchEventResult | null> {
     try {
       const result = await super.runMiddleware(params)
-      result?.promise.catch((error) =>
-        this.logErrorWithOriginalStack(error, 'unhandledRejection', 'client')
-      )
       result?.waitUntil.catch((error) =>
         this.logErrorWithOriginalStack(error, 'unhandledRejection', 'client')
       )

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -645,7 +645,6 @@ export default class Server {
 
         if (subrequests.includes(middlewareInfo.name)) {
           result = {
-            promise: Promise.resolve(),
             response: NextResponse.next(),
             waitUntil: Promise.resolve(),
           }
@@ -669,10 +668,6 @@ export default class Server {
         })
 
         if (!this.renderOpts.dev) {
-          result.promise.catch((error) => {
-            console.error(`Uncaught: middleware error after responding`, error)
-          })
-
           result.waitUntil.catch((error) => {
             console.error(`Uncaught: middleware waitUntil errored`, error)
           })

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -1,36 +1,51 @@
 import type { RequestData, FetchEventResult } from './types'
-
+import { DeprecationError } from './error'
 import { fromNodeHeaders } from './utils'
 import { NextFetchEvent } from './spec-extension/fetch-event'
-import { NextRequest } from './spec-extension/request'
+import { NextRequest, RequestInit } from './spec-extension/request'
 import { NextResponse } from './spec-extension/response'
-import { waitUntilSymbol, responseSymbol } from './spec-compliant/fetch-event'
+import { waitUntilSymbol } from './spec-compliant/fetch-event'
 
 export async function adapter(params: {
-  handler: (event: NextFetchEvent) => void | Promise<void>
+  handler: (request: NextRequest, event: NextFetchEvent) => Promise<Response>
   request: RequestData
 }): Promise<FetchEventResult> {
   const url = params.request.url.startsWith('/')
     ? `https://${params.request.headers.host}${params.request.url}`
     : params.request.url
 
-  const event = new NextFetchEvent(
-    new NextRequest(url, {
-      geo: params.request.geo,
-      headers: fromNodeHeaders(params.request.headers),
-      ip: params.request.ip,
-      method: params.request.method,
-      nextConfig: params.request.nextConfig,
-      page: params.request.page,
-    })
-  )
+  const request = new NextRequestHint(url, {
+    geo: params.request.geo,
+    headers: fromNodeHeaders(params.request.headers),
+    ip: params.request.ip,
+    method: params.request.method,
+    nextConfig: params.request.nextConfig,
+    page: params.request.page,
+  })
 
-  const handled = params.handler(event)
-  const original = await event[responseSymbol]
+  const event = new NextFetchEvent(request)
+  const original = await params.handler(request, event)
 
   return {
-    promise: Promise.resolve(handled),
     response: original || NextResponse.next(),
     waitUntil: Promise.all(event[waitUntilSymbol]),
+  }
+}
+
+class NextRequestHint extends NextRequest {
+  constructor(input: Request | string, init: RequestInit = {}) {
+    super(input, init)
+  }
+
+  get request() {
+    throw new DeprecationError()
+  }
+
+  respondWith() {
+    throw new DeprecationError()
+  }
+
+  waitUntil() {
+    throw new DeprecationError()
   }
 }

--- a/packages/next/server/web/error.ts
+++ b/packages/next/server/web/error.ts
@@ -1,0 +1,10 @@
+export class DeprecationError extends Error {
+  constructor() {
+    super(`Middleware now accepts an async API directly with the form:
+  
+  export function middleware(request, event) {
+    return new Response("Hello " + request.url)
+  }
+  `)
+  }
+}

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -187,7 +187,7 @@ function getFetchHeaders(middleware: string, init: RequestInit) {
   const prevsub = headers.get(`x-middleware-subrequest`) || ''
   const value = prevsub.split(':').concat(middleware).join(':')
   headers.set(`x-middleware-subrequest`, value)
-  headers.set(`user-agent`, `Next.JS Middleware`)
+  headers.set(`user-agent`, `Next.js Middleware`)
   return headers
 }
 
@@ -195,7 +195,7 @@ function getFetchURL(input: RequestInfo, headers: NodeHeaders = {}): string {
   const initurl = isRequestLike(input) ? input.url : input
   if (initurl.startsWith('/')) {
     const host = headers.host?.toString()
-    const localhost = host === 'localhost' || host?.startsWith('localhost:')
+    const localhost = host === '127.0.0.1' || host === 'localhost' || host?.startsWith('localhost:')
     return `${localhost ? 'http' : 'https'}://${host}${initurl}`
   }
   return initurl

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -1,4 +1,4 @@
-import type { RequestData, FetchEventResult } from '../types'
+import type { RequestData, FetchEventResult, NodeHeaders } from '../types'
 import { Blob, File, FormData } from 'next/dist/compiled/formdata-node'
 import { dirname } from 'path'
 import { ReadableStream } from 'next/dist/compiled/web-streams-polyfill'
@@ -57,7 +57,20 @@ export async function run(params: {
       },
       Crypto: polyfills.Crypto,
       crypto: new polyfills.Crypto(),
-      fetch,
+      fetch: (input: RequestInfo, init: RequestInit = {}) => {
+        const url = getFetchURL(input, params.request.headers)
+        init.headers = getFetchHeaders(params.name, init)
+        if (isRequestLike(input)) {
+          return fetch(url, {
+            ...init,
+            headers: {
+              ...Object.fromEntries(input.headers),
+              ...Object.fromEntries(init.headers),
+            },
+          })
+        }
+        return fetch(url, init)
+      },
       File,
       FormData,
       process: { env: { ...process.env } },
@@ -167,4 +180,27 @@ function sandboxRequire(referrer: string, specifier: string) {
   }
   module.loaded = true
   return module.exports
+}
+
+function getFetchHeaders(middleware: string, init: RequestInit) {
+  const headers = new Headers(init.headers ?? {})
+  const prevsub = headers.get(`x-middleware-subrequest`) || ''
+  const value = prevsub.split(':').concat(middleware).join(':')
+  headers.set(`x-middleware-subrequest`, value)
+  headers.set(`user-agent`, `Next.JS Middleware`)
+  return headers
+}
+
+function getFetchURL(input: RequestInfo, headers: NodeHeaders = {}): string {
+  const initurl = isRequestLike(input) ? input.url : input
+  if (initurl.startsWith('/')) {
+    const host = headers.host?.toString()
+    const localhost = host === 'localhost' || host?.startsWith('localhost:')
+    return `${localhost ? 'http' : 'https'}://${host}${initurl}`
+  }
+  return initurl
+}
+
+function isRequestLike(obj: unknown): obj is Request {
+  return Boolean(obj && typeof obj === 'object' && 'url' in obj)
 }

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -195,7 +195,10 @@ function getFetchURL(input: RequestInfo, headers: NodeHeaders = {}): string {
   const initurl = isRequestLike(input) ? input.url : input
   if (initurl.startsWith('/')) {
     const host = headers.host?.toString()
-    const localhost = host === '127.0.0.1' || host === 'localhost' || host?.startsWith('localhost:')
+    const localhost =
+      host === '127.0.0.1' ||
+      host === 'localhost' ||
+      host?.startsWith('localhost:')
     return `${localhost ? 'http' : 'https'}://${host}${initurl}`
   }
   return initurl

--- a/packages/next/server/web/spec-extension/fetch-event.ts
+++ b/packages/next/server/web/spec-extension/fetch-event.ts
@@ -1,3 +1,4 @@
+import { DeprecationError } from '../error'
 import { FetchEvent } from '../spec-compliant/fetch-event'
 import { NextRequest } from './request'
 
@@ -6,5 +7,9 @@ export class NextFetchEvent extends FetchEvent {
   constructor(request: NextRequest) {
     super(request)
     this.request = request
+  }
+
+  respondWith() {
+    throw new DeprecationError()
   }
 }

--- a/packages/next/server/web/spec-extension/request.ts
+++ b/packages/next/server/web/spec-extension/request.ts
@@ -91,7 +91,7 @@ export class NextRequest extends Request {
   }
 }
 
-interface RequestInit extends globalThis.RequestInit {
+export interface RequestInit extends globalThis.RequestInit {
   geo?: {
     city?: string
     country?: string

--- a/packages/next/server/web/types.ts
+++ b/packages/next/server/web/types.ts
@@ -26,7 +26,6 @@ export interface RequestData {
 }
 
 export interface FetchEventResult {
-  promise: Promise<any>
   response: Response
   waitUntil: Promise<any>
 }

--- a/test/integration/middleware-base-path/pages/_middleware.js
+++ b/test/integration/middleware-base-path/pages/_middleware.js
@@ -1,14 +1,14 @@
 import { NextResponse } from 'next/server'
 
-export function middleware(event) {
-  const url = event.request.nextUrl
+export async function middleware(request) {
+  const url = request.nextUrl
   if (url.pathname === '/redirect-with-basepath' && !url.basePath) {
     url.basePath = '/root'
-    event.respondWith(NextResponse.redirect(url))
+    return NextResponse.redirect(url)
   }
 
   if (url.pathname === '/redirect-with-basepath') {
     url.pathname = '/about'
-    event.respondWith(NextResponse.rewrite(url))
+    return NextResponse.rewrite(url)
   }
 }

--- a/test/integration/middleware-core/pages/interface/_middleware.js
+++ b/test/integration/middleware-core/pages/interface/_middleware.js
@@ -1,14 +1,12 @@
-export function middleware(event) {
-  event.respondWith(
-    new Response(null, {
-      headers: {
-        'req-url-basepath': event.request.nextUrl.basePath,
-        'req-url-pathname': event.request.nextUrl.pathname,
-        'req-url-params': JSON.stringify(event.request.page.params),
-        'req-url-page': event.request.page.name,
-        'req-url-query': event.request.nextUrl.searchParams.get('foo'),
-        'req-url-locale': event.request.nextUrl.locale,
-      },
-    })
-  )
+export function middleware(request) {
+  return new Response(null, {
+    headers: {
+      'req-url-basepath': request.nextUrl.basePath,
+      'req-url-pathname': request.nextUrl.pathname,
+      'req-url-params': JSON.stringify(request.page.params),
+      'req-url-page': request.page.name,
+      'req-url-query': request.nextUrl.searchParams.get('foo'),
+      'req-url-locale': request.nextUrl.locale,
+    },
+  })
 }

--- a/test/integration/middleware-core/pages/redirects/_middleware.js
+++ b/test/integration/middleware-core/pages/redirects/_middleware.js
@@ -1,9 +1,5 @@
-export function middleware(event) {
-  event.respondWith(handleRequest(event))
-}
-
-async function handleRequest(event) {
-  const url = event.request.nextUrl
+export async function middleware(request) {
+  const url = request.nextUrl
 
   if (url.searchParams.get('foo') === 'bar') {
     url.pathname = '/redirects/new-home'

--- a/test/integration/middleware-core/pages/responses/_middleware.js
+++ b/test/integration/middleware-core/pages/responses/_middleware.js
@@ -10,15 +10,14 @@ export async function middleware(request, ev) {
   const encoder = new TextEncoder()
   const next = NextResponse.next()
 
-  // Sends a header
-  if (url.pathname === '/responses/header') {
-    next.headers.set('x-first-header', 'valid')
-    return next
-  }
-
   // Header based on query param
   if (url.searchParams.get('nested-header') === 'true') {
     next.headers.set('x-nested-header', 'valid')
+  }
+
+  // Sends a header
+  if (url.pathname === '/responses/header') {
+    next.headers.set('x-first-header', 'valid')
     return next
   }
 

--- a/test/integration/middleware-core/pages/responses/_middleware.js
+++ b/test/integration/middleware-core/pages/responses/_middleware.js
@@ -2,10 +2,10 @@ import { createElement } from 'react'
 import { renderToString } from 'react-dom/server.browser'
 import { NextResponse } from 'next/server'
 
-export async function middleware(event) {
+export async function middleware(request, ev) {
   // eslint-disable-next-line no-undef
   const { readable, writable } = new TransformStream()
-  const url = event.request.nextUrl
+  const url = request.nextUrl
   const writer = writable.getWriter()
   const encoder = new TextEncoder()
   const next = NextResponse.next()
@@ -13,60 +13,64 @@ export async function middleware(event) {
   // Sends a header
   if (url.pathname === '/responses/header') {
     next.headers.set('x-first-header', 'valid')
-    event.respondWith(next)
+    return next
   }
 
   // Header based on query param
   if (url.searchParams.get('nested-header') === 'true') {
     next.headers.set('x-nested-header', 'valid')
-    event.respondWith(next)
+    return next
   }
 
   // Streams a basic response
   if (url.pathname === '/responses/stream-a-response') {
-    event.respondWith(new Response(readable))
-    writer.write(encoder.encode('this is a streamed '))
-    writer.write(encoder.encode('response'))
-    writer.close()
-    return
+    ev.waitUntil(
+      (async () => {
+        writer.write(encoder.encode('this is a streamed '))
+        writer.write(encoder.encode('response'))
+        writer.close()
+      })()
+    )
+
+    return new Response(readable)
   }
 
   if (url.pathname === '/responses/bad-status') {
-    event.respondWith(
-      new Response('Auth required', {
-        headers: { 'WWW-Authenticate': 'Basic realm="Secure Area"' },
-        status: 401,
-      })
-    )
+    return new Response('Auth required', {
+      headers: { 'WWW-Authenticate': 'Basic realm="Secure Area"' },
+      status: 401,
+    })
   }
 
   if (url.pathname === '/responses/stream-long') {
-    event.respondWith(new Response(readable))
-    writer.write(encoder.encode('this is a streamed '.repeat(10)))
-    await sleep(2000)
-    writer.write(encoder.encode('after 2 seconds '.repeat(10)))
-    await sleep(2000)
-    writer.write(encoder.encode('after 4 seconds '.repeat(10)))
-    await sleep(2000)
-    writer.close()
-    return
+    ev.waitUntil(
+      (async () => {
+        writer.write(encoder.encode('this is a streamed '.repeat(10)))
+        await sleep(2000)
+        writer.write(encoder.encode('after 2 seconds '.repeat(10)))
+        await sleep(2000)
+        writer.write(encoder.encode('after 4 seconds '.repeat(10)))
+        await sleep(2000)
+        writer.close()
+      })()
+    )
+
+    return new Response(readable)
   }
 
   // Sends response
   if (url.pathname === '/responses/send-response') {
-    return event.respondWith(new Response(JSON.stringify({ message: 'hi!' })))
+    return new Response(JSON.stringify({ message: 'hi!' }))
   }
 
   // Render React component
   if (url.pathname === '/responses/react') {
-    return event.respondWith(
-      new Response(
-        renderToString(
-          createElement(
-            'h1',
-            {},
-            'SSR with React! Hello, ' + url.searchParams.get('name')
-          )
+    return new Response(
+      renderToString(
+        createElement(
+          'h1',
+          {},
+          'SSR with React! Hello, ' + url.searchParams.get('name')
         )
       )
     )
@@ -74,21 +78,27 @@ export async function middleware(event) {
 
   // Stream React component
   if (url.pathname === '/responses/react-stream') {
-    event.respondWith(new Response(readable))
-    writer.write(
-      encoder.encode(renderToString(createElement('h1', {}, 'I am a stream')))
+    ev.waitUntil(
+      (async () => {
+        writer.write(
+          encoder.encode(
+            renderToString(createElement('h1', {}, 'I am a stream'))
+          )
+        )
+        await sleep(500)
+        writer.write(
+          encoder.encode(
+            renderToString(createElement('p', {}, 'I am another stream'))
+          )
+        )
+        writer.close()
+      })()
     )
-    await sleep(500)
-    writer.write(
-      encoder.encode(
-        renderToString(createElement('p', {}, 'I am another stream'))
-      )
-    )
-    writer.close()
-    return
+
+    return new Response(readable)
   }
 
-  event.respondWith(next)
+  return next
 }
 
 function sleep(time) {

--- a/test/integration/middleware-core/pages/rewrites/_middleware.js
+++ b/test/integration/middleware-core/pages/rewrites/_middleware.js
@@ -1,31 +1,31 @@
 import { NextResponse } from 'next/server'
 
-export function middleware(event) {
-  const url = event.request.nextUrl
+export async function middleware(request) {
+  const url = request.nextUrl
 
   if (url.pathname === '/rewrites/rewrite-to-ab-test') {
-    let bucket = event.request.cookies.bucket
+    let bucket = request.cookies.bucket
     if (!bucket) {
       bucket = Math.random() >= 0.5 ? 'a' : 'b'
       const response = NextResponse.rewrite(`/rewrites/${bucket}`)
       response.cookie('bucket', bucket)
-      return event.respondWith(response)
+      return response
     }
 
-    return event.respondWith(NextResponse.rewrite(`/rewrites/${bucket}`))
+    return NextResponse.rewrite(`/rewrites/${bucket}`)
   }
 
   if (url.pathname === '/rewrites/rewrite-me-to-about') {
-    return event.respondWith(NextResponse.rewrite('/rewrites/about'))
+    return NextResponse.rewrite('/rewrites/about')
   }
 
   if (url.pathname === '/rewrites/rewrite-me-to-vercel') {
-    return event.respondWith(NextResponse.rewrite('https://vercel.com'))
+    return NextResponse.rewrite('https://vercel.com')
   }
 
   if (url.pathname === '/rewrites/rewrite-me-without-hard-navigation') {
     url.pathname = '/rewrites/about'
     url.searchParams.set('middleware', 'foo')
-    event.respondWith(NextResponse.rewrite(url))
+    return NextResponse.rewrite(url)
   }
 }

--- a/test/integration/middleware-core/test/index.test.js
+++ b/test/integration/middleware-core/test/index.test.js
@@ -316,15 +316,6 @@ function responseTests(locale = '') {
     )
     expect(res.headers.get('x-first-header')).toBe('valid')
   })
-
-  it(`${locale} should respond with 2 nested headers`, async () => {
-    const res = await fetchViaHTTP(
-      context.appPort,
-      `${locale}/responses/header?nested-header=true`
-    )
-    expect(res.headers.get('x-first-header')).toBe('valid')
-    expect(res.headers.get('x-nested-header')).toBe('valid')
-  })
 }
 
 function interfaceTests(locale = '') {

--- a/test/integration/middleware-core/test/index.test.js
+++ b/test/integration/middleware-core/test/index.test.js
@@ -309,6 +309,15 @@ function responseTests(locale = '') {
     expect($('.title').text()).toBe('Hello World')
   })
 
+  it(`${locale} should respond with 2 nested headers`, async () => {
+    const res = await fetchViaHTTP(
+      context.appPort,
+      `${locale}/responses/header?nested-header=true`
+    )
+    expect(res.headers.get('x-first-header')).toBe('valid')
+    expect(res.headers.get('x-nested-header')).toBe('valid')
+  })
+
   it(`${locale} should respond with a header`, async () => {
     const res = await fetchViaHTTP(
       context.appPort,


### PR DESCRIPTION
This PR updates the middleware signature to instead expose an async function with an interface:

```typescript
export async function middleware(request, event) {
  // ....
}
```

The usage of `event.respondWith` will throw with an error showing the new API and so will do calling `request.respondWith` and `request.waitUntil` to help with the migration. This is much simpler since we don't have to deal with the definition of synchronous event handlers.

Also, this PR brings updates to improve the way we handle subrequests and avoid infinite loops.

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

