### PR TITLE
Fix process.env overriden in web runtime

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1337,8 +1337,10 @@ export default async function getBaseWebpackConfig(
       // Makes sure `Buffer` and `process` are polyfilled in client and flight bundles (same behavior as webpack 4)
       targetWeb &&
         new webpack.ProvidePlugin({
+          // Buffer is used by getInlineScriptSource
           Buffer: [require.resolve('buffer'), 'Buffer'],
-          process: [require.resolve('process')],
+          // Avoid process been overridden when in web run time
+          ...(!isServer && { process: [require.resolve('process')] }),
         }),
       new webpack.DefinePlugin({
         ...Object.keys(process.env).reduce(

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1339,7 +1339,7 @@ export default async function getBaseWebpackConfig(
         new webpack.ProvidePlugin({
           // Buffer is used by getInlineScriptSource
           Buffer: [require.resolve('buffer'), 'Buffer'],
-          // Avoid process been overridden when in web run time
+          // Avoid process being overridden when in web run time
           ...(!isServer && { process: [require.resolve('process')] }),
         }),
       new webpack.DefinePlugin({

--- a/test/integration/react-streaming-and-server-components/app/.env
+++ b/test/integration/react-streaming-and-server-components/app/.env
@@ -1,0 +1,1 @@
+ENV_VAR_TEST="env_var_test"

--- a/test/integration/react-streaming-and-server-components/app/pages/index.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/index.server.js
@@ -1,10 +1,15 @@
 import Foo from '../components/foo.client'
 
+const envVar = process.env.ENV_VAR_TEST
+
 export default function Index() {
   return (
     <div>
       <h1>{`thisistheindexpage.server`}</h1>
-      <Foo />
+      <div>{envVar}</div>
+      <div>
+        <Foo />
+      </div>
     </div>
   )
 }

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -224,6 +224,7 @@ async function runBasicTests(context) {
     )
 
     expect(homeHTML).toContain('thisistheindexpage.server')
+    expect(homeHTML).toContain('env_var_test')
     expect(homeHTML).toContain('foo.client')
 
     expect(dynamicRouteHTML1).toContain('[pid]')


### PR DESCRIPTION
Fixes #31258

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
