### PR TITLE
Fix copying swc binary for isolated tests locally

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -18,15 +18,16 @@ async function createNextInstall(dependencies) {
   )) {
     if (folder.startsWith('swc-')) {
       const swcPkgPath = path.join(origRepoDir, 'node_modules/@next', folder)
-      await fs.copy(
-        swcPkgPath,
-        path.join(origRepoDir, 'packages/next-swc/native'),
-        {
-          filter: (item) =>
+      const outputPath = path.join(origRepoDir, 'packages/next-swc/native')
+      await fs.copy(swcPkgPath, outputPath, {
+        filter: (item) => {
+          return (
             item === swcPkgPath ||
-            (item.endsWith('.node') && !fs.pathExistsSync(item)),
-        }
-      )
+            (item.endsWith('.node') &&
+              !fs.pathExistsSync(path.join(outputPath, path.basename(item))))
+          )
+        },
+      })
     }
   }
 


### PR DESCRIPTION
This updates to ensure we properly copy the swc binary to the `native` folder in the `next-swc` package for running isolated tests locally and the binary hasn't been built manually. 