### PR TITLE
fix(next/jest): do not watch `.next` folder

### DIFF
--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -95,7 +95,7 @@ export default function nextJest(options: { dir?: string } = {}) {
         testPathIgnorePatterns: [
           // Don't look for tests in node_modules
           '/node_modules/',
-          // Don't look for tests in the the Next.js build output
+          // Don't look for tests in the Next.js build output
           '/.next/',
           // Custom config can append to testPathIgnorePatterns but not modify it
           // This is to ensure `.next` and `node_modules` are always excluded
@@ -126,6 +126,11 @@ export default function nextJest(options: { dir?: string } = {}) {
           // Custom config can append to transformIgnorePatterns but not modify it
           // This is to ensure `node_modules` and .module.css/sass/scss are always excluded
           ...(resolvedJestConfig.transformIgnorePatterns || []),
+        ],
+        watchPathIgnorePatterns: [
+          // Don't re-run tests when the Next.js build output changes
+          '/.next/',
+          ...(resolvedJestConfig.watchPathIgnorePatterns || []),
         ],
       }
     }


### PR DESCRIPTION
`jest --watch` looks for [changes in dotfiles and folders by default](https://github.com/facebook/jest/pull/10075), which resulted in the tests being re-run when navigating between pages with `next dev`.

Fixes #32650

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
