### PR TITLE
fix(eslint-plugin-next): Broken links in eslint output

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/google-font-display.js
+++ b/packages/eslint-plugin-next/lib/rules/google-font-display.js
@@ -48,7 +48,7 @@ module.exports = {
         if (message) {
           context.report({
             node,
-            message: `${message} See https://nextjs.org/docs/messages/google-font-display.`,
+            message: `${message} See: https://nextjs.org/docs/messages/google-font-display`,
           })
         }
       },

--- a/packages/eslint-plugin-next/lib/rules/google-font-preconnect.js
+++ b/packages/eslint-plugin-next/lib/rules/google-font-preconnect.js
@@ -33,7 +33,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: `Preconnect is missing. See https://nextjs.org/docs/messages/google-font-preconnect.`,
+            message: `Preconnect is missing. See: https://nextjs.org/docs/messages/google-font-preconnect`,
           })
         }
       },

--- a/packages/eslint-plugin-next/lib/rules/link-passhref.js
+++ b/packages/eslint-plugin-next/lib/rules/link-passhref.js
@@ -55,7 +55,7 @@ module.exports = {
               attributes.value('passHref') !== true
                 ? 'must be set to true'
                 : 'is missing'
-            }. See https://nextjs.org/docs/messages/link-passhref`,
+            }. See: https://nextjs.org/docs/messages/link-passhref`,
           })
         }
       },

--- a/packages/eslint-plugin-next/lib/rules/next-script-for-ga.js
+++ b/packages/eslint-plugin-next/lib/rules/next-script-for-ga.js
@@ -9,7 +9,7 @@ const SUPPORTED_HTML_CONTENT_URLS = [
   'www.googletagmanager.com/gtm.js',
 ]
 const ERROR_MSG =
-  'Use the `next/script` component for loading third party scripts. See: https://nextjs.org/docs/messages/next-script-for-ga.'
+  'Use the `next/script` component for loading third party scripts. See: https://nextjs.org/docs/messages/next-script-for-ga'
 
 // Check if one of the items in the list is a substring of the passed string
 const containsStr = (str, strList) => {

--- a/packages/eslint-plugin-next/lib/rules/no-css-tags.js
+++ b/packages/eslint-plugin-next/lib/rules/no-css-tags.js
@@ -26,7 +26,7 @@ module.exports = function (context) {
         context.report({
           node,
           message:
-            'Do not include stylesheets manually. See: https://nextjs.org/docs/messages/no-css-tags.',
+            'Do not include stylesheets manually. See: https://nextjs.org/docs/messages/no-css-tags',
         })
       }
     },

--- a/packages/eslint-plugin-next/lib/rules/no-document-import-in-page.js
+++ b/packages/eslint-plugin-next/lib/rules/no-document-import-in-page.js
@@ -29,7 +29,7 @@ module.exports = {
 
         context.report({
           node,
-          message: `next/document should not be imported outside of pages/_document.js. See https://nextjs.org/docs/messages/no-document-import-in-page.`,
+          message: `next/document should not be imported outside of pages/_document.js. See: https://nextjs.org/docs/messages/no-document-import-in-page`,
         })
       },
     }

--- a/packages/eslint-plugin-next/lib/rules/no-head-import-in-document.js
+++ b/packages/eslint-plugin-next/lib/rules/no-head-import-in-document.js
@@ -28,7 +28,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: `next/head should not be imported in pages${document}. Import Head from next/document instead. See https://nextjs.org/docs/messages/no-head-import-in-document.`,
+            message: `next/head should not be imported in pages${document}. Import Head from next/document instead. See: https://nextjs.org/docs/messages/no-head-import-in-document`,
           })
         }
       },

--- a/packages/eslint-plugin-next/lib/rules/no-html-link-for-pages.js
+++ b/packages/eslint-plugin-next/lib/rules/no-html-link-for-pages.js
@@ -125,7 +125,7 @@ module.exports = {
           if (url.test(normalizeURL(hrefPath))) {
             context.report({
               node,
-              message: `Do not use the HTML <a> tag to navigate to ${hrefPath}. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages.`,
+              message: `Do not use the HTML <a> tag to navigate to ${hrefPath}. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages`,
             })
           }
         })

--- a/packages/eslint-plugin-next/lib/rules/no-img-element.js
+++ b/packages/eslint-plugin-next/lib/rules/no-img-element.js
@@ -22,7 +22,7 @@ module.exports = {
 
         context.report({
           node,
-          message: `Do not use <img>. Use Image from 'next/image' instead. See https://nextjs.org/docs/messages/no-img-element.`,
+          message: `Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element`,
         })
       },
     }

--- a/packages/eslint-plugin-next/lib/rules/no-page-custom-font.js
+++ b/packages/eslint-plugin-next/lib/rules/no-page-custom-font.js
@@ -138,7 +138,7 @@ module.exports = {
 
         if (isGoogleFont) {
           const end =
-            'This is discouraged. See https://nextjs.org/docs/messages/no-page-custom-font.'
+            'This is discouraged. See: https://nextjs.org/docs/messages/no-page-custom-font'
 
           const message = is_Document
             ? `Rendering this <link /> not inline within <Head> of Document disables font optimization. ${end}`

--- a/packages/eslint-plugin-next/lib/rules/no-script-in-document.js
+++ b/packages/eslint-plugin-next/lib/rules/no-script-in-document.js
@@ -22,7 +22,7 @@ module.exports = {
 
         context.report({
           node,
-          message: `next/script should not be used in pages/_document.js. See: https://nextjs.org/docs/messages/no-script-in-document-page `,
+          message: `next/script should not be used in pages/_document.js. See: https://nextjs.org/docs/messages/no-script-in-document-page`,
         })
       },
     }

--- a/packages/eslint-plugin-next/lib/rules/no-script-in-head.js
+++ b/packages/eslint-plugin-next/lib/rules/no-script-in-head.js
@@ -43,7 +43,7 @@ module.exports = {
           context.report({
             node,
             message:
-              "next/script shouldn't be used inside next/head. See: https://nextjs.org/docs/messages/no-script-in-head-component ",
+              "next/script shouldn't be used inside next/head. See: https://nextjs.org/docs/messages/no-script-in-head-component",
           })
         }
       },

--- a/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
+++ b/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
@@ -29,7 +29,7 @@ module.exports = {
 
         context.report({
           node,
-          message: `next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.`,
+          message: `next/server should not be imported outside of pages/_middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page`,
         })
       },
     }

--- a/packages/eslint-plugin-next/lib/rules/no-sync-scripts.js
+++ b/packages/eslint-plugin-next/lib/rules/no-sync-scripts.js
@@ -18,7 +18,7 @@ module.exports = function (context) {
         context.report({
           node,
           message:
-            'External synchronous scripts are forbidden. See: https://nextjs.org/docs/messages/no-sync-scripts.',
+            'External synchronous scripts are forbidden. See: https://nextjs.org/docs/messages/no-sync-scripts',
         })
       }
     },

--- a/packages/eslint-plugin-next/lib/rules/no-title-in-document-head.js
+++ b/packages/eslint-plugin-next/lib/rules/no-title-in-document-head.js
@@ -40,7 +40,7 @@ module.exports = {
           context.report({
             node: titleTag,
             message:
-              'Titles should be defined at the page-level using next/head. See https://nextjs.org/docs/messages/no-title-in-document-head.',
+              'Titles should be defined at the page-level using next/head. See: https://nextjs.org/docs/messages/no-title-in-document-head',
           })
         }
       },

--- a/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
+++ b/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
@@ -118,7 +118,7 @@ module.exports = {
                 ', '
               )} ${
                 unwantedFeatures.length > 1 ? 'are' : 'is'
-              } already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio.`,
+              } already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio`,
             })
           }
         }

--- a/test/unit/eslint-plugin-next/google-font-display.test.ts
+++ b/test/unit/eslint-plugin-next/google-font-display.test.ts
@@ -76,7 +76,7 @@ ruleTester.run('google-font-display', rule, {
       errors: [
         {
           message:
-            'Display parameter is missing. See https://nextjs.org/docs/messages/google-font-display.',
+            'Display parameter is missing. See: https://nextjs.org/docs/messages/google-font-display',
           type: 'JSXOpeningElement',
         },
       ],
@@ -98,7 +98,7 @@ ruleTester.run('google-font-display', rule, {
       errors: [
         {
           message:
-            'Block behavior is not recommended. See https://nextjs.org/docs/messages/google-font-display.',
+            'Block behavior is not recommended. See: https://nextjs.org/docs/messages/google-font-display',
           type: 'JSXOpeningElement',
         },
       ],
@@ -120,7 +120,7 @@ ruleTester.run('google-font-display', rule, {
       errors: [
         {
           message:
-            'Auto behavior is not recommended. See https://nextjs.org/docs/messages/google-font-display.',
+            'Auto behavior is not recommended. See: https://nextjs.org/docs/messages/google-font-display',
           type: 'JSXOpeningElement',
         },
       ],
@@ -142,7 +142,7 @@ ruleTester.run('google-font-display', rule, {
       errors: [
         {
           message:
-            'Fallback behavior is not recommended. See https://nextjs.org/docs/messages/google-font-display.',
+            'Fallback behavior is not recommended. See: https://nextjs.org/docs/messages/google-font-display',
           type: 'JSXOpeningElement',
         },
       ],

--- a/test/unit/eslint-plugin-next/google-font-preconnect.test.ts
+++ b/test/unit/eslint-plugin-next/google-font-preconnect.test.ts
@@ -42,7 +42,7 @@ ruleTester.run('google-font-preconnect', rule, {
       errors: [
         {
           message:
-            'Preconnect is missing. See https://nextjs.org/docs/messages/google-font-preconnect.',
+            'Preconnect is missing. See: https://nextjs.org/docs/messages/google-font-preconnect',
           type: 'JSXOpeningElement',
         },
       ],
@@ -58,7 +58,7 @@ ruleTester.run('google-font-preconnect', rule, {
       errors: [
         {
           message:
-            'Preconnect is missing. See https://nextjs.org/docs/messages/google-font-preconnect.',
+            'Preconnect is missing. See: https://nextjs.org/docs/messages/google-font-preconnect',
           type: 'JSXOpeningElement',
         },
       ],

--- a/test/unit/eslint-plugin-next/link-passhref.test.ts
+++ b/test/unit/eslint-plugin-next/link-passhref.test.ts
@@ -52,7 +52,7 @@ ruleTester.run('link-passhref', rule, {
       errors: [
         {
           message:
-            'passHref is missing. See https://nextjs.org/docs/messages/link-passhref',
+            'passHref is missing. See: https://nextjs.org/docs/messages/link-passhref',
           type: 'JSXOpeningElement',
         },
       ],
@@ -69,7 +69,7 @@ ruleTester.run('link-passhref', rule, {
       errors: [
         {
           message:
-            'passHref must be set to true. See https://nextjs.org/docs/messages/link-passhref',
+            'passHref must be set to true. See: https://nextjs.org/docs/messages/link-passhref',
           type: 'JSXOpeningElement',
         },
       ],

--- a/test/unit/eslint-plugin-next/next-script-for-ga.test.ts
+++ b/test/unit/eslint-plugin-next/next-script-for-ga.test.ts
@@ -12,7 +12,7 @@ import { RuleTester } from 'eslint'
 })
 
 const ERROR_MSG =
-  'Use the `next/script` component for loading third party scripts. See: https://nextjs.org/docs/messages/next-script-for-ga.'
+  'Use the `next/script` component for loading third party scripts. See: https://nextjs.org/docs/messages/next-script-for-ga'
 
 const ruleTester = new RuleTester()
 

--- a/test/unit/eslint-plugin-next/no-css-tags.test.ts
+++ b/test/unit/eslint-plugin-next/no-css-tags.test.ts
@@ -81,7 +81,7 @@ ruleTester.run('no-css-tags', rule, {
       errors: [
         {
           message:
-            'Do not include stylesheets manually. See: https://nextjs.org/docs/messages/no-css-tags.',
+            'Do not include stylesheets manually. See: https://nextjs.org/docs/messages/no-css-tags',
           type: 'JSXOpeningElement',
         },
       ],
@@ -94,7 +94,7 @@ ruleTester.run('no-css-tags', rule, {
       errors: [
         {
           message:
-            'Do not include stylesheets manually. See: https://nextjs.org/docs/messages/no-css-tags.',
+            'Do not include stylesheets manually. See: https://nextjs.org/docs/messages/no-css-tags',
           type: 'JSXOpeningElement',
         },
       ],

--- a/test/unit/eslint-plugin-next/no-document-import-in-page.test.ts
+++ b/test/unit/eslint-plugin-next/no-document-import-in-page.test.ts
@@ -125,7 +125,7 @@ ruleTester.run('no-document-import-in-page', rule, {
       errors: [
         {
           message:
-            'next/document should not be imported outside of pages/_document.js. See https://nextjs.org/docs/messages/no-document-import-in-page.',
+            'next/document should not be imported outside of pages/_document.js. See: https://nextjs.org/docs/messages/no-document-import-in-page',
           type: 'ImportDeclaration',
         },
       ],
@@ -139,7 +139,7 @@ ruleTester.run('no-document-import-in-page', rule, {
       errors: [
         {
           message:
-            'next/document should not be imported outside of pages/_document.js. See https://nextjs.org/docs/messages/no-document-import-in-page.',
+            'next/document should not be imported outside of pages/_document.js. See: https://nextjs.org/docs/messages/no-document-import-in-page',
           type: 'ImportDeclaration',
         },
       ],
@@ -153,7 +153,7 @@ ruleTester.run('no-document-import-in-page', rule, {
       errors: [
         {
           message:
-            'next/document should not be imported outside of pages/_document.js. See https://nextjs.org/docs/messages/no-document-import-in-page.',
+            'next/document should not be imported outside of pages/_document.js. See: https://nextjs.org/docs/messages/no-document-import-in-page',
           type: 'ImportDeclaration',
         },
       ],

--- a/test/unit/eslint-plugin-next/no-head-import-in-document.test.ts
+++ b/test/unit/eslint-plugin-next/no-head-import-in-document.test.ts
@@ -77,7 +77,7 @@ ruleTester.run('no-head-import-in-document', rule, {
       errors: [
         {
           message:
-            'next/head should not be imported in pages/_document.js. Import Head from next/document instead. See https://nextjs.org/docs/messages/no-head-import-in-document.',
+            'next/head should not be imported in pages/_document.js. Import Head from next/document instead. See: https://nextjs.org/docs/messages/no-head-import-in-document',
           type: 'ImportDeclaration',
         },
       ],
@@ -107,7 +107,7 @@ ruleTester.run('no-head-import-in-document', rule, {
       errors: [
         {
           message:
-            'next/head should not be imported in pages/_document.page.tsx. Import Head from next/document instead. See https://nextjs.org/docs/messages/no-head-import-in-document.',
+            'next/head should not be imported in pages/_document.page.tsx. Import Head from next/document instead. See: https://nextjs.org/docs/messages/no-head-import-in-document',
           type: 'ImportDeclaration',
         },
       ],
@@ -137,7 +137,7 @@ ruleTester.run('no-head-import-in-document', rule, {
       errors: [
         {
           message:
-            'next/head should not be imported in pages/_document/index.js. Import Head from next/document instead. See https://nextjs.org/docs/messages/no-head-import-in-document.',
+            'next/head should not be imported in pages/_document/index.js. Import Head from next/document instead. See: https://nextjs.org/docs/messages/no-head-import-in-document',
           type: 'ImportDeclaration',
         },
       ],
@@ -167,7 +167,7 @@ ruleTester.run('no-head-import-in-document', rule, {
       errors: [
         {
           message:
-            'next/head should not be imported in pages/_document/index.tsx. Import Head from next/document instead. See https://nextjs.org/docs/messages/no-head-import-in-document.',
+            'next/head should not be imported in pages/_document/index.tsx. Import Head from next/document instead. See: https://nextjs.org/docs/messages/no-head-import-in-document',
           type: 'ImportDeclaration',
         },
       ],

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -246,7 +246,7 @@ describe('no-html-link-for-pages', function () {
     assert.notEqual(report, undefined, 'No lint errors found.')
     assert.equal(
       report.message,
-      "Do not use the HTML <a> tag to navigate to /. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages."
+      "Do not use the HTML <a> tag to navigate to /. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages"
     )
   })
 
@@ -257,7 +257,7 @@ describe('no-html-link-for-pages', function () {
     assert.notEqual(report, undefined, 'No lint errors found.')
     assert.equal(
       report.message,
-      "Do not use the HTML <a> tag to navigate to /list/foo/bar/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages."
+      "Do not use the HTML <a> tag to navigate to /list/foo/bar/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages"
     )
     const [secondReport] = linter.verify(
       secondInvalidDynamicCode,
@@ -269,7 +269,7 @@ describe('no-html-link-for-pages', function () {
     assert.notEqual(secondReport, undefined, 'No lint errors found.')
     assert.equal(
       secondReport.message,
-      "Do not use the HTML <a> tag to navigate to /list/foo/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages."
+      "Do not use the HTML <a> tag to navigate to /list/foo/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages"
     )
     const [thirdReport] = linter.verify(thirdInvalidDynamicCode, linterConfig, {
       filename: 'foo.js',
@@ -277,7 +277,7 @@ describe('no-html-link-for-pages', function () {
     assert.notEqual(thirdReport, undefined, 'No lint errors found.')
     assert.equal(
       thirdReport.message,
-      "Do not use the HTML <a> tag to navigate to /list/lorem-ipsum/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages."
+      "Do not use the HTML <a> tag to navigate to /list/lorem-ipsum/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages"
     )
   })
 })

--- a/test/unit/eslint-plugin-next/no-img-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-img-element.test.ts
@@ -51,7 +51,7 @@ ruleTester.run('no-img-element', rule, {
       errors: [
         {
           message:
-            "Do not use <img>. Use Image from 'next/image' instead. See https://nextjs.org/docs/messages/no-img-element.",
+            "Do not use <img>. Use Image from 'next/image' instead. See: https://nextjs.org/docs/messages/no-img-element",
           type: 'JSXOpeningElement',
         },
       ],

--- a/test/unit/eslint-plugin-next/no-page-custom-font.test.ts
+++ b/test/unit/eslint-plugin-next/no-page-custom-font.test.ts
@@ -148,7 +148,7 @@ ruleTester.run('no-page-custom-font', rule, {
       errors: [
         {
           message:
-            'Custom fonts not added at the document level will only load for a single page. This is discouraged. See https://nextjs.org/docs/messages/no-page-custom-font.',
+            'Custom fonts not added at the document level will only load for a single page. This is discouraged. See: https://nextjs.org/docs/messages/no-page-custom-font',
           type: 'JSXOpeningElement',
         },
       ],
@@ -188,11 +188,11 @@ ruleTester.run('no-page-custom-font', rule, {
       errors: [
         {
           message:
-            'Rendering this <link /> not inline within <Head> of Document disables font optimization. This is discouraged. See https://nextjs.org/docs/messages/no-page-custom-font.',
+            'Rendering this <link /> not inline within <Head> of Document disables font optimization. This is discouraged. See: https://nextjs.org/docs/messages/no-page-custom-font',
         },
         {
           message:
-            'Rendering this <link /> not inline within <Head> of Document disables font optimization. This is discouraged. See https://nextjs.org/docs/messages/no-page-custom-font.',
+            'Rendering this <link /> not inline within <Head> of Document disables font optimization. This is discouraged. See: https://nextjs.org/docs/messages/no-page-custom-font',
         },
       ],
     },

--- a/test/unit/eslint-plugin-next/no-script-in-document.test.ts
+++ b/test/unit/eslint-plugin-next/no-script-in-document.test.ts
@@ -76,7 +76,7 @@ ruleTester.run('no-script-import-in-document', rule, {
       filename: 'pages/_document.js',
       errors: [
         {
-          message: `next/script should not be used in pages/_document.js. See: https://nextjs.org/docs/messages/no-script-in-document-page `,
+          message: `next/script should not be used in pages/_document.js. See: https://nextjs.org/docs/messages/no-script-in-document-page`,
         },
       ],
     },
@@ -107,7 +107,7 @@ ruleTester.run('no-script-import-in-document', rule, {
       filename: 'pages/_document.js',
       errors: [
         {
-          message: `next/script should not be used in pages/_document.js. See: https://nextjs.org/docs/messages/no-script-in-document-page `,
+          message: `next/script should not be used in pages/_document.js. See: https://nextjs.org/docs/messages/no-script-in-document-page`,
         },
       ],
     },

--- a/test/unit/eslint-plugin-next/no-script-in-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-script-in-head.test.ts
@@ -44,7 +44,7 @@ ruleTester.run('no-script-in-head', rule, {
       errors: [
         {
           message:
-            "next/script shouldn't be used inside next/head. See: https://nextjs.org/docs/messages/no-script-in-head-component ",
+            "next/script shouldn't be used inside next/head. See: https://nextjs.org/docs/messages/no-script-in-head-component",
         },
       ],
     },

--- a/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
+++ b/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
@@ -98,7 +98,7 @@ ruleTester.run('no-server-import-in-page', rule, {
       errors: [
         {
           message:
-            'next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.',
+            'next/server should not be imported outside of pages/_middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page',
           type: 'ImportDeclaration',
         },
       ],
@@ -112,7 +112,7 @@ ruleTester.run('no-server-import-in-page', rule, {
       errors: [
         {
           message:
-            'next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.',
+            'next/server should not be imported outside of pages/_middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page',
           type: 'ImportDeclaration',
         },
       ],
@@ -126,7 +126,7 @@ ruleTester.run('no-server-import-in-page', rule, {
       errors: [
         {
           message:
-            'next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.',
+            'next/server should not be imported outside of pages/_middleware.js. See: https://nextjs.org/docs/messages/no-server-import-in-page',
           type: 'ImportDeclaration',
         },
       ],

--- a/test/unit/eslint-plugin-next/no-sync-scripts.test.ts
+++ b/test/unit/eslint-plugin-next/no-sync-scripts.test.ts
@@ -58,7 +58,7 @@ ruleTester.run('sync-scripts', rule, {
       errors: [
         {
           message:
-            'External synchronous scripts are forbidden. See: https://nextjs.org/docs/messages/no-sync-scripts.',
+            'External synchronous scripts are forbidden. See: https://nextjs.org/docs/messages/no-sync-scripts',
           type: 'JSXOpeningElement',
         },
       ],
@@ -80,7 +80,7 @@ ruleTester.run('sync-scripts', rule, {
       errors: [
         {
           message:
-            'External synchronous scripts are forbidden. See: https://nextjs.org/docs/messages/no-sync-scripts.',
+            'External synchronous scripts are forbidden. See: https://nextjs.org/docs/messages/no-sync-scripts',
           type: 'JSXOpeningElement',
         },
       ],

--- a/test/unit/eslint-plugin-next/no-title-in-document-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-title-in-document-head.test.ts
@@ -60,7 +60,7 @@ ruleTester.run('no-title-in-document-head', rule, {
       errors: [
         {
           message:
-            'Titles should be defined at the page-level using next/head. See https://nextjs.org/docs/messages/no-title-in-document-head.',
+            'Titles should be defined at the page-level using next/head. See: https://nextjs.org/docs/messages/no-title-in-document-head',
           type: 'JSXElement',
         },
       ],

--- a/test/unit/eslint-plugin-next/no-unwanted-polyfillio.test.ts
+++ b/test/unit/eslint-plugin-next/no-unwanted-polyfillio.test.ts
@@ -67,7 +67,7 @@ ruleTester.run('unwanted-polyfillsio', rule, {
       errors: [
         {
           message:
-            'No duplicate polyfills from Polyfill.io are allowed. WeakSet, Promise, Promise.prototype.finally, es2015, es5, es6 are already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio.',
+            'No duplicate polyfills from Polyfill.io are allowed. WeakSet, Promise, Promise.prototype.finally, es2015, es5, es6 are already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio',
           type: 'JSXOpeningElement',
         },
       ],
@@ -87,7 +87,7 @@ ruleTester.run('unwanted-polyfillsio', rule, {
       errors: [
         {
           message:
-            'No duplicate polyfills from Polyfill.io are allowed. Array.prototype.copyWithin is already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio.',
+            'No duplicate polyfills from Polyfill.io are allowed. Array.prototype.copyWithin is already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio',
           type: 'JSXOpeningElement',
         },
       ],
@@ -106,7 +106,7 @@ ruleTester.run('unwanted-polyfillsio', rule, {
       errors: [
         {
           message:
-            'No duplicate polyfills from Polyfill.io are allowed. Array.prototype.copyWithin is already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio.',
+            'No duplicate polyfills from Polyfill.io are allowed. Array.prototype.copyWithin is already shipped with Next.js. See: https://nextjs.org/docs/messages/no-unwanted-polyfillio',
           type: 'JSXOpeningElement',
         },
       ],


### PR DESCRIPTION
This fixes broken links in the eslint output by removing the trailing full stop.
It also makes the formatting of (the output of) the various rules consistent.

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

> I don't think this is a bug, nor a feature, nor is it really documentation. 
> It's just a small nuisance that I bumped into and felt compelled to fix.
> I went with documentation as that seems the closest match

## What does this pull request do?

The elslint output of `eslint-plugin-next` contains useful links to the documentation about the various rules.
Unfortunately, on most (but not all) rules, those links are immediately followed by a full stop (`.`).

The terminal (or any parser) has no way of knowing that the full stop is not part of the URL. 
So it includes it and clicking the link leads to a 404 on the nextjs.org website.
 
![eslint](https://user-images.githubusercontent.com/1708494/147452577-43ad4ce7-df75-4d48-ab78-70b9b8212b7e.png)

This PR fixes that by removing the full stop. 

## But a final full stop is better grammar

I considered alternatives (such as [a zero-width space character](https://en.wikipedia.org/wiki/Zero-width_space#Prohibited_in_URLs)) in case the final full stop was part of the style guide or something.

However, as I went through the eslint rules, I notices that the messages for various rules were formatted inconsistently. 
Some with final full stop, some without.

As such, I made the all consistent with this structure:

> [message]. See: [url]

I feel this is a better solution than using the zero-width space as these sort of invisible characters 
in code can be a red flag that something fishy is going on.

I submit this pull request in the hope it will be useful, and a positive contribution to a project I have a great deal of appreciation for.
That being said, I fully understand if people would consider this a non-issue.