### PR TITLE
Move outputFileTracing config up

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -877,7 +877,7 @@ export default async function build(
                   )
                 })
 
-                if (config.experimental.outputFileTracing) {
+                if (config.outputFileTracing) {
                   pageTraceIncludes.set(page, workerResult.traceIncludes || [])
                   pageTraceExcludes.set(page, workerResult.traceExcludes || [])
                 }
@@ -1021,7 +1021,7 @@ export default async function build(
       )
     }
 
-    if (config.experimental.outputFileTracing) {
+    if (config.outputFileTracing) {
       const { nodeFileTrace } =
         require('next/dist/compiled/@vercel/nft') as typeof import('next/dist/compiled/@vercel/nft')
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1229,7 +1229,7 @@ export default async function getBaseWebpackConfig(
           pagesDir,
         }),
       !isServer && new DropClientPage(),
-      config.experimental.outputFileTracing &&
+      config.outputFileTracing &&
         !isLikeServerless &&
         isServer &&
         !dev &&

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -116,6 +116,7 @@ export type NextConfig = { [key: string]: any } & {
     webpack5?: false
     strictPostcssConfiguration?: boolean
   }
+  outputFileTracing?: boolean
   staticPageGenerationTimeout?: number
   crossOrigin?: false | 'anonymous' | 'use-credentials'
   swcMinify?: boolean
@@ -145,7 +146,6 @@ export type NextConfig = { [key: string]: any } & {
     craCompat?: boolean
     esmExternals?: boolean | 'loose'
     isrMemoryCacheSize?: number
-    outputFileTracing?: boolean
     concurrentFeatures?: boolean
     serverComponents?: boolean
     fullySpecified?: boolean
@@ -201,6 +201,7 @@ export const defaultConfig: NextConfig = {
   httpAgentOptions: {
     keepAlive: true,
   },
+  outputFileTracing: true,
   staticPageGenerationTimeout: 60,
   swcMinify: false,
   experimental: {
@@ -226,7 +227,6 @@ export const defaultConfig: NextConfig = {
     esmExternals: true,
     // default to 50MB limit
     isrMemoryCacheSize: 50 * 1024 * 1024,
-    outputFileTracing: true,
     concurrentFeatures: false,
     serverComponents: false,
     fullySpecified: false,

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -371,14 +371,6 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     )
   }
 
-  if (result.experimental && 'nftTracing' in (result.experimental as any)) {
-    // TODO: remove this warning and assignment when we leave experimental phase
-    Log.warn(
-      `Experimental \`nftTracing\` has been renamed to \`outputFileTracing\`. Please update your ${configFileName} file accordingly.`
-    )
-    result.outputFileTracing = (result.experimental as any).nftTracing
-  }
-
   // TODO: Change defaultConfig type to NextConfigComplete
   // so we don't need "!" here.
   setHttpAgentOptions(

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -376,9 +376,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     Log.warn(
       `Experimental \`nftTracing\` has been renamed to \`outputFileTracing\`. Please update your ${configFileName} file accordingly.`
     )
-    result.experimental.outputFileTracing = (
-      result.experimental as any
-    ).nftTracing
+    result.outputFileTracing = (result.experimental as any).nftTracing
   }
 
   // TODO: Change defaultConfig type to NextConfigComplete

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -20,11 +20,6 @@ describe('prerender native module', () => {
         sqlite: '4.0.22',
         sqlite3: '5.0.2',
       },
-      nextConfig: {
-        experimental: {
-          outputFileTracing: true,
-        },
-      },
     })
   })
   afterAll(() => next.destroy())

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -28,9 +28,6 @@ describe('Prerender', () => {
         firebase: '7.14.5',
       },
       nextConfig: {
-        experimental: {
-          outputFileTracing: true,
-        },
         async rewrites() {
           return [
             {

--- a/test/integration/build-trace-extra-entries/app/next.config.js
+++ b/test/integration/build-trace-extra-entries/app/next.config.js
@@ -1,9 +1,6 @@
 const path = require('path')
 
 module.exports = {
-  experimental: {
-    outputFileTracing: true,
-  },
   webpack(cfg, { isServer }) {
     console.log(cfg.entry)
     const origEntry = cfg.entry

--- a/test/integration/production-swcminify/next.config.js
+++ b/test/integration/production-swcminify/next.config.js
@@ -3,9 +3,6 @@ setInterval(() => {}, 250)
 
 module.exports = {
   swcMinify: true,
-  experimental: {
-    outputFileTracing: true,
-  },
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,

--- a/test/integration/production/next.config.js
+++ b/test/integration/production/next.config.js
@@ -2,9 +2,6 @@
 setInterval(() => {}, 250)
 
 module.exports = {
-  experimental: {
-    outputFileTracing: true,
-  },
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -30,9 +30,6 @@ describe('should set-up next', () => {
         ),
       },
       nextConfig: {
-        experimental: {
-          outputFileTracing: true,
-        },
         eslint: {
           ignoreDuringBuilds: true,
         },


### PR DESCRIPTION
This moves the `outputFileTracing` config up.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
