### PR TITLE
Add libc fields to Linux platform packages

### DIFF
--- a/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
@@ -11,6 +11,7 @@
   "files": [
     "next-swc.linux-arm64-gnu.node"
   ],
+  "libc": ["glibc"],
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
@@ -11,6 +11,7 @@
   "files": [
     "next-swc.linux-arm64-musl.node"
   ],
+  "libc": ["musl"],
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
@@ -11,6 +11,7 @@
   "files": [
     "next-swc.linux-x64-gnu.node"
   ],
+  "libc": ["glibc"],
   "license": "MIT",
   "engines": {
     "node": ">= 10"

--- a/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
@@ -11,6 +11,7 @@
   "files": [
     "next-swc.linux-x64-musl.node"
   ],
+  "libc": ["musl"],
   "license": "MIT",
   "engines": {
     "node": ">= 10"


### PR DESCRIPTION
Related: https://github.com/yarnpkg/berry/pull/3981

With `yarn 3.2` +, developers will install one less package on the Linux platform