### PR TITLE
Update test concurrency for CI

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -310,7 +310,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
@@ -340,7 +340,7 @@ jobs:
       - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
-      - run: xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/15
+      - run: xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/18
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
       - name: Upload test trace

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -181,7 +181,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -211,7 +211,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -261,7 +261,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -311,7 +311,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -351,7 +351,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -396,7 +396,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -446,7 +446,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -496,7 +496,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -531,7 +531,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -575,7 +575,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -612,7 +612,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 17
           check-latest: true
@@ -645,7 +645,7 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
           node-version: 14
 
@@ -680,7 +680,6 @@ jobs:
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
-        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
         with:
           node-version: 14
 

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -310,7 +310,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
@@ -340,7 +340,7 @@ jobs:
       - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
-      - run: xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/12
+      - run: xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/15
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
       - name: Upload test trace

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -340,7 +340,7 @@ jobs:
       - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
-      - run: xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/6
+      - run: xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/12
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
       - name: Upload test trace

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -255,6 +255,56 @@ jobs:
           path: |
             test/traces
 
+  testDevE2E:
+    name: Test Development (E2E)
+    runs-on: ubuntu-latest
+    needs: [build, build-native-dev]
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      NEXT_TEST_JOB: 1
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        with:
+          node-version: 14
+
+      - run: echo ${{needs.build.outputs.docsChange}}
+
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - uses: actions/cache@v2
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+
+      - uses: actions/download-artifact@v2
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+        with:
+          name: next-swc-dev-binary
+          path: packages/next-swc/native
+
+      - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+
+      - run: NEXT_TEST_MODE=dev node run-tests.js --type e2e
+        name: Run test/e2e (dev)
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+
+      - name: Upload test trace
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-trace
+          if-no-files-found: ignore
+          retention-days: 2
+          path: |
+            test/traces
+
   testProd:
     name: Test Production
     runs-on: ubuntu-latest
@@ -293,6 +343,46 @@ jobs:
 
       - run: node run-tests.js --type production
         name: Run test/production
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+
+      - run: NEXT_TEST_MODE=start node run-tests.js --type e2e
+        name: Run test/e2e (production)
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+
+  testProdE2E:
+    name: Test Production (E2E)
+    runs-on: ubuntu-latest
+    needs: [build, build-native-dev]
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      NEXT_TEST_JOB: 1
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        if: ${{ steps.docs-change.outputs.docsChange != 'docs only change' }}
+        with:
+          node-version: 14
+
+      - run: echo ${{needs.build.outputs.docsChange}}
+
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - uses: actions/cache@v2
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+
+      - uses: actions/download-artifact@v2
+        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
+        with:
+          name: next-swc-dev-binary
+          path: packages/next-swc/native
+
+      - run: npm i -g playwright-chromium@1.14.1 && npx playwright install-deps
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
       - run: NEXT_TEST_MODE=start node run-tests.js --type e2e

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -241,10 +241,6 @@ jobs:
         name: Run test/development
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
-      - run: NEXT_TEST_MODE=dev node run-tests.js --type e2e
-        name: Run test/e2e (dev)
-        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
-
       - name: Upload test trace
         if: always()
         uses: actions/upload-artifact@v2
@@ -343,10 +339,6 @@ jobs:
 
       - run: node run-tests.js --type production
         name: Run test/production
-        if: ${{needs.build.outputs.docsChange != 'docs only change'}}
-
-      - run: NEXT_TEST_MODE=start node run-tests.js --type e2e
-        name: Run test/e2e (production)
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
 
   testProdE2E:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -310,7 +310,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5, 6]
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     steps:
       - name: Setup node
         uses: actions/setup-node@v2


### PR DESCRIPTION
As discussed [in slack](https://vercel.slack.com/archives/C5MDPQUBU/p1645742977019439?thread_ts=1645562784.286099&cid=C5MDPQUBU) we have more concurrency available to us now and we are currently reaching almost 40 minutes for tests in CI so this parallelizes our jobs more to decrease our test times and leverage this additional concurrency. This brings our CI times closer to around 12 - 15 minutes. 