### PR TITLE
Revert "Reduce install size for linux glibc/musl"

### DIFF
--- a/packages/next-swc/crates/napi/npm/linux-arm64-gnu/install.js
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-gnu/install.js
@@ -1,2 +1,0 @@
-const { glibcVersionRuntime } = process.report.getReport().header;
-process.exit(glibcVersionRuntime ? 0 : 1);

--- a/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
@@ -9,12 +9,8 @@
   ],
   "main": "next-swc.linux-arm64-gnu.node",
   "files": [
-    "next-swc.linux-arm64-gnu.node",
-    "install.js"
+    "next-swc.linux-arm64-gnu.node"
   ],
-  "scripts": {
-    "install": "node install.js"
-  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-arm64-musl/install.js
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-musl/install.js
@@ -1,2 +1,0 @@
-const { glibcVersionRuntime } = process.report.getReport().header;
-process.exit(glibcVersionRuntime ? 1 : 0);

--- a/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
@@ -9,12 +9,8 @@
   ],
   "main": "next-swc.linux-arm64-musl.node",
   "files": [
-    "next-swc.linux-arm64-musl.node",
-    "install.js"
+    "next-swc.linux-arm64-musl.node"
   ],
-  "scripts": {
-    "install": "node install.js"
-  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-x64-gnu/install.js
+++ b/packages/next-swc/crates/napi/npm/linux-x64-gnu/install.js
@@ -1,2 +1,0 @@
-const { glibcVersionRuntime } = process.report.getReport().header;
-process.exit(glibcVersionRuntime ? 0 : 1);

--- a/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
@@ -9,12 +9,8 @@
   ],
   "main": "next-swc.linux-x64-gnu.node",
   "files": [
-    "next-swc.linux-x64-gnu.node",
-    "install.js"
+    "next-swc.linux-x64-gnu.node"
   ],
-  "scripts": {
-    "install": "node install.js"
-  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-x64-musl/install.js
+++ b/packages/next-swc/crates/napi/npm/linux-x64-musl/install.js
@@ -1,2 +1,0 @@
-const { glibcVersionRuntime } = process.report.getReport().header;
-process.exit(glibcVersionRuntime ? 1 : 0);

--- a/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
@@ -9,12 +9,8 @@
   ],
   "main": "next-swc.linux-x64-musl.node",
   "files": [
-    "next-swc.linux-x64-musl.node",
-    "install.js"
+    "next-swc.linux-x64-musl.node"
   ],
-  "scripts": {
-    "install": "node install.js"
-  },
   "license": "MIT",
   "engines": {
     "node": ">= 10"


### PR DESCRIPTION
Reverts vercel/next.js#32850 since its too noisy on Yarn 1.x

![image](https://user-images.githubusercontent.com/229881/147994708-d118be25-9942-4fbb-a869-ce3d2c231b1c.png)
