### PR TITLE
chore: decrease stale time before closing issues with no reproduction

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,8 @@ jobs:
         with:
           only-labels: 'please add a complete reproduction'
           close-issue-message: 'This issue has been automatically closed after 30 days of inactivity with no reproduction. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'
-          days-before-issue-close: 30
+          days-before-issue-close: 1
+          days-before-issue-stale: 30
           days-before-pr-close: -1
           days-before-pr-stale: -1
           exempt-issue-labels: 'blocked,must,should,keep'


### PR DESCRIPTION
#32214 intended to only allow 30 days of stale time and then close the issue.

After studying the docs:

- https://github.com/actions/stale#days-before-issue-stale
- https://github.com/actions/stale#days-before-issue-close

and the cron job action: https://github.com/vercel/next.js/actions/runs/1647416426

I realized that we currently mark an inactive issue without reproduction as stale after 60 days and wait another 30 days before actually closing it.

With this PR, we mark issues with no reproduction as stale after 30 days and close them the day after.

This should result in a lower count of issues that are unactionable and the author seems to have moved on.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
