### PR TITLE
Update examples/active-class-name

### DIFF
--- a/examples/active-class-name/components/ActiveLink.js
+++ b/examples/active-class-name/components/ActiveLink.js
@@ -1,20 +1,46 @@
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import React, { Children } from 'react'
 
 const ActiveLink = ({ children, activeClassName, ...props }) => {
-  const { pathname } = useRouter()
+  const { asPath, isReady } = useRouter()
+
   const child = Children.only(children)
   const childClassName = child.props.className || ''
+  const [className, setClassName] = useState(childClassName)
 
-  // pages/index.js will be matched via props.href
-  // pages/about.js will be matched via props.href
-  // pages/[slug].js will be matched via props.as
-  const className =
-    pathname === props.href || pathname === props.as
-      ? `${childClassName} ${activeClassName}`.trim()
-      : childClassName
+  useEffect(() => {
+    // Check if the router fields are updated client-side
+    if (isReady) {
+      // Dynamic route will be matched via props.as
+      // Static route will be matched via props.href
+      const linkPathname = new URL(props.as || props.href, location.href)
+        .pathname
+
+      // Using URL().pathname to get rid of query and hash
+      const activePathname = new URL(asPath, location.href).pathname
+
+      const newClassName =
+        linkPathname === activePathname
+          ? `${childClassName} ${activeClassName}`.trim()
+          : childClassName
+
+      if (newClassName !== className) {
+        setClassName(newClassName)
+      }
+    }
+  }, [
+    asPath,
+    isReady,
+    props.as,
+    props.href,
+    childClassName,
+    activeClassName,
+    setClassName,
+    className,
+  ])
 
   return (
     <Link {...props}>

--- a/examples/active-class-name/components/ActiveLink.js
+++ b/examples/active-class-name/components/ActiveLink.js
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import React, { Children } from 'react'
 
 const ActiveLink = ({ children, activeClassName, ...props }) => {
-  const { asPath } = useRouter()
+  const { pathname } = useRouter()
   const child = Children.only(children)
   const childClassName = child.props.className || ''
 
@@ -12,7 +12,7 @@ const ActiveLink = ({ children, activeClassName, ...props }) => {
   // pages/about.js will be matched via props.href
   // pages/[slug].js will be matched via props.as
   const className =
-    asPath === props.href || asPath === props.as
+    pathname === props.href || pathname === props.as
       ? `${childClassName} ${activeClassName}`.trim()
       : childClassName
 

--- a/examples/active-class-name/components/Nav.js
+++ b/examples/active-class-name/components/Nav.js
@@ -23,6 +23,11 @@ const Nav = () => (
         </ActiveLink>
       </li>
       <li>
+        <ActiveLink activeClassName="active" href="/blog">
+          <a className="nav-link">Blog</a>
+        </ActiveLink>
+      </li>
+      <li>
         <ActiveLink activeClassName="active" href="/[slug]" as="/dynamic-route">
           <a className="nav-link">Dynamic Route</a>
         </ActiveLink>

--- a/examples/active-class-name/next.config.js
+++ b/examples/active-class-name/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/blog',
+        destination: '/news',
+      },
+    ]
+  },
+}

--- a/examples/active-class-name/pages/news.js
+++ b/examples/active-class-name/pages/news.js
@@ -1,0 +1,10 @@
+import Nav from '../components/Nav'
+
+const News = () => (
+  <>
+    <Nav />
+    <p>Hello, I'm the news page</p>
+  </>
+)
+
+export default News


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
## Description

According to `Next.js` useRouter documentation:

- `asPath`: The path (including the query) shown in the browser without the configured basePath or locale.
- `pathname`: Current route. That is the path of the page in /pages, the configured basePath or locale is not included.

`asPath` should not be used as the props of components. There are many cases that `asPath` not working as expected. For example:

- `asPath` is different on server-side and client-side.
- `asPath` can contains `id` and `query`.

## Suggestion

- Warning the use of `asPath` can lead to the conflict of client and server-side.
- Update `useRouter` document.

## Bug

- [x] Related issues linked using `fixes #number`

Fixes: https://github.com/vercel/next.js/issues/34144
Fixes: https://github.com/vercel/next.js/issues/34016
Fixes: https://github.com/vercel/next.js/issues/34197
