### PR TITLE
TypeScript without JSX: fix types and provide example

### DIFF
--- a/examples/blog-starter-typescript/components/layout.tsx
+++ b/examples/blog-starter-typescript/components/layout.tsx
@@ -4,7 +4,7 @@ import Meta from './meta'
 
 type Props = {
   preview?: boolean
-  children: React.ReactNode
+  children?: React.ReactNode
 }
 
 const Layout = ({ preview, children }: Props) => {

--- a/examples/with-electron-typescript/renderer/components/Layout.tsx
+++ b/examples/with-electron-typescript/renderer/components/Layout.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import Head from 'next/head'
 
 type Props = {
-  children: ReactNode
+  children?: ReactNode
   title?: string
 }
 

--- a/examples/with-iron-session/components/Layout.tsx
+++ b/examples/with-iron-session/components/Layout.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import Header from 'components/Header'
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+const Layout: React.FC = ({ children }) => {
   return (
     <>
       <Head>
@@ -37,3 +37,5 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     </>
   )
 }
+
+export default Layout

--- a/examples/with-react-intl/components/Layout.tsx
+++ b/examples/with-react-intl/components/Layout.tsx
@@ -6,7 +6,7 @@ import Nav from './Nav'
 interface LayoutProps {
   title?: string
   description?: string
-  children: ReactChild | ReactChild[]
+  children?: ReactChild | ReactChild[]
 }
 
 export default function Layout({ title, description, children }: LayoutProps) {

--- a/examples/with-stripe-typescript/components/Cart.tsx
+++ b/examples/with-stripe-typescript/components/Cart.tsx
@@ -3,7 +3,7 @@ import { CartProvider } from 'use-shopping-cart'
 import getStripe from '../utils/get-stripejs'
 import * as config from '../config'
 
-const Cart = ({ children }: { children: ReactNode }) => (
+const Cart = ({ children }: { children?: ReactNode }) => (
   <CartProvider
     mode="checkout-session"
     stripe={getStripe()}

--- a/examples/with-stripe-typescript/components/Layout.tsx
+++ b/examples/with-stripe-typescript/components/Layout.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 type Props = {
-  children: ReactNode
+  children?: ReactNode
   title?: string
 }
 

--- a/examples/with-typescript-without-jsx/.gitignore
+++ b/examples/with-typescript-without-jsx/.gitignore
@@ -1,0 +1,34 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/examples/with-typescript-without-jsx/README.md
+++ b/examples/with-typescript-without-jsx/README.md
@@ -1,0 +1,47 @@
+# TypeScript Next.js example
+
+This is a really simple project that shows the usage of Next.js with TypeScript.
+
+## Preview
+
+Preview the example live on [StackBlitz](http://stackblitz.com/):
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-typescript)
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-typescript&project-name=with-typescript&repository-name=with-typescript)
+
+## How to use it?
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-typescript with-typescript-app
+# or
+yarn create next-app --example with-typescript with-typescript-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
+
+## Notes
+
+This example shows how to integrate the TypeScript type system into Next.js. Since TypeScript is supported out of the box with Next.js, all we have to do is to install TypeScript.
+
+```
+npm install --save-dev typescript
+```
+
+To enable TypeScript's features, we install the type declarations for React and Node.
+
+```
+npm install --save-dev @types/react @types/react-dom @types/node
+```
+
+When we run `next dev` the next time, Next.js will start looking for any `.ts` or `.tsx` files in our project and builds it. It even automatically creates a `tsconfig.json` file for our project with the recommended settings.
+
+Next.js has built-in TypeScript declarations, so we'll get autocompletion for Next.js' modules straight away.
+
+A `type-check` script is also added to `package.json`, which runs TypeScript's `tsc` CLI in `noEmit` mode to run type-checking separately. You can then include this, for example, in your `test` scripts.

--- a/examples/with-typescript-without-jsx/components/Layout.ts
+++ b/examples/with-typescript-without-jsx/components/Layout.ts
@@ -1,0 +1,45 @@
+import React, { ReactNode } from 'react'
+import Link from 'next/link'
+import Head from 'next/head'
+
+const e = React.createElement
+
+type Props = {
+  children?: ReactNode
+  title?: string
+}
+
+const Layout = ({ children, title = 'This is the default title' }: Props) =>
+  e(
+    'div',
+    {},
+    e(
+      Head,
+      {},
+      e('title', title),
+      e('meta', { charSet: 'utf-8' }),
+      e('meta', {
+        name: 'viewport',
+        content: 'initial-scale=1.0, width=device-width',
+      })
+    ),
+    e(
+      'header',
+      {},
+      e(
+        'nav',
+        {},
+        e(Link, { href: '/' }, e('a', {}, 'Home')),
+        ' | ',
+        e(Link, { href: '/about' }, e('a', {}, 'About')),
+        ' | ',
+        e(Link, { href: '/users' }, e('a', {}, 'Users List')),
+        ' | ',
+        e('a', { href: '/api/users' }, 'Users API')
+      )
+    ),
+    children,
+    e('footer', {}, e('hr'), e('span', {}, "I'm here to stay (Footer)"))
+  )
+
+export default Layout

--- a/examples/with-typescript-without-jsx/components/List.ts
+++ b/examples/with-typescript-without-jsx/components/List.ts
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import ListItem from './ListItem'
+import { User } from '../interfaces'
+
+const e = React.createElement
+
+type Props = {
+  items: User[]
+}
+
+const List = ({ items }: Props) =>
+  e(
+    'ul',
+    {},
+    items.map((item) => e('li', { key: item.id }, e(ListItem, { data: item })))
+  )
+
+export default List

--- a/examples/with-typescript-without-jsx/components/ListDetail.ts
+++ b/examples/with-typescript-without-jsx/components/ListDetail.ts
@@ -1,0 +1,14 @@
+import * as React from 'react'
+
+import { User } from '../interfaces'
+
+const e = React.createElement
+
+type ListDetailProps = {
+  item: User
+}
+
+const ListDetail = ({ item: user }: ListDetailProps) =>
+  e('div', {}, e('h1', {}, 'Detail for ', user.name), e('p', 'ID: ', user.id))
+
+export default ListDetail

--- a/examples/with-typescript-without-jsx/components/ListItem.ts
+++ b/examples/with-typescript-without-jsx/components/ListItem.ts
@@ -1,0 +1,19 @@
+import React from 'react'
+import Link from 'next/link'
+
+import { User } from '../interfaces'
+
+const e = React.createElement
+
+type Props = {
+  data: User
+}
+
+const ListItem = ({ data }: Props) =>
+  e(
+    Link,
+    { href: '/users/[id]', as: `/users/${data.id}` },
+    e('a', {}, data.id, ': ', data.name)
+  )
+
+export default ListItem

--- a/examples/with-typescript-without-jsx/interfaces/index.ts
+++ b/examples/with-typescript-without-jsx/interfaces/index.ts
@@ -1,0 +1,10 @@
+// You can include shared interfaces/types in a separate file
+// and then use them in any component by importing them. For
+// example, to import the interface below do:
+//
+// import { User } from 'path/to/interfaces';
+
+export type User = {
+  id: number
+  name: string
+}

--- a/examples/with-typescript-without-jsx/next-env.d.ts
+++ b/examples/with-typescript-without-jsx/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/with-typescript-without-jsx/package.json
+++ b/examples/with-typescript-without-jsx/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start",
+    "type-check": "tsc"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^12.12.21",
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.1",
+    "typescript": "4.0"
+  }
+}

--- a/examples/with-typescript-without-jsx/pages/about.ts
+++ b/examples/with-typescript-without-jsx/pages/about.ts
@@ -1,0 +1,16 @@
+import React from 'react'
+import Link from 'next/link'
+import Layout from '../components/Layout'
+
+const e = React.createElement
+
+const AboutPage = () =>
+  e(
+    Layout,
+    { title: 'About | Next.js + TypeScript Example' },
+    e('h1', {}, 'About'),
+    e('p', {}, 'This is the about page'),
+    e('p', {}, e(Link, { href: '/' }, e('a', {}, 'Go home')))
+  )
+
+export default AboutPage

--- a/examples/with-typescript-without-jsx/pages/api/users/index.ts
+++ b/examples/with-typescript-without-jsx/pages/api/users/index.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { sampleUserData } from '../../../utils/sample-data'
+
+const handler = (_req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    if (!Array.isArray(sampleUserData)) {
+      throw new Error('Cannot find user data')
+    }
+
+    res.status(200).json(sampleUserData)
+  } catch (err) {
+    res.status(500).json({ statusCode: 500, message: err.message })
+  }
+}
+
+export default handler

--- a/examples/with-typescript-without-jsx/pages/index.ts
+++ b/examples/with-typescript-without-jsx/pages/index.ts
@@ -1,0 +1,15 @@
+import React from 'react'
+import Link from 'next/link'
+import Layout from '../components/Layout'
+
+const e = React.createElement
+
+const IndexPage = () =>
+  e(
+    Layout,
+    { title: 'Home | Next.js + TypeScript Example' },
+    e('h1', {}, 'Hello Next.js 👋'),
+    e('p', {}, e(Link, { href: '/about' }, e('a', {}, 'About')))
+  )
+
+export default IndexPage

--- a/examples/with-typescript-without-jsx/pages/users/[id].ts
+++ b/examples/with-typescript-without-jsx/pages/users/[id].ts
@@ -1,0 +1,62 @@
+import React from 'react'
+import { GetStaticProps, GetStaticPaths } from 'next'
+
+import { User } from '../../interfaces'
+import { sampleUserData } from '../../utils/sample-data'
+import Layout from '../../components/Layout'
+import ListDetail from '../../components/ListDetail'
+
+const e = React.createElement
+
+type Props = {
+  item?: User
+  errors?: string
+}
+
+const StaticPropsDetail = ({ item, errors }: Props) => {
+  if (errors) {
+    return e(
+      Layout,
+      { title: 'Error | Next.js + TypeScript Example' },
+      e('p', {}, e('span', { style: { color: 'red' } }, 'Error:'), errors)
+    )
+  }
+
+  return e(
+    Layout,
+    {
+      title: `${
+        item ? item.name : 'User Detail'
+      } | Next.js + TypeScript Example`,
+    },
+    item && e(ListDetail, { item: item })
+  )
+}
+
+export default StaticPropsDetail
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Get the paths we want to pre-render based on users
+  const paths = sampleUserData.map((user) => ({
+    params: { id: user.id.toString() },
+  }))
+
+  // We'll pre-render only these paths at build time.
+  // { fallback: false } means other routes should 404.
+  return { paths, fallback: false }
+}
+
+// This function gets called at build time on server-side.
+// It won't be called on client-side, so you can even do
+// direct database queries.
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  try {
+    const id = params?.id
+    const item = sampleUserData.find((data) => data.id === Number(id))
+    // By returning { props: item }, the StaticPropsDetail component
+    // will receive `item` as a prop at build time
+    return { props: { item } }
+  } catch (err) {
+    return { props: { errors: err.message } }
+  }
+}

--- a/examples/with-typescript-without-jsx/pages/users/index.ts
+++ b/examples/with-typescript-without-jsx/pages/users/index.ts
@@ -1,0 +1,40 @@
+import React from 'react'
+import { GetStaticProps } from 'next'
+import Link from 'next/link'
+
+import { User } from '../../interfaces'
+import { sampleUserData } from '../../utils/sample-data'
+import Layout from '../../components/Layout'
+import List from '../../components/List'
+
+const e = React.createElement
+
+type Props = {
+  items: User[]
+}
+
+const WithStaticProps = ({ items }: Props) =>
+  e(
+    Layout,
+    { title: 'Users List | Next.js + TypeScript Example' },
+    e('h1', {}, 'Users List'),
+    e(
+      'p',
+      {},
+      'Example fetching data from inside ',
+      e('code', {}, 'getStaticProps()')
+    ),
+    e('p', {}, 'You are currently on: /users'),
+    e(List, { items: items }),
+    e('p', {}, e(Link, { href: '/' }, e('a', {}, 'Go home')))
+  )
+
+export const getStaticProps: GetStaticProps = async () => {
+  // Example for including static props in a Next.js function component page.
+  // Don't forget to include the respective types for any props passed into
+  // the component.
+  const items: User[] = sampleUserData
+  return { props: { items } }
+}
+
+export default WithStaticProps

--- a/examples/with-typescript-without-jsx/tsconfig.json
+++ b/examples/with-typescript-without-jsx/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/examples/with-typescript-without-jsx/utils/sample-data.ts
+++ b/examples/with-typescript-without-jsx/utils/sample-data.ts
@@ -1,0 +1,9 @@
+import { User } from '../interfaces'
+
+/** Dummy user data. */
+export const sampleUserData: User[] = [
+  { id: 101, name: 'Alice' },
+  { id: 102, name: 'Bob' },
+  { id: 103, name: 'Caroline' },
+  { id: 104, name: 'Dave' },
+]

--- a/packages/next/client/portal/index.tsx
+++ b/packages/next/client/portal/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { createPortal } from 'react-dom'
 
 type PortalProps = {
-  children: React.ReactNode
   type: string
 }
 

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -604,7 +604,7 @@ export async function renderToHTML(
   const nextExport =
     !isSSG && (renderOpts.nextExport || (dev && (isAutoExport || isFallback)))
 
-  const AppContainer = ({ children }: { children: JSX.Element }) => (
+  const AppContainer = ({ children }: { children?: JSX.Element }) => (
     <RouterContext.Provider value={router}>
       <AmpStateContext.Provider value={ampState}>
         <HeadManagerContext.Provider
@@ -641,7 +641,7 @@ export async function renderToHTML(
   const AppContainerWithIsomorphicFiberStructure = ({
     children,
   }: {
-    children: JSX.Element
+    children?: JSX.Element
   }) => {
     return (
       <>
@@ -1043,7 +1043,7 @@ export async function renderToHTML(
     }
   }
 
-  const Body = ({ children }: { children: JSX.Element }) => {
+  const Body = ({ children }: { children?: JSX.Element }) => {
     return inAmpMode ? children : <div id="__next">{children}</div>
   }
 

--- a/packages/next/shared/lib/head.tsx
+++ b/packages/next/shared/lib/head.tsx
@@ -169,7 +169,7 @@ function reduceComponents(
  * This component injects elements to `<head>` of your page.
  * To avoid duplicated `tags` in `<head>` you can use the `key` property, which will make sure every tag is only rendered once.
  */
-function Head({ children }: { children: React.ReactNode }) {
+const Head: React.FC = ({ children }) => {
   const ampState = useContext(AmpStateContext)
   const headManager = useContext(HeadManagerContext)
   return (

--- a/packages/react-dev-overlay/src/internal/components/ShadowPortal.tsx
+++ b/packages/react-dev-overlay/src/internal/components/ShadowPortal.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 
-export type ShadowPortalProps = {
-  children: React.ReactNode
-}
-
-export const ShadowPortal: React.FC<ShadowPortalProps> = function Portal({
-  children,
-}) {
+export const ShadowPortal: React.FC = function Portal({ children }) {
   let mountNode = React.useRef<HTMLDivElement | null>(null)
   let portalNode = React.useRef<HTMLElement | null>(null)
   let shadowNode = React.useRef<ShadowRoot | null>(null)


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/32032

As with React, Next.js users should not be forced to use JSX. However, Next.js projects do not currently typecheck without JSX.

This PR provides a new example, `with-typescript-without-jsx`. This is the `with-typescript` example but with JSX stripped.

With current Next.js, this fails to typecheck - but of course it shouldn't, because it's just desugaring JSX from an example that passes typechecking.

These spurious type errors are due to React component typings in Next.js that demand callers to provide a `children` property, e.g. `children: ReactNode`. This is inconsistent with the official React typing, which makes the `children` property optional.

This PR fixes several examples of Next.js components that unnecessarily demand a `children` property.
