### PR TITLE
rsc: remove router injection

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -741,7 +741,7 @@ export async function renderToHTML(
     AppTree: (props: any) => {
       return (
         <AppContainerWithIsomorphicFiberStructure>
-          {renderFlight(AppMod, ComponentMod, { ...props, router })}
+          {renderFlight(AppMod, ComponentMod, props)}
         </AppContainerWithIsomorphicFiberStructure>
       )
     },
@@ -1216,7 +1216,7 @@ export async function renderToHTML(
 
   // Pass router to the Server Component as a temporary workaround.
   if (isServerComponent) {
-    props.pageProps = Object.assign({}, props.pageProps, { router })
+    props.pageProps = Object.assign({}, props.pageProps)
   }
 
   // the response might be finished on the getInitialProps call

--- a/test/integration/react-streaming-and-server-components/app/pages/index.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/index.server.js
@@ -3,11 +3,10 @@ import Nav from '../components/nav'
 const envVar = process.env.ENV_VAR_TEST
 const headerKey = 'x-next-test-client'
 
-export default function Index({ header, router }) {
+export default function Index({ header }) {
   return (
     <div>
       <h1>{`component:index.server`}</h1>
-      <div>{'path:' + router.pathname}</div>
       <div>{'env:' + envVar}</div>
       <div>{'header:' + header}</div>
       <Nav />

--- a/test/integration/react-streaming-and-server-components/app/pages/next-api/link.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/next-api/link.server.js
@@ -1,9 +1,8 @@
 import Link from 'next/link'
 import Nav from '../../components/nav'
 
-export default function LinkPage({ router }) {
-  const { query } = router
-  const id = parseInt(query.id || '0', 10)
+export default function LinkPage({ queryId }) {
+  const id = parseInt(queryId)
   return (
     <>
       <h3 id="query">query:{id}</h3>
@@ -17,6 +16,10 @@ export default function LinkPage({ router }) {
   )
 }
 
-export const config = {
-  runtime: 'edge',
+export function getServerSideProps({ query }) {
+  return {
+    props: {
+      queryId: query.id || '0',
+    },
+  }
 }

--- a/test/integration/react-streaming-and-server-components/app/pages/routes/[dynamic].server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/routes/[dynamic].server.js
@@ -1,7 +1,11 @@
-export default function Pid({ router }) {
-  return <div>{`query: ${router.query.dynamic}`}</div>
+export default function Pid({ text }) {
+  return <div>{`query: ${text}`}</div>
 }
 
-export const config = {
-  runtime: 'edge',
+export function getServerSideProps({ params }) {
+  return {
+    props: {
+      text: params.dynamic,
+    },
+  }
 }

--- a/test/integration/react-streaming-and-server-components/test/rsc.js
+++ b/test/integration/react-streaming-and-server-components/test/rsc.js
@@ -19,7 +19,6 @@ export default function (context, { runtime, env }) {
     expect(homeHTML).toContain('component:index.server')
     expect(homeHTML).toContain('env:env_var_test')
     expect(homeHTML).toContain('header:test-util')
-    expect(homeHTML).toContain('path:/')
   })
 
   it('should reuse the inline flight response without sending extra requests', async () => {


### PR DESCRIPTION
Remove `router` injection for RSC page, recommend to access `query` or `params` through `getServerSideProps`, so that we can:
* keep aligned with normal next pages
* avoid static optimization for pages that require url query information