### PR TITLE
Do not hide body when concurrentFeatures is enabled

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -650,27 +650,28 @@ export class Head extends Component<
 
       return (
         <head {...this.props}>
-          {this.context.isDevelopment && (
-            <>
-              <style
-                data-next-hide-fouc
-                data-ampdevmode={inAmpMode ? 'true' : undefined}
-                dangerouslySetInnerHTML={{
-                  __html: `body{display:none}`,
-                }}
-              />
-              <noscript
-                data-next-hide-fouc
-                data-ampdevmode={inAmpMode ? 'true' : undefined}
-              >
+          {!process.env.__NEXT_CONCURRENT_FEATURES &&
+            this.context.isDevelopment && (
+              <>
                 <style
+                  data-next-hide-fouc
+                  data-ampdevmode={inAmpMode ? 'true' : undefined}
                   dangerouslySetInnerHTML={{
-                    __html: `body{display:block}`,
+                    __html: `body{display:none}`,
                   }}
                 />
-              </noscript>
-            </>
-          )}
+                <noscript
+                  data-next-hide-fouc
+                  data-ampdevmode={inAmpMode ? 'true' : undefined}
+                >
+                  <style
+                    dangerouslySetInnerHTML={{
+                      __html: `body{display:block}`,
+                    }}
+                  />
+                </noscript>
+              </>
+            )}
           {children}
           {process.env.__NEXT_OPTIMIZE_FONTS && (
             <meta name="next-font-preconnect" />


### PR DESCRIPTION
When Fizz is enabled, we want to always show the content of body even before it's loaded. Please hide whitespace changes when reviewing this PR.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
