### PR TITLE
Making inline scripts work with the beforeInteractive strategy

### DIFF
--- a/docs/basic-features/script.md
+++ b/docs/basic-features/script.md
@@ -243,9 +243,8 @@ Or by using the `dangerouslySetInnerHTML` property:
 />
 ```
 
-There are two limitations to be aware of when using the Script component for inline scripts:
+**Note when using the Script component with inline scripts**:
 
-- Only the `afterInteractive` and `lazyOnload` strategies can be used. The `beforeInteractive` loading strategy injects the contents of an external script into the initial HTML response. Inline scripts already do this, which is why **the `beforeInteractive` strategy cannot be used with inline scripts.**
 - An `id` attribute must be defined in order for Next.js to track and optimize the script
 
 ### Executing Code After Loading (`onLoad`)

--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -149,7 +149,6 @@ function Script(props: ScriptProps): JSX.Element | null {
   const {
     src = '',
     onLoad = () => {},
-    dangerouslySetInnerHTML,
     strategy = 'afterInteractive',
     onError,
     ...restProps

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -150,8 +150,9 @@ function getPreNextScripts(context: HtmlProps, props: OriginProps) {
 
   const webWorkerScripts = getPreNextWorkerScripts(context, props)
 
-  const beforeInteractiveScripts = (scriptLoader.beforeInteractive || []).map(
-    (file: ScriptProps, index: number) => {
+  const beforeInteractiveScripts = (scriptLoader.beforeInteractive || [])
+    .filter((script) => script.src)
+    .map((file: ScriptProps, index: number) => {
       const { strategy, ...scriptProps } = file
       return (
         <script
@@ -163,8 +164,7 @@ function getPreNextScripts(context: HtmlProps, props: OriginProps) {
           crossOrigin={props.crossOrigin || crossOrigin}
         />
       )
-    }
-  )
+    })
 
   return (
     <>
@@ -500,6 +500,44 @@ export class Head extends Component<
     ]
   }
 
+  getBeforeInteractiveInlineScripts() {
+    const { scriptLoader } = this.context
+    const { nonce, crossOrigin } = this.props
+
+    return (scriptLoader.beforeInteractive || [])
+      .filter(
+        (script) =>
+          !script.src && (script.dangerouslySetInnerHTML || script.children)
+      )
+      .map((file: ScriptProps, index: number) => {
+        const { strategy, children, dangerouslySetInnerHTML, ...scriptProps } =
+          file
+        let html = ''
+
+        if (dangerouslySetInnerHTML && dangerouslySetInnerHTML.__html) {
+          html = dangerouslySetInnerHTML.__html
+        } else if (children) {
+          html =
+            typeof children === 'string'
+              ? children
+              : Array.isArray(children)
+              ? children.join('')
+              : ''
+        }
+
+        return (
+          <script
+            {...scriptProps}
+            dangerouslySetInnerHTML={{ __html: html }}
+            key={scriptProps.id || index}
+            nonce={nonce}
+            data-nscript="beforeInteractive"
+            crossOrigin={crossOrigin || process.env.__NEXT_CROSS_ORIGIN}
+          />
+        )
+      })
+  }
+
   getDynamicChunks(files: DocumentFiles) {
     return getDynamicChunks(this.context, this.props, files)
   }
@@ -782,6 +820,7 @@ export class Head extends Component<
                 href={canonicalBase + getAmpPath(ampPath, dangerousAsPath)}
               />
             )}
+            {this.getBeforeInteractiveInlineScripts()}
             {!optimizeCss && this.getCssLinks(files)}
             {!optimizeCss && <noscript data-n-css={this.props.nonce ?? ''} />}
 

--- a/test/integration/script-loader/base/pages/_document.js
+++ b/test/integration/script-loader/base/pages/_document.js
@@ -16,6 +16,13 @@ export default function Document() {
           src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js?a=scriptBeforeInteractive"
           strategy="beforeInteractive"
         ></Script>
+        <Script
+          id="inline-before"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `console.log('inline beforeInteractive')`,
+          }}
+        ></Script>
       </Head>
       <body>
         <Main />

--- a/test/integration/script-loader/test/index.test.js
+++ b/test/integration/script-loader/test/index.test.js
@@ -176,6 +176,19 @@ describe('Next.js Script - Primary Strategies', () => {
     }
   })
 
+  it('priority beforeInteractive with inline script', async () => {
+    const html = await renderViaHTTP(appPort, '/page5')
+    const $ = cheerio.load(html)
+
+    const script = $('#inline-before')
+    expect(script.length).toBe(1)
+
+    // Script is inserted before CSS
+    expect(
+      $(`#inline-before ~ link[href^="/_next/static/css"]`).length
+    ).toBeGreaterThan(0)
+  })
+
   it('onload fires correctly', async () => {
     let browser
     try {


### PR DESCRIPTION
Make beforeInteractive strategy on `next/script` support inline scripts
Helps with #36318

## Bug

- [x]  `fixes #26591 #26343 #26240`
- [x] Integration tests added


## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
