### PR TITLE
Ensure standalone server handles SIGTERM

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1233,6 +1233,10 @@ const NextServer = require('next/dist/server/next-server').default
 const http = require('http')
 const path = require('path')
 
+// Make sure commands gracefully respect termination signals (e.g. from Docker)
+process.on('SIGTERM', () => process.exit(0))
+process.on('SIGINT', () => process.exit(0))
+
 let handler
 
 const server = http.createServer(async (req, res) => {


### PR DESCRIPTION
This copies our existing SIGTERM/SIGINT handling for the standalone server we output for `outputStandalone` to ensure `ctrl` + `c` works correctly with Docker. 

x-ref: https://github.com/vercel/next.js/blob/46343564a1c4269e40fbdf0785ec53b46199a04d/packages/next/bin/next.ts#L108-L110