### PR TITLE
Update ISR error handling

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1905,6 +1905,50 @@ describe('Prerender', () => {
     }
 
     if (!(global as any).isNextDev) {
+      it('should automatically reset cache TTL when an error occurs and build cache was available', async () => {
+        await next.patchFile('error.txt', 'yes')
+        await waitFor(2000)
+
+        for (let i = 0; i < 5; i++) {
+          const res = await fetchViaHTTP(
+            next.url,
+            '/blocking-fallback/test-errors-1'
+          )
+          expect(res.status).toBe(200)
+        }
+        await next.deleteFile('error.txt')
+        expect(
+          next.cliOutput.match(
+            /throwing error for \/blocking-fallback\/test-errors-1/
+          ).length
+        ).toBe(1)
+      })
+
+      it('should automatically reset cache TTL when an error occurs and runtime cache was available', async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/blocking-fallback/test-errors-2'
+        )
+
+        expect(res.status).toBe(200)
+        await waitFor(2000)
+        await next.patchFile('error.txt', 'yes')
+
+        for (let i = 0; i < 5; i++) {
+          const res = await fetchViaHTTP(
+            next.url,
+            '/blocking-fallback/test-errors-2'
+          )
+          expect(res.status).toBe(200)
+        }
+        await next.deleteFile('error.txt')
+        expect(
+          next.cliOutput.match(
+            /throwing error for \/blocking-fallback\/test-errors-2/
+          ).length
+        ).toBe(1)
+      })
+
       it('should handle manual revalidate for fallback: blocking', async () => {
         const res = await fetchViaHTTP(
           next.url,

--- a/test/e2e/prerender/pages/blocking-fallback/[slug].js
+++ b/test/e2e/prerender/pages/blocking-fallback/[slug].js
@@ -1,15 +1,31 @@
+import fs from 'fs'
+import path from 'path'
 import React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 export async function getStaticPaths() {
   return {
-    paths: [],
+    paths: [
+      {
+        params: { slug: 'test-errors-1' },
+      },
+    ],
     fallback: 'blocking',
   }
 }
 
 export async function getStaticProps({ params }) {
+  if (params.slug.startsWith('test-errors')) {
+    const errorFile = path.join(process.cwd(), 'error.txt')
+    if (fs.existsSync(errorFile)) {
+      const data = await fs.readFileSync(errorFile, 'utf8')
+      if (data.trim() === 'yes') {
+        throw new Error('throwing error for /blocking-fallback/' + params.slug)
+      }
+    }
+  }
+
   await new Promise((resolve) => setTimeout(resolve, 1000))
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4855,7 +4855,7 @@
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
 
-"@types/eslint-scope@^3.7.0", "@types/eslint-scope@^3.7.3":
+"@types/eslint-scope@^3.7.3":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
   integrity sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==
@@ -4879,11 +4879,6 @@
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-
-"@types/estree@^0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
-  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
 "@types/estree@^0.0.51":
   version "0.0.51"


### PR DESCRIPTION
This corrects our behavior for when an ISR page is erroring during revalidation as currently Next.js will retry every time a path is requested. This updates to reset the cache period when an error occurs using a max cache extension of 30 seconds and a minimum of 3 seconds. 