### PR TITLE
Fix suffix ordering while streaming

### DIFF
--- a/test/integration/react-streaming-and-server-components/test/streaming.js
+++ b/test/integration/react-streaming-and-server-components/test/streaming.js
@@ -104,4 +104,11 @@ export default function (context) {
       'count: 1'
     )
   })
+
+  it('should flush the suffix at the very end', async () => {
+    await fetchViaHTTP(context.appPort, '/').then(async (response) => {
+      const result = await resolveStreamResponse(response)
+      expect(result).toMatch(/<\/body><\/html>/)
+    })
+  })
 }


### PR DESCRIPTION
Fix an issue where the suffix was being flushed before the inline RSC data, and add a test case to catch it.