### PR TITLE
Ensure there is only 1 render pass in concurrent rendering with getInitialProps in `_document`

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1326,6 +1326,11 @@ export async function renderToHTML(
         options: ComponentsEnhancer = {}
       ): RenderPageResult | Promise<RenderPageResult> => {
         if (ctx.err && ErrorDebug) {
+          // Always start rendering the shell even if there's an error.
+          if (renderShell) {
+            renderShell({})
+          }
+
           const html = ReactDOMServer.renderToString(
             <Body>
               <ErrorDebug error={ctx.err} />

--- a/test/development/basic/styled-components.test.ts
+++ b/test/development/basic/styled-components.test.ts
@@ -73,4 +73,15 @@ describe('styled-components SWC transform', () => {
     expect(html).toContain('background:transparent')
     expect(html).toContain('color:white')
   })
+
+  it('should only render once on the server per request', async () => {
+    const outputs = []
+    next.on('stdout', (args) => {
+      outputs.push(args)
+    })
+    await renderViaHTTP(next.url, '/')
+    expect(
+      outputs.filter((output) => output.trim() === '__render__').length
+    ).toBe(1)
+  })
 })

--- a/test/development/basic/styled-components/pages/index.js
+++ b/test/development/basic/styled-components/pages/index.js
@@ -21,6 +21,7 @@ const Button = styled.a`
 `
 
 export default function Home() {
+  console.log('__render__')
   return (
     <div>
       <Button

--- a/test/integration/react-18/app/pages/index.js
+++ b/test/integration/react-18/app/pages/index.js
@@ -5,6 +5,7 @@ export default function Index() {
   if (typeof window !== 'undefined') {
     window.didHydrate = true
   }
+  console.log('__render__')
   return (
     <div>
       <p id="react-dom-version">{ReactDOM.version}</p>

--- a/test/integration/react-18/test/basics.js
+++ b/test/integration/react-18/test/basics.js
@@ -5,6 +5,11 @@ import cheerio from 'cheerio'
 import { renderViaHTTP } from 'next-test-utils'
 
 export default (context, env) => {
+  it('should only render once in SSR', async () => {
+    await renderViaHTTP(context.appPort, '/')
+    expect([...context.stdout.matchAll(/__render__/g)].length).toBe(1)
+  })
+
   it('no warnings for image related link props', async () => {
     await renderViaHTTP(context.appPort, '/')
     expect(context.stderr).not.toContain('Warning: Invalid DOM property')

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -758,6 +758,10 @@ function runSuite(suiteName, context, options) {
       const onStderr = (msg) => {
         context.stderr += msg
       }
+      context.stdout = ''
+      const onStdout = (msg) => {
+        context.stdout += msg
+      }
       if (env === 'prod') {
         context.appPort = await findPort()
         const { stdout, stderr, code } = await nextBuild(appDir, [], {
@@ -769,11 +773,13 @@ function runSuite(suiteName, context, options) {
         context.code = code
         context.server = await nextStart(context.appDir, context.appPort, {
           onStderr,
+          onStdout,
         })
       } else if (env === 'dev') {
         context.appPort = await findPort()
         context.server = await launchApp(context.appDir, context.appPort, {
           onStderr,
+          onStdout,
         })
       }
     })


### PR DESCRIPTION
This PR makes sure `renderPage` calls `renderShell` in concurrent features, and `renderToString` if not.

Closes #36268, #36229.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
