### PR TITLE
Maintain co-authors when kodiak merges

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -13,6 +13,7 @@ notify_on_conflict = false
 [merge.message]
 title = "pull_request_title"
 body = "pull_request_body"
+include_coauthors= true
 include_pr_number = true
 body_type = "markdown"
 strip_html_comments = true


### PR DESCRIPTION
This enables the `include_coauthors` config on Kodiak to ensure we don't drop contributors in PRs when Kodiak merges. 

Related docs https://kodiakhq.com/docs/config-reference#mergemessageinclude_coauthors

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
