### PR TITLE
Fix useStatic404 condition

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1394,9 +1394,7 @@ export default async function build(
     // Since custom _app.js can wrap the 404 page we have to opt-out of static optimization if it has getInitialProps
     // Only export the static 404 when there is no /_error present
     const useStatic404 =
-      !hasConcurrentFeatures &&
-      !customAppGetInitialProps &&
-      (!hasNonStaticErrorPage || hasPages404)
+      !customAppGetInitialProps && (!hasNonStaticErrorPage || hasPages404)
 
     if (invalidPages.size > 0) {
       const err = new Error(

--- a/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
+++ b/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
@@ -113,7 +113,7 @@ describe('Without global runtime configuration', () => {
       /^[┌├└/]/.test(line)
     )
     const expectedOutputLines = splitLines(`
-  ┌ λ /404
+  ┌ ○ /404
   ├ ℇ /edge
   ├ ℇ /edge-rsc
   ├ ○ /node

--- a/test/production/react-18-streaming-ssr/index.test.ts
+++ b/test/production/react-18-streaming-ssr/index.test.ts
@@ -38,6 +38,14 @@ describe('react 18 streaming SSR in minimal mode', () => {
     const html = await renderViaHTTP(next.url, '/')
     expect(html).toContain('static streaming')
   })
+
+  it('should have generated a static 404 page', async () => {
+    expect(await next.readFile('.next/server/pages/404.html')).toBeTruthy()
+
+    const res = await fetchViaHTTP(next.url, '/non-existent')
+    expect(res.status).toBe(404)
+    expect(await res.text()).toContain('This page could not be found')
+  })
 })
 
 describe('react 18 streaming SSR with custom next configs', () => {


### PR DESCRIPTION
Static optimization is now supported with concurrent features, this PR fixes the condition for `useStatic404`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
