### PR TITLE
remove Object.fromEntries polyfill for node 10 in test utils

### DIFF
--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -20,12 +20,6 @@ import treeKill from 'tree-kill'
 export const nextServer = server
 export const pkg = _pkg
 
-// polyfill Object.fromEntries for the test/integration/relay-analytics tests
-// on node 10, this can be removed after we no longer support node 10
-if (!Object.fromEntries) {
-  Object.fromEntries = require('core-js/features/object/from-entries')
-}
-
 export function initNextServerScript(
   scriptPath,
   successRegexp,


### PR DESCRIPTION
cleanup: this removes the `Object.fromEntries` poyfill in test utils, which should no longer be required in node 12+.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
