### PR TITLE
Update failing tests from upstream resource

### DIFF
--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -222,7 +222,7 @@ module.exports = {
         },
         {
           source: '/overridden',
-          destination: 'https://example.com',
+          destination: 'https://vercel.com',
         },
       ],
     }

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -39,19 +39,6 @@ let appPort
 let app
 
 const runTests = (isDev = false) => {
-  it('should handle external beforeFiles rewrite correctly', async () => {
-    const res = await fetchViaHTTP(appPort, '/overridden')
-    expect(res.status).toBe(200)
-    expect(await res.text()).toContain('Example Domain')
-
-    const browser = await webdriver(appPort, '/nav')
-    await browser.elementByCss('#to-before-files-overridden').click()
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /Example Domain/
-    )
-  })
-
   it('should handle has query encoding correctly', async () => {
     for (const expected of [
       {
@@ -92,6 +79,24 @@ const runTests = (isDev = false) => {
         })
       }
     }
+  })
+
+  it('should handle external beforeFiles rewrite correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/overridden')
+    const html = await res.text()
+
+    if (res.status !== 200) {
+      console.error('Invalid response', html)
+    }
+    expect(res.status).toBe(200)
+    expect(html).toContain('Example Domain')
+
+    const browser = await webdriver(appPort, '/nav')
+    await browser.elementByCss('#to-before-files-overridden').click()
+    await check(
+      () => browser.eval('document.documentElement.innerHTML'),
+      /Example Domain/
+    )
   })
 
   it('should support long URLs for rewrites', async () => {

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -89,13 +89,13 @@ const runTests = (isDev = false) => {
       console.error('Invalid response', html)
     }
     expect(res.status).toBe(200)
-    expect(html).toContain('Example Domain')
+    expect(html).toContain('Vercel')
 
     const browser = await webdriver(appPort, '/nav')
     await browser.elementByCss('#to-before-files-overridden').click()
     await check(
       () => browser.eval('document.documentElement.innerHTML'),
-      /Example Domain/
+      /Vercel/
     )
   })
 
@@ -1716,7 +1716,7 @@ const runTests = (isDev = false) => {
               source: '/old-blog/:path*',
             },
             {
-              destination: 'https://example.com',
+              destination: 'https://vercel.com',
               regex: normalizeRegEx('^\\/overridden(?:\\/)?$'),
               source: '/overridden',
             },

--- a/test/integration/middleware/core/pages/rewrites/_middleware.js
+++ b/test/integration/middleware/core/pages/rewrites/_middleware.js
@@ -12,7 +12,7 @@ export async function middleware(request) {
   ) {
     const isExternal = url.searchParams.get('override') === 'external'
     return NextResponse.rewrite(
-      isExternal ? 'https://example.com' : '/rewrites/a'
+      isExternal ? 'https://vercel.com' : '/rewrites/a'
     )
   }
 

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -196,18 +196,20 @@ function rewriteTests(log, locale = '') {
     )
 
     expect(res.status).toBe(200)
-    expect(await res.text()).toContain('Example Domain')
+    expect(await res.text()).toContain('Vercel')
 
     const browser = await webdriver(context.appPort, `${locale}/rewrites`)
     await browser.elementByCss('#override-with-external-rewrite').click()
     await check(
       () => browser.eval('document.documentElement.innerHTML'),
-      /Example Domain/
+      /Vercel/
     )
-    expect(await browser.eval('window.location.pathname')).toBe(
+    await check(
+      () => browser.eval('window.location.pathname'),
       `${locale || ''}/rewrites/about`
     )
-    expect(await browser.eval('window.location.search')).toBe(
+    await check(
+      () => browser.eval('window.location.search'),
       '?override=external'
     )
   })

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -165,7 +165,7 @@ function rewriteTests(log, locale = '') {
   it('should override with rewrite internally correctly', async () => {
     const res = await fetchViaHTTP(
       context.appPort,
-      '/rewrites/about',
+      `${locale}/rewrites/about`,
       { override: 'internal' },
       { redirect: 'manual' }
     )
@@ -190,7 +190,7 @@ function rewriteTests(log, locale = '') {
   it('should override with rewrite externally correctly', async () => {
     const res = await fetchViaHTTP(
       context.appPort,
-      '/rewrites/about',
+      `${locale}/rewrites/about`,
       { override: 'external' },
       { redirect: 'manual' }
     )


### PR DESCRIPTION
Seems these were failing from https://example.com randomly 404ing

x-ref: https://github.com/vercel/next.js/runs/5113528980?check_suite_focus=true#step:8:1465
x-ref: https://github.com/vercel/next.js/runs/5095808948?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/5086862695?check_suite_focus=true