### PR TITLE
Use check on prerender test assertion

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1922,11 +1922,15 @@ describe('Prerender', () => {
           expect(res.status).toBe(200)
         }
         await next.deleteFile('error.txt')
-        expect(
-          next.cliOutput.match(
-            /throwing error for \/blocking-fallback\/test-errors-1/
-          ).length
-        ).toBe(1)
+        await check(
+          () =>
+            next.cliOutput.match(
+              /throwing error for \/blocking-fallback\/test-errors-1/
+            ).length === 1
+              ? 'success'
+              : next.cliOutput,
+          'success'
+        )
       })
 
       it('should automatically reset cache TTL when an error occurs and runtime cache was available', async () => {
@@ -1947,11 +1951,16 @@ describe('Prerender', () => {
           expect(res.status).toBe(200)
         }
         await next.deleteFile('error.txt')
-        expect(
-          next.cliOutput.match(
-            /throwing error for \/blocking-fallback\/test-errors-2/
-          ).length
-        ).toBe(1)
+
+        await check(
+          () =>
+            next.cliOutput.match(
+              /throwing error for \/blocking-fallback\/test-errors-2/
+            ).length === 1
+              ? 'success'
+              : next.cliOutput,
+          'success'
+        )
       })
 
       it('should handle manual revalidate for fallback: blocking', async () => {


### PR DESCRIPTION
Updates to make these tests more stable by using check since the logs might not immediately be in the output. 

x-ref: https://github.com/vercel/next.js/runs/5620099491?check_suite_focus=true