### PR TITLE
Fix document styles with react 18

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1431,21 +1431,18 @@ export async function renderToHTML(
         })
       }
 
-      const styles = jsxStyleRegistry.styles()
-      jsxStyleRegistry.flush()
-
       const documentInitialPropsRes =
         isServerComponent || process.browser || !Document.getInitialProps
           ? {}
           : await documentInitialProps()
       if (documentInitialPropsRes === null) return null
 
+      const { docProps } = (documentInitialPropsRes as any) || {}
       const documentElement = () => {
         if (isServerComponent || process.browser) {
           return (Document as any)()
         }
 
-        const { docProps } = (documentInitialPropsRes as any) || {}
         return <Document {...htmlProps} {...docProps} />
       }
 
@@ -1454,7 +1451,7 @@ export async function renderToHTML(
         documentElement,
         head,
         headTags: [],
-        styles,
+        styles: docProps.styles,
       }
     }
   }

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1431,10 +1431,15 @@ export async function renderToHTML(
         })
       }
 
-      const documentInitialPropsRes =
-        isServerComponent || process.browser || !Document.getInitialProps
-          ? {}
-          : await documentInitialProps()
+      const hasDocumentGetInitialProps = !(
+        isServerComponent ||
+        process.browser ||
+        !Document.getInitialProps
+      )
+
+      const documentInitialPropsRes = hasDocumentGetInitialProps
+        ? await documentInitialProps()
+        : {}
       if (documentInitialPropsRes === null) return null
 
       const { docProps } = (documentInitialPropsRes as any) || {}
@@ -1445,13 +1450,21 @@ export async function renderToHTML(
 
         return <Document {...htmlProps} {...docProps} />
       }
+      let styles
+
+      if (hasDocumentGetInitialProps) {
+        styles = docProps.styles
+      } else {
+        styles = jsxStyleRegistry.styles()
+        jsxStyleRegistry.flush()
+      }
 
       return {
         bodyResult,
         documentElement,
         head,
         headTags: [],
-        styles: docProps.styles,
+        styles,
       }
     }
   }

--- a/test/development/basic/styled-components.test.ts
+++ b/test/development/basic/styled-components.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
-import { fetchViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 
 describe('styled-components SWC transform', () => {
   let next: NextInstance
@@ -68,5 +68,11 @@ describe('styled-components SWC transform', () => {
         `window.getComputedStyle(document.querySelector('#btn')).color`
       )
     ).toBe('rgb(255, 255, 255)')
+  })
+
+  it('should contain styles in initial HTML', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('background:transparent')
+    expect(html).toContain('color:white')
   })
 })


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/35736 that ensures we use the styles from `_document.getInitialProps` instead of only applying the `styled-jsx` styles. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/35758
x-ref: https://github.com/vercel/next.js/pull/35736