### PR TITLE
add eslint rule for next/server imports

### DIFF
--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -506,6 +506,10 @@
         {
           "title": "middleware-new-signature",
           "path": "/errors/middleware-new-signature.md"
+        },
+        {
+          "title": "no-next-server-outside-middleware",
+          "path": "/errors/no-next-server-outside-middleware.md"
         }
       ]
     }

--- a/errors/no-next-server-outside-middleware.md
+++ b/errors/no-next-server-outside-middleware.md
@@ -1,0 +1,14 @@
+# No Next Server Outside Middleware
+
+#### Why This Error Occurred
+
+You're importing types from `next/server` that should only be imported inside `_middleware` files. You likely want to import [these types](https://nextjs.org/docs/basic-features/typescript#api-routes) instead
+
+#### Possible Ways to Fix It
+
+Remove imports from `next/server` from files that are not `_middleware`
+
+### Useful Links
+
+- [Middleware](https://nextjs.org/docs/middleware)
+- [API Routes with Typescript](https://nextjs.org/docs/basic-features/typescript#api-routes)

--- a/packages/eslint-plugin-next/lib/index.js
+++ b/packages/eslint-plugin-next/lib/index.js
@@ -18,6 +18,7 @@ module.exports = {
     'no-duplicate-head': require('./rules/no-duplicate-head'),
     'inline-script-id': require('./rules/inline-script-id'),
     'next-script-for-ga': require('./rules/next-script-for-ga'),
+    'no-next-server-outside-middleware': require('./rules/no-next-server-outside-middleware'),
   },
   configs: {
     recommended: {
@@ -41,6 +42,7 @@ module.exports = {
         '@next/next/no-typos': 1,
         '@next/next/no-duplicate-head': 2,
         '@next/next/inline-script-id': 2,
+        '@next/next/no-next-server-outside-middleware': 2,
       },
     },
     'core-web-vitals': {

--- a/packages/eslint-plugin-next/lib/rules/no-next-server-outside-middleware.js
+++ b/packages/eslint-plugin-next/lib/rules/no-next-server-outside-middleware.js
@@ -1,0 +1,34 @@
+const path = require('path')
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'next/middleware',
+      recommended: true,
+      url: 'https://nextjs.org/docs/messages/no-script-in-document-page',
+    },
+  },
+  create: function (context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'next/server') {
+          return
+        }
+
+        const filename = path.basename(
+          context.getFilename(),
+          path.extname(context.getFilename())
+        )
+
+        if (filename === '_middleware') {
+          return
+        }
+
+        context.report({
+          node,
+          message: `You're importing from \`next/server\` in files that are not \`_middleware\`. See https://nextjs.org/docs/messages/no-next-server-outside-middleware .`,
+        })
+      },
+    }
+  },
+}


### PR DESCRIPTION
## Feature

- [x] Closes https://github.com/vercel/next.js/issues/30921 .
- [x] Eslint unit tests added
- [x] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

My only issue is that the test runner seems to not accept TS code so I had to change imports from
`import type { NextFetchEvent, NextRequest } from 'next/server'` to something like
`import * as A from 'next/server'`
This will not have an impact of the accuracy of the tests.

The rule can also be made more specific to check what's imported from `next/server` if you're planning to export other modules in the future from `next/server` that are not exclusive to `_middleware`