### PR TITLE
Stop exposing internal `render` and `renderError` methods from `next/client`

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -434,7 +434,7 @@ export async function initNext(
   render(renderCtx)
 }
 
-export async function render(renderingProps: RenderRouteInfo): Promise<void> {
+async function render(renderingProps: RenderRouteInfo): Promise<void> {
   if (renderingProps.err) {
     await renderError(renderingProps)
     return
@@ -462,7 +462,7 @@ export async function render(renderingProps: RenderRouteInfo): Promise<void> {
 // This method handles all runtime and debug errors.
 // 404 and 500 errors are special kind of errors
 // and they are still handle via the main render method.
-export function renderError(renderErrorProps: RenderErrorProps): Promise<any> {
+function renderError(renderErrorProps: RenderErrorProps): Promise<any> {
   const { App, err } = renderErrorProps
 
   // In development runtime errors are caught by our overlay

--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -44,8 +44,6 @@ window.next = {
     return router
   },
   emitter,
-  render,
-  renderError,
 }
 initNext({ webpackHMR, beforeRender: displayContent })
   .then(() => {

--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -1,4 +1,4 @@
-import { initNext, version, router, emitter, render, renderError } from './'
+import { initNext, version, router, emitter } from './'
 import initOnDemandEntries from './dev/on-demand-entries-client'
 import initWebpackHMR from './dev/webpack-hot-middleware-client'
 import initializeBuildWatcher from './dev/dev-build-watcher'

--- a/packages/next/client/next.js
+++ b/packages/next/client/next.js
@@ -1,4 +1,4 @@
-import { initNext, version, router, emitter, render, renderError } from './'
+import { initNext, version, router, emitter } from './'
 
 window.next = {
   version,

--- a/packages/next/client/next.js
+++ b/packages/next/client/next.js
@@ -7,8 +7,6 @@ window.next = {
     return router
   },
   emitter,
-  render,
-  renderError,
 }
 
 initNext().catch(console.error)


### PR DESCRIPTION
These should no longer need to be exposed.