### PR TITLE
Add link for revalidate from notFound section

### DIFF
--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -85,7 +85,7 @@ Learn more about [Incremental Static Regeneration](/docs/basic-features/data-fet
 
 ### `notFound`
 
-The `notFound` boolean allows the page to return a `404` status and [404 Page](/docs/advanced-features/custom-error-page.md#404-page). With `notFound: true`, the page will return a `404` even if there was a successfully generated page before. This is meant to support use cases like user-generated content getting removed by its author.
+The `notFound` boolean allows the page to return a `404` status and [404 Page](/docs/advanced-features/custom-error-page.md#404-page). With `notFound: true`, the page will return a `404` even if there was a successfully generated page before. This is meant to support use cases like user-generated content getting removed by its author. Note, `notFound` follows the same `revalidate` behavior [described here](/docs/api-reference/data-fetching/get-static-props.md#revalidate)
 
 ```js
 export async function getStaticProps(context) {


### PR DESCRIPTION
As discussed in Slack this adds a link to the `revalidate` section from the `notFound` to stress it follows the same behavior. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
