### PR TITLE
Update trace ignore check to check reasons correctly

### DIFF
--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -365,7 +365,9 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
                     // static image imports, CSS imports
                     file = nodePath.join(this.tracingRoot, file)
                     const depMod = depModMap.get(file)
-                    const isAsset = reasons.get(file)?.type.includes('asset')
+                    const isAsset = reasons
+                      .get(nodePath.relative(this.tracingRoot, file))
+                      ?.type.includes('asset')
 
                     return (
                       !isAsset &&

--- a/test/integration/production/pages/api/index.js
+++ b/test/integration/production/pages/api/index.js
@@ -1,12 +1,12 @@
 import fs from 'fs'
 import path from 'path'
-import data from '../../static/hello.json'
+import css from '../../components/logo/logo.module.css'
 
 export default (req, res) => {
   console.log({
-    importedData: data,
+    importedData: css,
     fsLoadedData: fs.readFileSync(
-      path.join(process.cwd(), 'static', 'hello.json'),
+      path.join(process.cwd(), 'components', 'logo', 'logo.module.css'),
       'utf8'
     ),
   })

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -225,7 +225,7 @@ describe('Production Usage', () => {
       },
       {
         page: '/api',
-        tests: [/webpack-runtime\.js/, /static\/hello\.json/],
+        tests: [/webpack-runtime\.js/, /\/logo\.module\.css/],
         notTests: [
           /next\/dist\/server\/next\.js/,
           /next\/dist\/bin/,


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/35446 and fixes our `reasons.get()` path as the `reasons` stores the file relative to `base` path provided which is the `tracingRoot`. This also updates our test case to ensure it's using a file handled by a loader instead of a JSON file which doesn't require a loader. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: https://github.com/vercel/next.js/pull/35446