### PR TITLE
avoid mutating response.cookie options

### DIFF
--- a/packages/next/server/web/spec-extension/response.ts
+++ b/packages/next/server/web/spec-extension/response.ts
@@ -46,16 +46,20 @@ export class NextResponse extends Response {
     const val =
       typeof value === 'object' ? 'j:' + JSON.stringify(value) : String(value)
 
-    if (opts.maxAge) {
-      opts.expires = new Date(Date.now() + opts.maxAge)
-      opts.maxAge /= 1000
+    const options = { ...opts }
+    if (options.maxAge) {
+      options.expires = new Date(Date.now() + options.maxAge)
+      options.maxAge /= 1000
     }
 
-    if (opts.path == null) {
-      opts.path = '/'
+    if (options.path == null) {
+      options.path = '/'
     }
 
-    this.headers.append('Set-Cookie', cookie.serialize(name, String(val), opts))
+    this.headers.append(
+      'Set-Cookie',
+      cookie.serialize(name, String(val), options)
+    )
     return this
   }
 

--- a/test/unit/web-runtime/next-response.test.ts
+++ b/test/unit/web-runtime/next-response.test.ts
@@ -52,3 +52,14 @@ it('automatically parses and formats JSON', async () => {
     body: '',
   })
 })
+
+it('response.cookie does not modify options', async () => {
+  const { NextResponse } = await import(
+    'next/dist/server/web/spec-extension/response'
+  )
+
+  const options = { maxAge: 10000 }
+  const response = NextResponse.json(null)
+  response.cookie('cookieName', 'cookieValue', options)
+  expect(options).toEqual({ maxAge: 10000 })
+})


### PR DESCRIPTION
Previously `response.cookie(name, value, options)` would mutate the passed in `options` which lead to unexpected behaviour as described in #31666.

This PR clones the `options` argument before mutating it.

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

closes #31666