### PR TITLE
Option to disable requestAnimationFrame in development mode

### DIFF
--- a/docs/api-reference/next.config.js/background-inactive-pages.md
+++ b/docs/api-reference/next.config.js/background-inactive-pages.md
@@ -9,10 +9,9 @@ In development, Next.js uses [Window.requestAnimationFrame](https://developer.mo
 
 For example, if you have an invisible IFrame:
 
-`
-
+```html
 <iframe style="visiblity: hidden;" src="http://next-dev-server:3000"></iframe>
-`
+```
 
 IFrame Next.js app:
 
@@ -29,7 +28,7 @@ In order to solve it, you can disable `Window.requestAnimationFrame` using:
 ```js
 module.exports = {
   devIndicators: {
-    foucUseAnimationFrame: true,
+    foucUseAnimationFrame: false,
   },
 }
 ```

--- a/docs/api-reference/next.config.js/background-inactive-pages.md
+++ b/docs/api-reference/next.config.js/background-inactive-pages.md
@@ -1,0 +1,35 @@
+---
+description: Background or inactive pages in development mode might not load correctly.
+---
+
+# Development over background or inactive pages
+
+When running Next.js in development mode Next.js will run pages using Fouc.
+In development, Next.js uses [Window.requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) which does not work in background pages.
+
+For example, if you have an invisible IFrame:
+
+`
+
+<iframe style="visiblity: hidden;" src="http://next-dev-server:3000"></iframe>
+`
+
+IFrame Next.js app:
+
+```js
+useEffect(() => {
+  console.log('foo')
+}, [])
+```
+
+In production mode, `foo` will be printed while in dev mode `foo` will _not_ be printed.
+
+In order to solve it, you can disable `Window.requestAnimationFrame` using:
+
+```js
+module.exports = {
+  devIndicators: {
+    foucUseAnimationFrame: true,
+  },
+}
+```

--- a/docs/api-reference/next.config.js/background-inactive-pages.md
+++ b/docs/api-reference/next.config.js/background-inactive-pages.md
@@ -10,7 +10,7 @@ In development, Next.js uses [Window.requestAnimationFrame](https://developer.mo
 For example, if you have an invisible IFrame:
 
 ```html
-<iframe style="visiblity: hidden;" src="http://next-dev-server:3000"></iframe>
+<iframe style="visibility: hidden;" src="http://next-dev-server:3000"></iframe>
 ```
 
 IFrame Next.js app:

--- a/examples/basic-css/next.config.js
+++ b/examples/basic-css/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  devIndicators: {
-    foucUseAnimationFrame: true,
-  },
-}

--- a/examples/basic-css/next.config.js
+++ b/examples/basic-css/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  devIndicators: {
+    foucUseAnimationFrame: true,
+  },
+}

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1318,6 +1318,9 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_TRAILING_SLASH': JSON.stringify(
           config.trailingSlash
         ),
+        'process.env.__NEXT_FOUC_USE_ANIMATION_FRAME': JSON.stringify(
+          config.devIndicators.foucUseAnimationFrame
+        ),
         'process.env.__NEXT_BUILD_INDICATOR': JSON.stringify(
           config.devIndicators.buildActivity
         ),

--- a/packages/next/client/dev/fouc.js
+++ b/packages/next/client/dev/fouc.js
@@ -2,7 +2,11 @@
 // `style-loader` in development. It must be called before hydration, or else
 // rendering won't have the correct computed values in effects.
 export function displayContent(callback) {
-  ;(window.requestAnimationFrame || setTimeout)(function () {
+  ;(
+    (process.env.__NEXT_FOUC_USE_ANIMATION_FRAME &&
+      window.requestAnimationFrame) ||
+    setTimeout
+  )(function () {
     for (
       var x = document.querySelectorAll('[data-next-hide-fouc]'), i = x.length;
       i--;

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -92,6 +92,7 @@ export type NextConfig = { [key: string]: any } & {
   poweredByHeader?: boolean
   images?: ImageConfig
   devIndicators?: {
+    foucUseAnimationFrame: boolean
     buildActivity?: boolean
     buildActivityPosition?:
       | 'bottom-right'
@@ -186,6 +187,7 @@ export const defaultConfig: NextConfig = {
   analyticsId: process.env.VERCEL_ANALYTICS_ID || '',
   images: imageConfigDefault,
   devIndicators: {
+    foucUseAnimationFrame: true,
     buildActivity: true,
     buildActivityPosition: 'bottom-right',
   },


### PR DESCRIPTION
Hello,
As you can see from the [doc](https://github.com/vercel/next.js/blob/3e6efb623dab43f5ce6a261f908d445ec7e7ae67/docs/api-reference/next.config.js/background-inactive-pages.md) I added, Next.js does not work when the page is hidden.
This is because of FOUC and [this](https://github.com/vercel/next.js/blob/99abb8bfd7f662efb942763332b87f4348b8844d/packages/next/client/dev/fouc.js#L5) line of code. 

`requestAnimationFrame` isnt called on background/invisible pages e.g hidden IFrames, and because of that, even simple code like
```js
React.useEffect(() => {
    console.log("foo");
}, []);
```
is not working and `foo` is not printed. 

Its happening only in development mode. 

Thank you!

