### PR TITLE
feat: treat shared components as server components

### DIFF
--- a/packages/next/build/webpack/loaders/next-flight-client-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-client-loader.ts
@@ -127,6 +127,13 @@ async function parseExportNamesInto(
   }
 }
 
+export const moduleReferenceDef = `const MODULE_REFERENCE = Symbol.for('react.module.reference')`
+export function createModuleReference(url: string, name: string): string {
+  return `{ $$typeof: MODULE_REFERENCE, filepath: ${JSON.stringify(
+    url
+  )}, name: ${JSON.stringify(name)}}`
+}
+
 export default async function transformSource(
   this: any,
   source: Source
@@ -154,8 +161,7 @@ export default async function transformSource(
     names.push('default')
   }
 
-  let newSrc =
-    "const MODULE_REFERENCE = Symbol.for('react.module.reference');\n"
+  let newSrc = moduleReferenceDef + '\n'
   for (let i = 0; i < names.length; i++) {
     const name = names[i]
     if (name === 'default') {
@@ -163,11 +169,7 @@ export default async function transformSource(
     } else {
       newSrc += 'export const ' + name + ' = '
     }
-    newSrc += '{ $$typeof: MODULE_REFERENCE, filepath: '
-    newSrc += JSON.stringify(url)
-    newSrc += ', name: '
-    newSrc += JSON.stringify(name)
-    newSrc += '};\n'
+    newSrc += createModuleReference(url, name) + ';\n'
   }
 
   return newSrc

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1152,40 +1152,30 @@ export async function renderToHTML(
       }
     } else {
       let bodyResult
+      const getContent = () =>
+        ctx.err && ErrorDebug ? (
+          <Body>
+            <ErrorDebug error={ctx.err} />
+          </Body>
+        ) : (
+          <Body>
+            {getWrappedApp(
+              <App {...props} Component={Component} router={router} />
+            )}
+          </Body>
+        )
 
       if (concurrentFeatures) {
         bodyResult = async () => {
           // this must be called inside bodyResult so appWrappers is
           // up to date when getWrappedApp is called
-          const content =
-            ctx.err && ErrorDebug ? (
-              <Body>
-                <ErrorDebug error={ctx.err} />
-              </Body>
-            ) : (
-              <Body>
-                {getWrappedApp(
-                  <App {...props} Component={Component} router={router} />
-                )}
-              </Body>
-            )
+          const content = getContent()
           return process.browser
             ? await renderToWebStream(content)
             : await renderToNodeStream(content, generateStaticHTML)
         }
       } else {
-        const content =
-          ctx.err && ErrorDebug ? (
-            <Body>
-              <ErrorDebug error={ctx.err} />
-            </Body>
-          ) : (
-            <Body>
-              {getWrappedApp(
-                <App {...props} Component={Component} router={router} />
-              )}
-            </Body>
-          )
+        const content = getContent()
         // for non-concurrent rendering we need to ensure App is rendered
         // before _document so that updateHead is called/collected before
         // rendering _document's head

--- a/test/integration/react-streaming-and-server-components/app/components/foo.client.js
+++ b/test/integration/react-streaming-and-server-components/app/components/foo.client.js
@@ -1,3 +1,6 @@
+import { useMemo } from 'react'
+
 export default function foo() {
-  return 'foo.client'
+  const value = useMemo(() => 'foo.client', [])
+  return value
 }

--- a/test/integration/react-streaming-and-server-components/app/components/shared.js
+++ b/test/integration/react-streaming-and-server-components/app/components/shared.js
@@ -1,0 +1,10 @@
+import Foo from './foo.client'
+
+export default function Shared(props) {
+  const hasWindow = (typeof window === 'undefined').toString()
+  return (
+    <div {...props}>
+      shared:server:{hasWindow}:<Foo />
+    </div>
+  )
+}

--- a/test/integration/react-streaming-and-server-components/app/pages/index.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/index.server.js
@@ -1,4 +1,5 @@
 import Foo from '../components/foo.client'
+import Shared from '../components/shared'
 
 const envVar = process.env.ENV_VAR_TEST
 const headerKey = 'x-next-test-client'
@@ -13,6 +14,7 @@ export default function Index({ header, router }) {
       <div>
         <Foo />
       </div>
+      <Shared id="shared" />
     </div>
   )
 }

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -268,11 +268,17 @@ async function runBasicTests(context, env) {
       '/this-is-not-found'
     )
 
+    const $ = cheerio.load(homeHTML)
+    const $shared = $('#shared')
+
     expect(homeHTML).toContain('component:index.server')
     expect(homeHTML).toContain('env:env_var_test')
     expect(homeHTML).toContain('header:test-util')
     expect(homeHTML).toContain('path:/')
     expect(homeHTML).toContain('foo.client')
+
+    // shared components are treated as server components
+    expect($shared.text()).toContain('shared:server:true:foo.client')
 
     expect(dynamicRouteHTML1).toContain('[pid]')
     expect(dynamicRouteHTML2).toContain('[pid]')


### PR DESCRIPTION
~~* Treate shared components in RSC as server components~~
~~* Allow server components to import shared components~~
~~* All client components imports should be treated as module reference (except `node_modules` so far)~~

need to re-think of it
