### PR TITLE
Update Middleware docs to add version history.

### DIFF
--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -152,26 +152,26 @@ export default async () => {
 
 ## Environment Variable Load Order
 
-Depending on the environment (as set by `NODE_ENV`), variables are loaded from the following sources in order from top-to-bottom. In all environments existing env is not overridden by following sources.
+Depending on the environment (as set by `NODE_ENV`), Environment Variables are loaded from the following sources in top-to-bottom order. In all environments, the existing `env` is not overridden by following sources:
 
 `NODE_ENV=production`
 
-- `.env.production.local`
-- `.env.local`
-- `.env.production`
-- `.env`
+1. `.env.production.local`
+1. `.env.local`
+1. `.env.production`
+1. `.env`
 
 `NODE_ENV=development`
 
-- `.env.development.local`
-- `.env.local`
-- `.env.development`
-- `.env`
+1. `.env.development.local`
+1. `.env.local`
+1. `.env.development`
+1. `.env`
 
 `NODE_ENV=test`
 
-- `.env.test.local`
-- `.env.test`
-- `.env`
+1. `.env.test.local`
+1. `.env.test`
+1. `.env`
 
-_(note: `.env.local` is not loaded when `NODE_ENV=test`)_
+> **Note:** `.env.local` is not loaded when `NODE_ENV=test`.

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -4,7 +4,7 @@ description: Learn how to use Middleware in Next.js to run code before a request
 
 # Middleware
 
-<details>
+<details open>
   <summary><b>Version History</b></summary>
 
 | Version   | Changes                                                                                    |

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -4,6 +4,16 @@ description: Learn how to use Middleware in Next.js to run code before a request
 
 # Middleware
 
+<details>
+  <summary><b>Version History</b></summary>
+
+| Version   | Changes                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------ |
+| `v12.0.9` | Enforce absolute URLs in Edge Runtime ([PR](https://github.com/vercel/next.js/pull/33410)) |
+| `v12.0.0` | Middleware (beta) added.                                                                   |
+
+</details>
+
 Middleware enables you to use code over configuration. This gives you full flexibility in Next.js, because you can run code before a request is completed. Based on the user's incoming request, you can modify the response by rewriting, redirecting, adding headers, or even streaming HTML.
 
 ## Usage
@@ -50,7 +60,7 @@ export type Middleware = (
 
 The function can be a default export and as such, does **not** have to be named `middleware`. Though this is a convention. Also note that you only need to make the function `async` if you are running asynchronous code.
 
-**Note:** Edge Functions are currently in Beta. The API might change as we look to continually make improvements.
+[Read the full Middleware API reference.](/docs/api-reference/next/server.md)
 
 ## Examples
 


### PR DESCRIPTION
Follow up from https://github.com/vercel/next.js/pull/33410.

Adds version history for Middleware so it's more clear it launched in beta, and that we have a place to track changes.