### PR TITLE
next/jest: Allow moduleNameMapper to match before Next.js internal mappings

### DIFF
--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -72,6 +72,10 @@ export default function nextJest(options: { dir?: string } = {}) {
         ...resolvedJestConfig,
 
         moduleNameMapper: {
+          // Custom config will be able to override the default mappings
+          // moduleNameMapper is matched top to bottom hence why this has to be before Next.js internal rules
+          ...(resolvedJestConfig.moduleNameMapper || {}),
+
           // Handle CSS imports (with CSS modules)
           // https://jestjs.io/docs/webpack#mocking-css-modules
           '^.+\\.module\\.(css|sass|scss)$':
@@ -84,9 +88,6 @@ export default function nextJest(options: { dir?: string } = {}) {
           '^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$': require.resolve(
             `./__mocks__/fileMock.js`
           ),
-
-          // Custom config will be able to override the default mappings
-          ...(resolvedJestConfig.moduleNameMapper || {}),
         },
         testPathIgnorePatterns: [
           // Don't look for tests in node_modules


### PR DESCRIPTION
Fixes #35634

This change doesn't require tests as importing svgs is not a supported feature, this just makes it slightly more ergonomic to override the matchers. 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
