### PR TITLE
[Docs][Fix] Broken Link to API Reference

### DIFF
--- a/docs/advanced-features/debugging.md
+++ b/docs/advanced-features/debugging.md
@@ -44,7 +44,7 @@ Create a file named `.vscode/launch.json` at the root of your project with the f
 }
 ```
 
-`npm run dev` can be replaced with `yarn dev` if you're using Yarn. If you're [changing the port number](<(/docs/api-reference/cli#development)>) your application starts on, replace the `3000` in `http://localhost:3000` with the port you're using instead.
+`npm run dev` can be replaced with `yarn dev` if you're using Yarn. If you're [changing the port number](/docs/api-reference/cli#development) your application starts on, replace the `3000` in `http://localhost:3000` with the port you're using instead.
 
 Now go to the Debug panel (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> on Windows/Linux, <kbd>⇧</kbd>+<kbd>⌘</kbd>+<kbd>D</kbd> on macOS), select a launch configuration, then press <kbd>F5</kbd> or select **Debug: Start Debugging** from the Command Palette to start your debugging session.
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples
- [x] Make sure the linting passes by running `yarn lint`

## Steps to Reproduce

1. Go to https://nextjs.org/docs/advanced-features/debugging#debugging-with-vs-code

2. Click on the link as shown in red underlined in below image.
<img width="835" alt="image" src="https://user-images.githubusercontent.com/53480076/143548215-ee75deac-3e8b-42b3-ba72-fae0b76b30a3.png">

3. Ending up with the **404 Error** screen
<img width="835" alt="image" src="https://user-images.githubusercontent.com/53480076/143548364-7ddf45c9-4e69-44eb-9217-3547419e103a.png">

## Fixing Steps

Replace the broken link with correct one.
