### PR TITLE
Fix warning unknown prettier option when running `yarn lint`.

### DIFF
--- a/examples/with-tailwindcss/prettier.config.js
+++ b/examples/with-tailwindcss/prettier.config.js
@@ -3,5 +3,4 @@ module.exports = {
   singleQuote: true,
   tabWidth: 2,
   semi: false,
-  tailwindConfig: './tailwind.config.js',
 }


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

---
I'm getting this warning when running `yarn lint` on the local:
![Screen Shot 2022-02-05 at 23 45 57](https://user-images.githubusercontent.com/38455472/152651090-be515630-591a-4602-8bd7-eda71174dfda.png)

After a quick check, it is caused by the `tailwindConfig` option in the `prettier.config.js` file, added in PR #33614
I guess the reason is because the workspace does not install that plugin.

We can safely remove that option in the example, because it's already [the default location](https://github.com/tailwindlabs/prettier-plugin-tailwindcss):

> By default the plugin will look for this file in the same directory as your Prettier configuration file. However, if your Tailwind configuration is somewhere else, you can specify this using the tailwindConfig option in your Prettier configuration.

![Screen Shot 2022-02-06 at 00 12 24](https://user-images.githubusercontent.com/38455472/152651623-86655e80-e8d0-45b1-968c-81b7beed48ea.png)

The warning is gone after removing that option.

