### PR TITLE
Updated failed to load error page to include info about node versions

### DIFF
--- a/errors/failed-loading-swc.md
+++ b/errors/failed-loading-swc.md
@@ -8,7 +8,9 @@ SWC requires a binary be downloaded that is compatible specific to your system. 
 
 #### Possible Ways to Fix It
 
-You might need to allow optional packages to be installed by your package manager (remove `--no-optional` flag) for the package to download correctly.
+If you are working from an M1 mac and running a node version above 14.x (such as 16), trying to install dependencies may result in an `SWC` error. Try removing your `node_modules` and downgrading your node version to 14.x, then installing dependencies again.
+
+Alternatively, you might need to allow optional packages to be installed by your package manager (remove `--no-optional` flag) for the package to download correctly.
 
 If SWC continues to fail to load you can opt-out by disabling `swcMinify` in your `next.config.js` or by adding a `.babelrc` to your project with the following content:
 

--- a/errors/failed-loading-swc.md
+++ b/errors/failed-loading-swc.md
@@ -8,7 +8,7 @@ SWC requires a binary be downloaded that is compatible specific to your system. 
 
 #### Possible Ways to Fix It
 
-If you are working from an M1 mac and running a node version above 14.x (such as 16), trying to install dependencies may result in an `SWC` error. Try removing your `node_modules` and downgrading your node version to 14.x, then installing dependencies again.
+When on an M1 Mac and switching from a Node.js version without M1 support e.g. v14 to a version with e.g. v16, you may need a different swc dependency which can require re-installing `node_modules` (`npm i --force` or `yarn install --force`).
 
 Alternatively, you might need to allow optional packages to be installed by your package manager (remove `--no-optional` flag) for the package to download correctly.
 


### PR DESCRIPTION
This PR updates the [failed loading swc](https://nextjs.org/docs/messages/failed-loading-swc) error page with information about switching node version and installing deps again.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
