### PR TITLE
Fix req.url of rsc dynamic routes pages gSSP in edge runtime

### DIFF
--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -125,7 +125,7 @@ export default class NextWebServer extends BaseServer {
   ): Promise<RenderResult | null> {
     return renderToHTML(
       {
-        url: pathname,
+        url: req.url,
         cookies: req.cookies,
         headers: req.headers,
       } as any,

--- a/test/integration/react-streaming-and-server-components/app/pages/routes/[dynamic].server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/routes/[dynamic].server.js
@@ -1,10 +1,18 @@
-export default function Pid({ text }) {
-  return <div>{`query: ${text}`}</div>
+import { parse } from 'url'
+
+export default function Pid({ text, pathname }) {
+  return (
+    <>
+      <div>{`query: ${text}`}</div>
+      <div>{`pathname: ${pathname}`}</div>
+    </>
+  )
 }
 
-export function getServerSideProps({ params }) {
+export function getServerSideProps({ params, req }) {
   return {
     props: {
+      pathname: parse(req.url).pathname,
       text: params.dynamic,
     },
   }

--- a/test/integration/react-streaming-and-server-components/test/basic.js
+++ b/test/integration/react-streaming-and-server-components/test/basic.js
@@ -10,20 +10,6 @@ export default async function basic(context, { env }) {
     expect(pathNotFoundHTML).toContain('custom-404-page')
   })
 
-  it('should render dynamic routes correctly', async () => {
-    const dynamicRoute1HTML = await renderViaHTTP(
-      context.appPort,
-      '/routes/dynamic1'
-    )
-    const dynamicRoute2HTML = await renderViaHTTP(
-      context.appPort,
-      '/routes/dynamic2'
-    )
-
-    expect(dynamicRoute1HTML).toContain('query: dynamic1')
-    expect(dynamicRoute2HTML).toContain('query: dynamic2')
-  })
-
   it('should support api routes', async () => {
     const res = await renderViaHTTP(context.appPort, '/api/ping')
     expect(res).toContain('pong')

--- a/test/integration/react-streaming-and-server-components/test/rsc.js
+++ b/test/integration/react-streaming-and-server-components/test/rsc.js
@@ -102,6 +102,22 @@ export default function (context, { runtime, env }) {
     expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
+  it('should render dynamic routes correctly', async () => {
+    const dynamicRoute1HTML = await renderViaHTTP(
+      context.appPort,
+      '/routes/dynamic1'
+    )
+    const dynamicRoute2HTML = await renderViaHTTP(
+      context.appPort,
+      '/routes/dynamic2'
+    )
+
+    expect(dynamicRoute1HTML).toContain('query: dynamic1')
+    expect(dynamicRoute1HTML).toContain('pathname: /routes/dynamic')
+    expect(dynamicRoute2HTML).toContain('query: dynamic2')
+    expect(dynamicRoute2HTML).toContain('pathname: /routes/dynamic')
+  })
+
   it('should be able to navigate between rsc pages', async () => {
     let content
     const browser = await webdriver(context.appPort, '/')


### PR DESCRIPTION
We were feeding pathname like `/routes/[dynamic]` as `req.url` to RSC pages in edge runtime, which is not aligned with node runtime

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

