### PR TITLE
Fix only byte stream writing is allowed in CF workers

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1842,8 +1842,8 @@ function createPrefixStream(
     transform(chunk, controller) {
       if (!prefixFlushed && prefix) {
         prefixFlushed = true
-        const prefixedChunk = prefix + decodeText(chunk)
-        controller.enqueue(encodeText(prefixedChunk))
+        controller.enqueue(chunk)
+        controller.enqueue(encodeText(prefix))
       } else {
         controller.enqueue(chunk)
       }
@@ -1973,7 +1973,6 @@ async function streamToString(
     const { done, value } = await reader.read()
 
     if (done) {
-      console.log('bufferedString', bufferedString)
       return bufferedString
     }
 

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1957,7 +1957,7 @@ function streamFromArray(strings: string[]): ReadableStream<Uint8Array> {
   const { readable, writable } = new TransformStream()
 
   const writer = writable.getWriter()
-  strings.forEach((str) => writer.write(str))
+  strings.forEach((str) => writer.write(encodeText(str)))
   writer.close()
 
   return readable


### PR DESCRIPTION
CF worker doesn't allow to use `writer.write(string)` but only byte stream, we have to transform the Uint8Array stream

![image](https://user-images.githubusercontent.com/4800338/156043536-25fcdb15-3f69-427e-9e31-97169609eb7a.png)
