### PR TITLE
Add port and hostname options to Next Server

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import arg from 'next/dist/compiled/arg/index.js'
 import { existsSync } from 'fs'
-import startServer from '../server/lib/start-server'
+import { startServer } from '../server/lib/start-server'
 import { printAndExit } from '../server/lib/utils'
 import * as Log from '../build/output/log'
 import { startedDevelopmentServer } from '../build/output'
@@ -88,16 +88,17 @@ const nextDev: cliCommand = (argv) => {
   // some set-ups that rely on listening on other interfaces
   const host = args['--hostname']
 
-  startServer(
-    { dir, dev: true, isNextDevCommand: true, allowRetry },
+  startServer({
+    allowRetry,
+    dev: true,
+    dir,
+    hostname: host,
+    isNextDevCommand: true,
     port,
-    host
-  )
-    .then(async ({ app, actualPort }) => {
-      const appUrl = `http://${
-        !host || host === '0.0.0.0' ? 'localhost' : host
-      }:${actualPort}`
-      startedDevelopmentServer(appUrl, `${host || '0.0.0.0'}:${actualPort}`)
+  })
+    .then(async (app) => {
+      const appUrl = `http://${app.hostname}:${app.port}`
+      startedDevelopmentServer(appUrl, `${host || '0.0.0.0'}:${app.port}`)
       // Start preflight after server is listening and ignore errors:
       preflight().catch(() => {})
       // Finalize server bootup:

--- a/packages/next/cli/next-start.ts
+++ b/packages/next/cli/next-start.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import arg from 'next/dist/compiled/arg/index.js'
-import startServer from '../server/lib/start-server'
+import { startServer } from '../server/lib/start-server'
 import { printAndExit } from '../server/lib/utils'
 import { cliCommand } from '../bin/next'
 import * as Log from '../build/output/log'
@@ -58,12 +58,14 @@ const nextStart: cliCommand = (argv) => {
     port = 0
   }
 
-  startServer({ dir }, port, host)
-    .then(async ({ app, actualPort }) => {
-      const appUrl = `http://${
-        host === '0.0.0.0' ? 'localhost' : host
-      }:${actualPort}`
-      Log.ready(`started server on ${host}:${actualPort}, url: ${appUrl}`)
+  startServer({
+    dir,
+    hostname: host,
+    port,
+  })
+    .then(async (app) => {
+      const appUrl = `http://${app.hostname}:${app.port}`
+      Log.ready(`started server on ${host}:${app.port}, url: ${appUrl}`)
       await app.prepare()
     })
     .catch((err) => {

--- a/packages/next/server/dev/static-paths-worker.ts
+++ b/packages/next/server/dev/static-paths-worker.ts
@@ -1,8 +1,11 @@
-import { buildStaticPaths } from '../../build/utils'
-import { setHttpAgentOptions } from '../config'
-import { NextConfigComplete } from '../config-shared'
-import { loadComponents } from '../load-components'
+import type { GetStaticPaths } from 'next/types'
+import type { NextConfigComplete } from '../config-shared'
+import type { UnwrapPromise } from '../../lib/coalesced-function'
+
 import '../node-polyfill-fetch'
+import { buildStaticPaths } from '../../build/utils'
+import { loadComponents } from '../load-components'
+import { setHttpAgentOptions } from '../config'
 
 type RuntimeConfig = any
 
@@ -19,7 +22,12 @@ export async function loadStaticPaths(
   httpAgentOptions: NextConfigComplete['httpAgentOptions'],
   locales?: string[],
   defaultLocale?: string
-) {
+): Promise<
+  Omit<UnwrapPromise<ReturnType<GetStaticPaths>>, 'paths'> & {
+    paths: string[]
+    encodedPaths: string[]
+  }
+> {
   // we only want to use each worker once to prevent any invalid
   // caches
   if (workerWasUsed) {

--- a/packages/next/server/lib/start-server.ts
+++ b/packages/next/server/lib/start-server.ts
@@ -1,4 +1,4 @@
-import type { NextServerOptions } from '../next'
+import type { NextServerOptions, NextServer, RequestHandler } from '../next'
 import { warn } from '../../build/output/log'
 import http from 'http'
 import next from '../next'
@@ -7,48 +7,52 @@ interface StartServerOptions extends NextServerOptions {
   allowRetry?: boolean
 }
 
-export default async function start(
-  serverOptions: StartServerOptions,
-  port?: number,
-  hostname?: string
-) {
-  let requestHandler: ReturnType<typeof app.getRequestHandler>
-  const srv = http.createServer((req, res) => {
+export function startServer(opts: StartServerOptions) {
+  let requestHandler: RequestHandler
+
+  const server = http.createServer((req, res) => {
     return requestHandler(req, res)
   })
-  const app = next({
-    ...serverOptions,
-    customServer: false,
-    httpServer: srv,
-  })
-  requestHandler = app.getRequestHandler()
 
-  await new Promise<void>((resolve, reject) => {
+  return new Promise<NextServer>((resolve, reject) => {
+    let port = opts.port
     let retryCount = 0
-    srv.on('error', (err: NodeJS.ErrnoException) => {
-      // This code catches EADDRINUSE error if the port is already in use
+
+    server.on('error', (err: NodeJS.ErrnoException) => {
       if (
-        err.code === 'EADDRINUSE' &&
-        serverOptions.allowRetry &&
         port &&
+        opts.allowRetry &&
+        err.code === 'EADDRINUSE' &&
         retryCount < 10
       ) {
         warn(`Port ${port} is in use, trying ${port + 1} instead.`)
         port += 1
         retryCount += 1
-        srv.listen(port, hostname)
+        server.listen(port, opts.hostname)
       } else {
         reject(err)
       }
     })
-    srv.on('listening', () => resolve())
-    srv.listen(port, hostname)
+
+    server.on('listening', () => {
+      const addr = server.address()
+      const hostname =
+        !opts.hostname || opts.hostname === '0.0.0.0'
+          ? 'localhost'
+          : opts.hostname
+
+      const app = next({
+        ...opts,
+        hostname,
+        customServer: false,
+        httpServer: server,
+        port: addr && typeof addr === 'object' ? addr.port : port,
+      })
+
+      requestHandler = app.getRequestHandler()
+      resolve(app)
+    })
+
+    server.listen(port, opts.hostname)
   })
-  // It's up to caller to run `app.prepare()`, so it can notify that the server
-  // is listening before starting any intensive operations.
-  const addr = srv.address()
-  return {
-    app,
-    actualPort: addr && typeof addr === 'object' ? addr.port : port,
-  }
 }

--- a/packages/next/server/lib/start-server.ts
+++ b/packages/next/server/lib/start-server.ts
@@ -1,9 +1,14 @@
+import type { NextServerOptions } from '../next'
+import { warn } from '../../build/output/log'
 import http from 'http'
 import next from '../next'
-import { warn } from '../../build/output/log'
+
+interface StartServerOptions extends NextServerOptions {
+  allowRetry?: boolean
+}
 
 export default async function start(
-  serverOptions: any,
+  serverOptions: StartServerOptions,
   port?: number,
   hostname?: string
 ) {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1,24 +1,31 @@
+import type { __ApiPreviewProps } from './api-utils'
+import type { CustomRoutes, Header } from '../lib/load-custom-routes'
+import type { DomainLocale } from './config'
+import type { DynamicRoutes, PageChecker, Params, Route } from './router'
+import type { FetchEventResult } from './web/types'
+import type { FontManifest } from './font-utils'
+import type { IncomingMessage, ServerResponse } from 'http'
+import type { LoadComponentsReturnType } from './load-components'
+import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'
+import type { NextApiRequest, NextApiResponse } from '../shared/lib/utils'
+import type { NextConfigComplete } from './config-shared'
+import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
+import type { ParsedNextUrl } from '../shared/lib/router/utils/parse-next-url'
+import type { ParsedUrl } from '../shared/lib/router/utils/parse-url'
+import type { ParsedUrlQuery } from 'querystring'
+import type { PrerenderManifest } from '../build'
+import type { Redirect, Rewrite, RouteType } from '../lib/load-custom-routes'
+import type { RenderOpts, RenderOptsPartial } from './render'
+import type { ResponseCacheEntry, ResponseCacheValue } from './response-cache'
+import type { UrlWithParsedQuery } from 'url'
+
 import compression from 'next/dist/compiled/compression'
 import fs from 'fs'
-import { IncomingMessage, ServerResponse } from 'http'
 import Proxy from 'next/dist/compiled/http-proxy'
 import { join, relative, resolve, sep } from 'path'
-import {
-  parse as parseQs,
-  stringify as stringifyQs,
-  ParsedUrlQuery,
-} from 'querystring'
-import { format as formatUrl, parse as parseUrl, UrlWithParsedQuery } from 'url'
-import { PrerenderManifest } from '../build'
-import {
-  getRedirectStatus,
-  Header,
-  Redirect,
-  Rewrite,
-  RouteType,
-  CustomRoutes,
-  modifyRouteRegex,
-} from '../lib/load-custom-routes'
+import { parse as parseQs, stringify as stringifyQs } from 'querystring'
+import { format as formatUrl, parse as parseUrl } from 'url'
+import { getRedirectStatus, modifyRouteRegex } from '../lib/load-custom-routes'
 import {
   BUILD_ID_FILE,
   CLIENT_PUBLIC_FILES_PATH,
@@ -45,8 +52,6 @@ import * as envConfig from '../shared/lib/runtime-config'
 import {
   DecodeError,
   isResSent,
-  NextApiRequest,
-  NextApiResponse,
   normalizeRepeatedSlashes,
 } from '../shared/lib/utils'
 import {
@@ -54,23 +59,15 @@ import {
   setLazyProp,
   getCookieParser,
   tryGetPreviewData,
-  __ApiPreviewProps,
 } from './api-utils'
-import { DomainLocale, isTargetLikeServerless, NextConfig } from './config'
+import { isTargetLikeServerless } from './config'
 import pathMatch from '../shared/lib/router/utils/path-match'
 import { recursiveReadDirSync } from './lib/recursive-readdir-sync'
-import { loadComponents, LoadComponentsReturnType } from './load-components'
+import { loadComponents } from './load-components'
 import { normalizePagePath } from './normalize-page-path'
-import { RenderOpts, RenderOptsPartial, renderToHTML } from './render'
+import { renderToHTML } from './render'
 import { getPagePath, requireFontManifest } from './require'
-import Router, {
-  DynamicRoutes,
-  PageChecker,
-  Params,
-  replaceBasePath,
-  route,
-  Route,
-} from './router'
+import Router, { replaceBasePath, route } from './router'
 import {
   compileNonPath,
   prepareDestination,
@@ -93,23 +90,13 @@ import { detectDomainLocale } from '../shared/lib/i18n/detect-domain-locale'
 import escapePathDelimiters from '../shared/lib/router/utils/escape-path-delimiters'
 import { getUtils } from '../build/webpack/loaders/next-serverless-loader/utils'
 import { PreviewData } from 'next/types'
-import ResponseCache, {
-  ResponseCacheEntry,
-  ResponseCacheValue,
-} from './response-cache'
-import { NextConfigComplete } from './config-shared'
+import ResponseCache from './response-cache'
 import { parseNextUrl } from '../shared/lib/router/utils/parse-next-url'
 import isError from '../lib/is-error'
 import { getMiddlewareInfo } from './require'
 import { MIDDLEWARE_ROUTE } from '../lib/constants'
 import { NextResponse } from './web/spec-extension/response'
 import { run } from './web/sandbox'
-import type { FontManifest } from './font-utils'
-import type { FetchEventResult } from './web/types'
-import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'
-import type { ParsedNextUrl } from '../shared/lib/router/utils/parse-next-url'
-import type { ParsedUrl } from '../shared/lib/router/utils/parse-url'
-import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import { addRequestMeta, getRequestMeta } from './request-meta'
 import { toNodeHeaders } from './web/utils'
 
@@ -132,21 +119,39 @@ interface RoutingItem {
   ssr?: boolean
 }
 
-export type ServerConstructor = {
+export interface Options {
   /**
-   * Where the Next project is located - @default '.'
+   * Object containing the configuration next.config.js
+   */
+  conf: NextConfigComplete
+  /**
+   * Set to false when the server was created by Next.js
+   */
+  customServer?: boolean
+  /**
+   * Tells if Next.js is running in dev mode
+   */
+  dev?: boolean
+  /**
+   * Where the Next project is located
    */
   dir?: string
   /**
-   * Hide error messages containing server information - @default false
+   * Tells if Next.js is running in a Serverless platform
+   */
+  minimalMode?: boolean
+  /**
+   * Hide error messages containing server information
    */
   quiet?: boolean
-  /**
-   * Object what you would use in next.config.js - @default {}
-   */
-  conf?: NextConfig | null
-  dev?: boolean
-  customServer?: boolean
+}
+
+export interface RequestHandler {
+  (
+    req: IncomingMessage,
+    res: ServerResponse,
+    parsedUrl?: NextUrlWithParsedQuery | undefined
+  ): Promise<void>
 }
 
 type RequestContext = {
@@ -210,12 +215,12 @@ export default class Server {
     dev = false,
     minimalMode = false,
     customServer = true,
-  }: ServerConstructor & { conf: NextConfig; minimalMode?: boolean }) {
+  }: Options) {
     this.dir = resolve(dir)
     this.quiet = quiet
     loadEnvConfig(this.dir, dev, Log)
 
-    this.nextConfig = conf as NextConfigComplete
+    this.nextConfig = conf
 
     this.distDir = join(this.dir, this.nextConfig.distDir)
     this.publicDir = join(this.dir, CLIENT_PUBLIC_FILES_PATH)
@@ -539,7 +544,7 @@ export default class Server {
     }
   }
 
-  public getRequestHandler() {
+  public getRequestHandler(): RequestHandler {
     return this.handleRequest.bind(this)
   }
 

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -144,6 +144,14 @@ export interface Options {
    * Hide error messages containing server information
    */
   quiet?: boolean
+  /**
+   * The hostname the server is running behind
+   */
+  hostname?: string
+  /**
+   * The port the server is running behind
+   */
+  port?: number
 }
 
 export interface RequestHandler {
@@ -207,6 +215,8 @@ export default class Server {
   protected customRoutes: CustomRoutes
   protected middlewareManifest?: MiddlewareManifest
   protected middleware?: RoutingItem[]
+  public readonly hostname?: string
+  public readonly port?: number
 
   public constructor({
     dir = '.',
@@ -215,12 +225,16 @@ export default class Server {
     dev = false,
     minimalMode = false,
     customServer = true,
+    hostname,
+    port,
   }: Options) {
     this.dir = resolve(dir)
     this.quiet = quiet
     loadEnvConfig(this.dir, dev, Log)
 
     this.nextConfig = conf
+    this.hostname = hostname
+    this.port = port
 
     this.distDir = join(this.dir, this.nextConfig.distDir)
     this.publicDir = join(this.dir, CLIENT_PUBLIC_FILES_PATH)

--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -1,22 +1,16 @@
-import './node-polyfill-fetch'
-import { default as Server, ServerConstructor } from './next-server'
-import { NON_STANDARD_NODE_ENV } from '../lib/constants'
-import * as log from '../build/output/log'
-import loadConfig, { NextConfig } from './config'
-import { resolve } from 'path'
-import {
-  PHASE_DEVELOPMENT_SERVER,
-  PHASE_PRODUCTION_SERVER,
-} from '../shared/lib/constants'
-import { IncomingMessage, ServerResponse } from 'http'
-import { UrlWithParsedQuery } from 'url'
+import type { IncomingMessage, ServerResponse } from 'http'
+import type { Options as DevServerOptions } from './dev/next-dev-server'
+import type { RequestHandler } from './next-server'
+import type { UrlWithParsedQuery } from 'url'
 
-type NextServerConstructor = ServerConstructor & {
-  /**
-   * Whether to launch Next.js in dev mode - @default false
-   */
-  dev?: boolean
-}
+import './node-polyfill-fetch'
+import { default as Server } from './next-server'
+import * as log from '../build/output/log'
+import loadConfig from './config'
+import { resolve } from 'path'
+import { NON_STANDARD_NODE_ENV } from '../lib/constants'
+import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
+import { PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 
 let ServerImpl: typeof Server
 
@@ -26,18 +20,20 @@ const getServerImpl = async () => {
   return ServerImpl
 }
 
+export type NextServerOptions = Partial<DevServerOptions>
+
 export class NextServer {
   private serverPromise?: Promise<Server>
   private server?: Server
-  private reqHandlerPromise?: Promise<any>
+  private reqHandlerPromise?: Promise<RequestHandler>
   private preparedAssetPrefix?: string
-  options: NextServerConstructor
+  public options: NextServerOptions
 
-  constructor(options: NextServerConstructor) {
+  constructor(options: NextServerOptions) {
     this.options = options
   }
 
-  getRequestHandler() {
+  getRequestHandler(): RequestHandler {
     return async (
       req: IncomingMessage,
       res: ServerResponse,
@@ -102,12 +98,7 @@ export class NextServer {
     return (server as any).close()
   }
 
-  private async createServer(
-    options: NextServerConstructor & {
-      conf: NextConfig
-      isNextDevCommand?: boolean
-    }
-  ): Promise<Server> {
+  private async createServer(options: DevServerOptions): Promise<Server> {
     if (options.dev) {
       const DevServer = require('./dev/next-dev-server').default
       return new DevServer(options)
@@ -154,9 +145,7 @@ export class NextServer {
 }
 
 // This file is used for when users run `require('next')`
-function createServer(options: NextServerConstructor): NextServer {
-  const standardEnv = ['production', 'development', 'test']
-
+function createServer(options: NextServerOptions): NextServer {
   if (options == null) {
     throw new Error(
       'The server has not been instantiated properly. https://nextjs.org/docs/messages/invalid-server-options'
@@ -164,19 +153,17 @@ function createServer(options: NextServerConstructor): NextServer {
   }
 
   if (
-    !(options as any).isNextDevCommand &&
+    !('isNextDevCommand' in options) &&
     process.env.NODE_ENV &&
-    !standardEnv.includes(process.env.NODE_ENV)
+    !['production', 'development', 'test'].includes(process.env.NODE_ENV)
   ) {
     log.warn(NON_STANDARD_NODE_ENV)
   }
 
-  if (options.dev) {
-    if (typeof options.dev !== 'boolean') {
-      console.warn(
-        "Warning: 'dev' is not a boolean which could introduce unexpected behavior. https://nextjs.org/docs/messages/invalid-server-options"
-      )
-    }
+  if (options.dev && typeof options.dev !== 'boolean') {
+    console.warn(
+      "Warning: 'dev' is not a boolean which could introduce unexpected behavior. https://nextjs.org/docs/messages/invalid-server-options"
+    )
   }
 
   return new NextServer(options)

--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -33,6 +33,14 @@ export class NextServer {
     this.options = options
   }
 
+  get hostname() {
+    return this.options.hostname
+  }
+
+  get port() {
+    return this.options.port
+  }
+
   getRequestHandler(): RequestHandler {
     return async (
       req: IncomingMessage,
@@ -175,3 +183,4 @@ exports = module.exports
 
 // Support `import next from 'next'`
 export default createServer
+export type { RequestHandler }


### PR DESCRIPTION
A middleware can work as a proxy intercepting requests and then performing a `fetch` to the destination adding headers to the request / response as a "man in the middle". When using `fetch` from a middleware we are not in the context of a browser so we can't really use relative URLs, they must be always absolute.

Now consider the previous case when middleware is running in *server mode*. Typically in order to know the host where we are fetching we can use the `request.nextUrl` which is given to the middleware but in this case the invoker (which is next-server) has no context of the hostname, nor the port. To solve this use case we must make the invoker of the middleware aware of the origin hostname and port.

This PR: 

- Introduces `hostname` and `port` as options for `NextServer`.
- Refactors types in `NextServer` and `NextDevServer` moving type only imports to the top of the file.
- Refactors `startServer` to do a best guess on the `hostname` and `port`, passing them down.
- Exposes `.port` and `.hostname` to be retrieved from the `app`.

In an upcoming PR we will pass the host guess to the middleware to solve the relative URL issue.