### PR TITLE
Fix next info test during stable release

### DIFF
--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -491,7 +491,12 @@ describe('CLI Usage', () => {
         stdout: true,
         stderr: true,
       })
-      expect(info.stderr || '').toBe('')
+
+      // when a stable release is done the non-latest canary
+      // warning will show so skip this check for the stable release
+      if (pkg.version.includes('-canary')) {
+        expect(info.stderr || '').toBe('')
+      }
       expect(info.stdout).toMatch(
         new RegExp(`
     Operating System:


### PR DESCRIPTION
This ensures the `next info` test doesn't cause a failure for the stable relase. 

Fixes: https://github.com/vercel/next.js/runs/5726017046?check_suite_focus=true#step:9:365