### PR TITLE
[Do not merge] Initial fix of #30549

### DIFF
--- a/packages/next/build/webpack/loaders/next-client-pages-loader.ts
+++ b/packages/next/build/webpack/loaders/next-client-pages-loader.ts
@@ -17,7 +17,7 @@ function nextClientPagesLoader(this: any) {
     ) as ClientPagesLoaderOptions
 
     pagesLoaderSpan.setAttribute('absolutePagePath', absolutePagePath)
-
+    console.log('next-client-page-loader: ', absolutePagePath)
     const stringifiedPagePath = loaderUtils.stringifyRequest(
       this,
       absolutePagePath

--- a/packages/next/build/webpack/loaders/next-flight-client-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-client-loader.ts
@@ -65,6 +65,7 @@ function resolveClientImport(
   // This resolution algorithm will not necessarily have the same configuration
   // as the actual client loader. It should mostly work and if it doesn't you can
   // always convert to explicit exported names instead.
+  console.log(parentURL)
   const conditions = ['node', 'import']
   if (stashedResolve === null) {
     throw new Error(

--- a/packages/next/build/webpack/loaders/next-flight-server-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-server-loader.ts
@@ -3,6 +3,7 @@ import * as acorn from 'acorn'
 import { getRawPageExtensions } from '../../utils'
 
 function isClientComponent(importSource: string, pageExtensions: string[]) {
+  // console.log("importSource", importSource)
   return new RegExp(`\\.client(\\.(${pageExtensions.join('|')}))?`).test(
     importSource
   )

--- a/packages/next/build/webpack/loaders/next-middleware-loader.ts
+++ b/packages/next/build/webpack/loaders/next-middleware-loader.ts
@@ -8,6 +8,8 @@ export type MiddlewareLoaderOptions = {
 export default function middlewareLoader(this: any) {
   const { absolutePagePath, page }: MiddlewareLoaderOptions =
     loaderUtils.getOptions(this)
+  console.log('page', page)
+  console.log(absolutePagePath)
   const stringifiedPagePath = loaderUtils.stringifyRequest(
     this,
     absolutePagePath

--- a/packages/next/build/webpack/loaders/next-middleware-ssr-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-middleware-ssr-loader/index.ts
@@ -13,14 +13,17 @@ export default function middlewareRSCLoader(this: any) {
     this,
     absolutePagePath
   )
+
   const stringifiedAbsoluteDocumentPath = getStringifiedAbsolutePath(
     this,
-    './pages/_document'
+    '/.next/server/pages/_document'
   )
+  console.log(stringifiedAbsoluteDocumentPath)
   const stringifiedAbsoluteAppPath = getStringifiedAbsolutePath(
     this,
-    './pages/_app'
+    '/.next/server/pages/_app'
   )
+  console.log(stringifiedAbsolutePagePath)
 
   const transformed = `
         import { adapter } from 'next/dist/server/web/adapter'

--- a/packages/next/build/webpack/loaders/next-middleware-ssr-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-middleware-ssr-loader/utils.ts
@@ -6,3 +6,10 @@ export function getStringifiedAbsolutePath(target: any, path: string) {
     target.utils.absolutify(target.rootContext, path)
   )
 }
+
+export function getStringifiedServerPath(target: any, path: string) {
+  return loaderUtils.stringifyRequest(
+    target,
+    target.utils.absolutify(target._compilation.outputOptions.path, path)
+  )
+}

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -800,10 +800,18 @@ export class NextScript extends Component<OriginProps> {
   static getInlineScriptSource(context: Readonly<HtmlProps>): string {
     const { __NEXT_DATA__ } = context
     try {
+      console.log('__NEXT_DATA__')
+      console.log(__NEXT_DATA__)
       const data = JSON.stringify(__NEXT_DATA__)
-
+      console.log(data)
       if (process.env.NODE_ENV === 'development') {
-        const bytes = Buffer.from(data).byteLength
+        let bytes = 0
+        if (typeof Buffer !== 'undefined') {
+          bytes = Buffer.from(data).byteLength
+        } else {
+          bytes = new TextEncoder().encode(data).length
+        }
+
         const prettyBytes = require('../lib/pretty-bytes').default
         if (bytes > 128 * 1000) {
           console.warn(
@@ -817,6 +825,7 @@ export class NextScript extends Component<OriginProps> {
       return htmlEscapeJsonString(data)
     } catch (err) {
       if (isError(err) && err.message.indexOf('circular structure')) {
+        console.error(err)
         throw new Error(
           `Circular structure in "getInitialProps" result of page "${__NEXT_DATA__.page}". https://nextjs.org/docs/messages/circular-structure`
         )


### PR DESCRIPTION
## Bug

- [x] fixes #30549
- [ ] Integration tests added

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`

This issue actually occurs due to two separate bugs. First we have [next/build/webpack/loaders/next-middleware-ssr-loader/index.ts](https://github.com/vercel/next.js/blob/canary/packages/next/build/webpack/loaders/next-middleware-ssr-loader/index.ts)

The bug occurs because the following code doesn't check whether `_app` & `_document` exists but just links to them, 
```js
  const stringifiedAbsoluteDocumentPath = getStringifiedAbsolutePath(
    this,
    './pages/_document'
  )
  const stringifiedAbsoluteAppPath = getStringifiedAbsolutePath(
    this,
    './pages/_app'
  )
```
I've currently added code to just link to the pages in `.next` as an initial fix.

Doing this fixes the `file not found` errors but reveals another issue. Upon visiting a route you will get an `Error: Circular structure in "getInitialProps" result of page "/rsc"` error. The error is thrown from this page [_document](https://github.com/vercel/next.js/blob/c730f7312e563497e8769cecba54b6607a289e64/packages/next/pages/_document.tsx#L800) . However upon reading the actual error, I found out that the issue is that `Buffer is not defined`. I added a temporary fix for that as well, however I'm not sure what the actual fix is here. 

I know that Buffer is provided by webpack in the client but that doesn't seem to work here?
```js
      targetWeb &&
        new webpack.ProvidePlugin({
          Buffer: [require.resolve('buffer'), 'Buffer'],
          process: [require.resolve('process')],
        }),
```

I opened this PR because I believe I've provided useful information. Hopefully that's the case.

I used the [rsc demo](https://github.com/vercel/next-rsc-demo) to help identify the issue (v12.0.2-canary.11) but **note**, I would advise to not use `yarn next-with-deps` as your local environment as it seems to be broken with react 18.
