### PR TITLE
Disable cache for rsc pages

### DIFF
--- a/packages/next/build/webpack/loaders/next-middleware-ssr-loader/render.ts
+++ b/packages/next/build/webpack/loaders/next-middleware-ssr-loader/render.ts
@@ -6,6 +6,7 @@ import { toNodeHeaders } from '../../../../server/web/utils'
 const createHeaders = (args?: any) => ({
   ...args,
   'x-middleware-ssr': '1',
+  'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
 })
 
 function sendError(req: any, error: Error) {

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -357,6 +357,18 @@ async function runBasicTests(context, env) {
     expect(pathNotFoundHTML).toContain(page404Content)
   })
 
+  it('should disable cache for RSC pages', async () => {
+    const urls = ['/', '/next-api/image', '/next-api/link']
+    await Promise.all(
+      urls.map(async (url) => {
+        const { headers } = await fetchViaHTTP(context.appPort, url)
+        expect(headers.get('cache-control')).toBe(
+          'no-cache, no-store, max-age=0, must-revalidate'
+        )
+      })
+    )
+  })
+
   it('should support next/link', async () => {
     const linkHTML = await renderViaHTTP(context.appPort, '/next-api/link')
     const $ = cheerio.load(linkHTML)


### PR DESCRIPTION
### Problem

When you navigate between pages, browsers will use bfcache to manage the page cache. RSC are fully dynamic and requires streaming to fill the suspended "content holes" before cache is well supported. But safari bfcache will stop it somehow, even chrome works well.


For safari it will only disable bfcache on when the cache header matches `no-cache` or `no-store`

x-ref: https://webkit.org/blog/427/webkit-page-cache-i-the-basics/
> allowing HTTPS pages to be cached unless their response headers include “cache-control: no-store” or “cache-control: no-cache” which has become the canonical way for a selective organization to secure your content.

