### PR TITLE
Fix included flight manifest on node runtime

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -570,7 +570,10 @@ export default async function build(
           PRERENDER_MANIFEST,
           path.join(SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
           hasServerComponents
-            ? path.join(SERVER_DIRECTORY, MIDDLEWARE_FLIGHT_MANIFEST + '.js')
+            ? path.join(
+                SERVER_DIRECTORY,
+                MIDDLEWARE_FLIGHT_MANIFEST + runtime == 'edge' ? '.js' : '.json'
+              )
             : null,
           REACT_LOADABLE_MANIFEST,
           config.optimizeFonts

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -572,7 +572,9 @@ export default async function build(
           hasServerComponents
             ? path.join(
                 SERVER_DIRECTORY,
-                MIDDLEWARE_FLIGHT_MANIFEST + runtime == 'edge' ? '.js' : '.json'
+                MIDDLEWARE_FLIGHT_MANIFEST + runtime === 'edge'
+                  ? '.js'
+                  : '.json'
               )
             : null,
           REACT_LOADABLE_MANIFEST,

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -146,7 +146,7 @@ describe('Edge runtime - prod', () => {
     await killApp(context.server)
   })
 
-  it('should generate rsc middleware manifests', async () => {
+  it('should generate middleware SSR manifests for edge runtime', async () => {
     const distServerDir = join(distDir, 'server')
     const hasFile = (filename) => fs.existsSync(join(distServerDir, filename))
 
@@ -246,6 +246,24 @@ const nodejsRuntimeBasicSuite = {
   runTests: (context, env) => {
     basic(context, env)
     streaming(context)
+
+    if (env === 'prod') {
+      it('should generate middleware SSR manifests for Node.js', async () => {
+        const distServerDir = join(distDir, 'server')
+        const hasFile = (filename) =>
+          fs.existsSync(join(distServerDir, filename))
+
+        const files = [
+          'middleware-build-manifest.js',
+          'middleware-flight-manifest.json',
+          'middleware-manifest.json',
+        ]
+        files.forEach((file) => {
+          if (!hasFile(file)) console.log(file)
+          expect(hasFile(file)).toBe(true)
+        })
+      })
+    }
   },
   beforeAll: () => nextConfig.replace("runtime: 'edge'", "runtime: 'nodejs'"),
   afterAll: () => nextConfig.restore(),


### PR DESCRIPTION
We need to switch to json flight manifest on node deployment for RSC