### PR TITLE
docs: fix typo in css-in-js page

### DIFF
--- a/docs/basic-features/built-in-css-support.md
+++ b/docs/basic-features/built-in-css-support.md
@@ -198,7 +198,7 @@ $primary-color: #64FF00
 
 ```js
 // pages/_app.js
-import variables from '../styles/variables.module.css'
+import variables from '../styles/variables.module.scss'
 
 export default function MyApp({ Component, pageProps }) {
   return (


### PR DESCRIPTION
## Purpose

fix minor typo in [css-in-js page](https://nextjs.org/docs/basic-features/built-in-css-support#sass-variables) 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

