### PR TITLE
Render `ReactDevOverlay` as part of `doRender`

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -164,14 +164,7 @@ class Container extends React.Component<{
   }
 
   render() {
-    if (process.env.NODE_ENV === 'production') {
-      return this.props.children
-    } else {
-      const {
-        ReactDevOverlay,
-      } = require('next/dist/compiled/@next/react-dev-overlay/client')
-      return <ReactDevOverlay>{this.props.children}</ReactDevOverlay>
-    }
+    return this.props.children
   }
 }
 
@@ -978,7 +971,7 @@ function doRender(input: RenderRouteInfo): Promise<any> {
 
   onStart()
 
-  const elem: JSX.Element = (
+  let elem: JSX.Element = (
     <>
       <Head callback={onHeadCommit} />
       <AppContainer>
@@ -990,15 +983,22 @@ function doRender(input: RenderRouteInfo): Promise<any> {
     </>
   )
 
+  elem = process.env.__NEXT_STRICT_MODE ? (
+    <React.StrictMode>{elem}</React.StrictMode>
+  ) : (
+    elem
+  )
+
+  if (process.env.NODE_ENV !== 'production') {
+    const {
+      ReactDevOverlay,
+    } = require('next/dist/compiled/@next/react-dev-overlay/client')
+    elem = <ReactDevOverlay>{elem}</ReactDevOverlay>
+  }
+
   // We catch runtime errors using componentDidCatch which will trigger renderError
   renderReactElement(appElement!, (callback) => (
-    <Root callbacks={[callback, onRootCommit]}>
-      {process.env.__NEXT_STRICT_MODE ? (
-        <React.StrictMode>{elem}</React.StrictMode>
-      ) : (
-        elem
-      )}
-    </Root>
+    <Root callbacks={[callback, onRootCommit]}>{elem}</Root>
   ))
 
   return renderPromise


### PR DESCRIPTION
Rather than relying on `AppContainer` to render `Container` to render `ReactDevOverlay`, we should just render it directly as part of `doRender` when it is required. This is needed because in a future PR, I'll be changing `doRender` to just take a `ReactElement` rather than a description of a route, and conceptually, the `ReactDevOverlay` should be static and a parent of that content, rather than part of the route content.