### PR TITLE
install musl-tools

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1064,7 +1064,7 @@ jobs:
       - name: Install cross compile toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
+          sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu musl-tools -y
 
       - name: Turbo Cache
         id: turbo-cache
@@ -1124,7 +1124,7 @@ jobs:
       - name: Install cross compile toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install gcc-aarch64-linux-gnu -y
+          sudo apt-get install gcc-aarch64-linux-gnu musl-tools -y
 
       - name: Turbo Cache
         id: turbo-cache


### PR DESCRIPTION
While I'm working on the changes in `relay-compiler` let's see if this helps unblock builds on linux.

This change is similar to what we've added here: https://github.com/facebook/relay/commit/f1435c3e3fd269ed48ab57807363945008075c38