### PR TITLE
add option to ignore tsconfig suggestions

### DIFF
--- a/packages/next/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/lib/typescript/writeConfigurationDefaults.ts
@@ -92,7 +92,8 @@ export function getRequiredConfiguration(
 export async function writeConfigurationDefaults(
   ts: typeof import('typescript'),
   tsConfigPath: string,
-  isFirstTimeSetup: boolean
+  isFirstTimeSetup: boolean,
+  ignoreConfigSuggestions = false
 ): Promise<void> {
   if (isFirstTimeSetup) {
     await fs.writeFile(tsConfigPath, '{}' + os.EOL)
@@ -116,7 +117,7 @@ export async function writeConfigurationDefaults(
   for (const optionKey of Object.keys(desiredCompilerOptions)) {
     const check = desiredCompilerOptions[optionKey]
     if ('suggested' in check) {
-      if (!(optionKey in tsOptions)) {
+      if (!(optionKey in tsOptions) && !ignoreConfigSuggestions) {
         if (!userTsConfig.compilerOptions) {
           userTsConfig.compilerOptions = {}
         }
@@ -151,7 +152,7 @@ export async function writeConfigurationDefaults(
     }
   }
 
-  if (!('include' in rawConfig)) {
+  if (!('include' in rawConfig) && !ignoreConfigSuggestions) {
     userTsConfig.include = ['next-env.d.ts', '**/*.ts', '**/*.tsx']
     suggestedActions.push(
       chalk.cyan('include') +
@@ -160,7 +161,7 @@ export async function writeConfigurationDefaults(
     )
   }
 
-  if (!('exclude' in rawConfig)) {
+  if (!('exclude' in rawConfig) && !ignoreConfigSuggestions) {
     userTsConfig.exclude = ['node_modules']
     suggestedActions.push(
       chalk.cyan('exclude') + ' was set to ' + chalk.bold(`['node_modules']`)

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -60,7 +60,12 @@ export async function verifyTypeScriptSetup(
     }
 
     // Reconfigure (or create) the user's `tsconfig.json` for them:
-    await writeConfigurationDefaults(ts, tsConfigPath, intent.firstTimeSetup)
+    await writeConfigurationDefaults(
+      ts,
+      tsConfigPath,
+      intent.firstTimeSetup,
+      config.typescript.ignoreConfigSuggestions
+    )
     // Write out the necessary `next-env.d.ts` file to correctly register
     // Next.js' types:
     await writeAppTypeDeclarations(dir, !config.images.disableStaticImages)

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -41,6 +41,8 @@ export interface TypeScriptConfig {
   ignoreBuildErrors?: boolean
   /** Relative path to a custom tsconfig file */
   tsconfigPath?: string
+  /** Do not modify tsconfig.json with suggested values */
+  ignoreConfigSuggestions?: boolean
 }
 
 export type NextConfig = { [key: string]: any } & {


### PR DESCRIPTION
This PR introduces the `typescript.ignoreConfigSuggestions` option. When it is `true` in `next.config.js` the suggested tsconfig options can be omitted. This doesn't change the default behavior, and the required tsconfig options will still be overridden.

Fixes #26593 -- Although I still believe that `include` and `exclude` should be completely removed.

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
