### PR TITLE
Fix function syntax for API Routes documentation

### DIFF
--- a/docs/api-routes/response-helpers.md
+++ b/docs/api-routes/response-helpers.md
@@ -89,7 +89,7 @@ type ResponseData {
   message: string
 }
 
-export default function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) => {
+export default function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
   res.status(200).json({ message: 'Hello from Next.js!' })
 }
 ```


### PR DESCRIPTION
There is a non-valid mix of classic and arrow function notation in the documentation. I've fixed it to be a classical function notation because all the other examples are like that.

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
