### PR TITLE
Fix data encoder and decoder to use `stream` in renderer

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -778,7 +778,7 @@ if (process.env.__NEXT_RSC) {
       if (serialized) {
         const readable = new ReadableStream({
           start(controller) {
-            controller.enqueue(new TextEncoder().encode(serialized))
+            controller.enqueue(encoder.encode(serialized))
             controller.close()
           },
         })

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1461,15 +1461,19 @@ export async function renderToHTML(
             // If it's a server component with the Node.js runtime, we also
             // statically generate the page data.
             let data = ''
+
             const readable = serverComponentsPageDataTransformStream.readable
             const reader = readable.getReader()
+            const textDecoder = new TextDecoder()
+
             while (true) {
               const { done, value } = await reader.read()
               if (done) {
                 break
               }
-              data += decodeText(value)
+              data += decodeText(value, textDecoder)
             }
+
             ;(renderOpts as any).pageData = {
               ...(renderOpts as any).pageData,
               __flight__: data,


### PR DESCRIPTION
There are several places where the decoder should have `stream: true`. Also changed the `encodeText(extraChunk + decodeText(chunk))` pattern to just emit two chunks.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
