### PR TITLE
Fix test-pnp stalling in CI

### DIFF
--- a/scripts/test-pnp.sh
+++ b/scripts/test-pnp.sh
@@ -35,9 +35,6 @@ do
   touch yarn.lock
   yarn set version berry
 
-  # Temporary fix for https://github.com/yarnpkg/berry/issues/2514:
-  yarn set version from sources
-
   yarn config set pnpFallbackMode none
   yarn config set enableGlobalCache true
   yarn link --all --private -r ../..


### PR DESCRIPTION
This fixes the `test-pnp` test job stalling in CI lately. 

x-ref: https://github.com/vercel/next.js/runs/4172582182?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/4173108617?check_suite_focus=true

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
