### PR TITLE
Adds `removeListener` handler to `with-electron-typescript` example.

### DIFF
--- a/examples/with-electron-typescript/renderer/pages/index.tsx
+++ b/examples/with-electron-typescript/renderer/pages/index.tsx
@@ -4,10 +4,14 @@ import Layout from '../components/Layout'
 
 const IndexPage = () => {
   useEffect(() => {
+    const handleMessage = (_event, args) => alert(args)
+
     // add a listener to 'message' channel
-    global.ipcRenderer.addListener('message', (_event, args) => {
-      alert(args)
-    })
+    global.ipcRenderer.addListener('message', handleMessage)
+
+    return () => {
+      global.ipcRenderer.removeListener('message', handleMessage)
+    }
   }, [])
 
   const onSayHiClick = () => {


### PR DESCRIPTION
Without removing the listener in `useEffect`, the home / index page will keep adding a new listener each time you come back to the home page.

![CleanShot 2022-04-20 at 15 38 44](https://user-images.githubusercontent.com/446260/164318945-f1779c57-ff30-437b-8914-961cd6ebc176.gif)