### PR TITLE
Add id to inline Segment script

### DIFF
--- a/examples/with-segment-analytics/pages/_app.js
+++ b/examples/with-segment-analytics/pages/_app.js
@@ -24,7 +24,10 @@ function MyApp({ Component, pageProps }) {
   return (
     <Page>
       {/* Inject the Segment snippet into the <head> of the document  */}
-      <Script id="segment-script" dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
+      <Script
+        id="segment-script"
+        dangerouslySetInnerHTML={{ __html: renderSnippet() }}
+      />
       <Component {...pageProps} />
     </Page>
   )

--- a/examples/with-segment-analytics/pages/_app.js
+++ b/examples/with-segment-analytics/pages/_app.js
@@ -24,7 +24,7 @@ function MyApp({ Component, pageProps }) {
   return (
     <Page>
       {/* Inject the Segment snippet into the <head> of the document  */}
-      <Script dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
+      <Script id="segment-script" dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
       <Component {...pageProps} />
     </Page>
   )


### PR DESCRIPTION
When I don't include an `id`, I see the console error "VM1624:1 Segment snippet included twice."
According to https://nextjs.org/docs/basic-features/script#inline-scripts, an id should be added for inline scripts.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
