### PR TITLE
Fix check compiled step 

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -71,7 +71,7 @@ jobs:
   checkPrecompiled:
     name: Check Pre-compiled
     runs-on: ubuntu-latest
-    needs: [build, build-native]
+    needs: build
     env:
       NEXT_TELEMETRY_DISABLED: 1
     steps:


### PR DESCRIPTION
This ensures the check compiled step runs without `build-native` since we only run `build-native` during publish now. 