### PR TITLE
`process.env.*` variables are replaced at run time

### DIFF
--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -47,7 +47,7 @@ export async function getStaticProps() {
 ```
 
 > **Note**: In order to keep server-only secrets safe, Next.js replaces `process.env.*` with the correct values
-> at build time. This means that `process.env` is not a standard JavaScript object, so you’re not able to
+> at run time. This means that `process.env` is not a standard JavaScript object, so you’re not able to
 > use [object destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 > Environment variables must be referenced as e.g. `process.env.PUBLISHABLE_KEY`, _not_ `const { PUBLISHABLE_KEY } = process.env`.
 


### PR DESCRIPTION
This updates the wording to be consistent with observed behavior within next. Changes to any of the `.env` files, or changes to the environment that are done after running `next build` are properly reflected in the running app. 

This is an important distinction for organizations adhering to the 12-factor idea of ["build, release, run"](https://12factor.net/build-release-run).

## Documentation / Examples

- [X] Make sure the linting passes by running `yarn lint`
