### PR TITLE
fix(router): allow relative navigation from index pages

### DIFF
--- a/test/integration/client-navigation/pages/nav/relative/index.js
+++ b/test/integration/client-navigation/pages/nav/relative/index.js
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Relative() {
+  return (
+    <div id="relative">
+      On relative index
+      <Link href="./relative-1">To relative 1</Link>
+    </div>
+  )
+}

--- a/test/integration/client-navigation/pages/nav/relative/relative-1.js
+++ b/test/integration/client-navigation/pages/nav/relative/relative-1.js
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Relative1() {
+  return (
+    <div id="relative-1">
+      On relative 1
+      <Link href="./relative-2">
+        <a>To relative 2</a>
+      </Link>
+    </div>
+  )
+}

--- a/test/integration/client-navigation/pages/nav/relative/relative-2.js
+++ b/test/integration/client-navigation/pages/nav/relative/relative-2.js
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router'
+
+export default function Relative2() {
+  const router = useRouter()
+  return (
+    <div id="relative-2">
+      On relative 2
+      <button
+        onClick={(e) => {
+          e.preventDefault()
+          router.push('.')
+        }}
+      >
+        To relative index
+      </button>
+    </div>
+  )
+}

--- a/test/integration/client-navigation/test/index.test.js
+++ b/test/integration/client-navigation/test/index.test.js
@@ -1564,6 +1564,28 @@ describe('Client Navigation', () => {
     expect(value).toBe(false)
   })
 
+  it('should navigate to paths relative to the current page', async () => {
+    const browser = await webdriver(context.appPort, '/nav/relative')
+    await browser.waitForElementByCss('body', 500)
+    let page
+
+    await browser.elementByCss('a').click()
+    page = await browser.elementByCss('body').text()
+    expect(page).toMatch('On relative 1')
+    await browser.elementByCss('a').click()
+
+    browser.waitForElementByCss('#relative-2', 500)
+    page = await browser.elementByCss('body').text()
+    expect(page).toMatch(/On relative 2/)
+
+    await browser.elementByCss('button').click()
+    browser.waitForElementByCss('#relative', 500)
+    page = await browser.elementByCss('body').text()
+    expect(page).toMatch(/On relative index/)
+
+    await browser.close()
+  })
+
   renderingSuite(
     (p, q) => renderViaHTTP(context.appPort, p, q),
     (p, q) => fetchViaHTTP(context.appPort, p, q),


### PR DESCRIPTION
Fixes #33081

It looks like navigating from an `index.js` with a relative `href` does not work.

All of these should be supported:

1. `/nav/relative` to `./relative-1` should render `/nav/relative/relative-1` (doesn't work currently)
2. `/nav/relative/relative-1` to `./relative-2` should render `/nav/relative/relative-2` (works)
3. `/nav/relative/relative-2` to `.` should render `/nav/relative` (works)

Using both `router` and `Link` in tests.

I also noticed that a page that uses a `Link` and a relative path in `href` ends up with a hydration mismatch (not just on index pages.)


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
