### PR TITLE
Ensure NODE_ENV is not inlined for next/jest

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -7,6 +7,7 @@ const regeneratorRuntimePath = require.resolve(
 
 function getBaseSWCOptions({
   filename,
+  jest,
   development,
   hasReactRefresh,
   globalWindow,
@@ -50,15 +51,17 @@ function getBaseSWCOptions({
         },
         optimizer: {
           simplify: false,
-          globals: {
-            typeofs: {
-              window: globalWindow ? 'object' : 'undefined',
-            },
-            envs: {
-              NODE_ENV: development ? '"development"' : '"production"',
-            },
-            // TODO: handle process.browser to match babel replacing as well
-          },
+          globals: jest
+            ? null
+            : {
+                typeofs: {
+                  window: globalWindow ? 'object' : 'undefined',
+                },
+                envs: {
+                  NODE_ENV: development ? '"development"' : '"production"',
+                },
+                // TODO: handle process.browser to match babel replacing as well
+              },
         },
         regenerator: {
           importPath: regeneratorRuntimePath,
@@ -86,6 +89,7 @@ export function getJestSWCOptions({
 }) {
   let baseOptions = getBaseSWCOptions({
     filename,
+    jest: true,
     development: false,
     hasReactRefresh: false,
     globalWindow: !isServer,

--- a/test/unit/jest-next-swc.test.ts
+++ b/test/unit/jest-next-swc.test.ts
@@ -1,0 +1,7 @@
+/* eslint-env jest */
+
+describe('jest next-swc preset', () => {
+  it('should have correct env', async () => {
+    expect(process.env.NODE_ENV).toBe('test')
+  })
+})


### PR DESCRIPTION
This ensures we don't do the env inlining optimizations when testing with `jest` since these values can vary and aren't needed for dead-code elimination while testing. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/33005