### PR TITLE
Export RouterContext

### DIFF
--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -5,6 +5,8 @@ import type { NextRouter } from '../shared/lib/router/router'
 import { RouterContext } from '../shared/lib/router-context'
 import isError from '../lib/is-error'
 
+export { RouterContext }
+
 type ClassArguments<T> = T extends new (...args: infer U) => any ? U : any
 
 type RouterArgs = ClassArguments<typeof Router>


### PR DESCRIPTION
Just a one-line change to export `RouterContext` so that it can be passed to `@react-three/drei`'s `useContextBridge` (and any other reconciler's context bridge) see https://github.com/pmndrs/drei#usecontextbridge

Cheers