### PR TITLE
Docs(React 18): add missing `Suspense` import

### DIFF
--- a/docs/advanced-features/react-18.md
+++ b/docs/advanced-features/react-18.md
@@ -33,7 +33,7 @@ Once enabled, you can use Suspense and SSR streaming for all pages. This also me
 
 ```jsx
 import dynamic from 'next/dynamic'
-import { lazy } from 'react'
+import { lazy, Suspense } from 'react'
 
 import Content from '../components/content'
 


### PR DESCRIPTION
This PR adds a missing import in React 18 documentation's sample code, where `Suspense` is used without being imported.

_(edit: fix typo)_