### PR TITLE
Keep attempting to load binary files after failure

### DIFF
--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -32,7 +32,6 @@ for (const triple of triples) {
   } catch (e) {
     if (e?.code !== 'MODULE_NOT_FOUND') {
       loadError = e
-      break
     }
   }
 }
@@ -46,6 +45,8 @@ if (!bindings) {
     `Failed to load SWC binary, see more info here: https://nextjs.org/docs/messages/failed-loading-swc`
   )
   process.exit(1)
+} else {
+  loadError = null
 }
 
 async function transform(src, options) {


### PR DESCRIPTION
Multiple binaries may be installed when only one of them will work with
the host machine (limitation of `optionalDependencies`). Failing to
`require` a binary that exists does not necessarily mean there is a
problem with the binary. We need to keep checking if other binaries work.

Fixes #30713

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
