### PR TITLE
Add test case for module resolution in node_modules from different contexts

### DIFF
--- a/packages/next/build/webpack/loaders/next-flight-client-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-client-loader.ts
@@ -87,9 +87,11 @@ async function parseModuleInfo(
         } = node
         // exports.xxx = xxx
         if (
+          left &&
+          left.object &&
           left.type === 'MemberExpression' &&
-          left?.object.type === 'Identifier' &&
-          left.object?.value === 'exports'
+          left.object.type === 'Identifier' &&
+          left.object.value === 'exports'
         ) {
           addExportNames(names, left.property)
         }

--- a/test/integration/react-streaming-and-server-components/app/components/random-module-instance.client.js
+++ b/test/integration/react-streaming-and-server-components/app/components/random-module-instance.client.js
@@ -1,0 +1,5 @@
+import { random } from 'random-module-instance'
+
+export default function () {
+  return `node_modules instance from .client.js:${random}`
+}

--- a/test/integration/react-streaming-and-server-components/app/node_modules/random-module-instance/index.js
+++ b/test/integration/react-streaming-and-server-components/app/node_modules/random-module-instance/index.js
@@ -1,0 +1,1 @@
+exports.random = ~~(Math.random() * 1e5)

--- a/test/integration/react-streaming-and-server-components/app/node_modules/random-module-instance/package.json
+++ b/test/integration/react-streaming-and-server-components/app/node_modules/random-module-instance/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "random-module-instance",
+  "main": "./index.js"
+}

--- a/test/integration/react-streaming-and-server-components/app/pages/shared.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/shared.server.js
@@ -1,13 +1,22 @@
 import ClientFromDirect from '../components/client.client'
 import ClientFromShared from '../components/shared'
 import SharedFromClient from '../components/shared.client'
+import Random from '../components/random-module-instance.client'
+
+import { random } from 'random-module-instance'
 
 export default function Page() {
   // All three client components should be rendered correctly, but only
   // shared component is a server component, and another is a client component.
   // These two shared components should be created as two module instances.
+
+  // It's expected to have hydration mismatch here.
   return (
-    <div id="main">
+    <div id="main" suppressHydrationWarning>
+      <Random />
+      <br />
+      {`node_modules instance from .server.js:` + random}
+      <br />
       <ClientFromDirect />
       <br />
       <ClientFromShared />

--- a/test/integration/react-streaming-and-server-components/test/rsc.js
+++ b/test/integration/react-streaming-and-server-components/test/rsc.js
@@ -64,6 +64,15 @@ export default function (context, { runtime, env }) {
     expect(sharedServerModule[0][1]).toBe(sharedServerModule[1][1])
     expect(sharedClientModule[0][1]).toBe(sharedClientModule[1][1])
     expect(sharedServerModule[0][1]).not.toBe(sharedClientModule[0][1])
+
+    // Should import 2 module instances for node_modules too.
+    const modFromClient = main.match(
+      /node_modules instance from \.client\.js:(\d+)/
+    )
+    const modFromServer = main.match(
+      /node_modules instance from \.server\.js:(\d+)/
+    )
+    expect(modFromClient[1]).not.toBe(modFromServer[1])
   })
 
   it('should support next/link in server components', async () => {


### PR DESCRIPTION
The same module should be created as 2 instances if it's imported from different contexts (server or client).

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
