### PR TITLE
Remove .only and ensure jest lint rules apply for all tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,14 +30,15 @@
   },
   "overrides": [
     {
-      "files": ["test/**/*.test.js"],
+      "files": ["test/**/*.js", "test/**/*.ts", "**/*.test.ts"],
       "extends": ["plugin:jest/recommended"],
       "rules": {
         "jest/expect-expect": "off",
         "jest/no-disabled-tests": "off",
         "jest/no-conditional-expect": "off",
         "jest/valid-title": "off",
-        "jest/no-interpolation-in-snapshots": "off"
+        "jest/no-interpolation-in-snapshots": "off",
+        "jest/no-export": "off"
       }
     },
     { "files": ["**/__tests__/**"], "env": { "jest": true } },

--- a/test/development/basic/styled-components-disabled.test.ts
+++ b/test/development/basic/styled-components-disabled.test.ts
@@ -54,6 +54,7 @@ describe('styled-components SWC transform', () => {
         throw new Error('did not find mismatch')
       } catch (err) {
         // Verify that it really has the logs
+        // eslint-disable-next-line jest/no-try-expect
         expect(await matchLogs$(browser)).toBe(true)
       }
     } finally {

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -36,7 +36,7 @@ async function addDefaultLocaleCookie(browser) {
 
 export function runTests(ctx) {
   if (ctx.basePath) {
-    it.only('should handle basePath like pathname', async () => {
+    it('should handle basePath like pathname', async () => {
       const { basePath } = ctx
 
       for (const pathname of [

--- a/test/integration/production-swcminify/test/security.js
+++ b/test/integration/production-swcminify/test/security.js
@@ -291,60 +291,6 @@ module.exports = (context) => {
       expect(hostname).not.toBe('example.com')
     })
 
-    it('should handle encoded value in the pathname correctly /', async () => {
-      const res = await fetchViaHTTP(
-        context.appPort,
-        '/redirect/me/to-about/%2fgoogle.com',
-        undefined,
-        {
-          redirect: 'manual',
-        }
-      )
-
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
-      expect(res.status).toBe(307)
-      expect(pathname).toBe('/%2fgoogle.com/about')
-      expect(hostname).not.toBe('google.com')
-    })
-
-    it('should handle encoded value in the pathname to query correctly (/)', async () => {
-      const res = await fetchViaHTTP(
-        context.appPort,
-        '/redirect-query-test/%2Fgoogle.com',
-        undefined,
-        {
-          redirect: 'manual',
-        }
-      )
-
-      const { pathname, hostname, query } = url.parse(
-        res.headers.get('location') || ''
-      )
-      expect(res.status).toBe(307)
-      expect(pathname).toBe('/about')
-      expect(query).toBe('foo=%2Fgoogle.com')
-      expect(hostname).not.toBe('google.com')
-      expect(hostname).not.toMatch(/google/)
-    })
-
-    it('should handle encoded / value for trailing slash correctly', async () => {
-      const res = await fetchViaHTTP(
-        context.appPort,
-        '/%2fexample.com/',
-        undefined,
-        { redirect: 'manual' }
-      )
-
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
-      expect(res.status).toBe(308)
-      expect(pathname).toBe('/%2fexample.com')
-      expect(hostname).not.toBe('example.com')
-    })
-
     if (browserName !== 'internet explorer') {
       it('should not execute script embedded inside svg image', async () => {
         let browser

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -291,60 +291,6 @@ module.exports = (context) => {
       expect(hostname).not.toBe('example.com')
     })
 
-    it('should handle encoded value in the pathname correctly /', async () => {
-      const res = await fetchViaHTTP(
-        context.appPort,
-        '/redirect/me/to-about/%2fgoogle.com',
-        undefined,
-        {
-          redirect: 'manual',
-        }
-      )
-
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
-      expect(res.status).toBe(307)
-      expect(pathname).toBe('/%2fgoogle.com/about')
-      expect(hostname).not.toBe('google.com')
-    })
-
-    it('should handle encoded value in the pathname to query correctly (/)', async () => {
-      const res = await fetchViaHTTP(
-        context.appPort,
-        '/redirect-query-test/%2Fgoogle.com',
-        undefined,
-        {
-          redirect: 'manual',
-        }
-      )
-
-      const { pathname, hostname, query } = url.parse(
-        res.headers.get('location') || ''
-      )
-      expect(res.status).toBe(307)
-      expect(pathname).toBe('/about')
-      expect(query).toBe('foo=%2Fgoogle.com')
-      expect(hostname).not.toBe('google.com')
-      expect(hostname).not.toMatch(/google/)
-    })
-
-    it('should handle encoded / value for trailing slash correctly', async () => {
-      const res = await fetchViaHTTP(
-        context.appPort,
-        '/%2fexample.com/',
-        undefined,
-        { redirect: 'manual' }
-      )
-
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
-      expect(res.status).toBe(308)
-      expect(pathname).toBe('/%2fexample.com')
-      expect(hostname).not.toBe('example.com')
-    })
-
     if (browserName !== 'internet explorer') {
       it('should not execute script embedded inside svg image', async () => {
         let browser

--- a/test/integration/react-streaming-and-server-components/test/css.js
+++ b/test/integration/react-streaming-and-server-components/test/css.js
@@ -17,11 +17,11 @@ export default function (context) {
     expect(currentColor).toMatchInlineSnapshot(`"rgb(255, 0, 0)"`)
   })
   // TODO: fix this test
-  // it.skip('should include css modules with `serverComponents: true`', async () => {
-  //   const browser = await webdriver(context.appPort, '/css-modules')
-  //   const currentColor = await browser.eval(
-  //     `window.getComputedStyle(document.querySelector('h1')).color`
-  //   )
-  //   expect(currentColor).toMatchInlineSnapshot(`"rgb(255, 0, 0)"`)
-  // })
+  it.skip('should include css modules with `serverComponents: true`', async () => {
+    const browser = await webdriver(context.appPort, '/css-modules')
+    const currentColor = await browser.eval(
+      `window.getComputedStyle(document.querySelector('h1')).color`
+    )
+    expect(currentColor).toMatchInlineSnapshot(`"rgb(255, 0, 0)"`)
+  })
 }

--- a/test/production/required-server-files-i18n.test.ts
+++ b/test/production/required-server-files-i18n.test.ts
@@ -701,7 +701,7 @@ describe('should set-up next', () => {
     expect(JSON.parse($('#router').text()).locale).toBe('en')
   })
 
-  it('should have the correct asPath for fallback page', async () => {
+  it('should have the correct asPath for fallback page locale', async () => {
     const res = await fetchViaHTTP(appPort, '/fr/fallback/[slug]', undefined, {
       headers: {
         'x-matched-path': '/fr/fallback/[slug]',


### PR DESCRIPTION
This removes a `.only` from a test and updates our `.eslintrc` config to ensure all test files have the jest rule applied so that we catch this automatically in the future. This also caught some duplicate tests in the production suite which are removed in this PR. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
