### PR TITLE
test(fix: Prevent page to scroll to top during data HMR)

### DIFF
--- a/packages/next/client/next-dev.js
+++ b/packages/next/client/next-dev.js
@@ -87,7 +87,8 @@ initialize({ webpackHMR })
                       new URLSearchParams(location.search)
                     )
                   ),
-                router.asPath
+                router.asPath,
+                { scroll: false }
               )
               .finally(clearIndicator)
           }

--- a/test/development/basic/gssp-ssr-change-reloading/pages/another/index.js
+++ b/test/development/basic/gssp-ssr-change-reloading/pages/another/index.js
@@ -9,6 +9,8 @@ export default function Gsp(props) {
     <>
       <p id="change">change me</p>
       <p id="props">{JSON.stringify(props)}</p>
+      <div style={{ height: 1000, width: 50, background: 'cyan' }}></div>
+      <p id="scroll-target">bottom</p>
     </>
   )
 }

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -163,7 +163,44 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
+    await check(
+      async () =>
+        JSON.parse(await browser.elementByCss('#props').text()).count + '',
+      '2'
+    )
     expect(await browser.eval('window.beforeChange')).toBe('hi')
+    await next.patchFile(page, originalContent)
+  })
+
+  it('should keep scroll position when updating from change in getStaticProps', async () => {
+    const browser = await webdriver(next.url, '/another')
+    await browser.eval(
+      'document.getElementById("scroll-target").scrollIntoView()'
+    )
+    const scrollPosition = await browser.eval(
+      'document.documentElement.scrollTop'
+    )
+    await browser.eval(`window.beforeChange = 'hi'`)
+
+    const props = JSON.parse(await browser.elementByCss('#props').text())
+    expect(props.count).toBe(1)
+
+    const page = 'pages/another/index.js'
+    const originalContent = await next.readFile(page)
+    await next.patchFile(
+      page,
+      originalContent.replace('count = 1', 'count = 2')
+    )
+
+    await check(
+      async () =>
+        JSON.parse(await browser.elementByCss('#props').text()).count + '',
+      '2'
+    )
+    expect(await browser.eval('window.beforeChange')).toBe('hi')
+    expect(await browser.eval('document.documentElement.scrollTop')).toBe(
+      scrollPosition
+    )
     await next.patchFile(page, originalContent)
   })
 


### PR DESCRIPTION
This adds a test case for https://github.com/vercel/next.js/pull/35739 ensuring we don't regress on this. Opened as a separate PR as it seems changes from contributors was disabled on the original PR. 