### PR TITLE
Implement abstract methods to get manifest files in the base server

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -27,8 +27,6 @@ import { format as formatUrl, parse as parseUrl } from 'url'
 import { getRedirectStatus, modifyRouteRegex } from '../lib/load-custom-routes'
 import {
   CLIENT_PUBLIC_FILES_PATH,
-  PRERENDER_MANIFEST,
-  ROUTES_MANIFEST,
   SERVERLESS_DIRECTORY,
   SERVER_DIRECTORY,
   STATIC_STATUS_PAGES,

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -213,6 +213,8 @@ export default abstract class Server {
   protected abstract getPagePath(pathname: string, locales?: string[]): string
   protected abstract getFontManifest(): FontManifest | undefined
   protected abstract getMiddlewareManifest(): MiddlewareManifest | undefined
+  protected abstract getPrerenderManifest(): PrerenderManifest
+  protected abstract getRoutesManifest(): CustomRoutes
 
   protected abstract sendRenderResult(
     req: BaseNextRequest,
@@ -623,7 +625,7 @@ export default abstract class Server {
   }
 
   protected getCustomRoutes(): CustomRoutes {
-    const customRoutes = require(join(this.distDir, ROUTES_MANIFEST))
+    const customRoutes = this.getRoutesManifest()
     let rewrites: CustomRoutes['rewrites']
 
     // rewrites can be stored as an array when an array is
@@ -639,15 +641,6 @@ export default abstract class Server {
       rewrites = customRoutes.rewrites
     }
     return Object.assign(customRoutes, { rewrites })
-  }
-
-  private _cachedPreviewManifest: PrerenderManifest | undefined
-  protected getPrerenderManifest(): PrerenderManifest {
-    if (this._cachedPreviewManifest) {
-      return this._cachedPreviewManifest
-    }
-    const manifest = require(join(this.distDir, PRERENDER_MANIFEST))
-    return (this._cachedPreviewManifest = manifest)
   }
 
   protected getPreviewProps(): __ApiPreviewProps {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -4,6 +4,7 @@ import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plu
 import type RenderResult from './render-result'
 import type { FetchEventResult } from './web/types'
 import type { ParsedNextUrl } from '../shared/lib/router/utils/parse-next-url'
+import type { PrerenderManifest } from '../build'
 
 import { execOnce } from '../shared/lib/utils'
 import {
@@ -24,6 +25,8 @@ import {
   MIDDLEWARE_MANIFEST,
   CLIENT_STATIC_FILES_PATH,
   CLIENT_STATIC_FILES_RUNTIME,
+  PRERENDER_MANIFEST,
+  ROUTES_MANIFEST,
 } from '../shared/lib/constants'
 import { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
 import { recursiveReadDirSync } from './lib/recursive-readdir-sync'
@@ -1068,5 +1071,18 @@ export default class NextNodeServer extends BaseServer {
     }
 
     return result
+  }
+
+  private _cachedPreviewManifest: PrerenderManifest | undefined
+  protected getPrerenderManifest(): PrerenderManifest {
+    if (this._cachedPreviewManifest) {
+      return this._cachedPreviewManifest
+    }
+    const manifest = require(join(this.distDir, PRERENDER_MANIFEST))
+    return (this._cachedPreviewManifest = manifest)
+  }
+
+  protected getRoutesManifest() {
+    return require(join(this.distDir, ROUTES_MANIFEST))
   }
 }


### PR DESCRIPTION
Related to #31506, this PR adds `getPrerenderManifest` and `getRoutesManifest` methods to provide manifest files to the base server. In the future, we can consider making these methods async, or provide necessary manifests from the very top.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
