### PR TITLE
RSC: handle commonjs in flight loader

### DIFF
--- a/packages/next/build/webpack/loaders/next-flight-client-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-client-loader.ts
@@ -59,7 +59,7 @@ async function parseModuleInfo(
       case 'ExportDefaultExpression':
       case 'ExportDefaultDeclaration':
         names.push('default')
-        continue
+        break
       case 'ExportNamedDeclaration':
         if (node.declaration) {
           if (node.declaration.type === 'VariableDeclaration') {
@@ -77,12 +77,12 @@ async function parseModuleInfo(
             addExportNames(names, specificers[j].exported)
           }
         }
-        continue
+        break
       case 'ExportDeclaration':
         if (node.declaration?.identifier) {
           addExportNames(names, node.declaration.identifier)
         }
-        continue
+        break
       case 'ExpressionStatement': {
         const {
           expression: { left },
@@ -95,6 +95,7 @@ async function parseModuleInfo(
         ) {
           addExportNames(names, left.property)
         }
+        break
       }
       default:
         break

--- a/packages/next/build/webpack/loaders/next-flight-server-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-server-loader.ts
@@ -1,5 +1,6 @@
 import { parse } from '../../swc'
 import { getRawPageExtensions } from '../../utils'
+import { buildExports, isEsmNode } from './utils'
 
 const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif']
 
@@ -24,7 +25,7 @@ const createServerComponentFilter = (pageExtensions: string[]) => {
   return (importSource: string) => regex.test(importSource)
 }
 
-async function parseImportsInfo({
+async function parseModuleInfo({
   resourcePath,
   source,
   isClientCompilation,
@@ -39,16 +40,18 @@ async function parseImportsInfo({
 }): Promise<{
   source: string
   imports: string
+  isEsm: boolean
 }> {
   const ast = await parse(source, { filename: resourcePath, isModule: true })
   const { body } = ast
-
   let transformedSource = ''
   let lastIndex = 0
   let imports = ''
+  let isEsm = false
 
   for (let i = 0; i < body.length; i++) {
     const node = body[i]
+    isEsm = isEsm || isEsmNode(node)
     switch (node.type) {
       case 'ImportDeclaration': {
         const importSource = node.source.value
@@ -117,7 +120,7 @@ async function parseImportsInfo({
     transformedSource += source.substring(lastIndex)
   }
 
-  return { source: transformedSource, imports }
+  return { source: transformedSource, imports, isEsm }
 }
 
 export default async function transformSource(
@@ -152,7 +155,11 @@ export default async function transformSource(
     }
   }
 
-  const { source: transformedSource, imports } = await parseImportsInfo({
+  const {
+    source: transformedSource,
+    imports,
+    isEsm,
+  } = await parseModuleInfo({
     resourcePath,
     source,
     isClientCompilation,
@@ -172,14 +179,17 @@ export default async function transformSource(
    *   export const __next_rsc__ = { __webpack_require__, _: () => { ... } }
    */
 
-  let rscExports = `export const __next_rsc__={
-    __webpack_require__,
-    _: () => {${imports}}
-  }`
-
-  if (isClientCompilation) {
-    rscExports += '\nexport default function RSC () {}'
+  const rscExports: any = {
+    __next_rsc__: `{
+      __webpack_require__,
+      _: () => {${imports}}
+    }`,
   }
 
-  return transformedSource + '\n' + rscExports
+  if (isClientCompilation) {
+    rscExports['default'] = 'function RSC() {}'
+  }
+
+  const output = transformedSource + '\n' + buildExports(rscExports, isEsm)
+  return output
 }

--- a/packages/next/build/webpack/loaders/next-flight-server-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-server-loader.ts
@@ -1,6 +1,6 @@
 import { parse } from '../../swc'
 import { getRawPageExtensions } from '../../utils'
-import { buildExports, isEsmNode } from './utils'
+import { buildExports, isEsmNodeType } from './utils'
 
 const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif']
 
@@ -51,7 +51,7 @@ async function parseModuleInfo({
 
   for (let i = 0; i < body.length; i++) {
     const node = body[i]
-    isEsm = isEsm || isEsmNode(node)
+    isEsm = isEsm || isEsmNodeType(node.type)
     switch (node.type) {
       case 'ImportDeclaration': {
         const importSource = node.source.value
@@ -182,7 +182,7 @@ export default async function transformSource(
   const rscExports: any = {
     __next_rsc__: `{
       __webpack_require__,
-      _: () => {${imports}}
+      _: () => {\n${imports}\n}
     }`,
   }
 

--- a/packages/next/build/webpack/loaders/utils.ts
+++ b/packages/next/build/webpack/loaders/utils.ts
@@ -18,4 +18,4 @@ const esmNodeTypes = [
   'ExportDefaultExpression',
   'ExportDefaultDeclaration',
 ]
-export const isEsmNode = (node: any) => esmNodeTypes.includes(node.type)
+export const isEsmNodeType = (type: string) => esmNodeTypes.includes(type)

--- a/packages/next/build/webpack/loaders/utils.ts
+++ b/packages/next/build/webpack/loaders/utils.ts
@@ -1,0 +1,21 @@
+export function buildExports(moduleExports: any, isESM: boolean) {
+  let ret = ''
+  Object.keys(moduleExports).forEach((key) => {
+    const exportExpression = isESM
+      ? `export ${key === 'default' ? key : `const ${key} =`} ${
+          moduleExports[key]
+        }`
+      : `exports.${key} = ${moduleExports[key]}`
+
+    ret += exportExpression + '\n'
+  })
+  return ret
+}
+
+const esmNodeTypes = [
+  'ImportDeclaration',
+  'ExportNamedDeclaration',
+  'ExportDefaultExpression',
+  'ExportDefaultDeclaration',
+]
+export const isEsmNode = (node: any) => esmNodeTypes.includes(node.type)

--- a/test/integration/react-streaming-and-server-components/app/components/cjs.client.js
+++ b/test/integration/react-streaming-and-server-components/app/components/cjs.client.js
@@ -1,0 +1,3 @@
+exports.Cjs = function Cjs() {
+  return 'cjs-client'
+}

--- a/test/integration/react-streaming-and-server-components/app/components/cjs.js
+++ b/test/integration/react-streaming-and-server-components/app/components/cjs.js
@@ -1,0 +1,3 @@
+exports.Cjs = function Cjs() {
+  return 'cjs-shared'
+}

--- a/test/integration/react-streaming-and-server-components/app/pages/various-exports.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/various-exports.server.js
@@ -4,6 +4,8 @@ import { a, b, c, d, e } from '../components/shared-exports'
 import DefaultArrow, {
   Named as ClientNamed,
 } from '../components/client-exports.client'
+import { Cjs as CjsShared } from '../components/cjs'
+import { Cjs as CjsClient } from '../components/cjs.client'
 
 export default function Page() {
   return (
@@ -21,6 +23,12 @@ export default function Page() {
       <div>
         <ClientNamed />
       </div>
+      <di>
+        <CjsShared />
+      </di>
+      <di>
+        <CjsClient />
+      </di>
     </div>
   )
 }

--- a/test/integration/react-streaming-and-server-components/test/rsc.js
+++ b/test/integration/react-streaming-and-server-components/test/rsc.js
@@ -206,6 +206,8 @@ export default function (context, { runtime, env }) {
     expect(hydratedContent).toContain('abcde')
     expect(hydratedContent).toContain('default-export-arrow.client')
     expect(hydratedContent).toContain('named.client')
+    expect(hydratedContent).toContain('cjs-shared')
+    expect(hydratedContent).toContain('cjs-client')
   })
 
   it('should handle 404 requests and missing routes correctly', async () => {


### PR DESCRIPTION
We need to handle cjs cases for client/server components when they're compiled to commonjs in some cases.
e.g. if there's an internal `_app.server.js` in nextjs, the assets in the dist files are compiled to cjs by swc. Or any 3rd party libraries are consumed could be cjs only.

### How it works

* Detect the source file is ESM or CJS first by detect if there's any ESM import/export
* Append the new exports or collect exports info based on the module type