### PR TITLE
Update to use whatwg validator for test

### DIFF
--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -1150,7 +1150,7 @@ function runTests(mode) {
     }
   })
 
-  it('should be valid W3C HTML', async () => {
+  it('should be valid HTML', async () => {
     let browser
     try {
       browser = await webdriver(appPort, '/valid-html-w3c')
@@ -1161,8 +1161,10 @@ function runTests(mode) {
         url,
         format: 'json',
         isLocal: true,
+        validator: 'whatwg',
       })
-      expect(result.messages).toEqual([])
+      expect(result.isValid).toBe(true)
+      expect(result.errors).toEqual([])
     } finally {
       if (browser) {
         await browser.close()


### PR DESCRIPTION
The w3c validator seems to be down and this shouldn't block our tests so this uses the whatwg validator instead

x-ref: https://github.com/vercel/next.js/runs/5361585193?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/5356851471?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/5361463120?check_suite_focus=true