### PR TITLE
Decrease lock time from 90 to 45.

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,6 +1,6 @@
 # Configuration for lock-threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 90
+daysUntilLock: 45
 # Comment to post before locking. Set to `false` to disable
 lockComment: 'This issue has been automatically locked due to no recent activity. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'


### PR DESCRIPTION
Follow up from https://github.com/vercel/next.js/pull/30902, making it a bit shorter.