### PR TITLE
Update note about .next/static in standalone mode

### DIFF
--- a/docs/advanced-features/output-file-tracing.md
+++ b/docs/advanced-features/output-file-tracing.md
@@ -34,7 +34,7 @@ module.exports = {
 
 This will create a folder at `.next/standalone` which can then be deployed on it's own without installing `node_modules`.
 
-Additionally, a minimal `server.js` file is also output which can be used instead of `next start`. This minimal server does not handle serving the `static` directory as this should be handled by a CDN instead.
+Additionally, a minimal `server.js` file is also output which can be used instead of `next start`. This minimal server does not copy the `.next/static` directory by default as this should ideally be handled by a CDN instead, although it can be copied to the `standalone` folder manually and the `server.js` file will serve it automatically.
 
 ## Caveats
 


### PR DESCRIPTION
Adds some more clarity around `.next/static` handling in standalone mode. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
