### PR TITLE
Fix trace case with tsconfig/jsconfig baseUrl

### DIFF
--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -476,10 +476,12 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
 
         const CJS_RESOLVE_OPTIONS = {
           ...NODE_RESOLVE_OPTIONS,
+          modules: undefined,
           extensions: undefined,
         }
         const ESM_RESOLVE_OPTIONS = {
           ...NODE_ESM_RESOLVE_OPTIONS,
+          modules: undefined,
           extensions: undefined,
         }
 

--- a/test/integration/jsconfig-baseurl/test/index.test.js
+++ b/test/integration/jsconfig-baseurl/test/index.test.js
@@ -8,6 +8,7 @@ import {
   findPort,
   launchApp,
   killApp,
+  nextBuild,
   check,
 } from 'next-test-utils'
 
@@ -59,6 +60,23 @@ describe('TypeScript Features', () => {
       )
       await fs.writeFile(basicPage, contents)
       expect(found).toBe(true)
+    })
+  })
+
+  describe('should build', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+    })
+    it('should trace correctly', async () => {
+      const helloTrace = await fs.readJSON(
+        join(appDir, '.next/server/pages/hello.js.nft.json')
+      )
+      expect(
+        helloTrace.files.some((file) => file.includes('components/world.js'))
+      ).toBe(true)
+      expect(
+        helloTrace.files.some((file) => file.includes('react/index.js'))
+      ).toBe(true)
     })
   })
 })

--- a/test/integration/jsconfig-paths/test/index.test.js
+++ b/test/integration/jsconfig-paths/test/index.test.js
@@ -7,6 +7,7 @@ import {
   renderViaHTTP,
   findPort,
   launchApp,
+  nextBuild,
   killApp,
   check,
 } from 'next-test-utils'
@@ -76,6 +77,52 @@ describe('TypeScript Features', () => {
       )
       await fs.writeFile(basicPage, contents)
       expect(found).toBe(true)
+    })
+  })
+
+  describe('should build', () => {
+    beforeAll(async () => {
+      await nextBuild(appDir)
+    })
+    it('should trace correctly', async () => {
+      const singleAliasTrace = await fs.readJSON(
+        join(appDir, '.next/server/pages/single-alias.js.nft.json')
+      )
+      const wildcardAliasTrace = await fs.readJSON(
+        join(appDir, '.next/server/pages/wildcard-alias.js.nft.json')
+      )
+      const resolveOrderTrace = await fs.readJSON(
+        join(appDir, '.next/server/pages/resolve-order.js.nft.json')
+      )
+      const resolveFallbackTrace = await fs.readJSON(
+        join(appDir, '.next/server/pages/resolve-fallback.js.nft.json')
+      )
+      const basicAliasTrace = await fs.readJSON(
+        join(appDir, '.next/server/pages/basic-alias.js.nft.json')
+      )
+      expect(
+        singleAliasTrace.files.some((file) =>
+          file.includes('components/hello.js')
+        )
+      ).toBe(true)
+      expect(
+        wildcardAliasTrace.files.some((file) =>
+          file.includes('mypackage/myfile.js')
+        )
+      ).toBe(true)
+      expect(
+        resolveOrderTrace.files.some((file) => file.includes('lib/a/api.js'))
+      ).toBe(true)
+      expect(
+        resolveFallbackTrace.files.some((file) =>
+          file.includes('lib/b/b-only.js')
+        )
+      ).toBe(true)
+      expect(
+        basicAliasTrace.files.some((file) =>
+          file.includes('components/world.js')
+        )
+      ).toBe(true)
     })
   })
 })


### PR DESCRIPTION
This ensures we resolves files using `baseUrl` correctly and adds tests for both only `baseUrl` being configured and `baseUrl` + `paths`. 

Fixes: https://github.com/vercel/next.js/issues/30279

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

