### PR TITLE
Add note about no-optional to swc error doc

### DIFF
--- a/errors/failed-loading-swc.md
+++ b/errors/failed-loading-swc.md
@@ -8,6 +8,8 @@ SWC requires a binary be downloaded that is compatible specific to your system. 
 
 #### Possible Ways to Fix It
 
+You might need to allow optional packages to be installed by your package manager (remove `--no-optional` flag) for the package to download correctly.
+
 If SWC continues to fail to load you can opt-out by disabling `swcMinify` in your `next.config.js` or by adding a `.babelrc` to your project with the following content:
 
 ```json


### PR DESCRIPTION
This adds a note mentioned here https://github.com/vercel/next.js/discussions/30468#discussioncomment-1553764 about optional dependencies being disabled causing conflict. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
