### PR TITLE
Fix initial compile timing incorrect measurement

### DIFF
--- a/packages/next/build/output/index.ts
+++ b/packages/next/build/output/index.ts
@@ -107,10 +107,7 @@ let serverWebWasLoading = false
 buildStore.subscribe((state) => {
   const { amp, client, server, serverWeb, trigger } = state
 
-  const { bootstrap: bootstrapping, appUrl } = consoleStore.getState()
-  if (bootstrapping && (client.loading || server.loading)) {
-    return
-  }
+  const { appUrl } = consoleStore.getState()
 
   if (client.loading || server.loading || serverWeb?.loading) {
     consoleStore.setState(

--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -56,17 +56,20 @@ store.subscribe((state) => {
     if (state.appUrl) {
       Log.ready(`started server on ${state.bindAddr}, url: ${state.appUrl}`)
     }
-    if (startTime === 0) startTime = Date.now()
     return
   }
 
   if (state.loading) {
     if (state.trigger) {
-      Log.wait(`compiling ${state.trigger}...`)
+      if (state.trigger !== 'initial') {
+        Log.wait(`compiling ${state.trigger}...`)
+      }
     } else {
       Log.wait('compiling...')
     }
-    if (startTime === 0) startTime = Date.now()
+    if (startTime === 0) {
+      startTime = Date.now()
+    }
     return
   }
 


### PR DESCRIPTION
I noticed in traces that the initial compilation is almost 2x faster than what was being reported, turns out the initial time was being set before the compiler runs, this fixes that.


<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
