### PR TITLE
Stabilize flakey prerender test

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1975,13 +1975,18 @@ describe('Prerender', () => {
 
         expect($('p').text()).toMatch(/Post:.*?test-manual-1/)
 
-        const res2 = await fetchViaHTTP(
-          next.url,
-          '/blocking-fallback/test-manual-1'
-        )
-        const html2 = await res2.text()
-        const $2 = cheerio.load(html2)
-        expect(res2.headers.get('x-nextjs-cache')).toMatch(/(HIT|STALE)/)
+        let $2
+
+        await check(async () => {
+          const res2 = await fetchViaHTTP(
+            next.url,
+            '/blocking-fallback/test-manual-1'
+          )
+          const html2 = await res2.text()
+          $2 = cheerio.load(html2)
+
+          return res2.headers.get('x-nextjs-cache')
+        }, /(HIT|STALE)/)
 
         expect(initialTime).toBe($2('#time').text())
 
@@ -1994,7 +1999,7 @@ describe('Prerender', () => {
           { redirect: 'manual' }
         )
 
-        expect(res2.status).toBe(200)
+        expect(res3.status).toBe(200)
         const revalidateData = await res3.json()
         expect(revalidateData.revalidated).toBe(true)
 


### PR DESCRIPTION
This fixes a race condition in a test where if we do a follow-up request fast enough the initial request could still be in the response-cache if writing the cache data to disk takes a bit. 

x-ref: https://github.com/vercel/next.js/runs/6039605037?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6039415211?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6040144437?check_suite_focus=true