### PR TITLE
Collect packages are used and eliminated in getServerSideProps

### DIFF
--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.
 
 use auto_cjs::contains_cjs;
 use either::Either;
+use fxhash::FxHashSet;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -113,6 +114,7 @@ pub fn custom_before_pass<'a, C: Comments + 'a>(
     file: Arc<SourceFile>,
     opts: &'a TransformOptions,
     comments: C,
+    eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
 ) -> impl Fold + 'a {
     #[cfg(target_arch = "wasm32")]
     let relay_plugin = noop();
@@ -148,7 +150,10 @@ pub fn custom_before_pass<'a, C: Comments + 'a>(
                 Either::Right(noop())
             }
         },
-        Optional::new(next_ssg::next_ssg(), !opts.disable_next_ssg),
+        Optional::new(
+            next_ssg::next_ssg(eliminated_packages),
+            !opts.disable_next_ssg
+        ),
         amp_attributes::amp_attributes(),
         next_dynamic::next_dynamic(
             opts.is_development,

--- a/packages/next-swc/crates/core/src/next_ssg.rs
+++ b/packages/next-swc/crates/core/src/next_ssg.rs
@@ -360,7 +360,11 @@ impl Fold for NextSsg {
             | ImportSpecifier::Default(ImportDefaultSpecifier { local, .. })
             | ImportSpecifier::Namespace(ImportStarAsSpecifier { local, .. }) => {
                 if self.should_remove(local.to_id()) {
-                    if self.state.is_server_props {
+                    if self.state.is_server_props
+                        // filter out non-packages import
+                        // third part packages must start with `a-z` or `@`
+                        && import_src.starts_with(|c: char| c.is_ascii_lowercase() || c == '@')
+                    {
                         self.state
                             .eliminated_packages
                             .borrow_mut()

--- a/packages/next-swc/crates/core/src/next_ssg.rs
+++ b/packages/next-swc/crates/core/src/next_ssg.rs
@@ -1,6 +1,8 @@
 use easy_error::{bail, Error};
 use fxhash::FxHashSet;
+use std::cell::RefCell;
 use std::mem::take;
+use std::rc::Rc;
 use swc_common::pass::{Repeat, Repeated};
 use swc_common::DUMMY_SP;
 use swc_ecmascript::ast::*;
@@ -12,9 +14,12 @@ use swc_ecmascript::{
 };
 
 /// Note: This paths requires running `resolver` **before** running this.
-pub fn next_ssg() -> impl Fold {
+pub fn next_ssg(eliminated_packages: Rc<RefCell<FxHashSet<String>>>) -> impl Fold {
     Repeat::new(NextSsg {
-        state: Default::default(),
+        state: State {
+            eliminated_packages,
+            ..Default::default()
+        },
         in_lhs_of_var: false,
     })
 }
@@ -41,6 +46,10 @@ struct State {
     done: bool,
 
     should_run_again: bool,
+
+    /// Track the import packages which are eliminated in the
+    /// `getServerSideProps`
+    pub eliminated_packages: Rc<RefCell<FxHashSet<String>>>,
 }
 
 impl State {
@@ -288,7 +297,7 @@ impl Fold for Analyzer<'_> {
 
 /// Actual implementation of the transform.
 struct NextSsg {
-    state: State,
+    pub state: State,
     in_lhs_of_var: bool,
 }
 
@@ -344,11 +353,19 @@ impl Fold for NextSsg {
             return i;
         }
 
+        let import_src = &i.src.value;
+
         i.specifiers.retain(|s| match s {
             ImportSpecifier::Named(ImportNamedSpecifier { local, .. })
             | ImportSpecifier::Default(ImportDefaultSpecifier { local, .. })
             | ImportSpecifier::Namespace(ImportStarAsSpecifier { local, .. }) => {
                 if self.should_remove(local.to_id()) {
+                    if self.state.is_server_props {
+                        self.state
+                            .eliminated_packages
+                            .borrow_mut()
+                            .insert(import_src.to_string());
+                    }
                     tracing::trace!(
                         "Dropping import `{}{:?}` because it should be removed",
                         local.sym,

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -63,5 +63,10 @@ fn styled_jsx_errors(input: PathBuf) {
 #[fixture("tests/errors/next-ssg/**/input.js")]
 fn next_ssg_errors(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture_allowing_error(syntax(), &|_tr| next_ssg(), &input, &output);
+    test_fixture_allowing_error(
+        syntax(),
+        &|_tr| next_ssg(Default::default()),
+        &input,
+        &output,
+    );
 }

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -113,7 +113,7 @@ fn next_ssg_fixture(input: PathBuf) {
                 },
                 top_level_mark,
             );
-            chain!(next_ssg(), jsx)
+            chain!(next_ssg(Default::default()), jsx)
         },
         &input,
         &output,

--- a/packages/next-swc/crates/core/tests/full.rs
+++ b/packages/next-swc/crates/core/tests/full.rs
@@ -73,7 +73,13 @@ fn test(input: &Path, minify: bool) {
                 &handler,
                 &options.swc,
                 |_, comments| {
-                    custom_before_pass(cm.clone(), fm.clone(), &options, comments.clone())
+                    custom_before_pass(
+                        cm.clone(),
+                        fm.clone(),
+                        &options,
+                        comments.clone(),
+                        Default::default(),
+                    )
                 },
                 |_, _| noop(),
             ) {

--- a/packages/next-swc/crates/core/tests/telemetry.rs
+++ b/packages/next-swc/crates/core/tests/telemetry.rs
@@ -1,0 +1,59 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use fxhash::FxHashSet;
+use next_swc::next_ssg::next_ssg;
+use once_cell::sync::Lazy;
+use swc::{try_with_handler, Compiler};
+use swc_common::{FileName, FilePathMapping, SourceMap};
+use swc_ecmascript::transforms::pass::noop;
+
+static COMPILER: Lazy<Arc<Compiler>> = Lazy::new(|| {
+    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
+
+    Arc::new(Compiler::new(cm))
+});
+
+#[test]
+fn should_collect_estimated_third_part_packages() {
+    let eliminated_packages: Rc<RefCell<FxHashSet<String>>> = Default::default();
+    let fm = COMPILER.cm.new_source_file(
+        FileName::Real("fixture.js".into()),
+        r#"import http from 'http'
+import { hash } from '@napi-rs/bcrypt'
+
+import { omit } from '~/utils/omit'
+import config from './data.json'
+
+export default () => 'Hello World'
+
+export function getServerSideProps() {
+  console.log(http)
+  console.log(config)
+  return { props: { digest: hash('hello') } }
+}
+"#
+        .to_owned(),
+    );
+    assert!(
+        try_with_handler(COMPILER.cm.clone(), Default::default(), |handler| {
+            COMPILER.process_js_with_custom_pass(
+                fm,
+                None,
+                handler,
+                &Default::default(),
+                |_, _| next_ssg(eliminated_packages.clone()),
+                |_, _| noop(),
+            )
+        })
+        .is_ok()
+    );
+    assert_eq!(
+        eliminated_packages
+            .borrow()
+            .iter()
+            .collect::<Vec<&String>>(),
+        vec!["@napi-rs/bcrypt", "http"]
+    );
+}

--- a/packages/next-swc/crates/napi/src/bundle/mod.rs
+++ b/packages/next-swc/crates/napi/src/bundle/mod.rs
@@ -132,7 +132,7 @@ impl Task for BundleTask {
     }
 
     fn resolve(self, env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
-        complete_output(&env, output)
+        complete_output(&env, output, Default::default())
     }
 }
 

--- a/packages/next-swc/crates/napi/src/minify.rs
+++ b/packages/next-swc/crates/napi/src/minify.rs
@@ -92,7 +92,7 @@ impl Task for MinifyTask {
     }
 
     fn resolve(self, env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
-        complete_output(&env, output)
+        complete_output(&env, output, Default::default())
     }
 }
 
@@ -127,5 +127,5 @@ pub fn minify_sync(cx: CallContext) -> napi::Result<JsObject> {
     )
     .convert_err()?;
 
-    complete_output(cx.env, output)
+    complete_output(cx.env, output, Default::default())
 }

--- a/packages/next-swc/crates/napi/src/transform.rs
+++ b/packages/next-swc/crates/napi/src/transform.rs
@@ -31,12 +31,15 @@ use crate::{
     util::{deserialize_json, CtxtExt, MapErr},
 };
 use anyhow::{anyhow, bail, Context as _, Error};
+use fxhash::FxHashSet;
 use napi::{CallContext, Env, JsBoolean, JsBuffer, JsObject, JsString, JsUnknown, Status, Task};
 use next_swc::{custom_before_pass, TransformOptions};
 use std::fs::read_to_string;
 use std::{
+    cell::RefCell,
     convert::TryFrom,
     panic::{catch_unwind, AssertUnwindSafe},
+    rc::Rc,
     sync::Arc,
 };
 use swc::{try_with_handler, Compiler, TransformOutput};
@@ -60,10 +63,11 @@ pub struct TransformTask {
 }
 
 impl Task for TransformTask {
-    type Output = TransformOutput;
+    type Output = (TransformOutput, FxHashSet<String>);
     type JsValue = JsObject;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        let eliminated_packages: Rc<RefCell<fxhash::FxHashSet<String>>> = Default::default();
         let res = catch_unwind(AssertUnwindSafe(|| {
             try_with_handler(
                 self.c.cm.clone(),
@@ -108,7 +112,15 @@ impl Task for TransformTask {
                             None,
                             handler,
                             &options.swc,
-                            |_, comments| custom_before_pass(cm, file, &options, comments.clone()),
+                            |_, comments| {
+                                custom_before_pass(
+                                    cm,
+                                    file,
+                                    &options,
+                                    comments.clone(),
+                                    eliminated_packages.clone(),
+                                )
+                            },
                             |_, _| noop(),
                         )
                     })
@@ -124,7 +136,9 @@ impl Task for TransformTask {
         });
 
         match res {
-            Ok(res) => res.convert_err(),
+            Ok(res) => res
+                .map(|o| (o, eliminated_packages.replace(Default::default())))
+                .convert_err(),
             Err(err) => Err(napi::Error::new(
                 Status::GenericFailure,
                 format!("{:?}", err),
@@ -132,8 +146,12 @@ impl Task for TransformTask {
         }
     }
 
-    fn resolve(self, env: Env, result: Self::Output) -> napi::Result<Self::JsValue> {
-        complete_output(&env, result)
+    fn resolve(
+        self,
+        env: Env,
+        (output, eliminated_packages): Self::Output,
+    ) -> napi::Result<Self::JsValue> {
+        complete_output(&env, output, eliminated_packages)
     }
 }
 
@@ -203,7 +221,7 @@ where
     )
     .convert_err()?;
 
-    complete_output(cx.env, output)
+    complete_output(cx.env, output, Default::default())
 }
 
 #[js_function(4)]

--- a/packages/next-swc/crates/wasm/src/lib.rs
+++ b/packages/next-swc/crates/wasm/src/lib.rs
@@ -68,7 +68,9 @@ pub fn transform_sync(s: &str, opts: JsValue) -> Result<JsValue, JsValue> {
                     None,
                     handler,
                     &opts.swc,
-                    |_, comments| custom_before_pass(cm, file, &opts, comments.clone()),
+                    |_, comments| {
+                        custom_before_pass(cm, file, &opts, comments.clone(), Default::default())
+                    },
                     |_, _| noop(),
                 )
                 .context("failed to process js file")?;

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -73,6 +73,7 @@ import {
   eventTypeCheckCompleted,
   EVENT_BUILD_FEATURE_USAGE,
   EventBuildFeatureUsage,
+  eventPackageUsedInGetServerSideProps,
 } from '../telemetry/events'
 import { Telemetry } from '../telemetry/storage'
 import { CompilerResult, runCompiler } from './compiler'
@@ -1961,6 +1962,7 @@ export default async function build(
     if (telemetryPlugin) {
       const events = eventBuildFeatureUsage(telemetryPlugin)
       telemetry.record(events)
+      telemetry.record(eventPackageUsedInGetServerSideProps(telemetryPlugin))
     }
 
     if (ssgPages.size > 0) {

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -88,6 +88,11 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
   const swcSpan = parentTrace.traceChild('next-swc-transform')
   return swcSpan.traceAsyncFn(() =>
     transform(source, programmaticOptions).then((output) => {
+      if (output.eliminatedPackages && this.eliminatedPackages) {
+        for (const pkg of JSON.parse(output.eliminatedPackages)) {
+          this.eliminatedPackages.add(pkg)
+        }
+      }
       return [output.code, output.map ? JSON.parse(output.map) : undefined]
     })
   )

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -160,3 +160,21 @@ export function eventBuildFeatureUsage(
     },
   }))
 }
+
+export const EVENT_NAME_PACKAGE_USED_IN_GET_SERVER_SIDE_PROPS =
+  'NEXT_PACKAGE_USED_IN_GET_SERVER_SIDE_PROPS'
+
+export type EventPackageUsedInGetServerSideProps = {
+  package: string
+}
+
+export function eventPackageUsedInGetServerSideProps(
+  telemetryPlugin: TelemetryPlugin
+): Array<{ eventName: string; payload: EventPackageUsedInGetServerSideProps }> {
+  return telemetryPlugin.packagesUsedInServerSideProps().map((packageName) => ({
+    eventName: EVENT_NAME_PACKAGE_USED_IN_GET_SERVER_SIDE_PROPS,
+    payload: {
+      package: packageName,
+    },
+  }))
+}

--- a/test/integration/telemetry/pages/data.json
+++ b/test/integration/telemetry/pages/data.json
@@ -1,0 +1,1 @@
+{ "hello": "world" }

--- a/test/integration/telemetry/pages/gssp-again.js
+++ b/test/integration/telemetry/pages/gssp-again.js
@@ -1,0 +1,10 @@
+import http from 'http'
+import config from './data.json'
+
+export default () => 'Hello World'
+
+export function getServerSideProps() {
+  console.log(http)
+  console.log(config)
+  return { props: {} }
+}

--- a/test/integration/telemetry/pages/gssp.js
+++ b/test/integration/telemetry/pages/gssp.js
@@ -1,5 +1,11 @@
+import fs from 'fs'
+import path from 'path'
+
 export default () => 'Hello World'
 
 export function getServerSideProps() {
+  try {
+    fs.readyFile(path.join(process.cwd(), 'public/small.jpg'))
+  } catch (_) {}
   return { props: {} }
 }

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -71,6 +71,8 @@ describe('Telemetry CLI', () => {
   })
 
   it('detects isSrcDir dir correctly for `next build`', async () => {
+    // must clear cache for GSSP imports to be detected correctly
+    await fs.remove(path.join(appDir, '.next'))
     const { stderr } = await runNextCommand(['build', appDir], {
       stderr: true,
       env: {
@@ -79,6 +81,10 @@ describe('Telemetry CLI', () => {
     })
 
     expect(stderr).toMatch(/isSrcDir.*?false/)
+    expect(stderr).toMatch(/package.*?"fs"/)
+    expect(stderr).toMatch(/package.*?"path"/)
+    expect(stderr).toMatch(/package.*?"http"/)
+    expect(stderr).toMatch(/NEXT_PACKAGE_USED_IN_GET_SERVER_SIDE_PROPS/)
 
     await fs.move(path.join(appDir, 'pages'), path.join(appDir, 'src/pages'))
     const { stderr: stderr2 } = await runNextCommand(['build', appDir], {
@@ -329,10 +335,10 @@ describe('Telemetry CLI', () => {
 
     const event1 = /NEXT_BUILD_OPTIMIZED[\s\S]+?{([\s\S]+?)}/.exec(stderr).pop()
     expect(event1).toMatch(/"staticPropsPageCount": 2/)
-    expect(event1).toMatch(/"serverPropsPageCount": 1/)
+    expect(event1).toMatch(/"serverPropsPageCount": 2/)
     expect(event1).toMatch(/"ssrPageCount": 1/)
     expect(event1).toMatch(/"staticPageCount": 4/)
-    expect(event1).toMatch(/"totalPageCount": 8/)
+    expect(event1).toMatch(/"totalPageCount": 9/)
   })
 
   it('detects isSrcDir dir correctly for `next dev`', async () => {


### PR DESCRIPTION
Collect telemetry info about packages are used and eliminated in `getServerSideProps`

https://github.com/vercel/next-telemetry/pull/71
