### PR TITLE
Fix `next/image` incorrectly warning for `position: absolute` parent

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -280,7 +280,8 @@ function handleLoading(
             } else if (
               layout === 'fill' &&
               parent.position !== 'relative' &&
-              parent.position !== 'fixed'
+              parent.position !== 'fixed' &&
+              parent.position !== 'absolute'
             ) {
               console.warn(
                 `Image with src "${src}" may not render properly with a parent using position:"${parent.position}". Consider changing the parent style to position:"relative" with a width and height.`

--- a/test/integration/image-component/default/pages/layout-fill-inside-nonrelative.js
+++ b/test/integration/image-component/default/pages/layout-fill-inside-nonrelative.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import jpg from '../public/test.jpg'
 import png from '../public/test.png'
+import avif from '../public/test.avif'
 import webp from '../public/test.webp'
 
 const Page = () => {
@@ -13,6 +14,9 @@ const Page = () => {
       </div>
       <div style={{ position: 'fixed', width: '200px', height: '200px' }}>
         <Image id="fixed" layout="fill" priority src={png} />
+      </div>
+      <div style={{ position: 'absolute', width: '200px', height: '200px' }}>
+        <Image id="absolute" layout="fill" priority src={avif} />
       </div>
       <div style={{ position: 'relative', width: '200px', height: '200px' }}>
         <Image id="relative" layout="fill" priority src={webp} />

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -670,6 +670,9 @@ function runTests(mode) {
         /Image with src (.*)png(.*) may not render properly/gm
       )
       expect(warnings).not.toMatch(
+        /Image with src (.*)avif(.*) may not render properly/gm
+      )
+      expect(warnings).not.toMatch(
         /Image with src (.*)webp(.*) may not render properly/gm
       )
       expect(await hasRedbox(browser)).toBe(false)


### PR DESCRIPTION
- Fixes #33007 
- Fixes #31340 