### PR TITLE
Use absolute page paths from page mappings for the middleware SSR loader

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -159,6 +159,10 @@ export function createEntrypoints(
         name: '[name].js',
         value: `next-middleware-ssr-loader?${stringify({
           page,
+          absoluteAppPath: pages['/_app'],
+          absoluteDocumentPath: pages['/_document'],
+          absoluteErrorPath: pages['/_error'],
+          absolute404Path: pages['/404'] || '',
           absolutePagePath,
           isServerComponent: isFlight,
           buildId,

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -156,6 +156,7 @@ export default class HotReloader {
   private rewrites: CustomRoutes['rewrites']
   private fallbackWatcher: any
   private hotReloaderSpan: Span
+  private pagesMapping: any
 
   constructor(
     dir: string,
@@ -303,7 +304,7 @@ export default class HotReloader {
           ])
         )
 
-      const pages = webpackConfigSpan
+      this.pagesMapping = webpackConfigSpan
         .traceChild('create-pages-mapping')
         .traceFn(() =>
           createPagesMapping(
@@ -317,7 +318,7 @@ export default class HotReloader {
         .traceChild('create-entrypoints')
         .traceFn(() =>
           createEntrypoints(
-            pages,
+            this.pagesMapping,
             'server',
             this.buildId,
             this.previewProps,
@@ -511,6 +512,10 @@ export default class HotReloader {
                   name: '[name].js',
                   value: `next-middleware-ssr-loader?${stringify({
                     page,
+                    absoluteAppPath: this.pagesMapping['/_app'],
+                    absoluteDocumentPath: this.pagesMapping['/_document'],
+                    absoluteErrorPath: this.pagesMapping['/_error'],
+                    absolute404Path: this.pagesMapping['/404'] || '',
                     absolutePagePath,
                     isServerComponent,
                     buildId: this.buildId,

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -21,7 +21,7 @@ const nodeArgs = ['-r', join(__dirname, '../../react-18/test/require-hook.js')]
 const appDir = join(__dirname, '../app')
 const nativeModuleTestAppDir = join(__dirname, '../unsupported-native-module')
 const distDir = join(__dirname, '../app/.next')
-const documentPage = new File(join(appDir, 'pages/_document.js'))
+const documentPage = new File(join(appDir, 'pages/_document.tsx'))
 const appPage = new File(join(appDir, 'pages/_app.js'))
 
 const documentWithGip = `
@@ -173,7 +173,7 @@ const documentSuite = {
 
       expect(res.status).toBe(500)
       expect(html).toContain(
-        'Document.getInitialProps is not supported with server components, please remove it from pages/_document'
+        '`Document.getInitialProps` is not supported in the Edge Runtime, please make sure pages/_document exports a function component.'
       )
     })
   },


### PR DESCRIPTION
This also removes the fallback Document, so it's required to have a function Document now (but this is mentioned in the docs already).

Fixes #30714.

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
