### PR TITLE
Mention HTTP 303 See Other in redirects section

### DIFF
--- a/docs/api-reference/next/server.md
+++ b/docs/api-reference/next/server.md
@@ -164,6 +164,8 @@ The introduction of the `307` status code means that the request method is prese
 
 The `redirect()` method uses a `307` by default, instead of a `302` temporary redirect, meaning your requests will _always_ be preserved as `POST` requests.
 
+If you want to cause a `GET` request in response a `POST` request, use [HTTP 303 See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303)
+
 ### How do I access Environment Variables?
 
 `process.env` can be used to access [Environment Variables](/docs/basic-features/environment-variables.md) from Middleware. These are evaluated at build time, so only environment variables _actually_ used will be included.

--- a/docs/api-reference/next/server.md
+++ b/docs/api-reference/next/server.md
@@ -164,7 +164,9 @@ The introduction of the `307` status code means that the request method is prese
 
 The `redirect()` method uses a `307` by default, instead of a `302` temporary redirect, meaning your requests will _always_ be preserved as `POST` requests.
 
-If you want to cause a `GET` request in response a `POST` request, use [HTTP 303 See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303)
+If you want to cause a `GET` response to a `POST` request, use `303`.
+
+[Learn more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections) about HTTP Redirects.
 
 ### How do I access Environment Variables?
 


### PR DESCRIPTION
Migrating from express to nextjs API routes broke one of our APIs because of how `redirect` works in nextjs vs. how it works in express. We need to redirect the user to a confirmation page via GET after making a POST request, which is not possible with `redirect`.

HTTP 303 seems to be the way to go in that case and I think it should be mentioned here.


## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
