### PR TITLE
Feature request: support the plugin option for swc compiler

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -31,6 +31,7 @@ function getBaseSWCOptions({
   nextConfig,
   resolvedBaseUrl,
   jsConfig,
+  plugin,
 }) {
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
@@ -101,6 +102,7 @@ function getBaseSWCOptions({
     removeConsole: nextConfig?.compiler?.removeConsole,
     reactRemoveProperties: nextConfig?.compiler?.reactRemoveProperties,
     relay: nextConfig?.compiler?.relay,
+    plugin,
   }
 }
 
@@ -110,6 +112,7 @@ export function getJestSWCOptions({
   esm,
   nextConfig,
   jsConfig,
+  plugin,
   // This is not passed yet as "paths" resolving needs a test first
   // resolvedBaseUrl,
 }) {
@@ -121,6 +124,7 @@ export function getJestSWCOptions({
     globalWindow: !isServer,
     nextConfig,
     jsConfig,
+    plugin,
     // resolvedBaseUrl,
   })
 
@@ -158,6 +162,7 @@ export function getLoaderSWCOptions({
   hasReactRefresh,
   nextConfig,
   jsConfig,
+  plugin,
   // This is not passed yet as "paths" resolving is handled by webpack currently.
   // resolvedBaseUrl,
 }) {
@@ -168,6 +173,7 @@ export function getLoaderSWCOptions({
     hasReactRefresh,
     nextConfig,
     jsConfig,
+    plugin,
     // resolvedBaseUrl,
   })
 

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -36,7 +36,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
 
   let loaderOptions = this.getOptions() || {}
 
-  const { isServer, pagesDir, hasReactRefresh, nextConfig, jsConfig } =
+  const { isServer, pagesDir, hasReactRefresh, nextConfig, jsConfig, plugin } =
     loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
 
@@ -49,6 +49,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
     hasReactRefresh,
     nextConfig,
     jsConfig,
+    plugin,
   })
 
   const programmaticOptions = {


### PR DESCRIPTION
I'm a bit out of my depth here. I am trying to integrate [swc-plugin-transform-import](https://www.npmjs.com/package/swc-plugin-transform-import) into my Next.js build so that our imports of @mui are converted into default exports. The only solution that works is to fall back to the Babel compiler and use [babel-plugin-transform-imports](https://www.npmjs.com/package/babel-plugin-transform-imports). 

I couldn't find definitive documentation about the API from swc, but it seems like they support a 'plugin' option which allows transformations in Javascript. This is also based on what I've seen in the links i shared below. With the changes I've included, I can see that my plugin is getting passed to the 'transform' method of the SWC binary on my machine: `swc-darwin-x64` but my investigation ends there. I can tell that my plugin function is still not being called, but I'm hoping it's a simple fix maybe to continue passing the plugin function down into swc.

The code I've added to `next.config.js` can be found here: https://github.com/vercel/next.js/discussions/30862#discussioncomment-2312660. I am trying to apply the plugin to the `next-swc-loader`. I tried adding a new rule, tried using swc-loader, etc. but ran into other issues, so I'm just asking for next-swc-loader to support this additional field instead.

Two related issues posted against next.js related to people wanting to transform their imports:
- https://github.com/vercel/next.js/issues/29559
- https://github.com/vercel/next.js/discussions/30862

Other links:
- The plugin in question: https://www.npmjs.com/package/swc-plugin-transform-import which uses the `plugin` option for swc-loader.
- Someone saying that "plugin" is a supported option on swc-loader: https://github.com/swc-project/swc-loader/issues/29
- SWC plugin docs: https://swc.rs/docs/usage/plugins (although they don't mention how to include a plugin with webpack)
