### PR TITLE
Ensure optional chaining in swc matches babel

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -117,6 +117,13 @@ export function getJestSWCOptions({
         // Targets the current version of Node.js
         node: process.versions.node,
       },
+      // we always transpile optional chaining and nullish coalescing
+      // since it can cause issues with webpack even if the node target
+      // supports them
+      include: [
+        'proposal-optional-chaining',
+        'proposal-nullish-coalescing-operator',
+      ],
     },
     module: {
       type: esm && !isNextDist ? 'es6' : 'commonjs',
@@ -165,6 +172,13 @@ export function getLoaderSWCOptions({
           // Targets the current version of Node.js
           node: process.versions.node,
         },
+        // we always transpile optional chaining and nullish coalescing
+        // since it can cause issues with webpack even if the node target
+        // supports them
+        include: [
+          'proposal-optional-chaining',
+          'proposal-nullish-coalescing-operator',
+        ],
       },
     }
   } else {

--- a/test/integration/production/pages/about.js
+++ b/test/integration/production/pages/about.js
@@ -1,1 +1,5 @@
+import info from '../info.json'
+
+console.log('info:', info?.something?.nested)
+
 export default () => <div className="about-page">About Page</div>


### PR DESCRIPTION
This ensures we always transpile optional chaining and nullish coalescing with swc the same as we do [with babel](https://github.com/vercel/next.js/blob/4812e229928dc01ae21ee0533685f6813694c136/packages/next/build/babel/preset.ts#L97-L98) since it can cause issues with webpack even when the node target supports these features. 

The specific case this seems to cause issues with webpack is when a value is imported and optional chaining is used on the import value webpack is stripping the optional chaining cc @sokra 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/33915