### PR TITLE
Add explicit client bootloader

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -508,17 +508,21 @@ export default async function getBaseWebpackConfig(
                 ).replace(/\\/g, '/'),
             }
           : {}),
-        [CLIENT_STATIC_FILES_RUNTIME_MAIN]:
-          `./` +
-          path
-            .relative(
-              dir,
-              path.join(
-                NEXT_PROJECT_ROOT_DIST_CLIENT,
-                dev ? `next-dev.js` : 'next.js'
-              )
-            )
-            .replace(/\\/g, '/'),
+        [CLIENT_STATIC_FILES_RUNTIME_MAIN]: `next-bootloader-loader?${stringify(
+          {
+            relativeMainPath:
+              `./` +
+              path
+                .relative(
+                  dir,
+                  path.join(
+                    NEXT_PROJECT_ROOT_DIST_CLIENT,
+                    dev ? `next-dev.js` : 'next.js'
+                  )
+                )
+                .replace(/\\/g, '/'),
+          }
+        )}!`,
       } as ClientEntries)
     : undefined
 
@@ -1153,6 +1157,7 @@ export default async function getBaseWebpackConfig(
         'noop-loader',
         'next-middleware-loader',
         'next-middleware-ssr-loader',
+        'next-bootloader-loader',
       ].reduce((alias, loader) => {
         // using multiple aliases to replace `resolveLoader.modules`
         alias[loader] = path.join(__dirname, 'webpack', 'loaders', loader)

--- a/packages/next/build/webpack/loaders/next-bootloader-loader.ts
+++ b/packages/next/build/webpack/loaders/next-bootloader-loader.ts
@@ -1,0 +1,15 @@
+import { stringifyRequest } from '../stringify-request'
+
+export type NextBootloaderLoaderOptions = {
+  relativeMainPath: string
+}
+
+export default function nextBootloaderLoader(this: any) {
+  const { relativeMainPath }: NextBootloaderLoaderOptions = this.getOptions()
+  const stringifiedMainPath = stringifyRequest(this, relativeMainPath)
+
+  return `
+        import { onBoot } from 'next/dist/client/bootloader'
+        onBoot(() => import(/* webpackMode: "eager" */${stringifiedMainPath}))
+    `
+}

--- a/packages/next/client/bootloader.ts
+++ b/packages/next/client/bootloader.ts
@@ -1,4 +1,4 @@
-type NextBootloadCommand = {}
+type NextBootloadCommand = [string]
 
 interface NextBootloader {
   push(command: NextBootloadCommand): number
@@ -20,9 +20,14 @@ export function onBoot(callback: () => void) {
 
   let didBoot = false
   const bootloader: NextBootloader = (window.__NEXT_BL = {
-    push(_: NextBootloadCommand) {
+    push(command: NextBootloadCommand) {
       if (!didBoot) {
         didBoot = true
+
+        assetPrefix = command[0] || ''
+        // @ts-ignore
+        __webpack_public_path__ = `${assetPrefix}/_next/` //eslint-disable-line
+
         callback()
       }
       return 0
@@ -30,4 +35,14 @@ export function onBoot(callback: () => void) {
   })
 
   queuedCommands.forEach((command) => bootloader.push(command))
+}
+
+let assetPrefix: string
+export function getAssetPrefix(): string {
+  if (!assetPrefix) {
+    throw new Error(
+      'invariant: getAssetPrefix() called before bootstrap. This is a bug in Next.js'
+    )
+  }
+  return assetPrefix
 }

--- a/packages/next/client/bootloader.ts
+++ b/packages/next/client/bootloader.ts
@@ -29,7 +29,5 @@ export function onBoot(callback: () => void) {
     },
   })
 
-  for (const command of queuedCommands) {
-    bootloader.push(command)
-  }
+  queuedCommands.forEach((command) => bootloader.push(command))
 }

--- a/packages/next/client/bootloader.ts
+++ b/packages/next/client/bootloader.ts
@@ -37,9 +37,9 @@ export function onBoot(callback: () => void) {
   queuedCommands.forEach((command) => bootloader.push(command))
 }
 
-let assetPrefix: string
+let assetPrefix: string | null = null
 export function getAssetPrefix(): string {
-  if (!assetPrefix) {
+  if (assetPrefix == null) {
     throw new Error(
       'invariant: getAssetPrefix() called before bootstrap. This is a bug in Next.js'
     )

--- a/packages/next/client/bootloader.ts
+++ b/packages/next/client/bootloader.ts
@@ -1,0 +1,35 @@
+type NextBootloadCommand = {}
+
+interface NextBootloader {
+  push(command: NextBootloadCommand): number
+}
+
+declare global {
+  interface Window {
+    __NEXT_BL: Array<NextBootloadCommand> | NextBootloader
+  }
+}
+
+export function onBoot(callback: () => void) {
+  const queuedCommands = window.__NEXT_BL
+  if (!Array.isArray(queuedCommands)) {
+    throw new Error(
+      'invariant: onBoot should only be called once. This is a bug in Next.js'
+    )
+  }
+
+  let didBoot = false
+  const bootloader: NextBootloader = (window.__NEXT_BL = {
+    push(_: NextBootloadCommand) {
+      if (!didBoot) {
+        didBoot = true
+        callback()
+      }
+      return 0
+    },
+  })
+
+  for (const command of queuedCommands) {
+    bootloader.push(command)
+  }
+}

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -35,6 +35,7 @@ import { createRouter, makePublicRouterInstance } from './router'
 import { getProperError } from '../lib/is-error'
 import { trackWebVitalMetric } from './vitals'
 import { RefreshContext } from './rsc/refresh'
+import { getAssetPrefix } from './bootloader'
 
 /// <reference types="react-dom/experimental" />
 
@@ -87,11 +88,6 @@ const {
 
 let { defaultLocale } = data
 
-const prefix: string = assetPrefix || ''
-
-// With dynamic assetPrefix it's no longer possible to set assetPrefix at the build time
-// So, this is how we do it in the client side at runtime
-__webpack_public_path__ = `${prefix}/_next/` //eslint-disable-line
 // Initialize next/config with the environment configuration
 setConfig({
   serverRuntimeConfig: {},
@@ -153,7 +149,7 @@ if (data.scriptLoader) {
 
 type RegisterFn = (input: [string, () => void]) => void
 
-const pageLoader: PageLoader = new PageLoader(buildId, prefix)
+const pageLoader: PageLoader = new PageLoader(buildId, getAssetPrefix())
 const register: RegisterFn = ([r, f]) =>
   pageLoader.routeLoader.onEntrypoint(r, f)
 if (window.__NEXT_P) {

--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -8,15 +8,12 @@ import {
   assign,
   urlQueryToSearchParams,
 } from '../shared/lib/router/utils/querystring'
+import { getAssetPrefix } from './bootloader'
 
-const {
-  __NEXT_DATA__: { assetPrefix },
-} = window
-
-const prefix = assetPrefix || ''
 const webpackHMR = initWebpackHMR()
 
-connectHMR({ assetPrefix: prefix, path: '/_next/webpack-hmr' })
+const assetPrefix = getAssetPrefix()
+connectHMR({ assetPrefix, path: '/_next/webpack-hmr' })
 
 if (!window._nextSetupHydrationWarning) {
   const origConsoleError = window.console.error
@@ -55,7 +52,7 @@ initNext({ webpackHMR })
 
     function devPagesManifestListener(event) {
       if (event.data.indexOf('devPagesManifest') !== -1) {
-        fetch(`${prefix}/_next/static/development/_devPagesManifest.json`)
+        fetch(`${assetPrefix}/_next/static/development/_devPagesManifest.json`)
           .then((res) => res.json())
           .then((manifest) => {
             window.__DEV_PAGES_MANIFEST = manifest

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -869,6 +869,7 @@ export class NextScript extends Component<OriginProps> {
                     dangerouslySetInnerHTML={{
                       __html: `(self.__NEXT_BL=self.__NEXT_BL||[]).push({})`,
                     }}
+                    data-ampdevmode
                   />
                 </>
               )}

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -844,6 +844,10 @@ export class NextScript extends Component<OriginProps> {
     // Must nest component to use custom hook
     const DeferrableNextScript = () => {
       const [, content] = useMaybeDeferContent('NEXT_SCRIPT', () => {
+        const bootloaderScript = `(self.__NEXT_BL=self.__NEXT_BL||[]).push(${JSON.stringify(
+          [assetPrefix]
+        )})`
+
         if (inAmpMode) {
           const ampDevFiles = [
             ...buildManifest.devFiles,
@@ -869,7 +873,7 @@ export class NextScript extends Component<OriginProps> {
                     nonce={this.props.nonce}
                     crossOrigin={this.props.crossOrigin || crossOrigin}
                     dangerouslySetInnerHTML={{
-                      __html: `(self.__NEXT_BL=self.__NEXT_BL||[]).push({})`,
+                      __html: bootloaderScript,
                     }}
                     data-ampdevmode
                   />
@@ -930,7 +934,7 @@ export class NextScript extends Component<OriginProps> {
                   nonce={this.props.nonce}
                   crossOrigin={this.props.crossOrigin || crossOrigin}
                   dangerouslySetInnerHTML={{
-                    __html: `(self.__NEXT_BL=self.__NEXT_BL||[]).push({})`,
+                    __html: bootloaderScript,
                   }}
                 />
               </>

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -866,6 +866,8 @@ export class NextScript extends Component<OriginProps> {
                     data-ampdevmode
                   />
                   <script
+                    nonce={this.props.nonce}
+                    crossOrigin={this.props.crossOrigin || crossOrigin}
                     dangerouslySetInnerHTML={{
                       __html: `(self.__NEXT_BL=self.__NEXT_BL||[]).push({})`,
                     }}
@@ -925,6 +927,8 @@ export class NextScript extends Component<OriginProps> {
                   }}
                 />
                 <script
+                  nonce={this.props.nonce}
+                  crossOrigin={this.props.crossOrigin || crossOrigin}
                   dangerouslySetInnerHTML={{
                     __html: `(self.__NEXT_BL=self.__NEXT_BL||[]).push({})`,
                   }}

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -854,16 +854,23 @@ export class NextScript extends Component<OriginProps> {
           return (
             <>
               {disableRuntimeJS ? null : (
-                <script
-                  id="__NEXT_DATA__"
-                  type="application/json"
-                  nonce={this.props.nonce}
-                  crossOrigin={this.props.crossOrigin || crossOrigin}
-                  dangerouslySetInnerHTML={{
-                    __html: NextScript.getInlineScriptSource(this.context),
-                  }}
-                  data-ampdevmode
-                />
+                <>
+                  <script
+                    id="__NEXT_DATA__"
+                    type="application/json"
+                    nonce={this.props.nonce}
+                    crossOrigin={this.props.crossOrigin || crossOrigin}
+                    dangerouslySetInnerHTML={{
+                      __html: NextScript.getInlineScriptSource(this.context),
+                    }}
+                    data-ampdevmode
+                  />
+                  <script
+                    dangerouslySetInnerHTML={{
+                      __html: `(self.__NEXT_BL=self.__NEXT_BL||[]).push({})`,
+                    }}
+                  />
+                </>
               )}
               {ampDevFiles.map((file) => (
                 <script
@@ -906,15 +913,22 @@ export class NextScript extends Component<OriginProps> {
                 ))
               : null}
             {disableRuntimeJS ? null : (
-              <script
-                id="__NEXT_DATA__"
-                type="application/json"
-                nonce={this.props.nonce}
-                crossOrigin={this.props.crossOrigin || crossOrigin}
-                dangerouslySetInnerHTML={{
-                  __html: NextScript.getInlineScriptSource(this.context),
-                }}
-              />
+              <>
+                <script
+                  id="__NEXT_DATA__"
+                  type="application/json"
+                  nonce={this.props.nonce}
+                  crossOrigin={this.props.crossOrigin || crossOrigin}
+                  dangerouslySetInnerHTML={{
+                    __html: NextScript.getInlineScriptSource(this.context),
+                  }}
+                />
+                <script
+                  dangerouslySetInnerHTML={{
+                    __html: `(self.__NEXT_BL=self.__NEXT_BL||[]).push({})`,
+                  }}
+                />
+              </>
             )}
             {disableOptimizedLoading &&
               !disableRuntimeJS &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -20572,7 +20572,7 @@ webpack-bundle-analyzer@4.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-"webpack-sources3@npm:webpack-sources@3.2.3", webpack-sources@^3.2.2, webpack-sources@^3.2.3:
+"webpack-sources3@npm:webpack-sources@3.2.3", webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==


### PR DESCRIPTION
Today, the Next.js client is initialized as a side effect of the `next/client/next.js` or `next/client/next-dev.js` module being loaded. For streaming, we want the loading of the code and the initialization step to be separate.

The short term solution implemented by this PR is to keep the aforementioned modules unchanged. Instead, we use a webpack loader to make sure the module is only loaded after it has been explicitly bootloaded by a separate script tag.

In the near future, we should rework the related modules to export initialization functions, rather than relying on a side effect.