### PR TITLE
docs: failed-loading-swc possible fix for Windows users

### DIFF
--- a/errors/failed-loading-swc.md
+++ b/errors/failed-loading-swc.md
@@ -10,6 +10,8 @@ SWC requires a binary be downloaded that is compatible specific to your system. 
 
 When on an M1 Mac and switching from a Node.js version without M1 support e.g. v14 to a version with e.g. v16, you may need a different swc dependency which can require re-installing `node_modules` (`npm i --force` or `yarn install --force`).
 
+On Windows make sure you have Microsoft Visual C++ Redistributable installed. https://aka.ms/vs/17/release/vc_redist.x64.exe
+
 Alternatively, you might need to allow optional packages to be installed by your package manager (remove `--no-optional` flag) for the package to download correctly.
 
 If SWC continues to fail to load you can opt-out by disabling `swcMinify` in your `next.config.js` or by adding a `.babelrc` to your project with the following content:

--- a/errors/failed-loading-swc.md
+++ b/errors/failed-loading-swc.md
@@ -10,7 +10,7 @@ SWC requires a binary be downloaded that is compatible specific to your system. 
 
 When on an M1 Mac and switching from a Node.js version without M1 support e.g. v14 to a version with e.g. v16, you may need a different swc dependency which can require re-installing `node_modules` (`npm i --force` or `yarn install --force`).
 
-On Windows make sure you have Microsoft Visual C++ Redistributable installed. https://aka.ms/vs/17/release/vc_redist.x64.exe
+On Windows make sure you have Microsoft Visual C++ Redistributable installed. https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
 
 Alternatively, you might need to allow optional packages to be installed by your package manager (remove `--no-optional` flag) for the package to download correctly.
 


### PR DESCRIPTION
Apparently, Microsoft Visual C++ Redistributable is required for Windows users. 

> The issue is because the package is failing due to a missing library on the computer. fs-search requires Microsoft Visual C++ 2015 Redistributable (x64).
> You can get the download here -> https://aka.ms/vs/17/release/vc_redist.x64.exe

from https://stackoverflow.com/questions/69859120/the-specified-module-could-not-be-found-d-next-js-firstapp-node-modules-n

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
