### PR TITLE
Fix `next info` accidentally printing stderr

### DIFF
--- a/packages/next/cli/next-info.ts
+++ b/packages/next/cli/next-info.ts
@@ -99,7 +99,10 @@ function getPackageVersion(packageName: string) {
 
 function getBinaryVersion(binaryName: string) {
   try {
-    return childProcess.execSync(`${binaryName} --version`).toString().trim()
+    return childProcess
+      .execFileSync(binaryName, ['--version'])
+      .toString()
+      .trim()
   } catch {
     return 'N/A'
   }

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -489,7 +489,9 @@ describe('CLI Usage', () => {
     test('should print output', async () => {
       const info = await runNextCommand(['info'], {
         stdout: true,
+        stderr: true,
       })
+      expect(info.stderr || '').toBe('')
       expect(info.stdout).toMatch(
         new RegExp(`
     Operating System:


### PR DESCRIPTION
I noticed a few issues that had "Output from `next info`" with the first line as

```
/bin/sh: pnpm: command not found
```

This was because `execSync()` was still printing to stderr when a command was not found.

Changing to `execFileSync()` fixed it so we no longer print to stderr when a command is not found.