### PR TITLE
35873 - fix

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1608,6 +1608,7 @@ export default class Router implements BaseRouter {
 
       routeInfo.props = props
       this.components[route] = routeInfo
+      window.location.href = as
       return routeInfo
     } catch (err) {
       return this.handleRouteInfoError(


### PR DESCRIPTION
## Bug

I have noticed that, the page refresh is required in order to for the route to be redirected. The page reload is implemented in the error exception, whilst in success, it is not.

fixes https://github.com/vercel/next.js/issues/35837