### PR TITLE
Don't import internally from types in `next-env.d.ts`

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -61,6 +61,13 @@ type OnLoadingComplete = (result: {
 
 type ImgElementStyle = NonNullable<JSX.IntrinsicElements['img']['style']>
 
+export interface StaticImageData {
+  src: string
+  height: number
+  width: number
+  blurDataURL?: string
+}
+
 interface StaticRequire {
   default: StaticImageData
 }

--- a/packages/next/image-types/global.d.ts
+++ b/packages/next/image-types/global.d.ts
@@ -1,12 +1,7 @@
 // this file is conditionally added/removed to next-env.d.ts
 // if the static image import handling is enabled
 
-interface StaticImageData {
-  src: string
-  height: number
-  width: number
-  blurDataURL?: string
-}
+import type { StaticImageData } from '../dist/client/image'
 
 declare module '*.png' {
   const content: StaticImageData

--- a/packages/next/image-types/global.d.ts
+++ b/packages/next/image-types/global.d.ts
@@ -1,10 +1,8 @@
 // this file is conditionally added/removed to next-env.d.ts
 // if the static image import handling is enabled
 
-import type { StaticImageData } from '../dist/client/image'
-
 declare module '*.png' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }
@@ -21,43 +19,43 @@ declare module '*.svg' {
 }
 
 declare module '*.jpg' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }
 
 declare module '*.jpeg' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }
 
 declare module '*.gif' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }
 
 declare module '*.webp' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }
 
 declare module '*.avif' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }
 
 declare module '*.ico' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }
 
 declare module '*.bmp' {
-  const content: StaticImageData
+  const content: import('../dist/client/image').StaticImageData
 
   export default content
 }

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -7,5 +7,5 @@
     "moduleResolution": "node",
     "jsx": "react"
   },
-  "exclude": ["dist", "./*.d.ts"]
+  "exclude": ["dist", "./*.d.ts", "image-types/global.d.ts"]
 }

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -7,5 +7,10 @@
     "moduleResolution": "node",
     "jsx": "react"
   },
-  "exclude": ["dist", "./*.d.ts", "image-types/global.d.ts"]
+  "exclude": [
+    "dist",
+    "./*.d.ts",
+    "image-types/global.d.ts",
+    "types/global.d.ts"
+  ]
 }

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -7,10 +7,5 @@
     "moduleResolution": "node",
     "jsx": "react"
   },
-  "exclude": [
-    "dist",
-    "./*.d.ts",
-    "image-types/global.d.ts",
-    "types/global.d.ts"
-  ]
+  "exclude": ["dist", "./*.d.ts", "image-types/global.d.ts"]
 }


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/29788

This PR fixes an issue where `StaticImageData` is declared inside a global declaration file (`image-types/global.d.ts`) but it's not available in the published package.

Having `StaticImageData` defined globally works when working inside the Next.js repo because TypeScript takes care of adding global declarations to the scope, however the same isn't true when the package is published, the declaration file doesn't get included by default and therefore using the `StaticImageData` fails inside the image component types.

With this change the type is now defined in the Image component and the global declaration file is importing it from there instead, this file is also excluded in tsconfig to make sure it doesn't break when developing inside the Next.js repo, because the import goes to `/dist`

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
