### PR TITLE
Remove un-necessary second yarn install from example Dockerfile

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -9,9 +9,9 @@ RUN yarn install --frozen-lockfile
 # Rebuild the source code only when needed
 FROM node:16-alpine AS builder
 WORKDIR /app
-COPY . .
 COPY --from=deps /app/node_modules ./node_modules
-RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
+COPY . .
+RUN yarn build
 
 # Production image, copy all the files and run next
 FROM node:16-alpine AS runner


### PR DESCRIPTION
Update to remove the second `yarn install` step from the docker example as it is no longer needed since we only include necessary files from the output file traces now. 

Closes: https://github.com/vercel/next.js/pull/29360

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
