### PR TITLE
Fix custom 404 page when concurrentFeatures is enabled

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -37,6 +37,7 @@ import { NextConfigComplete } from '../server/config-shared'
 import isError from '../lib/is-error'
 
 const { builtinModules } = require('module')
+const RESERVED_PAGE = /^\/(_app|_error|_document|api(\/|$))/
 const fileGzipStats: { [k: string]: Promise<number> | undefined } = {}
 const fsStatGzip = (file: string) => {
   const cached = fileGzipStats[file]
@@ -1143,4 +1144,12 @@ export function getUnresolvedModuleFromError(
   )
   const [, moduleName] = error.match(moduleErrorRegex) || []
   return builtinModules.find((item: string) => item === moduleName)
+}
+
+export function isReservedPage(page: string) {
+  return RESERVED_PAGE.test(page)
+}
+
+export function isCustomErrorPage(page: string) {
+  return page === '/404' || page === '/500'
 }

--- a/packages/next/build/webpack/loaders/next-middleware-ssr-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-middleware-ssr-loader/index.ts
@@ -96,13 +96,13 @@ export default async function middlewareRSCLoader(this: any) {
             createElement(FlightWrapper, props)
           )
         }`
-            : `
-        const Component = Page`
+            : `const Component = Page`
         }
 
         async function render(request) {
           const url = request.nextUrl
-          const query = Object.fromEntries(url.searchParams)
+          const { pathname, searchParams } = url
+          const query = Object.fromEntries(searchParams)
 
           // Preflight request
           if (request.method === 'HEAD') {
@@ -122,9 +122,9 @@ export default async function middlewareRSCLoader(this: any) {
               wrapReadable(
                 renderFlight({
                   router: {
-                    route: url.pathname,
-                    asPath: url.pathname,
-                    pathname: url.pathname,
+                    route: pathname,
+                    asPath: pathname,
+                    pathname: pathname,
                     query,
                   }
                 })
@@ -165,9 +165,9 @@ export default async function middlewareRSCLoader(this: any) {
 
           try {
             const result = await renderToHTML(
-              { url: url.pathname },
+              { url: pathname },
               {},
-              url.pathname,
+              pathname,
               query,
               renderOpts
             )
@@ -177,7 +177,7 @@ export default async function middlewareRSCLoader(this: any) {
             })
           } catch (err) {
             return new Response(
-              (err || 'An error occurred while rendering ' + url.pathname + '.').toString(),
+              (err || 'An error occurred while rendering ' + pathname + '.').toString(),
               {
                 status: 500,
                 headers: { 'x-middleware-ssr': '1' }

--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -100,9 +100,8 @@ export default class MiddlewarePlugin {
     )
     middlewareManifest.clientInfo = middlewareManifest.sortedMiddleware.map(
       (key) => {
-        const ssrEntryInfo = ssrEntries.get(
-          middlewareManifest.middleware[key].name
-        )
+        const middleware = middlewareManifest.middleware[key]
+        const ssrEntryInfo = ssrEntries.get(middleware.name)
         return [key, !!ssrEntryInfo]
       }
     )

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -59,6 +59,7 @@ import isError from '../../lib/is-error'
 import { getMiddlewareRegex } from '../../shared/lib/router/utils/get-middleware-regex'
 import type { FetchEventResult } from '../web/types'
 import type { ParsedNextUrl } from '../../shared/lib/router/utils/parse-next-url'
+import { isCustomErrorPage, isReservedPage } from '../../build/utils'
 
 // Load ReactDevOverlay only when needed
 let ReactDevOverlayImpl: React.FunctionComponent
@@ -272,11 +273,7 @@ export default class DevServer extends Server {
             ssrMiddleware.add(pageName)
           } else if (
             isWebServerRuntime &&
-            !(
-              pageName === '/_app' ||
-              pageName === '/_error' ||
-              pageName === '/_document'
-            )
+            !(isReservedPage(pageName) || isCustomErrorPage(pageName))
           ) {
             routedMiddleware.push(pageName)
             ssrMiddleware.add(pageName)

--- a/test/integration/react-streaming-and-server-components/app/pages/404.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/404.js
@@ -1,0 +1,3 @@
+export default function Page404() {
+  return 'custom-404-page'
+}

--- a/test/integration/react-streaming-and-server-components/app/pages/normal.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/normal.js
@@ -1,0 +1,3 @@
+export default function Normal() {
+  return 'normal'
+}

--- a/test/integration/react-streaming-and-server-components/app/pages/normal.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/normal.js
@@ -1,3 +1,0 @@
-export default function Normal() {
-  return 'normal'
-}

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -140,6 +140,7 @@ describe('concurrentFeatures - prod', () => {
     ]) {
       expect(content.clientInfo).toContainEqual(item)
     }
+    expect(context.clientInfo).not.toContainEqual([['/404', true]])
   })
 
   it('should support React.lazy and dynamic imports', async () => {
@@ -215,11 +216,20 @@ async function runBasicTests(context) {
       '/routes/dynamic2'
     )
 
+    const path404HTML = await renderViaHTTP(context.appPort, '/404')
+    const pathNotFoundHTML = await renderViaHTTP(
+      context.appPort,
+      '/this-is-not-found'
+    )
+
     expect(homeHTML).toContain('thisistheindexpage.server')
     expect(homeHTML).toContain('foo.client')
 
     expect(dynamicRouteHTML1).toContain('[pid]')
     expect(dynamicRouteHTML2).toContain('[pid]')
+
+    expect(path404HTML).toContain('custom-404-page')
+    expect(pathNotFoundHTML).toContain('custom-404-page')
   })
 
   it('should suspense next/link on server side', async () => {

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -140,7 +140,7 @@ describe('concurrentFeatures - prod', () => {
     ]) {
       expect(content.clientInfo).toContainEqual(item)
     }
-    expect(context.clientInfo).not.toContainEqual([['/404', true]])
+    expect(content.clientInfo).not.toContainEqual([['/404', true]])
   })
 
   it('should support React.lazy and dynamic imports', async () => {


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/issues/30424#issuecomment-955615781

This fix the custom 404 is not rendering properly and can’t be built in web runtime when `concurrentFeatures` is enabled. We force 404 page to be rendered outside of middleware ssr. Then it could be the real fallback 404 page in next-server when any routes is not macthed. 
Will check 500 related after #31057 is landed.

## Bug

- [x] Related to #30989
- [x] Integration tests added



