### PR TITLE
feat(config-exports): Export WebpackConfig alongside NextConfig

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -43,6 +43,17 @@ export interface TypeScriptConfig {
   tsconfigPath?: string
 }
 
+export type NextWebpackContext = {
+  dir: string
+  dev: boolean
+  isServer: boolean
+  buildId: string
+  config: NextConfigComplete
+  defaultLoaders: { babel: any }
+  totalPages: number
+  webpack: any
+}
+
 export type NextConfig = { [key: string]: any } & {
   i18n?: I18NConfig | null
 
@@ -63,21 +74,7 @@ export type NextConfig = { [key: string]: any } & {
   webpack5?: false
   excludeDefaultMomentLocales?: boolean
 
-  webpack?:
-    | ((
-        config: any,
-        context: {
-          dir: string
-          dev: boolean
-          isServer: boolean
-          buildId: string
-          config: NextConfigComplete
-          defaultLoaders: { babel: any }
-          totalPages: number
-          webpack: any
-        }
-      ) => any)
-    | null
+  webpack?: ((config: any, context: NextWebpackContext) => any) | null
 
   trailingSlash?: boolean
   env?: { [key: string]: string }

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -54,6 +54,10 @@ export type NextWebpackContext = {
   webpack: any
 }
 
+export type WebpackConfig =
+  | ((config: any, context: NextWebpackContext) => any)
+  | null
+
 export type NextConfig = { [key: string]: any } & {
   i18n?: I18NConfig | null
 
@@ -74,7 +78,7 @@ export type NextConfig = { [key: string]: any } & {
   webpack5?: false
   excludeDefaultMomentLocales?: boolean
 
-  webpack?: ((config: any, context: NextWebpackContext) => any) | null
+  webpack?: WebpackConfig
 
   trailingSlash?: boolean
   env?: { [key: string]: string }

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -25,7 +25,7 @@ import {
 import next from '../dist/server/next'
 
 // @ts-ignore This path is generated at build time and conflicts otherwise
-export { NextConfig } from '../dist/server/config'
+export { NextConfig, WebpackConfig } from '../dist/server/config'
 
 // Extend the React types with missing properties
 declare module 'react' {


### PR DESCRIPTION
This PR exposes `WebpackConfig` as part of the main type exports. Knowing this type becomes a requirement for integrating with the webpack build process in `next`. Since `next` has several custom types coming in from the webpack function (`NextConfigComplete` for example), one must copy locally every type related to the `webpack` property of the config to make a congruent representation that TypeScript accepts. By exposing this type in this PR, consumers can eliminate the need to maintain these types internally for our integrations.

Example of need to copy types: https://github.com/reside-eng/next-bootstrap/blob/main/src/types.ts#L13-L66

In the types above, we ultimately require the `NextWebpackFunction`

This type is only required to make the correct return type on the webpack function: https://github.com/reside-eng/next-bootstrap/blob/main/src/webpack.ts#L152-L154