### PR TITLE
Fix failed-loading-swc link in Troubleshooting

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -169,7 +169,7 @@ There are two options to develop with your local version of the codebase:
 - If you see the below error while running `yarn dev` with next:
 
 ```
-Failed to load SWC binary, see more info here: https://nextjs.org/docs/messages/failed-loadin
+Failed to load SWC binary, see more info here: https://nextjs.org/docs/messages/failed-loading-swc
 ```
 
 Try to add the below section to your `package.json`, then run again


### PR DESCRIPTION
## Documentation / Examples

#31265

- [x] Make sure the linting passes by running `yarn lint`
