### PR TITLE
Ensure only one doctype is rendered

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -71,6 +71,8 @@ let tryGetPreviewData: typeof import('./api-utils').tryGetPreviewData
 let warn: typeof import('../build/output/log').warn
 let postProcess: typeof import('../shared/lib/post-process').default
 
+const DOCTYPE = '<!DOCTYPE html>'
+
 if (!process.browser) {
   Writable = require('stream').Writable
   Buffer = require('buffer').Buffer
@@ -1323,7 +1325,9 @@ export async function renderToHTML(
     /<next-js-internal-body-render-target><\/next-js-internal-body-render-target>/
   )
   const prefix: Array<string> = []
-  prefix.push('<!DOCTYPE html>')
+  if (!documentHTML.startsWith(DOCTYPE)) {
+    prefix.push(DOCTYPE)
+  }
   prefix.push(renderTargetPrefix)
   if (inAmpMode) {
     prefix.push('<!-- __NEXT_DATA__ -->')

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -218,6 +218,9 @@ async function runBasicTests(context, env) {
   it('should render the correct html', async () => {
     const homeHTML = await renderViaHTTP(context.appPort, '/')
 
+    // should have only 1 DOCTYPE
+    expect(homeHTML).toMatch(/^<!DOCTYPE html><html/)
+
     // dynamic routes
     const dynamicRouteHTML1 = await renderViaHTTP(
       context.appPort,


### PR DESCRIPTION
React-dom renders doctype automatically when `<html>` is detected. We should append `DOCTYPE` prefix only when necessary.
x-ref: https://github.com/facebook/react/pull/21680

## Bug

![image](https://user-images.githubusercontent.com/4800338/142215292-4af4a61d-2d75-48ae-a31a-0af641c72dcf.png)

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

