### PR TITLE
Disable turbo for build-native temporarily

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -663,16 +663,16 @@ jobs:
       - id: get-week
         run: echo ::set-output name=WEEK::$(date +%U)
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ steps.get-week.outputs.WEEK }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ steps.get-week.outputs.WEEK }}-
-            turbo-${{ github.job }}-canary-${{ steps.get-week.outputs.WEEK }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ steps.get-week.outputs.WEEK }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ steps.get-week.outputs.WEEK }}-
+      #       turbo-${{ github.job }}-canary-${{ steps.get-week.outputs.WEEK }}-
 
       # We use restore-key to pick latest cache.
       # We will not get exact match, but doc says
@@ -780,7 +780,7 @@ jobs:
   # Build binaries for publishing
   build-native:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-latest]
@@ -848,15 +848,15 @@ jobs:
           path: ~/.cargo/git
           key: stable-${{ matrix.os }}-node@14-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Turbo cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ matrix.name }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ matrix.name }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-${{ matrix.name }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ matrix.name }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ matrix.name }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-${{ matrix.name }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64 setup
         if: ${{ matrix.target == 'aarch64-apple-darwin' }}
@@ -900,7 +900,7 @@ jobs:
 
   build-windows-i686:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - windows-i686 - node@14
     runs-on: windows-latest
     env:
@@ -936,15 +936,15 @@ jobs:
           override: true
           target: i686-pc-windows-msvc
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Build
         shell: bash
@@ -959,7 +959,7 @@ jobs:
 
   build-windows-aarch64:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - windows-aarch64 - node@14
     runs-on: windows-latest
     steps:
@@ -984,15 +984,15 @@ jobs:
           override: true
           target: aarch64-pc-windows-msvc
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Build
         shell: bash
@@ -1007,7 +1007,7 @@ jobs:
 
   build-linux-musl:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - linux-musl - node@lts
     runs-on: ubuntu-latest
     steps:
@@ -1035,15 +1035,15 @@ jobs:
           docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: 'Build'
         run: |
@@ -1057,7 +1057,7 @@ jobs:
 
   build-linux-aarch64:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - aarch64-unknown-linux-gnu - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -1097,15 +1097,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
         working-directory: packages/next-swc
@@ -1120,7 +1120,7 @@ jobs:
 
   build-linux-aarch64-musl:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - aarch64-unknown-linux-musl - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -1157,15 +1157,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-aarch64-linux-gnu -y
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
         working-directory: packages/next-swc
@@ -1179,7 +1179,7 @@ jobs:
 
   build-linux-arm7:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - arm7-unknown-linux-gnu - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -1219,15 +1219,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-arm-linux-gnueabihf -y
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
         working-directory: packages/next-swc
@@ -1241,7 +1241,7 @@ jobs:
 
   build-android-aarch64:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - Android - aarch64
     runs-on: macos-latest
     steps:
@@ -1267,15 +1267,15 @@ jobs:
           override: true
           target: aarch64-linux-android
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: .turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
-            turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
+      # - name: Turbo Cache
+      #   id: turbo-cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .turbo
+      #     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-${{ github.sha }}
+      #     restore-keys: |
+      #       turbo-${{ github.job }}-${{ github.ref_name }}-${{ needs.build.outputs.weekNum }}-
+      #       turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Build
         shell: bash
@@ -1292,7 +1292,7 @@ jobs:
 
   build-wasm:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     strategy:
       matrix:
         target: [web, nodejs]

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -693,7 +693,7 @@ jobs:
 
       - name: Build
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-        run: yarn build-native --cache-dir=".turbo"
+        run: yarn build-native
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -878,7 +878,7 @@ jobs:
             next-swc-cargo-cache-${{ matrix.os }}
 
       - name: 'Build'
-        run: yarn build-native --cache-dir=".turbo" -- --release --target ${{ matrix.target }}
+        run: yarn build-native --release --target ${{ matrix.target }}
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
           TURBO_TOKEN: ${{secrets.TURBO_TOKEN}}
@@ -946,7 +946,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: yarn build-native --cache-dir=".turbo" -- --release --target i686-pc-windows-msvc
+        run: yarn build-native --release --target i686-pc-windows-msvc
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -993,7 +993,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: yarn build-native --cache-dir=".turbo" -- --release --target aarch64-pc-windows-msvc
+        run: yarn build-native --release --target aarch64-pc-windows-msvc
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1043,7 +1043,7 @@ jobs:
 
       - name: 'Build'
         run: |
-          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd)/packages/next-swc:/build -w /build builder sh -c "npm i -g @napi-rs/cli@1.2.1 && npm i -g turbo@1.0.14 && yarn build-native --cache-dir=".turbo" -- --release --target x86_64-unknown-linux-musl"
+          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd)/packages/next-swc:/build -w /build builder sh -c "npm i -g @napi-rs/cli@1.2.1 && npm i -g turbo@1.0.14 && yarn build-native --release --target x86_64-unknown-linux-musl"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1105,7 +1105,7 @@ jobs:
 
       - name: Cross build aarch64
         if: ${{ steps.binary-cache.outputs.cache-hit != 'true' }}
-        run: yarn build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-gnu
+        run: yarn build-native --release --target aarch64-unknown-linux-gnu
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1163,7 +1163,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
-        run: yarn build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-musl
+        run: yarn build-native --release --target aarch64-unknown-linux-musl
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1224,7 +1224,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
-        run: yarn build-native --cache-dir=".turbo" -- --release --target armv7-unknown-linux-gnueabihf
+        run: yarn build-native --release --target armv7-unknown-linux-gnueabihf
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1274,7 +1274,7 @@ jobs:
         shell: bash
         run: |
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
-          yarn build-native --cache-dir=".turbo" -- --release --target aarch64-linux-android
+          yarn build-native --release --target aarch64-linux-android
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -693,7 +693,7 @@ jobs:
 
       - name: Build
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
-        run: turbo run build-native --cache-dir=".turbo"
+        run: yarn build-native --cache-dir=".turbo"
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -878,7 +878,7 @@ jobs:
             next-swc-cargo-cache-${{ matrix.os }}
 
       - name: 'Build'
-        run: turbo run  build-native --cache-dir=".turbo" -- --release --target ${{ matrix.target }}
+        run: yarn build-native --cache-dir=".turbo" -- --release --target ${{ matrix.target }}
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
           TURBO_TOKEN: ${{secrets.TURBO_TOKEN}}
@@ -946,7 +946,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: turbo run build-native --cache-dir=".turbo" -- --release --target i686-pc-windows-msvc
+        run: yarn build-native --cache-dir=".turbo" -- --release --target i686-pc-windows-msvc
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -993,7 +993,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: turbo run build-native --cache-dir=".turbo" -- --release --target aarch64-pc-windows-msvc
+        run: yarn build-native --cache-dir=".turbo" -- --release --target aarch64-pc-windows-msvc
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1043,7 +1043,7 @@ jobs:
 
       - name: 'Build'
         run: |
-          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd)/packages/next-swc:/build -w /build builder sh -c "npm i -g @napi-rs/cli@1.2.1 && npm i -g turbo@1.0.14 && turbo run build-native --cache-dir=".turbo" -- --release --target x86_64-unknown-linux-musl"
+          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd)/packages/next-swc:/build -w /build builder sh -c "npm i -g @napi-rs/cli@1.2.1 && npm i -g turbo@1.0.14 && yarn build-native --cache-dir=".turbo" -- --release --target x86_64-unknown-linux-musl"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1105,7 +1105,7 @@ jobs:
 
       - name: Cross build aarch64
         if: ${{ steps.binary-cache.outputs.cache-hit != 'true' }}
-        run: turbo run build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-gnu
+        run: yarn build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-gnu
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1163,7 +1163,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
-        run: turbo run build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-musl
+        run: yarn build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-musl
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1224,7 +1224,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
-        run: turbo run build-native --cache-dir=".turbo" -- --release --target armv7-unknown-linux-gnueabihf
+        run: yarn build-native --cache-dir=".turbo" -- --release --target armv7-unknown-linux-gnueabihf
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1274,7 +1274,7 @@ jobs:
         shell: bash
         run: |
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
-          turbo run build-native --cache-dir=".turbo" -- --release --target aarch64-linux-android
+          yarn build-native --cache-dir=".turbo" -- --release --target aarch64-linux-android
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -693,6 +693,7 @@ jobs:
 
       - name: Build
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        working-directory: packages/next-swc
         run: yarn build-native
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -779,7 +780,7 @@ jobs:
   # Build binaries for publishing
   build-native:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest, windows-latest]
@@ -878,6 +879,7 @@ jobs:
             next-swc-cargo-cache-${{ matrix.os }}
 
       - name: 'Build'
+        working-directory: packages/next-swc
         run: yarn build-native --release --target ${{ matrix.target }}
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -898,7 +900,7 @@ jobs:
 
   build-windows-i686:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - windows-i686 - node@14
     runs-on: windows-latest
     env:
@@ -946,6 +948,7 @@ jobs:
 
       - name: Build
         shell: bash
+        working-directory: packages/next-swc
         run: yarn build-native --release --target i686-pc-windows-msvc
 
       - name: Upload artifact
@@ -956,7 +959,7 @@ jobs:
 
   build-windows-aarch64:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - windows-aarch64 - node@14
     runs-on: windows-latest
     steps:
@@ -993,6 +996,7 @@ jobs:
 
       - name: Build
         shell: bash
+        working-directory: packages/next-swc
         run: yarn build-native --release --target aarch64-pc-windows-msvc
 
       - name: Upload artifact
@@ -1003,7 +1007,7 @@ jobs:
 
   build-linux-musl:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - linux-musl - node@lts
     runs-on: ubuntu-latest
     steps:
@@ -1053,7 +1057,7 @@ jobs:
 
   build-linux-aarch64:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - aarch64-unknown-linux-gnu - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -1104,6 +1108,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
+        working-directory: packages/next-swc
         if: ${{ steps.binary-cache.outputs.cache-hit != 'true' }}
         run: yarn build-native --release --target aarch64-unknown-linux-gnu
 
@@ -1115,7 +1120,7 @@ jobs:
 
   build-linux-aarch64-musl:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - aarch64-unknown-linux-musl - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -1163,6 +1168,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
+        working-directory: packages/next-swc
         run: yarn build-native --release --target aarch64-unknown-linux-musl
 
       - name: Upload artifact
@@ -1173,7 +1179,7 @@ jobs:
 
   build-linux-arm7:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - arm7-unknown-linux-gnu - node@14
     runs-on: ubuntu-18.04
     steps:
@@ -1224,6 +1230,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
+        working-directory: packages/next-swc
         run: yarn build-native --release --target armv7-unknown-linux-gnueabihf
 
       - name: Upload artifact
@@ -1234,7 +1241,7 @@ jobs:
 
   build-android-aarch64:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     name: next-swc - Android - aarch64
     runs-on: macos-latest
     steps:
@@ -1272,6 +1279,7 @@ jobs:
 
       - name: Build
         shell: bash
+        working-directory: packages/next-swc
         run: |
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
           yarn build-native --release --target aarch64-linux-android
@@ -1284,7 +1292,7 @@ jobs:
 
   build-wasm:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     strategy:
       matrix:
         target: [web, nodejs]


### PR DESCRIPTION
It seems the build-native jobs are currently failing with turbo and we will need to investigate this further before enabling it, this disables using turbo for these jobs to allow publishing to continue. 

x-ref: https://github.com/vercel/next.js/pull/32617
x-ref: https://github.com/vercel/turborepo/issues/326
x-ref: https://github.com/vercel/next.js/runs/4565785923?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/4565785720?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/4565786003?check_suite_focus=true