### PR TITLE
fix(examples/with-docker): add npm comment for yarn build

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -23,6 +23,9 @@ COPY . .
 
 RUN yarn build
 
+# If using npm comment out above and use below instead
+# RUN npm run build
+
 # Production image, copy all the files and run next
 FROM node:16-alpine AS runner
 WORKDIR /app


### PR DESCRIPTION
There was an `npm` equivalent for `yarn install` (`npm ci`) but not one for `yarn build`. I've added `npm run build` as a commented out option.

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
