### PR TITLE
Ensure workers are not left open

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1910,6 +1910,9 @@ export default async function build(
       })
     }
 
+    // ensure the worker is not left hanging
+    staticWorkers.close()
+
     const analysisEnd = process.hrtime(analysisBegin)
     telemetry.record(
       eventBuildOptimize(pagePaths, {

--- a/packages/next/lib/worker.ts
+++ b/packages/next/lib/worker.ts
@@ -85,4 +85,13 @@ export class Worker {
     this._worker = undefined
     return worker.end()
   }
+
+  /**
+   * Quietly end the worker if it exists
+   */
+  close(): void {
+    if (this._worker) {
+      this._worker.end()
+    }
+  }
 }


### PR DESCRIPTION
This fixes #33615. If an App uses `getInitialProps`, the build function never enters [this conditional block](https://github.com/vercel/next.js/blob/a52bd712fe797b59cfd05ceaa4c33096a0c346ff/packages/next/build/index.ts#L1481-L1484) and the static worker is left open.