### PR TITLE
Add CLI command typo detection

### DIFF
--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -15,7 +15,7 @@ import { NON_STANDARD_NODE_ENV } from '../lib/constants'
 
 const defaultCommand = 'dev'
 export type cliCommand = (argv?: string[]) => void
-const commands: { [command: string]: () => Promise<cliCommand> } = {
+export const commands: { [command: string]: () => Promise<cliCommand> } = {
   build: () => Promise.resolve(require('../cli/next-build').nextBuild),
   start: () => Promise.resolve(require('../cli/next-start').nextStart),
   export: () => Promise.resolve(require('../cli/next-export').nextExport),

--- a/packages/next/lib/detect-typo.ts
+++ b/packages/next/lib/detect-typo.ts
@@ -1,0 +1,44 @@
+// the minimum number of operations required to convert string a to string b.
+function minDistance(a: string, b: string, threshold: number): number {
+  const m = a.length
+  const n = b.length
+
+  if (m < n) {
+    return minDistance(b, a, threshold)
+  }
+
+  if (n === 0) {
+    return m
+  }
+
+  let previousRow = Array.from({ length: n + 1 }, (_, i) => i)
+
+  for (let i = 0; i < m; i++) {
+    const s1 = a[i]
+    let currentRow = [i + 1]
+    for (let j = 0; j < n; j++) {
+      const s2 = b[j]
+      const insertions = previousRow[j + 1] + 1
+      const deletions = currentRow[j] + 1
+      const substitutions = previousRow[j] + Number(s1 !== s2)
+      currentRow.push(Math.min(insertions, deletions, substitutions))
+    }
+    previousRow = currentRow
+  }
+  return previousRow[previousRow.length - 1]
+}
+
+export function detectTypo(input: string, options: string[], threshold = 2) {
+  const potentialTypos = options
+    .map((o) => ({
+      option: o,
+      distance: minDistance(o, input, threshold),
+    }))
+    .filter(({ distance }) => distance <= threshold && distance > 0)
+    .sort((a, b) => a.distance - b.distance)
+
+  if (potentialTypos.length) {
+    return potentialTypos[0].option
+  }
+  return null
+}

--- a/packages/next/lib/get-project-dir.ts
+++ b/packages/next/lib/get-project-dir.ts
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
+import { commands } from '../bin/next'
 import * as Log from '../build/output/log'
+import { detectTypo } from './detect-typo'
 
 export function getProjectDir(dir?: string) {
   try {
@@ -19,6 +21,17 @@ export function getProjectDir(dir?: string) {
     return realDir
   } catch (err: any) {
     if (err.code === 'ENOENT') {
+      if (typeof dir === 'string') {
+        const detectedTypo = detectTypo(dir, Object.keys(commands))
+
+        if (detectedTypo) {
+          Log.error(
+            `"${dir}" seems to be a typo, did you mean: next ${detectedTypo}`
+          )
+          process.exit(1)
+        }
+      }
+
       Log.error(
         `Invalid project directory provided, no such directory: ${path.resolve(
           dir || '.'

--- a/packages/next/lib/get-project-dir.ts
+++ b/packages/next/lib/get-project-dir.ts
@@ -26,7 +26,7 @@ export function getProjectDir(dir?: string) {
 
         if (detectedTypo) {
           Log.error(
-            `"${dir}" seems to be a typo, did you mean: next ${detectedTypo}`
+            `"next ${dir}" does not exist. Did you mean "next ${detectedTypo}"?`
           )
           process.exit(1)
         }

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -73,7 +73,7 @@ describe('CLI Usage', () => {
           stderr: true,
         })
         expect(output.stderr).toContain(
-          `"${check[0]}" seems to be a typo, did you mean: next ${check[1]}`
+          `"next ${check[0]}" does not exist. Did you mean "next ${check[1]}"? `
         )
       }
     })

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -73,7 +73,7 @@ describe('CLI Usage', () => {
           stderr: true,
         })
         expect(output.stderr).toContain(
-          `"next ${check[0]}" does not exist. Did you mean "next ${check[1]}"? `
+          `"next ${check[0]}" does not exist. Did you mean "next ${check[1]}"?`
         )
       }
     })

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -57,6 +57,26 @@ describe('CLI Usage', () => {
         'Invalid project directory provided, no such directory'
       )
     })
+
+    test('detects command typos', async () => {
+      const typos = [
+        ['buidl', 'build'],
+        ['buill', 'build'],
+        ['biild', 'build'],
+        ['exporr', 'export'],
+        ['starr', 'start'],
+        ['dee', 'dev'],
+      ]
+
+      for (const check of typos) {
+        const output = await runNextCommand([check[0]], {
+          stderr: true,
+        })
+        expect(output.stderr).toContain(
+          `"${check[0]}" seems to be a typo, did you mean: next ${check[1]}`
+        )
+      }
+    })
   })
 
   describe('build', () => {


### PR DESCRIPTION
This adds detecting CLI command typos when we fail to find a project directory. 

<details>

<summary>screenshot</summary>

<img width="977" alt="Screen Shot 2022-02-25 at 4 21 37 PM" src="https://user-images.githubusercontent.com/22380829/155820351-73ed0507-03f1-4a27-b184-8495843a9ff4.png">


</details>

x-ref: https://github.com/vercel/next.js/pull/34830#discussion_r815162384