### PR TITLE
telemetry: track usage of 'optimizeFonts'

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1350,14 +1350,24 @@ export default async function build(
       )
     }
 
-    const optimizeCss: EventBuildFeatureUsage = {
-      featureName: 'experimental/optimizeCss',
-      invocationCount: config.experimental.optimizeCss ? 1 : 0,
-    }
-    telemetry.record({
-      eventName: EVENT_BUILD_FEATURE_USAGE,
-      payload: optimizeCss,
-    })
+    const features: EventBuildFeatureUsage[] = [
+      {
+        featureName: 'experimental/optimizeCss',
+        invocationCount: config.experimental.optimizeCss ? 1 : 0,
+      },
+      {
+        featureName: 'optimizeFonts',
+        invocationCount: config.optimizeFonts ? 1 : 0,
+      },
+    ]
+    telemetry.record(
+      features.map((feature) => {
+        return {
+          eventName: EVENT_BUILD_FEATURE_USAGE,
+          payload: feature,
+        }
+      })
+    )
 
     await promises.writeFile(
       path.join(distDir, SERVER_FILES_MANIFEST),

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -131,6 +131,7 @@ export type EventBuildFeatureUsage = {
     | 'next/script'
     | 'next/dynamic'
     | 'experimental/optimizeCss'
+    | 'optimizeFonts'
     | 'swcLoader'
     | 'swcMinify'
   invocationCount: number

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -575,6 +575,9 @@ describe('Telemetry CLI', () => {
     })
     const regex = /NEXT_BUILD_FEATURE_USAGE[\s\S]+?{([\s\S]+?)}/g
     regex.exec(stderr).pop() // optimizeCss
+    const optimizeFonts = regex.exec(stderr).pop()
+    expect(optimizeFonts).toContain(`"featureName": "optimizeFonts"`)
+    expect(optimizeFonts).toContain(`"invocationCount": 1`)
     const swcLoader = regex.exec(stderr).pop()
     expect(swcLoader).toContain(`"featureName": "swcLoader"`)
     expect(swcLoader).toContain(`"invocationCount": 1`)


### PR DESCRIPTION
`optimizeFonts` is enabled by default, but the Aurora team would like
to find out how many users explicitly turn it off.

Backend PR: https://github.com/vercel/next-telemetry/pull/56

https://nextjs.org/docs/basic-features/font-optimization

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
