### PR TITLE
fix(next-swc/ssg): less aggressive exports drop

### DIFF
--- a/packages/next-swc/crates/core/tests/fixture/ssg/getStaticProps/issue-31855/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/ssg/getStaticProps/issue-31855/input.js
@@ -1,0 +1,16 @@
+export const revalidateInSeconds = 5 * 60;
+
+export const getStaticProps = async () => {
+  return {
+    props: {},
+    revalidate: revalidateInSeconds,
+  };
+};
+
+export default function Home({}) {
+  return (
+      <div>
+          <p>Hello World</p>
+      </div>
+  )
+}

--- a/packages/next-swc/crates/core/tests/fixture/ssg/getStaticProps/issue-31855/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/ssg/getStaticProps/issue-31855/output.js
@@ -1,0 +1,5 @@
+export var __N_SSG = true;
+export const revalidateInSeconds = 5 * 60;
+export default function Home({}) {
+    return __jsx("div", null, __jsx("p", null, "Hello World"));
+};


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR attempts to fix #31855, by loosening conditions to determine what to drop when swc runs transform. Currently, it drops all the export declaration if it's being referenced only in getstatic* in local scope. But as `export` implies, there's no guarantee given export will be used in other modules even if it's not being used in local scope. PR tries to not to drop exports declarations as much if it's not being used locally other than getstatic*. This makes dropping bit ineffecient, but as long as we can't cross-ref across modules that's something unavoidable in my opinion.

I don't think implementation itself is quite acceptable: probably need review & revise to the logics. 

## Bug

- Attempt to close #31855

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
