### PR TITLE
chore(deps): upgrade `webpack` to 5.71.0

### DIFF
--- a/packages/next/build/babel/preset.ts
+++ b/packages/next/build/babel/preset.ts
@@ -93,10 +93,6 @@ export default (
     // In production/development this option is set to `false` so that webpack can handle import/export with tree-shaking
     modules: 'auto',
     exclude: ['transform-typeof-symbol'],
-    include: [
-      '@babel/plugin-proposal-optional-chaining',
-      '@babel/plugin-proposal-nullish-coalescing-operator',
-    ],
     ...options['preset-env'],
   }
 

--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -164,13 +164,6 @@ export function getJestSWCOptions({
         // Targets the current version of Node.js
         node: process.versions.node,
       },
-      // we always transpile optional chaining and nullish coalescing
-      // since it can cause issues with webpack even if the node target
-      // supports them
-      include: [
-        'proposal-optional-chaining',
-        'proposal-nullish-coalescing-operator',
-      ],
     },
     module: {
       type: esm && !isNextDist ? 'es6' : 'commonjs',
@@ -219,13 +212,6 @@ export function getLoaderSWCOptions({
           // Targets the current version of Node.js
           node: process.versions.node,
         },
-        // we always transpile optional chaining and nullish coalescing
-        // since it can cause issues with webpack even if the node target
-        // supports them
-        include: [
-          'proposal-optional-chaining',
-          'proposal-nullish-coalescing-operator',
-        ],
       },
     }
   } else {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -270,7 +270,7 @@
     "webpack-sources1": "npm:webpack-sources@1.4.3",
     "webpack-sources3": "npm:webpack-sources@3.2.3",
     "webpack4": "npm:webpack@4.44.1",
-    "webpack5": "npm:webpack@5.69.1",
+    "webpack5": "npm:webpack@5.71.0",
     "ws": "8.2.3"
   },
   "resolutions": {

--- a/test/unit/next-babel-loader-prod.test.ts
+++ b/test/unit/next-babel-loader-prod.test.ts
@@ -216,7 +216,6 @@ describe('next-babel-loader', () => {
     })
 
     const pageFile = path.resolve(dir, 'pages', 'index.js')
-    const tsPageFile = pageFile.replace(/\.js$/, '.ts')
 
     it('should not drop unused exports by default in a page', async () => {
       const code = await babel(
@@ -321,76 +320,6 @@ describe('next-babel-loader', () => {
       )
       expect(code).toContain(
         `var __jsx = React.createElement;import "core-js";import { bar } from "a";import baz from "b";import * as React from "react";import { yeet } from "c";import baz3, { cats } from "d";import { c, d } from "e";import { e as ee } from "f";export var __N_SSG = true;export default function () {  return __jsx("div", {    __self: this,    __source: {      fileName: _jsxFileName,      lineNumber: 1,      columnNumber: 326    }  }, cats + bar());}`
-      )
-    })
-
-    it('should support optional chaining for JS file', async () => {
-      const code = await babel(
-        `let hello;` +
-          `export default () => hello?.world ? 'something' : 'nothing' `,
-        {
-          resourcePath: pageFile,
-        }
-      )
-      expect(code).toMatchInlineSnapshot(
-        `"let hello;export default (() => hello !== null && hello !== void 0 && hello.world ? 'something' : 'nothing');"`
-      )
-    })
-
-    it('should support optional chaining for TS file', async () => {
-      const code = await babel(
-        `let hello;` +
-          `export default () => hello?.world ? 'something' : 'nothing' `,
-        {
-          resourcePath: tsPageFile,
-        }
-      )
-      expect(code).toMatchInlineSnapshot(
-        `"let hello;export default (() => hello !== null && hello !== void 0 && hello.world ? 'something' : 'nothing');"`
-      )
-    })
-
-    it('should support nullish coalescing for JS file', async () => {
-      const code = await babel(
-        `const res = {
-          status: 0,
-          nullVal: null,
-          statusText: '',
-
-        }
-        const status = res.status ?? 999
-        const nullVal = res.nullVal ?? 'another'
-        const statusText = res.nullVal ?? 'not found'
-        export default () => 'hello'
-        `,
-        {
-          resourcePath: pageFile,
-        }
-      )
-      expect(code).toMatchInlineSnapshot(
-        `"var _res$status, _res$nullVal, _res$nullVal2;const res = {  status: 0,  nullVal: null,  statusText: ''};const status = (_res$status = res.status) !== null && _res$status !== void 0 ? _res$status : 999;const nullVal = (_res$nullVal = res.nullVal) !== null && _res$nullVal !== void 0 ? _res$nullVal : 'another';const statusText = (_res$nullVal2 = res.nullVal) !== null && _res$nullVal2 !== void 0 ? _res$nullVal2 : 'not found';export default (() => 'hello');"`
-      )
-    })
-
-    it('should support nullish coalescing for TS file', async () => {
-      const code = await babel(
-        `const res = {
-          status: 0,
-          nullVal: null,
-          statusText: '',
-
-        }
-        const status = res.status ?? 999
-        const nullVal = res.nullVal ?? 'another'
-        const statusText = res.nullVal ?? 'not found'
-        export default () => 'hello'
-        `,
-        {
-          resourcePath: tsPageFile,
-        }
-      )
-      expect(code).toMatchInlineSnapshot(
-        `"const res = {  status: 0,  nullVal: null,  statusText: ''};const status = res.status ?? 999;const nullVal = res.nullVal ?? 'another';const statusText = res.nullVal ?? 'not found';export default (() => 'hello');"`
       )
     })
   })

--- a/test/unit/next-babel-loader-prod.test.ts
+++ b/test/unit/next-babel-loader-prod.test.ts
@@ -390,7 +390,7 @@ describe('next-babel-loader', () => {
         }
       )
       expect(code).toMatchInlineSnapshot(
-        `"var _res$status, _res$nullVal, _res$nullVal2;const res = {  status: 0,  nullVal: null,  statusText: ''};const status = (_res$status = res.status) !== null && _res$status !== void 0 ? _res$status : 999;const nullVal = (_res$nullVal = res.nullVal) !== null && _res$nullVal !== void 0 ? _res$nullVal : 'another';const statusText = (_res$nullVal2 = res.nullVal) !== null && _res$nullVal2 !== void 0 ? _res$nullVal2 : 'not found';export default (() => 'hello');"`
+        `"const res = {  status: 0,  nullVal: null,  statusText: ''};const status = res.status ?? 999;const nullVal = res.nullVal ?? 'another';const statusText = res.nullVal ?? 'not found';export default (() => 'hello');"`
       )
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -9376,6 +9376,14 @@ enhanced-resolve@^5.8.3:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+enhanced-resolve@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz#0224dcd6a43389ebfb2d55efee517e5466772dd9"
+  integrity sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -21506,10 +21514,10 @@ webpack-bundle-analyzer@4.3.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-"webpack5@npm:webpack@5.69.1":
-  version "5.69.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.69.1.tgz#8cfd92c192c6a52c99ab00529b5a0d33aa848dc5"
-  integrity sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==
+"webpack5@npm:webpack@5.71.0":
+  version "5.71.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.71.0.tgz#b01fcf379570b8c5ee06ca06c829ca168c951884"
+  integrity sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
@@ -21520,7 +21528,7 @@ webpack-bundle-analyzer@4.3.0:
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.3"
+    enhanced-resolve "^5.9.2"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

x-ref:
- https://github.com/vercel/next.js/issues/17273
- https://github.com/vercel/next.js/pull/17429
- https://github.com/vercel/next.js/pull/33995
- https://github.com/vercel/next.js/issues/35275
- https://github.com/webpack/webpack/issues/12960

Previously, a critical bug was reported to webpack exactly a year ago (https://github.com/webpack/webpack/issues/12960), that webpack will emit incorrect code when encountering optional chaining. To fix the issue, Next.js forces transpile away nullish operator and optional chaining.

The issue has been fixed by upstream in https://github.com/webpack/webpack/pull/15327 and is released in https://github.com/webpack/webpack/releases/tag/v5.71.0. 

The PR bump webpack to `5.71.0` and the workaround can actually be removed.
