### PR TITLE
Auth0 Example: `getSession` should be called with `req` and `res`

### DIFF
--- a/examples/auth0/pages/advanced/ssr-profile.js
+++ b/examples/auth0/pages/advanced/ssr-profile.js
@@ -21,7 +21,7 @@ export async function getServerSideProps({ req, res }) {
   // Here you can check authentication status directly before rendering the page,
   // however the page would be a serverless function, which is more expensive and
   // slower than a static page with client side authentication
-  const session = await auth0.getSession(req)
+  const session = await auth0.getSession(req, res)
 
   if (!session || !session.user) {
     res.writeHead(302, {


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

![image](https://user-images.githubusercontent.com/20026577/141427071-18705f89-c4b8-428e-a9b3-ffeaa70fcbff.png)

