### PR TITLE
rsc: mark next head as client component

### DIFF
--- a/packages/next/build/webpack/loaders/utils.ts
+++ b/packages/next/build/webpack/loaders/utils.ts
@@ -1,6 +1,6 @@
 const defaultJsFileExtensions = ['js', 'mjs', 'jsx', 'ts', 'tsx', 'json']
 const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif']
-const nextClientComponents = ['link', 'image', 'script']
+const nextClientComponents = ['link', 'image', 'head', 'script']
 
 const NEXT_BUILT_IN_CLIENT_RSC_REGEX = new RegExp(
   `[\\\\/]next[\\\\/](${nextClientComponents.join('|')})\\.js$`

--- a/test/integration/react-streaming-and-server-components/app/pages/index.server.js
+++ b/test/integration/react-streaming-and-server-components/app/pages/index.server.js
@@ -1,5 +1,6 @@
 import Nav from '../components/nav'
 import Script from 'next/script'
+import Head from 'next/head'
 
 const envVar = process.env.ENV_VAR_TEST
 const headerKey = 'x-next-test-client'
@@ -7,6 +8,9 @@ const headerKey = 'x-next-test-client'
 export default function Index({ header }) {
   return (
     <div>
+      <Head>
+        <meta name="rsc-title" content="index" />
+      </Head>
       <h1>{`component:index.server`}</h1>
       <div>{'env:' + envVar}</div>
       <div>{'header:' + header}</div>

--- a/test/integration/react-streaming-and-server-components/test/rsc.js
+++ b/test/integration/react-streaming-and-server-components/test/rsc.js
@@ -18,6 +18,7 @@ export default function (context, { runtime, env }) {
     const scriptTagContent = await browser.elementById('client-script').text()
     // should have only 1 DOCTYPE
     expect(homeHTML).toMatch(/^<!DOCTYPE html><html/)
+    expect(homeHTML).toMatch('<meta name="rsc-title" content="index"/>')
     expect(homeHTML).toContain('component:index.server')
     expect(homeHTML).toContain('env:env_var_test')
     expect(homeHTML).toContain('header:test-util')


### PR DESCRIPTION
Follow up of #36135 

Add `next/head` as client component