### PR TITLE
Stabilize flakey build-output test

### DIFF
--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -162,7 +162,7 @@ describe('Build Output', () => {
           / \/slow-static\/.+\/.+(?: \(\d+ ms\))?| \[\+\d+ more paths\]/g
         )
 
-        expect(matches).toEqual([
+        for (const check of [
           // summary
           expect.stringMatching(
             /\/\[propsDuration\]\/\[renderDuration\] \(\d+ ms\)/
@@ -178,7 +178,12 @@ describe('Build Output', () => {
           expect.stringMatching(/\/10\/10$/),
           // max of 7 preview paths
           ' [+2 more paths]',
-        ])
+        ]) {
+          // the order isn't guaranteed on the timing tests as while() is being
+          // used in the render so can block the thread of other renders sharing
+          // the same worker
+          expect(matches).toContainEqual(check)
+        }
       })
 
       it('should not emit extracted comments', async () => {


### PR DESCRIPTION
Fixes another case where the build-output test can be flakey due to blocking the thread if two time based tests end up sharing the same worker. 

x-ref: https://github.com/vercel/next.js/runs/6040615132?check_suite_focus=true