### PR TITLE
Disable styled-components displayName in production

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -43,7 +43,11 @@ function getBaseSWCOptions({
         },
       },
     },
-    styledComponents: styledComponents ? {} : null,
+    styledComponents: styledComponents
+      ? {
+          displayName: Boolean(development),
+        }
+      : null,
   }
 }
 


### PR DESCRIPTION
This makes more sense as a default for production given that displayName is stripped for other components too.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
