### PR TITLE
Add onLoad gotcha note to basic-features doc

### DIFF
--- a/docs/basic-features/script.md
+++ b/docs/basic-features/script.md
@@ -256,6 +256,8 @@ export default function Home() {
 }
 ```
 
+> **Note: `onLoad` can't be used with the `beforeInteractive` loading strategy.**
+
 Sometimes it is helpful to catch when a script fails to load. These errors can be handled with the `onError` property:
 
 ```jsx


### PR DESCRIPTION
#33097 adds a note to the `Script` documentation explaining that `onLoad` cannot be used with the `beforeInteractive` strategy. However, this note was missing in the [Basic Features](https://nextjs.org/docs/basic-features/script) documentation, causing some confusion. This adds the note there too.

This will hopefully fix a lot of confusion noted in https://github.com/vercel/next.js/issues/33191.