### PR TITLE
Fix typo in getServerSideProps doc page

### DIFF
--- a/docs/basic-features/data-fetching/get-server-side-props.md
+++ b/docs/basic-features/data-fetching/get-server-side-props.md
@@ -21,7 +21,7 @@ export async function getServerSideProps(context) {
 - When you request this page directly, `getServerSideProps` runs at request time, and this page will be pre-rendered with the returned props
 - When you request this page on client-side page transitions through [`next/link`](/docs/api-reference/next/link.md) or [`next/router`](/docs/api-reference/next/router.md), Next.js sends an API request to the server, which runs `getServerSideProps`
 
-It then returns `JSON` that contains the result of running `getServerSideProps`. That `JSON` will be used to render the page. All this work will be handled automatically by Next.js, so you don’t need to do anything extra as long as you have `getServerSideProps` defined.
+`getServerSideProps` returns JSON which will be used to render the page. All this work will be handled automatically by Next.js, so you don’t need to do anything extra as long as you have `getServerSideProps` defined.
 
 You can use the [next-code-elimination tool](https://next-code-elimination.vercel.app/) to verify what Next.js eliminates from the client-side bundle.
 

--- a/docs/basic-features/data-fetching/get-server-side-props.md
+++ b/docs/basic-features/data-fetching/get-server-side-props.md
@@ -21,7 +21,7 @@ export async function getServerSideProps(context) {
 - When you request this page directly, `getServerSideProps` runs at request time, and this page will be pre-rendered with the returned props
 - When you request this page on client-side page transitions through [`next/link`](/docs/api-reference/next/link.md) or [`next/router`](/docs/api-reference/next/router.md), Next.js sends an API request to the server, which runs `getServerSideProps`
 
-It then returns `JSON` that contains the result of running `getServerSideProps`, that `JSON` will be used to render the page. All this work will be handled automatically by Next.js, so you don’t need to do anything extra as long as you have `getServerSideProps` defined.
+It then returns `JSON` that contains the result of running `getServerSideProps`. That `JSON` will be used to render the page. All this work will be handled automatically by Next.js, so you don’t need to do anything extra as long as you have `getServerSideProps` defined.
 
 You can use the [next-code-elimination tool](https://next-code-elimination.vercel.app/) to verify what Next.js eliminates from the client-side bundle.
 


### PR DESCRIPTION
While reading the documentation, I noticed that this paragraph was not correctly written and was hard to read. I fixed it adding a dot.

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
