### PR TITLE
feat(eslint): disallow Node.js APIs outside server

### DIFF
--- a/packages/eslint-plugin-next/lib/index.js
+++ b/packages/eslint-plugin-next/lib/index.js
@@ -19,6 +19,7 @@ module.exports = {
     'no-duplicate-head': require('./rules/no-duplicate-head'),
     'inline-script-id': require('./rules/inline-script-id'),
     'next-script-for-ga': require('./rules/next-script-for-ga'),
+    'no-node-api-outside-server': require('./rules/no-node-api-outside-server'),
   },
   configs: {
     recommended: {
@@ -43,6 +44,7 @@ module.exports = {
         '@next/next/no-typos': 1,
         '@next/next/no-duplicate-head': 2,
         '@next/next/inline-script-id': 2,
+        '@next/next/no-node-api-outside-server': 2,
       },
     },
     'core-web-vitals': {

--- a/packages/eslint-plugin-next/lib/rules/no-node-api-outside-server.js
+++ b/packages/eslint-plugin-next/lib/rules/no-node-api-outside-server.js
@@ -1,10 +1,10 @@
+const { builtinModules } = require('module')
+
 const SERVER_METHODS = [
   'getStaticPaths',
   'getStaticProps',
   'getServerSideProps',
 ]
-
-const COMMON_NODE_APIS = ['fs', 'fs/promises', 'path']
 
 module.exports = {
   meta: {
@@ -28,7 +28,10 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        if (COMMON_NODE_APIS.includes(node.source.value)) {
+        if (
+          builtinModules.includes(node.source.value) ||
+          node.source.value.startsWith('node:')
+        ) {
           node.specifiers.map((s) => nodeImportSpecifiers.push(s.local.name))
         }
       },

--- a/packages/eslint-plugin-next/lib/rules/no-node-api-outside-server.js
+++ b/packages/eslint-plugin-next/lib/rules/no-node-api-outside-server.js
@@ -1,0 +1,80 @@
+const SERVER_METHODS = [
+  'getStaticPaths',
+  'getStaticProps',
+  'getServerSideProps',
+]
+
+const COMMON_NODE_APIS = ['fs', 'fs/promises', 'path']
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Disallow referencing common Node.js APIs outside server-side methods',
+      recommended: true,
+      url: 'https://nextjs.org/docs/messages/no-node-api-outside-server',
+    },
+  },
+  create: function (context) {
+    const paths = context.getFilename().split('pages')
+    const page = paths[paths.length - 1]
+
+    // outside of a file within `pages`, bail
+    if (!page) {
+      return {}
+    }
+
+    const nodeImportSpecifiers = []
+    const serverMethodDeclarations = []
+
+    return {
+      ImportDeclaration(node) {
+        if (COMMON_NODE_APIS.includes(node.source.value)) {
+          node.specifiers.map((s) => nodeImportSpecifiers.push(s.local.name))
+        }
+      },
+      ExportNamedDeclaration(node) {
+        const d = node.declaration
+        if (
+          (d.type === 'FunctionDeclaration' &&
+            SERVER_METHODS.includes(d.id.name)) ||
+          (d.type === 'VariableDeclaration' &&
+            SERVER_METHODS.includes(d.declarations[0].id.name))
+        ) {
+          serverMethodDeclarations.push(node)
+        }
+      },
+      ExpressionStatement(node) {
+        if (nodeImportSpecifiers.every((s) => s !== node.expression.name)) {
+          return
+        }
+        const ancestors = context.getAncestors()
+        const allowedParents = ancestors.filter((ancestor) => {
+          return serverMethodDeclarations.some(
+            ({ declaration: d }) =>
+              // export function ...
+              (d.type === 'FunctionDeclaration' &&
+                isIdentifierMatch(d.id, ancestor.id)) ||
+              // export const
+              (d.type === 'VariableDeclaration' &&
+                isIdentifierMatch(d.declarations[0].id, ancestor.id))
+          )
+        })
+
+        if (allowedParents.length) {
+          return
+        }
+
+        context.report({
+          node,
+          message:
+            'Node.js APIs should only be referenced within server-side methods. See https://nextjs.org/docs/messages/no-node-api-outside-server.',
+        })
+      },
+    }
+  },
+}
+
+function isIdentifierMatch(id1, id2) {
+  return (id1 === null && id2 === null) || (id1 && id2 && id1.name === id2.name)
+}


### PR DESCRIPTION
Common Node.js APIs like `fs`, `path` should not be used client-side.

This new ESLint rule detects when such an API is being accessed outside one of these methods:

`getStaticPaths`, `getStaticProps`, `getServerSideProps`


Based on the request at https://github.com/vercel/next.js/issues/27051#issuecomment-884139234


<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
