### PR TITLE
Ensure config's `experimental` field exists

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -678,6 +678,8 @@ export default async function loadConfig(
 
     const hasReactRoot = shouldUseReactRoot()
     if (hasReactRoot) {
+      // users might not have the `experimental` key in their config
+      userConfig.experimental = userConfig.experimental || {}
       userConfig.experimental.reactRoot = true
     }
 


### PR DESCRIPTION
Fixes #34499 

Starting with `v12.1.0`, you can't use React 18 when you don't use the `experimental` field in the `next.config.js`

![image](https://user-images.githubusercontent.com/29319414/154569017-38f72690-6879-47d1-a0cd-09072af2967c.png)

That's because [this recent change](https://github.com/vercel/next.js/commit/1aee93581f7154ca4c191388904c33980cd74653) sets `reactRoot` on the user's config without checking if the key already exists:

https://github.com/vercel/next.js/blob/787186a85a054ea870fc964583fe65e9f2286354/packages/next/server/config.ts#L679-L682


This change initializes `experimental` on the `userConfig` if necessary.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`


