### PR TITLE
Use hasConcurrentFeatures instead of reactRoot as the condition of Fizz

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -449,7 +449,7 @@ export async function renderToHTML(
     devOnlyCacheBusterQueryString,
     supportsDynamicHTML,
     images,
-    reactRoot,
+    // reactRoot,
     runtime,
     ComponentMod,
     AppMod,
@@ -1216,7 +1216,7 @@ export async function renderToHTML(
     return inAmpMode ? children : <div id="__next">{children}</div>
   }
 
-  const ReactDOMServer = reactRoot
+  const ReactDOMServer = hasConcurrentFeatures
     ? require('react-dom/server.browser')
     : require('react-dom/server')
 
@@ -1339,7 +1339,7 @@ export async function renderToHTML(
         )
       }
 
-      if (reactRoot) {
+      if (hasConcurrentFeatures) {
         bodyResult = async (suffix: string) => {
           // this must be called inside bodyResult so appWrappers is
           // up to date when getWrappedApp is called


### PR DESCRIPTION
We should use the `hasConcurrentFeatures` as the condition to enable Fizz, instead of reactRoot, otherwise just by installing React 18 will break stuff such as CSS imports.

Currently `hasConcurrentFeatures` still needs to opt-in via the global `runtime` option. Once we fixed all the CSS bugs and add back #35245, we can flip the condition here again.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
