### PR TITLE
RFC: [next/jest] Compile in development mode, and leave `NODE_ENV` blank

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -57,9 +57,13 @@ function getBaseSWCOptions({
                 typeofs: {
                   window: globalWindow ? 'object' : 'undefined',
                 },
-                envs: {
-                  NODE_ENV: development ? '"development"' : '"production"',
-                },
+                // By default, Jest will set `NODE_ENV` to `"test"`.
+                // You can override the behavior via explicitly setting the `NODE_ENV` environment variable
+                envs: jest
+                  ? {}
+                  : {
+                      NODE_ENV: development ? '"development"' : '"production"',
+                    },
                 // TODO: handle process.browser to match babel replacing as well
               },
         },
@@ -90,7 +94,7 @@ export function getJestSWCOptions({
   let baseOptions = getBaseSWCOptions({
     filename,
     jest: true,
-    development: false,
+    development: true,
     hasReactRefresh: false,
     globalWindow: !isServer,
     nextConfig,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
## Problem
Currently, `process.env.NODE_ENV` is set to be `production` in the `next/jest` environment. I think the behavior isn't desirable — there are legit cases where we need to assert on DEV-only warnings in tests (for instance, make sure React doesn't fire `unique "key"` warnings).

## Solution
This PR changes the behavior: source code gets compiled in development mode such that React and friends don't omit dev mode warnings. The actual `NODE_ENV` value is left blank. By default, Jest will set `NODE_ENV` to `"test"` (see https://github.com/facebook/jest/commit/3a38ddf64289a19c3a176c8c0a4e89c03314a85e). You can override the behavior via explicitly setting the `NODE_ENV` environment variable.

## Test Plan
* run `yarn test-unit`: `process.env.NODE_ENV === "test"`
* run `NODE_ENV=development yarn test-unit`: `process.env.NODE_ENV === "development"`

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
