### PR TITLE
Allow to delete URL search params in middleware rewrites

### DIFF
--- a/errors/deleting-query-params-in-middlewares.md
+++ b/errors/deleting-query-params-in-middlewares.md
@@ -1,0 +1,35 @@
+# Deleting Query Parameters In Middlewares
+
+#### Why This Error Occurred
+
+In previous versions of Next.js, we were merging query parameters with the incoming request for rewrites happening in middlewares, to match the behavior of static rewrites declared in the config. This forced Next.js users to use empty query parameters values to delete keys.
+
+We are changing this behavior to allow extra flexibility and a more streamlined experience for users. So from now on, query parameters will not be merged and thus the warning.
+
+```typescript
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  const nextUrl = request.nextUrl
+  nextUrl.searchParams.delete('key') // this is now possible! 🎉
+  return NextResponse.rewrite(nextUrl)
+}
+```
+
+#### Possible Ways to Fix It
+
+If you are relying on the old behavior, please add the query parameters manually to the rewritten URL. Using `request.nextUrl` would do that automatically for you.
+
+```typescript
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  const nextUrl = request.nextUrl
+  nextUrl.pathname = '/dest'
+  return NextResponse.rewrite(url)
+}
+```
+
+This warning will be removed in a next version of Next.js.

--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -531,6 +531,10 @@
         {
           "title": "middleware-relative-urls",
           "path": "/errors/middleware-relative-urls.md"
+        },
+        {
+          "title": "deleting-query-params-in-middlewares",
+          "path": "/errors/deleting-query-params-in-middlewares.md"
         }
       ]
     }

--- a/packages/next/server/request-meta.ts
+++ b/packages/next/server/request-meta.ts
@@ -53,16 +53,43 @@ export function addRequestMeta<K extends keyof RequestMeta>(
   return setRequestMeta(request, meta)
 }
 
-export type NextParsedUrlQuery = ParsedUrlQuery & {
+type NextQueryMetadata = {
   __nextDefaultLocale?: string
   __nextFallback?: 'true'
   __nextLocale?: string
   __nextSsgPath?: string
   _nextBubbleNoFallback?: '1'
   _nextDataReq?: '1'
-  amp?: '1'
 }
+
+export type NextParsedUrlQuery = ParsedUrlQuery &
+  NextQueryMetadata & {
+    amp?: '1'
+  }
 
 export interface NextUrlWithParsedQuery extends UrlWithParsedQuery {
   query: NextParsedUrlQuery
+}
+
+export function getNextInternalQuery(
+  query: NextParsedUrlQuery
+): NextQueryMetadata {
+  const keysToInclude: (keyof NextQueryMetadata)[] = [
+    '__nextDefaultLocale',
+    '__nextFallback',
+    '__nextLocale',
+    '__nextSsgPath',
+    '_nextBubbleNoFallback',
+    '_nextDataReq',
+  ]
+  const nextInternalQuery: NextQueryMetadata = {}
+
+  for (const key of keysToInclude) {
+    if (key in query) {
+      // @ts-ignore this can't be typed correctly
+      nextInternalQuery[key] = query[key]
+    }
+  }
+
+  return nextInternalQuery
 }

--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -1,5 +1,5 @@
 import type { ParsedUrlQuery } from 'querystring'
-import type { NextUrlWithParsedQuery } from './request-meta'
+import { getNextInternalQuery, NextUrlWithParsedQuery } from './request-meta'
 
 import pathMatch from '../shared/lib/router/utils/path-match'
 import { removePathTrailingSlash } from '../client/normalize-trailing-slash'
@@ -400,7 +400,7 @@ export default class Router {
 
         if (result.query) {
           parsedUrlUpdated.query = {
-            ...parsedUrlUpdated.query,
+            ...getNextInternalQuery(parsedUrlUpdated.query),
             ...result.query,
           }
         }

--- a/test/integration/middleware/core/pages/rewrites/_middleware.js
+++ b/test/integration/middleware/core/pages/rewrites/_middleware.js
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server'
 
+/**
+ * @param {import('next/server').NextRequest} request
+ */
 export async function middleware(request) {
   const url = request.nextUrl
 
@@ -30,6 +33,16 @@ export async function middleware(request) {
 
   if (url.pathname === '/rewrites/rewrite-me-to-vercel') {
     return NextResponse.rewrite('https://vercel.com')
+  }
+
+  if (url.pathname === '/rewrites/clear-query-params') {
+    const allowedKeys = ['allowed']
+    for (const key of [...url.searchParams.keys()]) {
+      if (!allowedKeys.includes(key)) {
+        url.searchParams.delete(key)
+      }
+    }
+    return NextResponse.rewrite(url)
   }
 
   if (url.pathname === '/rewrites/rewrite-me-without-hard-navigation') {

--- a/test/integration/middleware/core/pages/rewrites/clear-query-params.js
+++ b/test/integration/middleware/core/pages/rewrites/clear-query-params.js
@@ -1,0 +1,12 @@
+export default function ClearQueryParams(props) {
+  return <pre id="my-query-params">{JSON.stringify(props.query)}</pre>
+}
+
+/** @type {import('next').GetServerSideProps} */
+export const getServerSideProps = (req) => {
+  return {
+    props: {
+      query: { ...req.query },
+    },
+  }
+}

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -212,6 +212,24 @@ function rewriteTests(locale = '') {
     expect($('.title').text()).toBe(expectedText)
   })
 
+  it(`${locale} should clear query parameters`, async () => {
+    const res = await fetchViaHTTP(
+      context.appPort,
+      `${locale}/rewrites/clear-query-params`,
+      {
+        a: '1',
+        b: '2',
+        foo: 'bar',
+        allowed: 'kept',
+      }
+    )
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    expect(JSON.parse($('#my-query-params').text())).toEqual({
+      allowed: 'kept',
+    })
+  })
+
   it(`${locale} should rewrite to about page`, async () => {
     const res = await fetchViaHTTP(
       context.appPort,


### PR DESCRIPTION
This allows to have a more streamlined API for rewrites.
Since middlewares are code and not static configurations, we can allow people to
delete query params and not just overwrite them.

**⚠️ Warning ⚠️** this is a breaking change in query parameter behavior with middlewares, but the API will make more sense now. Compare the following:

```diff
  import {NextResponse} from 'next/server'
  export default function middleware({ nextUrl }) {
-   nextUrl.searchParams.set('ignored-query-param', '');
+   nextUrl.searchParams.delete('ignored-query-param'); // 🎉
    return NextResponse.rewrite(nextUrl);
  }
```

Since this is a breaking change, we're adding a warning every time we find a query param that is missing, and eventually--the warning will be deleted.

Related:
* This is the opposite of #33454

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
-->
