### PR TITLE
fix: use github action instead of bot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,6 +1,0 @@
-# Configuration for lock-threads - https://github.com/dessant/lock-threads
-
-# Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 30
-# Comment to post before locking. Set to `false` to disable
-lockComment: 'This issue has been automatically locked due to no recent activity. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3
+        github-token: ${{ secrets.LOCK_TOKEN }}
         issue-inactive-days: 30
         issue-comment: 'This issue has been automatically locked due to no recent activity. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'
         pr-inactive-days: 30

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,22 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        issue-inactive-days: 30
+        issue-comment: 'This issue has been automatically locked due to no recent activity. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'
+        pr-inactive-days: 30

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: dessant/lock-threads@v3
         github-token: ${{ secrets.LOCK_TOKEN }}
         issue-inactive-days: 30
-        issue-comment: 'This issue has been automatically locked due to no recent activity. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'
+        issue-comment: 'This issue has been automatically locked due to no recent activity. If you are running into a similar issue, please create a new issue with the steps to reproduce. Thank you.'
         pr-inactive-days: 30

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,6 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
+    # This runs every hour: https://crontab.guru/every-1-hour
     - cron: '0 * * * *'
   workflow_dispatch:
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
         id: stale
         name: 'Close stale issues with no reproduction'
         with:
+          repo-token: ${{ secrets.STALE_TOKEN }}
           only-labels: 'please add a complete reproduction'
           close-issue-message: 'This issue has been automatically closed after 30 days of inactivity with no reproduction. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'
           days-before-issue-close: 1
@@ -19,3 +20,4 @@ jobs:
           days-before-pr-close: -1
           days-before-pr-stale: -1
           exempt-issue-labels: 'blocked,must,should,keep'
+          operation-per-run: 300 # 1 operation per 100 issues, the rest is to label/comment/close

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: 'Stale issue handler'
 on:
   workflow_dispatch:
   schedule:
+    # This runs every day 20 minutes before midnight: https://crontab.guru/#40_23_*_*_*
     - cron: '40 23 * * *'
 
 jobs:


### PR DESCRIPTION
The current workflow did not actually work anymore, since the bot was deprecated, and migration has been advised: https://github.com/dessant/lock-threads/issues/30

This action will run hourly to scan for inactive closed issues/PRs. (There are many, so running it hourly is reasonable)

This PR also increases the operations allowed for the Stale action. from 30 to 300. That should cover all of our issues/PRs currently.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
