### PR TITLE
Add Caveats section to custom error page

### DIFF
--- a/docs/advanced-features/custom-error-page.md
+++ b/docs/advanced-features/custom-error-page.md
@@ -94,3 +94,7 @@ export default function Page({ errorCode, stars }) {
 The `Error` component also takes `title` as a property if you want to pass in a text message along with a `statusCode`.
 
 If you have a custom `Error` component be sure to import that one instead. `next/error` exports the default component used by Next.js.
+
+### Caveats
+
+- `Error` currently does not support Next.js [Data Fetching methods](/docs/basic-features/data-fetching.md) like [`getStaticProps`](/docs/basic-features/data-fetching.md#getstaticprops-static-generation) or [`getServerSideProps`](/docs/basic-features/data-fetching.md#getserversideprops-server-side-rendering).


### PR DESCRIPTION
## Desscription

This is a follow up of https://github.com/vercel/next.js/pull/32873. As discussed in #32873, currently it's not recommended to use getServerSideProps in the `Error` component, so this PR will add that caveat to the documentation page, like `Document` and `App` also have.

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
