### PR TITLE
fix(next): use moduleGraph.getIssuer to avoid deprecation warning (#36329)

### DIFF
--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -106,12 +106,16 @@ const matchNextPageBundleRequest = route(
 )
 
 // Recursively look up the issuer till it ends up at the root
-function findEntryModule(issuer: any): any {
-  if (issuer.issuer) {
-    return findEntryModule(issuer.issuer)
+function findEntryModule(
+  compilation: webpack5.Compilation,
+  issuerModule: any
+): any {
+  const issuer = compilation.moduleGraph.getIssuer(issuerModule)
+  if (issuer) {
+    return findEntryModule(compilation, issuer)
   }
 
-  return issuer
+  return issuerModule
 }
 
 function erroredPages(compilation: webpack5.Compilation) {
@@ -121,7 +125,7 @@ function erroredPages(compilation: webpack5.Compilation) {
       continue
     }
 
-    const entryModule = findEntryModule(error.module)
+    const entryModule = findEntryModule(compilation, error.module)
     const { name } = entryModule
     if (!name) {
       continue

--- a/test/development/webpack-issuer-deprecation-warning/index.test.ts
+++ b/test/development/webpack-issuer-deprecation-warning/index.test.ts
@@ -1,0 +1,29 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { renderViaHTTP } from 'next-test-utils'
+
+describe('webpack-issuer-deprecation-warning', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.js': `
+          export default function Page() { 
+            return <p>hello world
+          } 
+        `,
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should not appear deprecation warning about webpack module issuer', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('Syntax Error')
+    expect(next.cliOutput).not.toContain(
+      '[DEP_WEBPACK_MODULE_ISSUER] DeprecationWarning: Module.issuer: Use new ModuleGraph API'
+    )
+  })
+})

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -40,6 +40,8 @@ export class NextDevInstance extends NextInstance {
         },
       })
 
+      this._cliOutput = ''
+
       this.childProcess.stdout.on('data', (chunk) => {
         const msg = chunk.toString()
         process.stdout.write(chunk)


### PR DESCRIPTION
fix: #36329 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
