### PR TITLE
Removed unrequired path in docs' manifest

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -15,7 +15,6 @@
             },
             {
               "title": "Data Fetching",
-              "path": "/docs/basic-features/data-fetching/index.md",
               "routes": [
                 {
                   "title": "Overview",


### PR DESCRIPTION
Minor change to remove duplicated route in the documentation manifest, this should change the title of https://nextjs.org/docs/basic-features/data-fetching/index from

![image](https://user-images.githubusercontent.com/4278345/150690965-8f3faf8f-715c-44a5-8ccf-3d6c21f8c9ec.png)

To: `Data Fetching: Overview | Next.js`. That's because our routes reducer is matching the parent route which doesn't have a title.