### PR TITLE
Add originalUrl field for middleware uses

### DIFF
--- a/packages/next/server/web/next-url.ts
+++ b/packages/next/server/web/next-url.ts
@@ -35,6 +35,7 @@ export class NextURL extends URL {
   }
   private _options: Options
   private _url: URL
+  originalUrl: URL
 
   constructor(input: string, options: Options = {}) {
     const url = createWHATWGURL(input)
@@ -42,6 +43,7 @@ export class NextURL extends URL {
     this._options = options
     this._basePath = ''
     this._url = url
+    this.originalUrl = url
     this.analyzeUrl()
   }
 


### PR DESCRIPTION
Hey guys,

this PR was never in a feature request and neither it's a bug. It's rather a feature that I wanted to use in Nextjs where there was an existing discussion here already: https://github.com/vercel/next.js/discussions/18419

However, the marked answer is not really an answer as doing it that way makes the usage of `router.locales` more annoying to deal with and in general it _felt off_ that one doesn't have access to the original url (or other means) of adding a simple fix for this.

On that note, a usage of this field could be this:

```typescript
import { NextRequest, NextResponse } from "next/server";

const PUBLIC_FILE = /\.(.*)$/;

export function middleware(request: NextRequest) {
  const isNotPage = PUBLIC_FILE.test(request.nextUrl.pathname) || request.nextUrl.pathname.startsWith("/api/");
  const isNotDefaultLocale = request.nextUrl.locale !== request.nextUrl.defaultLocale;
  if (isNotPage || isNotDefaultLocale) return undefined;

  const hasDefaultLocalePrefix = request.nextUrl.originalUrl.pathname.startsWith(`/${request.nextUrl.defaultLocale}`);
  if (hasDefaultLocalePrefix) return undefined;

  return NextResponse.redirect(`/${request.nextUrl.defaultLocale}${request.nextUrl.pathname}`);
}

```
