### PR TITLE
Improve exported root definitions

### DIFF
--- a/packages/next/app.d.ts
+++ b/packages/next/app.d.ts
@@ -1,2 +1,3 @@
+import App from './dist/pages/_app'
 export * from './dist/pages/_app'
-export { default } from './dist/pages/_app'
+export default App

--- a/packages/next/client.d.ts
+++ b/packages/next/client.d.ts
@@ -1,2 +1,1 @@
 export * from './dist/client/index'
-export { default } from './dist/client/index'

--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -1,2 +1,3 @@
+import getConfig from './dist/shared/lib/runtime-config'
 export * from './dist/shared/lib/runtime-config'
-export { default } from './dist/shared/lib/runtime-config'
+export default getConfig

--- a/packages/next/document.d.ts
+++ b/packages/next/document.d.ts
@@ -1,2 +1,3 @@
+import Document from './dist/shared/lib/runtime-config'
 export * from './dist/pages/_document'
-export { default } from './dist/pages/_document'
+export default Document

--- a/packages/next/dynamic.d.ts
+++ b/packages/next/dynamic.d.ts
@@ -1,2 +1,3 @@
+import dynamic from './dist/shared/lib/dynamic'
 export * from './dist/shared/lib/dynamic'
-export { default } from './dist/shared/lib/dynamic'
+export default dynamic

--- a/packages/next/error.d.ts
+++ b/packages/next/error.d.ts
@@ -1,2 +1,3 @@
+import Error from './dist/pages/_error'
 export * from './dist/pages/_error'
-export { default } from './dist/pages/_error'
+export default Error

--- a/packages/next/head.d.ts
+++ b/packages/next/head.d.ts
@@ -1,2 +1,3 @@
+import Head from './dist/shared/lib/head'
 export * from './dist/shared/lib/head'
-export { default } from './dist/shared/lib/head'
+export default Head

--- a/packages/next/image.d.ts
+++ b/packages/next/image.d.ts
@@ -1,2 +1,3 @@
+import Image from './dist/client/image'
 export * from './dist/client/image'
-export { default } from './dist/client/image'
+export default Image

--- a/packages/next/jest.d.ts
+++ b/packages/next/jest.d.ts
@@ -1,2 +1,3 @@
+import nextJest from './dist/build/jest/jest'
 export * from './dist/build/jest/jest'
-export { default } from './dist/build/jest/jest'
+export default nextJest

--- a/packages/next/link.d.ts
+++ b/packages/next/link.d.ts
@@ -1,2 +1,3 @@
+import Link from './dist/client/link'
 export * from './dist/client/link'
-export { default } from './dist/client/link'
+export default Link

--- a/packages/next/router.d.ts
+++ b/packages/next/router.d.ts
@@ -1,2 +1,3 @@
+import Router from './dist/client/router'
 export * from './dist/client/router'
-export { default } from './dist/client/router'
+export default Router

--- a/packages/next/script.d.ts
+++ b/packages/next/script.d.ts
@@ -1,2 +1,3 @@
+import Script from './dist/client/script'
 export * from './dist/client/script'
-export { default } from './dist/client/script'
+export default Script


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/32045

doing `export { default } from 'module'` has some unexpected results for autocompletion in TypeScript, this PR changes root definitions to have a named default export where needed.

## Bug

- [x] Related issues linked using `fixes #number`