### PR TITLE
Ensure non-error thrown in getStaticPaths shows correctly

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1029,7 +1029,7 @@ export default async function build(
                   )
                 }
               } catch (err) {
-                if (isError(err) && err.message !== 'INVALID_DEFAULT_EXPORT')
+                if (!isError(err) || err.message !== 'INVALID_DEFAULT_EXPORT')
                   throw err
                 invalidPages.add(page)
               }

--- a/test/integration/invalid-page-automatic-static-optimization/test/index.test.js
+++ b/test/integration/invalid-page-automatic-static-optimization/test/index.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 
+import fs from 'fs-extra'
 import path from 'path'
 import { nextBuild } from 'next-test-utils'
 
@@ -14,5 +15,44 @@ describe('Invalid Page automatic static optimization', () => {
     )
     expect(stderr).toMatch(/pages\/invalid/)
     expect(stderr).toMatch(/pages\/also-invalid/)
+  })
+
+  it('handles non-error correctly', async () => {
+    const testPage = path.join(appDir, 'pages/[slug].js')
+    await fs.rename(path.join(appDir, 'pages'), path.join(appDir, 'pages-bak'))
+
+    await fs.ensureDir(path.join(appDir, 'pages'))
+    await fs.writeFile(
+      testPage,
+      `
+      export default function Page() {
+        return <p>hello world</p>
+      }
+      
+      export function getStaticPaths() {
+        throw 'invalid API token'
+      }
+      
+      export function getStaticProps() {
+        return {
+          props: {
+            hello: 'world'
+          }
+        }
+      }
+    `
+    )
+
+    try {
+      const { stderr } = await nextBuild(appDir, [], { stderr: true })
+      expect(stderr).toMatch(/invalid API token/)
+      expect(stderr).not.toMatch(/without a React Component/)
+    } finally {
+      await fs.remove(path.join(appDir, 'pages'))
+      await fs.rename(
+        path.join(appDir, 'pages-bak'),
+        path.join(appDir, 'pages')
+      )
+    }
   })
 })


### PR DESCRIPTION
This ensures if a string error `throw 'invalid API token'` is thrown inside of `getStaticPaths` that we properly show the error instead of showing an unrelated non-default React component export warning. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/C0290CZ3U6Q/p1643219956087600)