### PR TITLE
chore: decrease lock action runs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,8 +2,8 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    # This runs every hour: https://crontab.guru/every-1-hour
-    - cron: '0 * * * *'
+    # This runs twice a day: https://crontab.guru/#0_0,12_*_*_*
+    - cron: '0 0,12 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The Lock action has finished processing all issues and PRs, now it is fine to run it only twice a day to batch up notifications to the maintainers

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
