### PR TITLE
Remove unnecessary awaits

### DIFF
--- a/packages/next/server/load-components.ts
+++ b/packages/next/server/load-components.ts
@@ -57,7 +57,7 @@ export async function loadComponents(
   serverless: boolean
 ): Promise<LoadComponentsReturnType> {
   if (serverless) {
-    const ComponentMod = await requirePage(pathname, distDir, serverless)
+    const ComponentMod = requirePage(pathname, distDir, serverless)
     if (typeof ComponentMod === 'string') {
       return {
         Component: ComponentMod as any,
@@ -89,16 +89,12 @@ export async function loadComponents(
     } as LoadComponentsReturnType
   }
 
-  const [DocumentMod, AppMod, ComponentMod] = await Promise.all([
-    requirePage('/_document', distDir, serverless),
-    requirePage('/_app', distDir, serverless),
-    requirePage(pathname, distDir, serverless),
-  ])
+  const DocumentMod = requirePage('/_document', distDir, serverless)
+  const AppMod = requirePage('/_app', distDir, serverless)
+  const ComponentMod = requirePage(pathname, distDir, serverless)
 
-  const [buildManifest, reactLoadableManifest] = await Promise.all([
-    require(join(distDir, BUILD_MANIFEST)),
-    require(join(distDir, REACT_LOADABLE_MANIFEST)),
-  ])
+  const buildManifest = require(join(distDir, BUILD_MANIFEST))
+  const reactLoadableManifest = require(join(distDir, REACT_LOADABLE_MANIFEST))
 
   const Component = interopDefault(ComponentMod)
   const Document = interopDefault(DocumentMod)


### PR DESCRIPTION
`requirePage` and `require` aren't returning any promise, so awaiting on them introduces a bit performance overhead which is totally unnecessary.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
