### PR TITLE
fix: support babelrc to skip SWC error

### DIFF
--- a/examples/api-routes/.babelrc
+++ b/examples/api-routes/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}


### PR DESCRIPTION
## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Errors have helpful link attached, see https://nextjs.org/docs/messages/failed-loading-swc

![image](https://user-images.githubusercontent.com/2106987/140885589-c71a7496-8642-4799-9f58-b2f855d80813.png)
