### PR TITLE
fix: don't wrap `profile` in firebase example

### DIFF
--- a/examples/with-firebase/pages/index.js
+++ b/examples/with-firebase/pages/index.js
@@ -20,9 +20,7 @@ export default function Home() {
 
   const createUser = async () => {
     const db = getFirestore()
-    await setDoc(doc(db, 'profile', profile.username), {
-      profile,
-    })
+    await setDoc(doc(db, 'profile', profile.username), profile)
 
     alert('User created!!')
   }


### PR DESCRIPTION
Previous PR made this unnecessary change: https://github.com/vercel/next.js/pull/29581/files#diff-91aef2a7b24c67f77e8915e05ec22cdd71398650236a08e44420a1555367e99fL23-R25

Fixes #34077

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
