### PR TITLE
No info on environment variables in the src folder (#33110)

### DIFF
--- a/docs/advanced-features/src-directory.md
+++ b/docs/advanced-features/src-directory.md
@@ -11,7 +11,7 @@ The `src` directory is very common in many apps and Next.js supports it by defau
 ## Caveats
 
 - `src/pages` will be ignored if `pages` is present in the root directory
-- Config files like `next.config.js` and `tsconfig.json` should be inside the root directory, moving them to `src` won't work. Same goes for the [`public` directory](/docs/basic-features/static-file-serving.md)
+- Config files like `next.config.js` and `tsconfig.json`, as well as environment variables, should be inside the root directory, moving them to `src` won't work. Same goes for the [`public` directory](/docs/basic-features/static-file-serving.md)
 
 ## Related
 

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -76,6 +76,9 @@ export async function getStaticProps() {
 > CORRECT=pre\$A
 > ```
 
+> **Note**: If you are using a `/src` folder, please note that Next.JS will load the .env files **only** from the parent
+> folder and **not** from the `/src` folder.
+
 ## Exposing Environment Variables to the Browser
 
 By default environment variables are only available in the Node.js environment, meaning they won't be exposed to the browser.

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -76,8 +76,7 @@ export async function getStaticProps() {
 > CORRECT=pre\$A
 > ```
 
-> **Note**: If you are using a `/src` folder, please note that Next.js will load the .env files **only** from the parent
-> folder and **not** from the `/src` folder.
+> **Note**: If you are using a `/src` folder, please note that Next.js will load the .env files **only** from the parent folder and **not** from the `/src` folder.
 
 ## Exposing Environment Variables to the Browser
 

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -76,7 +76,7 @@ export async function getStaticProps() {
 > CORRECT=pre\$A
 > ```
 
-> **Note**: If you are using a `/src` folder, please note that Next.JS will load the .env files **only** from the parent
+> **Note**: If you are using a `/src` folder, please note that Next.js will load the .env files **only** from the parent
 > folder and **not** from the `/src` folder.
 
 ## Exposing Environment Variables to the Browser


### PR DESCRIPTION
Proposes fix to #33110

Adds info on environment variables and the /src folder in the following docs:

- https://nextjs.org/docs/advanced-features/src-directory
- https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
