### PR TITLE
Adds linting rule to avoid assignment to 'module' variable

### DIFF
--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -649,6 +649,10 @@
         {
           "title": "invalid-getserversideprops-return-value",
           "path": "/errors/invalid-getserversideprops-return-value.md"
+        },
+        {
+          "title": "no-assign-module-variable",
+          "path": "/errors/no-assign-module-variable.md"
         }
       ]
     }

--- a/errors/no-assign-module-variable.md
+++ b/errors/no-assign-module-variable.md
@@ -1,0 +1,13 @@
+# No assign module variable
+
+#### Why This Error Occurred
+
+A value is being assigned to the `module` variable. The `module` variable is already used and it is highly likely that assigning to this variable will cause errors.
+
+#### Possible Ways to Fix It
+
+Use a different variable name:
+
+```js
+let myModule = {...}
+```

--- a/packages/eslint-plugin-next/lib/index.js
+++ b/packages/eslint-plugin-next/lib/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'no-duplicate-head': require('./rules/no-duplicate-head'),
     'inline-script-id': require('./rules/inline-script-id'),
     'next-script-for-ga': require('./rules/next-script-for-ga'),
+    'no-assign-module-variable': require('./rules/no-assign-module-variable'),
   },
   configs: {
     recommended: {
@@ -45,6 +46,7 @@ module.exports = {
         '@next/next/no-typos': 1,
         '@next/next/no-duplicate-head': 2,
         '@next/next/inline-script-id': 2,
+        '@next/next/no-assign-module-variable': 2,
       },
     },
     'core-web-vitals': {

--- a/packages/eslint-plugin-next/lib/rules/no-assign-module-variable.js
+++ b/packages/eslint-plugin-next/lib/rules/no-assign-module-variable.js
@@ -1,0 +1,30 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: `Prohibit assignment to the 'module' variable`,
+      recommended: true,
+      url: 'https://nextjs.org/docs/messages/no-assign-module-variable',
+    },
+  },
+
+  create: function (context) {
+    return {
+      VariableDeclaration(node) {
+        // Checks node.declarations array for variable with id.name of 'module'
+        const moduleVariableFound = node.declarations.some(
+          (declaration) => declaration.id.name === 'module'
+        )
+
+        // Return early if no 'module' variable is found
+        if (!moduleVariableFound) {
+          return
+        }
+
+        context.report({
+          node,
+          message: `Do not assign to the variable 'module'. See: https://nextjs.org/docs/messages/no-assign-module-variable`,
+        })
+      },
+    }
+  },
+}

--- a/test/unit/eslint-plugin-next/no-assign-module-variable.test.ts
+++ b/test/unit/eslint-plugin-next/no-assign-module-variable.test.ts
@@ -1,0 +1,42 @@
+import rule from '@next/eslint-plugin-next/lib/rules/no-assign-module-variable'
+import { RuleTester } from 'eslint'
+;(RuleTester as any).setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      modules: true,
+      jsx: true,
+    },
+  },
+})
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-assign-module-variable', rule, {
+  valid: [
+    `
+      let myModule = {};
+      
+      export default function MyComponent() {
+        return <></>
+      }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+      let module = {};
+      
+      export default function MyComponent() {
+        return <></>
+      }
+      `,
+      errors: [
+        {
+          message:
+            "Do not assign to the variable 'module'. See: https://nextjs.org/docs/messages/no-assign-module-variable",
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
Fixes #34859

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
