### PR TITLE
fix: toBeInTheDocument is not a function

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -439,6 +439,7 @@ For example, we can add a test to check if the `<Home />` component successfully
 
 import { render, screen } from '@testing-library/react'
 import Home from '../pages/index'
+import '@testing-library/jest-dom'
 
 describe('Home', () => {
   it('renders a heading', () => {


### PR DESCRIPTION
fix when run jest with error "TypeError: expect(...).toBeInTheDocument is not a function"



![image](https://user-images.githubusercontent.com/13283837/161903133-501f6f6b-8623-4b1f-986f-0faa32b3ef91.png)

## Feature
- [x] Documentation added

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
