### PR TITLE
Stop passing `webpackHMR` to `initialize`

### DIFF
--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -38,7 +38,13 @@ window.next = {
 }
 
 const webpackHMR = initWebpackHMR()
-initialize({ webpackHMR })
+initialize({
+  onError: (_) => {
+    // A Next.js rendering runtime error is always unrecoverable
+    // FIXME: let's make this recoverable (error in GIP client-transition)
+    webpackHMR.onUnrecoverableError()
+  },
+})
   .then(({ assetPrefix }) => {
     connectHMR({ assetPrefix, path: '/_next/webpack-hmr' })
 


### PR DESCRIPTION
We're only passing `webpackHMR` so that we can call `onUnrecoverableError` if an error occurs. Let's just make that explicit by passing an optional `onError` handler. This is useful because I'm going to be moving error handling to the router in an upcoming PR, and I don't want to have to pass `webpackHMR` to it.