### PR TITLE
fix(Link): Do not ignore onMouseEnter prop with absolute href

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -291,11 +291,12 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
   }
 
   childProps.onMouseEnter = (e: React.MouseEvent) => {
-    if (!isLocalURL(href)) return
     if (child.props && typeof child.props.onMouseEnter === 'function') {
       child.props.onMouseEnter(e)
     }
-    prefetch(router, href, as, { priority: true })
+    if (isLocalURL(href)) {
+      prefetch(router, href, as, { priority: true })
+    }
   }
 
   // If child is an <a> tag and doesn't have a href attribute, or if the 'passHref' property is

--- a/test/integration/client-navigation/pages/absolute-url.js
+++ b/test/integration/client-navigation/pages/absolute-url.js
@@ -11,6 +11,8 @@ export async function getServerSideProps({ query: { port } }) {
 
 export default function Page({ port }) {
   const router = useRouter()
+  const [hover, setHover] = React.useState(false)
+
   return (
     <>
       <Link href="https://vercel.com/">
@@ -60,6 +62,17 @@ export default function Page({ port }) {
       <br />
       <Link href="mailto:idk@idk.com">
         <a id="mailto-link">mailto:idk@idk.com</a>
+      </Link>
+      <br />
+      <Link href="https://vercel.com/">
+        <a
+          id="absolute-link-mouse-events"
+          data-hover={hover}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+        >
+          https://vercel.com/
+        </a>
       </Link>
     </>
   )

--- a/test/integration/client-navigation/test/index.test.js
+++ b/test/integration/client-navigation/test/index.test.js
@@ -118,6 +118,21 @@ describe('Client Navigation', () => {
       )
     })
 
+    it('should call mouse handlers with an absolute url', async () => {
+      const browser = await webdriver(
+        context.appPort,
+        `/absolute-url?port=${context.appPort}`
+      )
+
+      await browser.elementByCss('#absolute-link-mouse-events').moveTo()
+
+      expect(
+        await browser
+          .waitForElementByCss('#absolute-link-mouse-events')
+          .getAttribute('data-hover')
+      ).toBe('true')
+    })
+
     it('should navigate an absolute local url', async () => {
       const browser = await webdriver(
         context.appPort,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
Fixes #22733

Regardless of whether it's recommended that Link be used with external href values or not, they can be used and `onMouseEnter` being swallowed with an external href value is unexpected behavior.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
