### PR TITLE
Fix a typo in docs on data fetching

### DIFF
--- a/docs/basic-features/data-fetching.md
+++ b/docs/basic-features/data-fetching.md
@@ -323,7 +323,7 @@ Files can be read directly from the filesystem in `getStaticProps`.
 
 In order to do so you have to get the full path to a file.
 
-Since Next.js compiles your code into a separate directory you can't use `__dirname` as the path it will return will be different from the pages directory.
+Since Next.js compiles your code into a separate directory you can't use `__dirname` as the path. It will be different from the pages directory.
 
 Instead you can use `process.cwd()` which gives you the directory where Next.js is being executed.
 


### PR DESCRIPTION
While reading the docs, I stumbled over this phrasing. It seems to have been introduced with the whole [section](https://nextjs.org/docs/basic-features/data-fetching#reading-files-use-processcwd) on _Reading files: Use process.cwd()_ with https://github.com/vercel/next.js/pull/11084.

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
