### PR TITLE
Update response-helpers.md

### DIFF
--- a/docs/api-routes/response-helpers.md
+++ b/docs/api-routes/response-helpers.md
@@ -17,7 +17,7 @@ The included helpers are:
 
 When sending a response back to the client, you can set the status code of the response.
 
-The following example sets the status code of the response to `200` (`OK`) and returns a `name` property with the value of `John Doe` as a JSON response:
+The following example sets the status code of the response to `200` (`OK`) and returns a `message` property with the value of `Hello from Next.js!` as a JSON response:
 
 ```js
 export default function handler(req, res) {


### PR DESCRIPTION
In Setting the status code of a response, it says "returns a name property with the value of John Doe as a JSON response". But, the code example actually returns a message property with a different value.

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
