### PR TITLE
Fixes scripts in Electron examples.

### DIFF
--- a/examples/with-electron-typescript/.gitignore
+++ b/examples/with-electron-typescript/.gitignore
@@ -19,7 +19,6 @@
 # misc
 .DS_Store
 *.pem
-*.tsbuildinfo
 
 # debug
 npm-debug.log*

--- a/examples/with-electron-typescript/.gitignore
+++ b/examples/with-electron-typescript/.gitignore
@@ -19,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+*.tsbuildinfo
 
 # debug
 npm-debug.log*

--- a/examples/with-electron-typescript/package.json
+++ b/examples/with-electron-typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "electron-typescript-next",
+  "name": "electron-typescript-next-app",
   "version": "0.0.0",
   "private": true,
   "main": "main/index.js",

--- a/examples/with-electron-typescript/package.json
+++ b/examples/with-electron-typescript/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "electron-typescript-next-app",
-  "version": "0.0.0",
   "private": true,
   "main": "main/index.js",
   "productName": "ElectronTypescriptNext",

--- a/examples/with-electron-typescript/package.json
+++ b/examples/with-electron-typescript/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "electron-typescript-next",
+  "version": "0.0.0",
   "private": true,
   "main": "main/index.js",
   "productName": "ElectronTypescriptNext",
@@ -10,7 +12,7 @@
     "build": "npm run build-renderer && npm run build-electron",
     "pack-app": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder",
-    "type-check": "tsc"
+    "type-check": "tsc -p ./renderer/tsconfig.json && tsc -p ./electron-src/tsconfig.json"
   },
   "dependencies": {
     "electron-is-dev": "^1.1.0",
@@ -23,7 +25,7 @@
     "@types/react": "^16.9.9",
     "@types/react-dom": "^16.9.9",
     "electron": "^13",
-    "electron-builder": "^22.9.1",
+    "electron-builder": "^23.0.3",
     "next": "latest",
     "rimraf": "^3.0.0",
     "typescript": "^4.0.5"

--- a/examples/with-electron/package.json
+++ b/examples/with-electron/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "electron-next-app",
+  "version": "0.0.0",
   "private": true,
   "productName": "ElectronNext",
   "main": "main/index.js",
@@ -18,7 +20,7 @@
   },
   "devDependencies": {
     "electron": "^12.0.2",
-    "electron-builder": "^22.10.5",
+    "electron-builder": "^23.0.3",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/examples/with-electron/package.json
+++ b/examples/with-electron/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "electron-next-app",
-  "version": "0.0.0",
   "private": true,
   "productName": "ElectronNext",
   "main": "main/index.js",


### PR DESCRIPTION
There were a few issues with the scripts in the Electron examples:

* `dist` and `pack-app` would fail without a `name` and `version` in `package.json`.
* `type-check` didn't work because there isn't a `tsconfig.json` at the root. It needs to look in the `electron-src` and `renderer` folders respectively.

`electron-builder` also needed to be updated in order to run on macOS 12.3+ (see https://github.com/electron-userland/electron-builder/issues/6606). 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
