### PR TITLE
fix(next-url): print properly using logger symbol

### DIFF
--- a/packages/next/server/web/next-url.ts
+++ b/packages/next/server/web/next-url.ts
@@ -245,6 +245,23 @@ export class NextURL {
     return this.href
   }
 
+  [Symbol.for('edge-runtime.inspect.custom')]() {
+    return {
+      href: this.href,
+      origin: this.origin,
+      protocol: this.protocol,
+      username: this.username,
+      password: this.password,
+      host: this.host,
+      hostname: this.hostname,
+      port: this.port,
+      pathname: this.pathname,
+      search: this.search,
+      searchParams: this.searchParams,
+      hash: this.hash,
+    }
+  }
+
   clone() {
     return new NextURL(String(this), this[Internal].options)
   }


### PR DESCRIPTION
Hello,

This PR adds a method to have a custom inspect for `NextURL`

closes #35519