### PR TITLE
feat: allowing user to specify i18n cookie name on config

### DIFF
--- a/docs/advanced-features/i18n-routing.md
+++ b/docs/advanced-features/i18n-routing.md
@@ -290,6 +290,8 @@ Next.js supports overriding the accept-language header with a `NEXT_LOCALE=the-l
 
 For example, if a user prefers the locale `fr` in their accept-language header but a `NEXT_LOCALE=en` cookie is set the `en` locale when visiting `/` the user will be redirected to the `en` locale location until the cookie is removed or expired.
 
+The default cookie name is `NEXT_LOCALE` but it can also be customized by setting the `cookieName` option in the `next.config.js` file.
+
 ## Search Engine Optimization
 
 Since Next.js knows what language the user is visiting it will automatically add the `lang` attribute to the `<html>` tag.

--- a/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/page-handler.ts
@@ -123,6 +123,7 @@ export function getPageHandler(ctx: ServerlessHandlerCtx) {
     let _nextData = false
     let defaultLocale = i18n?.defaultLocale
     let detectedLocale = i18n?.defaultLocale
+    let cookieName = i18n?.cookieName || 'NEXT_LOCALE'
     let parsedUrl: UrlWithParsedQuery
 
     try {
@@ -170,7 +171,8 @@ export function getPageHandler(ctx: ServerlessHandlerCtx) {
         res,
         parsedUrl,
         routeNoAssetPath,
-        fromExport || nextStartMode
+        fromExport || nextStartMode,
+        cookieName
       )
       defaultLocale = localeResult?.defaultLocale || defaultLocale
       detectedLocale = localeResult?.detectedLocale || detectedLocale

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -366,13 +366,14 @@ export function getUtils({
     res: ServerResponse,
     parsedUrl: UrlWithParsedQuery,
     routeNoAssetPath: string,
-    shouldNotRedirect: boolean
+    shouldNotRedirect: boolean,
+    cookieName: string
   ) {
     if (!i18n) return
     const pathname = parsedUrl.pathname || '/'
 
     let defaultLocale = i18n.defaultLocale
-    let detectedLocale = detectLocaleCookie(req, i18n.locales)
+    let detectedLocale = detectLocaleCookie(req, i18n.locales, cookieName)
     let acceptPreferredLocale
     try {
       acceptPreferredLocale =
@@ -457,7 +458,7 @@ export function getUtils({
         shouldAddLocalePrefix ||
         shouldStripDefaultLocale)
     ) {
-      // set the NEXT_LOCALE cookie when a user visits the default locale
+      // set the `cookieName` cookie when a user visits the default locale
       // with the locale prefix so that they aren't redirected back to
       // their accept-language preferred locale
       if (shouldStripDefaultLocale && acceptPreferredLocale !== defaultLocale) {
@@ -469,7 +470,7 @@ export function getUtils({
             : Array.isArray(previous)
             ? previous
             : []),
-          cookie.serialize('NEXT_LOCALE', defaultLocale, {
+          cookie.serialize(cookieName, defaultLocale, {
             httpOnly: true,
             path: '/',
           }),

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -20,6 +20,7 @@ export interface I18NConfig {
   domains?: DomainLocale[]
   localeDetection?: false
   locales: string[]
+  cookieName?: string
 }
 
 export interface DomainLocale {

--- a/packages/next/shared/lib/i18n/detect-locale-cookie.ts
+++ b/packages/next/shared/lib/i18n/detect-locale-cookie.ts
@@ -1,10 +1,15 @@
 import { IncomingMessage } from 'http'
 
-export function detectLocaleCookie(req: IncomingMessage, locales: string[]) {
-  const { NEXT_LOCALE } = (req as any).cookies || {}
-  return NEXT_LOCALE
+export function detectLocaleCookie(
+  req: IncomingMessage,
+  locales: string[],
+  cookieName: string
+) {
+  const { [cookieName]: cookie } = (req as any).cookies || {}
+
+  return cookie
     ? locales.find(
-        (locale: string) => NEXT_LOCALE.toLowerCase() === locale.toLowerCase()
+        (locale: string) => cookie.toLowerCase() === locale.toLowerCase()
       )
     : undefined
 }

--- a/packages/next/shared/lib/i18n/get-locale-metadata.ts
+++ b/packages/next/shared/lib/i18n/get-locale-metadata.ts
@@ -50,9 +50,12 @@ function getLocaleFromCookie(
   i18n: I18NConfig,
   cookies: () => { [key: string]: string }
 ) {
-  const nextLocale = cookies()?.NEXT_LOCALE?.toLowerCase()
-  return nextLocale
-    ? i18n.locales.find((locale) => nextLocale === locale.toLowerCase())
+  const cookieName = i18n.cookieName || 'NEXT_LOCALE'
+  const { [cookieName]: cookie } = cookies() || {}
+  return cookie
+    ? i18n.locales.find(
+        (locale) => cookie.toLocaleLowerCase() === locale.toLowerCase()
+      )
     : undefined
 }
 


### PR DESCRIPTION
## Feature
Implements the feature as suggested in #24852. Our use case is that we have multiple apps managed by different teams and we want to have a frictionless experience through all of them. One part of it is to preserve the same language. Some of our apps are in NextJS and it would be great if we don't have to force other teams to follow the NextJS convention.

I have not added integration tests because the fixture is pretty much locked with the `NEXT_LOCALE` default cookie, which I think is right, but let me know what you think about that.

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `implements #24852`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
- [x] Added setting to the `docs`

## How to test

1. Create a i18n project. e.g. `yarn create next-app --example i18n-routing i18n-app`
2. Check out this branch and link the project as per the guidelines
3. Run the project with `yarn dev`
4. Open a browser (e.g. Firefox) and add the `NEXT_LOCALE` cookie value to `fr`
5. Go to `localhost:3000` and check that it goes to the `fr` locale. So far so good.
6. Now add the new property `cookieName: custom` to the `next.config.js`
7. Add now a cookie called `custom` with value `nl`
8. Go to `localhost:3000` and check that it goes to the `fr` locale.
9. Happy days

