### PR TITLE
Lock yarn pnp version in tests

### DIFF
--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -31,7 +31,7 @@ export function runTests(example = '') {
           prev.push(`${cur}@${dependencies[cur]}`)
           return prev
         }, [] as string[])
-        return `yarn set version berry && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
+        return `yarn set version 3.1.1 && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
           ' '
         )}`
       },


### PR DESCRIPTION
It seems the most recent [publish for yarn berry](https://github.com/yarnpkg/berry/commit/58dd22e47eb46da5c2c32377ed5f749754b9ea64) is causing a breaking change with `jest-worker` breaking tests. This temporarily locks the version we test against until this is resolved.

x-ref: https://github.com/vercel/next.js/runs/5290374235?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/5289675273?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/5282660046?check_suite_focus=true 