### PR TITLE
Add moduleDirectories for TS Jest Config

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -282,6 +282,8 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
+  moduleDirectories: ['node_modules', '<rootDir>/'],
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
It took me a while to work out that if using TypeScript with the `baseUrl` set to `.` (quite common) - then the tests fail as Jest can't find the modules.

Explicitly setting the `moduleDirectories`, as per the change to the config, fixes this issue.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Fixup commit
- [x] Make sure the linting passes by running `yarn lint`
