### PR TITLE
Change to loadBindings for swc parse

### DIFF
--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -229,7 +229,7 @@ export async function bundle(options) {
 }
 
 export async function parse(src, options) {
-  let bindings = loadBindingsSync()
+  let bindings = await loadBindings()
   let parserOptions = getParserOptions(options)
   return bindings.parse(src, parserOptions).then((astStr) => JSON.parse(astStr))
 }


### PR DESCRIPTION
CI test `TEST_WASM=true xvfb-run node run-tests.js test/integration/production/test/index.test.js` is aways failing in recent PRs

`loadBindingsSync` does not import `next-swc/wasm` unlike `loadBindings`

x-ref: https://github.com/vercel/next.js/runs/5479076388?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/5471650765?check_suite_focus=true