### PR TITLE
docs: fix variable name from `profileData` to `data` in CSR page

### DIFF
--- a/docs/basic-features/data-fetching/client-side.md
+++ b/docs/basic-features/data-fetching/client-side.md
@@ -30,7 +30,7 @@ function Profile() {
   }, [])
 
   if (isLoading) return <p>Loading...</p>
-  if (!profileData) return <p>No profile data</p>
+  if (!data) return <p>No profile data</p>
 
   return (
     <div>


### PR DESCRIPTION
Since the variable name is called `data`, I believe checking `profileData` will always be `undefined`.

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
