### PR TITLE
Fix flight root failed to hydrate in strict mode

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -775,9 +775,11 @@ if (process.env.__NEXT_RSC) {
     serialized?: string
     _fresh?: boolean
   }) => {
+    React.useEffect(() => {
+      rscCache.delete(cacheKey)
+    })
     const response = useServerResponse(cacheKey, serialized)
     const root = response.readRoot()
-    rscCache.delete(cacheKey)
     return root
   }
 

--- a/test/integration/react-streaming-and-server-components/app/next.config.js
+++ b/test/integration/react-streaming-and-server-components/app/next.config.js
@@ -1,6 +1,7 @@
 const withReact18 = require('../../react-18/test/with-react-18')
 
 module.exports = withReact18({
+  reactStrictMode: true,
   onDemandEntries: {
     maxInactiveAge: 1000 * 60 * 60,
   },


### PR DESCRIPTION
To make sure we refetch the data on client transitions, we remove the flight cache after hydrating the root. However with strict mode enabled, the hydration process (initial render) will be invoked twice before hydration ends. This PR moves the cache clean up logic to an effect so we only do that after the successful hydration (and every rerender).

Changed tests to enable strict mode to ensure it works.

Relies on #34338.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
