### PR TITLE
Fix only generated case in minimal mode

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1449,7 +1449,12 @@ export default abstract class Server {
 
         // skip manual revalidate if cache is not present and
         // revalidate-if-generated is set
-        if (isManualRevalidate && revalidateOnlyGenerated && !hadCache) {
+        if (
+          isManualRevalidate &&
+          revalidateOnlyGenerated &&
+          !hadCache &&
+          !this.minimalMode
+        ) {
           await this.render404(req, res)
           return null
         }

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -235,6 +235,25 @@ describe('should set-up next', () => {
     expect(props2.gspCalls).not.toBe(props.gspCalls)
   })
 
+  it('should not 404 for onlyGenerated manual revalidate in minimal mode', async () => {
+    const previewProps = JSON.parse(
+      await next.readFile('standalone/.next/prerender-manifest.json')
+    ).preview
+
+    const res = await fetchViaHTTP(
+      appPort,
+      '/optional-ssg/only-generated-1',
+      undefined,
+      {
+        headers: {
+          'x-prerender-revalidate': previewProps.previewModeId,
+          'x-prerender-revalidate-if-generated': '1',
+        },
+      }
+    )
+    expect(res.status).toBe(200)
+  })
+
   it('should set correct SWR headers with notFound gsp', async () => {
     await waitFor(2000)
     await next.patchFile('standalone/data.txt', 'show')


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/36108 this fixes a case noticed during testing where we unexpectedly render the 404 in minimal mode since no cache is present in the serverless function but we always want to be sure to render in minimal mode. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
