### PR TITLE
ReferenceError in authentication.md example fixed

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -71,7 +71,9 @@ import withSession from '../lib/session'
 import Layout from '../components/Layout'
 
 export const getServerSideProps = withSession(async function ({ req, res }) {
-  if (!req.session.user) {
+  const { user } = req.session
+
+  if (!user) {
     return {
       redirect: {
         destination: '/login',


### PR DESCRIPTION
Before
```jsx
export const getServerSideProps = withSession(async function ({ req, res }) {
  if (!req.session.user) {
    return {
      redirect: {
        destination: '/login',
        permanent: false,
      },
    }
  }

  return {
    props: { user }, // User not defined
  }
})
```