### PR TITLE
[Docs] Testing docs: Comment out optional config that points to a file

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -281,7 +281,8 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  // Add more setup options before each test is run
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
@@ -329,7 +330,8 @@ module.exports = {
     // Handle module aliases
     '^@/components/(.*)$': '<rootDir>/components/$1',
   },
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  // Add more setup options before each test is run
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
   testEnvironment: 'jsdom',
   transform: {


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

This prevents users who copy and paste the options without creating the associated file from experiencing an error. The option is explained in the Jest Docs and in the `Optional: Extend Jest with custom matchers` section.
