### PR TITLE
Polyfill pipeTo and pipeThrough

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1675,20 +1675,23 @@ function renderToStream(
 
         // React will call our callbacks synchronously, so we need to
         // defer to a microtask to ensure `stream` is set.
-        Promise.resolve().then(() =>
-          resolve(
-            stream
-              .pipeThrough(createBufferedTransformStream())
-              .pipeThrough(
-                createInlineDataStream(
-                  dataStream.pipeThrough(
-                    createPrefixStream(suffixState?.suffixUnclosed ?? null)
-                  )
-                )
+        Promise.resolve().then(() => {
+          let readable = pipeThrough(stream, createBufferedTransformStream())
+          readable = pipeThrough(
+            readable,
+            createInlineDataStream(
+              pipeThrough(
+                dataStream,
+                createPrefixStream(suffixState?.suffixUnclosed ?? null)
               )
-              .pipeThrough(createSuffixStream(suffixState?.closeTag ?? null))
+            )
           )
-        )
+          readable = pipeThrough(
+            readable,
+            createSuffixStream(suffixState?.closeTag ?? null)
+          )
+          resolve(readable)
+        })
       }
     }
 

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1781,7 +1781,7 @@ function createInlineDataStream(
 function pipeTo(
   readable: ReadableStream,
   writable: WritableStream,
-  options: { preventClose: boolean }
+  options?: { preventClose: boolean }
 ) {
   let resolver: () => void
   const promise = new Promise<void>((resolve) => (resolver = resolve))
@@ -1791,7 +1791,7 @@ function pipeTo(
   function process() {
     reader.read().then(({ done, value }) => {
       if (done) {
-        if (!options.preventClose) {
+        if (!options?.preventClose) {
           writer.close()
         } else {
           writer.releaseLock()
@@ -1808,7 +1808,7 @@ function pipeTo(
 }
 
 function pipeThrough(readable: ReadableStream, ts: TransformStream) {
-  readable.pipeTo(ts.writable)
+  pipeTo(readable, ts.writable)
   return ts.readable
 }
 

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1133,7 +1133,9 @@ export async function renderToHTML(
       }),
       serverComponentManifest
     )
-    return new RenderResult(stream.pipeThrough(createBufferedTransformStream()))
+    return new RenderResult(
+      pipeThrough(stream, createBufferedTransformStream())
+    )
   }
 
   // we preload the buildManifest for auto-export dynamic pages
@@ -1800,6 +1802,11 @@ function pipeTo(
   }
   process()
   return promise
+}
+
+function pipeThrough(readable: ReadableStream, ts: TransformStream) {
+  readable.pipeTo(ts.writable)
+  return ts.readable
 }
 
 function chainStreams(streams: ReadableStream[]): ReadableStream {


### PR DESCRIPTION
Similar to #32602, `pipeTo` and `pipeThrough` are not polyfilled/implemented properly in the Edge runtime. This PR adds basic polyfill for our use case to make sure it doesn't break.

I've tested it in Node.js and it worked well (also covered by the existing integration tests too).
