### PR TITLE
docs: specify minimum required `react` version

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -12,7 +12,7 @@ The minimum Node.js version has been bumped from 12.0.0 to 12.22.0 which is the 
 
 ### Upgrade React version to latest
 
-To upgrade you can run the following command:
+The minimum required React version is `17.0.2`. To upgrade you can run the following command in the terminal:
 
 ```
 npm install react@latest react-dom@latest


### PR DESCRIPTION
Fixes #36041

This might be a useful addition in light of third-party lib issues around React 18, even if Next.js itself does not concern itself with those issues.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
