### PR TITLE
[Script] Use `__non_webpack_require__` to fetch partytown server-side

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1573,7 +1573,6 @@ export default async function getBaseWebpackConfig(
   webpack5Config.module!.parser = {
     javascript: {
       url: 'relative',
-      commonjsMagicComments: true,
     },
   }
   webpack5Config.module!.generator = {

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -85,7 +85,8 @@ function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {
   try {
     let {
       partytownSnippet,
-    } = require(/* webpackIgnore: true */ '@builder.io/partytown/integration'!)
+      // @ts-ignore: Prevent webpack from processing this require
+    } = __non_webpack_require__('@builder.io/partytown/integration'!)
 
     const children = Array.isArray(props.children)
       ? props.children
@@ -135,9 +136,11 @@ function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {
       </>
     )
   } catch (err) {
-    console.warn(
-      `Warning: Partytown could not be instantiated in your application due to an error. ${err}`
-    )
+    if (isError(err) && err.code !== 'MODULE_NOT_FOUND') {
+      console.warn(
+        `Warning: Partytown could not be instantiated in your application due to an error. ${err.message}`
+      )
+    }
     return null
   }
 }


### PR DESCRIPTION
A few errors about Next.js not correctly handling the missing partytown dependency in `_document.js` have been flagged. Instead of `/* webpackIgnore: true */`, this PR switches to use [`__non_webpack_require__`](https://webpack.js.org/api/module-variables/#__non_webpack_require__-webpack-specific) to ensure webpack doesn't process fetching the dep server-side. 

-----

Related issues: 

- #35645 
- https://github.com/vercel/next.js/issues/35630#issuecomment-1084365365