### PR TITLE
Fix dev router usage before router initializing

### DIFF
--- a/packages/next/client/dev/amp-dev.js
+++ b/packages/next/client/dev/amp-dev.js
@@ -4,6 +4,8 @@ import initOnDemandEntries from './on-demand-entries-client'
 import { addMessageListener, connectHMR } from './error-overlay/websocket'
 
 const data = JSON.parse(document.getElementById('__NEXT_DATA__').textContent)
+window.__NEXT_DATA__ = data
+
 let { assetPrefix, page } = data
 assetPrefix = assetPrefix || ''
 let mostRecentHash = null

--- a/packages/next/client/dev/error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev/error-overlay/hot-dev-client.js
@@ -35,7 +35,6 @@ import {
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { addMessageListener } from './websocket'
 import formatWebpackMessages from './format-webpack-messages'
-import Router from 'next/router'
 
 // This alternative WebpackDevServer combines the functionality of:
 // https://github.com/webpack/webpack-dev-server/blob/webpack-1/client/index.js
@@ -57,7 +56,7 @@ export default function connect() {
     try {
       processMessage(event)
     } catch (ex) {
-      console.warn('Invalid HMR message: ' + event.data + '\n' + ex)
+      console.warn('Invalid HMR message: ' + event.data + '\n', ex)
     }
   })
 
@@ -91,7 +90,7 @@ function handleSuccess() {
 
   const isHotUpdate =
     !isFirstCompilation ||
-    (Router.pathname !== '/_error' && isUpdateAvailable())
+    (window.__NEXT_DATA__.page !== '/_error' && isUpdateAvailable())
   isFirstCompilation = false
   hasCompileErrors = false
 


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/31588 ensuring the other usage of `next/router` in `next dev` that can be called before the router is initialized is fixed. A test case for this isn't really able to be added as it is a race condition between the router initializing and the HMR message. 

This also fixes the `console.warn` shown when processing an HMR message fails to show the error stack correctly which made tracking this down easier. 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/30710