### PR TITLE
Edge Functions: expose `globalThis`

### DIFF
--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -85,6 +85,7 @@ export async function run(params: {
     }
 
     context.self = context
+    context.globalThis = context
 
     cache = {
       context,

--- a/test/integration/middleware-core/pages/interface/_middleware.js
+++ b/test/integration/middleware-core/pages/interface/_middleware.js
@@ -1,3 +1,7 @@
+/* global globalThis */
+
+import { NextResponse } from 'next/server'
+
 export function middleware(request) {
   const url = request.nextUrl
 

--- a/test/integration/middleware-core/pages/interface/_middleware.js
+++ b/test/integration/middleware-core/pages/interface/_middleware.js
@@ -1,4 +1,14 @@
 export function middleware(request) {
+  const url = request.nextUrl
+
+  if (url.pathname === '/globalthis') {
+    return new NextResponse(JSON.stringify(Object.keys(globalThis)), {
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+      },
+    })
+  }
+
   return new Response(null, {
     headers: {
       'req-url-basepath': request.nextUrl.basePath,

--- a/test/integration/middleware-core/pages/interface/_middleware.js
+++ b/test/integration/middleware-core/pages/interface/_middleware.js
@@ -5,7 +5,7 @@ import { NextResponse } from 'next/server'
 export function middleware(request) {
   const url = request.nextUrl
 
-  if (url.pathname === '/globalthis') {
+  if (url.pathname.endsWith('/globalthis')) {
     return new NextResponse(JSON.stringify(Object.keys(globalThis)), {
       headers: {
         'content-type': 'application/json; charset=utf-8',

--- a/test/integration/middleware-core/test/index.test.js
+++ b/test/integration/middleware-core/test/index.test.js
@@ -346,7 +346,7 @@ function responseTests(locale = '') {
 function interfaceTests(locale = '') {
   it(`${locale} \`globalThis\` is accesible`, async () => {
     const res = await fetchViaHTTP(context.appPort, '/interface/globalthis')
-    const globals = await response.json()
+    const globals = await res.json()
     expect(globals.length > 0).toBe(true)
   })
 

--- a/test/integration/middleware-core/test/index.test.js
+++ b/test/integration/middleware-core/test/index.test.js
@@ -344,6 +344,12 @@ function responseTests(locale = '') {
 }
 
 function interfaceTests(locale = '') {
+  it(`${locale} \`globalThis\` is accesible`, async () => {
+    const res = await fetchViaHTTP(context.appPort, '/interface/globalthis')
+    const globals = await response.json()
+    expect(globals.length > 0).toBe(true)
+  })
+
   it(`${locale} should validate request url parameters from a static route`, async () => {
     const res = await fetchViaHTTP(
       context.appPort,


### PR DESCRIPTION
This PR enables to access to `globalThis` in the context of a Edge function