### PR TITLE
Move fs API for inc cache to node server

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -18,6 +18,7 @@ import type { Redirect, Rewrite, RouteType } from '../lib/load-custom-routes'
 import type { RenderOpts, RenderOptsPartial } from './render'
 import type { ResponseCacheEntry, ResponseCacheValue } from './response-cache'
 import type { UrlWithParsedQuery } from 'url'
+import type { CacheFs } from '../shared/lib/utils'
 
 import compression from 'next/dist/compiled/compression'
 import Proxy from 'next/dist/compiled/http-proxy'
@@ -220,6 +221,7 @@ export default abstract class Server {
   protected abstract getBuildId(): string
   protected abstract generatePublicRoutes(): Route[]
   protected abstract getFilesystemPaths(): Set<string>
+  protected abstract getCacheFilesystem(): CacheFs
 
   public constructor({
     dir = '.',
@@ -314,6 +316,7 @@ export default abstract class Server {
     this.setAssetPrefix(assetPrefix)
 
     this.incrementalCache = new IncrementalCache({
+      fs: this.getCacheFilesystem(),
       dev,
       distDir: this.distDir,
       pagesDir: join(
@@ -1331,7 +1334,7 @@ export default abstract class Server {
 
           if (result.response.headers.has('x-middleware-refresh')) {
             res.writeHead(result.response.status)
-            for await (const chunk of result.response.body || []) {
+            for await (const chunk of result.response.body || ([] as any)) {
               res.write(chunk)
             }
             res.end()

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -221,7 +221,6 @@ export default abstract class Server {
   protected abstract getBuildId(): string
   protected abstract generatePublicRoutes(): Route[]
   protected abstract getFilesystemPaths(): Set<string>
-  protected abstract getCacheFilesystem(): CacheFs
 
   public constructor({
     dir = '.',
@@ -2483,6 +2482,16 @@ export default abstract class Server {
       pathname,
       query,
     })
+  }
+
+  protected getCacheFilesystem(): CacheFs {
+    return {
+      readFile: () => Promise.resolve(''),
+      readFileSync: () => '',
+      writeFile: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+      stat: () => Promise.resolve({ mtime: new Date() }),
+    }
   }
 
   protected async getFallbackErrorComponents(): Promise<LoadComponentsReturnType | null> {

--- a/packages/next/server/incremental-cache.ts
+++ b/packages/next/server/incremental-cache.ts
@@ -1,9 +1,9 @@
-import { promises, readFileSync } from 'fs'
 import LRUCache from 'next/dist/compiled/lru-cache'
 import path from 'path'
 import { PrerenderManifest } from '../build'
 import { PRERENDER_MANIFEST } from '../shared/lib/constants'
 import { normalizePagePath } from './normalize-page-path'
+import type { CacheFs } from '../shared/lib/utils'
 
 function toRoute(pathname: string): string {
   return pathname.replace(/\/$/, '').replace(/\/index$/, '') || '/'
@@ -41,8 +41,10 @@ export class IncrementalCache {
   prerenderManifest: PrerenderManifest
   cache?: LRUCache<string, IncrementalCacheEntry>
   locales?: string[]
+  fs: CacheFs
 
   constructor({
+    fs,
     max,
     dev,
     distDir,
@@ -50,6 +52,7 @@ export class IncrementalCache {
     flushToDisk,
     locales,
   }: {
+    fs: CacheFs
     dev: boolean
     max?: number
     distDir: string
@@ -57,6 +60,7 @@ export class IncrementalCache {
     flushToDisk?: boolean
     locales?: string[]
   }) {
+    this.fs = fs
     this.incrementalOptions = {
       dev,
       distDir,
@@ -76,7 +80,7 @@ export class IncrementalCache {
       }
     } else {
       this.prerenderManifest = JSON.parse(
-        readFileSync(path.join(distDir, PRERENDER_MANIFEST), 'utf8')
+        this.fs.readFileSync(path.join(distDir, PRERENDER_MANIFEST))
       )
     }
 
@@ -126,7 +130,7 @@ export class IncrementalCache {
 
   getFallback(page: string): Promise<string> {
     page = normalizePagePath(page)
-    return promises.readFile(this.getSeedPath(page, 'html'), 'utf8')
+    return this.fs.readFile(this.getSeedPath(page, 'html'))
   }
 
   // get data from cache if available
@@ -149,11 +153,10 @@ export class IncrementalCache {
 
       try {
         const htmlPath = this.getSeedPath(pathname, 'html')
-        const html = await promises.readFile(htmlPath, 'utf8')
-        const { mtime } = await promises.stat(htmlPath)
-        const pageData = JSON.parse(
-          await promises.readFile(this.getSeedPath(pathname, 'json'), 'utf8')
-        )
+        const jsonPath = this.getSeedPath(pathname, 'json')
+        const html = await this.fs.readFile(htmlPath)
+        const pageData = JSON.parse(await this.fs.readFile(jsonPath))
+        const { mtime } = await this.fs.stat(htmlPath)
 
         data = {
           revalidateAfter: this.calculateRevalidate(pathname, mtime.getTime()),
@@ -226,14 +229,11 @@ export class IncrementalCache {
     // `next build` output's manifest.
     if (this.incrementalOptions.flushToDisk && data?.kind === 'PAGE') {
       try {
-        const seedPath = this.getSeedPath(pathname, 'html')
-        await promises.mkdir(path.dirname(seedPath), { recursive: true })
-        await promises.writeFile(seedPath, data.html, 'utf8')
-        await promises.writeFile(
-          this.getSeedPath(pathname, 'json'),
-          JSON.stringify(data.pageData),
-          'utf8'
-        )
+        const seedHtmlPath = this.getSeedPath(pathname, 'html')
+        const seedJsonPath = this.getSeedPath(pathname, 'json')
+        await this.fs.mkdir(seedHtmlPath)
+        await this.fs.writeFile(seedHtmlPath, data.html)
+        await this.fs.writeFile(seedJsonPath, JSON.stringify(data.pageData))
       } catch (error) {
         // failed to flush to disk
         console.warn('Failed to update prerender files for', pathname, error)

--- a/packages/next/server/incremental-cache.ts
+++ b/packages/next/server/incremental-cache.ts
@@ -79,9 +79,10 @@ export class IncrementalCache {
         preview: null as any, // `preview` is special case read in next-dev-server
       }
     } else {
-      this.prerenderManifest = JSON.parse(
-        this.fs.readFileSync(path.join(distDir, PRERENDER_MANIFEST))
+      const manifestJson = this.fs.readFileSync(
+        path.join(distDir, PRERENDER_MANIFEST)
       )
+      this.prerenderManifest = JSON.parse(manifestJson)
     }
 
     if (process.env.__NEXT_TEST_MAX_ISR_CACHE) {
@@ -231,7 +232,7 @@ export class IncrementalCache {
       try {
         const seedHtmlPath = this.getSeedPath(pathname, 'html')
         const seedJsonPath = this.getSeedPath(pathname, 'json')
-        await this.fs.mkdir(seedHtmlPath)
+        await this.fs.mkdir(path.dirname(seedHtmlPath))
         await this.fs.writeFile(seedHtmlPath, data.html)
         await this.fs.writeFile(seedJsonPath, JSON.stringify(data.pageData))
       } catch (error) {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1,13 +1,14 @@
+import type { Route } from './router'
+import type { CacheFs } from '../shared/lib/utils'
+
 import fs from 'fs'
 import { join, relative } from 'path'
-
 import { PAGES_MANIFEST, BUILD_ID_FILE } from '../shared/lib/constants'
 import { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
-import type { Route } from './router'
 import { recursiveReadDirSync } from './lib/recursive-readdir-sync'
 import { route } from './router'
-
 import BaseServer from './base-server'
+
 export * from './base-server'
 
 export default class NextNodeServer extends BaseServer {
@@ -132,5 +133,15 @@ export default class NextNodeServer extends BaseServer {
       ...userFilesPublic,
       ...userFilesStatic,
     ]))
+  }
+
+  protected getCacheFilesystem(): CacheFs {
+    return {
+      readFile: (f) => fs.promises.readFile(f, 'utf8'),
+      readFileSync: (f) => fs.readFileSync(f, 'utf8'),
+      writeFile: (f, d) => fs.promises.writeFile(f, d, 'utf8'),
+      mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
+      stat: (f) => fs.promises.stat(f),
+    }
   }
 }

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -451,3 +451,11 @@ export const HtmlContext = createContext<HtmlProps>(null as any)
 if (process.env.NODE_ENV !== 'production') {
   HtmlContext.displayName = 'HtmlContext'
 }
+
+export interface CacheFs {
+  readFile(f: string): Promise<string>
+  readFileSync(f: string): string
+  writeFile(f: string, d: any): Promise<void>
+  mkdir(dir: string): Promise<void>
+  stat(f: string): Promise<{ mtime: Date }>
+}


### PR DESCRIPTION
Move fs API for incremental cache to node-server, leave a small group of mock file system for base server