### PR TITLE
Add redirect for error doc rename

### DIFF
--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -41,8 +41,10 @@
           "path": "/errors/amp-export-validation.md"
         },
         {
-          "title": "api-routes-body-size-limit",
-          "path": "/errors/api-routes-response-size-limit.md"
+          "path": "/errors/api-routes-body-size-limit.md",
+          "redirect": {
+            "destination": "/docs/messages/api-routes-response-size-limit"
+          }
         },
         {
           "title": "api-routes-response-size-limit",


### PR DESCRIPTION
Adds a redirect for the error document rename in https://github.com/vercel/next.js/pull/34700

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
