### PR TITLE
Update swc-minify-enabled link

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -367,7 +367,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
 
   if (result.swcMinify) {
     Log.warn(
-      'SWC minify beta enabled. nextjs.org/docs/messages/swc-minify-enabled'
+      'SWC minify beta enabled. https://nextjs.org/docs/messages/swc-minify-enabled'
     )
   }
 


### PR DESCRIPTION
Makes sure we prefix the docs link with `https://`
## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
