### PR TITLE
fix: remove lock for eslint-plugin-react in eslint-config-next

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -16,7 +16,7 @@
     "eslint-import-resolver-typescript": "2.4.0",
     "eslint-plugin-import": "2.25.2",
     "eslint-plugin-jsx-a11y": "6.5.1",
-    "eslint-plugin-react": "7.28.0",
+    "eslint-plugin-react": "^7.27.0",
     "eslint-plugin-react-hooks": "4.3.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4060,7 +4060,7 @@
   resolved "https://registry.yarnpkg.com/@napi-rs/cli/-/cli-2.4.4.tgz#878a38f0fba1709d89d66eba706745ce728a61a5"
   integrity sha512-f+tvwCv1ka24dBqI2DgBhR7Oxl3DKHOp4onxLXwyBFt6iCADnr3YZIr1/2Iq5r3uqxFgaf01bfPsRQZPkEp0kQ==
 
-"@napi-rs/triples@1.1.0", "@napi-rs/triples@^1.0.3":
+"@napi-rs/triples@^1.0.3", "@napi-rs/triples@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.1.0.tgz#88c35b72e79a20b79bb4c9b3e2817241a1c9f4f9"
   integrity sha512-XQr74QaLeMiqhStEhLn1im9EOMnkypp7MZOwQhGzqp2Weu5eQJbpPxWxixxlYRKWPOmJjsk6qYfYH9kq43yc2w==
@@ -9600,10 +9600,10 @@ eslint-plugin-react@7.23.2:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.4"
 
-eslint-plugin-react@7.28.0:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz#8f3ff450677571a659ce76efc6d80b6a525adbdf"
-  integrity sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==
+eslint-plugin-react@^7.27.0:
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz#f952c76517a3915b81c7788b220b2b4c96703124"
+  integrity sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flatmap "^1.2.5"


### PR DESCRIPTION
Remove lock for eslint-plugin-react in eslint-config-next

Context: [yannickcr/eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) was released in [7.29.1](https://github.com/yannickcr/eslint-plugin-react/releases/tag/v7.29.1) and fix the issue causing unnecessary warning for react-jsx-key

Related: https://github.com/vercel/next.js/pull/34800

See: https://github.com/yannickcr/eslint-plugin-react/compare/v7.29.0...v7.29.1
