### PR TITLE
Update example to prevent user error

### DIFF
--- a/errors/no-html-link-for-pages.md
+++ b/errors/no-html-link-for-pages.md
@@ -53,7 +53,7 @@ In some cases, you may also need to configure this rule directly by providing a 
 ```json
 {
   "rules": {
-    "@next/next/no-html-link-for-pages": ["error", "/my-app/pages/"]
+    "@next/next/no-html-link-for-pages": ["error", "/my-app/"]
   }
 }
 ```


### PR DESCRIPTION
This rule looks for a `pages` folder in the given path.

Using `/web/src/pages` will result in an error, providing `/web/src/` will work as expected.
___

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

