### PR TITLE
Improve and refactor some types

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -2057,8 +2057,6 @@ export default async function build(
   return buildResult
 }
 
-export type ClientSsgManifest = Set<string>
-
 function generateClientSsgManifest(
   prerenderManifest: PrerenderManifest,
   {
@@ -2067,7 +2065,7 @@ function generateClientSsgManifest(
     locales,
   }: { buildId: string; distDir: string; locales: string[] }
 ) {
-  const ssgPages: ClientSsgManifest = new Set<string>([
+  const ssgPages = new Set<string>([
     ...Object.entries(prerenderManifest.routes)
       // Filter out dynamic routes
       .filter(([, { srcRoute }]) => srcRoute == null)

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -209,7 +209,7 @@ export default class BuildManifestPlugin {
         assetMap.lowPriorityFiles.push(ssgManifestPath)
         assets[ssgManifestPath] = new sources.RawSource(srcEmptySsgManifest)
 
-        const srcEmptyMiddlewareManifest = `self.__MIDDLEWARE_MANIFEST=new Set;self.__MIDDLEWARE_MANIFEST_CB&&self.__MIDDLEWARE_MANIFEST_CB()`
+        const srcEmptyMiddlewareManifest = `self.__MIDDLEWARE_MANIFEST=[];self.__MIDDLEWARE_MANIFEST_CB&&self.__MIDDLEWARE_MANIFEST_CB()`
         const middlewareManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_middlewareManifest.js`
         assetMap.lowPriorityFiles.push(middlewareManifestPath)
         assets[middlewareManifestPath] = new sources.RawSource(

--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -18,7 +18,7 @@ export const ssrEntries = new Map<string, { requireFlightManifest: boolean }>()
 export interface MiddlewareManifest {
   version: 1
   sortedMiddleware: string[]
-  clientInfo: [string, boolean][]
+  clientInfo: [location: string, isSSR: boolean][]
   middleware: {
     [page: string]: {
       env: string[]

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -6,7 +6,8 @@ import { StyleRegistry } from 'styled-jsx'
 import { HeadManagerContext } from '../shared/lib/head-manager-context'
 import mitt, { MittEmitter } from '../shared/lib/mitt'
 import { RouterContext } from '../shared/lib/router-context'
-import Router, {
+import type Router from '../shared/lib/router/router'
+import {
   AppComponent,
   AppProps,
   delBasePath,

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -1,5 +1,5 @@
-import { ComponentType } from 'react'
-import { ClientSsgManifest } from '../build'
+import type { ComponentType } from 'react'
+import type { RouteLoader } from './route-loader'
 import {
   addBasePath,
   addLocale,
@@ -13,7 +13,6 @@ import {
   createRouteLoader,
   getClientBuildManifest,
   getMiddlewareManifest,
-  RouteLoader,
 } from './route-loader'
 
 function normalizeRoute(route: string): string {
@@ -23,6 +22,15 @@ function normalizeRoute(route: string): string {
 
   if (route === '/') return route
   return route.replace(/\/$/, '')
+}
+
+declare global {
+  interface Window {
+    __DEV_MIDDLEWARE_MANIFEST?: [location: string, isSSR: boolean][]
+    __DEV_PAGES_MANIFEST?: { pages: string[] }
+    __SSG_MANIFEST_CB?: () => void
+    __SSG_MANIFEST?: Set<string>
+  }
 }
 
 export type StyleSheetTuple = { href: string; text: string }
@@ -35,10 +43,12 @@ export type GoodPageCache = {
 export default class PageLoader {
   private buildId: string
   private assetPrefix: string
+  private promisedSsgManifest: Promise<Set<string>>
+  private promisedDevPagesManifest?: Promise<string[]>
+  private promisedMiddlewareManifest?: Promise<
+    [location: string, isSSR: boolean][]
+  >
 
-  private promisedSsgManifest?: Promise<ClientSsgManifest>
-  private promisedDevPagesManifest?: Promise<any>
-  private promisedMiddlewareManifest?: Promise<[string, boolean][]>
   public routeLoader: RouteLoader
 
   constructor(buildId: string, assetPrefix: string) {
@@ -47,13 +57,12 @@ export default class PageLoader {
     this.buildId = buildId
     this.assetPrefix = assetPrefix
 
-    /** @type {Promise<Set<string>>} */
     this.promisedSsgManifest = new Promise((resolve) => {
-      if ((window as any).__SSG_MANIFEST) {
-        resolve((window as any).__SSG_MANIFEST)
+      if (window.__SSG_MANIFEST) {
+        resolve(window.__SSG_MANIFEST)
       } else {
-        ;(window as any).__SSG_MANIFEST_CB = () => {
-          resolve((window as any).__SSG_MANIFEST)
+        window.__SSG_MANIFEST_CB = () => {
+          resolve(window.__SSG_MANIFEST!)
         }
       }
     })
@@ -63,48 +72,54 @@ export default class PageLoader {
     if (process.env.NODE_ENV === 'production') {
       return getClientBuildManifest().then((manifest) => manifest.sortedPages)
     } else {
-      if ((window as any).__DEV_PAGES_MANIFEST) {
-        return (window as any).__DEV_PAGES_MANIFEST.pages
+      if (window.__DEV_PAGES_MANIFEST) {
+        return window.__DEV_PAGES_MANIFEST.pages
       } else {
         if (!this.promisedDevPagesManifest) {
+          // TODO: Decide what should happen when fetching fails instead of asserting
+          // @ts-ignore
           this.promisedDevPagesManifest = fetch(
             `${this.assetPrefix}/_next/static/development/_devPagesManifest.json`
           )
             .then((res) => res.json())
-            .then((manifest) => {
-              ;(window as any).__DEV_PAGES_MANIFEST = manifest
+            .then((manifest: { pages: string[] }) => {
+              window.__DEV_PAGES_MANIFEST = manifest
               return manifest.pages
             })
             .catch((err) => {
               console.log(`Failed to fetch devPagesManifest`, err)
             })
         }
-        return this.promisedDevPagesManifest
+        // TODO Remove this assertion as this could be undefined
+        return this.promisedDevPagesManifest!
       }
     }
   }
 
-  getMiddlewareList(): Promise<[string, boolean][]> {
+  getMiddlewareList() {
     if (process.env.NODE_ENV === 'production') {
       return getMiddlewareManifest()
     } else {
-      if ((window as any).__DEV_MIDDLEWARE_MANIFEST) {
-        return (window as any).__DEV_MIDDLEWARE_MANIFEST
+      if (window.__DEV_MIDDLEWARE_MANIFEST) {
+        return window.__DEV_MIDDLEWARE_MANIFEST
       } else {
         if (!this.promisedMiddlewareManifest) {
+          // TODO: Decide what should happen when fetching fails instead of asserting
+          // @ts-ignore
           this.promisedMiddlewareManifest = fetch(
             `${this.assetPrefix}/_next/static/${this.buildId}/_devMiddlewareManifest.json`
           )
             .then((res) => res.json())
-            .then((manifest) => {
-              ;(window as any).__DEV_MIDDLEWARE_MANIFEST = manifest
+            .then((manifest: [location: string, isSSR: boolean][]) => {
+              window.__DEV_MIDDLEWARE_MANIFEST = manifest
               return manifest
             })
             .catch((err) => {
               console.log(`Failed to fetch _devMiddlewareManifest`, err)
             })
         }
-        return this.promisedMiddlewareManifest
+        // TODO Remove this assertion as this could be undefined
+        return this.promisedMiddlewareManifest!
       }
     }
   }
@@ -123,7 +138,7 @@ export default class PageLoader {
   }: {
     href: string
     asPath: string
-    ssg: boolean
+    ssg?: boolean
     rsc?: boolean
     locale?: string | false
   }): string {
@@ -157,9 +172,7 @@ export default class PageLoader {
    * @param {string} route - the route (file-system path)
    */
   _isSsg(route: string): Promise<boolean> {
-    return this.promisedSsgManifest!.then((s: ClientSsgManifest) =>
-      s.has(route)
-    )
+    return this.promisedSsgManifest.then((manifest) => manifest.has(route))
   }
 
   loadPage(route: string): Promise<GoodPageCache> {

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -6,7 +6,7 @@ import {
   AppPropsType,
   NextWebVitalsMetric,
 } from '../shared/lib/utils'
-import { Router } from '../client/router'
+import type { Router } from '../client/router'
 
 export { AppInitialProps }
 

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1,23 +1,25 @@
 // tslint:disable:no-console
-import { ParsedUrlQuery } from 'querystring'
-import { ComponentType } from 'react'
-import { UrlObject } from 'url'
+import type { ComponentType } from 'react'
+import type { DomainLocale } from '../../../server/config'
+import type { MittEmitter } from '../mitt'
+import type { ParsedUrlQuery } from 'querystring'
+import type { RouterEvent } from '../../../client/router'
+import type { StyleSheetTuple } from '../../../client/page-loader'
+import type { UrlObject } from 'url'
+import type PageLoader from '../../../client/page-loader'
 import {
   normalizePathTrailingSlash,
   removePathTrailingSlash,
 } from '../../../client/normalize-trailing-slash'
-import { GoodPageCache, StyleSheetTuple } from '../../../client/page-loader'
 import {
   getClientBuildManifest,
   isAssetError,
   markAssetError,
 } from '../../../client/route-loader'
-import { RouterEvent } from '../../../client/router'
 import isError from '../../../lib/is-error'
-import type { DomainLocale } from '../../../server/config'
 import { denormalizePagePath } from '../../../server/denormalize-page-path'
 import { normalizeLocalePath } from '../i18n/normalize-locale-path'
-import mitt, { MittEmitter } from '../mitt'
+import mitt from '../mitt'
 import {
   AppContextType,
   formatWithValidation,
@@ -612,7 +614,7 @@ export default class Router implements BaseRouter {
 
   sub: Subscription
   clc: ComponentLoadCancel
-  pageLoader: any
+  pageLoader: PageLoader
   _bps: BeforePopStateCallback | undefined
   events: MittEmitter<RouterEvent>
   _wrapApp: (App: AppComponent) => any
@@ -1738,7 +1740,7 @@ export default class Router implements BaseRouter {
     ])
   }
 
-  async fetchComponent(route: string): Promise<GoodPageCache> {
+  async fetchComponent(route: string) {
     let cancelled = false
     const cancel = (this.clc = () => {
       cancelled = true
@@ -1819,7 +1821,7 @@ export default class Router implements BaseRouter {
       this.locale
     )
 
-    const fns: [string, boolean][] = await this.pageLoader.getMiddlewareList()
+    const fns = await this.pageLoader.getMiddlewareList()
     const requiresPreflight = fns.some(([middleware, isSSR]) => {
       return getRouteMatcher(getMiddlewareRegex(middleware, !isSSR))(cleanedAs)
     })


### PR DESCRIPTION
While investigating #30833 I've noticed we are typing in `router` the `PageLoader` as `any`. In an attempt to fix that this PR refactors and simplify some types across the Router and the Pages Loader to leverage type inference more.

This also adds two TODO for two cases where the manifest can be set to empty which might be the cause of the mentioned issue. Nonetheless this can happen for `pages` as well and we must decide what to do about it (which can happen in a different PR) that is, falling back or failing right away.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
