### PR TITLE
bug: allow scheme-relative url in links

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -214,10 +214,10 @@ export function delBasePath(path: string): string {
  */
 export function isLocalURL(url: string): boolean {
   // prevent a hydration mismatch on href for url with anchor refs
-  if (url.startsWith('/') || url.startsWith('#') || url.startsWith('?'))
+  if (/^\/(?!\/)/.test(url) || url.startsWith('#') || url.startsWith('?'))
     return true
   try {
-    // absolute urls can be local if they are on the same origin
+    // absolute and scheme-relative urls can be local if they are on the same origin
     const locationOrigin = getLocationOrigin()
     const resolved = new URL(url, locationOrigin)
     return resolved.origin === locationOrigin && hasBasePath(resolved.pathname)
@@ -318,19 +318,19 @@ export function resolveHref(
 
   // repeated slashes and backslashes in the URL are considered
   // invalid and will never match a Next.js page/file
-  const urlProtoMatch = urlAsString.match(/^[a-zA-Z]{1,}:\/\//)
-  const urlAsStringNoProto = urlProtoMatch
-    ? urlAsString.slice(urlProtoMatch[0].length)
+  const urlSchemeMatch = urlAsString.match(/^(?:[a-zA-Z]+:)?\/\//)
+  const urlAsStringNoScheme = urlSchemeMatch
+    ? urlAsString.slice(urlSchemeMatch[0].length)
     : urlAsString
 
-  const urlParts = urlAsStringNoProto.split('?')
+  const urlParts = urlAsStringNoScheme.split('?')
 
   if ((urlParts[0] || '').match(/(\/\/|\\)/)) {
     console.error(
       `Invalid href passed to next/router: ${urlAsString}, repeated forward-slashes (//) or backslashes \\ are not valid in the href`
     )
-    const normalizedUrl = normalizeRepeatedSlashes(urlAsStringNoProto)
-    urlAsString = (urlProtoMatch ? urlProtoMatch[0] : '') + normalizedUrl
+    const normalizedUrl = normalizeRepeatedSlashes(urlAsStringNoScheme)
+    urlAsString = (urlSchemeMatch ? urlSchemeMatch[0] : '') + normalizedUrl
   }
 
   // Return because it cannot be routed by the Next.js router

--- a/test/integration/repeated-slashes/app/pages/invalid.js
+++ b/test/integration/repeated-slashes/app/pages/invalid.js
@@ -14,43 +14,47 @@ export default function Invalid() {
   return (
     <>
       <p id="invalid">invalid page</p>
-      <Link href="/another" as="//google.com">
-        <a id="page-with-as-slashes">to /another as //google.com</a>
+      <Link href="/another" as="/google.com//maps">
+        <a id="page-with-as-slashes">to /another as /google.com//maps</a>
       </Link>
       <br />
 
-      <Link href="//google.com">
-        <a id="href-with-slashes">to //google.com</a>
+      <Link href="/google.com//maps">
+        <a id="href-with-slashes">to /google.com//maps</a>
       </Link>
       <br />
 
-      <Link href="//google.com?hello=1">
-        <a id="href-with-slashes-query">to //google.com?hello=1</a>
+      <Link href="/google.com//maps?hello=1">
+        <a id="href-with-slashes-query">to /google.com//maps?hello=1</a>
       </Link>
       <br />
 
-      <Link href="//google.com#hello">
-        <a id="href-with-slashes-hash">to //google.com#hello</a>
+      <Link href="/google.com//maps#hello">
+        <a id="href-with-slashes-hash">to /google.com//maps#hello</a>
       </Link>
       <br />
 
-      <Link href="/another" as="\/\/google.com">
-        <a id="page-with-as-backslashes">to /another as \\/\\/google.com</a>
+      <Link href="/another" as="\/google.com\/\/maps">
+        <a id="page-with-as-backslashes">
+          to /another as \\/google.com\\/\\/maps
+        </a>
       </Link>
       <br />
 
-      <Link href="\/\/google.com">
-        <a id="href-with-backslashes">to \\/\\/google.com</a>
+      <Link href="\/google.com\/\/maps">
+        <a id="href-with-backslashes">to \\/google.com\\/\\/maps</a>
       </Link>
       <br />
 
-      <Link href="\/\/google.com?hello=1">
-        <a id="href-with-backslashes-query">to \\/\\/google.com?hello=1</a>
+      <Link href="\/google.com\/\/maps?hello=1">
+        <a id="href-with-backslashes-query">
+          to \\/google.com\\/\\/maps?hello=1
+        </a>
       </Link>
       <br />
 
-      <Link href="\/\/google.com#hello">
-        <a id="href-with-backslashes-hash">to \\/\\/google.com#hello</a>
+      <Link href="\/google.com\/\/maps#hello">
+        <a id="href-with-backslashes-hash">to \\/google.com\\/\\/maps#hello</a>
       </Link>
       <br />
     </>

--- a/test/integration/repeated-slashes/test/index.test.js
+++ b/test/integration/repeated-slashes/test/index.test.js
@@ -289,12 +289,12 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       `/invalid${isExport ? '.html' : ''}`
     )
     const invalidHrefs = [
-      '//google.com',
-      '//google.com?hello=1',
-      '//google.com#hello',
-      '\\/\\/google.com',
-      '\\/\\/google.com?hello=1',
-      '\\/\\/google.com#hello',
+      '/google.com//maps',
+      '/google.com//maps?hello=1',
+      '/google.com//maps#hello',
+      '\\/google.com\\/\\/maps',
+      '\\/google.com\\/\\/maps?hello=1',
+      '\\/google.com\\/\\/maps#hello',
     ]
 
     for (const href of invalidHrefs) {
@@ -313,24 +313,24 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       {
         page: '/another',
         href: '/another',
-        as: '//google.com',
-        pathname: '/google.com',
+        as: '/google.com//maps',
+        pathname: '/google.com/maps',
       },
       {
         page: isPages404 ? '/404' : '/_error',
-        href: '//google.com',
-        pathname: '/google.com',
+        href: '/google.com//maps',
+        pathname: '/google.com/maps',
       },
       {
         page: isPages404 ? '/404' : '/_error',
-        href: '//google.com?hello=1',
-        pathname: '/google.com',
+        href: '/google.com//maps?hello=1',
+        pathname: '/google.com/maps',
         search: '?hello=1',
       },
       {
         page: isPages404 ? '/404' : '/_error',
-        href: '//google.com#hello',
-        pathname: '/google.com',
+        href: '/google.com//maps#hello',
+        pathname: '/google.com/maps',
         hash: '#hello',
       },
     ]) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

## Relates Issues
* Fixes https://github.com/vercel/next.js/issues/30947

This change considers `//` at the start of the URL to be a valid match for `urlProtoMatch` and separates it from the rest of the URL. This way, Next.js will stop changing scheme-relative to normal relative URLs.

> ```
> <a href="//example.com">Scheme-relative URL</a>
> ```
> — https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a