### PR TITLE
Fix snippet language sh -> bash

### DIFF
--- a/errors/opening-an-issue.md
+++ b/errors/opening-an-issue.md
@@ -10,13 +10,13 @@ Some issues may already be fixed in the canary version, so please verify that yo
 
 Run the following in the codebase:
 
-```sh
+```bash
 npm install next@canary
 ```
 
 or
 
-```sh
+```bash
 yarn add next@canary
 ```
 


### PR DESCRIPTION
Fixes `sh` being un-recognized by our renderer. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
