### PR TITLE
docs: use function for components in general

### DIFF
--- a/errors/next-script-for-ga.md
+++ b/errors/next-script-for-ga.md
@@ -13,7 +13,7 @@ If you are using the [gtag.js](https://developers.google.com/analytics/devguides
 ```jsx
 import Script from 'next/script'
 
-const Home = () => {
+function Home() {
   return (
     <div class="container">
       <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -44,7 +44,7 @@ If you are using the [analytics.js](https://developers.google.com/analytics/devg
 ```jsx
 import Script from 'next/script'
 
-const Home = () => {
+function Home() {
   return (
     <div class="container">
       <Script id="google-analytics" strategy="afterInteractive">
@@ -70,7 +70,7 @@ If you are using the [alternative async variant](https://developers.google.com/a
 ```jsx
 import Script from 'next/script'
 
-const Home = () => {
+function Home() {
   return (
     <div class="container">
       <Script id="google-analytics" strategy="afterInteractive">

--- a/errors/no-sync-scripts.md
+++ b/errors/no-sync-scripts.md
@@ -13,7 +13,7 @@ Use the Script component with the right loading strategy to defer loading of the
 ```jsx
 import Script from 'next/script'
 
-const Home = () => {
+function Home() {
   return (
     <div class="container">
       <Script src="https://third-party-script.js"></Script>


### PR DESCRIPTION
## Documentation / Examples

In general all docs use function to ensure it matches up with general recommendations (e.g. React docs).

- [x] Make sure the linting passes by running `yarn lint`
