### PR TITLE
Normalize image optimizer error status codes

### DIFF
--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -259,7 +259,13 @@ export class ImageError extends Error {
 
   constructor(statusCode: number, message: string) {
     super(message)
-    this.statusCode = statusCode
+
+    // ensure an error status is used > 400
+    if (statusCode >= 400) {
+      this.statusCode = statusCode
+    } else {
+      this.statusCode = 500
+    }
   }
 }
 


### PR DESCRIPTION
Updates to ensure we return an error status code when ImageError is used regardless of the upstream status. 