### PR TITLE
Remove noop import

### DIFF
--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -1,4 +1,3 @@
-/* globals __REPLACE_NOOP_IMPORT__ */
 import { initNext, version, router, emitter, render, renderError } from './'
 import initOnDemandEntries from './dev/on-demand-entries-client'
 import initWebpackHMR from './dev/webpack-hot-middleware-client'
@@ -9,13 +8,6 @@ import {
   assign,
   urlQueryToSearchParams,
 } from '../shared/lib/router/utils/querystring'
-
-// Temporary workaround for the issue described here:
-// https://github.com/vercel/next.js/issues/3775#issuecomment-407438123
-// The runtimeChunk doesn't have dynamic import handling code when there hasn't been a dynamic import
-// The runtimeChunk can't hot reload itself currently to correct it when adding pages using on-demand-entries
-// eslint-disable-next-line no-unused-expressions
-__REPLACE_NOOP_IMPORT__
 
 const {
   __NEXT_DATA__: { assetPrefix },

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -97,14 +97,6 @@ module.exports = function (task) {
         file.base = file.base.replace(extRegex, stripExtension ? '' : '.js')
       }
 
-      // Workaround for noop.js loading
-      if (file.base === 'next-dev.js') {
-        output.code = output.code.replace(
-          /__REPLACE_NOOP_IMPORT__/g,
-          `import('./dev/noop');`
-        )
-      }
-
       if (output.map) {
         const map = `${file.base}.map`
 


### PR DESCRIPTION
This is no longer needed with webpack 5.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
