### PR TITLE
import webpack not webpack5

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -1,5 +1,5 @@
 import os from 'os'
-import type { webpack5 } from 'next/dist/compiled/webpack/webpack'
+import type { webpack as webpack5 } from 'next/dist/compiled/webpack/webpack'
 import { Header, Redirect, Rewrite } from '../lib/load-custom-routes'
 import {
   ImageConfig,


### PR DESCRIPTION
next/dist/compiled/webpack/webpack exports webpack5 as webpack so we need to import webpack and not webpack5 inside https://github.com/vercel/next.js/blob/canary/packages/next/server/config-shared.ts#L2


next/dist/compiled/webpack/webpack
```js
exports.init = function () {
  if (process.env.NEXT_PRIVATE_LOCAL_WEBPACK5) {
    Object.assign(exports, {
      webpack: require('webpack5'),
    })
  } 
}
```

https://github.com/vercel/next.js/blob/canary/packages/next/server/config-shared.ts#L2

```js
import type { webpack5 } from 'next/dist/compiled/webpack/webpack'
```

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`


fixes #31419