### PR TITLE
add --skip-install arg to create-next-app

### DIFF
--- a/packages/create-next-app/README.md
+++ b/packages/create-next-app/README.md
@@ -26,6 +26,7 @@ npx create-next-app blog-app
 - **-e, --example [name]|[github-url]** - An example to bootstrap the app with. You can use an example name from the [Next.js repo](https://github.com/vercel/next.js/tree/master/examples) or a GitHub URL. The URL can use any branch and/or subdirectory.
 - **--example-path &lt;path-to-example&gt;** - In a rare case, your GitHub URL might contain a branch name with a slash (e.g. bug/fix-1) and the path to the example (e.g. foo/bar). In this case, you must specify the path to the example separately: `--example-path foo/bar`
 - **--use-npm** - Explicitly tell the CLI to bootstrap the app using npm. To bootstrap using yarn we recommend to run `yarn create next-app`
+- **--skip-install** - Skips dependency installation step. You can use your favorite package manager.
 
 ## Why use Create Next App?
 

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -192,7 +192,7 @@ export async function createApp({
     console.log('Installing packages. This might take a couple of minutes.')
     console.log()
 
-    if (!skipInstall) console.log('Skipping dependency installation step.')
+    if (skipInstall) console.log('Skipping dependency installation step.')
     else await install(root, null, { useYarn, isOnline })
 
     console.log()

--- a/packages/create-next-app/helpers/write-package-json.ts
+++ b/packages/create-next-app/helpers/write-package-json.ts
@@ -1,0 +1,13 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+/**
+ * Write packageJson it to disk.
+ */
+export function writePackageJsonToDisk(root: string, value: any) {
+  return fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify(value, null, 2) + os.EOL
+  )
+}

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -52,6 +52,13 @@ const program = new Commander.Command(packageJson.name)
   --example-path foo/bar
 `
   )
+  .option(
+    '--skip-install',
+    `
+
+  Skips dependencies installation step
+`
+  )
   .allowUnknownOption()
   .parse(process.argv)
 
@@ -127,6 +134,7 @@ async function run(): Promise<void> {
       example: example && example !== 'default' ? example : undefined,
       examplePath: program.examplePath,
       typescript: program.typescript,
+      skipInstall: program.skipInstall,
     })
   } catch (reason) {
     if (!(reason instanceof DownloadError)) {
@@ -149,6 +157,7 @@ async function run(): Promise<void> {
       appPath: resolvedProjectPath,
       useNpm: !!program.useNpm,
       typescript: program.typescript,
+      skipInstall: program.skipInstall,
     })
   }
 }


### PR DESCRIPTION
- adds feature issue #32367
- facilitates using any package manager, not just npm/yarn
- for default templates, writes "latest" dist tag for deps in package.json
```json
"dependencies": {
  "react": "latest",
  "react-dom": "latest",
  "next": "latest"
},
"devDependencies": {
  "eslint": "latest",
  "eslint-config-next": "latest"
}
```

Please comment below if there are any changes required

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
