### PR TITLE
Fix static result being piped

### DIFF
--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -150,14 +150,20 @@ export default class NextWebServer extends BaseServer {
   ): Promise<void> {
     // @TODO
     const writer = res.transformStream.writable.getWriter()
-    options.result.pipe({
-      write: (chunk: Uint8Array) => writer.write(chunk),
-      end: () => writer.close(),
-      destroy: (err: Error) => writer.abort(err),
-      cork: () => {},
-      uncork: () => {},
-      // Not implemented: on/removeListener
-    } as any)
+
+    if (options.result.isDynamic()) {
+      options.result.pipe({
+        write: (chunk: Uint8Array) => writer.write(chunk),
+        end: () => writer.close(),
+        destroy: (err: Error) => writer.abort(err),
+        cork: () => {},
+        uncork: () => {},
+        // Not implemented: on/removeListener
+      } as any)
+    } else {
+      res.body(await options.result.toUnchunkedString())
+    }
+
     res.send()
   }
   protected async runApi() {


### PR DESCRIPTION
We need to check if the render result is dynamic or not, before using `pipe`.