### PR TITLE
Fix image-optimizer requires in next-server

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -95,7 +95,7 @@ export interface NodeRequestHandler {
 }
 
 export default class NextNodeServer extends BaseServer {
-  private imageResponseCache: ResponseCache
+  private imageResponseCache?: ResponseCache
 
   constructor(options: Options) {
     // Initialize super class
@@ -117,15 +117,17 @@ export default class NextNodeServer extends BaseServer {
       process.env.__NEXT_OPTIMIZE_CSS = JSON.stringify(true)
     }
 
-    const { ImageOptimizerCache } =
-      require('./image-optimizer') as typeof import('./image-optimizer')
+    if (!this.minimalMode) {
+      const { ImageOptimizerCache } =
+        require('./image-optimizer') as typeof import('./image-optimizer')
 
-    this.imageResponseCache = new ResponseCache(
-      new ImageOptimizerCache({
-        distDir: this.distDir,
-        nextConfig: this.nextConfig,
-      })
-    )
+      this.imageResponseCache = new ResponseCache(
+        new ImageOptimizerCache({
+          distDir: this.distDir,
+          nextConfig: this.nextConfig,
+        })
+      )
+    }
   }
 
   private compression =
@@ -170,8 +172,6 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected generateImageRoutes(): Route[] {
-    const { getHash, ImageOptimizerCache, sendResponse, ImageError } =
-      require('./image-optimizer') as typeof import('./image-optimizer')
     return [
       {
         match: route('/_next/image'),
@@ -185,6 +185,15 @@ export default class NextNodeServer extends BaseServer {
               finished: true,
             }
           }
+          const { getHash, ImageOptimizerCache, sendResponse, ImageError } =
+            require('./image-optimizer') as typeof import('./image-optimizer')
+
+          if (!this.imageResponseCache) {
+            throw new Error(
+              'invariant image optimizer cache was not initialized'
+            )
+          }
+
           const imagesConfig = this.nextConfig.images
 
           if (imagesConfig.loader !== 'default') {

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -21,6 +21,9 @@ describe('should set-up next', () => {
   let requiredFilesManifest
 
   beforeAll(async () => {
+    // test build against environment with next support
+    process.env.NOW_BUILDER = '1'
+
     next = await createNext({
       files: {
         pages: new FileRef(join(__dirname, 'required-server-files/pages')),


### PR DESCRIPTION
This ensures we don't attempt requiring `image-optimizer` when it was configured to not include it e.g. when deployed on Vercel or similar environments, this also updates our test to ensure we don't regress on this. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/34134