### PR TITLE
Fix rsc export component name detection

### DIFF
--- a/packages/next/build/webpack/loaders/next-flight-server-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-server-loader.ts
@@ -43,7 +43,7 @@ async function parseImportsInfo(
 
   let transformedSource = ''
   let lastIndex = 0
-  let defaultExportName = 'RSComponent'
+  let defaultExportName = 'RSCComponent'
 
   for (let i = 0; i < body.length; i++) {
     const node = body[i]
@@ -89,7 +89,12 @@ async function parseImportsInfo(
         continue
       }
       case 'ExportDefaultDeclaration': {
-        defaultExportName = node.declaration.id.name
+        const def = node.declaration
+        if (def.type === 'Identifier') {
+          defaultExportName = def.name
+        } else if (def.type === 'FunctionDeclaration') {
+          defaultExportName = def.id.name
+        }
         break
       }
       default:

--- a/test/integration/react-streaming-and-server-components/app/pages/next-api/image.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/next-api/image.server.js
@@ -1,6 +1,9 @@
 import NextImage from 'next/image'
 import src from '../../public/test.jpg'
 
-export default function Image() {
+// Keep arrow function to test rsc loaders
+const Page = () => {
   return <NextImage src={src} />
 }
+
+export default Page


### PR DESCRIPTION
## Bug

Related to #33604 when using an anonymous function export, rsc loader parsing will fail

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`
