### PR TITLE
Move root div to an app wrapper

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -766,13 +766,10 @@ export function Main({
 }: {
   children?: (content: JSX.Element) => JSX.Element
 }) {
-  const { inAmpMode, docComponentsRendered, useMainContent } =
-    useContext(HtmlContext)
+  const { docComponentsRendered, useMainContent } = useContext(HtmlContext)
   const content = useMainContent(children)
   docComponentsRendered.Main = true
-
-  if (inAmpMode) return content
-  return <div id="__next">{content}</div>
+  return content
 }
 
 export class NextScript extends Component<OriginProps> {

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1041,21 +1041,19 @@ export async function renderToHTML(
     }
   }
 
-  const appWrappers: Array<(content: JSX.Element) => JSX.Element> = [
-    (content) =>
-      inAmpMode ? <>{content}</> : <div id="__next">{content}</div>,
-  ]
+  const appWrappers: Array<(content: JSX.Element) => JSX.Element> = []
   const getWrappedApp = (app: JSX.Element) => {
     // Prevent wrappers from reading/writing props by rendering inside an
     // opaque component. Wrappers should use context instead.
     const InnerApp = () => app
-    return (
+    const content = (
       <AppContainerWithIsomorphicFiberStructure>
         {appWrappers.reduceRight((innerContent, fn) => {
           return fn(innerContent)
         }, <InnerApp />)}
       </AppContainerWithIsomorphicFiberStructure>
     )
+    return inAmpMode ? content : <div id="__next">{content}</div>
   }
 
   /**

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1041,14 +1041,17 @@ export async function renderToHTML(
     }
   }
 
-  const appWrappers: Array<(content: JSX.Element) => JSX.Element> = []
+  const appWrappers: Array<(content: JSX.Element) => JSX.Element> = [
+    (content) =>
+      inAmpMode ? <>{content}</> : <div id="__next">{content}</div>,
+  ]
   const getWrappedApp = (app: JSX.Element) => {
     // Prevent wrappers from reading/writing props by rendering inside an
     // opaque component. Wrappers should use context instead.
     const InnerApp = () => app
     return (
       <AppContainerWithIsomorphicFiberStructure>
-        {appWrappers.reduce((innerContent, fn) => {
+        {appWrappers.reduceRight((innerContent, fn) => {
           return fn(innerContent)
         }, <InnerApp />)}
       </AppContainerWithIsomorphicFiberStructure>


### PR DESCRIPTION
Extracted from #31223.

We need to move the root `<div id="__next">` wrapper to be rendered as part of the page content, rather than the`Document`, so that flush effects (like styles) are flushed before (or after) the div, rather than inside, where they would cause hydration mismatches.