### PR TITLE
Only resolve page runtime for react 18 and error on read failure

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -109,7 +109,7 @@ const cachedPageRuntimeConfig = new Map<string, [number, PageRuntime]>()
 // could be thousands of pages existing.
 export async function getPageRuntime(
   pageFilePath: string,
-  nextConfig: NextConfig
+  nextConfig: Partial<NextConfig>
 ): Promise<PageRuntime> {
   if (!nextConfig.experimental?.reactRoot) return undefined
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -971,13 +971,9 @@ export default async function build(
                 p.startsWith(actualPage + '.') ||
                 p.startsWith(actualPage + '/index.')
             )
-            const pageRuntime =
-              hasConcurrentFeatures && pagePath
-                ? await getPageRuntime(
-                    join(pagesDir, pagePath),
-                    config.experimental.runtime
-                  )
-                : undefined
+            const pageRuntime = pagePath
+              ? await getPageRuntime(join(pagesDir, pagePath), config)
+              : undefined
 
             if (
               !isMiddlewareRoute &&

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -507,10 +507,9 @@ export default class HotReloader {
               this.hasServerComponents &&
               isFlightPage(this.config, absolutePagePath)
 
-            const pageRuntimeConfig = await getPageRuntime(
-              absolutePagePath,
-              this.runtime
-            )
+            const pageRuntimeConfig = this.hasReactRoot
+              ? await getPageRuntime(absolutePagePath, this.runtime)
+              : undefined
             const isEdgeSSRPage = pageRuntimeConfig === 'edge' && !isApiRoute
 
             if (isNodeServerCompilation && isEdgeSSRPage && !isCustomError) {

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -507,9 +507,10 @@ export default class HotReloader {
               this.hasServerComponents &&
               isFlightPage(this.config, absolutePagePath)
 
-            const pageRuntimeConfig = this.hasReactRoot
-              ? await getPageRuntime(absolutePagePath, this.runtime)
-              : undefined
+            const pageRuntimeConfig = await getPageRuntime(
+              absolutePagePath,
+              this.config
+            )
             const isEdgeSSRPage = pageRuntimeConfig === 'edge' && !isApiRoute
 
             if (isNodeServerCompilation && isEdgeSSRPage && !isCustomError) {

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -283,10 +283,12 @@ export default class DevServer extends Server {
           pageName = pageName.replace(/\/index$/, '') || '/'
 
           invalidatePageRuntimeCache(fileName, safeTime)
-          const pageRuntimeConfig = await getPageRuntime(
-            fileName,
-            this.nextConfig.experimental.runtime
-          )
+          const pageRuntimeConfig = this.renderOpts.reactRoot
+            ? await getPageRuntime(
+                fileName,
+                this.nextConfig.experimental.runtime
+              )
+            : undefined
           const isEdgeRuntime = pageRuntimeConfig === 'edge'
 
           if (

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -283,12 +283,10 @@ export default class DevServer extends Server {
           pageName = pageName.replace(/\/index$/, '') || '/'
 
           invalidatePageRuntimeCache(fileName, safeTime)
-          const pageRuntimeConfig = this.renderOpts.reactRoot
-            ? await getPageRuntime(
-                fileName,
-                this.nextConfig.experimental.runtime
-              )
-            : undefined
+          const pageRuntimeConfig = await getPageRuntime(
+            fileName,
+            this.nextConfig
+          )
           const isEdgeRuntime = pageRuntimeConfig === 'edge'
 
           if (

--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -206,12 +206,10 @@ export default function onDemandEntryHandler(
 
       const isMiddleware = normalizedPage.match(MIDDLEWARE_ROUTE)
       const isApiRoute = normalizedPage.match(API_ROUTE) && !isMiddleware
-      const pageRuntimeConfig = hasReactRoot
-        ? await getPageRuntime(
-            absolutePagePath,
-            nextConfig.experimental.runtime
-          )
-        : undefined
+      const pageRuntimeConfig = await getPageRuntime(
+        absolutePagePath,
+        nextConfig
+      )
       const isEdgeServer = pageRuntimeConfig === 'edge'
 
       const isCustomError = isCustomErrorPage(page)

--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -43,7 +43,6 @@ export default function onDemandEntryHandler(
 ) {
   const { compilers } = multiCompiler
   const invalidator = new Invalidator(watcher, multiCompiler)
-  const hasReactRoot = !!nextConfig.experimental.reactRoot
 
   let lastClientAccessPages = ['']
   let doneCallbacks: EventEmitter | null = new EventEmitter()

--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -43,6 +43,7 @@ export default function onDemandEntryHandler(
 ) {
   const { compilers } = multiCompiler
   const invalidator = new Invalidator(watcher, multiCompiler)
+  const hasReactRoot = !!nextConfig.experimental.reactRoot
 
   let lastClientAccessPages = ['']
   let doneCallbacks: EventEmitter | null = new EventEmitter()
@@ -205,10 +206,12 @@ export default function onDemandEntryHandler(
 
       const isMiddleware = normalizedPage.match(MIDDLEWARE_ROUTE)
       const isApiRoute = normalizedPage.match(API_ROUTE) && !isMiddleware
-      const pageRuntimeConfig = await getPageRuntime(
-        absolutePagePath,
-        nextConfig.experimental.runtime
-      )
+      const pageRuntimeConfig = hasReactRoot
+        ? await getPageRuntime(
+            absolutePagePath,
+            nextConfig.experimental.runtime
+          )
+        : undefined
       const isEdgeServer = pageRuntimeConfig === 'edge'
 
       const isCustomError = isCustomErrorPage(page)

--- a/test/unit/parse-page-runtime.test.ts
+++ b/test/unit/parse-page-runtime.test.ts
@@ -1,9 +1,10 @@
 import { getPageRuntime } from 'next/dist/build/entries'
+import type { PageRuntime } from 'next/dist/server/config-shared'
 import { join } from 'path'
 
 const fixtureDir = join(__dirname, 'fixtures')
 
-function createNextConfig(runtime?: string) {
+function createNextConfig(runtime?: PageRuntime) {
   return {
     experimental: { reactRoot: true, runtime },
   }

--- a/test/unit/parse-page-runtime.test.ts
+++ b/test/unit/parse-page-runtime.test.ts
@@ -3,24 +3,33 @@ import { join } from 'path'
 
 const fixtureDir = join(__dirname, 'fixtures')
 
+function createNextConfig(runtime?: string) {
+  return {
+    experimental: { reactRoot: true, runtime },
+  }
+}
+
 describe('parse page runtime config', () => {
   it('should parse nodejs runtime correctly', async () => {
     const runtime = await getPageRuntime(
-      join(fixtureDir, 'page-runtime/nodejs.js')
+      join(fixtureDir, 'page-runtime/nodejs.js'),
+      createNextConfig()
     )
     expect(runtime).toBe('nodejs')
   })
 
   it('should parse edge runtime correctly', async () => {
     const runtime = await getPageRuntime(
-      join(fixtureDir, 'page-runtime/edge.js')
+      join(fixtureDir, 'page-runtime/edge.js'),
+      createNextConfig()
     )
     expect(runtime).toBe('edge')
   })
 
   it('should return undefined if no runtime is specified', async () => {
     const runtime = await getPageRuntime(
-      join(fixtureDir, 'page-runtime/static.js')
+      join(fixtureDir, 'page-runtime/static.js'),
+      createNextConfig()
     )
     expect(runtime).toBe(undefined)
   })
@@ -30,7 +39,7 @@ describe('fallback to the global runtime configuration', () => {
   it('should fallback when gSP is defined and exported', async () => {
     const runtime = await getPageRuntime(
       join(fixtureDir, 'page-runtime/fallback-with-gsp.js'),
-      'edge'
+      createNextConfig('edge')
     )
     expect(runtime).toBe('edge')
   })
@@ -38,7 +47,7 @@ describe('fallback to the global runtime configuration', () => {
   it('should fallback when gSP is re-exported from other module', async () => {
     const runtime = await getPageRuntime(
       join(fixtureDir, 'page-runtime/fallback-re-export-gsp.js'),
-      'edge'
+      createNextConfig('edge')
     )
     expect(runtime).toBe('edge')
   })


### PR DESCRIPTION
* Read the proper page file from either pages directory or from node_modules (inernal pages like _app, _document)
* Only reading page runtime when `reactRoot` is enabled, reduce time for react 17 apps