### PR TITLE
Ensure wasm dev artifact uploads even on cache hit

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1355,7 +1355,7 @@ jobs:
         run: mv packages/next-swc/crates/wasm/pkg packages/next-swc/crates/wasm/pkg-nodejs
 
       - name: Upload artifact
-        if: ${{needs.build.outputs.docsChange != 'docs only change' && steps.binary-cache.outputs.cache-hit != 'true'}}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         uses: actions/upload-artifact@v2
         with:
           name: wasm-dev-binary


### PR DESCRIPTION
This fixes the artifact download failing when the cache was used. 

x-ref: https://github.com/vercel/next.js/runs/4445308610?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/4446223182?check_suite_focus=true