### PR TITLE
Fix build activity indicator position

### DIFF
--- a/packages/next/client/dev/dev-build-watcher.js
+++ b/packages/next/client/dev/dev-build-watcher.js
@@ -5,21 +5,15 @@ export default function initializeBuildWatcher(
   position = 'bottom-right'
 ) {
   const shadowHost = document.createElement('div')
+  const horizontalPositionProperty = position.split('-')[1]
+  const verticalPositionProperty = position.split('-')[0]
   shadowHost.id = '__next-build-watcher'
   // Make sure container is fixed and on a high zIndex so it shows
   shadowHost.style.position = 'fixed'
   // Ensure container's position to be top or bottom (default)
-  if (['top-left', 'top-right'].indexOf(position) > -1) {
-    shadowHost.style.top = '10px'
-  } else {
-    shadowHost.style.bottom = '10px'
-  }
+  shadowHost.style[verticalPositionProperty] = '10px'
   // Ensure container's position to be left or right (default)
-  if (['bottom-left', 'top-left'].indexOf(position) > -1) {
-    shadowHost.style.left = '20px'
-  } else {
-    shadowHost.style.right = '20px'
-  }
+  shadowHost.style[horizontalPositionProperty] = '20px'
   shadowHost.style.width = 0
   shadowHost.style.height = 0
   shadowHost.style.zIndex = 99999
@@ -43,7 +37,11 @@ export default function initializeBuildWatcher(
   shadowRoot.appendChild(container)
 
   // CSS
-  const css = createCss(prefix)
+  const css = createCss(prefix, {
+    horizontalPositionProperty,
+    verticalPositionProperty,
+  })
+
   shadowRoot.appendChild(css)
 
   // State
@@ -134,13 +132,16 @@ function createContainer(prefix) {
   return container
 }
 
-function createCss(prefix) {
+function createCss(
+  prefix,
+  { horizontalPositionProperty, verticalPositionProperty }
+) {
   const css = document.createElement('style')
   css.textContent = `
     #${prefix}container {
       position: absolute;
-      bottom: 10px;
-      right: 30px;
+      ${verticalPositionProperty}: 10px;
+      ${horizontalPositionProperty}: 30px;
 
       border-radius: 3px;
       background: #000;
@@ -158,7 +159,7 @@ function createCss(prefix) {
 
       display: none;
       opacity: 0;
-      transition: opacity 0.1s ease, bottom 0.1s ease;
+      transition: opacity 0.1s ease, ${verticalPositionProperty} 0.1s ease;
       animation: ${prefix}fade-in 0.1s ease-in-out;
     }
 
@@ -167,7 +168,7 @@ function createCss(prefix) {
     }
 
     #${prefix}container.${prefix}building {
-      bottom: 20px;
+      ${verticalPositionProperty}: 20px;
       opacity: 1;
     }
 
@@ -187,11 +188,11 @@ function createCss(prefix) {
 
     @keyframes ${prefix}fade-in {
       from {
-        bottom: 10px;
+        ${verticalPositionProperty}: 10px;
         opacity: 0;
       }
       to {
-        bottom: 20px;
+        ${verticalPositionProperty}: 20px;
         opacity: 1;
       }
     }

--- a/packages/next/client/dev/dev-build-watcher.js
+++ b/packages/next/client/dev/dev-build-watcher.js
@@ -5,15 +5,14 @@ export default function initializeBuildWatcher(
   position = 'bottom-right'
 ) {
   const shadowHost = document.createElement('div')
-  const horizontalPositionProperty = position.split('-')[1]
-  const verticalPositionProperty = position.split('-')[0]
+  const [verticalProperty, horizontalProperty] = position.split('-')
   shadowHost.id = '__next-build-watcher'
   // Make sure container is fixed and on a high zIndex so it shows
   shadowHost.style.position = 'fixed'
   // Ensure container's position to be top or bottom (default)
-  shadowHost.style[verticalPositionProperty] = '10px'
+  shadowHost.style[verticalProperty] = '10px'
   // Ensure container's position to be left or right (default)
-  shadowHost.style[horizontalPositionProperty] = '20px'
+  shadowHost.style[horizontalProperty] = '20px'
   shadowHost.style.width = 0
   shadowHost.style.height = 0
   shadowHost.style.zIndex = 99999
@@ -37,11 +36,7 @@ export default function initializeBuildWatcher(
   shadowRoot.appendChild(container)
 
   // CSS
-  const css = createCss(prefix, {
-    horizontalPositionProperty,
-    verticalPositionProperty,
-  })
-
+  const css = createCss(prefix, { horizontalProperty, verticalProperty })
   shadowRoot.appendChild(css)
 
   // State
@@ -132,16 +127,13 @@ function createContainer(prefix) {
   return container
 }
 
-function createCss(
-  prefix,
-  { horizontalPositionProperty, verticalPositionProperty }
-) {
+function createCss(prefix, { horizontalProperty, verticalProperty }) {
   const css = document.createElement('style')
   css.textContent = `
     #${prefix}container {
       position: absolute;
-      ${verticalPositionProperty}: 10px;
-      ${horizontalPositionProperty}: 30px;
+      ${verticalProperty}: 10px;
+      ${horizontalProperty}: 30px;
 
       border-radius: 3px;
       background: #000;
@@ -159,7 +151,7 @@ function createCss(
 
       display: none;
       opacity: 0;
-      transition: opacity 0.1s ease, ${verticalPositionProperty} 0.1s ease;
+      transition: opacity 0.1s ease, ${verticalProperty} 0.1s ease;
       animation: ${prefix}fade-in 0.1s ease-in-out;
     }
 
@@ -168,7 +160,7 @@ function createCss(
     }
 
     #${prefix}container.${prefix}building {
-      ${verticalPositionProperty}: 20px;
+      ${verticalProperty}: 20px;
       opacity: 1;
     }
 
@@ -188,11 +180,11 @@ function createCss(
 
     @keyframes ${prefix}fade-in {
       from {
-        ${verticalPositionProperty}: 10px;
+        ${verticalProperty}: 10px;
         opacity: 0;
       }
       to {
-        ${verticalPositionProperty}: 20px;
+        ${verticalProperty}: 20px;
         opacity: 1;
       }
     }


### PR DESCRIPTION
`devIndicators.buildActivityPosition` introduced in https://github.com/vercel/next.js/pull/30109 needed more tweaks to properly position the build indicator container. The build indicator was being rendered off screen when set to a non-default position.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
