### PR TITLE
remove the warning of query params merging

### DIFF
--- a/errors/deleting-query-params-in-middlewares.md
+++ b/errors/deleting-query-params-in-middlewares.md
@@ -4,7 +4,7 @@
 
 In previous versions of Next.js, we were merging query parameters with the incoming request for rewrites happening in middlewares, to match the behavior of static rewrites declared in the config. This forced Next.js users to use empty query parameters values to delete keys.
 
-We are changing this behavior to allow extra flexibility and a more streamlined experience for users. So from now on, query parameters will not be merged and thus the warning.
+Since Next 12.1, this behavior is changed to allow extra flexibility and a more streamlined experience for users. So from now on, query parameters will not be merged and thus the warning.
 
 ```typescript
 import type { NextRequest } from 'next/server'

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -71,7 +71,6 @@ import { getMiddlewareRegex, getRouteMatcher } from '../shared/lib/router/utils'
 import { MIDDLEWARE_ROUTE } from '../lib/constants'
 import { loadEnvConfig } from '@next/env'
 import { getCustomRoute } from './server-route-utils'
-import { urlQueryToSearchParams } from '../shared/lib/router/utils/querystring'
 import ResponseCache from '../server/response-cache'
 import { clonableBodyForRequest } from './body-streams'
 
@@ -1128,12 +1127,6 @@ export default class NextNodeServer extends BaseServer {
             query: {},
           })
 
-          // TODO: remove after next minor version current `v12.0.9`
-          this.warnIfQueryParametersWereDeleted(
-            parsedUrl.query,
-            parsedDestination.query
-          )
-
           if (
             parsedDestination.protocol &&
             (parsedDestination.port
@@ -1320,25 +1313,5 @@ export default class NextNodeServer extends BaseServer {
 
   protected getRoutesManifest() {
     return require(join(this.distDir, ROUTES_MANIFEST))
-  }
-
-  // TODO: remove after next minor version current `v12.0.9`
-  private warnIfQueryParametersWereDeleted(
-    incoming: ParsedUrlQuery,
-    rewritten: ParsedUrlQuery
-  ): void {
-    const incomingQuery = urlQueryToSearchParams(incoming)
-    const rewrittenQuery = urlQueryToSearchParams(rewritten)
-
-    const missingKeys = [...incomingQuery.keys()].filter((key) => {
-      return !rewrittenQuery.has(key)
-    })
-
-    if (missingKeys.length > 0) {
-      Log.warn(
-        `Query params are no longer automatically merged for rewrites in middleware, see more info here: https://nextjs.org/docs/messages/deleting-query-params-in-middlewares`
-      )
-      this.warnIfQueryParametersWereDeleted = () => {}
-    }
   }
 }

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -161,7 +161,7 @@ function urlTests(log, locale = '') {
   })
 }
 
-function rewriteTests(log, locale = '') {
+function rewriteTests(_log, locale = '') {
   it('should override with rewrite internally correctly', async () => {
     const res = await fetchViaHTTP(
       context.appPort,
@@ -280,17 +280,6 @@ function rewriteTests(log, locale = '') {
     expect(JSON.parse($('#my-query-params').text())).toEqual({
       allowed: 'kept',
     })
-  })
-
-  it(`warns about a query param deleted`, async () => {
-    await fetchViaHTTP(
-      context.appPort,
-      `${locale}/rewrites/clear-query-params`,
-      { a: '1', allowed: 'kept' }
-    )
-    expect(log.output).toContain(
-      'Query params are no longer automatically merged for rewrites in middleware'
-    )
   })
 
   it(`${locale} should rewrite to about page`, async () => {


### PR DESCRIPTION
Remove warning for query params merging. This was a `TODO` for "the next minor after 12.0.9"
