### PR TITLE
initialProps redundant problem fix

### DIFF
--- a/docs/advanced-features/custom-document.md
+++ b/docs/advanced-features/custom-document.md
@@ -71,7 +71,9 @@ class MyDocument extends Document {
     // Run the parent `getInitialProps`, it now includes the custom `renderPage`
     const initialProps = await Document.getInitialProps(ctx)
 
-    return initialProps
+    return (
+        initialProps
+    );
   }
 
   render() {
@@ -103,7 +105,9 @@ class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx)
 
-    return initialProps
+    return (
+        initialProps
+    );
   }
 }
 


### PR DESCRIPTION
I referred to the ``Custom Document`` page of the ``next.js document`` for the ``_document.tsx`` setting.
However, copied and used the code on the ``customized render page``, there was one problem.

My IDE has displayed this kind of notification ``Local variable 'initialProps' is redundant ``

This is how I fixed the problem. ⬇️  ⬇️
``
return initialProps;
``  ->  ``
return (
        initialProps
    );
``

<img width="835" alt="Screen Shot 2022-04-12 at 2 07 09 PM" src="https://user-images.githubusercontent.com/67637706/162900794-e186eb3f-cc1e-4ca8-910c-e2eb6c1083d6.png">

The same problem was also identified in versions ``React 17`` and ``React 18``.