### PR TITLE
Fix link to Elasticsearch products page

### DIFF
--- a/examples/with-elasticsearch/README.md
+++ b/examples/with-elasticsearch/README.md
@@ -4,7 +4,7 @@
 
 If you want to learn more about Elasticsearch, visit the following pages:
 
-- [Elastic Stack](https://https://www.elastic.co/products)
+- [Elastic Stack](https://www.elastic.co/products)
 - [Elastic Documentation](https://elastic.co/docs)
 
 ## Deploy your own


### PR DESCRIPTION
Small typo fix in `with-elasticsearch` example

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`