### PR TITLE
Remove extra config for PR stats

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -133,13 +133,7 @@ module.exports = {
           content: `
             module.exports = {
               generateBuildId: () => 'BUILD_ID',
-              swcMinify: ${
-                // TODO: remove after stable release > 11.1.2
-                process.env.STATS_IS_RELEASE ? 'false' : 'true'
-              },
-              experimental: {
-                swcLoader: true,
-              },
+              swcMinify: true,
               webpack(config) {
                 config.optimization.minimize = false
                 config.optimization.minimizer = undefined
@@ -160,14 +154,7 @@ module.exports = {
           path: 'next.config.js',
           content: `
             module.exports = {
-              swcMinify: ${
-                // TODO: remove after stable release > 11.1.2
-                process.env.STATS_IS_RELEASE ? 'false' : 'true'
-              },
-              experimental: {
-                swcLoader: true,
-                
-              },
+              swcMinify: true,
               generateBuildId: () => 'BUILD_ID'
             }
           `,


### PR DESCRIPTION
This config can be removed now that we have done a stable release and the previous stable we are comparing against has all SWC patches. 

Note, we aren't currently comparing against babel in the default build since it doesn't have a `.babelrc` do we want to compare against this? 