### PR TITLE
Fix: Use `react-dom/server.browser` when `reactRoot: true`

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1175,7 +1175,7 @@ export async function renderToHTML(
     return inAmpMode ? children : <div id="__next">{children}</div>
   }
 
-  const ReactDOMServer = hasConcurrentFeatures
+  const ReactDOMServer = reactRoot
     ? require('react-dom/server.browser')
     : require('react-dom/server')
 


### PR DESCRIPTION
Since we want to use the streaming renderer when `reactRoot: true`, we have to make sure we use the right server implementation too.