### PR TITLE
Merge query params in middleware redirects

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -62,7 +62,10 @@ import { prepareDestination } from '../shared/lib/router/utils/prepare-destinati
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { getMiddlewareRegex, getRouteMatcher } from '../shared/lib/router/utils'
 import { MIDDLEWARE_ROUTE } from '../lib/constants'
-import { urlQueryToSearchParams } from '../shared/lib/router/utils/querystring'
+import {
+  searchParamsToUrlQuery,
+  urlQueryToSearchParams,
+} from '../shared/lib/router/utils/querystring'
 
 export * from './base-server'
 
@@ -832,7 +835,10 @@ export default class NextNodeServer extends BaseServer {
             }
           }
 
-          parsedRel.search = newQuery.toString()
+          const queryAsString = `${newQuery}`
+          parsedRel.query = searchParamsToUrlQuery(newQuery)
+          parsedRel.search = queryAsString ? `?${queryAsString}` : ''
+
           const location = formatUrl(parsedRel)
 
           if (location !== rel) {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -821,6 +821,12 @@ export default class NextNodeServer extends BaseServer {
 
           for (const key of relQuery.keys()) {
             newQuery.delete(key)
+            const allValues = relQuery.getAll(key)
+
+            if (allValues.length === 1 && allValues[0] === '') {
+              continue
+            }
+
             for (const param of relQuery.getAll(key)) {
               newQuery.append(key, param)
             }

--- a/test/integration/middleware/core/pages/redirects/_middleware.js
+++ b/test/integration/middleware/core/pages/redirects/_middleware.js
@@ -3,7 +3,7 @@ export async function middleware(request) {
 
   if (url.searchParams.get('foo') === 'bar') {
     url.pathname = '/redirects/new-home'
-    url.searchParams.delete('foo')
+    url.searchParams.set('foo', '')
     return Response.redirect(url)
   }
 

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -302,7 +302,7 @@ function redirectTests(locale = '') {
     expect($('.title').text()).toBe('Welcome to a new page')
   })
 
-  it(`${locale} should redirect cleanly with the original url param`, async () => {
+  it(`${locale} should redirect with the original url param empty`, async () => {
     const browser = await webdriver(
       context.appPort,
       `${locale}/redirects/blank-page?foo=bar`
@@ -312,7 +312,7 @@ function redirectTests(locale = '') {
         await browser.eval(
           `window.location.href.replace(window.location.origin, '')`
         )
-      ).toBe(`${locale}/redirects/new-home`)
+      ).toBe(`${locale}/redirects/new-home?foo=`)
     } finally {
       await browser.close()
     }

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -312,7 +312,7 @@ function redirectTests(locale = '') {
         await browser.eval(
           `window.location.href.replace(window.location.origin, '')`
         )
-      ).toBe(`${locale}/redirects/new-home?foo=`)
+      ).toBe(`${locale}/redirects/new-home`)
     } finally {
       await browser.close()
     }

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -302,7 +302,7 @@ function redirectTests(locale = '') {
     expect($('.title').text()).toBe('Welcome to a new page')
   })
 
-  it(`${locale} should redirect with the original url param empty`, async () => {
+  it(`${locale} should redirect cleanly with the original url param`, async () => {
     const browser = await webdriver(
       context.appPort,
       `${locale}/redirects/blank-page?foo=bar`

--- a/test/production/middleware-redirects-merge-the-query-params/index.test.ts
+++ b/test/production/middleware-redirects-merge-the-query-params/index.test.ts
@@ -12,9 +12,7 @@ describe('middleware redirects merge the query params', () => {
           import { NextResponse } from 'next/server';
 
           export default function middleware({ nextUrl }) {
-            for (const key of nextUrl.searchParams.keys()) {
-              nextUrl.searchParams.delete(key);
-            }
+            nextUrl.searchParams.delete('foo');
             nextUrl.searchParams.set('overridden', 'middleware');
             nextUrl.searchParams.set('getsEmpty', '');
             return NextResponse.redirect(nextUrl);
@@ -40,7 +38,6 @@ describe('middleware redirects merge the query params', () => {
     expect(query).toEqual({
       foo: 'bar',
       overridden: 'middleware',
-      getsEmpty: '',
     })
   })
 })

--- a/test/production/middleware-redirects-merge-the-query-params/index.test.ts
+++ b/test/production/middleware-redirects-merge-the-query-params/index.test.ts
@@ -1,0 +1,46 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { fetchViaHTTP } from 'next-test-utils'
+
+describe('middleware redirects merge the query params', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/_middleware.js': `
+          import { NextResponse } from 'next/server';
+
+          export default function middleware({ nextUrl }) {
+            for (const key of nextUrl.searchParams.keys()) {
+              nextUrl.searchParams.delete(key);
+            }
+            nextUrl.searchParams.set('overridden', 'middleware');
+            nextUrl.searchParams.set('getsEmpty', '');
+            return NextResponse.redirect(nextUrl);
+          }
+        `,
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('merges the params for redirects and matches rewrites', async () => {
+    const response = await fetchViaHTTP(
+      next.url,
+      '/',
+      { foo: 'bar', overridden: 'overridden', getsEmpty: 'getsEmpty' },
+      {
+        redirect: 'manual',
+      }
+    )
+    const newLocation = new URL(response.headers.get('location'))
+    const query = Object.fromEntries([...newLocation.searchParams])
+    expect(query).toEqual({
+      foo: 'bar',
+      overridden: 'middleware',
+      getsEmpty: '',
+    })
+  })
+})


### PR DESCRIPTION
The current implementation of redirection does not match how rewrites are being handled.

This commit changes the behavior of query params in redirects to match
rewrites, so it will be merged with the input query params. And by that,
it will be consistent with static redirects (done in the config file).

:warning: **Warning:** this is a breaking change in routing for `next start`. However, this makes redirects behave more consistently across Next.js. This means _some test expectations changed_ in this PR, which show the new behavior.

* Fixes https://github.com/vercel/next.js/issues/31323