### PR TITLE
Update authentication docs with middleware

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -15,9 +15,14 @@ The first step to identifying which authentication pattern you need is understan
 
 ### Authenticating Statically Generated Pages
 
-Next.js automatically determines that a page is static if there are no blocking data requirements. This means the absence of [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering) and `getInitialProps` in the page. Instead, your page can render a loading state from the server, followed by fetching the user client-side.
+Next.js automatically determines that a page is static if there are no blocking data requirements. This means the absence of [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering) and `getInitialProps` in the page. One advantage of statically-generating pages is it allows them to be served from a global CDN and preloaded using [`next/link`](/docs/api-reference/next/link.md). In practice, this results in a faster TTI ([Time to Interactive](https://web.dev/interactive/)).
 
-One advantage of this pattern is it allows pages to be served from a global CDN and preloaded using [`next/link`](/docs/api-reference/next/link.md). In practice, this results in a faster TTI ([Time to Interactive](https://web.dev/interactive/)).
+There are generally two situations in which you want to authenticate a page without using `getServerSideProps` or `getInitialProps`:
+
+1. The page has user-specific data that must be fetched with their authentication information, for example a profile page. In this case, your page can render a loading state from the server, followed by fetching the user-specific data client-side.  
+2. The page has non user-specific data that users need to be authenticated to view, for example a static article behind a paywall. The content doesn't change user to user, and thus we would like to statically generate the page for speed, while still checking a user is authenticated before displaying it.
+
+#### Case 1: User-specific pages
 
 Let's look at an example for a profile page. This will initially render a loading skeleton. Once the request for a user has finished, it will show the user's name:
 
@@ -49,6 +54,82 @@ export default Profile
 ```
 
 You can view this [example in action](https://iron-session-example.vercel.app/). Check out the [`with-iron-session`](https://github.com/vercel/next.js/tree/canary/examples/with-iron-session) example to see how it works.
+
+#### Case 2: Static data behind authentication
+
+Let's now look at an example of static articles that sit behind a paywall. This example uses middleware to check a user's authentication state before sending them a statically-generated page. On Edge platforms like Vercel, this middleware will be run as an [Edge Function](https://vercel.com/features/edge-functions). 
+
+```jsx
+// pages/articles/_middleware.js
+
+import { verifyAuth } from '@lib/auth'
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(req) {
+  const basicAuth = req.headers.get('authorization')
+
+  if (basicAuth) {
+    const isAuthenticated = verifyAuth(basicAuth)
+
+    if (isAuthenticated) {
+      return NextResponse.next()
+    }
+  }
+  
+  return return NextResponse.redirect("/login")
+}
+```
+
+```jsx
+// pages/articles/[id]
+
+export default function Article({article}){
+
+  // we can still get user-specific data without delaying
+  // the display of the article. For example, to show their
+  // username in the page's header bar.
+  const user = useUser()
+  
+  return (
+    <Layout user={user}>
+      <Article article={article} />
+    </Layout>
+  );
+}
+
+export async function getStaticProps(context) {
+  // fetch the article from your CMS
+  const article = await fetchArticle(context.params.id)
+  
+  return {
+    props: {
+      article
+    }, // will be passed to the page component as props
+  }
+}
+
+// this will pre-render all of the articles at build time.
+export async function getStaticPaths() {
+  const articles = await fetchAllArticles()
+
+  // Get the paths we want to pre-render based on articles
+  const paths = articles.map((article) => ({
+    params: { id: article.id },
+  }))
+
+  // We'll pre-render only these paths at build time.
+  // { fallback: false } will respond with a 404 for
+  // any ids that don't match a pre-renderered page.
+  return { paths, fallback: false }
+}
+```
+
+The advantage of this approach is twofold:
+
+1. Authentication happens server-side, and thus there is only one round-trip to the client before they see the main article. If we used the previous approach and sent a loading indicator initially, a second round-trip would be needed to fetch the article data with their authentication information.
+2. The article HTML is pre-generated at build time, so it can be served and rendered immediately once the user is authenticated with the middleware. In the previous approach, the article would have been rendered on the client after being fetched client-side. If you instead use `getServerSideProps`, the article is rendered server-side, but is being rendered on every request. 
+
+Therefore, the middleware authentication approach will result in the fastest LCP ([Largest Contentful Paint](https://web.dev/lcp/)), which essentially means the user will get the content they requested as fast as possible.
 
 ### Authenticating Server-Rendered Pages
 


### PR DESCRIPTION
This PR adds an explanation of how middleware can be used in the authentication flow for pages with static content that sits behind authentication. One thought is that it might be worth re-working this whole page to be divided between authenticating static content and authenticating user-specific content, with specific options in order of recommendation:

**User-specific, dynamic content:**
1. Statically render a loading skeleton, then fetch user data client-side
2. If you would rather render server-side, use `getServerSideProps`. This will come with the downside of blocking requests.

**Static (but authenticated) content:**
1. Use middleware to authenticate server-side, but serve statically-generated pages.
2. Statically render a loading skeleton and then fetch and render authenticated content client-side.
3. Use `getServerSideProps` to render static content server-side. 

If you would like, I'm happy to update this PR breaking it down that way. Just lmk, and also lmk if you have any other situations you think should be covered, or if there are other recommendations I'm not providing. For example, can middleware be used in the user-specific content case somehow?

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
