### PR TITLE
Revert 33699 revert 33240 relay plugin

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1015,7 +1015,7 @@ jobs:
 
       - name: 'Build'
         run: |
-          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder sh -c "npm i -g @napi-rs/cli@1.2.1 && npm i -g turbo@1.0.28 && turbo run build-native --cache-dir=".turbo" -- --release --target x86_64-unknown-linux-musl"
+          docker run --rm -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry -v $(pwd):/build -w /build builder sh -c "npm i -g @napi-rs/cli@1.2.1 && npm i -g turbo@1.0.28 && turbo run build-native --cache-dir=".turbo" -- --release --target x86_64-unknown-linux-musl --features vendored"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -1137,7 +1137,7 @@ jobs:
             turbo-${{ github.job }}-canary-${{ needs.build.outputs.weekNum }}-
 
       - name: Cross build aarch64
-        run: turbo run build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-musl
+        run: turbo run build-native --cache-dir=".turbo" -- --release --target aarch64-unknown-linux-musl --features vendored
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -38,4 +38,5 @@ swc_ecma_transforms_testing = "0.59.0"
 testing = "0.18.0"
 walkdir = "2.3.2"
 
-
+[features]
+vendored = ["hyper-tls/vendored"]


### PR DESCRIPTION
I'm not really sure if this will help with the build issues on `linux` with the recent `relay` addition (Relay Support in Rust Compiler #33702). But I think these features fixed build for us.

