### PR TITLE
make HTML props available for function document component

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1272,7 +1272,9 @@ export async function renderToHTML(
 
       return {
         bodyResult,
-        documentElement: () => (Document as any)(),
+        documentElement: (htmlProps: HtmlProps) => (
+          <Document {...(htmlProps as any)} />
+        ),
         head,
         headTags: [],
         styles: jsxStyleRegistry.styles(),


### PR DESCRIPTION
For the `concurrentFeatures` rollout we need to change our document to not have `.getInitialProps()` but we do still need the `htmlProps` in the render method. This PR adds the `htmlProps` to the `renderElement()` function.

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using (https://github.com/vercel/next.js/issues/31225)
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`
