### PR TITLE
Add heading to `invalid-api-status-body` error

### DIFF
--- a/errors/invalid-api-status-body.md
+++ b/errors/invalid-api-status-body.md
@@ -1,4 +1,4 @@
-Invalid API Route Status/Body Response
+# Invalid API Route Status/Body Response
 
 #### Why This Error Occurred
 


### PR DESCRIPTION
Make first line a heading for `invalid-api-status-body` error page here: https://nextjs.org/docs/messages/invalid-api-status-body