### PR TITLE
fix: typescript example supporting strict w/ version >= 4.4

### DIFF
--- a/examples/with-typescript/pages/api/users/index.ts
+++ b/examples/with-typescript/pages/api/users/index.ts
@@ -8,7 +8,7 @@ const handler = (_req: NextApiRequest, res: NextApiResponse) => {
     }
 
     res.status(200).json(sampleUserData)
-  } catch (err) {
+  } catch (err: any) {
     res.status(500).json({ statusCode: 500, message: err.message })
   }
 }


### PR DESCRIPTION
fixes https://github.com/vercel/next.js/issues/32015

[In typescript 4.4,](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables) errors were changed to `unknown` type instead of `any`. With `strict` mode enabled, this breaks the `with-typescript` example as `err.message` isn't valid.

Thanks! my first PR here 😄 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
