### PR TITLE
feat: use ESM-CJS interoperable import in `find-config`

### DIFF
--- a/packages/next/lib/find-config.ts
+++ b/packages/next/lib/find-config.ts
@@ -1,6 +1,5 @@
 import findUp from 'next/dist/compiled/find-up'
-import fs from 'fs'
-import JSON5 from 'next/dist/compiled/json5'
+import { importDefaultInterop } from './import-interop'
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>
@@ -16,7 +15,7 @@ export async function findConfig<T>(
   // `package.json` configuration always wins. Let's check that first.
   const packageJsonPath = await findUp('package.json', { cwd: directory })
   if (packageJsonPath) {
-    const packageJson = require(packageJsonPath)
+    const packageJson = await importDefaultInterop(packageJsonPath)
     if (packageJson[key] != null && typeof packageJson[key] === 'object') {
       return packageJson[key]
     }
@@ -35,15 +34,9 @@ export async function findConfig<T>(
       cwd: directory,
     }
   )
-  if (filePath) {
-    if (filePath.endsWith('.js')) {
-      return require(filePath)
-    }
 
-    // We load JSON contents with JSON5 to allow users to comment in their
-    // configuration file. This pattern was popularized by TypeScript.
-    const fileContents = fs.readFileSync(filePath, 'utf8')
-    return JSON5.parse(fileContents)
+  if (filePath) {
+    return importDefaultInterop(filePath)
   }
 
   return null

--- a/packages/next/lib/import-interop.ts
+++ b/packages/next/lib/import-interop.ts
@@ -1,0 +1,42 @@
+import { promises as fs } from 'fs'
+import { extname } from 'path'
+import JSON5 from 'next/dist/compiled/json5'
+
+/**
+ * CJS-ESM interoperable module import.
+ *
+ * @param specifier The specifier of the module to load.
+ * @returns The loaded module.
+ */
+export const importInterop = async (specifier: string) => {
+  /**
+   * If this is a JSON file, load it and imitate require("file.json") behavior.
+   */
+  if (extname(specifier) === '.json') {
+    const json = await fs.readFile(specifier, 'utf-8')
+    /**
+     * We load JSON contents with JSON5 to allow users to comment in their
+     * configuration file. This pattern was popularized by TypeScript.
+     */
+    return JSON5.parse(json)
+  } else {
+    try {
+      const importedModule = await import(specifier)
+      return importedModule
+    } catch (e) {
+      const importedModule = require(specifier)
+      return importedModule.default || importedModule
+    }
+  }
+}
+
+/**
+ * CJS-ESM interoperable default module import.
+ *
+ * @param specifier The specifier of the module to load.
+ * @returns The interop equivalent of the default export.
+ */
+export const importDefaultInterop = async (specifier: string) => {
+  const importedModule = await importInterop(specifier)
+  return importedModule.default || importedModule
+}

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -82,7 +82,7 @@ module.exports = {
         },
         {
           source: '/proxy-me/:path*',
-          destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
+          destination: 'http://localhost:42033/:path*',
         },
         {
           source: '/api-hello',

--- a/yarn.lock
+++ b/yarn.lock
@@ -20812,8 +20812,7 @@ webpack-bundle-analyzer@4.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-"webpack-sources3@npm:webpack-sources@3.2.3", webpack-sources@^3.2.3:
-  name webpack-sources3
+"webpack-sources3@npm:webpack-sources@3.2.3", webpack-sources@^3.2.2, webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==


### PR DESCRIPTION
It will eventually be appropriate to replace `require()` calls throughout the codebase with an ESM-CJS interoperable equivalent.  I implemented that here to try to work around #34448, but it will not actually resolve that issue.

## Bug

See #34448. Does not fix: It will take Tailwind merging changes into the `tailwindcss` library before Tailwind-related configs (incl. PostCSS) can be ESM and that specific issue can be resolved.

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
