### PR TITLE
refactor: reuse isBrowser & isServer

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -8,6 +8,7 @@ import {
 } from '../server/image-config'
 import { useIntersection } from './use-intersection'
 import { ImageConfigContext } from '../shared/lib/image-config-context'
+import { isBrowser, isServer } from '../shared/lib/utils'
 
 const configEnv = process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete
 const loadedImageURLs = new Set<string>()
@@ -19,7 +20,7 @@ let perfObserver: PerformanceObserver | undefined
 const emptyDataURL =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 
-if (typeof window === 'undefined') {
+if (isServer) {
   ;(global as any).__NEXT_IMAGE_IMPORTED = true
 }
 
@@ -381,7 +382,7 @@ export default function Image({
     unoptimized = true
     isLazy = false
   }
-  if (typeof window !== 'undefined' && loadedImageURLs.has(src)) {
+  if (isBrowser && loadedImageURLs.has(src)) {
     isLazy = false
   }
 
@@ -481,11 +482,7 @@ export default function Image({
       }
     }
 
-    if (
-      typeof window !== 'undefined' &&
-      !perfObserver &&
-      window.PerformanceObserver
-    ) {
+    if (isBrowser && !perfObserver && window.PerformanceObserver) {
       perfObserver = new PerformanceObserver((entryList) => {
         for (const entry of entryList.getEntries()) {
           // @ts-ignore - missing "LargestContentfulPaint" class with "element" prop
@@ -641,7 +638,7 @@ export default function Image({
   let srcString: string = src
 
   if (process.env.NODE_ENV !== 'production') {
-    if (typeof window !== 'undefined') {
+    if (isBrowser) {
       let fullUrl: URL
       try {
         fullUrl = new URL(imgAttributes.src)
@@ -664,8 +661,7 @@ export default function Image({
     [imageSizesPropName]: imgAttributes.sizes,
   }
 
-  const useLayoutEffect =
-    typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect
+  const useLayoutEffect = isServer ? React.useEffect : React.useLayoutEffect
   const onLoadingCompleteRef = useRef(onLoadingComplete)
 
   useEffect(() => {

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -9,6 +9,7 @@ import {
   PrefetchOptions,
   resolveHref,
 } from '../shared/lib/router/router'
+import { isBrowser, isServer } from '../shared/lib/utils'
 import { useRouter } from './router'
 import { useIntersection } from './use-intersection'
 
@@ -41,7 +42,7 @@ function prefetch(
   as: string,
   options?: PrefetchOptions
 ): void {
-  if (typeof window === 'undefined' || !router) return
+  if (isServer || !router) return
   if (!isLocalURL(href)) return
   // Prefetch the JSON page if asked (only in the client)
   // We need to handle a prefetch error here since we may be
@@ -113,7 +114,7 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
     }) {
       return new Error(
         `Failed prop type: The prop \`${args.key}\` expects a ${args.expected} in \`<Link>\`, but got \`${args.actual}\` instead.` +
-          (typeof window !== 'undefined'
+          (isBrowser
             ? "\nOpen your browser's console to view the Component stack trace."
             : '')
       )
@@ -233,7 +234,7 @@ function Link(props: React.PropsWithChildren<LinkProps>) {
     } catch (err) {
       throw new Error(
         `Multiple children were passed to <Link> with \`href\` of \`${props.href}\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children` +
-          (typeof window !== 'undefined'
+          (isBrowser
             ? " \nOpen your browser's console to view the Component stack trace."
             : '')
       )

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -1,9 +1,9 @@
-/* global window */
 import React from 'react'
 import Router from '../shared/lib/router/router'
 import type { NextRouter } from '../shared/lib/router/router'
 import { RouterContext } from '../shared/lib/router-context'
 import isError from '../lib/is-error'
+import { isBrowser } from '../shared/lib/utils'
 
 type ClassArguments<T> = T extends new (...args: infer U) => any ? U : any
 
@@ -26,7 +26,7 @@ const singletonRouter: SingletonRouterBase = {
   readyCallbacks: [],
   ready(cb: () => void) {
     if (this.router) return cb()
-    if (typeof window !== 'undefined') {
+    if (isBrowser) {
       this.readyCallbacks.push(cb)
     }
   },

--- a/packages/next/shared/lib/dynamic.tsx
+++ b/packages/next/shared/lib/dynamic.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Loadable from './loadable'
-
-const isServerSide = typeof window === 'undefined'
+import { isServer } from './utils'
 
 export type LoaderComponent<P = {}> = Promise<
   React.ComponentType<P> | { default: React.ComponentType<P> }
@@ -58,7 +57,7 @@ export function noSSR<P = {}>(
   delete loadableOptions.modules
 
   // This check is necessary to prevent react-loadable from initializing on the server
-  if (!isServerSide) {
+  if (!isServer) {
     return LoadableInitializer(loadableOptions)
   }
 

--- a/packages/next/shared/lib/loadable.js
+++ b/packages/next/shared/lib/loadable.js
@@ -24,6 +24,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 import React from 'react'
 import { useSubscription } from 'use-subscription'
 import { LoadableContext } from './loadable-context'
+import { isBrowser, isServer } from '../shared/lib/utils'
 
 const ALL_INITIALIZERS = []
 const READY_INITIALIZERS = []
@@ -90,12 +91,12 @@ function createLoadableComponent(loadFn, options) {
   }
 
   // Server only
-  if (typeof window === 'undefined' && !opts.suspense) {
+  if (isServer && !opts.suspense) {
     ALL_INITIALIZERS.push(init)
   }
 
   // Client only
-  if (!initialized && typeof window !== 'undefined' && !opts.suspense) {
+  if (!initialized && isBrowser && !opts.suspense) {
     // require.resolveWeak check is needed for environments that don't have it available like Jest
     const moduleIds =
       opts.webpack && typeof require.resolveWeak === 'function'
@@ -281,7 +282,7 @@ Loadable.preloadReady = (ids = []) => {
   })
 }
 
-if (typeof window !== 'undefined') {
+if (isBrowser) {
   window.__NEXT_PRELOADREADY = Loadable.preloadReady
 }
 

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -30,6 +30,7 @@ import {
   NextPageContext,
   ST,
   NEXT_DATA,
+  isBrowser,
 } from '../utils'
 import { isDynamicRoute } from './utils/is-dynamic'
 import { parseRelativeUrl } from './utils/parse-relative-url'
@@ -503,7 +504,7 @@ type HistoryMethod = 'replaceState' | 'pushState'
 
 const manualScrollRestoration =
   process.env.__NEXT_SCROLL_RESTORATION &&
-  typeof window !== 'undefined' &&
+  isBrowser &&
   'scrollRestoration' in window.history &&
   !!(function () {
     try {
@@ -746,7 +747,7 @@ export default class Router implements BaseRouter {
       isFallback,
     }
 
-    if (typeof window !== 'undefined') {
+    if (isBrowser) {
       // make sure "as" doesn't start with double slashes or else it can
       // throw an error as it's considered invalid
       if (as.substr(0, 2) !== '//') {

--- a/packages/next/shared/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/shared/lib/router/utils/parse-relative-url.ts
@@ -1,4 +1,4 @@
-import { getLocationOrigin } from '../../utils'
+import { getLocationOrigin, isServer } from '../../utils'
 import { searchParamsToUrlQuery } from './querystring'
 
 /**
@@ -8,9 +8,7 @@ import { searchParamsToUrlQuery } from './querystring'
  * the current origin will be parsed as relative
  */
 export function parseRelativeUrl(url: string, base?: string) {
-  const globalBase = new URL(
-    typeof window === 'undefined' ? 'http://n' : getLocationOrigin()
-  )
+  const globalBase = new URL(isServer ? 'http://n' : getLocationOrigin())
   const resolvedBase = base ? new URL(base, globalBase) : globalBase
   const { pathname, searchParams, search, hash, href, origin } = new URL(
     url,

--- a/packages/next/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/shared/lib/router/utils/route-regex.ts
@@ -1,3 +1,5 @@
+import { isServer } from '../../utils'
+
 interface Group {
   pos: number
   repeat: boolean
@@ -41,7 +43,7 @@ export function getParametrizedRoute(route: string) {
 
   // dead code eliminate for browser since it's only needed
   // while generating routes-manifest
-  if (typeof window === 'undefined') {
+  if (isServer) {
     let routeKeyCharCode = 97
     let routeKeyCharLength = 1
 

--- a/packages/next/shared/lib/side-effect.tsx
+++ b/packages/next/shared/lib/side-effect.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
-
-const isServer = typeof window === 'undefined'
+import { isServer } from '../../shared/lib/utils'
 
 type State = JSX.Element[] | undefined
 

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -441,6 +441,9 @@ export function formatWithValidation(url: UrlObject): string {
   return formatUrl(url)
 }
 
+export const isBrowser = typeof window !== 'undefined'
+export const isServer = !isBrowser
+
 export const SP = typeof performance !== 'undefined'
 export const ST =
   SP &&


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

Extract `isBrowser` and `isServer` into `shared/lib/util`.
