### PR TITLE
Update runtime-configuration.md

### DIFF
--- a/docs/api-reference/next.config.js/runtime-configuration.md
+++ b/docs/api-reference/next.config.js/runtime-configuration.md
@@ -41,7 +41,7 @@ console.log(serverRuntimeConfig.mySecret)
 // Will be available on both server-side and client-side
 console.log(publicRuntimeConfig.staticFolder)
 
-function MyImage() {
+const ImagePage: NextPage = () => {
   return (
     <div>
       <Image
@@ -53,7 +53,9 @@ function MyImage() {
   )
 }
 
-export default MyImage
+ImagePage.getInitialProps = async ({}) => ({});
+
+export default ImagePage
 ```
 
 ## Related


### PR DESCRIPTION
The public runtime configuration requires that a page uses getInitialProps. Therefore, it would make sense to somehow include that in the example.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
