### PR TITLE
unlock eslint-config deps versions

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -11,13 +11,13 @@
   "dependencies": {
     "@next/eslint-plugin-next": "12.1.6-canary.2",
     "@rushstack/eslint-patch": "1.0.8",
-    "@typescript-eslint/parser": "5.19.0",
-    "eslint-import-resolver-node": "0.3.4",
-    "eslint-import-resolver-typescript": "2.4.0",
-    "eslint-plugin-import": "2.25.2",
-    "eslint-plugin-jsx-a11y": "6.5.1",
-    "eslint-plugin-react": "7.29.1",
-    "eslint-plugin-react-hooks": "4.3.0"
+    "@typescript-eslint/parser": "^5.19.0",
+    "eslint-import-resolver-node": "^0.3.4",
+    "eslint-import-resolver-typescript": "^2.4.0",
+    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-react": "^7.29.1",
+    "eslint-plugin-react-hooks": "^4.3.0"
   },
   "peerDependencies": {
     "eslint": "^7.23.0 || ^8.0.0",


### PR DESCRIPTION
Unlock eslint-config-next dependency versions, so that it works best in a monorepo setup and custom eslint configs.

I'm getting eslint errors like below because we have monorepo setup, also use other shared eslint configs and plugins. And it's almost impossible to setup package resolutions manually for each version upgrade.

```
ESLint couldn't determine the plugin "react-hooks" uniquely.
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
