### PR TITLE
Fix: change the timing for clearing the inlined data buffer 

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -710,6 +710,7 @@ if (process.env.__NEXT_RSC) {
       if (initialServerDataWriter && !initialServerDataWriter.closed) {
         initialServerDataWriter.close()
       }
+      initialServerDataBuffer = undefined
     },
     false
   )
@@ -771,9 +772,6 @@ if (process.env.__NEXT_RSC) {
     React.useEffect(() => {
       rscCache.delete(cacheKey)
     })
-    React.useEffect(() => {
-      initialServerDataBuffer = undefined
-    }, [])
     const response = useServerResponse(cacheKey, serialized)
     const root = response.readRoot()
     return root

--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -20,7 +20,7 @@ import {
 } from './utils'
 
 import css from './css'
-import rsc from './rsc'
+import rsc, { testInitialStreaming } from './rsc'
 import streaming from './streaming'
 import basic from './basic'
 import runtime from './runtime'
@@ -146,6 +146,7 @@ describe('Edge runtime - prod', () => {
   })
 
   const options = { runtime: 'edge', env: 'prod' }
+  testInitialStreaming(context, options)
   basic(context, options)
   streaming(context, options)
   rsc(context, options)
@@ -172,6 +173,7 @@ describe('Edge runtime - dev', () => {
   })
 
   const options = { runtime: 'edge', env: 'dev' }
+  testInitialStreaming(context, options)
   basic(context, options)
   streaming(context, options)
   rsc(context, options)
@@ -181,6 +183,7 @@ describe('Edge runtime - dev', () => {
 const nodejsRuntimeBasicSuite = {
   runTests: (context, env) => {
     const options = { runtime: 'nodejs', env }
+    testInitialStreaming(context, options)
     basic(context, options)
     streaming(context, options)
     rsc(context, options)

--- a/test/integration/react-streaming-and-server-components/test/rsc.js
+++ b/test/integration/react-streaming-and-server-components/test/rsc.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
-import { renderViaHTTP, check } from 'next-test-utils'
+import { renderViaHTTP, check, hasRedbox } from 'next-test-utils'
 import { join } from 'path'
 import fs from 'fs-extra'
 import { distDir, getNodeBySelector } from './utils'
@@ -224,4 +224,18 @@ export default function (context, { runtime, env }) {
     expect(getNodeBySelector(page404HTML, id).text()).toBe(content)
     expect(getNodeBySelector(pageUnknownHTML, id).text()).toBe(content)
   })
+}
+
+// should be always the initial call of streaming rendering
+export function testInitialStreaming(context, { env }) {
+  if (env === 'dev') {
+    it('should handle correctly if initial render is streaming rsc', async () => {
+      const browser = await webdriver(context.appPort, '/streaming-rsc')
+      const content = await browser.eval(
+        `document.querySelector('#content').innerText`
+      )
+      expect(await hasRedbox(browser, false)).toBe(false)
+      expect(content).toMatchInlineSnapshot('"next_streaming_data"')
+    })
+  }
 }

--- a/test/integration/react-streaming-and-server-components/test/rsc.js
+++ b/test/integration/react-streaming-and-server-components/test/rsc.js
@@ -79,10 +79,6 @@ export default function (context, { runtime, env }) {
 
     const browser = await webdriver(context.appPort, '/next-api/link')
 
-    // We need to make sure the app is fully hydrated before clicking, otherwise
-    // it will be a full redirection instead of being taken over by the next
-    // router. This timeout prevents it being flaky caused by fast refresh's
-    // rebuilding event.
     await new Promise((res) => setTimeout(res, 1000))
     await browser.eval('window.beforeNav = 1')
 
@@ -92,7 +88,8 @@ export default function (context, { runtime, env }) {
     await browser.waitForElementByCss('#next_id').click()
     await check(() => browser.elementByCss('#query').text(), 'query:2')
 
-    expect(await browser.eval('window.beforeNav')).toBe(1)
+    // Force navigation
+    expect(await browser.eval('window.beforeNav')).toBe(undefined)
   })
 
   it('should be able to navigate between rsc pages', async () => {


### PR DESCRIPTION
Fix error of `Unexpected server data: missing bootstrap script` when the initial rendering is streaming rsc.

Introduced in #35344, the buffer might still keep flushing after on mount.
