### PR TITLE
feat: ignore incremental TS compilation build info

### DIFF
--- a/packages/create-next-app/templates/typescript/gitignore
+++ b/packages/create-next-app/templates/typescript/gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo


### PR DESCRIPTION
Adds `*.tsbuildinfo` to the gitignore file of the official TypeScript starter, as incremental TypeScript builds are suggested since Next.js 12.