### PR TITLE
Update only fetch all tags for publish commits

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -42,9 +42,9 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
-      - run: node ./scripts/fetch-tags.mjs
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js --timings --write-timings -g 1/1
+      - run: node ./scripts/fetch-tags.mjs
 
       - name: Check docs only change
         run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js --timings --write-timings -g 1/1
-      - run: node ./scripts/fetch-tags.mjs
+      - run: node ./scripts/fetch-tags.mjs ${{ github.sha }}
 
       - name: Check docs only change
         run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -42,9 +42,9 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
+      - run: node ./scripts/fetch-tags.mjs
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js --timings --write-timings -g 1/1
-      - run: node ./scripts/fetch-tags.mjs
 
       - name: Check docs only change
         run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -42,14 +42,15 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: yarn install --frozen-lockfile --check-files
       - run: node run-tests.js --timings --write-timings -g 1/1
+      - run: node ./scripts/fetch-tags.mjs
+
       - name: Check docs only change
         run: echo ::set-output name=DOCS_CHANGE::$(node skip-docs-change.js echo 'not-docs-only-change')
         id: docs-change
+
       - run: echo ${{steps.docs-change.outputs.DOCS_CHANGE}}
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - id: check-release
         run: |
           if [[ $(git describe --exact-match 2> /dev/null || :) = v* ]];
@@ -58,6 +59,7 @@ jobs:
             else
               echo "::set-output name=IS_RELEASE::false"
           fi
+
       - uses: actions/cache@v2
         id: cache-build
         with:

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -11,10 +11,11 @@ import execa from 'execa'
   // parse only the last string which should be version if
   // it's a publish commit
   const commitMsg = execSync(
-    `git log --oneline -n 1 ${commitId ? ` ${commitId}` : ''}`
+    `git log --oneline -n 1${commitId ? ` ${commitId}` : ''}`
   )
     .toString()
     .trim()
+
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
 

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -1,14 +1,22 @@
 import { execSync } from 'child_process'
 import execa from 'execa'
 ;(async () => {
+  let commitId = process.argv[process.argv.length - 1]
+  
+  if (commitId.match(/[a-zA-Z0-9]/)) {
+    commitId = ''
+  }
+  
   // <hash> (<tag>) <message>
   // parse only the last string which should be version if
   // it's a publish commit
-  const commitMsg = execSync('git log --oneline -1').toString().trim()
+  const commitMsg = execSync(
+    `git log --oneline -n 1 ${commitId ? ` ${commitId}` : ''}`
+  ).toString().trim()
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
 
-  console.log({ commitMsg, versionString })
+  console.log({ commitId, commitMsg, versionString })
 
   if (publishMsgRegex.test(versionString)) {
     console.log('publish commit, fetching tags')

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -1,0 +1,32 @@
+import {execSync} from 'child_process'
+import execa from 'execa'
+
+;(async () => {
+  // <hash> (<tag>) <message>
+  // parse only the last string which should be version if
+  // it's a publish commit
+  const commitMsg = execSync('git log --oneline -1').toString().trim()
+  const versionString = commitMsg.split(' ').pop().trim()
+  const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
+  
+  console.log({commitMsg, versionString});
+  
+  if (publishMsgRegex.test(versionString)) {
+    console.log('publish commit, fetching tags'); 
+    
+    const result = await execa('git', ['fetch', '--depth=1', 'origin', '+refs/tags/*:refs/tags/*'], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      env: {
+        ...process.env,
+      },
+    })
+    
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to fetch tags, exited with code ${result.exitCode}`
+      )
+    }
+  } else {
+    console.log('not publish commit');
+  }
+})()

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -1,11 +1,7 @@
 import { execSync } from 'child_process'
 import execa from 'execa'
 ;(async () => {
-  let commitId = process.argv[process.argv.length - 1]
-
-  if (commitId.endsWith('fetch-tags.mjs')) {
-    commitId = ''
-  }
+  let commitId = process.argv[2] || ''
 
   // <hash> (<tag>) <message>
   // parse only the last string which should be version if

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -1,6 +1,5 @@
-import {execSync} from 'child_process'
+import { execSync } from 'child_process'
 import execa from 'execa'
-
 ;(async () => {
   // <hash> (<tag>) <message>
   // parse only the last string which should be version if
@@ -8,25 +7,29 @@ import execa from 'execa'
   const commitMsg = execSync('git log --oneline -1').toString().trim()
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
-  
-  console.log({commitMsg, versionString});
-  
+
+  console.log({ commitMsg, versionString })
+
   if (publishMsgRegex.test(versionString)) {
-    console.log('publish commit, fetching tags'); 
-    
-    const result = await execa('git', ['fetch', '--depth=1', 'origin', '+refs/tags/*:refs/tags/*'], {
-      stdio: ['ignore', 'inherit', 'inherit'],
-      env: {
-        ...process.env,
-      },
-    })
-    
+    console.log('publish commit, fetching tags')
+
+    const result = await execa(
+      'git',
+      ['fetch', '--depth=1', 'origin', '+refs/tags/*:refs/tags/*'],
+      {
+        stdio: ['ignore', 'inherit', 'inherit'],
+        env: {
+          ...process.env,
+        },
+      }
+    )
+
     if (result.exitCode !== 0) {
       throw new Error(
         `Failed to fetch tags, exited with code ${result.exitCode}`
       )
     }
   } else {
-    console.log('not publish commit');
+    console.log('not publish commit')
   }
 })()

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -3,7 +3,7 @@ import execa from 'execa'
 ;(async () => {
   let commitId = process.argv[process.argv.length - 1]
 
-  if (commitId.match(/[a-zA-Z0-9]/)) {
+  if (commitId.endsWith('fetch-tags.mjs')) {
     commitId = ''
   }
 

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -3,11 +3,10 @@ import execa from 'execa'
 ;(async () => {
   let commitId = process.argv[2] || ''
 
-  // <hash> (<tag>) <message>
   // parse only the last string which should be version if
   // it's a publish commit
   const commitMsg = execSync(
-    `git log --oneline -n 1${commitId ? ` ${commitId}` : ''}`
+    `git log -n 1 --pretty='format:%B'${commitId ? ` ${commitId}` : ''}`
   )
     .toString()
     .trim()
@@ -25,17 +24,10 @@ import execa from 'execa'
       ['fetch', '--depth=1', 'origin', '+refs/tags/*:refs/tags/*'],
       {
         stdio: ['ignore', 'inherit', 'inherit'],
-        env: {
-          ...process.env,
-        },
       }
     )
 
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to fetch tags, exited with code ${result.exitCode}`
-      )
-    }
+    process.exit(result.exitCode)
   } else {
     console.log('not publish commit')
   }

--- a/scripts/fetch-tags.mjs
+++ b/scripts/fetch-tags.mjs
@@ -2,17 +2,19 @@ import { execSync } from 'child_process'
 import execa from 'execa'
 ;(async () => {
   let commitId = process.argv[process.argv.length - 1]
-  
+
   if (commitId.match(/[a-zA-Z0-9]/)) {
     commitId = ''
   }
-  
+
   // <hash> (<tag>) <message>
   // parse only the last string which should be version if
   // it's a publish commit
   const commitMsg = execSync(
     `git log --oneline -n 1 ${commitId ? ` ${commitId}` : ''}`
-  ).toString().trim()
+  )
+    .toString()
+    .trim()
   const versionString = commitMsg.split(' ').pop().trim()
   const publishMsgRegex = /^v\d{1,}\.\d{1,}\.\d{1,}(-\w{1,}\.\d{1,})?$/
 


### PR DESCRIPTION
Alternative to https://github.com/vercel/next.js/pull/30350 this aims to remove the 3 minute `git fetch` step for each `build_test_deploy` workflow run as it should only be needed for releases and all release commit messages contain only the version