### PR TITLE
Fix: broken npm install

### DIFF
--- a/examples/with-supertokens/package.json
+++ b/examples/with-supertokens/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "supertokens-auth-react": "^0.18.0",
     "supertokens-node": "^8.1.0"
   },


### PR DESCRIPTION
Previous versions of react and next would mismatch and result in failing `npm i`


<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

CRITIACAL bug:
![image](https://user-images.githubusercontent.com/23448421/151566047-29f630a7-2885-489b-aea2-c4e9a75599ee.png)

