### PR TITLE
Move custom server note from middleware doc

### DIFF
--- a/docs/advanced-features/custom-server.md
+++ b/docs/advanced-features/custom-server.md
@@ -28,10 +28,11 @@ const { createServer } = require('http')
 const { parse } = require('url')
 const next = require('next')
 
-const port = 3000
 const dev = process.env.NODE_ENV !== 'production'
+const hostname = 'localhost'
+const port = 3000
 // when using middleware `hostname` and `port` must be provided below
-const app = next({ dev, hostname: 'localhost', port })
+const app = next({ dev, hostname, port })
 const handle = app.getRequestHandler()
 
 app.prepare().then(() => {

--- a/docs/advanced-features/custom-server.md
+++ b/docs/advanced-features/custom-server.md
@@ -51,7 +51,7 @@ app.prepare().then(() => {
     }
   }).listen(port, (err) => {
     if (err) throw err
-    console.log(`> Ready on http://localhost:${port}`)
+    console.log(`> Ready on http://${hostname}:${port}`)
   })
 })
 ```

--- a/docs/advanced-features/custom-server.md
+++ b/docs/advanced-features/custom-server.md
@@ -28,8 +28,10 @@ const { createServer } = require('http')
 const { parse } = require('url')
 const next = require('next')
 
+const port = 3000
 const dev = process.env.NODE_ENV !== 'production'
-const app = next({ dev })
+// when using middleware `hostname` and `port` must be provided below
+const app = next({ dev, hostname: 'localhost', port })
 const handle = app.getRequestHandler()
 
 app.prepare().then(() => {
@@ -46,9 +48,9 @@ app.prepare().then(() => {
     } else {
       handle(req, res, parsedUrl)
     }
-  }).listen(3000, (err) => {
+  }).listen(port, (err) => {
     if (err) throw err
-    console.log('> Ready on http://localhost:3000')
+    console.log(`> Ready on http://localhost:${port}`)
   })
 })
 ```

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -76,18 +76,6 @@ Middleware runs directly after `redirects` and `headers`, before the first files
 
 Middleware uses a [strict runtime](/docs/api-reference/edge-runtime.md) that supports standard Web APIs like `fetch`. This works out of the box using `next start`, as well as on Edge platforms like Vercel, which use [Edge Functions](http://www.vercel.com/edge).
 
-## Custom Server
-
-When using a custom server with middleware, you must specify the hostname and port when instantiating your `NextApp`.
-
-```ts
-import next from 'next'
-// ...
-const port = process.env.PORT ? +process.env.PORT : 3000
-const dev = process.env.NODE_ENV !== 'production'
-const app = next({ dev, customServer: true, hostname: 'localhost', port })
-```
-
 ## Related
 
 <div class="card">


### PR DESCRIPTION
This moves the note about custom server handling for middleware to the custom server document. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

x-ref: https://github.com/vercel/next.js/pull/33535#discussion_r790110427