### PR TITLE
fix: typo in gitignore in typescript template

### DIFF
--- a/packages/create-next-app/templates/typescript/gitignore
+++ b/packages/create-next-app/templates/typescript/gitignore
@@ -23,7 +23,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-.pnpm-debug.log**
+.pnpm-debug.log*
 
 # local env files
 .env.local


### PR DESCRIPTION
`gitignore` template for typescript starter project
```diff
- .pnpm-debug.log**
+ .pnpm-debug.log*
```