### PR TITLE
Reduce styled-jsx size in client bundle

### DIFF
--- a/examples/with-storybook-styled-jsx-scss/.storybook/preview.js
+++ b/examples/with-storybook-styled-jsx-scss/.storybook/preview.js
@@ -1,13 +1,3 @@
-import { StyleRegistry } from 'styled-jsx'
-
-export const decorators = [
-  (Story) => (
-    <StyleRegistry>
-      <Story />
-    </StyleRegistry>
-  ),
-]
-
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
 }

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -2,7 +2,6 @@
 import '../build/polyfills/polyfill-module'
 import React, { useState } from 'react'
 import ReactDOM from 'react-dom'
-import { StyleRegistry } from 'styled-jsx'
 import { HeadManagerContext } from '../shared/lib/head-manager-context'
 import mitt, { MittEmitter } from '../shared/lib/mitt'
 import { RouterContext } from '../shared/lib/router-context'
@@ -623,7 +622,7 @@ function AppContainer({
     >
       <RouterContext.Provider value={makePublicRouterInstance(router)}>
         <HeadManagerContext.Provider value={headManager}>
-          <StyleRegistry>{children}</StyleRegistry>
+          {children}
         </HeadManagerContext.Provider>
       </RouterContext.Provider>
     </Container>

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -80,7 +80,7 @@
     "react-is": "17.0.2",
     "react-refresh": "0.8.3",
     "stream-browserify": "3.0.0",
-    "styled-jsx": "5.0.0-beta.5",
+    "styled-jsx": "5.0.0-beta.6",
     "use-subscription": "1.5.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18428,10 +18428,10 @@ styled-jsx-plugin-postcss@3.0.2:
     postcss "^7.0.2"
     postcss-load-plugins "^2.3.0"
 
-styled-jsx@5.0.0-beta.5:
-  version "5.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.0-beta.5.tgz#f603c20bda0625a2aa3b6bed40211e21641e5410"
-  integrity sha512-QTdBoD+vmxQX68DHMwKTYdC6Z5DLVuNoGoFf+Ih3yZ8jch4WjpR83s21uQA44ZDeB6iUFKs8N60W3y/vkl6ehA==
+styled-jsx@5.0.0-beta.6:
+  version "5.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.0-beta.6.tgz#666552f8831a06f80c9084a47afc4b32b0c9f461"
+  integrity sha512-b1cM7Xyp2r1lsNpvoZ6wmTI8qxD0557vH2feHakNU8LMkzfJDgTQMul6O7sSYY0GxQ73pKEN69hCDp71w6Q0nA==
   dependencies:
     "@babel/plugin-syntax-jsx" "7.14.5"
     "@babel/types" "7.15.0"


### PR DESCRIPTION
We introduced the `StyleRegistry` on server side to make it concurrent safe for requests. For client we can have only 1 registry since there's only 1 instance per browser window. Keep consistence with previous usage

Closes vercel/next.js#32417
Closes vercel/next.js#30377

Revert change in #31357, it's not required anymore