### PR TITLE
Add test case for middleware rewrite to fallback: true page

### DIFF
--- a/test/integration/middleware/core/pages/rewrites/_middleware.js
+++ b/test/integration/middleware/core/pages/rewrites/_middleware.js
@@ -3,6 +3,12 @@ import { NextResponse } from 'next/server'
 export async function middleware(request) {
   const url = request.nextUrl
 
+  if (url.pathname.startsWith('/rewrites/to-blog')) {
+    const slug = url.pathname.split('/').pop()
+    console.log('rewriting to slug', slug)
+    return NextResponse.rewrite(`/rewrites/fallback-true-blog/${slug}`)
+  }
+
   if (url.pathname === '/rewrites/rewrite-to-ab-test') {
     let bucket = request.cookies.bucket
     if (!bucket) {

--- a/test/integration/middleware/core/pages/rewrites/fallback-true-blog/[slug].js
+++ b/test/integration/middleware/core/pages/rewrites/fallback-true-blog/[slug].js
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/router'
+
+export default function Page(props) {
+  if (useRouter().isFallback) {
+    return <p>Loading...</p>
+  }
+
+  return <p id="props">{JSON.stringify(props)}</p>
+}
+
+export function getStaticPaths() {
+  return {
+    paths: ['/rewrites/fallback-true-blog/first'],
+    fallback: true,
+  }
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      time: Date.now(),
+    },
+  }
+}

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import {
+  check,
   fetchViaHTTP,
   findPort,
   killApp,
@@ -108,6 +109,29 @@ describe('Middleware base tests', () => {
 })
 
 function rewriteTests(locale = '') {
+  it('should rewrite to fallback: true page successfully', async () => {
+    const randomSlug = `another-${Date.now()}`
+    const res2 = await fetchViaHTTP(
+      context.appPort,
+      `${locale}/rewrites/to-blog/${randomSlug}`
+    )
+    expect(res2.status).toBe(200)
+    expect(await res2.text()).toContain('Loading...')
+
+    const randomSlug2 = `another-${Date.now()}`
+    const browser = await webdriver(
+      context.appPort,
+      `${locale}/rewrites/to-blog/${randomSlug2}`
+    )
+
+    await check(async () => {
+      const props = JSON.parse(await browser.elementByCss('#props').text())
+      return props.params.slug === randomSlug2
+        ? 'success'
+        : JSON.stringify(props)
+    }, 'success')
+  })
+
   it(`${locale} should add a cookie and rewrite to a/b test`, async () => {
     const res = await fetchViaHTTP(
       context.appPort,


### PR DESCRIPTION
This adds a regression for a previous bug that is now working properly to ensure we don't break it again in the future ([related slack thread](https://vercel.slack.com/archives/C0289CGVAR2/p1639786775203700?thread_ts=1639507423.065000&cid=C0289CGVAR2)). 