### PR TITLE
watch node_modules

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -54,7 +54,7 @@ import { getMiddlewareSourceMapPlugins } from './webpack/plugins/middleware-sour
 
 const watchOptions = Object.freeze({
   aggregateTimeout: 5,
-  ignored: ['**/.git/**', '**/node_modules/**', '**/.next/**'],
+  ignored: ['**/.git/**', '**/.next/**'],
 })
 
 function getSupportedBrowsers(


### PR DESCRIPTION
next.js doesn't HMR when installing node_modules.

This fixes it.

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
