### PR TITLE
Next dev cmd for viewing on phone or external devices

### DIFF
--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -87,6 +87,10 @@ You can also set the hostname to be different from the default of `0.0.0.0`, thi
 ```bash
 npx next dev -H 192.168.1.2
 ```
+If you would like to view your app on your phone. We suggest setting your local ip as your host.
+```bash
+next dev -H $(ipconfig getifaddr en0)
+```
 
 ## Production
 


### PR DESCRIPTION
I've been looking for this functionality a bunch of times and finally found what I think is a good solution. The problem I've been trying to solve is how to view the app on my phone whilst developing. I've managed to set the host, but my ip changes quite often so I have to check my local ip each time. The terminal always outputs `0.0.0.0:3000` which doesn't help me. With the proposed approach the terminal outputs the ip and port so that I can easily click it and open it in my browser or phone or whatever.

I am not sure how cross platform this approach is, but I'm pretty sure there are close equal solutions on most systems.

Might be a small thing, but this has really been bugging me. Gatsby for instance gives (or at least did give) you localhost and a hostname when starting dev server, so that was never an issue. It's is very useful when working with designers or other people that should be able to view the live changes made.

The text in the PR can for sure be improved, but just to give an idea and or context.