### PR TITLE
Change getStaticProps to getStaticPaths in getStaticPaths docs

### DIFF
--- a/docs/basic-features/data-fetching/get-static-paths.md
+++ b/docs/basic-features/data-fetching/get-static-paths.md
@@ -37,9 +37,9 @@ You should use `getStaticPaths` if you’re statically pre-rendering pages that 
 
 `getStaticPaths` will only run during build in production, it will not be called during runtime. You can validate code written inside `getStaticPaths` is removed from the client-side bundle [with this tool](https://next-code-elimination.vercel.app/).
 
-- `getStaticProps` runs during `next build` for any `paths` returned during build
-- `getStaticProps` runs in the background when using `fallback: true`
-- `getStaticProps` is called before initial render when using `fallback: blocking`
+- `getStaticPaths` runs during `next build` for any `paths` returned during build
+- `getStaticPaths` runs in the background when using `fallback: true`
+- `getStaticPaths` is called before initial render when using `fallback: blocking`
 
 ## Where can I use getStaticPaths
 


### PR DESCRIPTION
## Overview
The subject is `When does getStaticPaths run` but this docs denotes about `getStaticProps`.
So could you check `getStaticProps` is right?

## Documentation / Examples

- [X] Make sure the linting passes by running `yarn lint`
