### PR TITLE
add support for changing /route/#hashes

### DIFF
--- a/examples/with-google-analytics/pages/_app.js
+++ b/examples/with-google-analytics/pages/_app.js
@@ -10,8 +10,10 @@ const App = ({ Component, pageProps }) => {
       gtag.pageview(url)
     }
     router.events.on('routeChangeComplete', handleRouteChange)
+    router.events.on('hashChangeComplete', handleRouteChange)
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange)
+      router.events.off('hashChangeComplete', handleRouteChange)
     }
   }, [router.events])
 


### PR DESCRIPTION
update with-google-analytics example to also fire events when the hash section of the URL changes.