### PR TITLE
Ensure unstable_revalidate does not error from notFound: true

### DIFF
--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -315,7 +315,13 @@ async function unstable_revalidate(
       },
     })
 
-    if (!res.ok) {
+    // we use the cache header to determine successful revalidate as
+    // a non-200 status code can be returned from a successful revalidate
+    // e.g. notFound: true returns 404 status code but is successful
+    const cacheHeader =
+      res.headers.get('x-vercel-cache') || res.headers.get('x-nextjs-cache')
+
+    if (cacheHeader?.toUpperCase() !== 'REVALIDATED') {
       throw new Error(`Invalid response ${res.status}`)
     }
   } catch (err) {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1528,6 +1528,21 @@ export default abstract class Server {
       return null
     }
 
+    if (isSSG) {
+      // set x-nextjs-cache header to match the header
+      // we set for the image-optimizer
+      res.setHeader(
+        'x-nextjs-cache',
+        isManualRevalidate
+          ? 'REVALIDATED'
+          : cacheEntry.isMiss
+          ? 'MISS'
+          : cacheEntry.isStale
+          ? 'STALE'
+          : 'HIT'
+      )
+    }
+
     const { revalidate, value: cachedData } = cacheEntry
     const revalidateOptions: any =
       typeof revalidate !== 'undefined' &&

--- a/test/e2e/prerender/pages/blocking-fallback-once/[slug].js
+++ b/test/e2e/prerender/pages/blocking-fallback-once/[slug].js
@@ -4,13 +4,25 @@ import { useRouter } from 'next/router'
 
 export async function getStaticPaths() {
   return {
-    paths: [],
+    paths: [
+      {
+        params: { slug: '404-on-manual-revalidate' },
+      },
+    ],
     fallback: 'blocking',
   }
 }
 
 export async function getStaticProps({ params }) {
   await new Promise((resolve) => setTimeout(resolve, 1000))
+
+  if (process.env.NEXT_PHASE !== 'phase-production-build') {
+    if (params.slug === '404-on-manual-revalidate') {
+      return {
+        notFound: true,
+      }
+    }
+  }
 
   return {
     props: {


### PR DESCRIPTION
We are currently deriving a successful revalidation in `unstable_revalidate` from the response status although this can incorrectly signal a failed revalidation when returning `notFound: true` since the status will be 404 but it was successful. This updates to rely on the cache header instead which will be set to `REVALIDATED` when successfully revalidated. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/34809