### PR TITLE
next/jest: Ensure typeof window is not transformed in jsdom environment

### DIFF
--- a/packages/next/build/swc/jest-transformer.js
+++ b/packages/next/build/swc/jest-transformer.js
@@ -41,14 +41,19 @@ module.exports = {
         return src
       }
 
+      const jestConfig = getJestConfig(jestOptions)
+
       let swcTransformOpts = getJestSWCOptions({
+        // When target is node it's similar to the server option set in SWC.
+        isServer:
+          jestConfig.testEnvironment && jestConfig.testEnvironment === 'node',
         filename,
         styledComponents: inputOptions.styledComponents,
         paths: inputOptions.paths,
         baseUrl: inputOptions.resolvedBaseUrl,
         esm:
           isSupportEsm &&
-          isEsm(Boolean(inputOptions.isEsmProject), filename, jestOptions),
+          isEsm(Boolean(inputOptions.isEsmProject), filename, jestConfig),
       })
 
       return transformSync(src, { ...swcTransformOpts, filename })
@@ -64,11 +69,9 @@ function getJestConfig(jestConfig) {
       jestConfig
 }
 
-function isEsm(isEsmProject, filename, jestOptions) {
+function isEsm(isEsmProject, filename, jestConfig) {
   return (
     (/\.jsx?$/.test(filename) && isEsmProject) ||
-    getJestConfig(jestOptions).extensionsToTreatAsEsm?.find((ext) =>
-      filename.endsWith(ext)
-    )
+    jestConfig.extensionsToTreatAsEsm?.find((ext) => filename.endsWith(ext))
   )
 }

--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -60,6 +60,7 @@ function getBaseSWCOptions({
 }
 
 export function getJestSWCOptions({
+  isServer,
   filename,
   esm,
   styledComponents,
@@ -70,7 +71,7 @@ export function getJestSWCOptions({
     filename,
     development: false,
     hasReactRefresh: false,
-    globalWindow: false,
+    globalWindow: !isServer,
     styledComponents,
     paths,
     baseUrl,


### PR DESCRIPTION
Found that when the target is `jsdom` instead of `node` the "typeof window" transform is incorrect. This was causing an unexpected failure in on of the tests for vercel.com.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
