### PR TITLE
Avoid extra asset generation for the SSR middleware

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -23,7 +23,6 @@ import {
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS_SYMBOL,
   CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH,
   CLIENT_STATIC_FILES_RUNTIME_WEBPACK,
-  MIDDLEWARE_REACT_LOADABLE_MANIFEST,
   REACT_LOADABLE_MANIFEST,
   SERVERLESS_DIRECTORY,
   SERVER_DIRECTORY,
@@ -1399,9 +1398,6 @@ export default async function getBaseWebpackConfig(
         new ReactLoadablePlugin({
           filename: REACT_LOADABLE_MANIFEST,
           pagesDir,
-          runtimeAsset: hasConcurrentFeatures
-            ? `server/${MIDDLEWARE_REACT_LOADABLE_MANIFEST}.js`
-            : undefined,
           dev,
         }),
       targetWeb && new DropClientPage(),
@@ -1460,7 +1456,6 @@ export default async function getBaseWebpackConfig(
           buildId,
           rewrites,
           isDevFallback,
-          exportRuntime: hasConcurrentFeatures,
         }),
       new ProfilingPlugin({ runWebpackSpan }),
       config.optimizeFonts &&

--- a/packages/next/build/webpack/loaders/next-middleware-ssr-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-middleware-ssr-loader/index.ts
@@ -1,4 +1,11 @@
+import { join } from 'path'
+
 import { stringifyRequest } from '../../stringify-request'
+import {
+  BUILD_MANIFEST,
+  REACT_LOADABLE_MANIFEST,
+} from '../../../../shared/lib/constants'
+import { DOT_NEXT_ALIAS } from '../../../../lib/constants'
 
 export default async function middlewareSSRLoader(this: any) {
   const {
@@ -21,6 +28,11 @@ export default async function middlewareSSRLoader(this: any) {
     this,
     absoluteDocumentPath
   )
+  const buildManifest = join(DOT_NEXT_ALIAS, BUILD_MANIFEST).replace(/\\/g, '/')
+  const ReactLoadableManifest = join(
+    DOT_NEXT_ALIAS,
+    REACT_LOADABLE_MANIFEST
+  ).replace(/\\/g, '/')
 
   const transformed = `
     import { adapter } from 'next/dist/server/web/adapter'
@@ -29,13 +41,14 @@ export default async function middlewareSSRLoader(this: any) {
     import App from ${stringifiedAbsoluteAppPath}
     import Document from ${stringifiedAbsoluteDocumentPath}
 
+    import buildManifest from '${buildManifest}'
+    import reactLoadableManifest from '${ReactLoadableManifest}'
+
     import { getRender } from 'next/dist/build/webpack/loaders/next-middleware-ssr-loader/render'
 
     const pageMod = require(${stringifiedAbsolutePagePath})
     const errorMod = require(${stringifiedAbsolute500PagePath})
 
-    const buildManifest = self.__BUILD_MANIFEST
-    const reactLoadableManifest = self.__REACT_LOADABLE_MANIFEST
     const rscManifest = self.__RSC_MANIFEST
 
     if (typeof pageMod.default !== 'function') {

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -2,7 +2,6 @@ import devalue from 'next/dist/compiled/devalue'
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import {
   BUILD_MANIFEST,
-  MIDDLEWARE_BUILD_MANIFEST,
   CLIENT_STATIC_FILES_PATH,
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS_SYMBOL,
@@ -94,13 +93,11 @@ export default class BuildManifestPlugin {
   private buildId: string
   private rewrites: CustomRoutes['rewrites']
   private isDevFallback: boolean
-  private exportRuntime: boolean
 
   constructor(options: {
     buildId: string
     rewrites: CustomRoutes['rewrites']
     isDevFallback?: boolean
-    exportRuntime?: boolean
   }) {
     this.buildId = options.buildId
     this.isDevFallback = !!options.isDevFallback
@@ -112,7 +109,6 @@ export default class BuildManifestPlugin {
     this.rewrites.beforeFiles = options.rewrites.beforeFiles.map(processRoute)
     this.rewrites.afterFiles = options.rewrites.afterFiles.map(processRoute)
     this.rewrites.fallback = options.rewrites.fallback.map(processRoute)
-    this.exportRuntime = !!options.exportRuntime
   }
 
   createAssets(compiler: any, compilation: any, assets: any) {
@@ -231,13 +227,6 @@ export default class BuildManifestPlugin {
       assets[buildManifestName] = new sources.RawSource(
         JSON.stringify(assetMap, null, 2)
       )
-
-      if (this.exportRuntime) {
-        assets[`server/${MIDDLEWARE_BUILD_MANIFEST}.js`] =
-          new sources.RawSource(
-            `self.__BUILD_MANIFEST=${JSON.stringify(assetMap)}`
-          )
-      }
 
       if (!this.isDevFallback) {
         const clientManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`

--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -4,8 +4,6 @@ import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import {
   MIDDLEWARE_MANIFEST,
   MIDDLEWARE_FLIGHT_MANIFEST,
-  MIDDLEWARE_BUILD_MANIFEST,
-  MIDDLEWARE_REACT_LOADABLE_MANIFEST,
 } from '../../../shared/lib/constants'
 import { MIDDLEWARE_ROUTE } from '../../../lib/constants'
 import { nonNullable } from '../../../lib/non-nullable'
@@ -85,8 +83,6 @@ export default class MiddlewarePlugin {
             ssrEntryInfo.requireFlightManifest
               ? `server/${MIDDLEWARE_FLIGHT_MANIFEST}.js`
               : null,
-            `server/${MIDDLEWARE_BUILD_MANIFEST}.js`,
-            `server/${MIDDLEWARE_REACT_LOADABLE_MANIFEST}.js`,
             ...entryFiles.map((file) => 'server/' + file),
           ].filter(nonNullable)
         : entryFiles.map((file: string) =>

--- a/packages/next/build/webpack/plugins/react-loadable-plugin.ts
+++ b/packages/next/build/webpack/plugins/react-loadable-plugin.ts
@@ -146,18 +146,11 @@ function buildManifest(
 export class ReactLoadablePlugin {
   private filename: string
   private pagesDir: string
-  private runtimeAsset?: string
   private dev: boolean
 
-  constructor(opts: {
-    filename: string
-    pagesDir: string
-    runtimeAsset?: string
-    dev: boolean
-  }) {
+  constructor(opts: { filename: string; pagesDir: string, dev: boolean }) {
     this.filename = opts.filename
     this.pagesDir = opts.pagesDir
-    this.runtimeAsset = opts.runtimeAsset
     this.dev = opts.dev
   }
 
@@ -172,11 +165,6 @@ export class ReactLoadablePlugin {
     assets[this.filename] = new sources.RawSource(
       JSON.stringify(manifest, null, 2)
     )
-    if (this.runtimeAsset) {
-      assets[this.runtimeAsset] = new sources.RawSource(
-        `self.__REACT_LOADABLE_MANIFEST=${JSON.stringify(manifest)}`
-      )
-    }
     return assets
   }
 

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -543,7 +543,6 @@ export default class HotReloader {
                     canonicalBase: this.config.amp.canonicalBase,
                     i18n: this.config.i18n,
                     previewProps: this.previewProps,
-                    distDir: this.config.distDir,
                   } as any)}!`,
                   isServer: false,
                   isServerWeb: true,

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -543,6 +543,7 @@ export default class HotReloader {
                     canonicalBase: this.config.amp.canonicalBase,
                     i18n: this.config.i18n,
                     previewProps: this.previewProps,
+                    distDir: this.config.distDir,
                   } as any)}!`,
                   isServer: false,
                   isServerWeb: true,

--- a/packages/next/shared/lib/constants.ts
+++ b/packages/next/shared/lib/constants.ts
@@ -28,11 +28,6 @@ export const STRING_LITERAL_DROP_BUNDLE = '__NEXT_DROP_CLIENT_FILE__'
 
 // server/middleware-flight-manifest.js
 export const MIDDLEWARE_FLIGHT_MANIFEST = 'middleware-flight-manifest'
-// server/middleware-build-manifest.js
-export const MIDDLEWARE_BUILD_MANIFEST = 'middleware-build-manifest'
-// server/middleware-react-loadable-manifest.js
-export const MIDDLEWARE_REACT_LOADABLE_MANIFEST =
-  'middleware-react-loadable-manifest'
 
 // static/runtime/main.js
 export const CLIENT_STATIC_FILES_RUNTIME_MAIN = `main`

--- a/test/integration/react-18/test/concurrent.js
+++ b/test/integration/react-18/test/concurrent.js
@@ -16,6 +16,20 @@ export default (context, _render) => {
     }
   }
 
+  it('should resolve suspense on server side if suspended on server', async () => {
+    await withBrowser('/suspense/thrown', async (browser) => {
+      await check(
+        () => browser.waitForElementByCss('#server-rendered').text(),
+        /true/
+      )
+      await check(() => browser.waitForElementByCss('#hydrated').text(), /true/)
+      await check(
+        () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
+        /undefined/
+      )
+    })
+  })
+
   it('should resolve suspense modules on server side if suspense', async () => {
     await withBrowser('/suspense/no-preload', async (browser) => {
       await check(() => browser.waitForElementByCss('#__next').text(), /barfoo/)
@@ -32,29 +46,6 @@ export default (context, _render) => {
         () => browser.waitForElementByCss('#server-rendered').text(),
         /true/
       )
-      await check(
-        () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
-        /undefined/
-      )
-    })
-  })
-
-  it('should resolve suspense on server side if suspended on server', async () => {
-    await withBrowser('/suspense/thrown', async (browser) => {
-      await check(
-        () => browser.waitForElementByCss('#server-rendered').text(),
-        /true/
-      )
-      await check(
-        () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
-        /undefined/
-      )
-    })
-  })
-
-  it('should hydrate suspenses on client side if suspended on server', async () => {
-    await withBrowser('/suspense/thrown', async (browser) => {
-      await check(() => browser.waitForElementByCss('#hydrated').text(), /true/)
       await check(
         () => browser.eval('typeof __NEXT_DATA__.dynamicIds'),
         /undefined/

--- a/test/integration/react-18/test/index.test.js
+++ b/test/integration/react-18/test/index.test.js
@@ -140,8 +140,9 @@ describe('Blocking mode', () => {
   beforeAll(() => {
     dynamicHello.replace('suspense = false', `suspense = true`)
   })
-  afterAll(() => {
+  afterAll(async () => {
     dynamicHello.restore()
+    await fs.removeSync(join(appDir, '.next'))
   })
 
   runTests('concurrentFeatures is disabled', (context) =>
@@ -207,6 +208,7 @@ function runTest(mode, name, fn) {
   const context = { appDir }
   describe(`${name} (${mode})`, () => {
     beforeAll(async () => {
+      await fs.remove(join(appDir, '.next'))
       context.appPort = await findPort()
       context.stderr = ''
       if (mode === 'dev') {

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -137,7 +137,6 @@ describe('concurrentFeatures - prod', () => {
     const hasFile = (filename) => fs.existsSync(join(distServerDir, filename))
 
     const files = [
-      'middleware-build-manifest.js',
       'middleware-flight-manifest.js',
       'middleware-ssr-runtime.js',
       'middleware-manifest.json',


### PR DESCRIPTION
Currently we are generating extra JS assets like `build-manifest.js` for the SSR middleware to consume. This PR removes it with directly importing those manifests. This is also needed by #31971, to remove special processes between the 2 runtimes.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
