### PR TITLE
Update contributing guidelines for examples

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -223,10 +223,10 @@ When you add an example to the [examples](examples) directory, don’t forget to
 
 - Replace `DIRECTORY_NAME` with the directory name you’re adding.
 - Fill in `Example Name` and `Description`.
-- Make sure the examples you're added are Typescript-first
-- You don’t need to add name or version in your package.json
-- Ensure all your dependencies are up to date
-- Ensure you’re using [next/image](https://nextjs.org/docs/api-reference/next/image)
+- Examples should be TypeScript first, if possible.
+- You don’t need to add `name` or `version` in your `package.json`.
+- Ensure all your dependencies are up to date.
+- Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image).
 - To add additional installation instructions, please add it where appropriate.
 - To add additional notes, add `## Notes` section at the end.
 - Remove the `Deploy your own` section if your example can’t be immediately deployed to Vercel.

--- a/contributing.md
+++ b/contributing.md
@@ -223,21 +223,18 @@ When you add an example to the [examples](examples) directory, don’t forget to
 
 - Replace `DIRECTORY_NAME` with the directory name you’re adding.
 - Fill in `Example Name` and `Description`.
+- Make sure the examples you're added are Typescript-first
+- You don’t need to add name or version in your package.json
+- Ensure all your dependencies are up to date
+- Ensure you’re using [next/image](https://nextjs.org/docs/api-reference/next/image)
 - To add additional installation instructions, please add it where appropriate.
 - To add additional notes, add `## Notes` section at the end.
 - Remove the `Deploy your own` section if your example can’t be immediately deployed to Vercel.
-- Remove the `Preview` section if the example doesn't work on [StackBlitz](http://stackblitz.com/) and file an issue [here](https://github.com/stackblitz/webcontainer-core).
 
 ````markdown
 # Example Name
 
 Description
-
-## Preview
-
-Preview the example live on [StackBlitz](http://stackblitz.com/):
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/DIRECTORY_NAME)
 
 ## Deploy your own
 


### PR DESCRIPTION
To make it more clear that we're moving to TypeScript first examples, to prevent duplicate JS and TS versions and confusion around which are accepted. Further, we now have linting rules in place so you don't need to add `name` of `version` for any of the example `package.json` files.