### PR TITLE
Fix styled-jsx tests from swc bump

### DIFF
--- a/test/integration/client-navigation/test/rendering.js
+++ b/test/integration/client-navigation/test/rendering.js
@@ -218,7 +218,7 @@ export default function (render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId} {color:blue`)).toBeTruthy()
+      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
     })
 
     test('renders styled jsx external', async () => {
@@ -226,7 +226,7 @@ export default function (render, fetch, ctx) {
       const styleId = $('#blue-box').attr('class')
       const style = $('style')
 
-      expect(style.text().includes(`p.${styleId} {color:blue`)).toBeTruthy()
+      expect(style.text().includes(`p.${styleId}{color:blue`)).toBeTruthy()
     })
 
     test('renders properties populated asynchronously', async () => {


### PR DESCRIPTION
Fixes failing tests from swc bump in https://github.com/vercel/next.js/pull/32210 which removed some whitespace. 

x-ref: https://github.com/vercel/next.js/runs/4456734159?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/4461064714?check_suite_focus=true