### PR TITLE
Fix typo in rewrites docs

### DIFF
--- a/docs/api-reference/next.config.js/rewrites.md
+++ b/docs/api-reference/next.config.js/rewrites.md
@@ -327,7 +327,7 @@ If you're using `trailingSlash: true`, you also need to insert a trailing slash 
 
 ```js
 module.exports = {
-  trailingSlash: 'true',
+  trailingSlash: true,
   async rewrites() {
     return [
       {


### PR DESCRIPTION
Correct the type of `trailingSlash` in config example

Modified: `docs/api-reference/next.config.js/rewrites.md`

```diff
- trailingSlash: 'true',
+ trailingSlash: true,
```
