### PR TITLE
feat: handle non-desired TS options more gracefully read-only environment

### DIFF
--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -631,6 +631,10 @@
         {
           "title": "client-flush-effects",
           "path": "/errors/client-flush-effects.md"
+        },
+        {
+          "title": "ts-config-readonly",
+          "path": "/errors/ts-config-readonly.md"
         }
       ]
     }

--- a/errors/ts-config-readonly.md
+++ b/errors/ts-config-readonly.md
@@ -1,0 +1,25 @@
+# TypeScript configuration in read-only environments
+
+#### Why This Error Occurred
+
+Next.js automatically detects if your project is using TypeScript and will try to reconfigure it to give the most optimal output. This is done by updating the `tsconfig.json` and `next-env.d.ts` files. The detection runs for both `next dev` and `next build`. In read-only environments (like CI) Next.js won't be able to apply the suggested changes.
+
+#### Possible Ways to Fix It
+
+You should make sure that the suggested changes are applied before running the `next build` command in a read-only environment. Run
+
+```bash
+npm run dev
+```
+
+or
+
+```bash
+yarn dev
+```
+
+in your development environment, and commit and push the changes made to the `tsconfig.json` and `next-env.d.ts` files.
+
+### Useful Links
+
+- [Next.js TypeScript documentation](https://nextjs.org/docs/basic-features/typescript#existing-projects)

--- a/test/e2e/ts-config-readonly/app/pages/index.ts
+++ b/test/e2e/ts-config-readonly/app/pages/index.ts
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'Hello World'
+}

--- a/test/e2e/ts-config-readonly/app/tsconfig.json
+++ b/test/e2e/ts-config-readonly/app/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}

--- a/test/e2e/ts-config-readonly/index.test.ts
+++ b/test/e2e/ts-config-readonly/index.test.ts
@@ -1,0 +1,38 @@
+import { join } from 'path'
+import { promises as fs, constants as fsConstants } from 'fs'
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+
+const appDir = join(__dirname, 'app')
+
+describe('Should warn when tsconfig.json and next-env.d.ts are read-only', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      skipStart: true,
+      files: {
+        pages: new FileRef(join(appDir, 'pages')),
+        'tsconfig.json': new FileRef(join(appDir, 'tsconfig.json')),
+      },
+      dependencies: {
+        '@types/node': '17.0.19',
+        '@types/react': '17.0.39',
+        typescript: '4.5.5',
+      },
+    })
+
+    await fs.chmod(join(next.testDir, 'tsconfig.json'), fsConstants.R_OK)
+  })
+
+  afterAll(async () => {
+    await fs.chmod(join(next.testDir, 'tsconfig.json'), fsConstants.W_OK)
+    await next.destroy()
+  })
+
+  it('should work', async () => {
+    console.log(next.cliOutput)
+
+    expect(true).toBe(true)
+  })
+})

--- a/test/e2e/ts-config-readonly/tsconfig.json
+++ b/test/e2e/ts-config-readonly/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+    // "lib": [ "dom", "dom.iterable", "esnext" ], // suggested
+    // "moduleResolution": "node" // required
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Our TypeScript detection tries to correct `tsconfig.json` and `next-env.d.ts` non-desired options which can result in an error in read-only environments (for example CI).

In those cases, we should continue if all the required options are present, but still, show a warning if some of the suggested warnings are missing.

Fixes #34536

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
