### PR TITLE
Ensure conf type for createServer is not changed

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -8,7 +8,7 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import type { LoadComponentsReturnType } from './load-components'
 import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'
 import type { NextApiRequest, NextApiResponse } from '../shared/lib/utils'
-import type { NextConfigComplete } from './config-shared'
+import type { NextConfig, NextConfigComplete } from './config-shared'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import type { ParsedNextUrl } from '../shared/lib/router/utils/parse-next-url'
 import type { ParsedUrl } from '../shared/lib/router/utils/parse-url'
@@ -123,7 +123,7 @@ export interface Options {
   /**
    * Object containing the configuration next.config.js
    */
-  conf: NextConfigComplete
+  conf: NextConfig
   /**
    * Set to false when the server was created by Next.js
    */
@@ -233,7 +233,9 @@ export default class Server {
     this.quiet = quiet
     loadEnvConfig(this.dir, dev, Log)
 
-    this.nextConfig = conf
+    // TODO: should conf be normalized to prevent missing
+    // values from causing issues as this can be user provided
+    this.nextConfig = conf as NextConfigComplete
     this.hostname = hostname
     this.port = port
 

--- a/test/production/typescript-basic.test.ts
+++ b/test/production/typescript-basic.test.ts
@@ -24,6 +24,18 @@ describe('TypeScript basic', () => {
             )
           } 
         `,
+        'server.ts': `
+          import next from 'next';
+          const app = next({
+            dir: '.',
+            dev: process.env.NODE_ENV !== 'production',
+            conf: {
+              compress: false,
+            },
+            quiet: false,
+          });
+          const requestHandler = app.getRequestHandler();
+        `,
       },
       dependencies: {
         typescript: '4.4.3',


### PR DESCRIPTION
This reverts the type for the `conf` field in `ServerOptions` isn't changed to require all `NextConfig` values as this is a breaking change from what was previously required. We should investigate making sure this field is normalized when it is provided via a user. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/32123
x-ref: https://github.com/vercel/next.js/pull/31858