### PR TITLE
Ensure /index route is redirected correctly for docs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -23,6 +23,12 @@
                   }
                 },
                 {
+                  "path": "/docs/basic-features/data-fetching/index",
+                  "redirect": {
+                    "destination": "/docs/basic-features/data-fetching/overview"
+                  }
+                },
+                {
                   "title": "Overview",
                   "path": "/docs/basic-features/data-fetching/overview.md"
                 },


### PR DESCRIPTION
This adds an additional redirect to ensure `/index` on the data-fetching doc is handled correctly since the first search result currently links to `/index`

<img width="985" alt="Screen Shot 2022-02-10 at 4 33 17 PM" src="https://user-images.githubusercontent.com/22380829/153508022-cc7a1e08-7f7c-4e9e-a0f6-c10fd1f764c5.png">


## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
