### PR TITLE
Update links in `next export` + `next/image` error message

### DIFF
--- a/errors/export-image-api.md
+++ b/errors/export-image-api.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-You are attempting to run `next export` while importing the `next/image` component configured using the default `loader`.
+You are attempting to run `next export` while importing the `next/image` component using the default `loader` configuration.
 
 However, the default `loader` relies on the Image Optimization API which is not available for exported applications.
 
@@ -10,15 +10,15 @@ This is because Next.js optimizes images on-demand, as users request them (not a
 
 #### Possible Ways to Fix It
 
-- Use `next start` to run a server, which includes the Image Optimization API.
-- Use any provider which supports Image Optimization (like [Vercel](https://vercel.com/docs/next.js/image-optimization)).
-- Configure a third-party [loader](https://nextjs.org/docs/basic-features/image-optimization#loader) in `next.config.js`.
-- Use the [`loader`](https://nextjs.org/docs/api-reference/next/image#loader) prop for `next/image`.
+- Use [`next start`](https://nextjs.org/docs/api-reference/cli#production) to run a server, which includes the Image Optimization API.
+- Use any provider which supports Image Optimization (such as [Vercel](https://vercel.com)).
+- [Configure the loader](https://nextjs.org/docs/api-reference/next/image#loader-configuration) in `next.config.js`.
+- Use the [`loader`](https://nextjs.org/docs/api-reference/next/image#loader) prop for each instance of `next/image`.
 
 ### Useful Links
 
-- [Deployment Documentation](https://nextjs.org/docs/deployment#vercel-recommended)
+- [Deployment Documentation](https://nextjs.org/docs/deployment#managed-nextjs-with-vercel)
 - [Image Optimization Documentation](https://nextjs.org/docs/basic-features/image-optimization)
 - [`next export` Documentation](https://nextjs.org/docs/advanced-features/static-html-export)
 - [`next/image` Documentation](https://nextjs.org/docs/api-reference/next/image)
-- [Vercel Documentation](https://vercel.com/docs/next.js/image-optimization)
+- [Vercel Documentation](https://vercel.com/docs/concepts/next.js/image-optimization)


### PR DESCRIPTION
Minor changes to this error message to link to latest docs