### PR TITLE
Replace old static path by public | typo

### DIFF
--- a/examples/with-firebase-cloud-messaging/README.md
+++ b/examples/with-firebase-cloud-messaging/README.md
@@ -14,7 +14,7 @@ yarn create next-app --example with-firebase-cloud-messaging with-firebase-cloud
 
 ## Set your send id
 
-set your `messagingSenderId` in `static/firebase-messaging-sw.js` and `utils/webPush.js`
+set your `messagingSenderId` in `public/firebase-messaging-sw.js` and `utils/webPush.js`
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
 


### PR DESCRIPTION
An issue in the path of the public directory

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
