### PR TITLE
Update root binary package versions after publish

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -509,6 +509,12 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: ./scripts/publish-native.js $GITHUB_REF
       - run: ./scripts/publish-release.sh
+      - run: git update-index --no-skip-worktree package.json
+      - run: yarn
+      - uses: EndBug/add-and-commit@v7
+        with:
+          add: 'package.json yarn.lock'
+          message: '⚙ Update binary package versions'
 
   releaseStats:
     name: Release Stats

--- a/package.json
+++ b/package.json
@@ -161,17 +161,17 @@
     "worker-loader": "3.0.7"
   },
   "optionalDependencies": {
-    "@next/swc-android-arm64": "canary",
-    "@next/swc-darwin-arm64": "canary",
-    "@next/swc-darwin-x64": "canary",
-    "@next/swc-linux-arm-gnueabihf": "canary",
-    "@next/swc-linux-arm64-gnu": "canary",
-    "@next/swc-linux-arm64-musl": "canary",
-    "@next/swc-linux-x64-gnu": "canary",
-    "@next/swc-linux-x64-musl": "canary",
-    "@next/swc-win32-arm64-msvc": "canary",
-    "@next/swc-win32-ia32-msvc": "canary",
-    "@next/swc-win32-x64-msvc": "canary"
+    "@next/swc-android-arm64": "12.0.3-canary.1",
+    "@next/swc-darwin-arm64": "12.0.3-canary.1",
+    "@next/swc-darwin-x64": "12.0.3-canary.1",
+    "@next/swc-linux-arm-gnueabihf": "12.0.3-canary.1",
+    "@next/swc-linux-arm64-gnu": "12.0.3-canary.1",
+    "@next/swc-linux-arm64-musl": "12.0.3-canary.1",
+    "@next/swc-linux-x64-gnu": "12.0.3-canary.1",
+    "@next/swc-linux-x64-musl": "12.0.2-canary.2",
+    "@next/swc-win32-arm64-msvc": "12.0.3-canary.1",
+    "@next/swc-win32-ia32-msvc": "12.0.3-canary.1",
+    "@next/swc-win32-x64-msvc": "12.0.3-canary.1"
   },
   "resolutions": {
     "browserslist": "4.16.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,60 +3558,60 @@
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
   integrity sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA==
 
-"@next/swc-android-arm64@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.0.2-canary.6.tgz#565ae8142102059cc2ae287daac31567855e1eb3"
-  integrity sha512-1wwB9DOPRrlyLFud16NzszDuaI+Tv8AoD0oGTtropjyXlVZTWQb2YDqCZScCaOdnAs1Vc/MDF07bdXIpC3If0g==
+"@next/swc-android-arm64@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.0.3-canary.1.tgz#828b4c4b3f132cffeed81be5700937e17d001a20"
+  integrity sha512-wJ4B4U9T1Nv59nlEiuMSAt3GT+aF8cyKiRGB9r5TGzgC5i/BoMFaVbLvAC1f2dDg5sb0blN6f75o8C30qkdzfg==
 
-"@next/swc-darwin-arm64@canary":
-  version "12.0.2-canary.5"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.2-canary.5.tgz#bc76e5432d15bfd293bcd0be8972a82eadcbdc5f"
-  integrity sha512-6ro6LoIjF5eMjadwNDdESge7XNsZfC9xcbmPX45jzLSI/W3Q7LFBBrxkwFGME/FYJWJrabgRaQd6wBH0+mQKYQ==
+"@next/swc-darwin-arm64@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.3-canary.1.tgz#e00b37aa2a99b83f505f30130136035efd4fb7b1"
+  integrity sha512-oKmE2EwzHpVSC7efxE2GAHb+smCfvZ0VkYivATbZNj+Gd2wZzzNS9ofDHU1rhQTaftmUu77Ybku6WPdtO7GrrA==
 
-"@next/swc-darwin-x64@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.2-canary.6.tgz#90c11c8f6526bad08769a710d83d3eebb5ac9dfe"
-  integrity sha512-tSLZoEBb4DipRK20Gy15iwe44pXYnSzkP2bb+oXRXYnf/TqSr4cLqRtImw+hVm+uBtX5TCQwhDwMJPLX1C9pAg==
+"@next/swc-darwin-x64@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.3-canary.1.tgz#b01cb93e70f29e56f60636efd6ca0caf0ec12a65"
+  integrity sha512-1xnc6SAIL8gVh0H2AyCZaoD08htpgQPaZShoJysY+aebCYf6MBflhILkxCGXvGhs6pvv0rNDSXHa5bZ/ezoHsA==
 
-"@next/swc-linux-arm-gnueabihf@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.2-canary.6.tgz#a5c06dd79c3f3e4da74ac84e42538a26bf87fc88"
-  integrity sha512-WIsTGpOBRcDG2S9gllyM/BswBNnD1oYt8V6PHZGCk1+MvY73IvjvuW2Mq/w7kT8onWzqe6mJec+DdoBKXpZMSQ==
+"@next/swc-linux-arm-gnueabihf@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.3-canary.1.tgz#b0308b433edb50648fbcfac8fdfd2fdeb70ee533"
+  integrity sha512-8p5HnJE6bnEE6ycZ7+1yfe11n/syc1ucgIWCgTjbEvJWKhQIySrj782kWmp2rA0qs/glhAzKZqRRHBYDEhWjrg==
 
-"@next/swc-linux-arm64-gnu@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.2-canary.6.tgz#0b371b7bb2e7036581b54dc28c5deb9fa47b22df"
-  integrity sha512-Wv1mVMkhVU027Bai9c3pKlRTFE/4lrYkA5E4naiQnTIgyh6zf/y7DK7BaQVqQdcAAV7OxcQu7AHSdA1Lco9YOQ==
+"@next/swc-linux-arm64-gnu@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.3-canary.1.tgz#d690a107b7ff0c1f893c558291bda2709e0c3c72"
+  integrity sha512-HTMSyAOkNbSQVhU8FADHOnf7a3BhaWat/ERCDsHNbH6ZyYSJ7bgRfoA6NLYsIYR/3iwp3ooHwk4z1AeC6P/shA==
 
-"@next/swc-linux-arm64-musl@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.2-canary.6.tgz#a2ada1198e59d5c37c86fc93a16bf8b48aa104eb"
-  integrity sha512-+7LL9Zsk+JemQ1qSju/bwv9tqMdD+xHsTuudbqkui+/2D0l+lGjf5xuVJd+1BLXJMJm1l0eD/ZOTdzo6UT9fdQ==
+"@next/swc-linux-arm64-musl@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.3-canary.1.tgz#2d1ae10a30c589fa31b17e0d46ce76608c23569f"
+  integrity sha512-5ER9oOQjzc8Ck2kFm4+RKDfDO4FR369brLicUDdwCbhFh3IV6kbQo0qy0KNJwN9Ck7EqRtfLE5kNHZldTNseTA==
 
-"@next/swc-linux-x64-gnu@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.2-canary.6.tgz#f25441bbd9aa8b39eca9056900762e68ebaf4fe5"
-  integrity sha512-3qLl07K+EYCM9eQlogg0GX/A7rPLecMKU/2Aq6iSvdPALzBfRxuYQNR9RgRvIzxcaGqPJmwEKm/+omTJakYnOg==
+"@next/swc-linux-x64-gnu@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.3-canary.1.tgz#f16fe509a33226d89d43f3d93c42fd21f4d658f7"
+  integrity sha512-aaw1aXHPfiw38Q3CpGzYbe0R/EdlplpHN4X8BZJLdWHu79x5U1SYoO385n/fSSkot5JSjGFFcXlqi74o65lBDg==
 
-"@next/swc-linux-x64-musl@canary":
+"@next/swc-linux-x64-musl@12.0.2-canary.2":
   version "12.0.2-canary.2"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.2-canary.2.tgz#b3ce05442610e16d50cba8302f243bebdc2d61bc"
   integrity sha512-RnWuxoHmYB4JEo0Yt9pdx5+8mbqvxr0vfULPWOzY03qLILNQakYFuZzKgtuE3DkFYeJF7yEtEAMhJ0cAwVKRSw==
 
-"@next/swc-win32-arm64-msvc@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.2-canary.6.tgz#1a8bbc514bcf544f6fe718a4394c3f236d847e90"
-  integrity sha512-2JPb7/8Dh1LS1iNC96hyWpZ4DFPi31m+bCMT1E5HaXkj75hkVjGFTNGiN3WRQ0t30kGIaBwhEh9scEWoyTcGyw==
+"@next/swc-win32-arm64-msvc@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.3-canary.1.tgz#58276bf8eb4489bfe354245b5fc0a54b79706e4e"
+  integrity sha512-qM9oit7cA9iMupd9x7IxFFNEu2f6SLntBCVZtwV1WyKOh/vr7Iq8aaMmc440HVPwZhAY7DD8Ddpu1Zfh8Uje6Q==
 
-"@next/swc-win32-ia32-msvc@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.2-canary.6.tgz#5b97d35e13c6877efb9701f91bd8dc6a0e0763f9"
-  integrity sha512-qHczht2xKYMi/ufz1zahihrmToCKUvkwz3Rdn4M8GRbYyKlrlmiv/hRskjVx6iyU34LUPzGWasaL/xcckMe00w==
+"@next/swc-win32-ia32-msvc@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.3-canary.1.tgz#14da2dbb8bb21f2ae9796bfee183dc0d2a8b35a5"
+  integrity sha512-0TBN/Y/ilack7HEkrOR0hTVLcRfJ2nCKyqjokyrZgL+NN0m4idXxRyAwAGre4o3Ye2ItNoGoHB46vr7y/LusLg==
 
-"@next/swc-win32-x64-msvc@canary":
-  version "12.0.2-canary.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.2-canary.6.tgz#031d808abd611a22e8c930baf8c15991bacb8112"
-  integrity sha512-ndmHXAtMwHr98HulDWNtVEXQXS/aXrQZncLCCtkKMztqGSExLYZtjrGpHnFuKfcuwGEC9izmnVDpm5hG0rPxbQ==
+"@next/swc-win32-x64-msvc@12.0.3-canary.1":
+  version "12.0.3-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.3-canary.1.tgz#91ed16282c1cb5c08ae760ac133ebdb3cbef3362"
+  integrity sha512-B1IZN4NcGpLcD5JwTsvRkbSfbMjF8WXBkly4JjMwmY+gGbVysVuX0InMQr6DRIttbYa8HwSYouYk4/uGxIe39w==
 
 "@node-rs/helper@^1.0.0":
   version "1.2.1"


### PR DESCRIPTION
This change will update the binary package versions in the root package's `optionalDependencies` as well as the yarn lock at the end of the `publishRelease` job.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
