### PR TITLE
Make NextServer runtime agnostic

### DIFF
--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -696,6 +696,13 @@ export default class DevServer extends Server {
     })
   }
 
+  protected getPagesManifest(): undefined {
+    return undefined
+  }
+  protected getMiddlewareManifest(): undefined {
+    return undefined
+  }
+
   protected getMiddleware(): never[] {
     return []
   }

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -749,9 +749,7 @@ export default class Server {
     locales: string[]
   } {
     const server: Server = this
-    const publicRoutes = fs.existsSync(this.publicDir)
-      ? this.generatePublicRoutes()
-      : []
+    const publicRoutes = this.generatePublicRoutes()
 
     const staticFilesRoute = this.hasStaticDir
       ? [
@@ -1493,6 +1491,8 @@ export default class Server {
   }
 
   protected generatePublicRoutes(): Route[] {
+    if (!fs.existsSync(this.publicDir)) return []
+
     const publicFiles = new Set(
       recursiveReadDirSync(this.publicDir).map((p) =>
         encodeURI(p.replace(/\\/g, '/'))

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -278,18 +278,9 @@ export default class Server {
       this.distDir,
       this._isLikeServerless ? SERVERLESS_DIRECTORY : SERVER_DIRECTORY
     )
-    const pagesManifestPath = join(this.serverBuildDir, PAGES_MANIFEST)
-    const middlewareManifestPath = join(
-      join(this.distDir, SERVER_DIRECTORY),
-      MIDDLEWARE_MANIFEST
-    )
 
-    if (!dev) {
-      this.pagesManifest = require(pagesManifestPath)
-      if (!this.minimalMode) {
-        this.middlewareManifest = require(middlewareManifestPath)
-      }
-    }
+    this.pagesManifest = this.getPagesManifest()
+    this.middlewareManifest = this.getMiddlewareManifest()
 
     this.customRoutes = this.getCustomRoutes()
     this.router = new Router(this.generateRoutes())
@@ -587,6 +578,22 @@ export default class Server {
 
   protected getPreviewProps(): __ApiPreviewProps {
     return this.getPrerenderManifest().preview
+  }
+
+  protected getPagesManifest(): PagesManifest | undefined {
+    const pagesManifestPath = join(this.serverBuildDir, PAGES_MANIFEST)
+    return require(pagesManifestPath)
+  }
+
+  protected getMiddlewareManifest(): MiddlewareManifest | undefined {
+    if (!this.minimalMode) {
+      const middlewareManifestPath = join(
+        join(this.distDir, SERVER_DIRECTORY),
+        MIDDLEWARE_MANIFEST
+      )
+      return require(middlewareManifestPath)
+    }
+    return undefined
   }
 
   protected getMiddleware() {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -219,7 +219,7 @@ export default class Server {
 
     this.distDir = join(this.dir, this.nextConfig.distDir)
     this.publicDir = join(this.dir, CLIENT_PUBLIC_FILES_PATH)
-    this.hasStaticDir = !minimalMode && fs.existsSync(join(this.dir, 'static'))
+    this.hasStaticDir = !minimalMode && this.getHasStaticDir()
 
     // Only serverRuntimeConfig needs the default
     // publicRuntimeConfig gets it's default in client/index.js
@@ -1488,6 +1488,10 @@ export default class Server {
       page
     )
     return true
+  }
+
+  protected getHasStaticDir(): boolean {
+    return fs.existsSync(join(this.dir, 'static'))
   }
 
   protected generatePublicRoutes(): Route[] {

--- a/packages/next/server/web/next-web-server.ts
+++ b/packages/next/server/web/next-web-server.ts
@@ -1,7 +1,33 @@
-import Server from '../next-server'
+import Server, { ServerConstructor } from '../next-server'
+import { NextConfig } from '../config'
+import { PagesManifest } from '../../build/webpack/plugins/pages-manifest-plugin'
+import { Route } from '../router'
+
+type WebRuntimeConfig = {
+  buildId: string
+  pagesManifest: PagesManifest
+}
 
 export default class WebServer extends Server {
+  protected runtimeConfig: WebRuntimeConfig
+
+  constructor(
+    options: ServerConstructor & {
+      conf: NextConfig
+      runtimeConfig: WebRuntimeConfig
+    }
+  ) {
+    super(options)
+    this.runtimeConfig = options.runtimeConfig
+  }
+
+  protected generatePublicRoutes(): Route[] {
+    return []
+  }
   protected getHasStaticDir(): boolean {
     return false
+  }
+  protected readBuildId(): string {
+    return this.runtimeConfig.buildId
   }
 }

--- a/packages/next/server/web/next-web-server.ts
+++ b/packages/next/server/web/next-web-server.ts
@@ -1,0 +1,7 @@
+import Server from '../next-server'
+
+export default class WebServer extends Server {
+  protected getHasStaticDir(): boolean {
+    return false
+  }
+}

--- a/packages/next/server/web/next-web-server.ts
+++ b/packages/next/server/web/next-web-server.ts
@@ -30,4 +30,8 @@ export default class WebServer extends Server {
   protected readBuildId(): string {
     return this.runtimeConfig.buildId
   }
+  // The web runtime doesn't need to serve any static files
+  protected isServeableUrl(): boolean {
+    return false
+  }
 }


### PR DESCRIPTION
As an important step for #31506, this PR adds a `WebServer` class similar to `DevServer`, overriding methods from the default server that depends on native APIs.

- [x] `fs`
- [ ] `require`
- [ ] manifests

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
