### PR TITLE
Bump styled-jsx to 5.0.1

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -72,7 +72,7 @@
     "@next/env": "12.1.1-canary.10",
     "caniuse-lite": "^1.0.30001283",
     "postcss": "8.4.5",
-    "styled-jsx": "5.0.0",
+    "styled-jsx": "5.0.1",
     "use-subscription": "1.5.1"
   },
   "peerDependencies": {

--- a/test/production/react-18-streaming-ssr/index.test.ts
+++ b/test/production/react-18-streaming-ssr/index.test.ts
@@ -46,6 +46,16 @@ describe('react 18 streaming SSR with custom next configs', () => {
   beforeAll(async () => {
     next = await createNext({
       files: {
+        'pages/index.js': `
+          export default function Page() {
+            return (
+              <div>
+                <style jsx>{\`p { color: blue } \`}</style>
+                <p>index</p>
+              </div>
+            )
+          }
+        `,
         'pages/hello.js': `
           export default function Page() {
             return <p>hello nextjs</p>
@@ -63,9 +73,15 @@ describe('react 18 streaming SSR with custom next configs', () => {
         react: '18.0.0-rc.2',
         'react-dom': '18.0.0-rc.2',
       },
+      installCommand: 'npm install',
     })
   })
   afterAll(() => next.destroy())
+
+  it('should render styled-jsx styles in streaming', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('color:blue')
+  })
 
   it('should redirect paths without trailing-slash and render when slash is appended', async () => {
     const page = '/hello'

--- a/yarn.lock
+++ b/yarn.lock
@@ -14842,7 +14842,6 @@ minipass-fetch@^1.3.0, minipass-fetch@^1.3.2:
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.3.3.tgz#34c7cea038c817a8658461bf35174551dce17a0a"
   integrity sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==
   dependencies:
-    encoding "^0.1.12"
     minipass "^3.1.0"
     minipass-sized "^1.0.3"
     minizlib "^2.0.0"
@@ -19806,10 +19805,10 @@ styled-jsx-plugin-postcss@3.0.2:
     postcss "^7.0.2"
     postcss-load-plugins "^2.3.0"
 
-styled-jsx@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.0.tgz#816b4b92e07b1786c6b7111821750e0ba4d26e77"
-  integrity sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==
+styled-jsx@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.1.tgz#78fecbbad2bf95ce6cd981a08918ce4696f5fc80"
+  integrity sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
x-ref: https://github.com/vercel/next-react-server-components/issues/35
x-ref: https://github.com/vercel/styled-jsx/pull/788

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

