### PR TITLE
enhance: detect ESM by ast type

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -135,7 +135,7 @@ export async function getPageRuntime(
     try {
       const { body } = await parse(pageContent, {
         filename: pageFilePath,
-        isModule: true,
+        isModule: 'unknown',
       })
 
       for (const node of body) {

--- a/packages/next/build/webpack/loaders/next-flight-client-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-client-loader.ts
@@ -47,7 +47,7 @@ async function parseModuleInfo(
 ): Promise<void> {
   const { body } = await parse(transformedSource, {
     filename: resourcePath,
-    isModule: true,
+    isModule: 'unknown',
   })
   for (let i = 0; i < body.length; i++) {
     const node = body[i]

--- a/packages/next/build/webpack/loaders/next-flight-server-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-server-loader.ts
@@ -1,6 +1,6 @@
 import { parse } from '../../swc'
 import { getRawPageExtensions } from '../../utils'
-import { buildExports, isEsmNodeType } from './utils'
+import { buildExports } from './utils'
 
 const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif']
 
@@ -42,16 +42,18 @@ async function parseModuleInfo({
   imports: string
   isEsm: boolean
 }> {
-  const ast = await parse(source, { filename: resourcePath, isModule: true })
-  const { body } = ast
+  const ast = await parse(source, {
+    filename: resourcePath,
+    isModule: 'unknown',
+  })
+  const { type, body } = ast
   let transformedSource = ''
   let lastIndex = 0
   let imports = ''
-  let isEsm = false
+  const isEsm = type === 'Module'
 
   for (let i = 0; i < body.length; i++) {
     const node = body[i]
-    isEsm = isEsm || isEsmNodeType(node.type)
     switch (node.type) {
       case 'ImportDeclaration': {
         const importSource = node.source.value

--- a/packages/next/build/webpack/loaders/utils.ts
+++ b/packages/next/build/webpack/loaders/utils.ts
@@ -11,12 +11,3 @@ export function buildExports(moduleExports: any, isESM: boolean) {
   })
   return ret
 }
-
-const esmNodeTypes = [
-  'ImportDeclaration',
-  'ExportDeclaration',
-  'ExportNamedDeclaration',
-  'ExportDefaultExpression',
-  'ExportDefaultDeclaration',
-]
-export const isEsmNodeType = (type: string) => esmNodeTypes.includes(type)


### PR DESCRIPTION
Simplify the esmodule detection. If there's any import/exprt usage, it will return `Module` in ast.type otherwise `Script` when `isModule` is set to `"unknown"`