### PR TITLE
Use eager import to include rsc dependencies

### DIFF
--- a/test/integration/react-streaming-and-server-components/app/components/foo.client.js
+++ b/test/integration/react-streaming-and-server-components/app/components/foo.client.js
@@ -1,5 +1,8 @@
-export default function foo() {
-  return 'foo.client'
+import { useState } from 'react'
+
+export default function Foo() {
+  const [value] = useState('foo.client')
+  return value
 }
 
 export const config = 'this is not page config'


### PR DESCRIPTION
Change the way of including dependencies into bundle for server components. Previous `require` calls in unused exported function is pretty hacky, switched to `import` with webpack magic comment to include them.