### PR TITLE
Fix multiple calls to image `onLoadingComplete()`

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -249,21 +249,21 @@ function defaultImageLoader(loaderProps: ImageLoaderProps) {
 // See https://stackoverflow.com/q/39777833/266535 for why we use this ref
 // handler instead of the img's onLoad attribute.
 function handleLoading(
-  ref: React.RefObject<HTMLImageElement>,
+  imgRef: React.RefObject<HTMLImageElement>,
   src: string,
   layout: LayoutValue,
   placeholder: PlaceholderValue,
-  onLoadingComplete: React.MutableRefObject<OnLoadingComplete | undefined>
+  onLoadingCompleteRef: React.MutableRefObject<OnLoadingComplete | undefined>
 ) {
   const handleLoad = () => {
-    const img = ref.current
+    const img = imgRef.current
     if (!img) {
       return
     }
     if (img.src !== emptyDataURL) {
       const p = 'decode' in img ? img.decode() : Promise.resolve()
       p.catch(() => {}).then(() => {
-        if (!ref.current) {
+        if (!imgRef.current) {
           return
         }
         if (placeholder === 'blur') {
@@ -272,11 +272,11 @@ function handleLoading(
           img.style.backgroundImage = ''
           img.style.backgroundPosition = ''
         }
-        if (onLoadingComplete.current) {
+        if (onLoadingCompleteRef.current) {
           const { naturalWidth, naturalHeight } = img
           // Pass back read-only primitive values but not the
           // underlying DOM element because it could be misused.
-          onLoadingComplete.current({ naturalWidth, naturalHeight })
+          onLoadingCompleteRef.current({ naturalWidth, naturalHeight })
         }
         if (process.env.NODE_ENV !== 'production') {
           if (img.parentElement?.parentElement) {
@@ -301,14 +301,14 @@ function handleLoading(
       })
     }
   }
-  if (ref.current) {
-    if (ref.current.complete) {
+  if (imgRef.current) {
+    if (imgRef.current.complete) {
       // If the real image fails to load, this will still remove the placeholder.
       // This is the desired behavior for now, and will be revisited when error
       // handling is worked on for the image component itself.
       handleLoad()
     } else {
-      ref.current.onload = handleLoad
+      imgRef.current.onload = handleLoad
     }
   }
 }
@@ -332,7 +332,7 @@ export default function Image({
   blurDataURL,
   ...all
 }: ImageProps) {
-  const ref = useRef<HTMLImageElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
   let rest: Partial<ImageProps> = all
   let layout: NonNullable<LayoutValue> = sizes ? 'responsive' : 'intrinsic'
   if ('layout' in rest) {
@@ -381,7 +381,7 @@ export default function Image({
     unoptimized = true
     isLazy = false
   }
-  if (typeof window !== 'undefined' && ref.current?.complete) {
+  if (typeof window !== 'undefined' && imgRef.current?.complete) {
     isLazy = false
   }
 
@@ -671,15 +671,11 @@ export default function Image({
   }, [onLoadingComplete])
 
   useLayoutEffect(() => {
-    if (ref.current) {
-      setIntersection(ref.current)
-    }
+    setIntersection(imgRef.current)
   }, [setIntersection])
 
   useEffect(() => {
-    if (ref.current) {
-      handleLoading(ref, srcString, layout, placeholder, onLoadingCompleteRef)
-    }
+    handleLoading(imgRef, srcString, layout, placeholder, onLoadingCompleteRef)
   }, [srcString, layout, placeholder, isVisible])
 
   return (
@@ -712,7 +708,7 @@ export default function Image({
         decoding="async"
         data-nimg={layout}
         className={className}
-        ref={ref}
+        ref={imgRef}
         style={{ ...imgStyle, ...blurStyle }}
       />
       {isLazy && (

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -381,7 +381,7 @@ export default function Image({
     unoptimized = true
     isLazy = false
   }
-  if (typeof window !== 'undefined' && ref?.current?.complete) {
+  if (typeof window !== 'undefined' && ref.current?.complete) {
     isLazy = false
   }
 

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -263,14 +263,15 @@ function handleLoading(
     if (img.src !== emptyDataURL) {
       const p = 'decode' in img ? img.decode() : Promise.resolve()
       p.catch(() => {}).then(() => {
+        const isLoaded = loadedImageURLs.has(src)
+        loadedImageURLs.add(src)
         if (placeholder === 'blur') {
           img.style.filter = ''
           img.style.backgroundSize = ''
           img.style.backgroundImage = ''
           img.style.backgroundPosition = ''
         }
-        loadedImageURLs.add(src)
-        if (onLoadingComplete) {
+        if (onLoadingComplete && !isLoaded) {
           const { naturalWidth, naturalHeight } = img
           // Pass back read-only primitive values but not the
           // underlying DOM element because it could be misused.

--- a/test/integration/image-component/default/pages/on-loading-complete.js
+++ b/test/integration/image-component/default/pages/on-loading-complete.js
@@ -78,6 +78,7 @@ const Page = () => {
       <ImageWithMessage
         id="8"
         src={clicked ? '/foo/test-rect.jpg' : '/wide.png'}
+        layout={clicked ? 'fixed' : 'intrinsic'}
         width="500"
         height="500"
         idToCount={idToCount}

--- a/test/integration/image-component/default/pages/on-loading-complete.js
+++ b/test/integration/image-component/default/pages/on-loading-complete.js
@@ -90,7 +90,7 @@ function ImageWithMessage({ id, idToCount, setIdToCount, ...props }) {
         <Image
           id={`img${id}`}
           onLoadingComplete={({ naturalWidth, naturalHeight }) => {
-            const count = idToCount[id] || 0
+            let count = idToCount[id] || 0
             count++
             idToCount[id] = count
             setIdToCount(idToCount)

--- a/test/integration/image-component/default/pages/on-loading-complete.js
+++ b/test/integration/image-component/default/pages/on-loading-complete.js
@@ -58,7 +58,7 @@ const Page = () => {
 
       <ImageWithMessage
         id="6"
-        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAAFCAYAAACAcVaiAAAAE0lEQVR42mNk+P+/ngEKGMngAADDdwx3Uz/3AAAAAABJRU5ErkJggg=="
         layout="fill"
         idToCount={idToCount}
         setIdToCount={setIdToCount}

--- a/test/integration/image-component/default/pages/on-loading-complete.js
+++ b/test/integration/image-component/default/pages/on-loading-complete.js
@@ -1,74 +1,108 @@
 import { useState } from 'react'
 import Image from 'next/image'
 
-const Page = () => (
-  <div>
-    <h1>On Loading Complete Test</h1>
-    <ImageWithMessage
-      id="1"
-      src="/test.jpg"
-      layout="intrinsic"
-      width="128"
-      height="128"
-    />
-    <hr />
-    <ImageWithMessage
-      id="2"
-      src={require('../public/test.png')}
-      placeholder="blur"
-      layout="fixed"
-    />
-    <hr />
-    <ImageWithMessage
-      id="3"
-      src="/test.svg"
-      layout="responsive"
-      width="1200"
-      height="1200"
-    />
-    <hr />
-    <div style={{ position: 'relative', width: '64px', height: '64px' }}>
+const Page = () => {
+  // Hoisted state to count each image load callback
+  const [idToCount, setIdToCount] = useState({})
+
+  return (
+    <div>
+      <h1>On Loading Complete Test</h1>
+      <ImageWithMessage
+        id="1"
+        src="/test.jpg"
+        layout="intrinsic"
+        width="128"
+        height="128"
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
+      />
+
+      <ImageWithMessage
+        id="2"
+        src={require('../public/test.png')}
+        placeholder="blur"
+        layout="fixed"
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
+      />
+
+      <ImageWithMessage
+        id="3"
+        src="/test.svg"
+        layout="responsive"
+        width="1200"
+        height="1200"
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
+      />
+
       <ImageWithMessage
         id="4"
         src="/test.ico"
         layout="fill"
         objectFit="contain"
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
       />
-    </div>
-    <hr />
-    <ImageWithMessage
-      id="5"
-      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAAFCAYAAACAcVaiAAAAE0lEQVR42mNk+P+/ngEKGMngAADDdwx3Uz/3AAAAAABJRU5ErkJggg=="
-      layout="fixed"
-      width={64}
-      height={64}
-    />
-    <hr />
-    <div style={{ position: 'relative', width: '64px', height: '64px' }}>
+
+      <ImageWithMessage
+        id="5"
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAAFCAYAAACAcVaiAAAAE0lEQVR42mNk+P+/ngEKGMngAADDdwx3Uz/3AAAAAABJRU5ErkJggg=="
+        layout="fixed"
+        width={64}
+        height={64}
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
+      />
+
       <ImageWithMessage
         id="6"
-        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAAFCAYAAACAcVaiAAAAE0lEQVR42mNk+P+/ngEKGMngAADDdwx3Uz/3AAAAAABJRU5ErkJggg=="
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
         layout="fill"
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
       />
-    </div>
-    <div id="footer" />
-  </div>
-)
 
-function ImageWithMessage({ id, ...props }) {
+      <ImageWithMessage
+        id="7"
+        src="/test.bmp"
+        loading="eager"
+        width={400}
+        height={400}
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
+      />
+      <div id="footer" />
+    </div>
+  )
+}
+
+function ImageWithMessage({ id, idToCount, setIdToCount, ...props }) {
   const [msg, setMsg] = useState('[LOADING]')
+  const style =
+    props.layout === 'fill'
+      ? { position: 'relative', width: '64px', height: '64px' }
+      : {}
   return (
     <>
-      <Image
-        id={`img${id}`}
-        onLoadingComplete={({ naturalWidth, naturalHeight }) =>
-          setMsg(
-            `loaded img${id} with dimensions ${naturalWidth}x${naturalHeight}`
-          )
-        }
-        {...props}
-      />
+      <div className="wrap" style={style}>
+        <Image
+          id={`img${id}`}
+          onLoadingComplete={({ naturalWidth, naturalHeight }) => {
+            const count = idToCount[id] || 0
+            count++
+            idToCount[id] = count
+            setIdToCount(idToCount)
+            const msg = `loaded ${count} img${id} with dimensions ${naturalWidth}x${naturalHeight}`
+            setMsg(msg)
+            console.log(msg)
+          }}
+          {...props}
+        />
+      </div>
       <p id={`msg${id}`}>{msg}</p>
+      <hr />
     </>
   )
 }

--- a/test/integration/image-component/default/pages/on-loading-complete.js
+++ b/test/integration/image-component/default/pages/on-loading-complete.js
@@ -4,6 +4,7 @@ import Image from 'next/image'
 const Page = () => {
   // Hoisted state to count each image load callback
   const [idToCount, setIdToCount] = useState({})
+  const [clicked, setClicked] = useState(false)
 
   return (
     <div>
@@ -68,11 +69,23 @@ const Page = () => {
         id="7"
         src="/test.bmp"
         loading="eager"
-        width={400}
-        height={400}
+        width="400"
+        height="400"
         idToCount={idToCount}
         setIdToCount={setIdToCount}
       />
+
+      <ImageWithMessage
+        id="8"
+        src={clicked ? '/foo/test-rect.jpg' : '/wide.png'}
+        width="500"
+        height="500"
+        idToCount={idToCount}
+        setIdToCount={setIdToCount}
+      />
+      <button id="toggle" onClick={() => setClicked(!clicked)}>
+        Toggle
+      </button>
       <div id="footer" />
     </div>
   )

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -233,7 +233,7 @@ function runTests(mode) {
       )
       await check(
         () => browser.eval(`document.getElementById("msg6").textContent`),
-        'loaded 1 img6 with dimensions 1x1'
+        'loaded 1 img6 with dimensions 3x5'
       )
       await check(
         () => browser.eval(`document.getElementById("msg7").textContent`),

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -193,7 +193,9 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/on-loading-complete')
 
-      await browser.eval(`document.getElementById("footer").scrollIntoView()`)
+      await browser.eval(
+        `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
+      )
 
       await check(
         () => browser.eval(`document.getElementById("img1").src`),
@@ -238,6 +240,15 @@ function runTests(mode) {
       await check(
         () => browser.eval(`document.getElementById("msg7").textContent`),
         'loaded 1 img7 with dimensions 400x400'
+      )
+      await check(
+        () => browser.eval(`document.getElementById("msg8").textContent`),
+        'loaded 1 img8 with dimensions 640x373'
+      )
+      await browser.eval('document.getElementById("toggle").click()')
+      await check(
+        () => browser.eval(`document.getElementById("msg8").textContent`),
+        'loaded 2 img8 with dimensions 400x300'
       )
     } finally {
       if (browser) {

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -233,11 +233,11 @@ function runTests(mode) {
       )
       await check(
         () => browser.eval(`document.getElementById("msg6").textContent`),
-        'loaded 1 img6 with dimensions 3x5'
+        'loaded 1 img6 with dimensions 1x1'
       )
       await check(
         () => browser.eval(`document.getElementById("msg7").textContent`),
-        'loaded 1 img7 with dimensions 200x200'
+        'loaded 1 img7 with dimensions 400x400'
       )
     } finally {
       if (browser) {

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -198,19 +198,19 @@ function runTests(mode) {
       )
 
       await check(
-        () => browser.eval(`document.getElementById("img1").src`),
+        () => browser.eval(`document.getElementById("img1").currentSrc`),
         /test(.*)jpg/
       )
       await check(
-        () => browser.eval(`document.getElementById("img2").src`),
+        () => browser.eval(`document.getElementById("img2").currentSrc`),
         /test(.*).png/
       )
       await check(
-        () => browser.eval(`document.getElementById("img3").src`),
+        () => browser.eval(`document.getElementById("img3").currentSrc`),
         /test(.*)svg/
       )
       await check(
-        () => browser.eval(`document.getElementById("img4").src`),
+        () => browser.eval(`document.getElementById("img4").currentSrc`),
         /test(.*)ico/
       )
       await check(
@@ -252,6 +252,10 @@ function runTests(mode) {
           ),
         'intrinsic'
       )
+      await check(
+        () => browser.eval(`document.getElementById("img8").currentSrc`),
+        /wide.png/
+      )
       await browser.eval('document.getElementById("toggle").click()')
       await check(
         () => browser.eval(`document.getElementById("msg8").textContent`),
@@ -263,6 +267,10 @@ function runTests(mode) {
             `document.getElementById("img8").getAttribute("data-nimg")`
           ),
         'fixed'
+      )
+      await check(
+        () => browser.eval(`document.getElementById("img8").currentSrc`),
+        /test-rect.jpg/
       )
     } finally {
       if (browser) {

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -245,10 +245,24 @@ function runTests(mode) {
         () => browser.eval(`document.getElementById("msg8").textContent`),
         'loaded 1 img8 with dimensions 640x373'
       )
+      await check(
+        () =>
+          browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          ),
+        'intrinsic'
+      )
       await browser.eval('document.getElementById("toggle").click()')
       await check(
         () => browser.eval(`document.getElementById("msg8").textContent`),
         'loaded 2 img8 with dimensions 400x300'
+      )
+      await check(
+        () =>
+          browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          ),
+        'fixed'
       )
     } finally {
       if (browser) {

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -213,27 +213,31 @@ function runTests(mode) {
       )
       await check(
         () => browser.eval(`document.getElementById("msg1").textContent`),
-        'loaded img1 with dimensions 128x128'
+        'loaded 1 img1 with dimensions 128x128'
       )
       await check(
         () => browser.eval(`document.getElementById("msg2").textContent`),
-        'loaded img2 with dimensions 400x400'
+        'loaded 1 img2 with dimensions 400x400'
       )
       await check(
         () => browser.eval(`document.getElementById("msg3").textContent`),
-        'loaded img3 with dimensions 266x266'
+        'loaded 1 img3 with dimensions 266x266'
       )
       await check(
         () => browser.eval(`document.getElementById("msg4").textContent`),
-        'loaded img4 with dimensions 21x21'
+        'loaded 1 img4 with dimensions 21x21'
       )
       await check(
         () => browser.eval(`document.getElementById("msg5").textContent`),
-        'loaded img5 with dimensions 3x5'
+        'loaded 1 img5 with dimensions 3x5'
       )
       await check(
         () => browser.eval(`document.getElementById("msg6").textContent`),
-        'loaded img6 with dimensions 3x5'
+        'loaded 1 img6 with dimensions 3x5'
+      )
+      await check(
+        () => browser.eval(`document.getElementById("msg7").textContent`),
+        'loaded 1 img7 with dimensions 200x200'
       )
     } finally {
       if (browser) {


### PR DESCRIPTION
The image prop `onLoadingComplete()` was unexpectedly called multiple times because it uses a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs).

This could lead to an infinite loop if `onLoadingComplete()` calls `setState()` as demonstrated in the updated test.

The solution is to handle refs with `useRef()` and `useEffect` so `onLoadingComplete()` is called at most once per component instance.

- Fixes #33463 