### PR TITLE
Add docs for x-nextjs-cache header

### DIFF
--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -83,7 +83,7 @@ export async function getStaticProps() {
 
 Learn more about [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md)
 
-The current cache status of a page leveraging ISR can be seen through the `x-nextjs-cache` header. When a path is first generated and not available in the cache the header will be `MISS`, when a path is in the cache but is past the revalidate period it will be updated in the background and the header will be `STALE`, or when a path is in the cache and has not passed the revalidate period the header will be `HIT`.
+The current cache status of a page leveraging ISR can be seen through the `x-nextjs-cache` header. When a path is first generated and not available in the cache the header will be `MISS`, when a path is in the cache but is past the revalidate time it will be updated in the background and the header will be `STALE`, or when a path is in the cache and has not passed the revalidate time the header will be `HIT`.
 
 ### `notFound`
 

--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -83,6 +83,8 @@ export async function getStaticProps() {
 
 Learn more about [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md)
 
+The current cache status of a page leveraging ISR can be seen through the `x-nextjs-cache` header. When a path is first generated and not available in the cache the header will be `MISS`, when a path is in the cache but is past the revalidate period it will be updated in the background and the header will be `STALE`, or when a path is in the cache and has not passed the revalidate period the header will be `HIT`.
+
 ### `notFound`
 
 The `notFound` boolean allows the page to return a `404` status and [404 Page](/docs/advanced-features/custom-error-page.md#404-page). With `notFound: true`, the page will return a `404` even if there was a successfully generated page before. This is meant to support use cases like user-generated content getting removed by its author. Note, `notFound` follows the same `revalidate` behavior [described here](/docs/api-reference/data-fetching/get-static-props.md#revalidate)

--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -85,7 +85,7 @@ Learn more about [Incremental Static Regeneration](/docs/basic-features/data-fet
 
 The cache status of a page leveraging ISR can be determined by reading the value of the `x-nextjs-cache` response header. The possible values are the following:
 
-- `MISS` - the is not in the cache (occurs at most once, on the first visit)
+- `MISS` - the path is not in the cache (occurs at most once, on the first visit)
 - `STALE` - the path is in the cache but exceeded the revalidate time so it will be updated in the background
 - `HIT` - the path is in the cache and has not exceeded the revalidate time
 

--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -83,7 +83,11 @@ export async function getStaticProps() {
 
 Learn more about [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md)
 
-The current cache status of a page leveraging ISR can be seen through the `x-nextjs-cache` header. When a path is first generated and not available in the cache the header will be `MISS`, when a path is in the cache but is passed the revalidate time it will be updated in the background and the header will be `STALE`, or when a path is in the cache and has not passed the revalidate time the header will be `HIT`.
+The cache status of a page leveraging ISR can be determined by reading the value of the `x-nextjs-cache` response header. The possible values are the following:
+
+- `MISS` - the is not in the cache (occurs at most once, on the first visit)
+- `STALE` - the path is in the cache but exceeded the revalidate time so it will be updated in the background
+-  `HIT` - the path is in the cache and has not exceeded the revalidate time
 
 ### `notFound`
 

--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -83,7 +83,7 @@ export async function getStaticProps() {
 
 Learn more about [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md)
 
-The current cache status of a page leveraging ISR can be seen through the `x-nextjs-cache` header. When a path is first generated and not available in the cache the header will be `MISS`, when a path is in the cache but is past the revalidate time it will be updated in the background and the header will be `STALE`, or when a path is in the cache and has not passed the revalidate time the header will be `HIT`.
+The current cache status of a page leveraging ISR can be seen through the `x-nextjs-cache` header. When a path is first generated and not available in the cache the header will be `MISS`, when a path is in the cache but is passed the revalidate time it will be updated in the background and the header will be `STALE`, or when a path is in the cache and has not passed the revalidate time the header will be `HIT`.
 
 ### `notFound`
 

--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -87,7 +87,7 @@ The cache status of a page leveraging ISR can be determined by reading the value
 
 - `MISS` - the is not in the cache (occurs at most once, on the first visit)
 - `STALE` - the path is in the cache but exceeded the revalidate time so it will be updated in the background
--  `HIT` - the path is in the cache and has not exceeded the revalidate time
+- `HIT` - the path is in the cache and has not exceeded the revalidate time
 
 ### `notFound`
 

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -422,7 +422,11 @@ The following describes the caching algorithm for the default [loader](#loader).
 
 Images are optimized dynamically upon request and stored in the `<distDir>/cache/images` directory. The optimized image file will be served for subsequent requests until the expiration is reached. When a request is made that matches a cached but expired file, the expired image is served stale immediately. Then the image is optimized again in the background (also called revalidation) and saved to the cache with the new expiration date.
 
-A `x-nextjs-cache` header is exposed which signals if the image was served from cache and not expired (`HIT`), if the image is served from cache but expired and will be updated in the background (`STALE`), or if the image is being requested for the first and was not yet in the cache (`MISS`).
+The cache status of an image can be determined by reading the value of the `x-nextjs-cache` response header. The possible values are the following:
+	
+- `MISS` - the is not in the cache (occurs at most once, on the first visit)
+- `STALE` - the path is in the cache but exceeded the revalidate time so it will be updated in the background
+-  `HIT` - the path is in the cache and has not exceeded the revalidate time
 
 The expiration (or rather Max Age) is defined by either the [`minimumCacheTTL`](#minimum-cache-ttl) configuration or the upstream server's `Cache-Control` header, whichever is larger. Specifically, the `max-age` value of the `Cache-Control` header is used. If both `s-maxage` and `max-age` are found, then `s-maxage` is preferred.
 

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -423,10 +423,10 @@ The following describes the caching algorithm for the default [loader](#loader).
 Images are optimized dynamically upon request and stored in the `<distDir>/cache/images` directory. The optimized image file will be served for subsequent requests until the expiration is reached. When a request is made that matches a cached but expired file, the expired image is served stale immediately. Then the image is optimized again in the background (also called revalidation) and saved to the cache with the new expiration date.
 
 The cache status of an image can be determined by reading the value of the `x-nextjs-cache` response header. The possible values are the following:
-	
+
 - `MISS` - the is not in the cache (occurs at most once, on the first visit)
 - `STALE` - the path is in the cache but exceeded the revalidate time so it will be updated in the background
--  `HIT` - the path is in the cache and has not exceeded the revalidate time
+- `HIT` - the path is in the cache and has not exceeded the revalidate time
 
 The expiration (or rather Max Age) is defined by either the [`minimumCacheTTL`](#minimum-cache-ttl) configuration or the upstream server's `Cache-Control` header, whichever is larger. Specifically, the `max-age` value of the `Cache-Control` header is used. If both `s-maxage` and `max-age` are found, then `s-maxage` is preferred.
 

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -424,7 +424,7 @@ Images are optimized dynamically upon request and stored in the `<distDir>/cache
 
 The cache status of an image can be determined by reading the value of the `x-nextjs-cache` response header. The possible values are the following:
 
-- `MISS` - the is not in the cache (occurs at most once, on the first visit)
+- `MISS` - the path is not in the cache (occurs at most once, on the first visit)
 - `STALE` - the path is in the cache but exceeded the revalidate time so it will be updated in the background
 - `HIT` - the path is in the cache and has not exceeded the revalidate time
 

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -422,6 +422,8 @@ The following describes the caching algorithm for the default [loader](#loader).
 
 Images are optimized dynamically upon request and stored in the `<distDir>/cache/images` directory. The optimized image file will be served for subsequent requests until the expiration is reached. When a request is made that matches a cached but expired file, the expired image is served stale immediately. Then the image is optimized again in the background (also called revalidation) and saved to the cache with the new expiration date.
 
+A `x-nextjs-cache` header is exposed which signals if the image was served from cache and not expired (`HIT`), if the image is served from cache but expired and will be updated in the background (`STALE`), or if the image is being requested for the first and was not yet in the cache (`MISS`).
+
 The expiration (or rather Max Age) is defined by either the [`minimumCacheTTL`](#minimum-cache-ttl) configuration or the upstream server's `Cache-Control` header, whichever is larger. Specifically, the `max-age` value of the `Cache-Control` header is used. If both `s-maxage` and `max-age` are found, then `s-maxage` is preferred.
 
 - You can configure [`minimumCacheTTL`](#minimum-cache-ttl) to increase the cache duration when the upstream image does not include `Cache-Control` header or the value is very low.


### PR DESCRIPTION
This adds documentation for the `x-nextjs-cache` header which is now exposed for ISR pages and image optimization requests to help signal the cache state. 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
