### PR TITLE
Ensure rust-check skips on docs only change

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Install
         uses: actions-rs/toolchain@v1
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           profile: minimal
           toolchain: nightly-2021-11-15
@@ -102,25 +102,27 @@ jobs:
 
       - name: Cache cargo registry
         uses: actions/cache@v2
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           path: ~/.cargo/registry
           key: stable-ubuntu-clippy-cargo-registry
 
       - name: Cache cargo index
         uses: actions/cache@v2
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           path: ~/.cargo/git
           key: stable-ubuntu-clippy-cargo-index
 
       - uses: actions/cache@v2
         id: restore-build
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           path: ./*
           key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
 
       - name: Check
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         run: |
           cargo fmt -- --check
           cargo clippy --all -- -D warnings
@@ -135,7 +137,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/34625 this ensures we skip the `rust-check` job when only a docs change.  