### PR TITLE
Warn when mutating res if not streaming

### DIFF
--- a/errors/gssp-no-mutating-res.md
+++ b/errors/gssp-no-mutating-res.md
@@ -12,6 +12,8 @@ For this reason, accessing the object after this time is disallowed.
 
 You can fix this error by moving any access of the `res` object into `getServerSideProps()` itself or any functions that run before `getServerSideProps()` returns.
 
+If you’re using a custom server and running into this problem due to session middleware like `next-session` or `express-session`, try installing the middleware in the server instead of `getServerSideProps()`.
+
 ### Useful Links
 
 - [Data Fetching Docs](https://nextjs.org/docs/basic-features/data-fetching)

--- a/test/integration/getserversideprops/pages/promise/mutate-res-no-streaming.js
+++ b/test/integration/getserversideprops/pages/promise/mutate-res-no-streaming.js
@@ -1,0 +1,20 @@
+let mutatedResNoStreaming
+
+export async function getServerSideProps(context) {
+  mutatedResNoStreaming = context.res
+  return {
+    props: {
+      text: 'res',
+    },
+  }
+}
+
+export default ({ text }) => {
+  mutatedResNoStreaming.setHeader('test-header', 'this is a test header')
+
+  return (
+    <>
+      <div>hello {text}</div>
+    </>
+  )
+}

--- a/test/integration/getserversideprops/test/index.test.js
+++ b/test/integration/getserversideprops/test/index.test.js
@@ -151,6 +151,14 @@ const expectedManifestRoutes = () => [
     dataRouteRegex: normalizeRegEx(
       `^\\/_next\\/data\\/${escapeRegex(
         buildId
+      )}\\/promise\\/mutate-res-no-streaming.json$`
+    ),
+    page: '/promise/mutate-res-no-streaming',
+  },
+  {
+    dataRouteRegex: normalizeRegEx(
+      `^\\/_next\\/data\\/${escapeRegex(
+        buildId
       )}\\/promise\\/mutate-res-props.json$`
     ),
     page: '/promise/mutate-res-props',
@@ -738,6 +746,19 @@ const runTests = (dev = false) => {
         `You should not access 'res' after getServerSideProps resolves`
       )
     })
+
+    it('should only warn for accessing res if not streaming', async () => {
+      const html = await renderViaHTTP(
+        appPort,
+        '/promise/mutate-res-no-streaming'
+      )
+      expect(html).not.toContain(
+        `You should not access 'res' after getServerSideProps resolves`
+      )
+      expect(stderr).toContain(
+        `You should not access 'res' after getServerSideProps resolves`
+      )
+    })
   } else {
     it('should not fetch data on mount', async () => {
       const browser = await webdriver(appPort, '/blog/post-100')
@@ -797,6 +818,11 @@ const runTests = (dev = false) => {
     })
 
     it('should not show error for accessing res after gssp returns', async () => {
+      const html = await renderViaHTTP(appPort, '/promise/mutate-res')
+      expect(html).toMatch(/hello.*?res/)
+    })
+
+    it('should not warn for accessing res after gssp returns', async () => {
       const html = await renderViaHTTP(appPort, '/promise/mutate-res')
       expect(html).toMatch(/hello.*?res/)
     })


### PR DESCRIPTION
In #29010, we started throwing an error if the res was mutated after
getServerSideProps() returned. This was to support classic streaming,
where it would be possible to accidentally mutate the response headers
after they were already sent. However, this change also caught [a few
non-streaming cases](https://github.com/vercel/next.js/pull/29010#issuecomment-943482743)
that we don't want to break.

As such, with this change, we only throw the error if res is mutated
after gSSP returns *and* you've opted into using classic streaming.
Otherwise, we will only add a warning to the console.
