### PR TITLE
chore(ts): convert `defaultConfig` to `NextConfigComplete`

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1481,7 +1481,7 @@ export default async function build(
               }
             : undefined,
         }
-        const exportConfig: any = {
+        const exportConfig: NextConfigComplete = {
           ...config,
           initialPageRevalidationMap: {},
           pageDurationMap: {},

--- a/packages/next/build/webpack/config/index.ts
+++ b/packages/next/build/webpack/config/index.ts
@@ -34,7 +34,7 @@ export async function build(
     productionBrowserSourceMaps: boolean
     future: NextConfigComplete['future']
     experimental: NextConfigComplete['experimental']
-    disableStaticImages: NextConfigComplete['disableStaticImages']
+    disableStaticImages: NextConfigComplete['images']['disableStaticImages']
   }
 ): Promise<webpack.Configuration> {
   const ctx: ConfigurationContext = {

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -193,9 +193,9 @@ export default async function exportApp(
       )
     }
 
-    const customRoutesDetected = ['rewrites', 'redirects', 'headers'].filter(
-      (config) => typeof nextConfig[config] === 'function'
-    )
+    const customRoutesDetected = (
+      ['rewrites', 'redirects', 'headers'] as const
+    ).filter((config) => typeof nextConfig[config] === 'function')
 
     if (
       !hasNextSupport &&

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -26,7 +26,7 @@ export interface NextConfigComplete
   > {
   images: ImageConfigComplete
   typescript: Required<TypeScriptConfig>
-  configOrigin?: 'server' | 'default'
+  configOrigin?: string
   configFile?: string
   configFileName: string
   webpackDevMiddleware?: null | ((...args: any) => any)

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -65,7 +65,6 @@ export interface TypeScriptConfig {
 }
 
 export interface NextConfig {
-  configFileName?: string
   i18n?: I18NConfig | null
 
   eslint?: ESLintConfig

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -7,12 +7,33 @@ import {
   imageConfigDefault,
 } from './image-config'
 
-export type NextConfigComplete = Required<NextConfig> & {
+type RequiredExcept<T, U extends keyof T> = Required<
+  Pick<T, Exclude<keyof T, U>>
+> &
+  Pick<T, U>
+
+export interface NextConfigComplete
+  extends RequiredExcept<
+    NextConfig,
+    | 'headers'
+    | 'rewrites'
+    | 'redirects'
+    | 'webpack5'
+    | 'future'
+    | 'crossOrigin'
+    | 'exportTrailingSlash'
+    | 'exportPathMap'
+  > {
   images: ImageConfigComplete
   typescript: Required<TypeScriptConfig>
-  configOrigin?: string
+  configOrigin?: 'server' | 'default'
   configFile?: string
   configFileName: string
+  webpackDevMiddleware?: null | ((...args: any) => any)
+  analyticsId?: string
+  initialPageRevalidationMap: Record<string, any>
+  ssgNotFoundPaths: string[]
+  pageDurationMap: Record<string, any>
 }
 
 export interface I18NConfig {
@@ -43,7 +64,8 @@ export interface TypeScriptConfig {
   tsconfigPath?: string
 }
 
-export type NextConfig = { [key: string]: any } & {
+export interface NextConfig {
+  configFileName?: string
   i18n?: I18NConfig | null
 
   eslint?: ESLintConfig
@@ -79,6 +101,8 @@ export type NextConfig = { [key: string]: any } & {
       ) => any)
     | null
 
+  /** @deprecated Use `trailingSlash` instead */
+  exportTrailingSlash?: boolean
   trailingSlash?: boolean
   env?: { [key: string]: string }
   distDir?: string
@@ -170,9 +194,16 @@ export type NextConfig = { [key: string]: any } & {
     outputFileTracingRoot?: string
     outputStandalone?: boolean
   }
+  /** @deprecated See https://nextjs.org/blog/next-12#output-file-tracing */
+  target?: 'server' | 'serverless' | 'experimental-serverless-trace'
+  exportPathMap?: any
 }
 
-export const defaultConfig: NextConfig = {
+export const defaultConfig: NextConfigComplete = {
+  initialPageRevalidationMap: {},
+  pageDurationMap: {},
+  ssgNotFoundPaths: [],
+  configFileName: 'next.config.js',
   env: {},
   webpack: null,
   webpackDevMiddleware: null,
@@ -213,7 +244,6 @@ export const defaultConfig: NextConfig = {
   i18n: null,
   productionBrowserSourceMaps: false,
   optimizeFonts: true,
-  webpack5: undefined,
   excludeDefaultMomentLocales: true,
   serverRuntimeConfig: {},
   publicRuntimeConfig: {},

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -29,7 +29,8 @@ const experimentalWarning = execOnce(() => {
 })
 
 function assignDefaults(
-  userConfig: NextConfig & { configOrigin: NextConfigComplete['configOrigin'] }
+  userConfig: NextConfig &
+    Pick<NextConfigComplete, 'configOrigin' | 'configFileName'>
 ): NextConfigComplete {
   const configFileName = userConfig.configFileName
   if (typeof userConfig.exportTrailingSlash !== 'undefined') {


### PR DESCRIPTION
I noticed a [`TODO:` in the source code](https://github.com/vercel/next.js/pull/33064/files#diff-207ae8f32dbb5c5e77b18e26589b6121f92a0d423479f03c523a7a01bc184cb5L393) about this and felt like fixing it.

This gives stronger types internally, as well as marks some deprecated config options as such in hope that people who are strongly typing their `next.config.js` file won't open unnecessary issues about them.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
