### PR TITLE
add experimental.swcFileReading flag to disable file reading in swc

### DIFF
--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -19,6 +19,7 @@ async function loadWasm() {
         bindings = await bindings.default()
       }
       return {
+        isWasm: true,
         transform(src, options) {
           return Promise.resolve(
             bindings.transformSync(src.toString(), options)
@@ -63,6 +64,7 @@ function loadNative() {
 
   if (bindings) {
     return {
+      isWasm: false,
       transform(src, options) {
         const isModule =
           typeof src !== undefined &&
@@ -131,6 +133,11 @@ function loadNative() {
 
 function toBuffer(t) {
   return Buffer.from(JSON.stringify(t))
+}
+
+export async function isWasm() {
+  let bindings = await loadBindings()
+  return bindings.isWasm
 }
 
 export async function transform(src, options) {

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -445,6 +445,7 @@ export default async function getBaseWebpackConfig(
             isServer: isMiddleware || isServer,
             pagesDir,
             hasReactRefresh: !isMiddleware && hasReactRefresh,
+            fileReading: config.experimental.swcFileReading,
             nextConfig: config,
             jsConfig,
           },

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -107,7 +107,6 @@ export function pitch() {
       isAbsolute(this.resourcePath) &&
       !(await isWasm())
     ) {
-      console.log(this.resourcePath)
       const loaderSpan = this.currentTraceSpan.traceChild('next-swc-loader')
       this.addDependency(this.resourcePath)
       return loaderSpan.traceAsyncFn(() =>

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -26,7 +26,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-import { transform } from '../../swc'
+import { isWasm, transform } from '../../swc'
 import { getLoaderSWCOptions } from '../../swc/options'
 import { isAbsolute } from 'path'
 
@@ -93,26 +93,31 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
   )
 }
 
+const EXCLUDED_PATHS =
+  /[\\/](cache[\\/][^\\/]+\.zip[\\/]node_modules|__virtual__)[\\/]/g
+
 export function pitch() {
-  if (
-    this.loaders.length - 1 === this.loaderIndex &&
-    isAbsolute(this.resourcePath)
-  ) {
-    const loaderSpan = this.currentTraceSpan.traceChild('next-swc-loader')
-    const callback = this.async()
-    loaderSpan
-      .traceAsyncFn(() => loaderTransform.call(this, loaderSpan))
-      .then(
-        ([transformedSource, outputSourceMap]) => {
-          this.addDependency(this.resourcePath)
-          callback(null, transformedSource, outputSourceMap)
-        },
-        (err) => {
-          this.addDependency(this.resourcePath)
-          callback(err)
-        }
+  const callback = this.async()
+  ;(async () => {
+    let loaderOptions = this.getOptions() || {}
+    if (
+      loaderOptions.fileReading &&
+      !EXCLUDED_PATHS.test(this.resourcePath) &&
+      this.loaders.length - 1 === this.loaderIndex &&
+      isAbsolute(this.resourcePath) &&
+      !(await isWasm())
+    ) {
+      console.log(this.resourcePath)
+      const loaderSpan = this.currentTraceSpan.traceChild('next-swc-loader')
+      this.addDependency(this.resourcePath)
+      return loaderSpan.traceAsyncFn(() =>
+        loaderTransform.call(this, loaderSpan)
       )
-  }
+    }
+  })().then((r) => {
+    if (r) return callback(null, ...r)
+    callback()
+  }, callback)
 }
 
 export default function swcLoader(inputSource, inputSourceMap) {

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -139,6 +139,7 @@ export type NextConfig = { [key: string]: any } & {
         }
     styledComponents?: boolean
     swcMinify?: boolean
+    swcFileReading?: boolean
     cpus?: number
     sharedPool?: boolean
     plugins?: boolean
@@ -243,6 +244,7 @@ export const defaultConfig: NextConfig = {
     reactRoot: Number(process.env.NEXT_PRIVATE_REACT_ROOT) > 0,
     disableOptimizedLoading: false,
     gzipSize: true,
+    swcFileReading: true,
     craCompat: false,
     esmExternals: true,
     // default to 50MB limit


### PR DESCRIPTION
automatically disable swc file reading when wasm builds are used and for virtual or yarn cache paths

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
