### PR TITLE
Updated create-next-app docs to include pnpm usage

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -246,6 +246,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
 # or
 yarn create next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
+# or
+pnpm create next-app -- --example DIRECTORY_NAME DIRECTORY_NAME-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/docs/api-reference/create-next-app.md
+++ b/docs/api-reference/create-next-app.md
@@ -10,6 +10,8 @@ The easiest way to get started with Next.js is by using `create-next-app`. This 
 npx create-next-app@latest
 # or
 yarn create next-app
+# or
+pnpm create next-app
 ```
 
 You can create a [TypeScript project](https://github.com/vercel/next.js/blob/canary/docs/basic-features/typescript.md) with the `--ts, --typescript` flag:
@@ -18,6 +20,8 @@ You can create a [TypeScript project](https://github.com/vercel/next.js/blob/can
 npx create-next-app@latest --ts
 # or
 yarn create next-app --typescript
+# or
+pnpm create next-app -- --ts
 ```
 
 ### Options

--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -27,6 +27,8 @@ You can create a TypeScript project with [`create-next-app`](https://nextjs.org/
 npx create-next-app@latest --ts
 # or
 yarn create next-app --typescript
+# or
+pnpm create next-app -- --ts
 ```
 
 ## Existing projects

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,6 +25,8 @@ We recommend creating a new Next.js app using `create-next-app`, which sets up e
 npx create-next-app@latest
 # or
 yarn create next-app
+# or
+pnpm create next-app
 ```
 
 If you want to start with a TypeScript project you can use the `--typescript` flag:
@@ -33,6 +35,8 @@ If you want to start with a TypeScript project you can use the `--typescript` fl
 npx create-next-app@latest --typescript
 # or
 yarn create next-app --typescript
+# or
+pnpm create next-app -- --typescript
 ```
 
 After the installation is complete:

--- a/examples/active-class-name/README.md
+++ b/examples/active-class-name/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example active-class-name active-class-name-app
 # or
 yarn create next-app --example active-class-name active-class-name-app
+# or
+pnpm create next-app -- --example active-class-name active-class-name-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/amp-first/README.md
+++ b/examples/amp-first/README.md
@@ -21,6 +21,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example amp-first amp-first-app
 # or
 yarn create next-app --example amp-first amp-first-app
+# or
+pnpm create next-app -- --example amp-first amp-first-app
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser. The page will reload if you make edits. You will also see AMP validation errors in the console.

--- a/examples/amp-story/README.md
+++ b/examples/amp-story/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example amp-story amp-story-app
 # or
 yarn create next-app --example amp-story amp-story-app
+# or
+pnpm create next-app -- --example amp-story amp-story-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/amp/README.md
+++ b/examples/amp/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example amp amp-app
 # or
 yarn create next-app --example amp amp-app
+# or
+pnpm create next-app -- --example amp amp-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/analyze-bundles/README.md
+++ b/examples/analyze-bundles/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example analyze-bundles analyze-bundles-app
 # or
 yarn create next-app --example analyze-bundles analyze-bundles-app
+# or
+pnpm create next-app -- --example analyze-bundles analyze-bundles-app
 ```
 
 ### Analyze webpack output

--- a/examples/api-routes-apollo-server-and-client-auth/README.md
+++ b/examples/api-routes-apollo-server-and-client-auth/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-apollo-server-and-client-auth api-routes-apollo-server-and-client-auth-app
 # or
 yarn create next-app --example api-routes-apollo-server-and-client-auth api-routes-apollo-server-and-client-auth-app
+# or
+pnpm create next-app -- --example api-routes-apollo-server-and-client-auth api-routes-apollo-server-and-client-auth-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/api-routes-apollo-server-and-client/README.md
+++ b/examples/api-routes-apollo-server-and-client/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-apollo-server-and-client api-routes-apollo-server-and-client-app
 # or
 yarn create next-app --example api-routes-apollo-server-and-client api-routes-apollo-server-and-client-app
+# or
+pnpm create next-app -- --example api-routes-apollo-server-and-client api-routes-apollo-server-and-client-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/api-routes-apollo-server/README.md
+++ b/examples/api-routes-apollo-server/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-apollo-server api-routes-apollo-server-app
 # or
 yarn create next-app --example api-routes-apollo-server api-routes-apollo-server-app
+# or
+pnpm create next-app -- --example api-routes-apollo-server api-routes-apollo-server-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/api-routes-cors/README.md
+++ b/examples/api-routes-cors/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-cors api-routes-cors-app
 # or
 yarn create next-app --example api-routes-cors api-routes-cors-app
+# or
+pnpm create next-app -- --example api-routes-cors api-routes-cors-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/api-routes-graphql/README.md
+++ b/examples/api-routes-graphql/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-graphql api-routes-graphql-app
 # or
 yarn create next-app --example api-routes-graphql api-routes-graphql-app
+# or
+pnpm create next-app -- --example api-routes-graphql api-routes-graphql-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/api-routes-middleware/README.md
+++ b/examples/api-routes-middleware/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-middleware api-routes-middleware-app
 # or
 yarn create next-app --example api-routes-middleware api-routes-middleware-app
+# or
+pnpm create next-app -- --example api-routes-middleware api-routes-middleware-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/api-routes-rate-limit/README.md
+++ b/examples/api-routes-rate-limit/README.md
@@ -30,6 +30,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-rate-limit api-routes-rate-limit-app
 # or
 yarn create next-app --example api-routes-rate-limit api-routes-rate-limit-app
+# or
+pnpm create next-app -- --example api-routes-rate-limit api-routes-rate-limit-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/api-routes-rest/README.md
+++ b/examples/api-routes-rest/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes-rest api-routes-rest-app
 # or
 yarn create next-app --example api-routes-rest api-routes-rest-app
+# or
+pnpm create next-app -- --example api-routes-rest api-routes-rest-app
 ```
 
 ### Deploy to Vercel

--- a/examples/api-routes/README.md
+++ b/examples/api-routes/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example api-routes api-routes-app
 # or
 yarn create next-app --example api-routes api-routes-app
+# or
+pnpm create next-app -- --example api-routes api-routes-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/auth0/README.md
+++ b/examples/auth0/README.md
@@ -19,6 +19,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example auth0 auth0-app
 # or
 yarn create next-app --example auth0 auth0-app
+# or
+pnpm create next-app -- --example auth0 auth0-app
 ```
 
 ## Configuring Auth0

--- a/examples/basic-css/README.md
+++ b/examples/basic-css/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example basic-css basic-css-app
 # or
 yarn create next-app --example basic-css basic-css-app
+# or
+pnpm create next-app -- --example basic-css basic-css-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/basic-export/README.md
+++ b/examples/basic-export/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example basic-export basic-export-app
 # or
 yarn create next-app --example basic-export basic-export-app
+# or
+pnpm create next-app -- --example basic-export basic-export-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/blog-starter-typescript/README.md
+++ b/examples/blog-starter-typescript/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example blog-starter-typescript blog-starter-typescript-app
 # or
 yarn create next-app --example blog-starter-typescript blog-starter-typescript-app
+# or
+pnpm create next-app -- --example blog-starter-typescript blog-starter-typescript-app
 ```
 
 Your blog should be up and running on [http://localhost:3000](http://localhost:3000)! If it doesn't work, post on [GitHub discussions](https://github.com/vercel/next.js/discussions).

--- a/examples/blog-starter/README.md
+++ b/examples/blog-starter/README.md
@@ -47,6 +47,8 @@ or
 
 ```
 yarn create next-app --example blog-starter blog-starter-app
+# or
+pnpm create next-app -- --example blog-starter blog-starter-app
 
 ```
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -31,6 +31,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example blog my-blog
 # or
 yarn create next-app --example blog my-blog
+# or
+pnpm create next-app -- --example blog my-blog
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/catch-all-routes/README.md
+++ b/examples/catch-all-routes/README.md
@@ -25,6 +25,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example catch-all-routes catch-all-routes-app
 # or
 yarn create next-app --example catch-all-routes catch-all-routes-app
+# or
+pnpm create next-app -- --example catch-all-routes catch-all-routes-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/cms-agilitycms/README.md
+++ b/examples/cms-agilitycms/README.md
@@ -42,6 +42,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-agilitycms cms-agilitycms-app
 # or
 yarn create next-app --example cms-agilitycms cms-agilitycms-app
+# or
+pnpm create next-app -- --example cms-agilitycms cms-agilitycms-app
 ```
 
 ## Configuration

--- a/examples/cms-builder-io/README.md
+++ b/examples/cms-builder-io/README.md
@@ -14,6 +14,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-builder-io cms-builder-io-app
 # or
 yarn create next-app --example cms-builder-io cms-builder-io-app
+# or
+pnpm create next-app -- --example cms-builder-io cms-builder-io-app
 ```
 
 ## Configuration

--- a/examples/cms-buttercms/README.md
+++ b/examples/cms-buttercms/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-buttercms cms-buttercms-app
 # or
 yarn create next-app --example cms-buttercms cms-buttercms-app
+# or
+pnpm create next-app -- --example cms-buttercms cms-buttercms-app
 ```
 
 ## Configuration

--- a/examples/cms-contentful/README.md
+++ b/examples/cms-contentful/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-contentful cms-contentful-app
 # or
 yarn create next-app --example cms-contentful cms-contentful-app
+# or
+pnpm create next-app -- --example cms-contentful cms-contentful-app
 ```
 
 ## Configuration

--- a/examples/cms-cosmic/README.md
+++ b/examples/cms-cosmic/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-cosmic cms-cosmic-app
 # or
 yarn create next-app --example cms-cosmic cms-cosmic-app
+# or
+pnpm create next-app -- --example cms-cosmic cms-cosmic-app
 ```
 
 ## Configuration

--- a/examples/cms-datocms/README.md
+++ b/examples/cms-datocms/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-datocms cms-datocms-app
 # or
 yarn create next-app --example cms-datocms cms-datocms-app
+# or
+pnpm create next-app -- --example cms-datocms cms-datocms-app
 ```
 
 ## Configuration

--- a/examples/cms-drupal/README.md
+++ b/examples/cms-drupal/README.md
@@ -38,6 +38,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-drupal cms-drupal-app
 # or
 yarn create next-app --example cms-drupal cms-drupal-app
+# or
+pnpm create next-app -- --example cms-drupal cms-drupal-app
 ```
 
 ## Setup Drupal

--- a/examples/cms-ghost/README.md
+++ b/examples/cms-ghost/README.md
@@ -37,6 +37,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-ghost cms-ghost-app
 # or
 yarn create next-app --example cms-ghost cms-ghost-app
+# or
+pnpm create next-app -- --example cms-ghost cms-ghost-app
 ```
 
 ### Setp 1. Run Next.js in development mode

--- a/examples/cms-graphcms/README.md
+++ b/examples/cms-graphcms/README.md
@@ -42,6 +42,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-graphcms cms-graphcms-app
 # or
 yarn create next-app --example cms-graphcms cms-graphcms-app
+# or
+pnpm create next-app -- --example cms-graphcms cms-graphcms-app
 ```
 
 ## Configuration

--- a/examples/cms-kontent/README.md
+++ b/examples/cms-kontent/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-kontent cms-kontent-app
 # or
 yarn create next-app --example cms-kontent cms-kontent-app
+# or
+pnpm create next-app -- --example cms-kontent cms-kontent-app
 ```
 
 ## Configuration

--- a/examples/cms-prepr/README.md
+++ b/examples/cms-prepr/README.md
@@ -41,6 +41,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-prepr cms-prepr-app
 # or
 yarn create next-app --example cms-prepr cms-prepr-app
+# or
+pnpm create next-app -- --example cms-prepr cms-prepr-app
 ```
 
 ## Configuration

--- a/examples/cms-prismic/README.md
+++ b/examples/cms-prismic/README.md
@@ -38,6 +38,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-prismic cms-prismic-app
 # or
 yarn create next-app --example cms-prismic cms-prismic-app
+# or
+pnpm create next-app -- --example cms-prismic cms-prismic-app
 ```
 
 ## Configuration

--- a/examples/cms-sanity/README.md
+++ b/examples/cms-sanity/README.md
@@ -45,6 +45,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-sanity cms-sanity-app
 # or
 yarn create next-app --example cms-sanity cms-sanity-app
+# or
+pnpm create next-app -- --example cms-sanity cms-sanity-app
 ```
 
 ## Configuration

--- a/examples/cms-storyblok/README.md
+++ b/examples/cms-storyblok/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-storyblok cms-storyblok-app
 # or
 yarn create next-app --example cms-storyblok cms-storyblok-app
+# or
+pnpm create next-app -- --example cms-storyblok cms-storyblok-app
 ```
 
 ## Configuration

--- a/examples/cms-strapi/README.md
+++ b/examples/cms-strapi/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-strapi cms-strapi-app
 # or
 yarn create next-app --example cms-strapi cms-strapi-app
+# or
+pnpm create next-app -- --example cms-strapi cms-strapi-app
 ```
 
 ## Configuration

--- a/examples/cms-takeshape/README.md
+++ b/examples/cms-takeshape/README.md
@@ -38,6 +38,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-takeshape cms-takeshape-app
 # or
 yarn create next-app --example cms-takeshape cms-takeshape-app
+# or
+pnpm create next-app -- --example cms-takeshape cms-takeshape-app
 ```
 
 ## Configuration

--- a/examples/cms-tina/README.md
+++ b/examples/cms-tina/README.md
@@ -31,6 +31,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-tina cms-tina-app
 # or
 yarn create next-app --example cms-ghost cms-tina-app
+# or
+pnpm create next-app -- --example cms-ghost cms-tina-app
 ```
 
 ### Setp 1. Run Next.js in development mode

--- a/examples/cms-umbraco-heartcore/README.md
+++ b/examples/cms-umbraco-heartcore/README.md
@@ -39,6 +39,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-umbraco-heartcore cms-umbraco-heartcore-app
 # or
 yarn create next-app --example cms-umbraco-heartcore cms-umbraco-heartcore-app
+# or
+pnpm create next-app -- --example cms-umbraco-heartcore cms-umbraco-heartcore-app
 ```
 
 ## Configuration

--- a/examples/cms-wordpress/README.md
+++ b/examples/cms-wordpress/README.md
@@ -38,6 +38,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example cms-wordpress cms-wordpress-app
 # or
 yarn create next-app --example cms-wordpress cms-wordpress-app
+# or
+pnpm create next-app -- --example cms-wordpress cms-wordpress-app
 ```
 
 ## Configuration

--- a/examples/custom-routes-proxying/README.md
+++ b/examples/custom-routes-proxying/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-routes-proxying custom-routes-proxying-app
 # or
 yarn create next-app --example custom-routes-proxying custom-routes-proxying-app
+# or
+pnpm create next-app -- --example custom-routes-proxying custom-routes-proxying-app
 ```
 
 ### Step 4. Run Next.js in development mode

--- a/examples/custom-server-actionhero/README.md
+++ b/examples/custom-server-actionhero/README.md
@@ -13,6 +13,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-server-actionhero custom-server-actionhero-app
 # or
 yarn create next-app --example custom-server-actionhero custom-server-actionhero-app
+# or
+pnpm create next-app -- --example custom-server-actionhero custom-server-actionhero-app
 ```
 
 ## How does this work?

--- a/examples/custom-server-express/README.md
+++ b/examples/custom-server-express/README.md
@@ -18,4 +18,6 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-server-express custom-server-express-app
 # or
 yarn create next-app --example custom-server-express custom-server-express-app
+# or
+pnpm create next-app -- --example custom-server-express custom-server-express-app
 ```

--- a/examples/custom-server-fastify/README.md
+++ b/examples/custom-server-fastify/README.md
@@ -20,4 +20,6 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-server-fastify custom-server-fastify-app
 # or
 yarn create next-app --example custom-server-fastify custom-server-fastify-app
+# or
+pnpm create next-app -- --example custom-server-fastify custom-server-fastify-app
 ```

--- a/examples/custom-server-hapi/README.md
+++ b/examples/custom-server-hapi/README.md
@@ -18,4 +18,6 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-server-hapi custom-server-hapi-app
 # or
 yarn create next-app --example custom-server-hapi custom-server-hapi-app
+# or
+pnpm create next-app -- --example custom-server-hapi custom-server-hapi-app
 ```

--- a/examples/custom-server-koa/README.md
+++ b/examples/custom-server-koa/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-server-koa custom-server-koa-app
 # or
 yarn create next-app --example custom-server-koa custom-server-koa-app
+# or
+pnpm create next-app -- --example custom-server-koa custom-server-koa-app
 ```
 
 ## Side note: Enabling gzip compression

--- a/examples/custom-server-polka/README.md
+++ b/examples/custom-server-polka/README.md
@@ -18,4 +18,6 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-server-polka custom-server-polka-app
 # or
 yarn create next-app --example custom-server-polka custom-server-polka-app
+# or
+pnpm create next-app -- --example custom-server-polka custom-server-polka-app
 ```

--- a/examples/custom-server-typescript/README.md
+++ b/examples/custom-server-typescript/README.md
@@ -19,4 +19,6 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example custom-server-typescript custom-server-typescript-app
 # or
 yarn create next-app --example custom-server-typescript custom-server-typescript-app
+# or
+pnpm create next-app -- --example custom-server-typescript custom-server-typescript-app
 ```

--- a/examples/data-fetch/README.md
+++ b/examples/data-fetch/README.md
@@ -19,6 +19,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example data-fetch data-fetch-app
 # or
 yarn create next-app --example data-fetch data-fetch-app
+# or
+pnpm create next-app -- --example data-fetch data-fetch-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/dynamic-routing/README.md
+++ b/examples/dynamic-routing/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example dynamic-routing dynamic-routing-app
 # or
 yarn create next-app --example dynamic-routing dynamic-routing-app
+# or
+pnpm create next-app -- --example dynamic-routing dynamic-routing-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/environment-variables/readme.md
+++ b/examples/environment-variables/readme.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example environment-variables environment-variables-app
 # or
 yarn create next-app --example environment-variables environment-variables-app
+# or
+pnpm create next-app -- --example environment-variables environment-variables-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/fast-refresh-demo/README.md
+++ b/examples/fast-refresh-demo/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example fast-refresh-demo fast-refresh-demo-app
 # or
 yarn create next-app --example fast-refresh-demo fast-refresh-demo-app
+# or
+pnpm create next-app -- --example fast-refresh-demo fast-refresh-demo-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/gh-pages/README.md
+++ b/examples/gh-pages/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example gh-pages gh-pages-app
 # or
 yarn create next-app --example gh-pages gh-pages-app
+# or
+pnpm create next-app -- --example gh-pages gh-pages-app
 ```
 
 ### Deploy it to github

--- a/examples/head-elements/README.md
+++ b/examples/head-elements/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example head-elements head-elements-app
 # or
 yarn create next-app --example head-elements head-elements-app
+# or
+pnpm create next-app -- --example head-elements head-elements-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/headers/README.md
+++ b/examples/headers/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example headers headers-app
 # or
 yarn create next-app --example headers headers-app
+# or
+pnpm create next-app -- --example headers headers-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example hello-world hello-world-app
 # or
 yarn create next-app --example hello-world hello-world-app
+# or
+pnpm create next-app -- --example hello-world hello-world-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/i18n-routing/README.md
+++ b/examples/i18n-routing/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example i18n-routing i18n-app
 # or
 yarn create next-app --example i18n-routing i18n-app
+# or
+pnpm create next-app -- --example i18n-routing i18n-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/image-component/README.md
+++ b/examples/image-component/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example image-component image-app
 # or
 yarn create next-app --example image-component image-app
+# or
+pnpm create next-app -- --example image-component image-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/layout-component/README.md
+++ b/examples/layout-component/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example layout-component layout-component-app
 # or
 yarn create next-app --example layout-component layout-component-app
+# or
+pnpm create next-app -- --example layout-component layout-component-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/modularize-imports/README.md
+++ b/examples/modularize-imports/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example modularize-imports modularize-imports-app
 # or
 yarn create next-app --example modularize-imports modularize-imports-app
+# or
+pnpm create next-app -- --example modularize-imports modularize-imports-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/nested-components/README.md
+++ b/examples/nested-components/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example nested-components nested-components-app
 # or
 yarn create next-app --example nested-components nested-components-app
+# or
+pnpm create next-app -- --example nested-components nested-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/next-forms/README.md
+++ b/examples/next-forms/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example next-forms next-forms-app
 # or
 yarn create next-app --example next-forms next-forms-app
+# or
+pnpm create next-app -- --example next-forms next-forms-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/progressive-render/README.md
+++ b/examples/progressive-render/README.md
@@ -30,6 +30,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example progressive-render progressive-render-app
 # or
 yarn create next-app --example progressive-render progressive-render-app
+# or
+pnpm create next-app -- --example progressive-render progressive-render-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/progressive-web-app/README.md
+++ b/examples/progressive-web-app/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example progressive-web-app progressive-web-app
 # or
 yarn create next-app --example progressive-web-app progressive-web-app
+# or
+pnpm create next-app -- --example progressive-web-app progressive-web-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/react-remove-properties/README.md
+++ b/examples/react-remove-properties/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example react-remove-properties react-remove-properties-app
 # or
 yarn create next-app --example react-remove-properties react-remove-properties-app
+# or
+pnpm create next-app -- --example react-remove-properties react-remove-properties-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/redirects/README.md
+++ b/examples/redirects/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example redirects redirects-app
 # or
 yarn create next-app --example redirects redirects-app
+# or
+pnpm create next-app -- --example redirects redirects-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/remove-console/README.md
+++ b/examples/remove-console/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example remove-console remove-console-app
 # or
 yarn create next-app --example remove-console remove-console-app
+# or
+pnpm create next-app -- --example remove-console remove-console-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/rewrites/README.md
+++ b/examples/rewrites/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example rewrites rewrites-app
 # or
 yarn create next-app --example rewrites rewrites-app
+# or
+pnpm create next-app -- --example rewrites rewrites-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/script-component/README.md
+++ b/examples/script-component/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example script-component script-component-app
 # or
 yarn create next-app --example script-component script-component-app
+# or
+pnpm create next-app -- --example script-component script-component-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/ssr-caching/README.md
+++ b/examples/ssr-caching/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example ssr-caching ssr-caching-app
 # or
 yarn create next-app --example ssr-caching ssr-caching-app
+# or
+pnpm create next-app -- --example ssr-caching ssr-caching-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/styled-jsx-with-csp/README.md
+++ b/examples/styled-jsx-with-csp/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example styled-jsx-with-csp styled-jsx-with-csp-app
 # or
 yarn create next-app --example styled-jsx-with-csp styled-jsx-with-csp-app
+# or
+pnpm create next-app -- --example styled-jsx-with-csp styled-jsx-with-csp-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/svg-components/README.md
+++ b/examples/svg-components/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example svg-components svg-components-app
 # or
 yarn create next-app --example svg-components svg-components-app
+# or
+pnpm create next-app -- --example svg-components svg-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/using-preact/README.md
+++ b/examples/using-preact/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example using-preact using-preact-app
 # or
 yarn create next-app --example using-preact using-preact-app
+# or
+pnpm create next-app -- --example using-preact using-preact-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/using-router/README.md
+++ b/examples/using-router/README.md
@@ -19,6 +19,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example using-router using-router-app
 # or
 yarn create next-app --example using-router using-router-app
+# or
+pnpm create next-app -- --example using-router using-router-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-absolute-imports/README.md
+++ b/examples/with-absolute-imports/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-absolute-imports with-absolute-imports-app
 # or
 yarn create next-app --example with-absolute-imports with-absolute-imports-app
+# or
+pnpm create next-app -- --example with-absolute-imports with-absolute-imports-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-algolia-react-instantsearch/README.md
+++ b/examples/with-algolia-react-instantsearch/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-algolia-react-instantsearch with-algolia-react-instantsearch-app
 # or
 yarn create next-app --example with-algolia-react-instantsearch with-algolia-react-instantsearch-app
+# or
+pnpm create next-app -- --example with-algolia-react-instantsearch with-algolia-react-instantsearch-app
 ```
 
 To set up Algolia:

--- a/examples/with-ant-design/README.md
+++ b/examples/with-ant-design/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-ant-design with-ant-design-app
 # or
 yarn create next-app --example with-ant-design with-ant-design-app
+# or
+pnpm create next-app -- --example with-ant-design with-ant-design-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-aphrodite/README.md
+++ b/examples/with-aphrodite/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-aphrodite with-aphrodite-app
 # or
 yarn create next-app --example with-aphrodite with-aphrodite-app
+# or
+pnpm create next-app -- --example with-aphrodite with-aphrodite-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-apollo-and-redux/README.md
+++ b/examples/with-apollo-and-redux/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-apollo-and-redux with-apollo-and-redux-app
 # or
 yarn create next-app --example with-apollo-and-redux with-apollo-and-redux-app
+# or
+pnpm create next-app -- --example with-apollo-and-redux with-apollo-and-redux-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-apollo-neo4j-graphql/README.md
+++ b/examples/with-apollo-neo4j-graphql/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-apollo-neo4j-graphql with-apollo-neo4j-graphql-app
 # or
 yarn create next-app --example with-apollo-neo4j-graphql with-apollo-neo4j-graphql-app
+# or
+pnpm create next-app -- --example with-apollo-neo4j-graphql with-apollo-neo4j-graphql-app
 ```
 
 ## Configuration

--- a/examples/with-apollo/README.md
+++ b/examples/with-apollo/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-apollo with-apollo-app
 # or
 yarn create next-app --example with-apollo with-apollo-app
+# or
+pnpm create next-app -- --example with-apollo with-apollo-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-app-layout/README.md
+++ b/examples/with-app-layout/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-app-layout with-app-layout-app
 # or
 yarn create next-app --example with-app-layout with-app-layout-app
+# or
+pnpm create next-app -- --example with-app-layout with-app-layout-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-aws-amplify-typescript/README.md
+++ b/examples/with-aws-amplify-typescript/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-aws-amplify-typescript nextjs-aws-amplify-typescript-app
 # or
 yarn create next-app --example with-aws-amplify-typescript nextjs-aws-amplify-typescript-app
+# or
+pnpm create next-app -- --example with-aws-amplify-typescript nextjs-aws-amplify-typescript-app
 ```
 
 ### Initialize and deploy the Amplify project

--- a/examples/with-aws-amplify/README.md
+++ b/examples/with-aws-amplify/README.md
@@ -17,6 +17,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-aws-amplify nextjs-aws-amplify-app
 # or
 yarn create next-app --example with-aws-amplify nextjs-aws-amplify-app
+# or
+pnpm create next-app -- --example with-aws-amplify nextjs-aws-amplify-app
 ```
 
 ### Initialize and deploy the Amplify project

--- a/examples/with-babel-macros/README.md
+++ b/examples/with-babel-macros/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-babel-macros with-babel-macros-app
 # or
 yarn create next-app --example with-babel-macros with-babel-macros-app
+# or
+pnpm create next-app -- --example with-babel-macros with-babel-macros-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-carbon-components/README.md
+++ b/examples/with-carbon-components/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-carbon-components with-carbon-components-app
 # or
 yarn create next-app --example with-carbon-components with-carbon-components-app
+# or
+pnpm create next-app -- --example with-carbon-components with-carbon-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-cerebral/README.md
+++ b/examples/with-cerebral/README.md
@@ -48,6 +48,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-cerebral with-cerebral-app
 # or
 yarn create next-app --example with-cerebral with-cerebral-app
+# or
+pnpm create next-app -- --example with-cerebral with-cerebral-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-chakra-ui-typescript/README.md
+++ b/examples/with-chakra-ui-typescript/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-chakra-ui-typescript with-chakra-ui-typescript-app
 # or
 yarn create next-app --example with-chakra-ui-typescript with-chakra-ui-typescript-app
+# or
+pnpm create next-app -- --example with-chakra-ui-typescript with-chakra-ui-typescript-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-chakra-ui/README.md
+++ b/examples/with-chakra-ui/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-chakra-ui with-chakra-ui-app
 # or
 yarn create next-app --example with-chakra-ui with-chakra-ui-app
+# or
+pnpm create next-app -- --example with-chakra-ui with-chakra-ui-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-clerk/README.md
+++ b/examples/with-clerk/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-clerk with-clerk-app
 # or
 yarn create next-app --example with-clerk with-clerk-app
+# or
+pnpm create next-app -- --example with-clerk with-clerk-app
 ```
 
 To run the example locally you need to:

--- a/examples/with-compiled-css/README.md
+++ b/examples/with-compiled-css/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-compiled-css with-compiled-css-app
 # or
 yarn create next-app --example with-compiled-css with-compiled-css-app
+# or
+pnpm create next-app -- --example with-compiled-css with-compiled-css-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-context-api/README.md
+++ b/examples/with-context-api/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-context-api with-context-api-app
 # or
 yarn create next-app --example with-context-api with-context-api-app
+# or
+pnpm create next-app -- --example with-context-api with-context-api-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-cookie-auth-fauna/README.md
+++ b/examples/with-cookie-auth-fauna/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-cookie-auth-fauna with-cookie-auth-fauna-app
 # or
 yarn create next-app --example with-cookie-auth-fauna with-cookie-auth-fauna-app
+# or
+pnpm create next-app -- --example with-cookie-auth-fauna with-cookie-auth-fauna-app
 ```
 
 ### Run locally

--- a/examples/with-couchbase/README.md
+++ b/examples/with-couchbase/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-couchbase with-couchbase-app
 # or
 yarn create next-app --example with-couchbase with-couchbase-app
+# or
+pnpm create next-app -- --example with-couchbase with-couchbase-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-cssed/README.md
+++ b/examples/with-cssed/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-cssed with-cssed-app
 # or
 yarn create next-app --example with-cssed with-cssed-app
+# or
+pnpm create next-app -- --example with-cssed with-cssed-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-custom-babel-config/README.md
+++ b/examples/with-custom-babel-config/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-custom-babel-config with-custom-babel-config-app
 # or
 yarn create next-app --example with-custom-babel-config with-custom-babel-config-app
+# or
+pnpm create next-app -- --example with-custom-babel-config with-custom-babel-config-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-cxs/README.md
+++ b/examples/with-cxs/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-cxs with-cxs-app
 # or
 yarn create next-app --example with-cxs with-cxs-app
+# or
+pnpm create next-app -- --example with-cxs with-cxs-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-cypress/README.md
+++ b/examples/with-cypress/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-cypress with-cypress-app
 # or
 yarn create next-app --example with-cypress with-cypress-app
+# or
+pnpm create next-app -- --example with-cypress with-cypress-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-deta-base/README.md
+++ b/examples/with-deta-base/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-deta-base with-deta-base-app
 # or
 yarn create next-app --example with-deta-base with-deta-base-app
+# or
+pnpm create next-app -- --example with-deta-base with-deta-base-app
 ```
 
 ## Configuration

--- a/examples/with-docker-multi-env/README.md
+++ b/examples/with-docker-multi-env/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-docker-multi-env nextjs-docker-multi-env
 # or
 yarn create next-app --example with-docker-multi-env nextjs-docker-multi-env
+# or
+pnpm create next-app -- --example with-docker-multi-env nextjs-docker-multi-env
 ```
 
 Enter the values in the `.env.development.sample`, `.env.staging.sample`, `.env.production.sample` files to be used for each environments.

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-docker nextjs-docker
 # or
 yarn create next-app --example with-docker nextjs-docker
+# or
+pnpm create next-app -- --example with-docker nextjs-docker
 ```
 
 ## Using Docker

--- a/examples/with-draft-js/README.md
+++ b/examples/with-draft-js/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-draft-js with-draft-js-app
 # or
 yarn create next-app --example with-draft-js with-draft-js-app
+# or
+pnpm create next-app -- --example with-draft-js with-draft-js-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-dynamic-import/README.md
+++ b/examples/with-dynamic-import/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-dynamic-import with-dynamic-import-app
 # or
 yarn create next-app --example with-dynamic-import with-dynamic-import-app
+# or
+pnpm create next-app -- --example with-dynamic-import with-dynamic-import-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-elasticsearch/README.md
+++ b/examples/with-elasticsearch/README.md
@@ -21,6 +21,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-elasticsearch with-elasticsearch-app
 # or
 yarn create next-app --example with-elasticsearch with-elasticsearch-app
+# or
+pnpm create next-app -- --example with-elasticsearch with-elasticsearch-app
 ```
 
 ## Configuration

--- a/examples/with-electron-typescript/README.md
+++ b/examples/with-electron-typescript/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-electron-typescript with-electron-typescript-app
 # or
 yarn create next-app --example with-electron-typescript with-electron-typescript-app
+# or
+pnpm create next-app -- --example with-electron-typescript with-electron-typescript-app
 ```
 
 Available commands:

--- a/examples/with-electron/README.md
+++ b/examples/with-electron/README.md
@@ -14,6 +14,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-electron with-electron-app
 # or
 yarn create next-app --example with-electron with-electron-app
+# or
+pnpm create next-app -- --example with-electron with-electron-app
 ```
 
 You can create the production app using `npm run dist`.

--- a/examples/with-emotion-swc/README.md
+++ b/examples/with-emotion-swc/README.md
@@ -26,6 +26,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-emotion with-emotion-app
 # or
 yarn create next-app --example with-emotion with-emotion-app
+# or
+pnpm create next-app -- --example with-emotion with-emotion-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-emotion-vanilla/README.md
+++ b/examples/with-emotion-vanilla/README.md
@@ -19,6 +19,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-emotion-vanilla with-emotion-vanilla-app
 # or
 yarn create next-app --example with-emotion-vanilla with-emotion-vanilla-app
+# or
+pnpm create next-app -- --example with-emotion-vanilla with-emotion-vanilla-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-emotion/README.md
+++ b/examples/with-emotion/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-emotion with-emotion-app
 # or
 yarn create next-app --example with-emotion with-emotion-app
+# or
+pnpm create next-app -- --example with-emotion with-emotion-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-env-from-next-config-js/README.md
+++ b/examples/with-env-from-next-config-js/README.md
@@ -26,6 +26,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-env-from-next-config-js with-env-from-next-config-js-app
 # or
 yarn create next-app --example with-env-from-next-config-js with-env-from-next-config-js-app
+# or
+pnpm create next-app -- --example with-env-from-next-config-js with-env-from-next-config-js-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-eslint/README.md
+++ b/examples/with-eslint/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-eslint with-eslint-app
 # or
 yarn create next-app --example with-eslint with-eslint-app
+# or
+pnpm create next-app -- --example with-eslint with-eslint-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-expo-typescript/README.md
+++ b/examples/with-expo-typescript/README.md
@@ -34,6 +34,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-expo-typescript with-expo-typescript-app
 # or
 yarn create next-app --example with-expo-typescript with-expo-typescript-app
+# or
+pnpm create next-app -- --example with-expo-typescript with-expo-typescript-app
 ```
 
 ### Running web

--- a/examples/with-expo/README.md
+++ b/examples/with-expo/README.md
@@ -34,6 +34,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-expo with-expo-app
 # or
 yarn create next-app --example with-expo with-expo-app
+# or
+pnpm create next-app -- --example with-expo with-expo-app
 ```
 
 ### Running web

--- a/examples/with-facebook-pixel/README.md
+++ b/examples/with-facebook-pixel/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-facebook-pixel with-facebook-pixel-app
 # or
 yarn create next-app --example with-facebook-pixel with-facebook-pixel-app
+# or
+pnpm create next-app -- --example with-facebook-pixel with-facebook-pixel-app
 ```
 
 Next, copy the `.env.local.example` file in this directory to `.env.local` (which will be ignored by Git):

--- a/examples/with-fauna/README.md
+++ b/examples/with-fauna/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-fauna with-fauna-app
 # or
 yarn create next-app --example with-fauna with-fauna-app
+# or
+pnpm create next-app -- --example with-fauna with-fauna-app
 ```
 
 You can start with this template [using `create-next-app`](#using-create-next-app) or by [downloading the repository manually](#download-manually).

--- a/examples/with-fela/README.md
+++ b/examples/with-fela/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-fela with-fela-app
 # or
 yarn create next-app --example with-fela with-fela-app
+# or
+pnpm create next-app -- --example with-fela with-fela-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-filbert/README.md
+++ b/examples/with-filbert/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-filbert with-filbert-app
 # or
 yarn create next-app --example with-filbert with-filbert-app
+# or
+pnpm create next-app -- --example with-filbert with-filbert-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-firebase-cloud-messaging/README.md
+++ b/examples/with-firebase-cloud-messaging/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-firebase-cloud-messaging with-firebase-cloud-messaging-app
 # or
 yarn create next-app --example with-firebase-cloud-messaging with-firebase-cloud-messaging-app
+# or
+pnpm create next-app -- --example with-firebase-cloud-messaging with-firebase-cloud-messaging-app
 ```
 
 ## Set your send id

--- a/examples/with-firebase-hosting/README.md
+++ b/examples/with-firebase-hosting/README.md
@@ -21,6 +21,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-firebase-hosting with-firebase-hosting-app
 # or
 yarn create next-app --example with-firebase-hosting with-firebase-hosting-app
+# or
+pnpm create next-app -- --example with-firebase-hosting with-firebase-hosting-app
 ```
 
 **Important:** Update `.firebaserc` and add your firebase project ID.

--- a/examples/with-firebase/README.md
+++ b/examples/with-firebase/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-firebase with-firebase-app
 # or
 yarn create next-app --example with-firebase with-firebase-app
+# or
+pnpm create next-app -- --example with-firebase with-firebase-app
 ```
 
 ## Configuration

--- a/examples/with-flow/README.md
+++ b/examples/with-flow/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-flow with-flow-app
 # or
 yarn create next-app --example with-flow with-flow-app
+# or
+pnpm create next-app -- --example with-flow with-flow-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-framer-motion/README.md
+++ b/examples/with-framer-motion/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-framer-motion with-framer-motion-app
 # or
 yarn create next-app --example with-framer-motion with-framer-motion-app
+# or
+pnpm create next-app -- --example with-framer-motion with-framer-motion-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-goober/README.md
+++ b/examples/with-goober/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-goober with-goober-app
 # or
 yarn create next-app --example with-goober with-goober-app
+# or
+pnpm create next-app -- --example with-goober with-goober-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-google-analytics-amp/README.md
+++ b/examples/with-google-analytics-amp/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-google-analytics-amp with-google-analytics-amp-app
 # or
 yarn create next-app --example with-google-analytics-amp with-google-analytics-amp-app
+# or
+pnpm create next-app -- --example with-google-analytics-amp with-google-analytics-amp-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-google-analytics/README.md
+++ b/examples/with-google-analytics/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-google-analytics with-google-analytics-app
 # or
 yarn create next-app --example with-google-analytics with-google-analytics-app
+# or
+pnpm create next-app -- --example with-google-analytics with-google-analytics-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-google-tag-manager/README.md
+++ b/examples/with-google-tag-manager/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-google-tag-manager with-google-tag-manager-app
 # or
 yarn create next-app --example with-google-tag-manager with-google-tag-manager-app
+# or
+pnpm create next-app -- --example with-google-tag-manager with-google-tag-manager-app
 ```
 
 Next, copy the `.env.local.example` file in this directory to `.env.local` (which will be ignored by Git):

--- a/examples/with-graphql-hooks/README.md
+++ b/examples/with-graphql-hooks/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-graphql-hooks with-graphql-hooks-app
 # or
 yarn create next-app --example with-graphql-hooks with-graphql-hooks-app
+# or
+pnpm create next-app -- --example with-graphql-hooks with-graphql-hooks-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-graphql-react/README.md
+++ b/examples/with-graphql-react/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-graphql-react with-graphql-react-app
 # or
 yarn create next-app --example with-graphql-react with-graphql-react-app
+# or
+pnpm create next-app -- --example with-graphql-react with-graphql-react-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-grommet/README.md
+++ b/examples/with-grommet/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-grommet with-grommet-app
 # or
 yarn create next-app --example with-grommet with-grommet-app
+# or
+pnpm create next-app -- --example with-grommet with-grommet-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-gsap/README.md
+++ b/examples/with-gsap/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-gsap with-gsap-app
 # or
 yarn create next-app --example with-gsap with-gsap-app
+# or
+pnpm create next-app -- --example with-gsap with-gsap-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-hls-js/README.md
+++ b/examples/with-hls-js/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-hls-js with-hls-js-app
 # or
 yarn create next-app --example with-hls-js with-hls-js-app
+# or
+pnpm create next-app -- --example with-hls-js with-hls-js-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-http2/README.md
+++ b/examples/with-http2/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-http2 with-http2-app
 # or
 yarn create next-app --example with-http2 with-http2-app
+# or
+pnpm create next-app -- --example with-http2 with-http2-app
 ```
 
 Create the public and private keys:

--- a/examples/with-i18n-next-intl/README.md
+++ b/examples/with-i18n-next-intl/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-i18n-next-intl
 # or
 yarn create next-app --example with-i18n-next-intl
+# or
+pnpm create next-app -- --example with-i18n-next-intl
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/import?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-i18n-rosetta/README.md
+++ b/examples/with-i18n-rosetta/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-i18n-rosetta with-i18n-rosetta-app
 # or
 yarn create next-app --example with-i18n-rosetta with-i18n-rosetta-app
+# or
+pnpm create next-app -- --example with-i18n-rosetta with-i18n-rosetta-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-ionic-typescript/README.md
+++ b/examples/with-ionic-typescript/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-ionic-typescript with-ionic-typescript-app
 # or
 yarn create next-app --example with-ionic-typescript with-ionic-typescript-app
+# or
+pnpm create next-app -- --example with-ionic-typescript with-ionic-typescript-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-iron-session/README.md
+++ b/examples/with-iron-session/README.md
@@ -35,6 +35,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-iron-session with-iron-session-app
 # or
 yarn create next-app --example with-iron-session with-iron-session-app
+# or
+pnpm create next-app -- --example with-iron-session with-iron-session-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-jest-babel/README.md
+++ b/examples/with-jest-babel/README.md
@@ -14,6 +14,8 @@ In your terminal, run the following command:
 npx create-next-app --example with-jest with-jest-app
 # or
 yarn create next-app --example with-jest with-jest-app
+# or
+pnpm create next-app -- --example with-jest with-jest-app
 ```
 
 ## Run Jest Tests

--- a/examples/with-jest/README.md
+++ b/examples/with-jest/README.md
@@ -14,6 +14,8 @@ In your terminal, run the following command:
 npx create-next-app --example with-jest with-jest-app
 # or
 yarn create next-app --example with-jest with-jest-app
+# or
+pnpm create next-app -- --example with-jest with-jest-app
 ```
 
 ## Run Jest Tests

--- a/examples/with-joi/README.md
+++ b/examples/with-joi/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-joi with-joi-app
 # or
 yarn create next-app --example with-joi with-joi-app
+# or
+pnpm create next-app -- --example with-joi with-joi-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-jotai/README.md
+++ b/examples/with-jotai/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-jotai with-jotai-app
 # or
 yarn create next-app --example with-jotai with-jotai-app
+# or
+pnpm create next-app -- --example with-jotai with-jotai-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-kea/README.md
+++ b/examples/with-kea/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-kea with-kea-app
 # or
 yarn create next-app --example with-kea with-kea-app
+# or
+pnpm create next-app -- --example with-kea with-kea-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-knex/README.md
+++ b/examples/with-knex/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-knex with-knex-app
 # or
 yarn create next-app --example with-knex with-knex-app
+# or
+pnpm create next-app -- --example with-knex with-knex-app
 ```
 
 ## Configuration

--- a/examples/with-linaria/README.md
+++ b/examples/with-linaria/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-linaria with-linaria-app
 # or
 yarn create next-app --example with-linaria with-linaria-app
+# or
+pnpm create next-app -- --example with-linaria with-linaria-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-lingui/README.md
+++ b/examples/with-lingui/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-lingui with-lingui-app
 # or
 yarn create next-app --example with-lingui with-lingui-app
+# or
+pnpm create next-app -- --example with-lingui with-lingui-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-loading/README.md
+++ b/examples/with-loading/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-loading with-loading-app
 # or
 yarn create next-app --example with-loading with-loading-app
+# or
+pnpm create next-app -- --example with-loading with-loading-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-magic/README.md
+++ b/examples/with-magic/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-magic with-magic-app
 # or
 yarn create next-app --example with-magic with-magic-app
+# or
+pnpm create next-app -- --example with-magic with-magic-app
 ```
 
 ## Configuration

--- a/examples/with-mdbreact/README.md
+++ b/examples/with-mdbreact/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mdbreact with-mdbreact-app
 # or
 yarn create next-app --example with-mdbreact with-mdbreact-app
+# or
+pnpm create next-app -- --example with-mdbreact with-mdbreact-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mdx-remote/README.md
+++ b/examples/with-mdx-remote/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mdx-remote with-mdx-remote-app
 # or
 yarn create next-app --example with-mdx-remote with-mdx-remote-app
+# or
+pnpm create next-app -- --example with-mdx-remote with-mdx-remote-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mdx/README.md
+++ b/examples/with-mdx/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mdx with-mdx-app
 # or
 yarn create next-app --example with-mdx with-mdx-app
+# or
+pnpm create next-app -- --example with-mdx with-mdx-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mobx-react-lite/README.md
+++ b/examples/with-mobx-react-lite/README.md
@@ -30,6 +30,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mobx-react-lite with-mobx-react-lite-app
 # or
 yarn create next-app --example with-mobx-react-lite with-mobx-react-lite-app
+# or
+pnpm create next-app -- --example with-mobx-react-lite with-mobx-react-lite-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mobx-state-tree-typescript/README.md
+++ b/examples/with-mobx-state-tree-typescript/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mobx-state-tree-typescript with-mobx-state-tree-typescript-app
 # or
 yarn create next-app --example with-mobx-state-tree-typescript with-mobx-state-tree-typescript-app
+# or
+pnpm create next-app -- --example with-mobx-state-tree-typescript with-mobx-state-tree-typescript-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mobx-state-tree/README.md
+++ b/examples/with-mobx-state-tree/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mobx-state-tree with-mobx-state-tree-app
 # or
 yarn create next-app --example with-mobx-state-tree with-mobx-state-tree-app
+# or
+pnpm create next-app -- --example with-mobx-state-tree with-mobx-state-tree-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mobx with-mobx-app
 # or
 yarn create next-app --example with-mobx with-mobx-app
+# or
+pnpm create next-app -- --example with-mobx with-mobx-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mocha/README.md
+++ b/examples/with-mocha/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mocha with-mocha-app
 # or
 yarn create next-app --example with-mocha with-mocha-app
+# or
+pnpm create next-app -- --example with-mocha with-mocha-app
 ```
 
 ## Run Mocha tests

--- a/examples/with-mongodb-mongoose/README.md
+++ b/examples/with-mongodb-mongoose/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mongodb-mongoose with-mongodb-mongoose-app
 # or
 yarn create next-app --example with-mongodb-mongoose with-mongodb-mongoose-app
+# or
+pnpm create next-app -- --example with-mongodb-mongoose with-mongodb-mongoose-app
 ```
 
 ## Configuration

--- a/examples/with-mongodb/README.md
+++ b/examples/with-mongodb/README.md
@@ -21,6 +21,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mongodb with-mongodb-app
 # or
 yarn create next-app --example with-mongodb with-mongodb-app
+# or
+pnpm create next-app -- --example with-mongodb with-mongodb-app
 ```
 
 ## Configuration

--- a/examples/with-msw/README.md
+++ b/examples/with-msw/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-msw with-msw-app
 # or
 yarn create next-app --example with-msw with-msw-app
+# or
+pnpm create next-app -- --example with-msw with-msw-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mux-video/README.md
+++ b/examples/with-mux-video/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mux-video with-mux-video-app
 # or
 yarn create next-app --example with-mux-video with-mux-video-app
+# or
+pnpm create next-app -- --example with-mux-video with-mux-video-app
 ```
 
 ## Note

--- a/examples/with-mysql/README.md
+++ b/examples/with-mysql/README.md
@@ -34,6 +34,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-mysql nextjs-mysql
 # or
 yarn create next-app --example with-mysql nextjs-mysql
+# or
+pnpm create next-app -- --example with-mysql nextjs-mysql
 ```
 
 Next, you'll need to create a database username and password through the CLI to connect to your application. If you'd prefer to use the dashboard for this step, you can find those instructions in the [Connection Strings documentation](https://docs.planetscale.com/concepts/connection-strings#creating-a-password) and then come back here to finish setup.

--- a/examples/with-neo4j/README.md
+++ b/examples/with-neo4j/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-neo4j with-neo4j-app
 # or
 yarn create next-app --example with-neo4j with-neo4j-app
+# or
+pnpm create next-app -- --example with-neo4j with-neo4j-app
 ```
 
 ## Configuration

--- a/examples/with-netlify-cms/README.md
+++ b/examples/with-netlify-cms/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-netlify-cms with-netlify-cms-app
 # or
 yarn create next-app --example with-netlify-cms with-netlify-cms-app
+# or
+pnpm create next-app -- --example with-netlify-cms with-netlify-cms-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-next-css/README.md
+++ b/examples/with-next-css/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-next-css with-next-css-app
 # or
 yarn create next-app --example with-next-css with-next-css-app
+# or
+pnpm create next-app -- --example with-next-css with-next-css-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-next-offline/README.md
+++ b/examples/with-next-offline/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-next-offline with-next-offline-app
 # or
 yarn create next-app --example with-next-offline with-next-offline-app
+# or
+pnpm create next-app -- --example with-next-offline with-next-offline-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-next-page-transitions/README.md
+++ b/examples/with-next-page-transitions/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-next-page-transitions with-next-page-transitions-app
 # or
 yarn create next-app --example with-next-page-transitions with-next-page-transitions-app
+# or
+pnpm create next-app -- --example with-next-page-transitions with-next-page-transitions-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-next-sass/README.md
+++ b/examples/with-next-sass/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-next-sass with-next-sass-app
 # or
 yarn create next-app --example with-next-sass with-next-sass-app
+# or
+pnpm create next-app -- --example with-next-sass with-next-sass-app
 ```
 
 Run production build with:

--- a/examples/with-next-seo/README.md
+++ b/examples/with-next-seo/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-next-seo next-seo-app
 # or
 yarn create next-app --example with-next-seo next-seo-app
+# or
+pnpm create next-app -- --example with-next-seo next-seo-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-next-sitemap/README.md
+++ b/examples/with-next-sitemap/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-next-sitemap with-next-sitemap-app
 # or
 yarn create next-app --example with-next-sitemap with-next-sitemap-app
+# or
+pnpm create next-app -- --example with-next-sitemap with-next-sitemap-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-next-translate/README.md
+++ b/examples/with-next-translate/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-next-translate with-next-translate-app
 # or
 yarn create next-app --example with-next-translate with-next-translate-app
+# or
+pnpm create next-app -- --example with-next-translate with-next-translate-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-nhost-auth-realtime-graphql/README.md
+++ b/examples/with-nhost-auth-realtime-graphql/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-nhost-auth-realtime-graphql nhost-app
 # or
 yarn create next-app --example with-nhost-auth-realtime-graphql nhost-app
+# or
+pnpm create next-app -- --example with-nhost-auth-realtime-graphql nhost-app
 ```
 
 ## Configuration

--- a/examples/with-orbit-components/README.md
+++ b/examples/with-orbit-components/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-orbit-components with-orbit-components-app
 # or
 yarn create next-app --example with-orbit-components with-orbit-components-app
+# or
+pnpm create next-app -- --example with-orbit-components with-orbit-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-overmind/README.md
+++ b/examples/with-overmind/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-overmind with-overmind-app
 # or
 yarn create next-app --example with-overmind with-overmind-app
+# or
+pnpm create next-app -- --example with-overmind with-overmind-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-passport-and-next-connect/README.md
+++ b/examples/with-passport-and-next-connect/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-passport-and-next-connect with-passport-and-next-connect-app
 # or
 yarn create next-app --example with-passport-and-next-connect with-passport-and-next-connect-app
+# or
+pnpm create next-app -- --example with-passport-and-next-connect with-passport-and-next-connect-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-passport/README.md
+++ b/examples/with-passport/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-passport with-passport-app
 # or
 yarn create next-app --example with-passport with-passport-app
+# or
+pnpm create next-app -- --example with-passport with-passport-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-paste-typescript/README.md
+++ b/examples/with-paste-typescript/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-paste-typescript with-paste-typescript-app
 # or
 yarn create next-app --example with-paste-typescript with-paste-typescript-app
+# or
+pnpm create next-app -- --example with-paste-typescript with-paste-typescript-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-patternfly/README.md
+++ b/examples/with-patternfly/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-patternfly with-patternfly-app
 # or
 yarn create next-app --example with-patternfly with-patternfly-app
+# or
+pnpm create next-app -- --example with-patternfly with-patternfly-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-plausible/README.md
+++ b/examples/with-plausible/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-plausible with-plausible-app
 # or
 yarn create next-app --example with-plausible with-plausible-app
+# or
+pnpm create next-app -- --example with-plausible with-plausible-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-playwright/README.md
+++ b/examples/with-playwright/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-playwright with-playwright-app
 # or
 yarn create next-app --example with-playwright with-playwright-app
+# or
+pnpm create next-app -- --example with-playwright with-playwright-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-polyfills/README.md
+++ b/examples/with-polyfills/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-polyfills with-polyfills-app
 # or
 yarn create next-app --example with-polyfills with-polyfills-app
+# or
+pnpm create next-app -- --example with-polyfills with-polyfills-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-portals-ssr/README.md
+++ b/examples/with-portals-ssr/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-portals-ssr with-portals-ssr-app
 # or
 yarn create next-app --example with-portals-ssr with-portals-ssr-app
+# or
+pnpm create next-app -- --example with-portals-ssr with-portals-ssr-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-portals/README.md
+++ b/examples/with-portals/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-portals with-portals-app
 # or
 yarn create next-app --example with-portals with-portals-app
+# or
+pnpm create next-app -- --example with-portals with-portals-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-prefetching/README.md
+++ b/examples/with-prefetching/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-prefetching with-prefetching-app
 # or
 yarn create next-app --example with-prefetching with-prefetching-app
+# or
+pnpm create next-app -- --example with-prefetching with-prefetching-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-quill-js/README.md
+++ b/examples/with-quill-js/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-quill-js with-quill-js-app
 # or
 yarn create next-app --example with-quill-js with-quill-js-app
+# or
+pnpm create next-app -- --example with-quill-js with-quill-js-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-rbx-bulma-pro/README.md
+++ b/examples/with-rbx-bulma-pro/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-rbx-bulma-pro with-rbx-bulma-pro-app
 # or
 yarn create next-app --example with-rbx-bulma-pro with-rbx-bulma-pro-app
+# or
+pnpm create next-app -- --example with-rbx-bulma-pro with-rbx-bulma-pro-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-bootstrap/README.md
+++ b/examples/with-react-bootstrap/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-bootstrap with-react-bootstrap-app
 # or
 yarn create next-app --example with-react-bootstrap with-react-bootstrap-app
+# or
+pnpm create next-app -- --example with-react-bootstrap with-react-bootstrap-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-ga/README.md
+++ b/examples/with-react-ga/README.md
@@ -17,6 +17,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-ga with-react-ga-app
 # or
 yarn create next-app --example with-react-ga with-react-ga-app
+# or
+pnpm create next-app -- --example with-react-ga with-react-ga-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-helmet/README.md
+++ b/examples/with-react-helmet/README.md
@@ -19,6 +19,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-helmet with-react-helmet-app
 # or
 yarn create next-app --example with-react-helmet with-react-helmet-app
+# or
+pnpm create next-app -- --example with-react-helmet with-react-helmet-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-hook-form/README.md
+++ b/examples/with-react-hook-form/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-hook-form with-react-hook-form-app
 # or
 yarn create next-app --example with-react-hook-form with-react-hook-form-app
+# or
+pnpm create next-app -- --example with-react-hook-form with-react-hook-form-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-intl/README.md
+++ b/examples/with-react-intl/README.md
@@ -10,6 +10,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-intl with-react-intl-app
 # or
 yarn create next-app --example with-react-intl with-react-intl-app
+# or
+pnpm create next-app -- --example with-react-intl with-react-intl-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-jss/README.md
+++ b/examples/with-react-jss/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-jss with-react-jss-app
 # or
 yarn create next-app --example with-react-jss with-react-jss-app
+# or
+pnpm create next-app -- --example with-react-jss with-react-jss-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-md-typescript/README.md
+++ b/examples/with-react-md-typescript/README.md
@@ -31,6 +31,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-md-typescript with-react-md-typescript-app
 # or
 yarn create next-app --example with-react-md-typescript with-react-md-typescript-app
+# or
+pnpm create next-app -- --example with-react-md-typescript with-react-md-typescript-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-md/README.md
+++ b/examples/with-react-md/README.md
@@ -32,6 +32,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-md with-react-md-app
 # or
 yarn create next-app --example with-react-md with-react-md-app
+# or
+pnpm create next-app -- --example with-react-md with-react-md-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-multi-carousel/README.md
+++ b/examples/with-react-multi-carousel/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-multi-carousel with-react-multi-carousel-app
 # or
 yarn create next-app --example with-react-multi-carousel with-react-multi-carousel-app
+# or
+pnpm create next-app -- --example with-react-multi-carousel with-react-multi-carousel-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-native-web/README.md
+++ b/examples/with-react-native-web/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-native-web with-react-native-web-app
 # or
 yarn create next-app --example with-react-native-web with-react-native-web-app
+# or
+pnpm create next-app -- --example with-react-native-web with-react-native-web-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-react-toolbox/README.md
+++ b/examples/with-react-toolbox/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-toolbox with-react-toolbox-app
 # or
 yarn create next-app --example with-react-toolbox with-react-toolbox-app
+# or
+pnpm create next-app -- --example with-react-toolbox with-react-toolbox-app
 ```
 
 Notice that `yarn toolbox` (or `npm run toolbox`) should be rerun every time the `"reactToolbox"` configuration in `package.json` is changed, in order to update `/theme.js` and `public/theme.css`. The `"reactToolbox"` configuration includes styling, and the list of react-toolbox components to include.

--- a/examples/with-react-with-styles/README.md
+++ b/examples/with-react-with-styles/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-react-with-styles with-react-with-styles-app
 # or
 yarn create next-app --example with-react-with-styles with-react-with-styles-app
+# or
+pnpm create next-app -- --example with-react-with-styles with-react-with-styles-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-reactstrap/README.md
+++ b/examples/with-reactstrap/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-reactstrap with-reactstrap-app
 # or
 yarn create next-app --example with-reactstrap with-reactstrap-app
+# or
+pnpm create next-app -- --example with-reactstrap with-reactstrap-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-realm-web/README.md
+++ b/examples/with-realm-web/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-realm-web with-realm-web-app
 # or
 yarn create next-app --example with-realm-web with-realm-web-app
+# or
+pnpm create next-app -- --example with-realm-web with-realm-web-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-reason-relay/README.md
+++ b/examples/with-reason-relay/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-reason-relay with-reason-relay-app
 # or
 yarn create next-app --example with-reason-relay with-reason-relay-app
+# or
+pnpm create next-app -- --example with-reason-relay with-reason-relay-app
 ```
 
 Download schema introspection data from configured Relay endpoint:

--- a/examples/with-reasonml-todo/README.md
+++ b/examples/with-reasonml-todo/README.md
@@ -28,6 +28,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-reasonml-todo with-reasonml-app
 # or
 yarn create next-app --example with-reasonml-todo with-reasonml-app
+# or
+pnpm create next-app -- --example with-reasonml-todo with-reasonml-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-reasonml/README.md
+++ b/examples/with-reasonml/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-reasonml with-reasonml-app
 # or
 yarn create next-app --example with-reasonml with-reasonml-app
+# or
+pnpm create next-app -- --example with-reasonml with-reasonml-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-rebass/README.md
+++ b/examples/with-rebass/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-rebass with-rebass-app
 # or
 yarn create next-app --example with-rebass with-rebass-app
+# or
+pnpm create next-app -- --example with-rebass with-rebass-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-recoil/README.md
+++ b/examples/with-recoil/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-recoil with-recoil-app
 # or
 yarn create next-app --example with-recoil with-recoil-app
+# or
+pnpm create next-app -- --example with-recoil with-recoil-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-redis/README.md
+++ b/examples/with-redis/README.md
@@ -27,6 +27,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-redis roadmap
 # or
 yarn create next-app --example with-redis roadmap
+# or
+pnpm create next-app -- --example with-redis roadmap
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-redux-observable/README.md
+++ b/examples/with-redux-observable/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-redux-observable with-redux-observable-app
 # or
 yarn create next-app --example with-redux-observable with-redux-observable-app
+# or
+pnpm create next-app -- --example with-redux-observable with-redux-observable-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-redux-persist/README.md
+++ b/examples/with-redux-persist/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-redux-persist with-redux-persist-app
 # or
 yarn create next-app --example with-redux-persist with-redux-persist-app
+# or
+pnpm create next-app -- --example with-redux-persist with-redux-persist-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-redux-saga/README.md
+++ b/examples/with-redux-saga/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-redux-saga with-redux-saga-app
 # or
 yarn create next-app --example with-redux-saga with-redux-saga-app
+# or
+pnpm create next-app -- --example with-redux-saga with-redux-saga-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-redux-thunk/README.md
+++ b/examples/with-redux-thunk/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-redux-thunk with-redux-thunk-app
 # or
 yarn create next-app --example with-redux-thunk with-redux-thunk-app
+# or
+pnpm create next-app -- --example with-redux-thunk with-redux-thunk-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-redux-wrapper/README.md
+++ b/examples/with-redux-wrapper/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-redux-wrapper with-redux-wrapper-app
 # or
 yarn create next-app --example with-redux-wrapper with-redux-wrapper-app
+# or
+pnpm create next-app -- --example with-redux-wrapper with-redux-wrapper-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-redux/README.md
+++ b/examples/with-redux/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-redux with-redux-app
 # or
 yarn create next-app --example with-redux with-redux-app
+# or
+pnpm create next-app -- --example with-redux with-redux-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-reflexjs/README.md
+++ b/examples/with-reflexjs/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-reflexjs with-reflexjs-app
 # or
 yarn create next-app --example with-reflexjs with-reflexjs-app
+# or
+pnpm create next-app -- --example with-reflexjs with-reflexjs-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-reflux/README.md
+++ b/examples/with-reflux/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-reflux with-reflux-app
 # or
 yarn create next-app --example with-reflux with-reflux-app
+# or
+pnpm create next-app -- --example with-reflux with-reflux-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-relay-modern/README.md
+++ b/examples/with-relay-modern/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-relay-modern with-relay-modern-app
 # or
 yarn create next-app --example with-relay-modern with-relay-modern-app
+# or
+pnpm create next-app -- --example with-relay-modern with-relay-modern-app
 ```
 
 Download schema introspection data from configured Relay endpoint

--- a/examples/with-rematch/README.md
+++ b/examples/with-rematch/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-rematch with-rematch-app
 # or
 yarn create next-app --example with-rematch with-rematch-app
+# or
+pnpm create next-app -- --example with-rematch with-rematch-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-route-as-modal/README.md
+++ b/examples/with-route-as-modal/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-route-as-modal with-route-as-modal-app
 # or
 yarn create next-app --example with-route-as-modal with-route-as-modal-app
+# or
+pnpm create next-app -- --example with-route-as-modal with-route-as-modal-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-segment-analytics/README.md
+++ b/examples/with-segment-analytics/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-segment-analytics with-segment-analytics-app
 # or
 yarn create next-app --example with-segment-analytics with-segment-analytics-app
+# or
+pnpm create next-app -- --example with-segment-analytics with-segment-analytics-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-semantic-ui/README.md
+++ b/examples/with-semantic-ui/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-semantic-ui with-semantic-ui-app
 # or
 yarn create next-app --example with-semantic-ui with-semantic-ui-app
+# or
+pnpm create next-app -- --example with-semantic-ui with-semantic-ui-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -39,6 +39,8 @@ To begin, execute [`create-next-app`](https://github.com/vercel/next.js/tree/can
 npx create-next-app --example with-sentry nextjs-sentry-example
 # or
 yarn create next-app --example with-sentry nextjs-sentry-example
+# or
+pnpm create next-app -- --example with-sentry nextjs-sentry-example
 ```
 
 Next, run [`sentry-wizard`](https://docs.sentry.io/platforms/javascript/guides/nextjs/#configure), which will create and populate the settings files needed by `@sentry/nextjs` to initialize the SDK and upload source maps to Sentry:

--- a/examples/with-service-worker/README.md
+++ b/examples/with-service-worker/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-service-worker with-service-worker-app
 # or
 yarn create next-app --example with-service-worker with-service-worker-app
+# or
+pnpm create next-app -- --example with-service-worker with-service-worker-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-shallow-routing/README.md
+++ b/examples/with-shallow-routing/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-shallow-routing with-shallow-routing-app
 # or
 yarn create next-app --example with-shallow-routing with-shallow-routing-app
+# or
+pnpm create next-app -- --example with-shallow-routing with-shallow-routing-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-sitemap/README.md
+++ b/examples/with-sitemap/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-sitemap with-sitemap-app
 # or
 yarn create next-app --example with-sitemap with-sitemap-app
+# or
+pnpm create next-app -- --example with-sitemap with-sitemap-app
 ```
 
 Your app should be up and running on [http://localhost:3000](http://localhost:3000) and the sitemap should now be available in [http://localhost:3000/sitemap.xml](http://localhost:3000/sitemap.xml)! If it doesn't work, post on [GitHub discussions](https://github.com/vercel/next.js/discussions).

--- a/examples/with-skynexui-components/README.md
+++ b/examples/with-skynexui-components/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-skynexui-components with-skynexui-components-app
 # or
 yarn create next-app --example with-skynexui-components with-skynexui-components-app
+# or
+pnpm create next-app -- --example with-skynexui-components with-skynexui-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-slate/README.md
+++ b/examples/with-slate/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-slate with-slate-app
 # or
 yarn create next-app --example with-slate with-slate-app
+# or
+pnpm create next-app -- --example with-slate with-slate-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-static-export/README.md
+++ b/examples/with-static-export/README.md
@@ -18,4 +18,6 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-static-export with-static-export-app
 # or
 yarn create next-app --example with-static-export with-static-export-app
+# or
+pnpm create next-app -- --example with-static-export with-static-export-app
 ```

--- a/examples/with-stencil/README.md
+++ b/examples/with-stencil/README.md
@@ -14,6 +14,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-stencil with-stencil-app
 # or
 yarn create next-app --example with-stencil with-stencil-app
+# or
+pnpm create next-app -- --example with-stencil with-stencil-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-stitches/README.md
+++ b/examples/with-stitches/README.md
@@ -16,6 +16,8 @@ Execute [Create Next App](https://github.com/vercel/next.js/tree/canary/packages
 npx create-next-app --example with-stitches with-stitches-app
 # or
 yarn create next-app --example with-stitches with-stitches-app
+# or
+pnpm create next-app -- --example with-stitches with-stitches-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-stomp/README.md
+++ b/examples/with-stomp/README.md
@@ -14,6 +14,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-stomp with-stomp-app
 # or
 yarn create next-app --example with-stomp with-stomp-app
+# or
+pnpm create next-app -- --example with-stomp with-stomp-app
 ```
 
 You'll need to provide the STOMP url of your server before running the app. Open [`.env`](.env) and update the `NEXT_PUBLIC_STOMP_SERVER` environment variable.

--- a/examples/with-storybook-styled-jsx-scss/README.md
+++ b/examples/with-storybook-styled-jsx-scss/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-storybook-styled-jsx-scss with-storybook-styled-jsx-scss-app
 # or
 yarn create next-app --example with-storybook-styled-jsx-scss with-storybook-styled-jsx-scss-app
+# or
+pnpm create next-app -- --example with-storybook-styled-jsx-scss with-storybook-styled-jsx-scss-app
 ```
 
 ### Run Storybook

--- a/examples/with-storybook/README.md
+++ b/examples/with-storybook/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-storybook with-storybook-app
 # or
 yarn create next-app --example with-storybook with-storybook-app
+# or
+pnpm create next-app -- --example with-storybook with-storybook-app
 ```
 
 ### Run Storybook

--- a/examples/with-strict-csp/README.md
+++ b/examples/with-strict-csp/README.md
@@ -19,6 +19,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-strict-csp with-strict-csp-app
 # or
 yarn create next-app --example with-strict-csp with-strict-csp-app
+# or
+pnpm create next-app -- --example with-strict-csp with-strict-csp-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-stripe-typescript/README.md
+++ b/examples/with-stripe-typescript/README.md
@@ -69,6 +69,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-stripe-typescript with-stripe-typescript-app
 # or
 yarn create next-app --example with-stripe-typescript with-stripe-typescript-app
+# or
+pnpm create next-app -- --example with-stripe-typescript with-stripe-typescript-app
 ```
 
 ### Required configuration

--- a/examples/with-styled-components-babel/README.md
+++ b/examples/with-styled-components-babel/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-styled-components-babel with-styled-components-babel-app
 # or
 yarn create next-app --example with-styled-components-babel with-styled-components-babel-app
+# or
+pnpm create next-app -- --example with-styled-components-babel with-styled-components-babel-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-styled-components-rtl/README.md
+++ b/examples/with-styled-components-rtl/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-styled-components-rtl with-styled-components-rtl-app
 # or
 yarn create next-app --example with-styled-components-rtl with-styled-components-rtl-app
+# or
+pnpm create next-app -- --example with-styled-components-rtl with-styled-components-rtl-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-styled-components/README.md
+++ b/examples/with-styled-components/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-styled-components with-styled-components-app
 # or
 yarn create next-app --example with-styled-components with-styled-components-app
+# or
+pnpm create next-app -- --example with-styled-components with-styled-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-styled-jsx-plugins/README.md
+++ b/examples/with-styled-jsx-plugins/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-styled-jsx-plugins with-styled-jsx-plugins-app
 # or
 yarn create next-app --example with-styled-jsx-plugins with-styled-jsx-plugins-app
+# or
+pnpm create next-app -- --example with-styled-jsx-plugins with-styled-jsx-plugins-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-styled-jsx-scss/README.md
+++ b/examples/with-styled-jsx-scss/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-styled-jsx-scss with-styled-jsx-scss-app
 # or
 yarn create next-app --example with-styled-jsx-scss with-styled-jsx-scss-app
+# or
+pnpm create next-app -- --example with-styled-jsx-scss with-styled-jsx-scss-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-styled-jsx/README.md
+++ b/examples/with-styled-jsx/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-styled-jsx with-styled-jsx-app
 # or
 yarn create next-app --example with-styled-jsx with-styled-jsx-app
+# or
+pnpm create next-app -- --example with-styled-jsx with-styled-jsx-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-styletron/README.md
+++ b/examples/with-styletron/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-styletron with-styletron-app
 # or
 yarn create next-app --example with-styletron with-styletron-app
+# or
+pnpm create next-app -- --example with-styletron with-styletron-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-supertokens/README.md
+++ b/examples/with-supertokens/README.md
@@ -10,6 +10,8 @@ This is a simple set up for applications protected by SuperTokens.
 npx create-next-app --example with-supertokens with-supertokens-app
 # or
 yarn create next-app --example with-supertokens with-supertokens-app
+# or
+pnpm create next-app -- --example with-supertokens with-supertokens-app
 ```
 
 - Run `yarn install`

--- a/examples/with-tailwindcss-emotion/README.md
+++ b/examples/with-tailwindcss-emotion/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-tailwindcss-emotion with-tailwindcss-emotion-app
 # or
 yarn create next-app --example with-tailwindcss-emotion with-tailwindcss-emotion-app
+# or
+pnpm create next-app -- --example with-tailwindcss-emotion with-tailwindcss-emotion-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-tailwindcss/README.md
+++ b/examples/with-tailwindcss/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-tailwindcss with-tailwindcss-app
 # or
 yarn create next-app --example with-tailwindcss with-tailwindcss-app
+# or
+pnpm create next-app -- --example with-tailwindcss with-tailwindcss-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-temporal/README.md
+++ b/examples/with-temporal/README.md
@@ -60,6 +60,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-temporal next-temporal-app
 # or
 yarn create next-app --example with-temporal next-temporal-app
+# or
+pnpm create next-app -- --example with-temporal next-temporal-app
 ```
 
 The Temporal Node SDK requires [Node `>= 14`, `node-gyp`, and Temporal Server](https://docs.temporal.io/docs/node/getting-started#step-0-prerequisites). Once you have everything installed, you can develop locally with the below commands in four different shells:

--- a/examples/with-tesfy/README.md
+++ b/examples/with-tesfy/README.md
@@ -24,6 +24,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-tesfy with-tesfy-app
 # or
 yarn create next-app --example with-tesfy with-tesfy-app
+# or
+pnpm create next-app -- --example with-tesfy with-tesfy-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-three-js/README.md
+++ b/examples/with-three-js/README.md
@@ -20,6 +20,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-three-js with-three-js-app
 # or
 yarn create next-app --example with-three-js with-three-js-app
+# or
+pnpm create next-app -- --example with-three-js with-three-js-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-typescript-graphql/README.md
+++ b/examples/with-typescript-graphql/README.md
@@ -31,6 +31,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-typescript-graphql with-typescript-graphql-app
 # or
 yarn create next-app --example with-typescript-graphql with-typescript-graphql-app
+# or
+pnpm create next-app -- --example with-typescript-graphql with-typescript-graphql-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-typescript-styled-components/README.md
+++ b/examples/with-typescript-styled-components/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-typescript-styled-components with-typescript-styled-components-app
 # or
 yarn create next-app --example with-typescript-styled-components with-typescript-styled-components-app
+# or
+pnpm create next-app -- --example with-typescript-styled-components with-typescript-styled-components-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-typescript with-typescript-app
 # or
 yarn create next-app --example with-typescript with-typescript-app
+# or
+pnpm create next-app -- --example with-typescript with-typescript-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-typestyle/README.md
+++ b/examples/with-typestyle/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-typestyle with-typestyle-app
 # or
 yarn create next-app --example with-typestyle with-typestyle-app
+# or
+pnpm create next-app -- --example with-typestyle with-typestyle-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-unsplash/README.md
+++ b/examples/with-unsplash/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-unsplash with-unsplash-app
 # or
 yarn create next-app --example with-unsplash with-unsplash-app
+# or
+pnpm create next-app -- --example with-unsplash with-unsplash-app
 ```
 
 ## Configuration

--- a/examples/with-unstated/README.md
+++ b/examples/with-unstated/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-unstated with-unstated-app
 # or
 yarn create next-app --example with-unstated with-unstated-app
+# or
+pnpm create next-app -- --example with-unstated with-unstated-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-urql/README.md
+++ b/examples/with-urql/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-urql with-urql-app
 # or
 yarn create next-app --example with-urql with-urql-app
+# or
+pnpm create next-app -- --example with-urql with-urql-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-userbase/README.md
+++ b/examples/with-userbase/README.md
@@ -18,6 +18,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-userbase next-userbase-app
 # or
 yarn create next-app --example with-userbase next-userbase-app
+# or
+pnpm create next-app -- --example with-userbase next-userbase-app
 ```
 
 ## Configuration

--- a/examples/with-vercel-fetch/README.md
+++ b/examples/with-vercel-fetch/README.md
@@ -16,4 +16,6 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-vercel-fetch with-vercel-fetch-app
 # or
 yarn create next-app --example with-vercel-fetch with-vercel-fetch-app
+# or
+pnpm create next-app -- --example with-vercel-fetch with-vercel-fetch-app
 ```

--- a/examples/with-videojs/README.md
+++ b/examples/with-videojs/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-videojs with-videojs-app
 # or
 yarn create next-app --example with-videojs with-videojs-app
+# or
+pnpm create next-app -- --example with-videojs with-videojs-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-web-worker/README.md
+++ b/examples/with-web-worker/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-web-worker with-web-worker-app
 # or
 yarn create next-app --example with-web-worker with-web-worker-app
+# or
+pnpm create next-app -- --example with-web-worker with-web-worker-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-webassembly/README.md
+++ b/examples/with-webassembly/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-webassembly with-webassembly-app
 # or
 yarn create next-app --example with-webassembly with-webassembly-app
+# or
+pnpm create next-app -- --example with-webassembly with-webassembly-app
 ```
 
 This example uses Rust compiled to wasm, the wasm file is included in the example, but to compile your own Rust code you'll have to [install](https://www.rust-lang.org/learn/get-started) Rust.

--- a/examples/with-why-did-you-render/README.md
+++ b/examples/with-why-did-you-render/README.md
@@ -71,6 +71,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-why-did-you-render with-why-did-you-render-app
 # or
 yarn create next-app --example with-why-did-you-render with-why-did-you-render-app
+# or
+pnpm create next-app -- --example with-why-did-you-render with-why-did-you-render-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?filter=next.js&utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-xstate/README.md
+++ b/examples/with-xstate/README.md
@@ -16,6 +16,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-xstate with-xstate-app
 # or
 yarn create next-app --example with-xstate with-xstate-app
+# or
+pnpm create next-app -- --example with-xstate with-xstate-app
 ```
 
 ### Inspect your machines using `@xstate/inspect`

--- a/examples/with-yarn-workspaces/README.md
+++ b/examples/with-yarn-workspaces/README.md
@@ -22,6 +22,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-yarn-workspaces with-yarn-workspaces-app
 # or
 yarn create next-app --example with-yarn-workspaces with-yarn-workspaces-app
+# or
+pnpm create next-app -- --example with-yarn-workspaces with-yarn-workspaces-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-zones/README.md
+++ b/examples/with-zones/README.md
@@ -14,6 +14,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-zones with-zones-app
 # or
 yarn create next-app --example with-zones with-zones-app
+# or
+pnpm create next-app -- --example with-zones with-zones-app
 ```
 
 With multi zones you have multiple Next.js apps over a single app, therefore every app has its own dependencies and it runs independently.

--- a/examples/with-zustand/README.md
+++ b/examples/with-zustand/README.md
@@ -28,6 +28,8 @@ Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packag
 npx create-next-app --example with-zustand with-zustand-app
 # or
 yarn create next-app --example with-zustand with-zustand-app
+# or
+pnpm create next-app -- --example with-zustand with-zustand-app
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/packages/create-next-app/README.md
+++ b/packages/create-next-app/README.md
@@ -3,19 +3,31 @@
 The easiest way to get started with Next.js is by using `create-next-app`. This CLI tool enables you to quickly start building a new Next.js application, with everything set up for you. You can create a new app using the default Next.js template, or by using one of the [official Next.js examples](https://github.com/vercel/next.js/tree/canary/examples). To get started, use the following command:
 
 ```bash
-npx create-next-app
+npx create-next-app@latest
+# or
+yarn create next-app
+# or
+pnpm create next-app
 ```
 
 Or, for a [TypeScript project](https://github.com/vercel/next.js/blob/canary/docs/basic-features/typescript.md):
 
 ```bash
-npx create-next-app --typescript
+npx create-next-app@latest --typescript
+# or
+yarn create next-app --typescript
+# or
+pnpm create next-app -- --typescript
 ```
 
 To create a new app in a specific folder, you can send a name as an argument. For example, the following command will create a new Next.js app called `blog-app` in a folder with the same name:
 
 ```bash
-npx create-next-app blog-app
+npx create-next-app@latest blog-app
+# or
+yarn create next-app blog-app
+# or
+pnpm create next-app blog-app
 ```
 
 ## Options


### PR DESCRIPTION
This PR updates the docs and examples for `create-next-app` to include pnpm usage.

The following script was used to update every example README:

```js
const fs = require('fs')
const examples = fs.readdirSync('./examples')

for (let example of examples) {
    const filename = `./examples/${example}/README.md`
    const markdown = fs.readFileSync(filename, 'utf8')
    const regex = new RegExp(`^yarn create next-app --example (.*)$`, 'gm')
    const output = markdown.replace(regex, (yarn, group) => {
        const pnpm = `pnpm create next-app -- --example ${group}`
        return `${yarn}\n# or\n${pnpm}`
    })
    fs.writeFileSync(filename, output)
}
```