### PR TITLE
Give priority to document.title over h1 when announcing page change

### DIFF
--- a/packages/next/client/route-announcer.tsx
+++ b/packages/next/client/route-announcer.tsx
@@ -5,12 +5,15 @@ export function RouteAnnouncer() {
   const { asPath } = useRouter()
   const [routeAnnouncement, setRouteAnnouncement] = React.useState('')
 
-  // Only announce the path change, but not for the first load because screen reader will do that automatically.
+  // Only announce the path change, but not for the first load because screen
+  // reader will do that automatically.
   const initialPathLoaded = React.useRef(false)
 
-  // Every time the path changes, announce the route change. The announcement will be prioritized by h1, then title
-  // (from metadata), and finally if those don't exist, then the pathName that is in the URL. This methodology is
-  // inspired by Marcy Sutton's accessible client routing user testing. More information can be found here:
+  // Every time the path changes, announce the new page’s title following this
+  // priority: first the document title (from head), otherwise the first h1, or
+  // if none of these exist, then the pathname from the URL. This methodology is
+  // inspired by Marcy Sutton’s accessible client routing user testing. More
+  // information can be found here:
   // https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
   React.useEffect(
     () => {
@@ -19,21 +22,14 @@ export function RouteAnnouncer() {
         return
       }
 
-      let newRouteAnnouncement
-      const pageHeader = document.querySelector('h1')
+      if (document.title) {
+        setRouteAnnouncement(document.title)
+      } else {
+        const pageHeader = document.querySelector('h1')
+        const content = pageHeader?.innerText ?? pageHeader?.textContent
 
-      if (pageHeader) {
-        newRouteAnnouncement = pageHeader.innerText || pageHeader.textContent
+        setRouteAnnouncement(content || asPath)
       }
-      if (!newRouteAnnouncement) {
-        if (document.title) {
-          newRouteAnnouncement = document.title
-        } else {
-          newRouteAnnouncement = asPath
-        }
-      }
-
-      setRouteAnnouncement(newRouteAnnouncement)
     },
     // TODO: switch to pathname + query object of dynamic route requirements
     [asPath]

--- a/test/integration/client-navigation-a11y/pages/index.js
+++ b/test/integration/client-navigation-a11y/pages/index.js
@@ -2,14 +2,22 @@ import Link from 'next/link'
 
 export default () => (
   <div id="page-container">
-    <Link href="/page-with-h1">
-      <a id="page-with-h1-link">Go to a page with an h1</a>
+    <Link href="/page-with-h1-and-title">
+      <a id="page-with-h1-and-title-link">
+        Go to a page with a title and an h1
+      </a>
     </Link>
+
+    <Link href="/page-with-h1">
+      <a id="page-with-h1-link">Go to a page without a title but with an h1</a>
+    </Link>
+
     <Link href="/page-with-title">
       <a id="page-with-title-link">
         Go to a page without an h1, but with a title
       </a>
     </Link>
+
     <Link href="/page-without-h1-or-title">
       <a id="page-without-h1-or-title-link">
         Go to a page without an h1 or a title

--- a/test/integration/client-navigation-a11y/pages/page-with-h1-and-title.js
+++ b/test/integration/client-navigation-a11y/pages/page-with-h1-and-title.js
@@ -1,7 +1,10 @@
 import Head from 'next/head'
 
 export default () => (
-  <div id="page-with-h1">
+  <div id="page-with-h1-and-title">
+    <Head>
+      <title>Another Page's Title</title>
+    </Head>
     <h1>My heading</h1>
     <div>Extraneous stuff</div>
   </div>

--- a/test/integration/client-navigation-a11y/pages/page-with-h1.js
+++ b/test/integration/client-navigation-a11y/pages/page-with-h1.js
@@ -1,5 +1,3 @@
-import Head from 'next/head'
-
 export default () => (
   <div id="page-with-h1">
     <h1>My heading</h1>


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Improvement

This pull-request should address https://github.com/vercel/next.js/issues/24021, improving the page change announcement for assistive technologies by giving priority to `document.title` over `h1`. Interestingly, it would also improve a potential performance bottleneck by skipping calls to `innerText` on the main `h1` raised in [this comment](https://github.com/vercel/next.js/pull/20428#issuecomment-962537038).
