### PR TITLE
Revert "Make check release job parallel to build job"

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -17,30 +17,13 @@ jobs:
       - name: Check examples
         run: ./scripts/check-examples.sh
 
-  checkIsRelease:
-    runs-on: ubuntu-latest
-    outputs:
-      isRelease: ${{ steps.check-release.outputs.IS_RELEASE }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 25
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - id: check-release
-        run: |
-          if [[ $(git describe --exact-match 2> /dev/null || :) = v* ]];
-            then
-              echo "::set-output name=IS_RELEASE::true"
-            else
-              echo "::set-output name=IS_RELEASE::false"
-          fi
-
   build:
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
     outputs:
       docsChange: ${{ steps.docs-change.outputs.DOCS_CHANGE }}
+      isRelease: ${{ steps.check-release.outputs.IS_RELEASE }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -49,12 +32,24 @@ jobs:
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
+
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js --timings --write-timings -g 1/1
       - name: Check docs only change
         run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
         id: docs-change
       - run: echo ${{steps.docs-change.outputs.DOCS_CHANGE}}
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - run: git describe
+      - id: check-release
+        run: |
+          if [[ $(git describe --exact-match 2> /dev/null || :) = v* ]];
+            then
+              echo "::set-output name=IS_RELEASE::true"
+            else
+              echo "::set-output name=IS_RELEASE::false"
+          fi
       - uses: actions/cache@v2
         id: cache-build
         with:
@@ -410,11 +405,10 @@ jobs:
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
   publishRelease:
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: Potentially publish release
     runs-on: ubuntu-latest
     needs:
-      - checkIsRelease
       - build
       - build-native
       - build-windows-i686
@@ -587,8 +581,8 @@ jobs:
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
 
   build-windows-i686:
-    needs: checkIsRelease
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - windows-i686 - node@14
     runs-on: windows-latest
     env:
@@ -646,8 +640,8 @@ jobs:
           path: packages/next/native/next-swc.win32-ia32-msvc.node
 
   build-windows-aarch64:
-    needs: checkIsRelease
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - windows-aarch64 - node@14
     runs-on: windows-latest
     steps:
@@ -693,8 +687,8 @@ jobs:
           path: packages/next/native/next-swc.win32-arm64-msvc.node
 
   build-linux-musl:
-    needs: checkIsRelease
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - linux-musl - node@lts
     runs-on: ubuntu-latest
     steps:
@@ -747,8 +741,8 @@ jobs:
           path: packages/next/native/next-swc.linux-x64-musl.node
 
   build-linux-aarch64:
-    needs: checkIsRelease
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - aarch64-unknown-linux-gnu - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -809,8 +803,8 @@ jobs:
           path: packages/next/native/next-swc.linux-arm64-gnu.node
 
   build-linux-aarch64-musl:
-    needs: checkIsRelease
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - aarch64-unknown-linux-musl - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -869,8 +863,8 @@ jobs:
           path: packages/next/native/next-swc.linux-arm64-musl.node
 
   build-linux-arm7:
-    needs: checkIsRelease
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - arm7-unknown-linux-gnu - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -931,8 +925,8 @@ jobs:
           path: packages/next/native/next-swc.linux-arm-gnueabihf.node
 
   build-android-aarch64:
-    needs: checkIsRelease
-    if: ${{ needs.checkIsRelease.outputs.isRelease == 'true' }}
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - Android - aarch64
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
This reverts vercel/next.js#30350 to unblock publishing and will be revisited in a follow-up PR