### PR TITLE
Fix create-next-app failing without yarn installed

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -129,7 +129,7 @@ async function run(): Promise<void> {
     ? 'npm'
     : !!program.usePnpm
     ? 'pnpm'
-    : 'yarn'
+    : getPkgManager()
 
   const example = typeof program.example === 'string' && program.example.trim()
   try {


### PR DESCRIPTION
This fixes our package manager detection which was changed slightly in https://github.com/vercel/next.js/pull/34947 for `pnpm` support to ensure the default case still attempts detecting the available package manager if no preference is specified in the command args. This also adds a test case to ensure the install succeeds when we fail to detect a valid `yarn` binary and no preference is set via the `npm_config_user_agent` env variable. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/35607
Fixes: https://github.com/vercel/next.js/issues/35599
Fixes: https://github.com/vercel/next.js/discussions/35611