### PR TITLE
Fix reference of Context to ctx in API reference

### DIFF
--- a/docs/api-reference/data-fetching/get-initial-props.md
+++ b/docs/api-reference/data-fetching/get-initial-props.md
@@ -54,7 +54,7 @@ For the initial page load, `getInitialProps` will run on the server only. `getIn
 
 ## Context Object
 
-`getInitialProps` receives a single argument called `context`, it's an object with the following properties:
+`getInitialProps` receives a single argument called `ctx`, it's an object with the following properties:
 
 - `pathname` - Current route. That is the path of the page in `/pages`
 - `query` - Query string section of URL parsed as an object

--- a/docs/api-reference/data-fetching/get-initial-props.md
+++ b/docs/api-reference/data-fetching/get-initial-props.md
@@ -54,7 +54,7 @@ For the initial page load, `getInitialProps` will run on the server only. `getIn
 
 ## Context Object
 
-`getInitialProps` receives a single argument called `ctx`, it's an object with the following properties:
+`getInitialProps` receives a single argument called `context.ctx`. It's an object with the following properties:
 
 - `pathname` - Current route. That is the path of the page in `/pages`
 - `query` - Query string section of URL parsed as an object


### PR DESCRIPTION
This PR fixes the reference of context object to use `ctx` used in the `getInitialProps` API reference.

## Bug

- [x] This fixes #33553
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
