### PR TITLE
feat: proposal Change `router._idx` to public field

### DIFF
--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -52,6 +52,7 @@ The following is the definition of the `router` object returned by both [`useRou
 - `domainLocales`: `Array<{domain, defaultLocale, locales}>` - Any configured domain locales.
 - `isReady`: `boolean` - Whether the router fields are updated client-side and ready for use. Should only be used inside of `useEffect` methods and not for conditionally rendering on the server. See related docs for use case with [automatically statically optimized pages](/docs/advanced-features/automatic-static-optimization.md)
 - `isPreview`: `boolean` - Whether the application is currently in [preview mode](/docs/advanced-features/preview-mode.md).
+- `idx`: `number` - History index. A value that is incremented each time a history is entered.
 
 The following methods are included inside `router`:
 

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -45,6 +45,7 @@ const urlPropertyFields = [
   'locales',
   'defaultLocale',
   'isReady',
+  'idx',
   'isPreview',
   'isLocaleDomain',
   'domainLocales',

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -119,6 +119,7 @@ class ServerRouter implements NextRouter {
   domainLocales?: DomainLocale[]
   isPreview: boolean
   isLocaleDomain: boolean
+  idx: number
 
   constructor(
     pathname: string,
@@ -147,6 +148,7 @@ class ServerRouter implements NextRouter {
     this.domainLocales = domainLocales
     this.isPreview = !!isPreview
     this.isLocaleDomain = !!isLocaleDomain
+    this.idx = 0
   }
 
   push(): any {

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -462,6 +462,7 @@ export type NextRouter = BaseRouter &
     | 'isFallback'
     | 'isReady'
     | 'isPreview'
+    | 'idx'
   >
 
 export type PrefetchOptions = {

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -623,6 +623,7 @@ export default class Router implements BaseRouter {
   domainLocales?: DomainLocale[]
   isReady: boolean
   isLocaleDomain: boolean
+  idx: number
 
   private state: Readonly<{
     route: string
@@ -633,8 +634,6 @@ export default class Router implements BaseRouter {
     isFallback: boolean
     isPreview: boolean
   }>
-
-  private _idx: number = 0
 
   static events: MittEmitter<RouterEvent> = mitt()
 
@@ -719,6 +718,7 @@ export default class Router implements BaseRouter {
     // back from external site
     this.isSsr = true
     this.isLocaleDomain = false
+    this.idx = 0
     this.isReady = !!(
       self.__NEXT_DATA__.gssp ||
       self.__NEXT_DATA__.gip ||
@@ -807,11 +807,11 @@ export default class Router implements BaseRouter {
     const { url, as, options, idx } = state
     if (process.env.__NEXT_SCROLL_RESTORATION) {
       if (manualScrollRestoration) {
-        if (this._idx !== idx) {
+        if (this.idx !== idx) {
           // Snapshot current scroll position:
           try {
             sessionStorage.setItem(
-              '__next_scroll_' + this._idx,
+              '__next_scroll_' + this.idx,
               JSON.stringify({ x: self.pageXOffset, y: self.pageYOffset })
             )
           } catch {}
@@ -826,7 +826,7 @@ export default class Router implements BaseRouter {
         }
       }
     }
-    this._idx = idx
+    this.idx = idx
 
     const { pathname } = parseRelativeUrl(url)
 
@@ -883,7 +883,7 @@ export default class Router implements BaseRouter {
         try {
           // Snapshot scroll position right before navigating to a new page:
           sessionStorage.setItem(
-            '__next_scroll_' + this._idx,
+            '__next_scroll_' + this.idx,
             JSON.stringify({ x: self.pageXOffset, y: self.pageYOffset })
           )
         } catch {}
@@ -1408,7 +1408,7 @@ export default class Router implements BaseRouter {
           as,
           options,
           __N: true,
-          idx: (this._idx = method !== 'pushState' ? this._idx : this._idx + 1),
+          idx: (this.idx = method !== 'pushState' ? this.idx : this.idx + 1),
         } as HistoryState,
         // Most browsers currently ignores this parameter, although they may use it in the future.
         // Passing the empty string here should be safe against future changes to the method.


### PR DESCRIPTION
This PR is a proposal.
Fixed to expose the `idx` variable in `router` based on the suggestion in Discussion(#34980).

## Ref
#34980 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
