### PR TITLE
Change .web extension of document page to part of path

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -65,7 +65,7 @@ export function createPagesMapping(
   // we alias these in development and allow webpack to
   // allow falling back to the correct source file so
   // that HMR can work properly when a file is added/removed
-  const documentPage = `_document${hasServerComponents ? '.web' : ''}`
+  const documentPage = `_document${hasServerComponents ? '-web' : ''}`
   if (isDev) {
     pages['/_app'] = `${PAGES_DIR_ALIAS}/_app`
     pages['/_error'] = `${PAGES_DIR_ALIAS}/_error`

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -629,7 +629,7 @@ export default async function getBaseWebpackConfig(
         prev.push(path.join(pagesDir, `_document.${ext}`))
         return prev
       }, [] as string[]),
-      `next/dist/pages/_document${hasServerComponents ? '.web' : ''}.js`,
+      `next/dist/pages/_document${hasServerComponents ? '-web' : ''}.js`,
     ]
   }
 

--- a/packages/next/pages/_document-web.tsx
+++ b/packages/next/pages/_document-web.tsx
@@ -1,3 +1,5 @@
+// Default _document page for web runtime
+
 import React from 'react'
 import { Html, Head, Main, NextScript } from './_document'
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1123,7 +1123,7 @@ export async function pages_document(task, opts) {
 
 export async function pages_document_server(task, opts) {
   await task
-    .source('pages/_document.web.tsx')
+    .source('pages/_document-web.tsx')
     .swc('client', { dev: opts.dev })
     .target('dist/pages')
 }


### PR DESCRIPTION
Fixes: #31104

This effecting users who are using expo with next [`@expo/next-adapter`](https://github.com/expo/expo-cli/blob/705f89fdcad7f4c1a141791746fddbca9796c6da/packages/next-adapter/src/withExpo.ts#L8) since react-native use `.web`, `.ios` and `.android` to identify platform. [Reference](https://docs.expo.dev/guides/using-electron/#%F0%9F%A7%B8-behavior).

Since the page extension can be any from user configuration, change `document.web.js` to `document-web.js` as fallback page in web runtime.

