### PR TITLE
chore: Move test for streaming and RSC

### DIFF
--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -69,16 +69,7 @@ export default function Page500() {
 }
 `
 
-describe('Edge runtime - basic', () => {
-  it('should warn user for experimental risk with server components', async () => {
-    const edgeRuntimeWarning =
-      'You are using the experimental Edge Runtime with `experimental.runtime`.'
-    const rscWarning = `You have experimental React Server Components enabled. Continue at your own risk.`
-    const { stderr } = await nextBuild(appDir)
-    expect(stderr).toContain(edgeRuntimeWarning)
-    expect(stderr).toContain(rscWarning)
-  })
-
+describe('Edge runtime - errors', () => {
   it('should warn user that native node APIs are not supported', async () => {
     const fsImportedErrorMessage =
       'Native Node.js APIs are not supported in the Edge Runtime. Found `dns` imported.'
@@ -93,12 +84,21 @@ describe('Edge runtime - prod', () => {
   beforeAll(async () => {
     error500Page.write(page500)
     context.appPort = await findPort()
-    await nextBuild(context.appDir)
+    const { stderr } = await nextBuild(context.appDir)
+    context.stderr = stderr
     context.server = await nextStart(context.appDir, context.appPort)
   })
   afterAll(async () => {
     error500Page.delete()
     await killApp(context.server)
+  })
+
+  it('should warn user for experimental risk with edge runtime and server components', async () => {
+    const edgeRuntimeWarning =
+      'You are using the experimental Edge Runtime with `experimental.runtime`.'
+    const rscWarning = `You have experimental React Server Components enabled. Continue at your own risk.`
+    expect(context.stderr).toContain(edgeRuntimeWarning)
+    expect(context.stderr).toContain(rscWarning)
   })
 
   it('should generate middleware SSR manifests for edge runtime', async () => {


### PR DESCRIPTION
This particular test can be moved to the "Edge runtime - prod" suite to avoid an extra build, which speeds up the test a bit :D

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
