### PR TITLE
Re-enable minifying middleware chunks

### DIFF
--- a/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
+++ b/packages/next/build/webpack/plugins/terser-webpack-plugin/src/index.js
@@ -107,7 +107,6 @@ export class TerserPlugin {
             // and doesn't provide too much of a benefit as it's server-side
             if (name.match(/(middleware-chunks|_middleware\.js$)/)) {
               hasMiddleware = true
-              return false
             }
 
             const { info } = res
@@ -134,7 +133,7 @@ export class TerserPlugin {
       )
 
       if (hasMiddleware && webpackAsset) {
-        // emit a separate un-minified version of the webpack
+        // emit a separate version of the webpack
         // runtime for the middleware
         const asset = compilation.getAsset(webpackAsset)
         compilation.emitAsset(


### PR DESCRIPTION
This re-enables minifying middleware chunks as testing on nextjs.org and front shows it is working properly now. The separation of middleware chunks from other client chunks is still kept in this PR to ensure client code doesn't leak into middleware bundles. 

Closes: https://github.com/vercel/next.js/issues/30798

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
