### PR TITLE
Don't polyfill `process` on Middleware

### DIFF
--- a/test/development/using-node.js-runtime-apis-in-middleware-emits-a-warning/index.test.ts
+++ b/test/development/using-node.js-runtime-apis-in-middleware-emits-a-warning/index.test.ts
@@ -1,0 +1,80 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { fetchViaHTTP } from 'next-test-utils'
+
+describe('Using Node.js runtime APIs in Middleware has descriptive error messages', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    process.env.NODE_JS_RUNTIME_API_TESTS = 'hello'
+    next = await createNext({
+      files: {
+        'pages/_middleware.js': `
+          import { NextResponse } from 'next/server'
+
+          export default function middleware(req) { 
+            const tag = req.headers.get('x-tag');
+            console.log('[invocation] ' + tag);
+            return NextResponse.json({
+              'process.env.NODE_JS_RUNTIME_API_TESTS': process.env.NODE_JS_RUNTIME_API_TESTS,
+              'process.cwd': process.cwd(),
+            });
+          } 
+        `,
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('prints a warning for each incompatible API', async () => {
+    const response = await fetchViaHTTP(
+      next.url,
+      '/',
+      {},
+      {
+        headers: {
+          'x-tag': 'warning-test',
+        },
+      }
+    )
+    const logs = getLogsForTag('warning-test', next)
+    expect(logs).toContain(
+      `You're using a Node.js API (process.cwd) which is not supported`
+    )
+    expect(response.ok).toBe(false)
+  })
+
+  it('fails the request', async () => {
+    const response = await fetchViaHTTP(
+      next.url,
+      '/',
+      {},
+      {
+        headers: {
+          'x-tag': 'fails-the-request',
+        },
+      }
+    )
+    const logs = getLogsForTag('fails-the-request', next)
+    expect(logs).toContain(`TypeError: process.cwd is not a function`)
+    expect(response.ok).toBe(false)
+  })
+})
+
+function getLogsForTag(tag: string, next: NextInstance) {
+  const lines = next.cliOutput.split('\n')
+  const startIndex = lines.findIndex((x) => x.trim() === `[invocation] ${tag}`)
+  if (startIndex === -1) {
+    throw new Error(`Could not find invocation for tag ${tag}`)
+  }
+
+  const linesFromIndex = lines.slice(startIndex + 1)
+  const endIndex = linesFromIndex.findIndex((x) => x.trim() === `[invocation] `)
+
+  if (endIndex === -1) {
+    return linesFromIndex.join('\n')
+  } else {
+    return linesFromIndex.slice(0, endIndex).join('\n')
+  }
+}

--- a/test/integration/middleware/core/pages/global/_middleware.js
+++ b/test/integration/middleware/core/pages/global/_middleware.js
@@ -6,7 +6,6 @@ export async function middleware(request, ev) {
   return NextResponse.json({
     process: {
       env: process.env,
-      nextTick: typeof process.nextTick,
     },
   })
 }

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -131,9 +131,6 @@ describe('Middleware base tests', () => {
           env: {
             MIDDLEWARE_TEST: 'asdf',
           },
-          // it's poflyfilled since there is the "process" module
-          // as a devDepencies of the next package
-          nextTick: 'function',
         },
       })
     })

--- a/test/production/using-node.js-runtime-apis-fails-to-build/index.test.ts
+++ b/test/production/using-node.js-runtime-apis-fails-to-build/index.test.ts
@@ -1,0 +1,54 @@
+import { nextBuild } from 'next-test-utils'
+import os from 'os'
+import path from 'path'
+import { outputFile } from 'fs-extra'
+
+it('fails to build Middleware with `eval`', async () => {
+  const rootDir = await createStructure({
+    'pages/_middleware.js': `
+      export default function middleware() { 
+        return new Response(eval("'hello'"))
+      } 
+    `,
+  })
+
+  const result = await nextBuild(rootDir, [], {
+    stderr: true,
+    stdout: true,
+  })
+
+  expect(result.stderr).toContain(
+    `Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Middleware pages/_middleware`
+  )
+})
+
+it('fails to build Middleware with `process.cwd`', async () => {
+  const rootDir = await createStructure({
+    'pages/_middleware.js': `
+      export default function middleware() { 
+        return new Response(process.cwd())
+      } 
+    `,
+  })
+
+  const result = await nextBuild(rootDir, [], {
+    stderr: true,
+    stdout: true,
+  })
+
+  expect(result.stderr).toContain(
+    `You're using a Node.js API (process.cwd) which is not supported in the Edge Runtime that Middleware uses (used in pages/_middleware)`
+  )
+})
+
+async function createStructure(
+  structure: Record<string, string>
+): Promise<string> {
+  const rootDir = path.join(os.tmpdir(), `next-${Date.now()}`)
+
+  for (const [filePath, contents] of Object.entries(structure)) {
+    await outputFile(path.join(rootDir, filePath), contents)
+  }
+
+  return rootDir
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9445,6 +9445,14 @@ enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^5.8.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz#44a342c012cbc473254af5cc6ae20ebd0aae5d88"
+  integrity sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enhanced-resolve@^5.9.2:
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz#0224dcd6a43389ebfb2d55efee517e5466772dd9"
@@ -14920,7 +14928,6 @@ minipass-fetch@^1.3.0, minipass-fetch@^1.3.2:
   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.3.3.tgz#34c7cea038c817a8658461bf35174551dce17a0a"
   integrity sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==
   dependencies:
-    encoding "^0.1.12"
     minipass "^3.1.0"
     minipass-sized "^1.0.3"
     minizlib "^2.0.0"


### PR DESCRIPTION
since Middleware run with a different runtime, the polyfills work like their browser counterparts,
which make no sense in a server-side environment and only get in the way.

This commit introduces a warning when using anything from `process` other than `process.env`,
and returning `undefined` so users won't use the polyfilled `process`