### PR TITLE
Keep fouc tags for streaming

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -585,10 +585,7 @@ export class Head extends Component<
       disableOptimizedLoading,
       optimizeCss,
       optimizeFonts,
-      runtime,
     } = this.context
-
-    const hasConcurrentFeatures = !!runtime
 
     const disableRuntimeJS = unstable_runtimeJS === false
     const disableJsPreload =

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -702,7 +702,7 @@ export class Head extends Component<
 
     return (
       <head {...this.props}>
-        {!hasConcurrentFeatures && this.context.isDevelopment && (
+        {this.context.isDevelopment && (
           <>
             <style
               data-next-hide-fouc

--- a/test/integration/react-streaming-and-server-components/test/css.js
+++ b/test/integration/react-streaming-and-server-components/test/css.js
@@ -16,8 +16,8 @@ export default function (context) {
     )
     expect(currentColor).toMatchInlineSnapshot(`"rgb(255, 0, 0)"`)
   })
-  // TODO: fix this test
-  it.skip('should include css modules with `serverComponents: true`', async () => {
+
+  it('should include css modules with `serverComponents: true`', async () => {
     const browser = await webdriver(context.appPort, '/css-modules')
     const currentColor = await browser.eval(
       `window.getComputedStyle(document.querySelector('h1')).color`


### PR DESCRIPTION
Basically the revert change of #31187

The fouc tag are rendered in first place, and the removing fouc tags script is executed before hydration which is early enough. This will unblock the dev mode of global CSS development

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`
