### PR TITLE
Removed the s from NextConfig

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -61,8 +61,8 @@ export type NextConfig = { [key: string]: any } & {
   redirects?: () => Promise<Redirect[]>
 
   /**
-  * @deprecated This option has been removed as webpack 5 is now default 
-  */
+   * @deprecated This option has been removed as webpack 5 is now default
+   */
   webpack5?: false
   excludeDefaultMomentLocales?: boolean
 

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -116,7 +116,7 @@ export type NextConfig = { [key: string]: any } & {
   httpAgentOptions?: { keepAlive?: boolean }
   future?: {
     /**
-     * @deprecated this options was moved to the top level
+     * @deprecated This option was moved to the top level
      */
     webpack5?: false
   }

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -116,7 +116,7 @@ export type NextConfig = { [key: string]: any } & {
   httpAgentOptions?: { keepAlive?: boolean }
   future?: {
     /**
-     * @deprecated This option was moved to the top level
+     * @deprecated This option has been removed as webpack 5 is now default
      */
     webpack5?: false
   }

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -60,6 +60,9 @@ export type NextConfig = { [key: string]: any } & {
   >
   redirects?: () => Promise<Redirect[]>
 
+  /**
+  * @deprecated This option has been removed as webpack 5 is now default 
+  */
   webpack5?: false
   excludeDefaultMomentLocales?: boolean
 


### PR DESCRIPTION
Removed the s of NextConfig
"This option was moved to the top level"
was before: "this options was moved to the top level"

## Documentation / Examples

- [X] Make sure the linting passes by running `yarn lint`

Just a little change, I mean I just saw it and it stressed me :)

Maybe you meant "These options were moved to the top level", but because there is only one option for now, I think without s , it makes more sense
