### PR TITLE
Fixed overwriting with local `node_modules` in Dockerfiles

### DIFF
--- a/examples/with-docker-multi-env/docker/development/Dockerfile
+++ b/examples/with-docker-multi-env/docker/development/Dockerfile
@@ -10,8 +10,8 @@ RUN yarn install --frozen-lockfile
 # 2. Rebuild the source code only when needed
 FROM node:16-alpine AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY --from=deps /app/node_modules ./node_modules
 # This will do the trick, use the corresponding env file for each environment.
 COPY .env.development.sample .env.production
 RUN yarn build

--- a/examples/with-docker-multi-env/docker/production/Dockerfile
+++ b/examples/with-docker-multi-env/docker/production/Dockerfile
@@ -10,8 +10,8 @@ RUN yarn install --frozen-lockfile
 # 2. Rebuild the source code only when needed
 FROM node:16-alpine AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY --from=deps /app/node_modules ./node_modules
 # This will do the trick, use the corresponding env file for each environment.
 COPY .env.production.sample .env.production
 RUN yarn build

--- a/examples/with-docker-multi-env/docker/staging/Dockerfile
+++ b/examples/with-docker-multi-env/docker/staging/Dockerfile
@@ -10,8 +10,8 @@ RUN yarn install --frozen-lockfile
 # 2. Rebuild the source code only when needed
 FROM node:16-alpine AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY --from=deps /app/node_modules ./node_modules
 # This will do the trick, use the corresponding env file for each environment.
 COPY .env.staging.sample .env.production
 RUN yarn build

--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -13,8 +13,8 @@ RUN yarn install --frozen-lockfile
 # Rebuild the source code only when needed
 FROM node:16-alpine AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY --from=deps /app/node_modules ./node_modules
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry


### PR DESCRIPTION
Update to fix the copy `node_modules` step from the docker example.
`COPY . .`, then `COPY --from=deps /app/node_modules ./node_modules`.

This change was from https://github.com/vercel/next.js/commit/c320249be17d9c2d54e2fd106a8b237a4969f87c.
This may have been a mistake.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
