### PR TITLE
Update readme.md of next-mdx to allow typescript file extensions for pages

### DIFF
--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -69,7 +69,7 @@ const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
 })
 module.exports = withMDX({
-  pageExtensions: ['js', 'jsx', 'md', 'mdx'],
+  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
 })
 ```
 


### PR DESCRIPTION
Hi there
I was using the typescript blog template and had some tsx pages. I saw they stopped working after using the mdx recommended here, but adding the tsx and ts extensions restored it.

This PR proposes just listing ts and tsx in the allowed extensions. It could conditionally mention only adding those if using typescript but may be ok like this?

Let me know what you think