### PR TITLE
Experimental swc external helpers options

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -91,6 +91,7 @@ function getBaseSWCOptions({
           importPath: regeneratorRuntimePath,
         },
       },
+      externalHelpers: nextConfig?.experimental?.swcExternalHelpers,
     },
     sourceMaps: jest ? 'inline' : undefined,
     styledComponents: nextConfig?.compiler?.styledComponents

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -77,6 +77,7 @@ export interface ExperimentalConfig {
   disablePostcssPresetEnv?: boolean
   swcMinify?: boolean
   swcFileReading?: boolean
+  swcExternalHelpers?: boolean
   cpus?: number
   sharedPool?: boolean
   plugins?: boolean
@@ -461,6 +462,7 @@ export const defaultConfig: NextConfig = {
     disableOptimizedLoading: false,
     gzipSize: true,
     swcFileReading: true,
+    swcExternalHelpers: false,
     craCompat: false,
     esmExternals: true,
     // default to 50MB limit

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -441,6 +441,12 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     )
   }
 
+  if (result.experimental?.swcExternalHelpers) {
+    Log.warn(
+      'SWC externalHelpers exprimental option is enabled, please make sure @swc/helpers is installed. [!!FIXME with actual link!!]'
+    )
+  }
+
   if (
     result.experimental?.outputFileTracingRoot &&
     !isAbsolute(result.experimental.outputFileTracingRoot)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked: Fixes #30806 
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

cc @timneutkens

Make swc's `externalHelpers` available as an experimental option.

A memo list:

- [ ] Do we need a `https://nextjs.org/message` link for that? If we need it, what should we put in there?
- [ ] It is up to the Next.js team to decide if it should be added to the telemetry.
- [ ] `swcExternalHelpers` is disabled by default thus there is no reason to include `@swc/helpers` in next's `package.json`, which means users will have to install it manually and locally.
- [ ] The impact of next's built-in compiled module should be measured before enabling it in `task` thus should be another PR.