### PR TITLE
Clarify `headers` config option description

### DIFF
--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -21,7 +21,7 @@ description: Add custom HTTP headers to your Next.js app.
 
 </details>
 
-Headers allow you to set custom HTTP headers for an incoming request path.
+Headers allow you to set custom HTTP headers on the response to an incoming request on a given path.
 
 To set custom HTTP headers you can use the `headers` key in `next.config.js`:
 
@@ -50,7 +50,7 @@ module.exports = {
 `headers` is an async function that expects an array to be returned holding objects with `source` and `headers` properties:
 
 - `source` is the incoming request path pattern.
-- `headers` is an array of header objects with the `key` and `value` properties.
+- `headers` is an array of headers to add to the response - each header is an object with `key` and `value` properties.
 - `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.

--- a/docs/api-reference/next.config.js/headers.md
+++ b/docs/api-reference/next.config.js/headers.md
@@ -50,7 +50,7 @@ module.exports = {
 `headers` is an async function that expects an array to be returned holding objects with `source` and `headers` properties:
 
 - `source` is the incoming request path pattern.
-- `headers` is an array of headers to add to the response - each header is an object with `key` and `value` properties.
+- `headers` is an array of response header objects, with `key` and `value` properties.
 - `basePath`: `false` or `undefined` - if false the basePath won't be included when matching, can be used for external rewrites only.
 - `locale`: `false` or `undefined` - whether the locale should not be included when matching.
 - `has` is an array of [has objects](#header-cookie-and-query-matching) with the `type`, `key` and `value` properties.


### PR DESCRIPTION
Reading over this page, it wasn't immediately clear to me if these were headers which would get read off of the incoming request, or headers to be added to the outgoing response.



## Documentation / Examples

- [X] Make sure the linting passes by running `yarn lint`
