### PR TITLE
Add types to nextConfig in default template 

### DIFF
--- a/packages/create-next-app/templates/default/next.config.js
+++ b/packages/create-next-app/templates/default/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-module.exports = {
+const nextConfig = {
   reactStrictMode: true,
 }
+
+module.exports = nextConfig

--- a/packages/create-next-app/templates/default/next.config.js
+++ b/packages/create-next-app/templates/default/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
 }

--- a/packages/create-next-app/templates/typescript/next.config.js
+++ b/packages/create-next-app/templates/typescript/next.config.js
@@ -1,3 +1,4 @@
+// @ts-check
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,

--- a/packages/create-next-app/templates/typescript/next.config.js
+++ b/packages/create-next-app/templates/typescript/next.config.js
@@ -1,4 +1,3 @@
-// @ts-check
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,


### PR DESCRIPTION
Enable editors to suggest properties for the config object. Also let TypeScript check for type errors in the configuration when using TypeScript