### PR TITLE
Tie the `router` instance to routing instead of rendering

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -662,16 +662,18 @@ function renderApp(App: AppComponent, appProps: AppProps) {
 }
 
 const wrapApp =
-  (App: AppComponent, router: NextRouter) =>
+  (App: AppComponent, pageRouter: NextRouter) =>
   (wrappedAppProps: Record<string, any>): JSX.Element => {
     const appProps: AppProps = {
       ...wrappedAppProps,
       Component: CachedComponent,
       err: initialData.err,
-      router,
+      router: pageRouter,
     }
     return (
-      <AppContainer router={router}>{renderApp(App, appProps)}</AppContainer>
+      <AppContainer router={pageRouter}>
+        {renderApp(App, appProps)}
+      </AppContainer>
     )
   }
 
@@ -839,7 +841,14 @@ if (process.env.__NEXT_RSC) {
 
 let lastAppProps: AppProps
 function doRender(input: RenderRouteInfo): Promise<any> {
-  let { App, Component, props, err, __N_RSC, router }: RenderRouteInfo = input
+  let {
+    App,
+    Component,
+    props,
+    err,
+    __N_RSC,
+    router: pageRouter,
+  }: RenderRouteInfo = input
   let styleSheets: StyleSheetTuple[] | undefined =
     'initial' in input ? undefined : input.styleSheets
   Component = Component || lastAppProps.Component
@@ -852,7 +861,7 @@ function doRender(input: RenderRouteInfo): Promise<any> {
     ...props,
     Component: isRSC ? RSCComponent : Component,
     err,
-    router,
+    router: pageRouter,
   }
   // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error.
   lastAppProps = appProps
@@ -995,7 +1004,7 @@ function doRender(input: RenderRouteInfo): Promise<any> {
   const elem: JSX.Element = (
     <>
       <Head callback={onHeadCommit} />
-      <AppContainer router={router}>
+      <AppContainer router={pageRouter}>
         {renderApp(App, appProps)}
         <Portal type="next-route-announcer">
           <RouteAnnouncer />

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -485,7 +485,7 @@ export type CompletePrivateRouteInfo = {
 }
 
 export type AppProps = Pick<CompletePrivateRouteInfo, 'Component' | 'err'> & {
-  router: Router
+  router: NextRouter
 } & Record<string, any>
 export type AppComponent = ComponentType<AppProps>
 
@@ -614,7 +614,7 @@ export default class Router implements BaseRouter {
   pageLoader: PageLoader
   _bps: BeforePopStateCallback | undefined
   events: MittEmitter<RouterEvent>
-  _wrapApp: (App: AppComponent) => any
+  _wrapApp: (App: AppComponent, router: NextRouter) => any
   isSsr: boolean
   _inFlightRoute?: string
   _shallow?: boolean
@@ -663,7 +663,7 @@ export default class Router implements BaseRouter {
       pageLoader: any
       Component: ComponentType
       App: AppComponent
-      wrapApp: (WrapAppComponent: AppComponent) => any
+      wrapApp: (WrapAppComponent: AppComponent, router: NextRouter) => any
       err?: Error
       isFallback: boolean
       locale?: string
@@ -2036,7 +2036,7 @@ export default class Router implements BaseRouter {
     ctx: NextPageContext
   ): Promise<any> {
     const { Component: App } = this.components['/_app']
-    const AppTree = this._wrapApp(App as AppComponent)
+    const AppTree = this._wrapApp(App as AppComponent, this)
     ctx.AppTree = AppTree
     return loadGetInitialProps<AppContextType<Router>>(App, {
       AppTree,


### PR DESCRIPTION
We want to call `makePublicRouterInstance(router)` when the route changes, not during rendering. This way, we don't break suspense, causing it to render the fallback during hydration due to changing context.