### PR TITLE
feat(telemetry): report swc target triple to telemetry

### DIFF
--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -76,6 +76,9 @@ async function loadWasm() {
         parse(src, options) {
           return Promise.resolve(bindings.parse(src.toString(), options))
         },
+        getTargetTriple() {
+          return undefined
+        },
       }
       return wasmBindings
     } catch (e) {
@@ -187,6 +190,8 @@ function loadNative() {
       parse(src, options) {
         return bindings.parse(src, toBuffer(options ?? {}))
       },
+
+      getTargetTriple: bindings.getTargetTriple,
     }
     return nativeBindings
   }
@@ -235,8 +240,14 @@ export async function parse(src, options) {
 }
 
 export function getBinaryMetadata() {
-  let bindings = loadBindingsSync()
+  let bindings
+  try {
+    bindings = loadNative()
+  } catch (e) {
+    // Suppress exceptions, this fn allows to fail to load native bindings
+  }
+
   return {
-    target: bindings.getTargetTriple(),
+    target: bindings?.getTargetTriple?.(),
   }
 }

--- a/packages/next/build/webpack/plugins/telemetry-plugin.ts
+++ b/packages/next/build/webpack/plugins/telemetry-plugin.ts
@@ -1,6 +1,24 @@
 import type { webpack5 as webpack } from 'next/dist/compiled/webpack/webpack'
 
-type Feature =
+/**
+ * List of target triples next-swc native binary supports.
+ */
+export type SWC_TARGET_TRIPLE =
+  | 'x86_64-apple-darwin'
+  | 'x86_64-unknown-linux-gnu'
+  | 'x86_64-pc-windows-msvc'
+  | 'i686-pc-windows-msvc'
+  | 'aarch64-unknown-linux-gnu'
+  | 'armv7-unknown-linux-gnueabihf'
+  | 'aarch64-apple-darwin'
+  | 'aarch64-linux-android'
+  | 'arm-linux-androideabi'
+  | 'x86_64-unknown-freebsd'
+  | 'x86_64-unknown-linux-musl'
+  | 'aarch64-unknown-linux-musl'
+  | 'aarch64-pc-windows-msvc'
+
+export type Feature =
   | 'next/image'
   | 'next/script'
   | 'next/dynamic'
@@ -13,6 +31,7 @@ type Feature =
   | 'swcRemoveConsole'
   | 'swcImportSource'
   | 'swcEmotion'
+  | `swc/target/${SWC_TARGET_TRIPLE}`
 
 interface FeatureUsage {
   featureName: Feature
@@ -52,6 +71,19 @@ const BUILD_FEATURES: Array<Feature> = [
   'swcRemoveConsole',
   'swcImportSource',
   'swcEmotion',
+  'swc/target/x86_64-apple-darwin',
+  'swc/target/x86_64-unknown-linux-gnu',
+  'swc/target/x86_64-pc-windows-msvc',
+  'swc/target/i686-pc-windows-msvc',
+  'swc/target/aarch64-unknown-linux-gnu',
+  'swc/target/armv7-unknown-linux-gnueabihf',
+  'swc/target/aarch64-apple-darwin',
+  'swc/target/aarch64-linux-android',
+  'swc/target/arm-linux-androideabi',
+  'swc/target/x86_64-unknown-freebsd',
+  'swc/target/x86_64-unknown-linux-musl',
+  'swc/target/aarch64-unknown-linux-musl',
+  'swc/target/aarch64-pc-windows-msvc',
 ]
 
 /**

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -1,4 +1,5 @@
 import { TelemetryPlugin } from '../../build/webpack/plugins/telemetry-plugin'
+import type { SWC_TARGET_TRIPLE } from '../../build/webpack/plugins/telemetry-plugin'
 
 const REGEXP_DIRECTORY_DUNDER =
   /[\\/]__[^\\/]+(?<![\\/]__(?:tests|mocks))__[\\/]/i
@@ -144,6 +145,7 @@ export type EventBuildFeatureUsage = {
     | 'swcRemoveConsole'
     | 'swcImportSource'
     | 'swcEmotion'
+    | `swc/target/${SWC_TARGET_TRIPLE}`
     | 'build-lint'
   invocationCount: number
 }

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -632,6 +632,19 @@ describe('Telemetry CLI', () => {
     regex.exec(stderr).pop() // swcRemoveConsole
     regex.exec(stderr).pop() // swcImportSource
     regex.exec(stderr).pop() // swcEmotion
+    regex.exec(stderr).pop() // swc/targets/*
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
+    regex.exec(stderr).pop()
     const image = regex.exec(stderr).pop()
     expect(image).toContain(`"featureName": "next/image"`)
     expect(image).toContain(`"invocationCount": 1`)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR requires https://github.com/vercel/next.js/pull/35416 as prerequisite.

Context: https://github.com/vercel/next-telemetry/pull/72 

As next-swc exposes way to access its target triple, this PR attempts to include it into telemetry if we can access those metadata in swc's binary. One of missing piece in here is `wasm` target - however, main purpose of this tracking is usage distribution of native binary which is fine to skip it for now.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
