### PR TITLE
Add experimental onlyGenereated flag for unstable_revalidate

### DIFF
--- a/packages/next/server/api-utils/index.ts
+++ b/packages/next/server/api-utils/index.ts
@@ -79,12 +79,12 @@ export function checkIsManualRevalidate(
   previewProps: __ApiPreviewProps
 ): {
   isManualRevalidate: boolean
-  revalidateIfGenerated: boolean
+  revalidateOnlyGenerated: boolean
 } {
   return {
     isManualRevalidate:
       req.headers[PRERENDER_REVALIDATE_HEADER] === previewProps.previewModeId,
-    revalidateIfGenerated:
+    revalidateOnlyGenerated:
       !!req.headers[PRERENDER_REVALIDATE_IF_GENERATED_HEADER],
   }
 }

--- a/packages/next/server/api-utils/index.ts
+++ b/packages/next/server/api-utils/index.ts
@@ -71,7 +71,7 @@ export function redirect(
 }
 
 export const PRERENDER_REVALIDATE_HEADER = 'x-prerender-revalidate'
-export const PRERENDER_REVALIDATE_IF_GENERATED_HEADER =
+export const PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER =
   'x-prerender-revalidate-if-generated'
 
 export function checkIsManualRevalidate(
@@ -85,7 +85,7 @@ export function checkIsManualRevalidate(
     isManualRevalidate:
       req.headers[PRERENDER_REVALIDATE_HEADER] === previewProps.previewModeId,
     revalidateOnlyGenerated:
-      !!req.headers[PRERENDER_REVALIDATE_IF_GENERATED_HEADER],
+      !!req.headers[PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER],
   }
 }
 

--- a/packages/next/server/api-utils/index.ts
+++ b/packages/next/server/api-utils/index.ts
@@ -71,12 +71,22 @@ export function redirect(
 }
 
 export const PRERENDER_REVALIDATE_HEADER = 'x-prerender-revalidate'
+export const PRERENDER_REVALIDATE_IF_GENERATED_HEADER =
+  'x-prerender-revalidate-if-generated'
 
 export function checkIsManualRevalidate(
   req: IncomingMessage | BaseNextRequest,
   previewProps: __ApiPreviewProps
-): boolean {
-  return req.headers[PRERENDER_REVALIDATE_HEADER] === previewProps.previewModeId
+): {
+  isManualRevalidate: boolean
+  revalidateIfGenerated: boolean
+} {
+  return {
+    isManualRevalidate:
+      req.headers[PRERENDER_REVALIDATE_HEADER] === previewProps.previewModeId,
+    revalidateIfGenerated:
+      !!req.headers[PRERENDER_REVALIDATE_IF_GENERATED_HEADER],
+  }
 }
 
 export const COOKIE_NAME_PRERENDER_BYPASS = `__prerender_bypass`

--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { NextApiRequest, NextApiResponse } from '../../shared/lib/utils'
 import type { PageConfig } from 'next/types'
-import type { __ApiPreviewProps } from '.'
+import { PRERENDER_REVALIDATE_IF_GENERATED_HEADER, __ApiPreviewProps } from '.'
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import type { CookieSerializeOptions } from 'next/dist/compiled/cookie'
 import type { PreviewData } from 'next/types'
@@ -233,8 +233,12 @@ export async function apiResolver(
     apiRes.setPreviewData = (data, options = {}) =>
       setPreviewData(apiRes, data, Object.assign({}, apiContext, options))
     apiRes.clearPreviewData = () => clearPreviewData(apiRes)
-    apiRes.unstable_revalidate = (urlPath: string) =>
-      unstable_revalidate(urlPath, req, apiContext)
+    apiRes.unstable_revalidate = (
+      urlPath: string,
+      opts?: {
+        unstable_ifGenerated?: boolean
+      }
+    ) => unstable_revalidate(urlPath, opts || {}, req, apiContext)
 
     const resolver = interopDefault(resolverModule)
     let wasPiped = false
@@ -279,6 +283,9 @@ export async function apiResolver(
 
 async function unstable_revalidate(
   urlPath: string,
+  opts: {
+    unstable_ifGenerated?: boolean
+  },
   req: IncomingMessage,
   context: ApiContext
 ) {
@@ -287,12 +294,20 @@ async function unstable_revalidate(
       `Invalid urlPath provided to revalidate(), must be a path e.g. /blog/post-1, received ${urlPath}`
     )
   }
+  const revalidateHeaders = {
+    [PRERENDER_REVALIDATE_HEADER]: context.previewModeId,
+    ...(opts.unstable_ifGenerated
+      ? {
+          [PRERENDER_REVALIDATE_IF_GENERATED_HEADER]: '1',
+        }
+      : {}),
+  }
 
   try {
     if (context.trustHostHeader) {
       const res = await fetch(`https://${req.headers.host}${urlPath}`, {
         headers: {
-          [PRERENDER_REVALIDATE_HEADER]: context.previewModeId,
+          ...revalidateHeaders,
           cookie: req.headers.cookie || '',
         },
       })
@@ -302,7 +317,10 @@ async function unstable_revalidate(
       const cacheHeader =
         res.headers.get('x-vercel-cache') || res.headers.get('x-nextjs-cache')
 
-      if (cacheHeader?.toUpperCase() !== 'REVALIDATED') {
+      if (
+        cacheHeader?.toUpperCase() !== 'REVALIDATED' &&
+        !(res.status === 404 && opts.unstable_ifGenerated)
+      ) {
         throw new Error(`Invalid response ${res.status}`)
       }
     } else if (context.revalidate) {
@@ -310,18 +328,15 @@ async function unstable_revalidate(
         req: mockReq,
         res: mockRes,
         streamPromise,
-      } = mockRequest(
-        urlPath,
-        {
-          [PRERENDER_REVALIDATE_HEADER]: context.previewModeId,
-        },
-        'GET'
-      )
+      } = mockRequest(urlPath, revalidateHeaders, 'GET')
       await context.revalidate(mockReq, mockRes)
       await streamPromise
 
-      if (mockRes.getHeader('x-nextjs-cache') !== 'REVALIDATED') {
-        throw new Error(`Invalid response ${mockRes.status}`)
+      if (
+        mockRes.getHeader('x-nextjs-cache') !== 'REVALIDATED' &&
+        !(mockRes.statusCode === 404 && opts.unstable_ifGenerated)
+      ) {
+        throw new Error(`Invalid response ${mockRes.statusCode}`)
       }
     } else {
       throw new Error(

--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -236,7 +236,7 @@ export async function apiResolver(
     apiRes.unstable_revalidate = (
       urlPath: string,
       opts?: {
-        unstable_ifGenerated?: boolean
+        unstable_onlyGenerated?: boolean
       }
     ) => unstable_revalidate(urlPath, opts || {}, req, apiContext)
 
@@ -284,7 +284,7 @@ export async function apiResolver(
 async function unstable_revalidate(
   urlPath: string,
   opts: {
-    unstable_ifGenerated?: boolean
+    unstable_onlyGenerated?: boolean
   },
   req: IncomingMessage,
   context: ApiContext
@@ -296,7 +296,7 @@ async function unstable_revalidate(
   }
   const revalidateHeaders = {
     [PRERENDER_REVALIDATE_HEADER]: context.previewModeId,
-    ...(opts.unstable_ifGenerated
+    ...(opts.unstable_onlyGenerated
       ? {
           [PRERENDER_REVALIDATE_IF_GENERATED_HEADER]: '1',
         }
@@ -319,7 +319,7 @@ async function unstable_revalidate(
 
       if (
         cacheHeader?.toUpperCase() !== 'REVALIDATED' &&
-        !(res.status === 404 && opts.unstable_ifGenerated)
+        !(res.status === 404 && opts.unstable_onlyGenerated)
       ) {
         throw new Error(`Invalid response ${res.status}`)
       }
@@ -334,7 +334,7 @@ async function unstable_revalidate(
 
       if (
         mockRes.getHeader('x-nextjs-cache') !== 'REVALIDATED' &&
-        !(mockRes.statusCode === 404 && opts.unstable_ifGenerated)
+        !(mockRes.statusCode === 404 && opts.unstable_onlyGenerated)
       ) {
         throw new Error(`Invalid response ${mockRes.statusCode}`)
       }

--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -1,7 +1,10 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { NextApiRequest, NextApiResponse } from '../../shared/lib/utils'
 import type { PageConfig } from 'next/types'
-import { PRERENDER_REVALIDATE_IF_GENERATED_HEADER, __ApiPreviewProps } from '.'
+import {
+  PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER,
+  __ApiPreviewProps,
+} from '.'
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import type { CookieSerializeOptions } from 'next/dist/compiled/cookie'
 import type { PreviewData } from 'next/types'
@@ -298,7 +301,7 @@ async function unstable_revalidate(
     [PRERENDER_REVALIDATE_HEADER]: context.previewModeId,
     ...(opts.unstable_onlyGenerated
       ? {
-          [PRERENDER_REVALIDATE_IF_GENERATED_HEADER]: '1',
+          [PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER]: '1',
         }
       : {}),
   }

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1228,13 +1228,11 @@ export default abstract class Server {
     }
 
     let isManualRevalidate = false
-    let revalidateIfGenerated = false
+    let revalidateOnlyGenerated = false
 
     if (isSSG) {
-      ;({ isManualRevalidate, revalidateIfGenerated } = checkIsManualRevalidate(
-        req,
-        this.renderOpts.previewProps
-      ))
+      ;({ isManualRevalidate, revalidateOnlyGenerated } =
+        checkIsManualRevalidate(req, this.renderOpts.previewProps))
     }
 
     // Compute the iSSG cache key. We use the rewroteUrl since
@@ -1451,7 +1449,7 @@ export default abstract class Server {
 
         // skip manual revalidate if cache is not present and
         // revalidate-if-generated is set
-        if (isManualRevalidate && revalidateIfGenerated && !hadCache) {
+        if (isManualRevalidate && revalidateOnlyGenerated && !hadCache) {
           await this.render404(req, res)
           return null
         }
@@ -1553,7 +1551,7 @@ export default abstract class Server {
     )
 
     if (!cacheEntry) {
-      if (ssgCacheKey && !(isManualRevalidate && revalidateIfGenerated)) {
+      if (ssgCacheKey && !(isManualRevalidate && revalidateOnlyGenerated)) {
         // A cache entry might not be generated if a response is written
         // in `getInitialProps` or `getServerSideProps`, but those shouldn't
         // have a cache key. If we do have a cache key but we don't end up

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -256,7 +256,7 @@ export type NextApiResponse<T = any> = ServerResponse & {
   unstable_revalidate: (
     urlPath: string,
     opts?: {
-      unstable_ifGenerated?: boolean
+      unstable_onlyGenerated?: boolean
     }
   ) => Promise<void>
 }

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -253,7 +253,12 @@ export type NextApiResponse<T = any> = ServerResponse & {
   ) => NextApiResponse<T>
   clearPreviewData: () => NextApiResponse<T>
 
-  unstable_revalidate: (urlPath: string) => Promise<void>
+  unstable_revalidate: (
+    urlPath: string,
+    opts?: {
+      unstable_ifGenerated?: boolean
+    }
+  ) => Promise<void>
 }
 
 /**

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2008,13 +2008,13 @@ describe('Prerender', () => {
         expect(res4.headers.get('x-nextjs-cache')).toMatch(/(HIT|STALE)/)
       })
 
-      it('should not manual revalidate for fallback: blocking with ifGenerated if not generated', async () => {
+      it('should not manual revalidate for fallback: blocking with onlyGenerated if not generated', async () => {
         const res = await fetchViaHTTP(
           next.url,
           '/api/manual-revalidate',
           {
             pathname: '/blocking-fallback/test-if-generated-1',
-            ifGenerated: '1',
+            onlyGenerated: '1',
           },
           { redirect: 'manual' }
         )
@@ -2035,7 +2035,7 @@ describe('Prerender', () => {
         expect(next.cliOutput).toContain(`getStaticProps test-if-generated-1`)
       })
 
-      it('should manual revalidate for fallback: blocking with ifGenerated if generated', async () => {
+      it('should manual revalidate for fallback: blocking with onlyGenerated if generated', async () => {
         const res = await fetchViaHTTP(
           next.url,
           '/blocking-fallback/test-if-generated-2'
@@ -2062,7 +2062,7 @@ describe('Prerender', () => {
           '/api/manual-revalidate',
           {
             pathname: '/blocking-fallback/test-if-generated-2',
-            ifGenerated: '1',
+            onlyGenerated: '1',
           },
           { redirect: 'manual' }
         )

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2067,7 +2067,7 @@ describe('Prerender', () => {
           { redirect: 'manual' }
         )
 
-        expect(res2.status).toBe(200)
+        expect(res3.status).toBe(200)
         const revalidateData = await res3.json()
         expect(revalidateData.revalidated).toBe(true)
 

--- a/test/e2e/prerender/pages/api/manual-revalidate.js
+++ b/test/e2e/prerender/pages/api/manual-revalidate.js
@@ -4,7 +4,7 @@ export default async function handler(req, res) {
   let revalidated = false
   try {
     await res.unstable_revalidate(req.query.pathname, {
-      unstable_ifGenerated: !!req.query.ifGenerated,
+      unstable_onlyGenerated: !!req.query.onlyGenerated,
     })
     revalidated = true
   } catch (err) {

--- a/test/e2e/prerender/pages/api/manual-revalidate.js
+++ b/test/e2e/prerender/pages/api/manual-revalidate.js
@@ -3,7 +3,9 @@ export default async function handler(req, res) {
   // make sure to use trusted value for revalidating
   let revalidated = false
   try {
-    await res.unstable_revalidate(req.query.pathname)
+    await res.unstable_revalidate(req.query.pathname, {
+      unstable_ifGenerated: !!req.query.ifGenerated,
+    })
     revalidated = true
   } catch (err) {
     console.error(err)

--- a/test/e2e/prerender/pages/blocking-fallback/[slug].js
+++ b/test/e2e/prerender/pages/blocking-fallback/[slug].js
@@ -28,6 +28,8 @@ export async function getStaticProps({ params }) {
 
   await new Promise((resolve) => setTimeout(resolve, 1000))
 
+  console.log(`getStaticProps ${params.slug}`)
+
   return {
     props: {
       params,


### PR DESCRIPTION
This adds experimental support for only manually revalidating if a page has been generated and is in the cache e.g. skipping revalidating pages that have yet to be generated with `fallback: true`. 