### PR TITLE
Switch lazy loading strategy to use native lazy loading by default

### DIFF
--- a/test/integration/image-component/basic/pages/lazy.js
+++ b/test/integration/image-component/basic/pages/lazy.js
@@ -18,6 +18,7 @@ const Lazy = () => {
         id="lazy-mid"
         src="lazy2.jpg"
         loading="lazy"
+        lazyBoundary="200px"
         height={400}
         width={300}
         className="exampleclass"
@@ -30,6 +31,7 @@ const Lazy = () => {
         width={300}
         unoptimized
         loading="lazy"
+        lazyBoundary="200px"
       ></Image>
       <div style={{ height: '2000px' }}></div>
       <Image

--- a/test/integration/image-component/basic/test/index.test.js
+++ b/test/integration/image-component/basic/test/index.test.js
@@ -106,6 +106,9 @@ function runTests() {
 
 function lazyLoadingTests() {
   it('should have loaded the first image immediately', async () => {
+    expect(await browser.elementById('lazy-top').getAttribute('loading')).toBe(
+      'lazy'
+    )
     expect(await browser.elementById('lazy-top').getAttribute('src')).toBe(
       'https://example.com/myaccount/lazy1.jpg?auto=format&fit=max&w=2000'
     )
@@ -169,22 +172,12 @@ function lazyLoadingTests() {
       await browser.elementById('lazy-bottom').getAttribute('srcset')
     ).toBeFalsy()
   })
-  it('should load the fourth image lazily after scrolling down', async () => {
+  it('should default to lazy', async () => {
     expect(
-      await browser.elementById('lazy-without-attribute').getAttribute('src')
-    ).toBe(emptyImage)
-    expect(
-      await browser.elementById('lazy-without-attribute').getAttribute('srcset')
-    ).toBeFalsy()
-    let viewportHeight = await browser.eval(`window.innerHeight`)
-    let topOfBottomImage = await browser.eval(
-      `document.getElementById('lazy-without-attribute').parentElement.offsetTop`
-    )
-    let buffer = 150
-    await browser.eval(
-      `window.scrollTo(0, ${topOfBottomImage - (viewportHeight + buffer)})`
-    )
-    await waitFor(200)
+      await browser
+        .elementById('lazy-without-attribute')
+        .getAttribute('loading')
+    ).toBe('lazy')
     expect(
       await browser.elementById('lazy-without-attribute').getAttribute('src')
     ).toBe('https://example.com/myaccount/lazy4.jpg?auto=format&fit=max&w=1600')
@@ -196,6 +189,9 @@ function lazyLoadingTests() {
   })
 
   it('should load the fifth image eagerly, without scrolling', async () => {
+    expect(
+      await browser.elementById('eager-loading').getAttribute('loading')
+    ).toBe('eager')
     expect(await browser.elementById('eager-loading').getAttribute('src')).toBe(
       'https://example.com/myaccount/lazy5.jpg?auto=format&fit=max&w=2000'
     )

--- a/test/integration/image-component/default/pages/blurry-placeholder.js
+++ b/test/integration/image-component/default/pages/blurry-placeholder.js
@@ -45,6 +45,7 @@ export default function Page() {
         width="400"
         height="400"
         placeholder="blur"
+        lazyBoundary="200px"
         blurDataURL="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400' viewBox='0 0 400 400'%3E%3Cfilter id='blur' filterUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20' edgeMode='duplicate' /%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1' /%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Cimage filter='url(%23blur)' href='data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMDAwMDAwQEBAQFBQUFBQcHBgYHBwsICQgJCAsRCwwLCwwLEQ8SDw4PEg8bFRMTFRsfGhkaHyYiIiYwLTA+PlT/wAALCAAKAAoBAREA/8QAMwABAQEAAAAAAAAAAAAAAAAAAAcJEAABAwUAAwAAAAAAAAAAAAAFAAYRAQMEEyEVMlH/2gAIAQEAAD8Az1bLPaxhiuk0QdeCOLDtHixN2dmd2bsc5FPX7VTREX//2Q==' x='0' y='0' height='100%25' width='100%25'/%3E%3C/svg%3E"
       />
     </div>

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -167,8 +167,7 @@ function runTests(mode) {
     expect(noscriptEl.attribs.srcset).toBeDefined()
 
     expect(el.attribs.src).toBeDefined()
-    expect(el.attribs.srcset).toBeUndefined()
-    expect(el.attribs.srcSet).toBeUndefined()
+    expect(el.attribs.srcset).toMatch(/_next/)
   })
 
   it('should update the image on src change', async () => {

--- a/test/integration/image-component/svgo-webpack/tsconfig.json
+++ b/test/integration/image-component/svgo-webpack/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- Safari shipped support today and so all major browsers now support it.
- Falls back to `IntersectionObserver` based loading if the `lazyRoot` or `lazyBoundary` arguments are provided.
- Should improve performance in the case where lazy loaded images are actually visible quickly, by not making the HTTP fetch depend on hydration.