### PR TITLE
Update middleware documentation for custom server

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -81,13 +81,12 @@ Middleware uses a [strict runtime](/docs/api-reference/edge-runtime.md) that sup
 When using a custom server with middleware, you must specify the hostname and port when instantiating your `NextApp`.
 
 ```ts
-import next from "next";
+import next from 'next'
 // ...
-const port = process.env.PORT ? +process.env.PORT : 3000;
-const dev = process.env.NODE_ENV !== "production";
-const app = next({ dev, customServer: true, hostname: "localhost", port });
+const port = process.env.PORT ? +process.env.PORT : 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev, customServer: true, hostname: 'localhost', port })
 ```
-
 
 ## Related
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -76,7 +76,7 @@ Middleware runs directly after `redirects` and `headers`, before the first files
 
 Middleware uses a [strict runtime](/docs/api-reference/edge-runtime.md) that supports standard Web APIs like `fetch`. This works out of the box using `next start`, as well as on Edge platforms like Vercel, which use [Edge Functions](http://www.vercel.com/edge).
 
-## Custom server
+## Custom Server
 
 When using a custom server with middleware, you must specify the hostname and port when instantiating your `NextApp`.
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -76,6 +76,19 @@ Middleware runs directly after `redirects` and `headers`, before the first files
 
 Middleware uses a [strict runtime](/docs/api-reference/edge-runtime.md) that supports standard Web APIs like `fetch`. This works out of the box using `next start`, as well as on Edge platforms like Vercel, which use [Edge Functions](http://www.vercel.com/edge).
 
+## Custom server
+
+When using a custom server with middleware, you must specify the hostname and port when instantiating your `NextApp`.
+
+```ts
+import next from "next";
+// ...
+const port = process.env.PORT ? +process.env.PORT : 3000;
+const dev = process.env.NODE_ENV !== "production";
+const app = next({ dev, customServer: true, hostname: "localhost", port });
+```
+
+
 ## Related
 
 <div class="card">


### PR DESCRIPTION
Upgrading from 12.0.0 to 12.0.8 results in `[dev] error - Error: To use middleware you must provide a `hostname` and `port` to the Next.js Server` and this requirement did not seem to be documented anywhere. Fixes #33450 which seems to have been erroneously closed.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [X] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
