### PR TITLE
Fix writing strings to the writable stream writer

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -285,6 +285,7 @@ function checkRedirectValues(
 function createRSCHook() {
   const rscCache = new Map()
   const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
 
   return (
     writable: WritableStream,
@@ -306,21 +307,22 @@ function createRSCHook() {
           if (bootstrap && !bootstrapped) {
             bootstrapped = true
             writer.write(
-              `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify([
-                0,
-                id,
-              ])})</script>`
+              encoder.encode(
+                `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify(
+                  [0, id]
+                )})</script>`
+              )
             )
           }
           if (done) {
             writer.close()
           } else {
             writer.write(
-              `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify([
-                1,
-                id,
-                decoder.decode(value),
-              ])})</script>`
+              encoder.encode(
+                `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify(
+                  [1, id, decoder.decode(value)]
+                )})</script>`
+              )
             )
             process()
           }


### PR DESCRIPTION
Only chunks are allowed to write to writable. This fixes the following error in the web runtime:

```
Uncaught (in promise) TypeError: This TransformStream is being used as a byte stream, but received a string on its
writable side. If you wish to write a string, you'll probably want to explicitly UTF-8-encode it with TextEncoder.
```

It doesn't fail in the Node.js sandbox since we polyfilled this case (which should be reverted back later).

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
