### PR TITLE
Add link to security email directly.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,9 @@
-# Security
+# Reporting Security Issues
 
-Email our security team (`security@vercel.com`) to disclose any security vulnerabilities.
+If you believe you have found a security vulnerability in Next.js, we encourage you to let us know right away.
+
+We will investigate all legitimate reports and do our best to quickly fix the problem.
+
+Email `security@vercel.com` to disclose any security vulnerabilities.
 
 https://vercel.com/security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,5 @@
-Visit https://vercel.com/security to view the disclosure policy.
+# Security
+
+Email our security team (`security@vercel.com`) to disclose any security vulnerabilities.
+
+https://vercel.com/security


### PR DESCRIPTION
Previously, this page linked to /security, which then had buttons to contact our security team. This removes a step by directly mentioning they should contact us by email to report vulnerabilities. 