### PR TITLE
Simplify getMiddlewareInfo calls

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -136,6 +136,7 @@ export default abstract class Server {
   protected nextConfig: NextConfigComplete
   protected distDir: string
   protected pagesDir?: string
+  protected publicDir: string
   protected hasStaticDir: boolean
   protected pagesManifest?: PagesManifest
   protected buildId: string
@@ -177,6 +178,7 @@ export default abstract class Server {
   public readonly hostname?: string
   public readonly port?: number
 
+  protected abstract getPublicDir(): string
   protected abstract getHasStaticDir(): boolean
   protected abstract getPagesManifest(): PagesManifest | undefined
   protected abstract getBuildId(): string
@@ -291,6 +293,7 @@ export default abstract class Server {
     this.hostname = hostname
     this.port = port
     this.distDir = join(this.dir, this.nextConfig.distDir)
+    this.publicDir = this.getPublicDir()
     this.hasStaticDir = !minimalMode && this.getHasStaticDir()
 
     // Only serverRuntimeConfig needs the default

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -89,9 +89,6 @@ export interface NodeRequestHandler {
 }
 
 export default class NextNodeServer extends BaseServer {
-  protected publicDir: string
-  protected serverBuildDir: string
-
   constructor(options: Options) {
     super(options)
     /**
@@ -109,12 +106,6 @@ export default class NextNodeServer extends BaseServer {
     if (this.renderOpts.optimizeCss) {
       process.env.__NEXT_OPTIMIZE_CSS = JSON.stringify(true)
     }
-
-    this.publicDir = join(this.dir, CLIENT_PUBLIC_FILES_PATH)
-    this.serverBuildDir = join(
-      this.distDir,
-      this._isLikeServerless ? SERVERLESS_DIRECTORY : SERVER_DIRECTORY
-    )
   }
 
   private compression =
@@ -126,12 +117,20 @@ export default class NextNodeServer extends BaseServer {
     loadEnvConfig(this.dir, dev, Log)
   }
 
+  protected getPublicDir(): string {
+    return join(this.dir, CLIENT_PUBLIC_FILES_PATH)
+  }
+
   protected getHasStaticDir(): boolean {
     return fs.existsSync(join(this.dir, 'static'))
   }
 
   protected getPagesManifest(): PagesManifest | undefined {
-    const pagesManifestPath = join(this.serverBuildDir, PAGES_MANIFEST)
+    const serverBuildDir = join(
+      this.distDir,
+      this._isLikeServerless ? SERVERLESS_DIRECTORY : SERVER_DIRECTORY
+    )
+    const pagesManifestPath = join(serverBuildDir, PAGES_MANIFEST)
     return require(pagesManifestPath)
   }
 


### PR DESCRIPTION
Subtask of #31506

* move `serverBuildDir` and getter function of `publicDir` to next-server as only used place
* simplify `getMiddlewareInfo`, remove `distDir` and other params could be accessed from web server itself