### PR TITLE
Fix link to documentation from deprecated target config message

### DIFF
--- a/errors/deprecated-target-config.md
+++ b/errors/deprecated-target-config.md
@@ -10,4 +10,4 @@ For serverless cases, leverage the new output file traces or deploy your applica
 
 ### Useful Links
 
-- [Output File Tracing Documentation](https://nextjs.org/docs/messages/deprecated-target-config)
+- [Output File Tracing Documentation](https://nextjs.org/docs/advanced-features/output-file-tracing)


### PR DESCRIPTION
The page links to itself, but was presumably meant to link to "Output File Tracing" under "Advanced Features".