### PR TITLE
Removed misleading id's from headings

### DIFF
--- a/docs/advanced-features/using-mdx.md
+++ b/docs/advanced-features/using-mdx.md
@@ -140,9 +140,9 @@ This is a list in markdown:
 The above generates the following `HTML`:
 
 ```html
-<h1 id="h1-heading">H1 heading</h1>
+<h1>H1 heading</h1>
 
-<h2 id="h2-heading">H2 heading</h2>
+<h2>H2 heading</h2>
 
 <p>This is a list in markdown:</p>
 


### PR DESCRIPTION
`id`'s are not generated automatically without plugins like `rehype-slug`.

https://github.com/vercel/next.js/issues/32158

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
