### PR TITLE
Run tests against node LTS (v16) and current (v17)

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -208,12 +208,16 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16, 17]
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
 
       - run: echo ${{needs.build.outputs.docsChange}}
 
@@ -258,12 +262,16 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16, 17]
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
 
       - run: echo ${{needs.build.outputs.docsChange}}
 
@@ -308,12 +316,16 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16, 17]
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
 
       - run: echo ${{needs.build.outputs.docsChange}}
 
@@ -348,12 +360,16 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16, 17]
     steps:
       - name: Setup node
         uses: actions/setup-node@v2
         if: ${{needs.build.outputs.docsChange != 'docs only change'}}
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
 
       - run: echo ${{needs.build.outputs.docsChange}}
 

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -7,49 +7,54 @@ import { NextInstance } from 'test/lib/next-modes/base'
 jest.setTimeout(2 * 60 * 1000)
 
 export function runTests(example = '') {
-  let next: NextInstance
+  const versionParts = process.versions.node.split('.').map((i) => Number(i))
 
-  beforeAll(async () => {
-    const srcDir = join(__dirname, '../../../../examples', example)
-    const srcFiles = await fs.readdir(srcDir)
+  if (
+    versionParts[0] > 16 ||
+    (versionParts[0] === 16 && versionParts[1] >= 14)
+  ) {
+    let next: NextInstance
 
-    const packageJson = await fs.readJson(join(srcDir, 'package.json'))
+    beforeAll(async () => {
+      const srcDir = join(__dirname, '../../../../examples', example)
+      const srcFiles = await fs.readdir(srcDir)
 
-    next = await createNext({
-      files: srcFiles.reduce((prev, file) => {
-        if (file !== 'package.json') {
-          prev[file] = new FileRef(join(srcDir, file))
-        }
-        return prev
-      }, {} as { [key: string]: FileRef }),
-      dependencies: {
-        ...packageJson.dependencies,
-        ...packageJson.devDependencies,
-      },
-      installCommand: ({ dependencies }) => {
-        const pkgs = Object.keys(dependencies).reduce((prev, cur) => {
-          prev.push(`${cur}@${dependencies[cur]}`)
+      const packageJson = await fs.readJson(join(srcDir, 'package.json'))
+
+      next = await createNext({
+        files: srcFiles.reduce((prev, file) => {
+          if (file !== 'package.json') {
+            prev[file] = new FileRef(join(srcDir, file))
+          }
           return prev
-        }, [] as string[])
-        return `yarn set version 3.1.1 && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
-          ' '
-        )}`
-      },
-      buildCommand: `yarn next build --no-lint`,
-      startCommand: (global as any).isNextDev ? `yarn next` : `yarn next start`,
+        }, {} as { [key: string]: FileRef }),
+        dependencies: {
+          ...packageJson.dependencies,
+          ...packageJson.devDependencies,
+        },
+        installCommand: ({ dependencies }) => {
+          const pkgs = Object.keys(dependencies).reduce((prev, cur) => {
+            prev.push(`${cur}@${dependencies[cur]}`)
+            return prev
+          }, [] as string[])
+          return `yarn set version berry && yarn config set enableGlobalCache true && yarn config set compressionLevel 0 && yarn add ${pkgs.join(
+            ' '
+          )}`
+        },
+        buildCommand: `yarn next build --no-lint`,
+        startCommand: (global as any).isNextDev
+          ? `yarn next`
+          : `yarn next start`,
+      })
     })
-  })
-  afterAll(() => next?.destroy())
+    afterAll(() => next?.destroy())
 
-  it('should warn on not fully supported node versions', async () => {
-    expect(next.cliOutput).toContain(
-      'Node.js 16.14+ is required for Yarn PnP 3.20+. More info'
-    )
-  })
-
-  it(`should compile and serve the index page correctly ${example}`, async () => {
-    const res = await fetchViaHTTP(next.url, '/')
-    expect(res.status).toBe(200)
-    expect(await res.text()).toContain('<html')
-  })
+    it(`should compile and serve the index page correctly ${example}`, async () => {
+      const res = await fetchViaHTTP(next.url, '/')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('<html')
+    })
+  } else {
+    it('should not run PnP test for older node versions', () => {})
+  }
 }


### PR DESCRIPTION
This updates to start testing against both the LTS version of node and the current version for all of our tests instead of specific ones. Since our integration tests rely on dependencies on the monorepo this can cause conflicts depending on the version so these will be updated in a separate PR. 