### PR TITLE
Fix link for "Delete Query Params in Middleware" error message in `next-server.ts`

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1335,7 +1335,7 @@ export default class NextNodeServer extends BaseServer {
 
     if (missingKeys.length > 0) {
       Log.warn(
-        `Query params are no longer automatically merged for rewrites in middleware, see more info here: https://nextjs.org/docs/messages/errors/deleting-query-params-in-middlewares`
+        `Query params are no longer automatically merged for rewrites in middleware, see more info here: https://nextjs.org/docs/messages/deleting-query-params-in-middlewares`
       )
       this.warnIfQueryParametersWereDeleted = () => {}
     }


### PR DESCRIPTION
The link inside `next-server.ts` [file](https://github.com/vercel/next.js/blob/46343564a1c4269e40fbdf0785ec53b46199a04d/packages/next/server/next-server.ts#L1338) for the "Delete Query Params in Middleware" error message was pointing to a 404 page. 

Since we've moved the `errors` directory to `docs/messages` in the Next.js repo ([See this](https://github.com/vercel/front/blob/a1c752ac46da3dcb875443532045cb58058b0d7f/next-site/pages/docs/messages/%5B...slug%5D.js#L133)). The PR adds these changes.

## Bug

- [x] Related [Slack thread](https://vercel.slack.com/archives/C02F56A54LU/p1644582812712219)

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
