### PR TITLE
refactor: move fs based inc cache to next-server

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -8,8 +8,12 @@ import fs from 'fs'
 import chalk from 'next/dist/compiled/chalk'
 import { posix, join } from 'path'
 import { stringify } from 'querystring'
-import { API_ROUTE, DOT_NEXT_ALIAS, PAGES_DIR_ALIAS } from '../lib/constants'
-import { MIDDLEWARE_ROUTE } from '../lib/constants'
+import {
+  API_ROUTE,
+  DOT_NEXT_ALIAS,
+  PAGES_DIR_ALIAS,
+  MIDDLEWARE_ROUTE,
+} from '../lib/constants'
 import { __ApiPreviewProps } from '../server/api-utils'
 import { isTargetLikeServerless } from '../server/utils'
 import { normalizePagePath } from '../server/normalize-page-path'

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -16,7 +16,6 @@ import type { PreviewData } from 'next/types'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
 import type { BaseNextRequest, BaseNextResponse } from './base-http'
 import type { PayloadOptions } from './send-payload'
-import type { IncrementalCache } from './incremental-cache'
 
 import { join, resolve } from 'path'
 import { parse as parseQs } from 'querystring'
@@ -62,6 +61,7 @@ import { createHeaderRoute, createRedirectRoute } from './server-route-utils'
 import { PrerenderManifest } from '../build'
 import { ImageConfigComplete } from '../shared/lib/image-config'
 import { replaceBasePath } from './router-utils'
+import { IncrementalCache } from './incremental-cache'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -168,8 +168,9 @@ export default abstract class Server {
     serverComponentProps?: any
     reactRoot: boolean
   }
-  private incrementalCache: IncrementalCache
-  private responseCache: ResponseCache
+
+  protected responseCache: ResponseCache
+  protected incrementalCache: IncrementalCache
   protected router: Router
   protected dynamicRoutes?: DynamicRoutes
   protected customRoutes: CustomRoutes
@@ -222,6 +223,7 @@ export default abstract class Server {
   protected abstract getPrerenderManifest(): PrerenderManifest
   protected abstract getServerComponentManifest(): any
   protected abstract getIncrementalCache(dev: boolean): any
+  protected abstract getResponseCache(): any
 
   protected abstract sendRenderResult(
     req: BaseNextRequest,
@@ -349,10 +351,7 @@ export default abstract class Server {
     this.setAssetPrefix(assetPrefix)
 
     this.incrementalCache = this.getIncrementalCache(dev)
-    this.responseCache = new ResponseCache(
-      this.incrementalCache,
-      this.minimalMode
-    )
+    this.responseCache = this.getResponseCache()
   }
 
   public logError(err: Error): void {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -61,7 +61,6 @@ import { createHeaderRoute, createRedirectRoute } from './server-route-utils'
 import { PrerenderManifest } from '../build'
 import { ImageConfigComplete } from '../shared/lib/image-config'
 import { replaceBasePath } from './router-utils'
-import { IncrementalCache } from './incremental-cache'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -170,7 +169,7 @@ export default abstract class Server {
   }
 
   protected responseCache: ResponseCache
-  protected incrementalCache: IncrementalCache
+  protected incrementalCache: any
   protected router: Router
   protected dynamicRoutes?: DynamicRoutes
   protected customRoutes: CustomRoutes

--- a/packages/next/server/incremental-cache.ts
+++ b/packages/next/server/incremental-cache.ts
@@ -1,5 +1,3 @@
-import type { CacheFs } from '../shared/lib/utils'
-
 import LRUCache from 'next/dist/compiled/lru-cache'
 import path from 'path'
 import { PrerenderManifest } from '../build'
@@ -8,6 +6,14 @@ import { IncrementalCacheValue, IncrementalCacheEntry } from './response-cache'
 
 function toRoute(pathname: string): string {
   return pathname.replace(/\/$/, '').replace(/\/index$/, '') || '/'
+}
+
+interface CacheFs {
+  readFile(f: string): Promise<string>
+  readFileSync(f: string): string
+  writeFile(f: string, d: any): Promise<void>
+  mkdir(dir: string): Promise<void | string>
+  stat(f: string): Promise<{ mtime: Date }>
 }
 
 export class IncrementalCache {

--- a/packages/next/server/incremental-cache.ts
+++ b/packages/next/server/incremental-cache.ts
@@ -25,7 +25,7 @@ export class IncrementalCache {
   }
 
   prerenderManifest: PrerenderManifest
-  cache?: LRUCache<string, IncrementalCacheEntry>
+  cache?: any
   locales?: string[]
   fs: CacheFs
 
@@ -67,7 +67,7 @@ export class IncrementalCache {
     if (max) {
       this.cache = new LRUCache({
         max,
-        length({ value }) {
+        length({ value }: any) {
           if (!value) {
             return 25
           } else if (value.kind === 'REDIRECT') {
@@ -109,7 +109,7 @@ export class IncrementalCache {
     return revalidateAfter
   }
 
-  getFallback(page: string): Promise<string> {
+  public getFallback(page: string): Promise<string> {
     page = normalizePagePath(page)
     return this.fs.readFile(this.getSeedPath(page, 'html'))
   }
@@ -222,3 +222,7 @@ export class IncrementalCache {
     }
   }
 }
+
+type IncrementalCacheType = typeof IncrementalCache
+
+export { IncrementalCacheType }

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -113,6 +113,11 @@ export default class NextNodeServer extends BaseServer {
       process.env.__NEXT_SCRIPT_WORKERS = JSON.stringify(true)
     }
 
+    this.responseCache = new ResponseCache(
+      this.incrementalCache,
+      this.minimalMode
+    )
+
     if (!this.minimalMode) {
       const { ImageOptimizerCache } =
         require('./image-optimizer') as typeof import('./image-optimizer')
@@ -1386,5 +1391,9 @@ export default class NextNodeServer extends BaseServer {
         }
       },
     })
+  }
+
+  protected getResponseCache() {
+    return new ResponseCache(this.incrementalCache, this.minimalMode)
   }
 }

--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -207,4 +207,26 @@ export default class NextWebServer extends BaseServer {
       components: result,
     }
   }
+
+  protected getIncrementalCache() {
+    return {
+      async set() {},
+      async get() {
+        return null
+      },
+      async getFallback() {
+        return ''
+      },
+    }
+  }
+
+  protected getCacheFilesystem() {
+    return {
+      readFile: () => Promise.resolve(''),
+      readFileSync: () => '',
+      writeFile: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+      stat: () => Promise.resolve({ mtime: new Date() }),
+    }
+  }
 }

--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -229,4 +229,12 @@ export default class NextWebServer extends BaseServer {
       stat: () => Promise.resolve({ mtime: new Date() }),
     }
   }
+
+  protected getResponseCache() {
+    return {
+      get() {
+        return null
+      },
+    }
+  }
 }

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -397,11 +397,3 @@ export const ST =
   typeof performance.measure === 'function'
 
 export class DecodeError extends Error {}
-
-export interface CacheFs {
-  readFile(f: string): Promise<string>
-  readFileSync(f: string): string
-  writeFile(f: string, d: any): Promise<void>
-  mkdir(dir: string): Promise<void | string>
-  stat(f: string): Promise<{ mtime: Date }>
-}

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -227,10 +227,7 @@ declare module 'next/dist/compiled/lodash.curry' {
   import m from 'lodash.curry'
   export = m
 }
-declare module 'next/dist/compiled/lru-cache' {
-  import m from 'lru-cache'
-  export = m
-}
+declare module 'next/dist/compiled/lru-cache'
 declare module 'next/dist/compiled/micromatch' {
   import m from 'micromatch'
   export = m

--- a/test/integration/react-18/app/pages/index.js
+++ b/test/integration/react-18/app/pages/index.js
@@ -19,3 +19,7 @@ export default function Index() {
     </div>
   )
 }
+
+export const config = {
+  // runtime: 'edge'
+}

--- a/test/integration/react-18/test/index.test.js
+++ b/test/integration/react-18/test/index.test.js
@@ -21,6 +21,7 @@ import webdriver from 'next-webdriver'
 const appDir = join(__dirname, '../app')
 const nextConfig = new File(join(appDir, 'next.config.js'))
 const invalidPage = new File(join(appDir, 'pages/invalid.js'))
+const indexPage = new File(join(appDir, 'pages/index.js'))
 
 describe('Basics', () => {
   runTests('default setting with react 18', basics)
@@ -67,11 +68,13 @@ function runTestsAgainstRuntime(runtime) {
           invalidPage.write(`export const value = 1`)
         }
         nextConfig.replace("// runtime: 'edge'", `runtime: '${runtime}'`)
+        indexPage.replace("// runtime: 'edge'", `runtime: '${runtime}'`)
       },
       afterAll: (env) => {
         if (env === 'dev') {
           invalidPage.delete()
         }
+        indexPage.restore()
         nextConfig.restore()
       },
     }


### PR DESCRIPTION
x-ref: #36190
x-ref: #31506

In edge runtime, node.js polyfills should not be applied, move more nodejs specific code (fs related) to next server before removing them

