### PR TITLE
fix: Prevent page to scroll to top during data HMR

### DIFF
--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -87,7 +87,8 @@ initialize({ webpackHMR })
                       new URLSearchParams(location.search)
                     )
                   ),
-                router.asPath
+                router.asPath,
+                { scroll: false }
               )
               .finally(clearIndicator)
           }


### PR DESCRIPTION
Prevents Next.js to accidentally scroll to the top of the page when live-reloading data via `getStaticProps`.

cc @timneutkens 

## Related

- https://github.com/contentlayerdev/contentlayer/issues/124