### PR TITLE
chore: update existing PR stat comment

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/action-info.js
+++ b/.github/actions/next-stats-action/src/prepare/action-info.js
@@ -46,6 +46,7 @@ module.exports = function actionInfo() {
 
   const info = {
     commentEndpoint,
+    commentIdentifier: '<!--pr-stats-comment-->',
     skipClone: SKIP_CLONE,
     actionName: GITHUB_ACTION,
     githubToken: PR_STATS_COMMENT_TOKEN,


### PR DESCRIPTION
To reduce the number of comments generated by the PR stat GitHub action.

This PR adds a change that first checks if a PR stat comment already exists, if it does, it will update that instead of adding a new one, sending out extra notifications to maintainers. The edit history is kept, so it's easy to compare to previous results as well.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
