### PR TITLE
Rename api in with-redis example

### DIFF
--- a/examples/with-redis/pages/api/create.js
+++ b/examples/with-redis/pages/api/create.js
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import redis from '../../lib/redis'
 
-export default async function upvote(req, res) {
+export default async function create(req, res) {
   const { title } = req.body
 
   if (!title) {

--- a/examples/with-redis/pages/api/features.js
+++ b/examples/with-redis/pages/api/features.js
@@ -1,6 +1,6 @@
 import redis from '../../lib/redis'
 
-export default async function upvote(req, res) {
+export default async function getAllFeatures(req, res) {
   const features = (await redis.hvals('features'))
     .map((entry) => JSON.parse(entry))
     .sort((a, b) => b.score - a.score)

--- a/examples/with-redis/pages/api/subscribe.js
+++ b/examples/with-redis/pages/api/subscribe.js
@@ -1,6 +1,6 @@
 import redis from '../../lib/redis'
 
-export default async function upvote(req, res) {
+export default async function subscribe(req, res) {
   const { email } = req.body
 
   if (email && validateEmail(email)) {


### PR DESCRIPTION
I'm following @leerob's tutorial on [Using Serverless Redis with Next.js](https://leerob.io/blog/serverless-redis-nextjs) and I think we can change some functions' name in `examples/with-redis/pages/api/*` to make it clearer. I think they are typos. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
