### PR TITLE
fix(examples): add missing dependencies

### DIFF
--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -17,10 +17,12 @@
     "@testing-library/jest-dom": "5.16.1",
     "@testing-library/react": "12.1.2",
     "@testing-library/user-event": "13.5.0",
+    "@types/react": "17.0.38",
     "babel-jest": "27.4.5",
     "eslint": "8.5.0",
     "eslint-config-next": "latest",
     "eslint-plugin-testing-library": "5.0.1",
-    "jest": "27.4.5"
+    "jest": "27.4.5",
+    "typescript": "4.5.4"
   }
 }


### PR DESCRIPTION
The `with-jest` example has been converted to TypeScript (#32705) , but `typescript` and `@types/react` were missing from `devDependencies`

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
