### PR TITLE
Allow listening for page requests in tests

### DIFF
--- a/test/lib/browsers/base.ts
+++ b/test/lib/browsers/base.ts
@@ -1,3 +1,5 @@
+export type Event = 'request'
+
 // This is the base Browser interface all browser
 // classes should build off of, it is the bare
 // methods we aim to support across tests
@@ -68,6 +70,8 @@ export class BrowserInterface {
   deleteCookies(): BrowserInterface {
     return this
   }
+  on(event: Event, cb: (...args: any[]) => void) {}
+  off(event: Event, cb: (...args: any[]) => void) {}
   async loadPage(url: string, { disableCache: boolean }): Promise<any> {}
   async get(url: string): Promise<void> {}
 


### PR DESCRIPTION
As discussed in [this thread](https://vercel.slack.com/archives/C02H1SJ9Z5E/p1644520248273879), it can be helpful to track the browser requests in tests so this exposes a listener for them. 