### PR TITLE
Added links to data fetching api refs, fixed title

### DIFF
--- a/docs/basic-features/data-fetching/get-server-side-props.md
+++ b/docs/basic-features/data-fetching/get-server-side-props.md
@@ -31,7 +31,7 @@ Note that you must export `getServerSideProps` as a standalone function — it w
 
 The [`getServerSideProps` API reference](/docs/api-reference/data-fetching/get-server-side-props.md) covers all parameters and props that can be used with `getServerSideProps`.
 
-## When should I use `getServerSideProps`?
+## When should I use getServerSideProps
 
 You should use `getServerSideProps` only if you need to pre-render a page whose data must be fetched at request time. [Time to First Byte (TTFB)](/learn/seo/web-performance) will be higher than [`getStaticProps`](/docs/basic-features/data-fetching/get-static-props.md) because the server must compute the result on every request, and the result can only be cached by a CDN using `cache-control` headers (which could require extra configuration).
 
@@ -73,3 +73,10 @@ export async function getServerSideProps() {
 
 export default Page
 ```
+
+<div class="card">
+  <a href="/docs/api-reference/data-fetching/get-server-side-props.md">
+    <b>getServerSideProps API Reference</b>
+    <small>Read the API Reference for getServerSideProps</small>
+  </a>
+</div>

--- a/docs/basic-features/data-fetching/get-static-paths.md
+++ b/docs/basic-features/data-fetching/get-static-paths.md
@@ -46,3 +46,10 @@ Note that you must use export `getStaticPaths` as a standalone function — it w
 ## Runs on every request in development
 
 In development (`next dev`), `getStaticPaths` will be called on every request.
+
+<div class="card">
+  <a href="/docs/api-reference/data-fetching/get-static-paths.md">
+    <b>getStaticPaths API Reference</b>
+    <small>Read the API Reference for getStaticPaths</small>
+  </a>
+</div>

--- a/docs/basic-features/data-fetching/get-static-props.md
+++ b/docs/basic-features/data-fetching/get-static-props.md
@@ -101,3 +101,10 @@ In development (`next dev`), `getStaticProps` will be called on every request.
 In some cases, you might want to temporarily bypass Static Generation and render the page at **request time** instead of build time. For example, you might be using a headless CMS and want to preview drafts before they're published.
 
 This use case is supported in Next.js by the [**Preview Mode**](/docs/advanced-features/preview-mode.md) feature.
+
+<div class="card">
+  <a href="/docs/api-reference/data-fetching/get-static-props.md">
+    <b>getStaticProps API Reference</b>
+    <small>Read the API Reference for getStaticProps</small>
+  </a>
+</div>


### PR DESCRIPTION
This PR adds links from the data fetching api pages to their api ref pages. Also removes rouge backticks on header

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
