### PR TITLE
Fix server be killed by handling unhandled promise with status 500

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -359,198 +359,199 @@ export default class Server {
     res: ServerResponse,
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
-    const urlParts = (req.url || '').split('?')
-    const urlNoQuery = urlParts[0]
+    try {
+      const urlParts = (req.url || '').split('?')
+      const urlNoQuery = urlParts[0]
 
-    if (urlNoQuery?.match(/(\\|\/\/)/)) {
-      const cleanUrl = normalizeRepeatedSlashes(req.url!)
-      res.setHeader('Location', cleanUrl)
-      res.setHeader('Refresh', `0;url=${cleanUrl}`)
-      res.statusCode = 308
-      res.end(cleanUrl)
-      return
-    }
-
-    setLazyProp({ req: req as any }, 'cookies', getCookieParser(req.headers))
-
-    // Parse url if parsedUrl not provided
-    if (!parsedUrl || typeof parsedUrl !== 'object') {
-      parsedUrl = parseUrl(req.url!, true)
-    }
-
-    // Parse the querystring ourselves if the user doesn't handle querystring parsing
-    if (typeof parsedUrl.query === 'string') {
-      parsedUrl.query = parseQs(parsedUrl.query)
-    }
-
-    addRequestMeta(req, '__NEXT_INIT_URL', req.url)
-    addRequestMeta(req, '__NEXT_INIT_QUERY', { ...parsedUrl.query })
-
-    const url = parseNextUrl({
-      headers: req.headers,
-      nextConfig: this.nextConfig,
-      url: req.url?.replace(/^\/+/, '/'),
-    })
-
-    if (url.basePath) {
-      req.url = replaceBasePath(req.url!, this.nextConfig.basePath)
-      addRequestMeta(req, '_nextHadBasePath', true)
-    }
-
-    if (
-      this.minimalMode &&
-      req.headers['x-matched-path'] &&
-      typeof req.headers['x-matched-path'] === 'string'
-    ) {
-      const reqUrlIsDataUrl = req.url?.includes('/_next/data')
-      const matchedPathIsDataUrl =
-        req.headers['x-matched-path']?.includes('/_next/data')
-      const isDataUrl = reqUrlIsDataUrl || matchedPathIsDataUrl
-
-      let parsedPath = parseUrl(
-        isDataUrl ? req.url! : (req.headers['x-matched-path'] as string),
-        true
-      )
-
-      let matchedPathname = parsedPath.pathname!
-
-      let matchedPathnameNoExt = isDataUrl
-        ? matchedPathname.replace(/\.json$/, '')
-        : matchedPathname
-
-      if (this.nextConfig.i18n) {
-        const localePathResult = normalizeLocalePath(
-          matchedPathname || '/',
-          this.nextConfig.i18n.locales
-        )
-
-        if (localePathResult.detectedLocale) {
-          parsedUrl.query.__nextLocale = localePathResult.detectedLocale
-        }
+      if (urlNoQuery?.match(/(\\|\/\/)/)) {
+        const cleanUrl = normalizeRepeatedSlashes(req.url!)
+        res.setHeader('Location', cleanUrl)
+        res.setHeader('Refresh', `0;url=${cleanUrl}`)
+        res.statusCode = 308
+        res.end(cleanUrl)
+        return
       }
 
-      if (isDataUrl) {
-        matchedPathname = denormalizePagePath(matchedPathname)
-        matchedPathnameNoExt = denormalizePagePath(matchedPathnameNoExt)
+      setLazyProp({ req: req as any }, 'cookies', getCookieParser(req.headers))
+
+      // Parse url if parsedUrl not provided
+      if (!parsedUrl || typeof parsedUrl !== 'object') {
+        parsedUrl = parseUrl(req.url!, true)
       }
 
-      const pageIsDynamic = isDynamicRoute(matchedPathnameNoExt)
-      const combinedRewrites: Rewrite[] = []
+      // Parse the querystring ourselves if the user doesn't handle querystring parsing
+      if (typeof parsedUrl.query === 'string') {
+        parsedUrl.query = parseQs(parsedUrl.query)
+      }
 
-      combinedRewrites.push(...this.customRoutes.rewrites.beforeFiles)
-      combinedRewrites.push(...this.customRoutes.rewrites.afterFiles)
-      combinedRewrites.push(...this.customRoutes.rewrites.fallback)
+      addRequestMeta(req, '__NEXT_INIT_URL', req.url)
+      addRequestMeta(req, '__NEXT_INIT_QUERY', { ...parsedUrl.query })
 
-      const utils = getUtils({
-        pageIsDynamic,
-        page: matchedPathnameNoExt,
-        i18n: this.nextConfig.i18n,
-        basePath: this.nextConfig.basePath,
-        rewrites: combinedRewrites,
+      const url = parseNextUrl({
+        headers: req.headers,
+        nextConfig: this.nextConfig,
+        url: req.url?.replace(/^\/+/, '/'),
       })
 
-      try {
-        // ensure parsedUrl.pathname includes URL before processing
-        // rewrites or they won't match correctly
-        if (this.nextConfig.i18n && !url.locale?.path.detectedLocale) {
-          parsedUrl.pathname = `/${url.locale?.locale}${parsedUrl.pathname}`
-        }
-        utils.handleRewrites(req, parsedUrl)
+      if (url.basePath) {
+        req.url = replaceBasePath(req.url!, this.nextConfig.basePath)
+        addRequestMeta(req, '_nextHadBasePath', true)
+      }
 
-        // interpolate dynamic params and normalize URL if needed
-        if (pageIsDynamic) {
-          let params: ParsedUrlQuery | false = {}
+      if (
+        this.minimalMode &&
+        req.headers['x-matched-path'] &&
+        typeof req.headers['x-matched-path'] === 'string'
+      ) {
+        const reqUrlIsDataUrl = req.url?.includes('/_next/data')
+        const matchedPathIsDataUrl =
+          req.headers['x-matched-path']?.includes('/_next/data')
+        const isDataUrl = reqUrlIsDataUrl || matchedPathIsDataUrl
 
-          Object.assign(parsedUrl.query, parsedPath.query)
-          const paramsResult = utils.normalizeDynamicRouteParams(
-            parsedUrl.query
+        let parsedPath = parseUrl(
+          isDataUrl ? req.url! : (req.headers['x-matched-path'] as string),
+          true
+        )
+
+        let matchedPathname = parsedPath.pathname!
+
+        let matchedPathnameNoExt = isDataUrl
+          ? matchedPathname.replace(/\.json$/, '')
+          : matchedPathname
+
+        if (this.nextConfig.i18n) {
+          const localePathResult = normalizeLocalePath(
+            matchedPathname || '/',
+            this.nextConfig.i18n.locales
           )
 
-          if (paramsResult.hasValidParams) {
-            params = paramsResult.params
-          } else if (req.headers['x-now-route-matches']) {
-            const opts: Record<string, string> = {}
-            params = utils.getParamsFromRouteMatches(
-              req,
-              opts,
-              parsedUrl.query.__nextLocale || ''
+          if (localePathResult.detectedLocale) {
+            parsedUrl.query.__nextLocale = localePathResult.detectedLocale
+          }
+        }
+
+        if (isDataUrl) {
+          matchedPathname = denormalizePagePath(matchedPathname)
+          matchedPathnameNoExt = denormalizePagePath(matchedPathnameNoExt)
+        }
+
+        const pageIsDynamic = isDynamicRoute(matchedPathnameNoExt)
+        const combinedRewrites: Rewrite[] = []
+
+        combinedRewrites.push(...this.customRoutes.rewrites.beforeFiles)
+        combinedRewrites.push(...this.customRoutes.rewrites.afterFiles)
+        combinedRewrites.push(...this.customRoutes.rewrites.fallback)
+
+        const utils = getUtils({
+          pageIsDynamic,
+          page: matchedPathnameNoExt,
+          i18n: this.nextConfig.i18n,
+          basePath: this.nextConfig.basePath,
+          rewrites: combinedRewrites,
+        })
+
+        try {
+          // ensure parsedUrl.pathname includes URL before processing
+          // rewrites or they won't match correctly
+          if (this.nextConfig.i18n && !url.locale?.path.detectedLocale) {
+            parsedUrl.pathname = `/${url.locale?.locale}${parsedUrl.pathname}`
+          }
+          utils.handleRewrites(req, parsedUrl)
+
+          // interpolate dynamic params and normalize URL if needed
+          if (pageIsDynamic) {
+            let params: ParsedUrlQuery | false = {}
+
+            Object.assign(parsedUrl.query, parsedPath.query)
+            const paramsResult = utils.normalizeDynamicRouteParams(
+              parsedUrl.query
             )
 
-            if (opts.locale) {
-              parsedUrl.query.__nextLocale = opts.locale
+            if (paramsResult.hasValidParams) {
+              params = paramsResult.params
+            } else if (req.headers['x-now-route-matches']) {
+              const opts: Record<string, string> = {}
+              params = utils.getParamsFromRouteMatches(
+                req,
+                opts,
+                parsedUrl.query.__nextLocale || ''
+              )
+
+              if (opts.locale) {
+                parsedUrl.query.__nextLocale = opts.locale
+              }
+            } else {
+              params = utils.dynamicRouteMatcher!(matchedPathnameNoExt)
             }
-          } else {
-            params = utils.dynamicRouteMatcher!(matchedPathnameNoExt)
+
+            if (params) {
+              params = utils.normalizeDynamicRouteParams(params).params
+
+              matchedPathname = utils.interpolateDynamicPath(
+                matchedPathname,
+                params
+              )
+              req.url = utils.interpolateDynamicPath(req.url!, params)
+            }
+
+            if (reqUrlIsDataUrl && matchedPathIsDataUrl) {
+              req.url = formatUrl({
+                ...parsedPath,
+                pathname: matchedPathname,
+              })
+            }
+
+            Object.assign(parsedUrl.query, params)
+            utils.normalizeVercelUrl(req, true)
           }
-
-          if (params) {
-            params = utils.normalizeDynamicRouteParams(params).params
-
-            matchedPathname = utils.interpolateDynamicPath(
-              matchedPathname,
-              params
-            )
-            req.url = utils.interpolateDynamicPath(req.url!, params)
+        } catch (err) {
+          if (err instanceof DecodeError) {
+            res.statusCode = 400
+            return this.renderError(null, req, res, '/_error', {})
           }
-
-          if (reqUrlIsDataUrl && matchedPathIsDataUrl) {
-            req.url = formatUrl({
-              ...parsedPath,
-              pathname: matchedPathname,
-            })
-          }
-
-          Object.assign(parsedUrl.query, params)
-          utils.normalizeVercelUrl(req, true)
+          throw err
         }
-      } catch (err) {
-        if (err instanceof DecodeError) {
-          res.statusCode = 400
-          return this.renderError(null, req, res, '/_error', {})
+
+        parsedUrl.pathname = `${this.nextConfig.basePath || ''}${
+          matchedPathname === '/' && this.nextConfig.basePath
+            ? ''
+            : matchedPathname
+        }`
+        url.pathname = parsedUrl.pathname
+      }
+
+      addRequestMeta(req, '__nextHadTrailingSlash', url.locale?.trailingSlash)
+      if (url.locale?.domain) {
+        addRequestMeta(req, '__nextIsLocaleDomain', true)
+      }
+
+      if (url.locale?.path.detectedLocale) {
+        req.url = formatUrl(url)
+        addRequestMeta(req, '__nextStrippedLocale', true)
+        if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+          return this.render404(req, res, parsedUrl)
         }
-        throw err
       }
 
-      parsedUrl.pathname = `${this.nextConfig.basePath || ''}${
-        matchedPathname === '/' && this.nextConfig.basePath
-          ? ''
-          : matchedPathname
-      }`
-      url.pathname = parsedUrl.pathname
-    }
-
-    addRequestMeta(req, '__nextHadTrailingSlash', url.locale?.trailingSlash)
-    if (url.locale?.domain) {
-      addRequestMeta(req, '__nextIsLocaleDomain', true)
-    }
-
-    if (url.locale?.path.detectedLocale) {
-      req.url = formatUrl(url)
-      addRequestMeta(req, '__nextStrippedLocale', true)
-      if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
-        return this.render404(req, res, parsedUrl)
+      if (!this.minimalMode || !parsedUrl.query.__nextLocale) {
+        if (url?.locale?.locale) {
+          parsedUrl.query.__nextLocale = url.locale.locale
+        }
       }
-    }
 
-    if (!this.minimalMode || !parsedUrl.query.__nextLocale) {
-      if (url?.locale?.locale) {
-        parsedUrl.query.__nextLocale = url.locale.locale
+      if (url?.locale?.defaultLocale) {
+        parsedUrl.query.__nextDefaultLocale = url.locale.defaultLocale
       }
-    }
 
-    if (url?.locale?.defaultLocale) {
-      parsedUrl.query.__nextDefaultLocale = url.locale.defaultLocale
-    }
+      if (url.locale?.redirect) {
+        res.setHeader('Location', url.locale.redirect)
+        res.statusCode = TEMPORARY_REDIRECT_STATUS
+        res.end()
+        return
+      }
 
-    if (url.locale?.redirect) {
-      res.setHeader('Location', url.locale.redirect)
-      res.statusCode = TEMPORARY_REDIRECT_STATUS
-      res.end()
-      return
-    }
+      res.statusCode = 200
 
-    res.statusCode = 200
-    try {
       return await this.run(req, res, parsedUrl)
     } catch (err) {
       if (this.minimalMode || this.renderOpts.dev) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Fixes #32075. 
Catching the whole request handling block seems reasonable to me. The server should not exit the process just because one request error happens.

## Bug

- [x] Related issues linked using `fixes #number`
