### PR TITLE
Update ServerlessPlugin to use chunkGraph

### DIFF
--- a/packages/next/build/webpack/plugins/serverless-plugin.ts
+++ b/packages/next/build/webpack/plugins/serverless-plugin.ts
@@ -14,7 +14,8 @@ export class ServerlessPlugin {
       hook.tap('ServerlessPlugin', (chunks) => {
         for (const chunk of chunks) {
           // If chunk is not an entry point skip them
-          if (!chunk.hasEntryModule()) {
+          // @ts-ignore TODO: Remove ignore when webpack 5 is stable
+          if (compilation.chunkGraph.getNumberOfEntryModules(chunk) === 0) {
             continue
           }
 
@@ -26,7 +27,11 @@ export class ServerlessPlugin {
               dynamicChunk
             )) {
               // Add module back into the entry chunk
-              chunk.addModule(module)
+              // @ts-ignore TODO: Remove ignore when webpack 5 is stable
+              if (!compilation.chunkGraph.isModuleInChunk(module, chunk)) {
+                // @ts-ignore TODO: Remove ignore when webpack 5 is stable
+                compilation.chunkGraph.connectChunkAndModule(chunk, module)
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes warnings like `[DEP_WEBPACK_CHUNK_HAS_ENTRY_MODULE] DeprecationWarning: Chunk.hasEntryModule: Use new ChunkGraph API`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
