### PR TITLE
bugfix: href value is not defined when typing out the href

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-html-link-for-pages.js
+++ b/packages/eslint-plugin-next/lib/rules/no-html-link-for-pages.js
@@ -94,7 +94,7 @@ module.exports = {
           (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'href'
         )
 
-        if (!href || href.value.type !== 'Literal') {
+        if (!href || (href.value && href.value.type !== 'Literal')) {
           return
         }
 


### PR DESCRIPTION
This PR fixes an issue where typing out `href=` inside an anchor tag in JSX is causing an ESLint error to popup

```
[Error - 1:24:30 PM] TypeError: Cannot read property 'type' of null
Occurred while linting /Desktop/project/src/components/Post/PostPreview.tsx:31
    at JSXOpeningElement (/Users/jmonson/Desktop/bundled/sol-test/node_modules/@next/eslint-plugin-next/lib/rules/no-html-link-for-pages.js:97:33)
```

This is related to the following issue: https://github.com/vercel/next.js/issues/5533

The workaround proposed [here](https://github.com/vercel/next.js/issues/5533#issuecomment-760242123) causes this error since we end up typing `href="..."` into the JSX element.