### PR TITLE
[docs] Fix 404 link for testing example.

### DIFF
--- a/test/readme.md
+++ b/test/readme.md
@@ -12,7 +12,7 @@ You can set-up a new test using `yarn new-test` which will start from a template
 - integration: These tests run misc checks and modes and is where tests used to be added before we added more specific folders. Ideally we don't add new test suites here as tests here are not isolated from the monorepo.
 - unit: These are very fast tests that should run without a browser or running next and should be testing a specific utility.
 
-For the e2e, production, and development tests the `createNext` utility should be used and an example is available [here](./e2e/example.test.txt). This creates an isolated Next.js install to ensure nothing in the monorepo is relied on accidentally causing incorrect tests.
+For the e2e, production, and development tests the `createNext` utility should be used and an example is available [here](./e2e/example.txt). This creates an isolated Next.js install to ensure nothing in the monorepo is relied on accidentally causing incorrect tests.
 
 All new test suites should be written in TypeScript either `.ts` (or `.tsx` for unit tests). This will help ensure we catch smaller issues in tests that could cause flakey or incorrect tests.
 


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/33406.

This PR is a demonstration of contributing to open source and fixes an issue with a 404 link in the testing documentation.