### PR TITLE
feat(next-swc): introduce experimental tracing support for swc

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -2885,8 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-chrome"
-version = "0.6.0"
-source = "git+https://github.com/kwonoj/tracing-chrome?rev=0dd9d6c9e0f74f43993b58560f4ac0103e058df8#0dd9d6c9e0f74f43993b58560f4ac0103e058df8"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb13184244c7cd22758b79e7c993c515ad67a8e730edcb7e05fe7bcabb283c7"
 dependencies = [
  "json",
  "tracing",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -718,6 +718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "json_comments"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1049,10 @@ dependencies = [
  "swc_ecma_loader",
  "swc_ecmascript",
  "swc_node_base",
+ "tracing",
+ "tracing-chrome",
+ "tracing-futures",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1301,6 +1311,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2555,7 +2585,9 @@ dependencies = [
  "swc_common",
  "swc_ecma_transforms_testing",
  "swc_ecmascript",
+ "swc_trace_macro",
  "testing",
+ "tracing",
 ]
 
 [[package]]
@@ -2852,6 +2884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-chrome"
+version = "0.6.0"
+source = "git+https://github.com/kwonoj/tracing-chrome?rev=0dd9d6c9e0f74f43993b58560f4ac0103e058df8#0dd9d6c9e0f74f43993b58560f4ac0103e058df8"
+dependencies = [
+ "json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-core"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,6 +2901,16 @@ checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -27,8 +27,7 @@ swc_common = { version = "0.17.25", features = ["concurrent", "sourcemap"] }
 swc_ecma_loader = { version = "0.29.1", features = ["node", "lru"] }
 swc_ecmascript = { version = "0.150.0", features = ["codegen", "minifier", "optimization", "parser", "react", "transforms", "typescript", "utils", "visit"] }
 swc_cached = "0.1.1"
-tracing = { version = "0.1.32", features = ["release_max_level_off"] }
-
+tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 
 [dev-dependencies]
 swc_ecma_transforms_testing = "0.82.0"

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -21,6 +21,8 @@ sourcemap = "6.0.1"
 swc_atoms = "0.2.11"
 swc_common = { version = "0.17.25", features = ["concurrent", "sourcemap"] }
 swc_ecmascript = { version = "0.150.0", features = ["codegen", "utils", "visit"] }
+swc_trace_macro = "0.1.1"
+tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 
 [dev-dependencies]
 swc_ecma_transforms_testing = "0.82.0"

--- a/packages/next-swc/crates/emotion/src/lib.rs
+++ b/packages/next-swc/crates/emotion/src/lib.rs
@@ -25,6 +25,7 @@ use swc_ecmascript::{
     codegen::util::SourceMapperExt,
     visit::{Fold, FoldWith},
 };
+use swc_trace_macro::swc_trace;
 
 mod hash;
 
@@ -164,6 +165,7 @@ pub struct EmotionTransformer<C: Comments> {
     in_jsx_element: bool,
 }
 
+#[swc_trace]
 impl<C: Comments> EmotionTransformer<C> {
     pub fn new(options: EmotionOptions, path: &Path, cm: Arc<SourceMap>, comments: C) -> Self {
         EmotionTransformer {

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -24,6 +24,12 @@ swc_common = { version = "0.17.25", features = ["concurrent", "sourcemap"] }
 swc_ecma_loader = { version = "0.29.1", features = ["node", "lru"] }
 swc_ecmascript = { version = "0.150.0", features = ["codegen", "minifier", "optimization", "parser", "react", "transforms", "typescript", "utils", "visit"] }
 swc_node_base = "0.5.2"
+tracing = { version = "0.1.32", features = ["release_max_level_info"] }
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.9"
+
+# https://github.com/thoren-d/tracing-chrome/pull/10
+tracing-chrome = { git = "https://github.com/kwonoj/tracing-chrome", rev = "0dd9d6c9e0f74f43993b58560f4ac0103e058df8" }
 
 [build-dependencies]
 napi-build = "1"

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -28,8 +28,7 @@ tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
 
-# https://github.com/thoren-d/tracing-chrome/pull/10
-tracing-chrome = { git = "https://github.com/kwonoj/tracing-chrome", rev = "0dd9d6c9e0f74f43993b58560f4ac0103e058df8" }
+tracing-chrome = "0.5.0"
 
 [build-dependencies]
 napi-build = "1"

--- a/packages/next-swc/crates/napi/src/lib.rs
+++ b/packages/next-swc/crates/napi/src/lib.rs
@@ -73,6 +73,11 @@ fn init(mut exports: JsObject) -> napi::Result<()> {
     exports.create_named_method("parse", parse::parse)?;
 
     exports.create_named_method("getTargetTriple", util::get_target_triple)?;
+    exports.create_named_method(
+        "initCustomTraceSubscriber",
+        util::init_custom_trace_subscriber,
+    )?;
+    exports.create_named_method("teardownTraceSubscriber", util::teardown_trace_subscriber)?;
 
     Ok(())
 }

--- a/packages/next-swc/crates/napi/src/util.rs
+++ b/packages/next-swc/crates/napi/src/util.rs
@@ -26,7 +26,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-use anyhow::{Context, Error};
+use anyhow::{anyhow, Context, Error};
 use napi::{CallContext, Env, JsBuffer, JsExternal, JsString, JsUndefined, JsUnknown, Status};
 use serde::de::DeserializeOwned;
 use std::{any::type_name, convert::TryFrom, path::PathBuf};
@@ -108,6 +108,12 @@ pub fn init_custom_trace_subscriber(cx: CallContext) -> napi::Result<JsExternal>
 
     let mut layer = ChromeLayerBuilder::new().include_args(true);
     if let Some(trace_out_file) = trace_out_file_path {
+        let dir = trace_out_file
+            .parent()
+            .ok_or_else(|| anyhow!("Not able to find path to the trace output"))
+            .convert_err()?;
+        std::fs::create_dir_all(dir)?;
+
         layer = layer.file(trace_out_file);
     }
 

--- a/packages/next-swc/crates/napi/src/util.rs
+++ b/packages/next-swc/crates/napi/src/util.rs
@@ -27,12 +27,13 @@ DEALINGS IN THE SOFTWARE.
 */
 
 use anyhow::{Context, Error};
-use napi::{CallContext, Env, JsBuffer, JsString, Status};
+use napi::{CallContext, Env, JsBuffer, JsExternal, JsString, JsUndefined, JsUnknown, Status};
 use serde::de::DeserializeOwned;
-use std::any::type_name;
+use std::{any::type_name, convert::TryFrom, path::PathBuf};
+use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
+use tracing_subscriber::{filter, prelude::*, util::SubscriberInitExt, Layer};
 
 static TARGET_TRIPLE: &str = include_str!(concat!(env!("OUT_DIR"), "/triple.txt"));
-
 #[contextless_function]
 pub fn get_target_triple(env: Env) -> napi::ContextlessResult<JsString> {
     env.create_string(TARGET_TRIPLE).map(Some)
@@ -88,4 +89,47 @@ where
 {
     serde_json::from_str(s)
         .with_context(|| format!("failed to deserialize as {}\nJSON: {}", type_name::<T>(), s))
+}
+
+/// Initialize tracing subscriber to emit traces. This configures subscribers
+/// for Trace Event Format (https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview).
+#[js_function(1)]
+pub fn init_custom_trace_subscriber(cx: CallContext) -> napi::Result<JsExternal> {
+    let optional_trace_out_file_path = cx.get::<JsUnknown>(0)?;
+    let trace_out_file_path = match optional_trace_out_file_path.get_type()? {
+        napi::ValueType::String => Some(PathBuf::from(
+            JsString::try_from(optional_trace_out_file_path)?
+                .into_utf8()?
+                .as_str()?
+                .to_owned(),
+        )),
+        _ => None,
+    };
+
+    let mut layer = ChromeLayerBuilder::new().include_args(true);
+    if let Some(trace_out_file) = trace_out_file_path {
+        layer = layer.file(trace_out_file);
+    }
+
+    let (chrome_layer, guard) = layer.build();
+    tracing_subscriber::registry()
+        .with(chrome_layer.with_filter(filter::filter_fn(|metadata| {
+            !metadata.target().contains("cranelift") && !metadata.name().contains("log ")
+        })))
+        .try_init()
+        .expect("Failed to register tracing subscriber");
+
+    cx.env.create_external(guard, None)
+}
+
+/// Teardown currently running tracing subscriber to flush out remaining traces.
+/// This should be called when parent node.js process exits, otherwise generated
+/// trace will missing traces in the buffer.
+#[js_function(1)]
+pub fn teardown_trace_subscriber(cx: CallContext) -> napi::Result<JsUndefined> {
+    let guard_external = cx.get::<JsExternal>(0)?;
+    let guard = &*cx.env.get_value_external::<FlushGuard>(&guard_external)?;
+
+    guard.close();
+    cx.env.get_undefined()
 }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -113,7 +113,7 @@ import { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 import { MiddlewareManifest } from './webpack/plugins/middleware-plugin'
 import { recursiveCopy } from '../lib/recursive-copy'
 import { recursiveReadDir } from '../lib/recursive-readdir'
-import { lockfilePatchPromise } from './swc'
+import { lockfilePatchPromise, teardownTraceSubscriber } from './swc'
 
 export type SsgRoute = {
   initialRevalidateSeconds: number | false
@@ -2212,6 +2212,7 @@ export default async function build(
 
     // Ensure all traces are flushed before finishing the command
     await flushAllTraces()
+    teardownTraceSubscriber()
   }
 }
 

--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -1,7 +1,7 @@
 import createStore from 'next/dist/compiled/unistore'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { flushAllTraces } from '../../trace'
-
+import { teardownTraceSubscriber } from '../swc'
 import * as Log from './log'
 
 export type OutputState =
@@ -91,6 +91,7 @@ store.subscribe((state) => {
 
     // Ensure traces are flushed after each compile in development mode
     flushAllTraces()
+    teardownTraceSubscriber()
     return
   }
 
@@ -117,6 +118,7 @@ store.subscribe((state) => {
     Log.warn(state.warnings.join('\n\n'))
     // Ensure traces are flushed after each compile in development mode
     flushAllTraces()
+    teardownTraceSubscriber()
     return
   }
 
@@ -132,4 +134,5 @@ store.subscribe((state) => {
   )
   // Ensure traces are flushed after each compile in development mode
   flushAllTraces()
+  teardownTraceSubscriber()
 })

--- a/packages/next/build/swc/index.d.ts
+++ b/packages/next/build/swc/index.d.ts
@@ -6,3 +6,4 @@ export function minifySync(src: string, options: any): string
 export function bundle(options: any): Promise<any>
 export function parse(src: string, options: any): any
 export const lockfilePatchPromise: { cur?: Promise<void> }
+export function initCustomTraceSubscriber(traceFileName?: string): void

--- a/packages/next/build/swc/index.d.ts
+++ b/packages/next/build/swc/index.d.ts
@@ -7,3 +7,4 @@ export function bundle(options: any): Promise<any>
 export function parse(src: string, options: any): any
 export const lockfilePatchPromise: { cur?: Promise<void> }
 export function initCustomTraceSubscriber(traceFileName?: string): void
+export function teardownTraceSubscriber(): void

--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -17,6 +17,7 @@ let nativeBindings
 let wasmBindings
 let downloadWasmPromise
 let pendingBindings
+let swcTraceFlushGuard
 export const lockfilePatchPromise = {}
 
 async function loadBindings() {
@@ -326,31 +327,39 @@ export function getBinaryMetadata() {
 /**
  * Initialize trace subscriber to emit traces.
  *
- * Returns an internal object to guard async flush emission if subscriber is initialized, caller should manually
- * tear it down via `teardownTraceSubscriber`.
  */
 export const initCustomTraceSubscriber = (() => {
-  let guard
-
   return (filename) => {
-    if (!guard) {
+    if (!swcTraceFlushGuard) {
       // Wasm binary doesn't support trace emission
       let bindings = loadNative()
-      guard = bindings.initCustomTraceSubscriber(filename)
+      swcTraceFlushGuard = bindings.initCustomTraceSubscriber(filename)
     }
-
-    return guard
   }
 })()
 
+/**
+ * Teardown swc's trace subscriber if there's an initialized flush guard exists.
+ *
+ * This is workaround to amend behavior with process.exit
+ * (https://github.com/vercel/next.js/blob/4db8c49cc31e4fc182391fae6903fb5ef4e8c66e/packages/next/bin/next.ts#L134=)
+ * seems preventing napi's cleanup hook execution (https://github.com/swc-project/swc/blob/main/crates/node/src/util.rs#L48-L51=),
+ *
+ * instead parent process manually drops guard when process gets signal to exit.
+ */
 export const teardownTraceSubscriber = (() => {
-  let bindings
-
-  return (guard) => {
-    if (!bindings && !!guard) {
-      // Wasm binary doesn't support trace emission
-      bindings = loadNative()
-      return bindings.teardownTraceSubscriber(guard)
+  let flushed = false
+  return () => {
+    if (!flushed) {
+      flushed = true
+      try {
+        let bindings = loadNative()
+        if (swcTraceFlushGuard) {
+          bindings.teardownTraceSubscriber(swcTraceFlushGuard)
+        }
+      } catch (e) {
+        // Suppress exceptions, this fn allows to fail to load native bindings
+      }
     }
   }
 })()

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -87,6 +87,22 @@ const devtoolRevertWarning = execOnce(
 
 let loggedSwcDisabled = false
 let loggedIgnoredCompilerOptions = false
+let swcTraceFlushGuard: unknown = null
+
+/**
+ * Teardown swc's trace subscriber if there's an initialized flush guard exists.
+ *
+ * This is workaround to amend behavior with process.exit
+ * (https://github.com/vercel/next.js/blob/4db8c49cc31e4fc182391fae6903fb5ef4e8c66e/packages/next/bin/next.ts#L134=)
+ * seems preventing napi's cleanup hook execution (https://github.com/swc-project/swc/blob/main/crates/node/src/util.rs#L48-L51=),
+ *
+ * instead parent process manually drops guard when process gets signal to exit.
+ */
+process.on('exit', () => {
+  if (swcTraceFlushGuard) {
+    require('./swc')?.teardownTraceSubscriber?.(swcTraceFlushGuard)
+  }
+})
 
 function getOptimizedAliases(): { [pkg: string]: string } {
   const stubWindowFetch = path.join(__dirname, 'polyfills', 'fetch', 'index.js')
@@ -436,6 +452,20 @@ export default async function getBaseWebpackConfig(
   }
 
   const getBabelOrSwcLoader = () => {
+    if (
+      useSWCLoader &&
+      config?.experimental?.swcTrace?.enabled &&
+      !swcTraceFlushGuard
+    ) {
+      // This will init subscribers once only in a single process lifecycle,
+      // even though it can be called multiple times.
+      // Subscriber need to be initialized _before_ any actual swc's call (transform, etcs)
+      // to collect correct trace spans when they are called.
+      swcTraceFlushGuard = require('./swc')?.initCustomTraceSubscriber?.(
+        config?.experimental?.swcTrace?.traceFileName
+      )
+    }
+
     return useSWCLoader
       ? {
           loader: 'next-swc-loader',

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -454,7 +454,7 @@ export default async function getBaseWebpackConfig(
   const getBabelOrSwcLoader = (buildDir: string) => {
     if (
       useSWCLoader &&
-      config?.experimental?.swcTraceProfiling?.enabled &&
+      config?.experimental?.swcTraceProfiling &&
       !swcTraceFlushGuard
     ) {
       // This will init subscribers once only in a single process lifecycle,
@@ -462,12 +462,11 @@ export default async function getBaseWebpackConfig(
       // Subscriber need to be initialized _before_ any actual swc's call (transform, etcs)
       // to collect correct trace spans when they are called.
       swcTraceFlushGuard = require('./swc')?.initCustomTraceSubscriber?.(
-        config?.experimental?.swcTraceProfiling?.traceFileName ??
-          path.join(
-            buildDir,
-            config.distDir,
-            `swc-trace-profile-${Date.now()}.json`
-          )
+        path.join(
+          buildDir,
+          config.distDir,
+          `swc-trace-profile-${Date.now()}.json`
+        )
       )
     }
 

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -132,7 +132,7 @@ export interface ExperimentalConfig {
       skipDefaultConversion?: boolean
     }
   >
-  swcTrace?: {
+  swcTraceProfiling?: {
     enabled: boolean
     traceFileName?: string
   }

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -132,6 +132,10 @@ export interface ExperimentalConfig {
       skipDefaultConversion?: boolean
     }
   >
+  swcTrace?: {
+    enabled: boolean
+    traceFileName?: string
+  }
 }
 
 /**

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -132,10 +132,7 @@ export interface ExperimentalConfig {
       skipDefaultConversion?: boolean
     }
   >
-  swcTraceProfiling?: {
-    enabled: boolean
-    traceFileName?: string
-  }
+  swcTraceProfiling?: boolean
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Context: https://github.com/vercel/next.js/pull/34687#issuecomment-1080829168

It is a bit tricky to understand underlying performance characteristics inside swc when build steps involving swc's internals. Technically it should be possible to use a profiler with some custom swc build, but it is not easy job to set it up.

SWC recently introduced trace features for those reasons (https://github.com/swc-project/swc/discussions/3953), allow emitting Trace event format compatible (https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview) output. This PR ports over those features into `next-swc` under `experimental` config value to user to try out.

With this PR, trace will emit core swc's traces as well as one custom transformation in next-swc (`emotion`). Expect to expand trace over all existing custom transform passes eventually in further PRs.

To configure traces, `next.config.js` exposes this new experimental config value:

```
// next.config.js

{
...
  experimental: {
    swcTraceProfiling: true
  }
}
```

SWC will generate `trace-${unixtimestamp}.json` by default.

It is important to aware enabling trace all time is highly discouraged: observing code path is not free, and if build scales up trace will cost expensive time as well. User may want to use env variable, or other dynamic way to selectively enable trace instead.

Generated trace is compatible to trace event format, so existing visualizer can be used out of the box. Notably,

- catapult: chrome://tracing
- perfetto: https://ui.perfetto.dev/
- speedscope: https://www.speedscope.app/

And possibly other flamegraph visualizer as well. Technically it is possible to make output to work with chrome devtools' profiler, but that's not supported now.

This is example trace screenshot from `bench/nested-deps`.

![image](https://user-images.githubusercontent.com/1210596/161158870-09f9bc88-eadd-49ee-ba85-979e2fe958de.png)

As config already implies, this is experimental due to 1. config / internal swc impl might change, 2. there are missing traces for custom passes in next-swc. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
