### PR TITLE
Ensure null bytes in resolved path are handled

### DIFF
--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -432,7 +432,9 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
                     // package.json could be needed for resolving e.g. stylis
                     // stylis/package.json -> stylis/dist/umd/package.json
                     if (result.includes('node_modules')) {
-                      let requestPath = result.replace(/\\/g, '/')
+                      let requestPath = result
+                        .replace(/\\/g, '/')
+                        .replace(/\0/g, '')
 
                       if (
                         !nodePath.isAbsolute(request) &&
@@ -444,7 +446,9 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
                           request.substr(getPkgName(request)?.length || 0) +
                           nodePath.sep +
                           'package.json'
-                        ).replace(/\\/g, '/')
+                        )
+                          .replace(/\\/g, '/')
+                          .replace(/\0/g, '')
                       }
 
                       const rootSeparatorIndex = requestPath.indexOf('/')
@@ -524,7 +528,7 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
           if (!res) {
             throw new Error(`failed to resolve ${request} from ${parent}`)
           }
-          return res
+          return res.replace(/\0/g, '')
         }
 
         this.tapfinishModules(

--- a/test/integration/production/pages/index.js
+++ b/test/integration/production/pages/index.js
@@ -1,6 +1,10 @@
 import Link from 'next/link'
 
 if (typeof window === 'undefined') {
+  try {
+    let file = 'clear.js'
+    require('es5-ext/array/#/' + file)
+  } catch (_) {}
   import('nanoid').then((mod) => console.log(mod.nanoid()))
 }
 

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -123,7 +123,7 @@ describe('Production Usage', () => {
           /node_modules\/react\/package\.json/,
           /node_modules\/react\/cjs\/react\.production\.min\.js/,
         ],
-        notTests: [/node_modules\/react\/cjs\/react\.development\.js/],
+        notTests: [/node_modules\/react\/cjs\/react\.development\.js/, /\0/],
       },
       {
         page: '/client-error',
@@ -139,7 +139,7 @@ describe('Production Usage', () => {
           /next\/dist\/pages\/_error\.js/,
           /next\/error\.js/,
         ],
-        notTests: [/node_modules\/react\/cjs\/react\.development\.js/],
+        notTests: [/node_modules\/react\/cjs\/react\.development\.js/, /\0/],
       },
       {
         page: '/dynamic',
@@ -153,7 +153,7 @@ describe('Production Usage', () => {
           /next\/dist\/client\/link\.js/,
           /next\/dist\/shared\/lib\/router\/utils\/resolve-rewrites\.js/,
         ],
-        notTests: [/node_modules\/react\/cjs\/react\.development\.js/],
+        notTests: [/node_modules\/react\/cjs\/react\.development\.js/, /\0/],
       },
       {
         page: '/index',
@@ -168,12 +168,14 @@ describe('Production Usage', () => {
           /next\/dist\/shared\/lib\/router\/utils\/resolve-rewrites\.js/,
           /node_modules\/nanoid\/index\.js/,
           /node_modules\/nanoid\/url-alphabet\/index\.js/,
+          /node_modules\/es5-ext\/array\/#\/clear\.js/,
         ],
         notTests: [
           /node_modules\/react\/cjs\/react\.development\.js/,
           /node_modules\/nanoid\/index\.cjs/,
           /next\/dist\/pages\/_error\.js/,
           /next\/error\.js/,
+          /\0/,
         ],
       },
       {
@@ -188,7 +190,7 @@ describe('Production Usage', () => {
           /next\/dist\/client\/router\.js/,
           /next\/dist\/shared\/lib\/router\/utils\/resolve-rewrites\.js/,
         ],
-        notTests: [/node_modules\/react\/cjs\/react\.development\.js/],
+        notTests: [/node_modules\/react\/cjs\/react\.development\.js/, /\0/],
       },
       {
         page: '/next-import',
@@ -202,7 +204,7 @@ describe('Production Usage', () => {
           /next\/dist\/client\/link\.js/,
           /next\/dist\/shared\/lib\/router\/utils\/resolve-rewrites\.js/,
         ],
-        notTests: [/next\/dist\/server\/next\.js/, /next\/dist\/bin/],
+        notTests: [/next\/dist\/server\/next\.js/, /next\/dist\/bin/, /\0/],
       },
     ]
 


### PR DESCRIPTION
This ensures we remove null bytes from the resolved path as it isn't valid when using `path`/`fs`. Additional tests have been added to ensure this is handled properly. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/30298
