### PR TITLE
Ensure device IP is used for safari browserstack test

### DIFF
--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -85,6 +85,10 @@ export function getFullUrl(appPortOrUrl, url, hostname) {
 
     parsedUrl.search = parsedPathQuery.search
     parsedUrl.pathname = parsedPathQuery.pathname
+
+    if (hostname && parsedUrl.hostname === 'localhost') {
+      parsedUrl.hostname = hostname
+    }
     fullUrl = parsedUrl.toString()
   }
   return fullUrl


### PR DESCRIPTION
browserstack has trouble proxying requests when `localhost` is used so this ensures the IP is used in the new test setup where a full URL is already provided to `next-webdriver`. 

x-ref: https://github.com/vercel/next.js/runs/4599598602?check_suite_focus=true