### PR TITLE
Ensure fetch polyfill is loaded in next-server

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1,3 +1,4 @@
+import '../server/node-polyfill-fetch'
 import chalk from 'next/dist/compiled/chalk'
 import getGzipSize from 'next/dist/compiled/gzip-size'
 import textTable from 'next/dist/compiled/text-table'

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1,3 +1,4 @@
+import './node-polyfill-fetch'
 import type { Params, Route } from './router'
 import type { CacheFs } from '../shared/lib/utils'
 import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'

--- a/test/production/required-server-files/pages/api/optional/[[...rest]].js
+++ b/test/production/required-server-files/pages/api/optional/[[...rest]].js
@@ -1,7 +1,9 @@
-export default (req, res) => {
+export default async (req, res) => {
   console.log(req.url, 'query', req.query)
   res.json({
     url: req.url,
     query: req.query,
+    // make sure fetch if polyfilled
+    example: await fetch('https://example.com').then((res) => res.text()),
   })
 }

--- a/test/production/required-server-files/pages/fallback/[slug].js
+++ b/test/production/required-server-files/pages/fallback/[slug].js
@@ -10,7 +10,10 @@ export const getStaticProps = ({ params }) => {
   }
 }
 
-export const getStaticPaths = () => {
+export const getStaticPaths = async () => {
+  // make sure fetch if polyfilled
+  await fetch('https://example.com').then((res) => res.text())
+
   return {
     paths: ['/fallback/first'],
     fallback: true,

--- a/test/production/required-server-files/pages/gssp.js
+++ b/test/production/required-server-files/pages/gssp.js
@@ -19,6 +19,8 @@ export async function getServerSideProps({ res }) {
     props: {
       hello: 'world',
       data,
+      // make sure fetch if polyfilled
+      example: await fetch('https://example.com').then((res) => res.text()),
     },
   }
 }


### PR DESCRIPTION
In https://github.com/vercel/next.js/pull/33395 we removed the `fetch` polyfill from `base-server` but it still needs to be loaded in `next-server` so this ensures it's added there and this also fixes the case where the shared worker pool is disabled so the `fetch` polyfill isn't loaded in `build/utils`. This also adds test cases to the isolated suite that leverage fetch in current failing ways. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

