### PR TITLE
Add telemetry for image config formats (avif/webp)

### DIFF
--- a/packages/next/telemetry/events/version.ts
+++ b/packages/next/telemetry/events/version.ts
@@ -23,6 +23,7 @@ type EventCliSessionStarted = {
   imageDomainsCount: number | null
   imageSizes: string | null
   imageLoader: string | null
+  imageFormats: string | null
   trailingSlashEnabled: boolean
   reactStrictMode: boolean
   webpackVersion: number | null
@@ -66,6 +67,7 @@ export function eventCliSession(
     | 'imageDomainsCount'
     | 'imageSizes'
     | 'imageLoader'
+    | 'imageFormats'
     | 'trailingSlashEnabled'
     | 'reactStrictMode'
   >
@@ -97,6 +99,7 @@ export function eventCliSession(
     imageDomainsCount: images?.domains ? images.domains.length : null,
     imageSizes: images?.imageSizes ? images.imageSizes.join(',') : null,
     imageLoader: images?.loader,
+    imageFormats: images?.formats ? images.formats.join(',') : null,
     trailingSlashEnabled: !!nextConfig?.trailingSlash,
     reactStrictMode: !!nextConfig?.reactStrictMode,
     webpackVersion: event.webpackVersion || null,

--- a/test/integration/telemetry/next.config.i18n-images
+++ b/test/integration/telemetry/next.config.i18n-images
@@ -1,6 +1,7 @@
 module.exports = phase => {
   return {
     images: {
+      formats: ['image/avif', 'image/webp'],
       imageSizes: [64, 128, 256, 512, 1024],
       domains: ['example.com'],
     },

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -485,6 +485,7 @@ describe('Telemetry CLI', () => {
     expect(event1).toMatch(/"localeDetectionEnabled": true/)
     expect(event1).toMatch(/"imageDomainsCount": 1/)
     expect(event1).toMatch(/"imageSizes": "64,128,256,512,1024"/)
+    expect(event1).toMatch(/"imageFormats": "image\/avif,image\/webp"/)
     expect(event1).toMatch(/"trailingSlashEnabled": false/)
     expect(event1).toMatch(/"reactStrictMode": false/)
 


### PR DESCRIPTION
This PR adds telemetry for image config formats since AVIF is opt-in (#30180).

See docs https://nextjs.org/docs/api-reference/next/image#acceptable-formats