### PR TITLE
Use finally to clean up seen requests

### DIFF
--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -146,287 +146,287 @@ export default class Router {
       )
     }
     this.seenRequests.add(req)
+    try {
 
-    // memoize page check calls so we don't duplicate checks for pages
-    const pageChecks: { [name: string]: Promise<boolean> } = {}
-    const memoizedPageChecker = async (p: string): Promise<boolean> => {
-      p = normalizeLocalePath(p, this.locales).pathname
+      // memoize page check calls so we don't duplicate checks for pages
+      const pageChecks: { [name: string]: Promise<boolean> } = {}
+      const memoizedPageChecker = async (p: string): Promise<boolean> => {
+        p = normalizeLocalePath(p, this.locales).pathname
 
-      if (pageChecks[p] !== undefined) {
-        return pageChecks[p]
+        if (pageChecks[p] !== undefined) {
+          return pageChecks[p]
+        }
+        const result = this.pageChecker(p)
+        pageChecks[p] = result
+        return result
       }
-      const result = this.pageChecker(p)
-      pageChecks[p] = result
-      return result
-    }
 
-    let parsedUrlUpdated = parsedUrl
+      let parsedUrlUpdated = parsedUrl
 
-    const applyCheckTrue = async (checkParsedUrl: NextUrlWithParsedQuery) => {
-      const originalFsPathname = checkParsedUrl.pathname
-      const fsPathname = replaceBasePath(originalFsPathname!, this.basePath)
+      const applyCheckTrue = async (checkParsedUrl: NextUrlWithParsedQuery) => {
+        const originalFsPathname = checkParsedUrl.pathname
+        const fsPathname = replaceBasePath(originalFsPathname!, this.basePath)
 
-      for (const fsRoute of this.fsRoutes) {
-        const fsParams = fsRoute.match(fsPathname)
+        for (const fsRoute of this.fsRoutes) {
+          const fsParams = fsRoute.match(fsPathname)
 
-        if (fsParams) {
+          if (fsParams) {
+            checkParsedUrl.pathname = fsPathname
+
+            const fsResult = await fsRoute.fn(req, res, fsParams, checkParsedUrl)
+
+            if (fsResult.finished) {
+              return true
+            }
+
+            checkParsedUrl.pathname = originalFsPathname
+          }
+        }
+        let matchedPage = await memoizedPageChecker(fsPathname)
+
+        // If we didn't match a page check dynamic routes
+        if (!matchedPage) {
+          const normalizedFsPathname = normalizeLocalePath(
+            fsPathname,
+            this.locales
+          ).pathname
+
+          for (const dynamicRoute of this.dynamicRoutes) {
+            if (dynamicRoute.match(normalizedFsPathname)) {
+              matchedPage = true
+            }
+          }
+        }
+
+        // Matched a page or dynamic route so render it using catchAllRoute
+        if (matchedPage) {
+          const pageParams = this.catchAllRoute.match(checkParsedUrl.pathname)
           checkParsedUrl.pathname = fsPathname
+          checkParsedUrl.query._nextBubbleNoFallback = '1'
 
-          const fsResult = await fsRoute.fn(req, res, fsParams, checkParsedUrl)
-
-          if (fsResult.finished) {
-            return true
-          }
-
-          checkParsedUrl.pathname = originalFsPathname
-        }
-      }
-      let matchedPage = await memoizedPageChecker(fsPathname)
-
-      // If we didn't match a page check dynamic routes
-      if (!matchedPage) {
-        const normalizedFsPathname = normalizeLocalePath(
-          fsPathname,
-          this.locales
-        ).pathname
-
-        for (const dynamicRoute of this.dynamicRoutes) {
-          if (dynamicRoute.match(normalizedFsPathname)) {
-            matchedPage = true
-          }
+          const result = await this.catchAllRoute.fn(
+            req,
+            res,
+            pageParams as Params,
+            checkParsedUrl
+          )
+          return result.finished
         }
       }
 
-      // Matched a page or dynamic route so render it using catchAllRoute
-      if (matchedPage) {
-        const pageParams = this.catchAllRoute.match(checkParsedUrl.pathname)
-        checkParsedUrl.pathname = fsPathname
-        checkParsedUrl.query._nextBubbleNoFallback = '1'
+      /*
+        Desired routes order
+        - headers
+        - redirects
+        - Check filesystem (including pages), if nothing found continue
+        - User rewrites (checking filesystem and pages each match)
+      */
 
-        const result = await this.catchAllRoute.fn(
-          req,
-          res,
-          pageParams as Params,
-          checkParsedUrl
-        )
-        return result.finished
-      }
-    }
+      const allRoutes = [
+        ...this.headers,
+        ...this.redirects,
+        ...this.rewrites.beforeFiles,
+        ...(this.useFileSystemPublicRoutes && this.catchAllMiddleware
+          ? [this.catchAllMiddleware]
+          : []),
+        ...this.fsRoutes,
+        // We only check the catch-all route if public page routes hasn't been
+        // disabled
+        ...(this.useFileSystemPublicRoutes
+          ? [
+              {
+                type: 'route',
+                name: 'page checker',
+                requireBasePath: false,
+                match: route('/:path*'),
+                fn: async (checkerReq, checkerRes, params, parsedCheckerUrl) => {
+                  let { pathname } = parsedCheckerUrl
+                  pathname = removePathTrailingSlash(pathname || '/')
 
-    /*
-      Desired routes order
-      - headers
-      - redirects
-      - Check filesystem (including pages), if nothing found continue
-      - User rewrites (checking filesystem and pages each match)
-    */
+                  if (!pathname) {
+                    return { finished: false }
+                  }
 
-    const allRoutes = [
-      ...this.headers,
-      ...this.redirects,
-      ...this.rewrites.beforeFiles,
-      ...(this.useFileSystemPublicRoutes && this.catchAllMiddleware
-        ? [this.catchAllMiddleware]
-        : []),
-      ...this.fsRoutes,
-      // We only check the catch-all route if public page routes hasn't been
-      // disabled
-      ...(this.useFileSystemPublicRoutes
-        ? [
-            {
-              type: 'route',
-              name: 'page checker',
-              requireBasePath: false,
-              match: route('/:path*'),
-              fn: async (checkerReq, checkerRes, params, parsedCheckerUrl) => {
-                let { pathname } = parsedCheckerUrl
-                pathname = removePathTrailingSlash(pathname || '/')
-
-                if (!pathname) {
+                  if (await memoizedPageChecker(pathname)) {
+                    return this.catchAllRoute.fn(
+                      checkerReq,
+                      checkerRes,
+                      params,
+                      parsedCheckerUrl
+                    )
+                  }
                   return { finished: false }
-                }
+                },
+              } as Route,
+            ]
+          : []),
+        ...this.rewrites.afterFiles,
+        ...(this.rewrites.fallback.length
+          ? [
+              {
+                type: 'route',
+                name: 'dynamic route/page check',
+                requireBasePath: false,
+                match: route('/:path*'),
+                fn: async (
+                  _checkerReq,
+                  _checkerRes,
+                  _params,
+                  parsedCheckerUrl
+                ) => {
+                  return {
+                    finished: await applyCheckTrue(parsedCheckerUrl),
+                  }
+                },
+              } as Route,
+              ...this.rewrites.fallback,
+            ]
+          : []),
 
-                if (await memoizedPageChecker(pathname)) {
-                  return this.catchAllRoute.fn(
-                    checkerReq,
-                    checkerRes,
-                    params,
-                    parsedCheckerUrl
-                  )
-                }
-                return { finished: false }
-              },
-            } as Route,
-          ]
-        : []),
-      ...this.rewrites.afterFiles,
-      ...(this.rewrites.fallback.length
-        ? [
-            {
-              type: 'route',
-              name: 'dynamic route/page check',
-              requireBasePath: false,
-              match: route('/:path*'),
-              fn: async (
-                _checkerReq,
-                _checkerRes,
-                _params,
-                parsedCheckerUrl
-              ) => {
-                return {
-                  finished: await applyCheckTrue(parsedCheckerUrl),
-                }
-              },
-            } as Route,
-            ...this.rewrites.fallback,
-          ]
-        : []),
+        // We only check the catch-all route if public page routes hasn't been
+        // disabled
+        ...(this.useFileSystemPublicRoutes ? [this.catchAllRoute] : []),
+      ]
+      const originallyHadBasePath =
+        !this.basePath || getRequestMeta(req, '_nextHadBasePath')
 
-      // We only check the catch-all route if public page routes hasn't been
-      // disabled
-      ...(this.useFileSystemPublicRoutes ? [this.catchAllRoute] : []),
-    ]
-    const originallyHadBasePath =
-      !this.basePath || getRequestMeta(req, '_nextHadBasePath')
+      for (const testRoute of allRoutes) {
+        // if basePath is being used, the basePath will still be included
+        // in the pathname here to allow custom-routes to require containing
+        // it or not, filesystem routes and pages must always include the basePath
+        // if it is set
+        let currentPathname = parsedUrlUpdated.pathname as string
+        const originalPathname = currentPathname
+        const requireBasePath = testRoute.requireBasePath !== false
+        const isCustomRoute = customRouteTypes.has(testRoute.type)
+        const isPublicFolderCatchall = testRoute.name === 'public folder catchall'
+        const isMiddlewareCatchall = testRoute.name === 'middleware catchall'
+        const keepBasePath =
+          isCustomRoute || isPublicFolderCatchall || isMiddlewareCatchall
+        const keepLocale = isCustomRoute
 
-    for (const testRoute of allRoutes) {
-      // if basePath is being used, the basePath will still be included
-      // in the pathname here to allow custom-routes to require containing
-      // it or not, filesystem routes and pages must always include the basePath
-      // if it is set
-      let currentPathname = parsedUrlUpdated.pathname as string
-      const originalPathname = currentPathname
-      const requireBasePath = testRoute.requireBasePath !== false
-      const isCustomRoute = customRouteTypes.has(testRoute.type)
-      const isPublicFolderCatchall = testRoute.name === 'public folder catchall'
-      const isMiddlewareCatchall = testRoute.name === 'middleware catchall'
-      const keepBasePath =
-        isCustomRoute || isPublicFolderCatchall || isMiddlewareCatchall
-      const keepLocale = isCustomRoute
+        const currentPathnameNoBasePath = replaceBasePath(
+          currentPathname,
+          this.basePath
+        )
 
-      const currentPathnameNoBasePath = replaceBasePath(
-        currentPathname,
-        this.basePath
-      )
+        if (!keepBasePath) {
+          currentPathname = currentPathnameNoBasePath
+        }
 
-      if (!keepBasePath) {
-        currentPathname = currentPathnameNoBasePath
-      }
+        const localePathResult = normalizeLocalePath(
+          currentPathnameNoBasePath,
+          this.locales
+        )
 
-      const localePathResult = normalizeLocalePath(
-        currentPathnameNoBasePath,
-        this.locales
-      )
+        const activeBasePath = keepBasePath ? this.basePath : ''
 
-      const activeBasePath = keepBasePath ? this.basePath : ''
-
-      // don't match API routes when they are locale prefixed
-      // e.g. /api/hello shouldn't match /en/api/hello as a page
-      // rewrites/redirects can match though
-      if (
-        !isCustomRoute &&
-        localePathResult.detectedLocale &&
-        localePathResult.pathname.match(/^\/api(?:\/|$)/)
-      ) {
-        continue
-      }
-
-      if (keepLocale) {
+        // don't match API routes when they are locale prefixed
+        // e.g. /api/hello shouldn't match /en/api/hello as a page
+        // rewrites/redirects can match though
         if (
-          !testRoute.internal &&
-          parsedUrl.query.__nextLocale &&
-          !localePathResult.detectedLocale
+          !isCustomRoute &&
+          localePathResult.detectedLocale &&
+          localePathResult.pathname.match(/^\/api(?:\/|$)/)
         ) {
-          currentPathname = `${activeBasePath}/${parsedUrl.query.__nextLocale}${
-            currentPathnameNoBasePath === '/' ? '' : currentPathnameNoBasePath
+          continue
+        }
+
+        if (keepLocale) {
+          if (
+            !testRoute.internal &&
+            parsedUrl.query.__nextLocale &&
+            !localePathResult.detectedLocale
+          ) {
+            currentPathname = `${activeBasePath}/${parsedUrl.query.__nextLocale}${
+              currentPathnameNoBasePath === '/' ? '' : currentPathnameNoBasePath
+            }`
+          }
+
+          if (
+            getRequestMeta(req, '__nextHadTrailingSlash') &&
+            !currentPathname.endsWith('/')
+          ) {
+            currentPathname += '/'
+          }
+        } else {
+          currentPathname = `${
+            getRequestMeta(req, '_nextHadBasePath') ? activeBasePath : ''
+          }${
+            activeBasePath && currentPathnameNoBasePath === '/'
+              ? ''
+              : currentPathnameNoBasePath
           }`
         }
 
-        if (
-          getRequestMeta(req, '__nextHadTrailingSlash') &&
-          !currentPathname.endsWith('/')
-        ) {
-          currentPathname += '/'
+        let newParams = testRoute.match(currentPathname)
+
+        if (testRoute.has && newParams) {
+          const hasParams = matchHas(req, testRoute.has, parsedUrlUpdated.query)
+
+          if (hasParams) {
+            Object.assign(newParams, hasParams)
+          } else {
+            newParams = false
+          }
         }
-      } else {
-        currentPathname = `${
-          getRequestMeta(req, '_nextHadBasePath') ? activeBasePath : ''
-        }${
-          activeBasePath && currentPathnameNoBasePath === '/'
-            ? ''
-            : currentPathnameNoBasePath
-        }`
-      }
 
-      let newParams = testRoute.match(currentPathname)
-
-      if (testRoute.has && newParams) {
-        const hasParams = matchHas(req, testRoute.has, parsedUrlUpdated.query)
-
-        if (hasParams) {
-          Object.assign(newParams, hasParams)
-        } else {
-          newParams = false
-        }
-      }
-
-      // Check if the match function matched
-      if (newParams) {
-        // since we require basePath be present for non-custom-routes we
-        // 404 here when we matched an fs route
-        if (!keepBasePath) {
-          if (
-            !originallyHadBasePath &&
-            !getRequestMeta(req, '_nextDidRewrite')
-          ) {
-            if (requireBasePath) {
-              // consider this a non-match so the 404 renders
-              this.seenRequests.delete(req)
-              return false
+        // Check if the match function matched
+        if (newParams) {
+          // since we require basePath be present for non-custom-routes we
+          // 404 here when we matched an fs route
+          if (!keepBasePath) {
+            if (
+              !originallyHadBasePath &&
+              !getRequestMeta(req, '_nextDidRewrite')
+            ) {
+              if (requireBasePath) {
+                // consider this a non-match so the 404 renders
+                return false
+              }
+              // page checker occurs before rewrites so we need to continue
+              // to check those since they don't always require basePath
+              continue
             }
-            // page checker occurs before rewrites so we need to continue
-            // to check those since they don't always require basePath
-            continue
+
+            parsedUrlUpdated.pathname = currentPathname
           }
 
-          parsedUrlUpdated.pathname = currentPathname
-        }
+          const result = await testRoute.fn(req, res, newParams, parsedUrlUpdated)
 
-        const result = await testRoute.fn(req, res, newParams, parsedUrlUpdated)
-
-        // The response was handled
-        if (result.finished) {
-          this.seenRequests.delete(req)
-          return true
-        }
-
-        // since the fs route didn't finish routing we need to re-add the
-        // basePath to continue checking with the basePath present
-        if (!keepBasePath) {
-          parsedUrlUpdated.pathname = originalPathname
-        }
-
-        if (result.pathname) {
-          parsedUrlUpdated.pathname = result.pathname
-        }
-
-        if (result.query) {
-          parsedUrlUpdated.query = {
-            ...getNextInternalQuery(parsedUrlUpdated.query),
-            ...result.query,
-          }
-        }
-
-        // check filesystem
-        if (testRoute.check === true) {
-          if (await applyCheckTrue(parsedUrlUpdated)) {
-            this.seenRequests.delete(req)
+          // The response was handled
+          if (result.finished) {
             return true
           }
+
+          // since the fs route didn't finish routing we need to re-add the
+          // basePath to continue checking with the basePath present
+          if (!keepBasePath) {
+            parsedUrlUpdated.pathname = originalPathname
+          }
+
+          if (result.pathname) {
+            parsedUrlUpdated.pathname = result.pathname
+          }
+
+          if (result.query) {
+            parsedUrlUpdated.query = {
+              ...getNextInternalQuery(parsedUrlUpdated.query),
+              ...result.query,
+            }
+          }
+
+          // check filesystem
+          if (testRoute.check === true) {
+            if (await applyCheckTrue(parsedUrlUpdated)) {
+              return true
+            }
+          }
         }
       }
+      return false
+    } finally {
+      this.seenRequests.delete(req)
     }
-    this.seenRequests.delete(req)
-    return false
   }
 }

--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -147,7 +147,6 @@ export default class Router {
     }
     this.seenRequests.add(req)
     try {
-
       // memoize page check calls so we don't duplicate checks for pages
       const pageChecks: { [name: string]: Promise<boolean> } = {}
       const memoizedPageChecker = async (p: string): Promise<boolean> => {
@@ -173,7 +172,12 @@ export default class Router {
           if (fsParams) {
             checkParsedUrl.pathname = fsPathname
 
-            const fsResult = await fsRoute.fn(req, res, fsParams, checkParsedUrl)
+            const fsResult = await fsRoute.fn(
+              req,
+              res,
+              fsParams,
+              checkParsedUrl
+            )
 
             if (fsResult.finished) {
               return true
@@ -239,7 +243,12 @@ export default class Router {
                 name: 'page checker',
                 requireBasePath: false,
                 match: route('/:path*'),
-                fn: async (checkerReq, checkerRes, params, parsedCheckerUrl) => {
+                fn: async (
+                  checkerReq,
+                  checkerRes,
+                  params,
+                  parsedCheckerUrl
+                ) => {
                   let { pathname } = parsedCheckerUrl
                   pathname = removePathTrailingSlash(pathname || '/')
 
@@ -299,7 +308,8 @@ export default class Router {
         const originalPathname = currentPathname
         const requireBasePath = testRoute.requireBasePath !== false
         const isCustomRoute = customRouteTypes.has(testRoute.type)
-        const isPublicFolderCatchall = testRoute.name === 'public folder catchall'
+        const isPublicFolderCatchall =
+          testRoute.name === 'public folder catchall'
         const isMiddlewareCatchall = testRoute.name === 'middleware catchall'
         const keepBasePath =
           isCustomRoute || isPublicFolderCatchall || isMiddlewareCatchall
@@ -338,7 +348,9 @@ export default class Router {
             parsedUrl.query.__nextLocale &&
             !localePathResult.detectedLocale
           ) {
-            currentPathname = `${activeBasePath}/${parsedUrl.query.__nextLocale}${
+            currentPathname = `${activeBasePath}/${
+              parsedUrl.query.__nextLocale
+            }${
               currentPathnameNoBasePath === '/' ? '' : currentPathnameNoBasePath
             }`
           }
@@ -392,7 +404,12 @@ export default class Router {
             parsedUrlUpdated.pathname = currentPathname
           }
 
-          const result = await testRoute.fn(req, res, newParams, parsedUrlUpdated)
+          const result = await testRoute.fn(
+            req,
+            res,
+            newParams,
+            parsedUrlUpdated
+          )
 
           // The response was handled
           if (result.finished) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

Saw that 1) if an exception in router.execute is ever thrown, next will have a memory leak, 2) this func looks painful to keep leaks out of.

To reviewers: Use PR settings -> diff view -> hide whitespace to see actual changes. Mass indent is hard to reveiw without it. Any lines not related to reference cleanup are just prettier auto-formatting long lines.