### PR TITLE
Re-enable linux-musl-x64 build target

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -896,7 +896,7 @@ jobs:
       - name: 'Build'
         if: ${{ steps.binary-cache.outputs.cache-hit != 'true' && steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
         run: |
-          docker run --rm -v $(pwd)/packages/next:/swc -w /swc builder sh -c "yarn build-native --release --target x86_64-unknown-linux-musl"
+          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd)/packages/next:/build -w /build builder sh -c "yarn build-native --release --target x86_64-unknown-linux-musl && strip native/swc.linux-x64-musl.node"
 
       - name: Upload artifact
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -851,60 +851,59 @@ jobs:
           name: next-swc-binaries
           path: packages/next/native/next-swc.win32-arm64-msvc.node
 
-  # Temporarily disabled
-  # build-linux-musl:
-  #   needs: build
-  #   if: ${{ needs.build.outputs.isRelease == 'true' }}
-  #   name: next-swc - linux-musl - node@lts
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
+  build-linux-musl:
+    needs: build
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    name: next-swc - linux-musl - node@lts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
-  #       id: docs-change
+      - run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
+        id: docs-change
 
-  #     - name: Login to registry
-  #       if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-  #       run: |
-  #         docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
-  #       env:
-  #         DOCKER_REGISTRY_URL: ghcr.io
-  #         DOCKER_USERNAME: ${{ github.actor }}
-  #         DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to registry
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        run: |
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
+        env:
+          DOCKER_REGISTRY_URL: ghcr.io
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Cache
-  #       if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: |
-  #           target/
-  #         key: linux-musl-publish-integration
+      - name: Cache
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            target/
+          key: linux-musl-publish-integration
 
-  #     - name: Pull docker image
-  #       if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-  #       run: |
-  #         docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-  #         docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
+      - name: Pull docker image
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        run: |
+          docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
 
-  #     - name: Cache native binary
-  #       if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-  #       id: binary-cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: packages/next/native/next-swc.linux-x64-musl.node
-  #         key: next-swc-nightly-2021-08-12-linux-x64-musl-${{ hashFiles('.github/workflows/build_test_deploy.yml', 'packages/next/build/swc/**') }}
+      - name: Cache native binary
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        id: binary-cache
+        uses: actions/cache@v2
+        with:
+          path: packages/next/native/next-swc.linux-x64-musl.node
+          key: next-swc-nightly-2021-08-12-linux-x64-musl-${{ hashFiles('.github/workflows/build_test_deploy.yml', 'packages/next/build/swc/**') }}
 
-  #     - name: 'Build'
-  #       if: ${{ steps.binary-cache.outputs.cache-hit != 'true' && steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-  #       run: |
-  #         docker run --rm -v $(pwd)/packages/next:/swc -w /swc builder sh -c "yarn build-native --release"
+      - name: 'Build'
+        if: ${{ steps.binary-cache.outputs.cache-hit != 'true' && steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        run: |
+          docker run --rm -v $(pwd)/packages/next:/swc -w /swc builder sh -c "yarn build-native --release --target x86_64-unknown-linux-musl"
 
-  #     - name: Upload artifact
-  #       if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: next-swc-binaries
-  #         path: packages/next/native/next-swc.linux-x64-musl.node
+      - name: Upload artifact
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: next-swc-binaries
+          path: packages/next/native/next-swc.linux-x64-musl.node
 
   build-linux-aarch64:
     needs: build

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -484,8 +484,7 @@ jobs:
       - build-native
       - build-windows-i686
       - build-windows-aarch64
-      # Temporarily disabled
-      # - build-linux-musl
+      - build-linux-musl
       - build-linux-arm7
       - build-linux-aarch64
       - build-android-aarch64

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -895,7 +895,7 @@ jobs:
       - name: 'Build'
         if: ${{ steps.binary-cache.outputs.cache-hit != 'true' && steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
         run: |
-          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd)/packages/next:/build -w /build builder sh -c "yarn build-native --release --target x86_64-unknown-linux-musl && strip native/swc.linux-x64-musl.node"
+          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd)/packages/next:/build -w /build builder sh -c "yarn build-native --release --target x86_64-unknown-linux-musl"
 
       - name: Upload artifact
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -286,7 +286,7 @@
         "aarch64-apple-darwin",
         "aarch64-linux-android",
         "x86_64-unknown-freebsd",
-        "linux-x64-musl",
+        "x86_64-unknown-linux-musll",
         "aarch64-unknown-linux-musl",
         "aarch64-pc-windows-msvc"
       ]

--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -20,11 +20,6 @@ const cwd = process.cwd()
       (name) => !name.startsWith('.')
     )
 
-    const publishedPkgs = new Set()
-    // TODO: update to latest version where all packages were
-    // successfully published
-    const fallbackVersion = `12.0.1`
-
     for (let platform of platforms) {
       try {
         let binaryName = `next-swc.${platform}.node`
@@ -48,10 +43,10 @@ const cwd = process.cwd()
             gitref.includes('canary') ? ' --tag canary' : ''
           }`
         )
-        publishedPkgs.add(platform)
       } catch (err) {
         // don't block publishing other versions on single platform error
-        console.error(`Failed to publish`, platform, err)
+        console.error(`Failed to publish`, platform)
+        throw err
       }
       // lerna publish in next step will fail if git status is not clean
       execSync(
@@ -69,11 +64,7 @@ const cwd = process.cwd()
     )
     for (let platform of platforms) {
       let optionalDependencies = nextPkg.optionalDependencies || {}
-      optionalDependencies['@next/swc-' + platform] = publishedPkgs.has(
-        platform
-      )
-        ? version
-        : fallbackVersion
+      optionalDependencies['@next/swc-' + platform] = version
       nextPkg.optionalDependencies = optionalDependencies
     }
     await writeFile(


### PR DESCRIPTION
This attempts re-enabling the linux-musl-x64 build target and fails publish-native when any target fails to publish again. 

x-ref: https://github.com/napi-rs/napi-rs/issues/816#issuecomment-953818657

