### PR TITLE
Update aws-amplify and aws-amplify/ui-react in with-aws-amplify-typescript

### DIFF
--- a/examples/with-aws-amplify-typescript/next-env.d.ts
+++ b/examples/with-aws-amplify-typescript/next-env.d.ts
@@ -3,3 +3,8 @@
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.
+
+declare module '*.css' {
+  const classes: { [key: string]: string }
+  export default classes
+}

--- a/examples/with-aws-amplify-typescript/package.json
+++ b/examples/with-aws-amplify-typescript/package.json
@@ -6,8 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@aws-amplify/ui-react": "^1.0.7",
-    "aws-amplify": "^3.3.27",
+    "@aws-amplify/ui-react": "^2.10.0",
+    "aws-amplify": "^4.3.16",
     "next": "10.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/examples/with-aws-amplify-typescript/src/pages/_app.tsx
+++ b/examples/with-aws-amplify-typescript/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app'
+import '../styles/globals.css'
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/examples/with-aws-amplify-typescript/src/pages/index.tsx
+++ b/examples/with-aws-amplify-typescript/src/pages/index.tsx
@@ -14,7 +14,7 @@ import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api'
 import { useRouter } from 'next/router'
 import { GetServerSideProps } from 'next'
 
-const styles = require('../styles/Home.module.css')
+import styles from '../styles/Home.module.css'
 
 Amplify.configure({ ...awsExports, ssr: true })
 

--- a/examples/with-aws-amplify-typescript/src/pages/index.tsx
+++ b/examples/with-aws-amplify-typescript/src/pages/index.tsx
@@ -1,5 +1,5 @@
-import { AmplifyAuthenticator } from '@aws-amplify/ui-react'
-import { Amplify, API, Auth, withSSRContext } from 'aws-amplify'
+import { Authenticator } from '@aws-amplify/ui-react'
+import { Amplify, API, withSSRContext } from 'aws-amplify'
 import Head from 'next/head'
 import awsExports from '../aws-exports'
 import { createTodo } from '../graphql/mutations'
@@ -13,7 +13,8 @@ import {
 import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api'
 import { useRouter } from 'next/router'
 import { GetServerSideProps } from 'next'
-import styles from '../styles/Home.module.css'
+
+const styles = require('../styles/Home.module.css')
 
 Amplify.configure({ ...awsExports, ssr: true })
 
@@ -72,30 +73,32 @@ export default function Home({ todos = [] }: { todos: Todo[] }) {
           <div className={styles.card}>
             <h3 className={styles.title}>New Todo</h3>
 
-            <AmplifyAuthenticator>
-              <form onSubmit={handleCreateTodo}>
-                <fieldset>
-                  <legend>Title</legend>
-                  <input
-                    defaultValue={`Today, ${new Date().toLocaleTimeString()}`}
-                    name="title"
-                  />
-                </fieldset>
+            <Authenticator>
+              {({ signOut }) => (
+                <form onSubmit={handleCreateTodo}>
+                  <fieldset>
+                    <legend>Title</legend>
+                    <input
+                      defaultValue={`Today, ${new Date().toLocaleTimeString()}`}
+                      name="title"
+                    />
+                  </fieldset>
 
-                <fieldset>
-                  <legend>Content</legend>
-                  <textarea
-                    defaultValue="I built an Amplify app with Next.js!"
-                    name="content"
-                  />
-                </fieldset>
+                  <fieldset>
+                    <legend>Content</legend>
+                    <textarea
+                      defaultValue="I built an Amplify app with Next.js!"
+                      name="content"
+                    />
+                  </fieldset>
 
-                <button>Create Todo</button>
-                <button type="button" onClick={() => Auth.signOut()}>
-                  Sign out
-                </button>
-              </form>
-            </AmplifyAuthenticator>
+                  <button>Create Todo</button>
+                  <button type="button" onClick={signOut}>
+                    Sign out
+                  </button>
+                </form>
+              )}
+            </Authenticator>
           </div>
         </div>
       </main>

--- a/examples/with-aws-amplify-typescript/src/pages/todo/[id].tsx
+++ b/examples/with-aws-amplify-typescript/src/pages/todo/[id].tsx
@@ -8,7 +8,7 @@ import { getTodo, listTodos } from '../../graphql/queries'
 import { GetStaticProps, GetStaticPaths } from 'next'
 import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api'
 
-const styles = require('../../styles/Home.module.css')
+import styles from '../../styles/Home.module.css'
 
 Amplify.configure({ ...awsExports, ssr: true })
 

--- a/examples/with-aws-amplify-typescript/src/pages/todo/[id].tsx
+++ b/examples/with-aws-amplify-typescript/src/pages/todo/[id].tsx
@@ -7,7 +7,8 @@ import { deleteTodo } from '../../graphql/mutations'
 import { getTodo, listTodos } from '../../graphql/queries'
 import { GetStaticProps, GetStaticPaths } from 'next'
 import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api'
-import styles from '../../styles/Home.module.css'
+
+const styles = require('../../styles/Home.module.css')
 
 Amplify.configure({ ...awsExports, ssr: true })
 

--- a/examples/with-aws-amplify-typescript/src/styles/globals.css
+++ b/examples/with-aws-amplify-typescript/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import '@aws-amplify/ui-react/styles.css';
+
 html,
 body {
   padding: 0;


### PR DESCRIPTION
Closes: https://github.com/vercel/next.js/issues/35222

This example was using AmplifyAuthenticator which is legacy. I've changed it to Authenticator. I've updated also `@aws-amplify/ui-react` and `aws-amplify` to the latest version.