### PR TITLE
chore: auto close inactive issues without reproduction

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@main
+        id: stale
+        name: 'Close stale issues with no reproduction'
+        with:
+          only-labels: 'please add a complete reproduction'
+          close-issue-message: 'This issue was closed after 30 days of inactivity because it provided no reproduction.'
+          days-before-issue-close: 30
+          days-before-pr-close: -1
+          days-before-pr-stale: -1
+          exempt-issue-labels: 'blocked,must,should,keep'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
         name: 'Close stale issues with no reproduction'
         with:
           only-labels: 'please add a complete reproduction'
-          close-issue-message: 'This issue was closed after 30 days of inactivity because it provided no reproduction.'
+          close-issue-message: 'This issue has been automatically closed after 30 days of inactivity with no reproduction. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'
           days-before-issue-close: 30
           days-before-pr-close: -1
           days-before-pr-stale: -1


### PR DESCRIPTION
When a user opens a bug report, we try to verify if the problem is caused by a bug in Next.js or originates from user code/other factors.

If a reproduction is not provided, and we are unable to make an educated guess about the user implementation and possible problems we label it with `please add a complete reproduction` inviting the user to provide more information.

If the user does not show a sign of activity in providing any more information, the issue becomes unactionable.

With this change, we are giving users a certain amount of time before we will close such issues.

> NOTE: Any action (comment, new label, edit etc.) on an issue with the label `please add a complete reproduction` resets the timer, and if the label is removed, the issue won't be closed anymore, until further manual inspection.

PRs are not considered through this change.