### PR TITLE
Ensure optional value normalizing is correct for index

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -510,7 +510,9 @@ export default abstract class Server {
             }
 
             if (params) {
-              params = utils.normalizeDynamicRouteParams(params).params
+              if (!paramsResult.hasValidParams) {
+                params = utils.normalizeDynamicRouteParams(params).params
+              }
 
               matchedPathname = utils.interpolateDynamicPath(
                 matchedPathname,

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -671,6 +671,23 @@ describe('should set-up next', () => {
     expect(json.url).toBe('/api/optional?another=value')
   })
 
+  it('should normalize index optional values correctly for API page', async () => {
+    const res = await fetchViaHTTP(
+      appPort,
+      '/api/optional/index',
+      { rest: 'index', another: 'value' },
+      {
+        headers: {
+          'x-matched-path': '/api/optional/[[...rest]]',
+        },
+      }
+    )
+
+    const json = await res.json()
+    expect(json.query).toEqual({ another: 'value', rest: ['index'] })
+    expect(json.url).toBe('/api/optional/index?another=value')
+  })
+
   it('should match the index page correctly', async () => {
     const res = await fetchViaHTTP(appPort, '/', undefined, {
       headers: {


### PR DESCRIPTION
This fixes a case where optional catch-all route values aren't normalized to an array properly when the `index` value is passed. An additional test case has been added to prevent regressing on this. 

x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1642791113093400)

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

