### PR TITLE
Use unfiltered SWC packages when updating optional

### DIFF
--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -16,15 +16,14 @@ const cwd = process.cwd()
 
     // Copy binaries to package folders, update version, and publish
     let nativePackagesDir = path.join(cwd, 'packages/next/build/swc/npm')
-    let platforms = (await readdir(nativePackagesDir)).filter(
-      (name) => !name.startsWith('.')
-    )
+    let platforms = await readdir(nativePackagesDir)
+    const filteredPlatforms = platforms.filter((name) => !name.startsWith('.'))
     const publishedPkgs = new Set()
     // TODO: update to latest version where all pacakges were
     // successfully published
     const fallbackVersion = `12.0.1`
 
-    for (let platform of platforms) {
+    for (let platform of filteredPlatforms) {
       try {
         let binaryName = `next-swc.${platform}.node`
         await copy(


### PR DESCRIPTION
This ensures we still add filtered packages that are using the `fallbackVersion` to the `optionalDependencies` field. 
