### PR TITLE
Fix missing _app component of AppTree in gIP context

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -197,20 +197,21 @@ function enhanceComponents(
 
 function renderFlight(AppMod: any, ComponentMod: any, props: any) {
   const isServerComponent = !!ComponentMod.__next_rsc__
-  const isServerApp = !!AppMod.__next_rsc__
   const App = interopDefault(AppMod)
   const Component = interopDefault(ComponentMod)
   const AppServer = isServerComponent
     ? (App as React.ComponentType)
     : React.Fragment
+  const { router: _, ...rest } = props
 
-  if (isServerApp) {
+  if (isServerComponent) {
     return (
       <AppServer>
-        <Component {...props} />
+        <Component {...rest} />
       </AppServer>
     )
   }
+
   return <App Component={Component} {...props} />
 }
 
@@ -738,7 +739,7 @@ export async function renderToHTML(
     AppTree: (props: any) => {
       return (
         <AppContainerWithIsomorphicFiberStructure>
-          {renderFlight(AppMod, ComponentMod, props)}
+          {renderFlight(AppMod, ComponentMod, { ...props, router })}
         </AppContainerWithIsomorphicFiberStructure>
       )
     },

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -197,17 +197,21 @@ function enhanceComponents(
 
 function renderFlight(AppMod: any, ComponentMod: any, props: any) {
   const isServerComponent = !!ComponentMod.__next_rsc__
+  const isServerApp = !!AppMod.__next_rsc__
   const App = interopDefault(AppMod)
   const Component = interopDefault(ComponentMod)
   const AppServer = isServerComponent
     ? (App as React.ComponentType)
     : React.Fragment
 
-  return (
-    <AppServer>
-      <Component {...props} />
-    </AppServer>
-  )
+  if (isServerApp) {
+    return (
+      <AppServer>
+        <Component {...props} />
+      </AppServer>
+    )
+  }
+  return <App Component={Component} {...props} />
 }
 
 export type RenderOptsPartial = {

--- a/test/integration/app-tree/pages/_app.tsx
+++ b/test/integration/app-tree/pages/_app.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import Link from 'next/link'
+import { createContext } from 'react'
 import { render } from 'react-dom'
 import App, { AppContext } from 'next/app'
 import { renderToString } from 'react-dom/server'
+
+export const DummyContext = createContext(null)
 
 class MyApp<P = {}> extends App<P & { html: string }> {
   static async getInitialProps({ Component, AppTree, ctx }: AppContext) {
@@ -32,15 +35,20 @@ class MyApp<P = {}> extends App<P & { html: string }> {
     const { Component, pageProps, html, router } = this.props
     const href = router.pathname === '/' ? '/another' : '/'
 
-    return html && router.pathname !== '/hello' ? (
-      <>
-        <div dangerouslySetInnerHTML={{ __html: html }} />
-        <Link href={href}>
-          <a id={href === '/' ? 'home' : 'another'}>to {href}</a>
-        </Link>
-      </>
-    ) : (
-      <Component {...pageProps} />
+    const child =
+      html && router.pathname !== '/hello' ? (
+        <>
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+          <Link href={href}>
+            <a id={href === '/' ? 'home' : 'another'}>to {href}</a>
+          </Link>
+        </>
+      ) : (
+        <Component {...pageProps} />
+      )
+
+    return (
+      <DummyContext.Provider value={'::ctx::'}>{child}</DummyContext.Provider>
     )
   }
 }

--- a/test/integration/app-tree/pages/index.js
+++ b/test/integration/app-tree/pages/index.js
@@ -1,7 +1,12 @@
+import { useContext } from 'react'
+import { DummyContext } from './_app'
 import { useRouter } from 'next/router'
 
 const Page = () => {
   const { pathname } = useRouter()
+  const ctx = useContext(DummyContext)
+  if (ctx == null) throw new Error('context consumes failed')
+
   return (
     <>
       <h3>page: {pathname}</h3>


### PR DESCRIPTION
## Bug

The custom app is missing in the `ctx.AppTree` that causing the issue, it was accidently missed in custom _app.server pr #35666

Fixes #36198

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

