### PR TITLE
Fix top-level router update forcing Suspense client fallbacks

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom'
 import { HeadManagerContext } from '../shared/lib/head-manager-context'
 import mitt, { MittEmitter } from '../shared/lib/mitt'
 import { RouterContext } from '../shared/lib/router-context'
-import type Router from '../shared/lib/router/router'
+import type Router, { NextRouter } from '../shared/lib/router/router'
 import {
   AppComponent,
   AppProps,
@@ -174,6 +174,7 @@ const appElement: HTMLElement | null = document.getElementById('__next')
 let lastRenderReject: (() => void) | null
 let webpackHMR: any
 export let router: Router
+let publicRouterInstance: NextRouter
 let CachedApp: AppComponent, onPerfEntry: (metric: any) => void
 headManager.getIsSsr = () => {
   return router.isSsr
@@ -413,6 +414,7 @@ export async function initNext(opts: { webpackHMR?: any } = {}) {
     domainLocales,
     isPreview,
   })
+  publicRouterInstance = makePublicRouterInstance(router)
 
   const renderCtx: RenderRouteInfo = {
     App: CachedApp,
@@ -620,7 +622,7 @@ function AppContainer({
         )
       }
     >
-      <RouterContext.Provider value={makePublicRouterInstance(router)}>
+      <RouterContext.Provider value={publicRouterInstance}>
         <HeadManagerContext.Provider value={headManager}>
           {children}
         </HeadManagerContext.Provider>

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -5,7 +5,8 @@ import ReactDOM from 'react-dom'
 import { HeadManagerContext } from '../shared/lib/head-manager-context'
 import mitt, { MittEmitter } from '../shared/lib/mitt'
 import { RouterContext } from '../shared/lib/router-context'
-import type Router, { NextRouter } from '../shared/lib/router/router'
+import type Router from '../shared/lib/router/router'
+import type { NextRouter } from '../shared/lib/router/router'
 import {
   AppComponent,
   AppProps,


### PR DESCRIPTION
This top-level component recreates the public router instance when it renders. I'm hoping this is unnecessary (but I might be wrong). I'm observing this because I'm seeing dehydrated Suspense HTML content being replaced with client fallbacks. This is known (and expected) to happen when there are top-level context updates before hydration is finished https://github.com/facebook/react/issues/22692. So we should avoid top-level context updates unless something meaningful actually changed.

## How to test

**I typed this on GH and didn't actually "test" this change.**

However, I tested a similar change locally, and it solved the issue with a minimal repro. It did not solve the issue in my real project which I suspect means there's more top-level context updates somewhere (either in Next.js or in my app). But this is a start.

Locally, my test was basically returning

```js
const Something = React.lazy(() => import('./Something').then(e =>
  new Promise(resolve => setTimeout(() => resolve(e), 5000))
);

export default function MyPage() {
  return (
    <Suspense fallback={<h2>oh no...</h2>}>
      <Something />
    </Suspense>
  )
}
```

I am running an `experimental` build of React. I verified that content from `<Something />` appeared in HTML but was getting deleted soon after hydration (but *not* in the hydration commit). There were no mismatches. After fixing this context provider, Suspense was no longer forced into fallbacks in my minimal repro. *This would be a good regression test to add to Next.js.*