### PR TITLE
fix(document): accepts nodearray for head's children

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -19,7 +19,7 @@ export { DocumentContext, DocumentInitialProps, DocumentProps }
 export type OriginProps = {
   nonce?: string
   crossOrigin?: string
-  children?: React.ReactElement
+  children?: React.ReactNode
 }
 
 type DocumentFiles = {
@@ -72,6 +72,10 @@ function getPolyfillScripts(context: HtmlProps, props: OriginProps) {
     ))
 }
 
+function hasComponentProps(child: any): child is React.ReactElement {
+  return !!child && !!child.props
+}
+
 function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {
   const { assetPrefix, scriptLoader, crossOrigin, nextScriptWorkers } = context
 
@@ -88,7 +92,8 @@ function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {
 
     // Check to see if the user has defined their own Partytown configuration
     const userDefinedConfig = children.find(
-      (child: React.ReactElement) =>
+      (child) =>
+        hasComponentProps(child) &&
         child?.props?.dangerouslySetInnerHTML?.__html.length &&
         'data-partytown-config' in child.props
     )


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR attempts to amends #35390. 

There's new property 'children' in `OriginProps` : https://github.com/vercel/next.js/blob/canary/packages/next/pages/_document.tsx#L22 which overwrites default prop's children defined at https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L504. Those 2 are incompatible, especially new one doesn't allow iterable children which results multiple children in head tag makes compilation fails.

PR matches type of new property same as default, then apply some workaround to bend over internal check logics. I'm not sure if it's worth to apply strict types as much or just bend it via `any` casting, PR tried to be strict as much.

## Bug
- closes https://github.com/vercel/next.js/issues/35390

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

test is added in https://github.com/vercel/next.js/pull/35426
