### PR TITLE
fix npm security vulnerability

### DIFF
--- a/examples/with-mdx-remote/package.json
+++ b/examples/with-mdx-remote/package.json
@@ -4,7 +4,8 @@
     "dev": "next",
     "dev:watch": "next-remote-watch ./posts",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "preinstall": "npx npm-force-resolutions"
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
@@ -13,5 +14,13 @@
     "next-remote-watch": "1.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-  }
+  },
+    "resolutions": {
+      "trim": "1.0.1",
+      "trim-off-newlines": "1.0.3"
+    },
+    "devDependencies": {
+      "trim": "1.0.1",
+      "trim-off-newlines": "1.0.3"
+    }
 }


### PR DESCRIPTION
My last PR got closed and they stated that node-fetch was no longer an issue due to the update to latest. Just to clarify, the previous that was closed and this current PR fixes the Regular Expression Denial of Service vulnerability in trim. I have updated it from the last PR and removed the unnecessary node-fetch fix. A screenshot of the audit is provided below:

<img width="878" alt="trimFix" src="https://user-images.githubusercontent.com/57104700/151724562-97051e55-4dfb-44e2-b411-8814f953989d.png">

