### PR TITLE
Support necessary headers in the web server response

### DIFF
--- a/packages/next/server/api-utils/web.ts
+++ b/packages/next/server/api-utils/web.ts
@@ -1,0 +1,5 @@
+// Buffer.byteLength polyfill in the Edge runtime, with only utf8 strings
+// supported at the moment.
+export function byteLength(payload: string): number {
+  return new TextEncoder().encode(payload).buffer.byteLength
+}

--- a/packages/next/server/api-utils/web.ts
+++ b/packages/next/server/api-utils/web.ts
@@ -3,3 +3,26 @@
 export function byteLength(payload: string): number {
   return new TextEncoder().encode(payload).buffer.byteLength
 }
+
+// Calculate the ETag for a payload.
+export async function generateETag(payload: string) {
+  if (payload.length === 0) {
+    // fast-path empty
+    return '"0-2jmj7l5rSw0yVb/vlWAYkK/YBwk"'
+  }
+
+  // compute hash of entity
+  const hash = btoa(
+    String.fromCharCode.apply(
+      null,
+      new Uint8Array(
+        await crypto.subtle.digest('SHA-1', new TextEncoder().encode(payload))
+      ) as any
+    )
+  ).substring(0, 27)
+
+  // compute length of entity
+  const len = byteLength(payload)
+
+  return '"' + len.toString(16) + '-' + hash + '"'
+}

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1749,7 +1749,9 @@ export async function renderToHTML(
     return new RenderResult(html)
   }
 
-  return new RenderResult(chainStreams(streams))
+  return new RenderResult(
+    chainStreams(streams).pipeThrough(createBufferedTransformStream())
+  )
 }
 
 function errorToJSON(err: Error) {

--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -169,7 +169,8 @@ export default class NextWebServer extends BaseServer {
     if (options.result.isDynamic()) {
       const writer = res.transformStream.writable.getWriter()
       options.result.pipe({
-        write: (chunk: Uint8Array) => new TextDecoder().decode(chunk),
+        write: (chunk: Uint8Array) =>
+          writer.write(new TextDecoder().decode(chunk)),
         end: () => writer.close(),
         destroy: (err: Error) => writer.abort(err),
         cork: () => {},

--- a/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
+++ b/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
@@ -8,6 +8,7 @@ import {
   launchApp,
   nextBuild,
   nextStart,
+  fetchViaHTTP,
   renderViaHTTP,
   waitFor,
 } from 'next-test-utils'
@@ -249,6 +250,16 @@ describe('Switchable runtime (prod)', () => {
     expect(await browser.elementByCss('body').text()).toContain(
       'This is a static RSC page.'
     )
+  })
+
+  it('should support etag header in the web server', async () => {
+    const res = await fetchViaHTTP(context.appPort, '/edge', '', {
+      headers: {
+        // Make sure the result is static so an etag can be generated.
+        'User-Agent': 'Googlebot',
+      },
+    })
+    expect(res.headers.get('ETag')).toBeDefined()
   })
 })
 


### PR DESCRIPTION
This PR adds support of `Content-Length`, `Etag` and `X-Edge-Runtime` headers to the web server.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
