### PR TITLE
Add support for server-side global CSS imports 

### DIFF
--- a/packages/next/server/require.ts
+++ b/packages/next/server/require.ts
@@ -69,7 +69,9 @@ export function requirePage(
   if (pagePath.endsWith('.html')) {
     return promises.readFile(pagePath, 'utf8')
   }
-  return require(pagePath)
+
+  // TODO Put CSS imports behind experimental flag
+  return safeRequire(pagePath)
 }
 
 export function requireFontManifest(distDir: string, serverless: boolean) {
@@ -123,5 +125,30 @@ export function getMiddlewareInfo(params: {
       ...binding,
       filePath: join(params.distDir, binding.filePath),
     })),
+  }
+}
+
+/**
+ * Safely load a module at the specified path, allowing for CSS imports by
+ * the requested module.
+ *
+ * @param path The path to the module to load.
+ * @param allowCssImports A flag to indicate that CSS imports are allowed.
+ */
+function safeRequire(path: string, allowCssImports: boolean = true): any {
+  let previous: any
+
+  if (allowCssImports) {
+    previous = require.extensions['.css']
+    // Make sure that we resolve CSS imports into empty objects on the server
+    require.extensions['.css'] = () => {}
+  }
+
+  try {
+    return require(path)
+  } finally {
+    if (allowCssImports) {
+      require.extensions['.css'] = previous
+    }
   }
 }

--- a/test/e2e/global-css/index.test.ts
+++ b/test/e2e/global-css/index.test.ts
@@ -1,0 +1,35 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { renderViaHTTP } from 'next-test-utils'
+
+describe('global-css', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.js': `
+          import { Button } from '@patternfly/react-core';
+
+          export default function Page() { 
+            return <Button variant="primary">hello world</Button>
+          }
+        `,
+      },
+      nextConfig: {
+        experimental: {
+          craCompat: true,
+        },
+      },
+      dependencies: {
+        '@patternfly/react-core': '4.198.19',
+      },
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should work', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('hello world')
+  })
+})


### PR DESCRIPTION
Hi,

Global CSS Imports have been a [much requested](https://github.com/vercel/next.js/discussions/27953) feature for Next.js. Various React component frameworks such as Spectrum or PatternFly require the use of global CSS imports to work. Although there exists workarounds for this issue in the form of [next-global-css](https://github.com/bem/next-global-css) and [next-transpile-modules](https://github.com/martpie/next-transpile-modules), these solutions are not ideal due to them needing to hack into the Webpack configuration.

Right now, global CSS imports seem to be (coincidentally) supported by Next.js client-side with the experimental `craCompat` option enabled.  However, it does not take into account dependencies that import CSS files on the server.

To address this, we ensure that imports for .css files result in a no-op, via the `require.extensions` object. Since `require.extensions` is deprecated, an alternative could be to patch `module.require` as done by [next-global-css](https://github.com/bem/next-global-css/blob/master/lib/patch-global-require.js).

I hope this can get the discussion started on how to bring this functionality to Next.js. 🙂