### PR TITLE
Skip next-swc canary postinstall in CI

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
+      # we build a dev binary for use in CI so skip downloading
+      # canary next-swc binaries in the monorepo
+      NEXT_SKIP_NATIVE_POSTINSTALL: 1
     outputs:
       docsChange: ${{ steps.docs-change.outputs.DOCS_CHANGE }}
       isRelease: ${{ steps.check-release.outputs.IS_RELEASE }}

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -6,10 +6,10 @@ import fs from 'fs-extra'
   if (process.env.NEXT_SKIP_NATIVE_POSTINSTALL) {
     console.log(
       `Skipping next-swc postinstall due to NEXT_SKIP_NATIVE_POSTINSTALL env`
-    );  
+    )
     return
   }
-  
+
   try {
     let tmpdir = path.join(os.tmpdir(), `next-swc-${Date.now()}`)
     await fs.ensureDir(tmpdir)

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -3,6 +3,13 @@ import path from 'path'
 import execa from 'execa'
 import fs from 'fs-extra'
 ;(async function () {
+  if (process.env.NEXT_SKIP_NATIVE_POSTINSTALL) {
+    console.log(
+      `Skipping next-swc postinstall due to NEXT_SKIP_NATIVE_POSTINSTALL env`
+    );  
+    return
+  }
+  
   try {
     let tmpdir = path.join(os.tmpdir(), `next-swc-${Date.now()}`)
     await fs.ensureDir(tmpdir)


### PR DESCRIPTION
We can skip the canary next-swc binaries download in CI since we build a dev version, this reduces our build cache size. 