### PR TITLE
use initial state for rootReducer in with-redux-saga example

### DIFF
--- a/examples/with-redux-saga/reducer.js
+++ b/examples/with-redux-saga/reducer.js
@@ -9,7 +9,7 @@ const initialState = {
   placeholderData: null,
 }
 
-function reducer(state, action) {
+function reducer(state = initialState, action) {
   switch (action.type) {
     case HYDRATE: {
       return { ...state, ...action.payload }


### PR DESCRIPTION
## Bug

Fix https://github.com/vercel/next.js/discussions/35285 

By default, the exemple doesn't use the initial redux state, resulting in `NaN` value being displayed.
See on https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-redux-saga 
![image](https://user-images.githubusercontent.com/9283289/158851630-d14af821-12c3-4081-8d20-a038d0311f4d.png)

