### PR TITLE
Update Advanced Error Page section in custom-error-page.md

### DIFF
--- a/docs/advanced-features/custom-error-page.md
+++ b/docs/advanced-features/custom-error-page.md
@@ -45,6 +45,14 @@ export default function Custom500() {
 500 errors are handled both client-side and server-side by the `Error` component. If you wish to override it, define the file `pages/_error.js` and add the following code:
 
 ```jsx
+export async function getServerSideProps({ res }) {
+  const { statusCode } = res
+
+  return {
+    props: { statusCode },
+  }
+}
+
 function Error({ statusCode }) {
   return (
     <p>
@@ -53,11 +61,6 @@ function Error({ statusCode }) {
         : 'An error occurred on client'}
     </p>
   )
-}
-
-Error.getInitialProps = ({ res, err }) => {
-  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
-  return { statusCode }
 }
 
 export default Error


### PR DESCRIPTION
## Description
Update More Advanced Error Page Customizing section in custom-error-page.md, by using `getServerSideProps` instead of `getInitialProps`.

Tested locally in my own project and seems to be working as expected. However, on the same docs page there is an example that is using `getServerSideProps` for the page where the `Error` component is being used so i'm wondering: is there a reason why the example of the custom `Error` page isn't using `getServerSideProps`? I was thinking that it maybe had the same constraint as the custom `Document` & `App` pages, where Next.js Data Fetching methods like `getServerSideProps` are not supported.

If there are no constraints, this update seems good to me, because it aligns with the latest practices of Next.js. Otherwise maybe a good idea to add the same line as https://nextjs.org/docs/advanced-features/custom-app#caveats where it says that those data fetching methods are not supported.


## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
