### PR TITLE
Update main field for nccd jest-worker

### DIFF
--- a/packages/next/compiled/jest-worker/package.json
+++ b/packages/next/compiled/jest-worker/package.json
@@ -1,1 +1,1 @@
-{"name":"jest-worker","main":"threadChild.js.tmp.js","license":"MIT"}
+{"name":"jest-worker","main":"index.js","license":"MIT"}

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -251,7 +251,7 @@ export async function ncc_jest_worker(task, opts) {
             )
           )
       )
-      .ncc({ packageName: 'jest-worker', externals })
+      .ncc({ externals })
       .target('compiled/jest-worker/out')
 
     await fs.move(


### PR DESCRIPTION
Fixes a deprecation warning from invalid `main` field:
```sh
DeprecationWarning: Invalid 'main' field in '/next.js/node_modules/next/dist/compiled/jest-worker/package.json' of 'threadChild.js.tmp.js'. Please either fix that or report it to the module author
```