### PR TITLE
Docs(React 18): remove unnecessary `React` import

### DIFF
--- a/docs/advanced-features/react-18.md
+++ b/docs/advanced-features/react-18.md
@@ -109,7 +109,7 @@ You can then import other server or client components from any server component.
 ```jsx
 // pages/home.server.js
 
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
 
 import Profile from '../components/profile.server'
 import Content from '../components/content.client'


### PR DESCRIPTION
In the `Server Components APIs (Alpha)` code sample, importing `React` is unnecessary. People may think that having `react`'s default export imported is needed to use `Suspense`