### PR TITLE
Update default test timeouts for yarn install times

### DIFF
--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -5,6 +5,9 @@ import { InstallCommand, NextInstance, PackageJson } from './next-modes/base'
 import { NextDevInstance } from './next-modes/next-dev'
 import { NextStartInstance } from './next-modes/next-start'
 
+// increase timeout to account for yarn install time
+jest.setTimeout((process.platform === 'win32' ? 240 : 180) * 1000)
+
 const testsFolder = path.join(__dirname, '..')
 
 let testFile


### PR DESCRIPTION
This updates our default test times as discussed to account for longer `yarn install` times for the isolated tests as GitHub actions network can be slow. 

x-ref: https://github.com/vercel/next.js/pull/35507#issuecomment-1074606737
x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1647919982840099)