### PR TITLE
Allows to generate eslint reports using --output-file

### DIFF
--- a/packages/next/cli/next-lint.ts
+++ b/packages/next/cli/next-lint.ts
@@ -71,6 +71,7 @@ const nextLint: cliCommand = async (argv) => {
     '--cache-strategy': String,
     '--error-on-unmatched-pattern': Boolean,
     '--format': String,
+    '--output-file': String,
 
     // Aliases
     '-c': '--config',


### PR DESCRIPTION
Running `next lint` doesn't allow to generate an output file. This can be useful to generate GitHub Annotations via Actions like [this one](https://github.com/ataylorme/eslint-annotate-action).

```sh
yarn next lint --format json --output-file test.json
yarn run v1.22.17
$ /node_modules/.bin/next lint --format json --output-file test.json
Unknown or unexpected option: --output-file
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Feature

- [x] Implements an existing feature request or RFC.
