### PR TITLE
fixes #30604 - Cannot read properties of null (reading 'tagName')

### DIFF
--- a/packages/next/client/head-manager.ts
+++ b/packages/next/client/head-manager.ts
@@ -62,7 +62,7 @@ function updateElements(type: string, components: JSX.Element[]): void {
     i < headCount;
     i++, j = j!.previousElementSibling
   ) {
-    if (j!.tagName?.toLowerCase() === type) {
+    if (j?.tagName?.toLowerCase() === type) {
       oldTags.push(j!)
     }
   }

--- a/packages/next/client/head-manager.ts
+++ b/packages/next/client/head-manager.ts
@@ -62,7 +62,7 @@ function updateElements(type: string, components: JSX.Element[]): void {
     i < headCount;
     i++, j = j!.previousElementSibling
   ) {
-    if (j!.tagName.toLowerCase() === type) {
+    if (j!.tagName?.toLowerCase() === type) {
       oldTags.push(j!)
     }
   }


### PR DESCRIPTION
TypeError: Cannot read properties of null (reading 'tagName') #30604

- Fixes https://github.com/vercel/next.js/issues/30604

