### PR TITLE
Fix musll typo

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -286,7 +286,7 @@
         "aarch64-apple-darwin",
         "aarch64-linux-android",
         "x86_64-unknown-freebsd",
-        "x86_64-unknown-linux-musll",
+        "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-musl",
         "aarch64-pc-windows-msvc"
       ]


### PR DESCRIPTION
Fixes typo in napi additional `musll` -> `musl`