### PR TITLE
Revert incremental config to fix missing types

### DIFF
--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -5,8 +5,7 @@
     "target": "ES2017",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "jsx": "react",
-    "incremental": true
+    "jsx": "react"
   },
   "exclude": ["dist", "./*.d.ts"]
 }

--- a/test/production/typescript-basic.test.ts
+++ b/test/production/typescript-basic.test.ts
@@ -1,0 +1,40 @@
+import { createNext } from 'e2e-utils'
+import { renderViaHTTP } from 'next-test-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+
+describe('TypeScript basic', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.tsx': `
+          import { useRouter } from 'next/router'
+          import Link from 'next/link' 
+          
+          export default function Page() { 
+            const router = useRouter()
+            return (
+              <>
+                <p>hello world</p>
+                <Link href='/another'>
+                  <a>to /another</a>
+                </Link>
+              </>
+            )
+          } 
+        `,
+      },
+      dependencies: {
+        typescript: '4.4.3',
+        '@types/react': '16.9.17',
+      },
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('have built and started correctly', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('hello world')
+  })
+})


### PR DESCRIPTION
This reverts the `incremental` config change from https://github.com/vercel/next.js/pull/30371 since it seems to cause missing types in our `dist` folder.  This also adds an initial isolated TypeScript test to ensure we don't regress on this. We should also work to migrate the other TypeScript tests to isolated so they are being tested properly. 