### PR TITLE
Fix `next/image` noscript when blur and priority

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -722,29 +722,30 @@ export default function Image({
         ref={imgRef}
         style={{ ...imgStyle, ...blurStyle }}
       />
-      {isLazy && (
-        <noscript>
-          <img
-            {...rest}
-            {...generateImgAttrs({
-              config,
-              src,
-              unoptimized,
-              layout,
-              width: widthInt,
-              quality: qualityInt,
-              sizes,
-              loader,
-            })}
-            decoding="async"
-            data-nimg={layout}
-            style={imgStyle}
-            className={className}
-            // @ts-ignore - TODO: upgrade to `@types/react@17`
-            loading={loading || 'lazy'}
-          />
-        </noscript>
-      )}
+      {isLazy ||
+        (placeholder === 'blur' && (
+          <noscript>
+            <img
+              {...rest}
+              {...generateImgAttrs({
+                config,
+                src,
+                unoptimized,
+                layout,
+                width: widthInt,
+                quality: qualityInt,
+                sizes,
+                loader,
+              })}
+              decoding="async"
+              data-nimg={layout}
+              style={imgStyle}
+              className={className}
+              // @ts-ignore - TODO: upgrade to `@types/react@17`
+              loading={loading || 'lazy'}
+            />
+          </noscript>
+        ))}
 
       {priority ? (
         // Note how we omit the `href` attribute, as it would only be relevant

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -722,30 +722,29 @@ export default function Image({
         ref={imgRef}
         style={{ ...imgStyle, ...blurStyle }}
       />
-      {isLazy ||
-        (placeholder === 'blur' && (
-          <noscript>
-            <img
-              {...rest}
-              {...generateImgAttrs({
-                config,
-                src,
-                unoptimized,
-                layout,
-                width: widthInt,
-                quality: qualityInt,
-                sizes,
-                loader,
-              })}
-              decoding="async"
-              data-nimg={layout}
-              style={imgStyle}
-              className={className}
-              // @ts-ignore - TODO: upgrade to `@types/react@17`
-              loading={loading || 'lazy'}
-            />
-          </noscript>
-        ))}
+      {(isLazy || placeholder === 'blur') && (
+        <noscript>
+          <img
+            {...rest}
+            {...generateImgAttrs({
+              config,
+              src,
+              unoptimized,
+              layout,
+              width: widthInt,
+              quality: qualityInt,
+              sizes,
+              loader,
+            })}
+            decoding="async"
+            data-nimg={layout}
+            style={imgStyle}
+            className={className}
+            // @ts-ignore - TODO: upgrade to `@types/react@17`
+            loading={loading || 'lazy'}
+          />
+        </noscript>
+      )}
 
       {priority ? (
         // Note how we omit the `href` attribute, as it would only be relevant

--- a/test/unit/image-rendering.test.ts
+++ b/test/unit/image-rendering.test.ts
@@ -46,4 +46,37 @@ describe('Image rendering', () => {
     expect($2('noscript').length).toBe(0)
     expect($lazy('noscript').length).toBe(1)
   })
+
+  it('should render noscript element when placeholder=blur', async () => {
+    const element1 = React.createElement(Image, {
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      loading: 'eager',
+      placeholder: 'blur',
+      blurDataURL: 'data:image/png;base64',
+    })
+    const element2 = React.createElement(Image, {
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      placeholder: 'blur',
+      blurDataURL: 'data:image/png;base64',
+      loading: 'eager',
+    })
+    const element3 = React.createElement(Image, {
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      placeholder: 'blur',
+      blurDataURL: 'data:image/png;base64',
+      priority: true,
+    })
+    const $1 = cheerio.load(ReactDOM.renderToString(element1))
+    const $2 = cheerio.load(ReactDOM.renderToString(element2))
+    const $3 = cheerio.load(ReactDOM.renderToString(element3))
+    expect($1('noscript').length).toBe(1)
+    expect($2('noscript').length).toBe(1)
+    expect($3('noscript').length).toBe(1)
+  })
 })


### PR DESCRIPTION
Fixes a bug where browsers with scripts disabled did not work with `<Image placeholder="blur" priority />`.

- Introduced in #32918 