### PR TITLE
Validate @types/react by fs API as it has exports fields

### DIFF
--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -34,8 +34,12 @@ function isValidSeverity(severity: string): severity is Severity {
 }
 
 const requiredPackages = [
-  { file: 'eslint', pkg: 'eslint' },
-  { file: 'eslint-config-next', pkg: 'eslint-config-next' },
+  { file: 'eslint', pkg: 'eslint', exportsRestrict: false },
+  {
+    file: 'eslint-config-next',
+    pkg: 'eslint-config-next',
+    exportsRestrict: false,
+  },
 ]
 
 async function cliPrompt() {

--- a/packages/next/lib/has-necessary-dependencies.ts
+++ b/packages/next/lib/has-necessary-dependencies.ts
@@ -1,6 +1,10 @@
+import { existsSync } from 'fs'
+import { join, relative } from 'path'
+
 export interface MissingDependency {
   file: string
   pkg: string
+  exportsRestrict: boolean
 }
 
 export type NecessaryDependencies = {
@@ -15,7 +19,24 @@ export async function hasNecessaryDependencies(
   let resolutions = new Map<string, string>()
   const missingPackages = requiredPackages.filter((p) => {
     try {
-      resolutions.set(p.pkg, require.resolve(p.file, { paths: [baseDir] }))
+      if (p.exportsRestrict) {
+        const pkgPath = require.resolve(`${p.pkg}/package.json`, {
+          paths: [baseDir],
+        })
+        const fileNameToVerify = relative(p.pkg, p.file)
+        if (fileNameToVerify) {
+          const fileToVerify = join(pkgPath, '..', fileNameToVerify)
+          if (existsSync(fileToVerify)) {
+            resolutions.set(p.pkg, join(pkgPath, '..'))
+          } else {
+            return true
+          }
+        } else {
+          resolutions.set(p.pkg, pkgPath)
+        }
+      } else {
+        resolutions.set(p.pkg, require.resolve(p.file, { paths: [baseDir] }))
+      }
       return false
     } catch (_) {
       return true

--- a/packages/next/lib/verify-partytown-setup.ts
+++ b/packages/next/lib/verify-partytown-setup.ts
@@ -61,7 +61,13 @@ export async function verifyPartytownSetup(
   try {
     const partytownDeps: NecessaryDependencies = await hasNecessaryDependencies(
       dir,
-      [{ file: '@builder.io/partytown', pkg: '@builder.io/partytown' }]
+      [
+        {
+          file: '@builder.io/partytown',
+          pkg: '@builder.io/partytown',
+          exportsRestrict: false,
+        },
+      ]
     )
 
     if (partytownDeps.missing?.length > 0) {

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -17,9 +17,17 @@ import { missingDepsError } from './typescript/missingDependencyError'
 import { NextConfigComplete } from '../server/config-shared'
 
 const requiredPackages = [
-  { file: 'typescript', pkg: 'typescript' },
-  { file: '@types/react/index.d.ts', pkg: '@types/react' },
-  { file: '@types/node/index.d.ts', pkg: '@types/node' },
+  { file: 'typescript', pkg: 'typescript', exportsRestrict: false },
+  {
+    file: '@types/react/index.d.ts',
+    pkg: '@types/react',
+    exportsRestrict: true,
+  },
+  {
+    file: '@types/node/index.d.ts',
+    pkg: '@types/node',
+    exportsRestrict: false,
+  },
 ]
 
 export async function verifyTypeScriptSetup(


### PR DESCRIPTION
`@types/react` published with `exports` field in package.json.

The `require.resolve('@react/types/index.d.ts')` expression will throw with `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './index.d.ts' is not defined by "exports" in /Users/longyinan/workspace/test/with-typescript-app/node_modules/@types/react/package.json`

fixes #36085