### PR TITLE
fix: match `redirect` and `rewrite` destination types

### DIFF
--- a/packages/next/server/web/spec-extension/response.ts
+++ b/packages/next/server/web/spec-extension/response.ts
@@ -87,7 +87,7 @@ export class NextResponse extends Response {
     })
   }
 
-  static rewrite(destination: string | NextURL) {
+  static rewrite(destination: string | NextURL | URL) {
     return new NextResponse(null, {
       headers: {
         'x-middleware-rewrite': validateURL(destination),


### PR DESCRIPTION
Both `NextResponse.redirect` and `NextResponse.rewrite` should equally accept a `URL` as an argument.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
