### PR TITLE
[Docs] add note to clarify use of Link when clearing preview cookies (issue #34129)

### DIFF
--- a/docs/advanced-features/preview-mode.md
+++ b/docs/advanced-features/preview-mode.md
@@ -186,6 +186,8 @@ export default function handler(req, res) {
 }
 ```
 
+> **Note:** If calling this route using `Link` component, you must pass in `prefetch={false}` to prevent calling `clearPreviewData` during prefetch.
+
 ### Specify the preview mode duration
 
 `setPreviewData` takes an optional second parameter which should be an options object. It accepts the following keys:


### PR DESCRIPTION
Add note that explains the need to pass `prefetch={false}` to `Link` component to prevent clearing cookies accidentally
(responding to issue "Docs: potential preview-mode error on production build #34129").

Note as follows:

> **Note:** If calling this route using `Link` component, you must pass in `prefetch={false}` to prevent calling `clearPreviewData` during prefetch.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ x] Make sure the linting passes by running `yarn lint`
