### PR TITLE
Correcting the link to iron session typescript example

### DIFF
--- a/examples/with-iron-session/README.md
+++ b/examples/with-iron-session/README.md
@@ -13,9 +13,9 @@ It uses current best practices for authentication in the Next.js ecosystem.
 On the next-iron-session repository (https://github.com/vvo/next-iron-session) you'll find:
 
 - full API documentation and explanations on how it works
-- [TypeScript example](https://github.com/vvo/next-iron-session/tree/master/examples/next.js-typescript)
-- [JavaScript example](https://github.com/vvo/next-iron-session/tree/master/examples/next.js)
-- [Express.js example](https://github.com/vvo/next-iron-session/tree/master/examples/express)
+- [TypeScript example](https://github.com/vvo/iron-session/tree/main/examples/next.js-typescript)
+- [JavaScript example](https://github.com/vvo/iron-session/tree/main/examples/next.js)
+- [Express.js example](https://github.com/vvo/iron-session/tree/main/examples/express)
 
 **Features:**
 

--- a/examples/with-iron-session/README.md
+++ b/examples/with-iron-session/README.md
@@ -13,7 +13,7 @@ It uses current best practices for authentication in the Next.js ecosystem.
 On the next-iron-session repository (https://github.com/vvo/next-iron-session) you'll find:
 
 - full API documentation and explanations on how it works
-- [TypeScript example](https://github.com/vvo/next-iron-session/tree/master/examples/next-typescript)
+- [TypeScript example](https://github.com/vvo/next-iron-session/tree/master/examples/next.js-typescript)
 - [JavaScript example](https://github.com/vvo/next-iron-session/tree/master/examples/next.js)
 - [Express.js example](https://github.com/vvo/next-iron-session/tree/master/examples/express)
 


### PR DESCRIPTION
Correcting the link to iron session example using typescript as it is currenlty linking to a 404 page

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
