### PR TITLE
REMOVE: duplicate key in docs/testing.md

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -341,7 +341,6 @@ module.exports = {
     '/node_modules/',
     '^.+\\.module\\.(css|sass|scss)$',
   ],
-  testEnvironment: 'jest-environment-jsdom',
 }
 ```
 


### PR DESCRIPTION
There is a duplicate key, `testEnvironment` in one of the examples that are located in docs/testing.md.
In my humble opinion, It is not good to have an error in examples.
My suggestion is we have only one key and it is up to developers what options they have for the `testEnvironment`.

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
