### PR TITLE
Add missing typings

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
@@ -5,7 +5,10 @@ import { sendRenderResult } from '../../../../server/send-payload'
 import { getUtils, vercelHeader, ServerlessHandlerCtx } from './utils'
 
 import { renderToHTML } from '../../../../server/render'
-import { tryGetPreviewData } from '../../../../server/api-utils'
+import {
+  NextApiIncomingMessage,
+  tryGetPreviewData,
+} from '../../../../server/api-utils'
 import { denormalizePagePath } from '../../../../server/denormalize-page-path'
 import { setLazyProp, getCookieParser } from '../../../../server/api-utils'
 import { getRedirectStatus } from '../../../../lib/load-custom-routes'
@@ -58,7 +61,7 @@ export function getPageHandler(ctx: ServerlessHandlerCtx) {
   } = getUtils(ctx)
 
   async function renderReqToHTML(
-    req: IncomingMessage,
+    req: NextApiIncomingMessage,
     res: ServerResponse,
     renderMode?: 'export' | 'passthrough' | true,
     _renderOpts?: any,
@@ -473,7 +476,10 @@ export function getPageHandler(ctx: ServerlessHandlerCtx) {
 
   return {
     renderReqToHTML,
-    render: async function render(req: IncomingMessage, res: ServerResponse) {
+    render: async function render(
+      req: NextApiIncomingMessage,
+      res: ServerResponse
+    ) {
       try {
         const html = await renderReqToHTML(req, res)
         if (html) {

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -23,6 +23,7 @@ import { isInAmpMode } from '../shared/lib/amp'
 import { setHttpAgentOptions } from '../server/config'
 import RenderResult from '../server/render-result'
 import isError from '../lib/is-error'
+import { NextApiIncomingMessage } from '../server/api-utils'
 
 const envConfig = require('../shared/lib/runtime-config')
 
@@ -188,12 +189,13 @@ export default async function exportPage({
         hasHeader: () => false,
         removeHeader: () => {},
         getHeaderNames: () => [],
+        cookies: {},
       }
 
       const req = {
         url: updatedPath,
         ...headerMocks,
-      } as unknown as IncomingMessage
+      } as unknown as NextApiIncomingMessage
       const res = {
         ...headerMocks,
       } as unknown as ServerResponse

--- a/packages/next/server/api-utils.ts
+++ b/packages/next/server/api-utils.ts
@@ -13,6 +13,9 @@ import { interopDefault } from '../lib/interop-default'
 
 export type NextApiRequestCookies = { [key: string]: string }
 export type NextApiRequestQuery = { [key: string]: string | string[] }
+export type NextApiIncomingMessage = IncomingMessage & {
+  cookies: NextApiRequestCookies
+}
 
 export type __ApiPreviewProps = {
   previewModeId: string

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -1,4 +1,4 @@
-import type { __ApiPreviewProps } from '../api-utils'
+import type { NextApiIncomingMessage, __ApiPreviewProps } from '../api-utils'
 import type { CustomRoutes } from '../../lib/load-custom-routes'
 import type { FetchEventResult } from '../web/types'
 import type { FindComponentsResult } from '../next-server'
@@ -443,7 +443,7 @@ export default class DevServer extends Server {
   }
 
   protected async _beforeCatchAllRender(
-    req: IncomingMessage,
+    req: NextApiIncomingMessage,
     res: ServerResponse,
     params: Params,
     parsedUrl: UrlWithParsedQuery
@@ -519,7 +519,7 @@ export default class DevServer extends Server {
   }
 
   async runMiddleware(params: {
-    request: IncomingMessage
+    request: NextApiIncomingMessage
     response: ServerResponse
     parsedUrl: ParsedNextUrl
     parsed: UrlWithParsedQuery
@@ -547,7 +547,7 @@ export default class DevServer extends Server {
   }
 
   async run(
-    req: IncomingMessage,
+    req: NextApiIncomingMessage,
     res: ServerResponse,
     parsedUrl: UrlWithParsedQuery
   ): Promise<void> {
@@ -932,7 +932,7 @@ export default class DevServer extends Server {
   }
 
   private servePublic(
-    req: IncomingMessage,
+    req: NextApiIncomingMessage,
     res: ServerResponse,
     pathParts: string[]
   ): Promise<void> {

--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -18,6 +18,7 @@ import type Server from './base-server'
 import { sendEtagResponse } from './send-payload'
 import { getContentType, getExtension } from './serve-static'
 import chalk from 'next/dist/compiled/chalk'
+import { NextApiIncomingMessage } from './api-utils'
 
 const AVIF = 'image/avif'
 const WEBP = 'image/webp'
@@ -48,7 +49,7 @@ let showSharpMissingWarning = process.env.NODE_ENV === 'production'
 
 export async function imageOptimizer(
   server: Server,
-  req: IncomingMessage,
+  req: NextApiIncomingMessage,
   res: ServerResponse,
   parsedUrl: UrlWithParsedQuery,
   nextConfig: NextConfig,

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -48,7 +48,11 @@ import {
   RenderPage,
   RenderPageResult,
 } from '../shared/lib/utils'
-import type { NextApiRequestCookies, __ApiPreviewProps } from './api-utils'
+import type {
+  NextApiIncomingMessage,
+  NextApiRequestCookies,
+  __ApiPreviewProps,
+} from './api-utils'
 import { denormalizePagePath } from './denormalize-page-path'
 import type { FontManifest } from './font-utils'
 import type { LoadComponentsReturnType, ManifestItem } from './load-components'
@@ -389,7 +393,7 @@ function createServerComponentRenderer(
 }
 
 export async function renderToHTML(
-  req: IncomingMessage,
+  req: NextApiIncomingMessage,
   res: ServerResponse,
   pathname: string,
   query: NextParsedUrlQuery,

--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -8,6 +8,7 @@ import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { RouteHas } from '../lib/load-custom-routes'
 import { matchHas } from '../shared/lib/router/utils/prepare-destination'
 import { getRequestMeta } from './request-meta'
+import { NextApiIncomingMessage } from './api-utils'
 
 export const route = pathMatch()
 
@@ -31,7 +32,7 @@ export type Route = {
   requireBasePath?: false
   internal?: true
   fn: (
-    req: IncomingMessage,
+    req: NextApiIncomingMessage,
     res: ServerResponse,
     params: Params,
     parsedUrl: NextUrlWithParsedQuery
@@ -134,7 +135,7 @@ export default class Router {
   }
 
   async execute(
-    req: IncomingMessage,
+    req: NextApiIncomingMessage,
     res: ServerResponse,
     parsedUrl: NextUrlWithParsedQuery
   ): Promise<boolean> {

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -1,4 +1,5 @@
 import { formatUrl } from './router/utils/format-url'
+import type { NextApiIncomingMessage } from '../../server/api-utils'
 import type { BuildManifest } from '../../server/get-page-files'
 import type { ComponentType } from 'react'
 import type { DomainLocale } from '../../server/config'
@@ -121,7 +122,7 @@ export interface NextPageContext {
   /**
    * `HTTP` request object.
    */
-  req?: IncomingMessage
+  req?: NextApiIncomingMessage
   /**
    * `HTTP` response object.
    */

--- a/test/production/typescript-basic.test.ts
+++ b/test/production/typescript-basic.test.ts
@@ -26,6 +26,7 @@ describe('TypeScript basic', () => {
         `,
         'server.ts': `
           import next from 'next';
+          import assert from 'assert';
           const app = next({
             dir: '.',
             dev: process.env.NODE_ENV !== 'production',
@@ -35,6 +36,7 @@ describe('TypeScript basic', () => {
             quiet: false,
           });
           const requestHandler = app.getRequestHandler();
+          assert(requestHandler.cookies);
         `,
       },
       dependencies: {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
Next.js has provided [a way](https://nextjs.org/docs/advanced-features/i18n-routing) to do internationalization, but it's URL-based, different locales have a different route.

It doesn't meet all scenes, so I detect the user's `Accept-Languages` header to choose a locale, or users can persist theirs prefer locale in Cookies. I did this in `App.getInitialProps`, read cookies, and then render the right locale, but the `AppContext`'s req doesn't have `cookies` typings, so I think it's maybe "missing"?



cookies were processed in:
https://github.com/vercel/next.js/blob/9836429beed54a7dffeaa88c199a77046b26608f/packages/next/server/base-server.ts#L372

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
