### PR TITLE
Allow matching an empty string value

### DIFF
--- a/packages/next/lib/load-custom-routes.ts
+++ b/packages/next/lib/load-custom-routes.ts
@@ -10,17 +10,21 @@ import {
 } from '../shared/lib/constants'
 import isError from './is-error'
 
-export type RouteHas =
-  | {
-      type: 'header' | 'query' | 'cookie'
-      key: string
-      value?: string
-    }
-  | {
-      type: 'host'
-      key?: undefined
-      value: string
-    }
+export type KeyedRouteHasTypes = 'header' | 'query' | 'cookie'
+export type KeyedRouteHas = {
+  type: KeyedRouteHasTypes
+  key: string
+  value?: string
+}
+
+export type KeylessRouteHasTypes = 'host'
+export type KeylessRouteHas = {
+  type: KeylessRouteHasTypes
+  value: string
+}
+
+export type HasTypes = KeyedRouteHasTypes | KeylessRouteHasTypes
+export type RouteHas = KeyedRouteHas | KeylessRouteHas
 
 export type Rewrite = {
   source: string
@@ -50,7 +54,12 @@ export type Redirect = {
 }
 
 export const allowedStatusCodes = new Set([301, 302, 303, 307, 308])
-const allowedHasTypes = new Set(['header', 'cookie', 'query', 'host'])
+const allowedHasTypes: Set<HasTypes> = new Set([
+  'header',
+  'cookie',
+  'query',
+  'host',
+])
 const namedGroupsRegex = /\(\?<([a-zA-Z][a-zA-Z0-9]*)>/g
 
 export function getRedirectStatus(route: {
@@ -267,7 +276,7 @@ function checkCustomRoutes(
         if (!allowedHasTypes.has(hasItem.type)) {
           invalidHasParts.push(`invalid type "${hasItem.type}"`)
         }
-        if (typeof hasItem.key !== 'string' && hasItem.type !== 'host') {
+        if (hasItem.type !== 'host' && typeof hasItem.key !== 'string') {
           invalidHasParts.push(`invalid key "${hasItem.key}"`)
         }
         if (
@@ -352,7 +361,7 @@ function checkCustomRoutes(
 
     if (route.has) {
       for (const hasItem of route.has) {
-        if (!hasItem.value && hasItem.key) {
+        if (!hasItem.value && 'key' in hasItem) {
           hasSegments.add(hasItem.key)
         }
 

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -17,13 +17,12 @@ export function matchHas(
   const params: Params = {}
 
   const allMatch = has.every((hasItem) => {
-    let value: undefined | string
-    let key = hasItem.key
+    type values = undefined | false | string
+    let value: values | values[]
 
     switch (hasItem.type) {
       case 'header': {
-        key = key!.toLowerCase()
-        value = req.headers[key] as string
+        value = req.headers[hasItem.key.toLowerCase()]
         break
       }
       case 'cookie': {
@@ -31,7 +30,7 @@ export function matchHas(
         break
       }
       case 'query': {
-        value = query[key!]
+        value = query[hasItem.key]
         break
       }
       case 'host': {
@@ -47,25 +46,34 @@ export function matchHas(
     }
 
     if (!hasItem.value && value) {
-      let found = value
+      let found
       if (Array.isArray(value)) {
         // ensure at least one value is truthy
-        if (!value.some((v) => found = v)) return false
+        if (!value.some((v) => (found = v))) return false
+      } else {
+        found = value
       }
 
-      params[getSafeParamName(key!)] = found
+      if ('key' in hasItem) {
+        params[getSafeParamName(hasItem.key)] = found
+      } else {
+        params[getSafeParamName(hasItem.type)] = found
+      }
+
       return true
     } else if (typeof value !== 'undefined') {
       const matcher = new RegExp(`^${hasItem.value}$`)
       // a value of false is equivalent to ''
       // e.g. /path?q - q is false and should be matched as ''
-      const match = (v?: string) => String(v || '').match(matcher)
+      const match = (v: string | false) => String(v || '').match(matcher)
 
       let matches: ReturnType<typeof match> = null
 
       if (Array.isArray(value)) {
         // any match in an array means we have it
-        value.some((v) => (matches = match(v)))
+        value.some(
+          (v) => (matches = typeof v !== 'undefined' ? match(v) : null)
+        )
       } else {
         matches = match(value)
       }
@@ -73,11 +81,12 @@ export function matchHas(
       if (matches) {
         if (Array.isArray(matches)) {
           if (matches.groups) {
-            Object.keys(matches.groups).forEach((groupKey) => {
-              params[groupKey] = matches?.groups![groupKey]
+            const groups = matches.groups
+            Object.keys(groups).forEach((groupKey) => {
+              params[groupKey] = groups[groupKey]
             })
-          } else if (hasItem.type === 'host' && matches[0]) {
-            params.host = matches[0]
+          } else if (!('key' in hasItem) && matches[0]) {
+            params[hasItem.type] = matches[0]
           }
         }
         return true

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -47,7 +47,13 @@ export function matchHas(
     }
 
     if (!hasItem.value && value) {
-      params[getSafeParamName(key!)] = value
+      let found = value
+      if (Array.isArray(value)) {
+        // ensure at least one value is truthy
+        if (!value.some((v) => found = v)) return false
+      }
+
+      params[getSafeParamName(key!)] = found
       return true
     } else if (typeof value !== 'undefined') {
       const matcher = new RegExp(`^${hasItem.value}$`)

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -49,16 +49,17 @@ export function matchHas(
     if (!hasItem.value && value) {
       params[getSafeParamName(key!)] = value
       return true
-    } else if (typeof(value) !== 'undefined') {
+    } else if (typeof value !== 'undefined') {
       const matcher = new RegExp(`^${hasItem.value}$`)
       // a value of false is equivalent to ''
       // e.g. /path?q - q is false and should be matched as ''
-      const match = (v) => String(v || '').match(matcher)
+      const match = (v?: string) => String(v || '').match(matcher)
 
-     let matches
+      let matches: ReturnType<typeof match> = null
+
       if (Array.isArray(value)) {
         // any match in an array means we have it
-        value.some((v) => matches = match(v))
+        value.some((v) => (matches = match(v)))
       } else {
         matches = match(value)
       }
@@ -67,7 +68,7 @@ export function matchHas(
         if (Array.isArray(matches)) {
           if (matches.groups) {
             Object.keys(matches.groups).forEach((groupKey) => {
-              params[groupKey] = matches.groups![groupKey]
+              params[groupKey] = matches?.groups![groupKey]
             })
           } else if (hasItem.type === 'host' && matches[0]) {
             params.host = matches[0]

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -49,11 +49,19 @@ export function matchHas(
     if (!hasItem.value && value) {
       params[getSafeParamName(key!)] = value
       return true
-    } else if (value) {
+    } else if (typeof(value) !== 'undefined') {
       const matcher = new RegExp(`^${hasItem.value}$`)
-      const matches = Array.isArray(value)
-        ? value.slice(-1)[0].match(matcher)
-        : value.match(matcher)
+      // a value of false is equivalent to ''
+      // e.g. /path?q - q is false and should be matched as ''
+      const match = (v) => String(v || '').match(matcher)
+
+     let matches
+      if (Array.isArray(value)) {
+        // any match in an array means we have it
+        value.some((v) => matches = match(v))
+      } else {
+        matches = match(value)
+      }
 
       if (matches) {
         if (Array.isArray(matches)) {

--- a/packages/next/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/shared/lib/router/utils/prepare-destination.ts
@@ -49,7 +49,11 @@ export function matchHas(
       let found
       if (Array.isArray(value)) {
         // ensure at least one value is truthy
-        if (!value.some((v) => (found = v))) return false
+        // ensure we return the last value
+        value.forEach((v) => {
+          if (v) found = v
+        })
+        if (!found) return false
       } else {
         found = value
       }
@@ -71,9 +75,13 @@ export function matchHas(
 
       if (Array.isArray(value)) {
         // any match in an array means we have it
-        value.some(
-          (v) => (matches = typeof v !== 'undefined' ? match(v) : null)
-        )
+        // ensure we return the last matching value
+        value.forEach((v) => {
+          if (typeof v !== 'undefined') {
+            const matched = match(v)
+            if (matched) matches = matched
+          }
+        })
       } else {
         matches = match(value)
       }


### PR DESCRIPTION
This should make matching arrays, `''` and `false` values more consistent

`has: [{ type: 'query', key: 'qs', value: '.*' }]`:

- `/path?qs` -> `true`
- `/path?qs=` -> `true`
- `/path?qs=something` -> `true`

`has: [{ type: 'query', key: 'qs' }]:`

- `/path?qs` -> `false`
- `/path?qs=` -> `false`
- `/path?qs=&ps=` -> `false`
- `/path?qs=something` -> `true`
- `/path?qs=&qs=something` -> `true`

`has: [{ type: 'query', key: 'qs', value: 'test' }]:` 

- `/path?qs=test` -> `true`
- `/path?qs=test&qs=other` -> `true` (it still has a query string `qs` with a value of `test`, it just so happens to be an array)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`
