### PR TITLE
[docs] Update docs about Cache-Control default headers.

### DIFF
--- a/docs/going-to-production.md
+++ b/docs/going-to-production.md
@@ -74,6 +74,8 @@ If the page is using `getServerSideProps` or `getInitialProps`, then it will use
 
 If the page is using `getStaticProps` or automatic static optimization, then it will have s-maxage=REVALIDATE_SECONDS, stale-while-revalidate or if revalidate is not used s-maxage=31536000, stale-while-revalidate.
 
+If you want a different Cache-Control while using SSR you can use res.setHeader('Cache-Control', 'value_you_prefer').
+
 > **Note:** Your deployment provider must support edge caching for dynamic responses. If you are self-hosting, you will need to add this logic to the edge yourself using a key/value store. If you are using Vercel, [edge caching works without configuration](https://vercel.com/docs/edge-network/caching).
 
 ## Reducing JavaScript Size

--- a/docs/going-to-production.md
+++ b/docs/going-to-production.md
@@ -68,6 +68,11 @@ export async function getServerSideProps({ req, res }) {
   }
 }
 ```
+By default, `Cache-Control` headers will be set differently depending on how your page fetches data.
+
+If the page is using `getServerSideProps` or `getInitialProps`, then it will use the default `Cache-Control` header configured by `next start` in order to prevent accidental caching of responses that cannot be cached.
+
+If the page is using `getStaticProps` or automatic static optimization, then it will have s-maxage=REVALIDATE_SECONDS, stale-while-revalidate or if revalidate is not used s-maxage=31536000, stale-while-revalidate.
 
 > **Note:** Your deployment provider must support edge caching for dynamic responses. If you are self-hosting, you will need to add this logic to the edge yourself using a key/value store. If you are using Vercel, [edge caching works without configuration](https://vercel.com/docs/edge-network/caching).
 

--- a/docs/going-to-production.md
+++ b/docs/going-to-production.md
@@ -70,11 +70,9 @@ export async function getServerSideProps({ req, res }) {
 ```
 By default, `Cache-Control` headers will be set differently depending on how your page fetches data.
 
-If the page is using `getServerSideProps` or `getInitialProps`, then it will use the default `Cache-Control` header configured by `next start` in order to prevent accidental caching of responses that cannot be cached.
+If the page is using `getServerSideProps` or `getInitialProps`, then it will use the default `Cache-Control` header configured by `next start` in order to prevent accidental caching of responses that cannot be cached. If you want a different cache behavior while using SSR you can use `res.setHeader('Cache-Control', 'value_you_prefer')`.
 
 If the page is using `getStaticProps` or automatic static optimization, then it will have s-maxage=REVALIDATE_SECONDS, stale-while-revalidate or if revalidate is not used s-maxage=31536000, stale-while-revalidate.
-
-If you want a different Cache-Control while using SSR you can use res.setHeader('Cache-Control', 'value_you_prefer').
 
 > **Note:** Your deployment provider must support edge caching for dynamic responses. If you are self-hosting, you will need to add this logic to the edge yourself using a key/value store. If you are using Vercel, [edge caching works without configuration](https://vercel.com/docs/edge-network/caching).
 

--- a/docs/going-to-production.md
+++ b/docs/going-to-production.md
@@ -68,6 +68,7 @@ export async function getServerSideProps({ req, res }) {
   }
 }
 ```
+
 By default, `Cache-Control` headers will be set differently depending on how your page fetches data.
 
 If the page is using `getServerSideProps` or `getInitialProps`, then it will use the default `Cache-Control` header configured by `next start` in order to prevent accidental caching of responses that cannot be cached. If you want a different cache behavior while using SSR you can use `res.setHeader('Cache-Control', 'value_you_prefer')`.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Closes https://github.com/vercel/next.js/issues/33210.

This PR `fixes #33210` with an update to the going-to-production.md file about how Cache-Control headers are set by default based on how a page requests data.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
