### PR TITLE
drop dynamic import with `ssr: false` on server-side

### DIFF
--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -34,6 +34,7 @@ fn amp_attributes_fixture(input: PathBuf) {
 fn next_dynamic_fixture(input: PathBuf) {
     let output_dev = input.parent().unwrap().join("output-dev.js");
     let output_prod = input.parent().unwrap().join("output-prod.js");
+    let output_server = input.parent().unwrap().join("output-server.js");
     test_fixture(
         syntax(),
         &|_tr| {
@@ -59,6 +60,19 @@ fn next_dynamic_fixture(input: PathBuf) {
         },
         &input,
         &output_prod,
+    );
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            next_dynamic(
+                false,
+                true,
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
+                Some("/some-project/src".into()),
+            )
+        },
+        &input,
+        &output_server,
     );
 }
 

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/duplicated-imports/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/duplicated-imports/output-server.js
@@ -1,0 +1,12 @@
+import dynamic1 from 'next/dynamic'
+import dynamic2 from 'next/dynamic'
+const DynamicComponent1 = dynamic1(() => import('../components/hello1'), {
+  loadableGenerated: {
+    modules: ['some-file.js -> ' + '../components/hello1'],
+  },
+})
+const DynamicComponent2 = dynamic2(() => import('../components/hello2'), {
+  loadableGenerated: {
+    modules: ['some-file.js -> ' + '../components/hello2'],
+  },
+})

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/member-with-same-name/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/member-with-same-name/output-server.js
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic'
+import somethingElse from 'something-else'
+const DynamicComponent = dynamic(() => import('../components/hello'), {
+  loadableGenerated: {
+    modules: ['some-file.js -> ' + '../components/hello'],
+  },
+})
+somethingElse.dynamic('should not be transformed')

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/no-options/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/no-options/output-server.js
@@ -1,0 +1,6 @@
+import dynamic from 'next/dynamic'
+const DynamicComponent = dynamic(() => import('../components/hello'), {
+  loadableGenerated: {
+    modules: ['some-file.js -> ' + '../components/hello'],
+  },
+})

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/input.js
@@ -4,3 +4,8 @@ const DynamicComponentWithCustomLoading = dynamic(
   () => import('../components/hello'),
   { loading: () => <p>...</p> }
 )
+
+const DynamicClientOnlyComponent = dynamic(
+  () => import('../components/hello'),
+  { ssr: false }
+)

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-dev.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-dev.js
@@ -8,3 +8,12 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import("../components/hell
     },
     loading: ()=><p >...</p>
 });
+const DynamicClientOnlyComponent = dynamic(()=>import("../components/hello")
+, {
+    loadableGenerated: {
+        modules: [
+            "some-file.js -> " + "../components/hello"
+        ]
+    },
+    ssr: false
+});

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-prod.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-prod.js
@@ -8,3 +8,12 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import("../components/hell
     },
     loading: ()=><p >...</p>
 });
+const DynamicClientOnlyComponent = dynamic(()=>import("../components/hello")
+, {
+    loadableGenerated: {
+        webpack: ()=>[
+                require.resolveWeak("../components/hello")
+            ]
+    },
+    ssr: false
+});

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/with-options/output-server.js
@@ -1,0 +1,16 @@
+import dynamic from 'next/dynamic'
+const DynamicComponentWithCustomLoading = dynamic(
+  () => import('../components/hello'),
+  {
+    loadableGenerated: {
+      modules: ['some-file.js -> ' + '../components/hello'],
+    },
+    loading: () => <p>...</p>,
+  }
+)
+const DynamicClientOnlyComponent = dynamic(null, {
+  loadableGenerated: {
+    modules: ['some-file.js -> ' + '../components/hello'],
+  },
+  ssr: false,
+})

--- a/packages/next-swc/crates/core/tests/fixture/next-dynamic/wrapped-import/output-server.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-dynamic/wrapped-import/output-server.js
@@ -1,0 +1,11 @@
+import dynamic from "next/dynamic";
+const DynamicComponent = dynamic(null, {
+    loadableGenerated: {
+        modules: [
+            "some-file.js -> " + "./components/hello"
+        ]
+    },
+    loading: ()=>null
+    ,
+    ssr: false
+});


### PR DESCRIPTION
This drops the function passed to `next/dynamic` on server-side when `ssr: false` is statically found in the options object.

Improves build performance, reduces bundle size on the server-side and avoids touching client-only libraries at all on server-side.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
