### PR TITLE
fix external fallback for invalid packages

### DIFF
--- a/test/integration/externals-esm/next.config.js
+++ b/test/integration/externals-esm/next.config.js
@@ -1,7 +1,4 @@
 module.exports = {
-  experimental: {
-    esmExternals: true,
-  },
   webpack(config, { isServer }) {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/test/integration/externals-esm/node_modules/esm-package1/correct.mjs
+++ b/test/integration/externals-esm/node_modules/esm-package1/correct.mjs
@@ -1,1 +1,4 @@
 export default "World";
+
+// ensure it's external
+if(!process.browser && Math.random() < 0) import("fail");

--- a/test/integration/externals-esm/node_modules/esm-package2/correct.js
+++ b/test/integration/externals-esm/node_modules/esm-package2/correct.js
@@ -1,1 +1,4 @@
 export default 'World'
+
+// ensure it's external
+if (!process.browser && Math.random() < 0) import('fail')

--- a/test/integration/externals-esm/node_modules/invalid-esm-package/correct.js
+++ b/test/integration/externals-esm/node_modules/invalid-esm-package/correct.js
@@ -1,0 +1,4 @@
+module.exports = 'World'
+
+// ensure it's external
+if (!process.browser && Math.random() < 0) require('fail')

--- a/test/integration/externals-esm/node_modules/invalid-esm-package/package.json
+++ b/test/integration/externals-esm/node_modules/invalid-esm-package/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "invalid-esm-package",
+  "exports": {
+    "./entry": {
+      "import": "./wrong.js",
+      "require": "./correct.js"
+    }
+  }
+}

--- a/test/integration/externals-esm/node_modules/invalid-esm-package/wrong.js
+++ b/test/integration/externals-esm/node_modules/invalid-esm-package/wrong.js
@@ -1,0 +1,1 @@
+export default 'Wrong'

--- a/test/integration/externals-esm/pages/ssg.js
+++ b/test/integration/externals-esm/pages/ssg.js
@@ -1,17 +1,20 @@
 import React from 'preact/compat'
 import World1 from 'esm-package1/entry'
 import World2 from 'esm-package2/entry'
+import World3 from 'invalid-esm-package/entry'
 
 export async function getStaticProps() {
   return {
-    props: {},
+    props: {
+      worlds: `${World1}+${World2}+${World3}`,
+    },
   }
 }
 
-export default function Index(props) {
+export default function Index({ worlds }) {
   return (
     <div>
-      Hello {World1}+{World2}
+      Hello {World1}+{World2}+{World3}+{worlds}
     </div>
   )
 }

--- a/test/integration/externals-esm/pages/ssr.js
+++ b/test/integration/externals-esm/pages/ssr.js
@@ -1,15 +1,20 @@
 import React from 'preact/compat'
 import World1 from 'esm-package1/entry'
 import World2 from 'esm-package2/entry'
+import World3 from 'invalid-esm-package/entry'
 
 export function getServerSideProps() {
-  return {}
+  return {
+    props: {
+      worlds: `${World1}+${World2}+${World3}`,
+    },
+  }
 }
 
-export default function Index(props) {
+export default function Index({ worlds }) {
   return (
     <div>
-      Hello {World1}+{World2}
+      Hello {World1}+{World2}+{World3}+{worlds}
     </div>
   )
 }

--- a/test/integration/externals-esm/pages/static.js
+++ b/test/integration/externals-esm/pages/static.js
@@ -1,11 +1,14 @@
 import React from 'preact/compat'
 import World1 from 'esm-package1/entry'
 import World2 from 'esm-package2/entry'
+import World3 from 'invalid-esm-package/entry'
 
-export default function Index(props) {
+const worlds = 'World+World+World'
+
+export default function Index() {
   return (
     <div>
-      Hello {World1}+{World2}
+      Hello {World1}+{World2}+{World3}+{worlds}
     </div>
   )
 }

--- a/test/integration/externals-esm/test/index.test.js
+++ b/test/integration/externals-esm/test/index.test.js
@@ -23,7 +23,8 @@ describe('Handle ESM externals with esmExternals: true', () => {
   })
   afterAll(() => killApp(app))
 
-  const expected = /Hello <!-- -->World<!-- -->\+<!-- -->World/
+  const expected =
+    /Hello <!-- -->World<!-- -->\+<!-- -->World<!-- -->\+<!-- -->World<!-- -->\+<!-- -->World\+World\+World/
 
   it('should render the static page', async () => {
     const html = await renderViaHTTP(appPort, '/static')


### PR DESCRIPTION
fallback to alternative external version also when it fails because of base resolve mismatch#

fix resolved .mjs modules treated as external

fixes #30330