### PR TITLE
test: disallow using pipe and pipeThrough for streaming

### DIFF
--- a/packages/next/server/web/sandbox/readable-stream.ts
+++ b/packages/next/server/web/sandbox/readable-stream.ts
@@ -61,6 +61,17 @@ class ReadableStream<T> {
 
     pull()
 
+    if (process.env.NODE_ENV !== 'production') {
+      // @ts-ignore
+      readable.pipeThrough = () => {
+        throw new Error('ReadableStream pipeThrough is not allowed to use')
+      }
+      // @ts-ignore
+      readable.pipeTo = () => {
+        throw new Error('ReadableStream pipeTo is not allowed to use')
+      }
+    }
+
     return readable
   }
 }


### PR DESCRIPTION
Follow up for #34112

Since the `web-streams-polyfill` has been used in other dependencies like `formdata-node`, we cannot directly mock it globally. In the test integration, next is spinned up through process and code is bundled for edge runtime cases, not able to mock through custom readable-stream polyfill through jest.

Use this as workaround: throw error for `readable.pipe` and `readable.pipeThrough` so that they cannot continue