### PR TITLE
Clean-up error when starting next with non-existent dir

### DIFF
--- a/packages/next/lib/get-project-dir.ts
+++ b/packages/next/lib/get-project-dir.ts
@@ -3,17 +3,29 @@ import path from 'path'
 import * as Log from '../build/output/log'
 
 export function getProjectDir(dir?: string) {
-  const resolvedDir = path.resolve(dir || '.')
-  const realDir = fs.realpathSync.native(resolvedDir)
+  try {
+    const resolvedDir = path.resolve(dir || '.')
+    const realDir = fs.realpathSync.native(resolvedDir)
 
-  if (
-    resolvedDir !== realDir &&
-    resolvedDir.toLowerCase() === realDir.toLowerCase()
-  ) {
-    Log.warn(
-      `Invalid casing detected for project dir, received ${resolvedDir} actual path ${realDir}, see more info here https://nextjs.org/docs/messages/invalid-project-dir-casing`
-    )
+    if (
+      resolvedDir !== realDir &&
+      resolvedDir.toLowerCase() === realDir.toLowerCase()
+    ) {
+      Log.warn(
+        `Invalid casing detected for project dir, received ${resolvedDir} actual path ${realDir}, see more info here https://nextjs.org/docs/messages/invalid-project-dir-casing`
+      )
+    }
+
+    return realDir
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      Log.error(
+        `Invalid project directory provided, no such directory: ${path.resolve(
+          dir || '.'
+        )}`
+      )
+      process.exit(1)
+    }
+    throw err
   }
-
-  return realDir
 }

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -48,7 +48,17 @@ describe('CLI Usage', () => {
         new RegExp(`Next\\.js v${pkg.version.replace(/\./g, '\\.')}`)
       )
     })
+
+    test('invalid directory', async () => {
+      const output = await runNextCommand(['non-existent'], {
+        stderr: true,
+      })
+      expect(output.stderr).toContain(
+        'Invalid project directory provided, no such directory'
+      )
+    })
   })
+
   describe('build', () => {
     test('--help', async () => {
       const help = await runNextCommand(['build', '--help'], {
@@ -108,6 +118,15 @@ describe('CLI Usage', () => {
       const expectedExitSignal = process.platform === `win32` ? 'SIGTERM' : null
       expect(code).toBe(expectedExitCode)
       expect(signal).toBe(expectedExitSignal)
+    })
+
+    test('invalid directory', async () => {
+      const output = await runNextCommand(['build', 'non-existent'], {
+        stderr: true,
+      })
+      expect(output.stderr).toContain(
+        'Invalid project directory provided, no such directory'
+      )
     })
   })
 
@@ -253,6 +272,15 @@ describe('CLI Usage', () => {
       expect(code).toBe(expectedExitCode)
       expect(signal).toBe(expectedExitSignal)
     })
+
+    test('invalid directory', async () => {
+      const output = await runNextCommand(['dev', 'non-existent'], {
+        stderr: true,
+      })
+      expect(output.stderr).toContain(
+        'Invalid project directory provided, no such directory'
+      )
+    })
   })
 
   describe('start', () => {
@@ -337,6 +365,15 @@ describe('CLI Usage', () => {
       expect(code).toBe(expectedExitCode)
       expect(signal).toBe(expectedExitSignal)
     })
+
+    test('invalid directory', async () => {
+      const output = await runNextCommand(['start', 'non-existent'], {
+        stderr: true,
+      })
+      expect(output.stderr).toContain(
+        'Invalid project directory provided, no such directory'
+      )
+    })
   })
 
   describe('export', () => {
@@ -365,6 +402,15 @@ describe('CLI Usage', () => {
         stderr: true,
       })
       expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+    })
+
+    test('invalid directory', async () => {
+      const output = await runNextCommand(['export', 'non-existent'], {
+        stderr: true,
+      })
+      expect(output.stderr).toContain(
+        'Invalid project directory provided, no such directory'
+      )
     })
   })
 


### PR DESCRIPTION
This ensures we show a proper error when a non-existent directory is passed to Next.js as the current error shown is quite noisy. 

<details>

<summary>before</summary>

<img width="977" alt="before" src="https://user-images.githubusercontent.com/22380829/155802900-9f45dd9b-1130-478f-92f7-d4b1e1c3259a.png">

</details>

<details>

<summary>after</summary>

<img width="977" alt="after" src="https://user-images.githubusercontent.com/22380829/155802937-69b60672-c5dd-4740-85a5-18dfefdb8ccb.png">


</details>
