### PR TITLE
Allow developers to disable concurrent rendering (reactRoot: false) with React 18

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -111,7 +111,6 @@ import { TelemetryPlugin } from './webpack/plugins/telemetry-plugin'
 import { MiddlewareManifest } from './webpack/plugins/middleware-plugin'
 import type { webpack5 as webpack } from 'next/dist/compiled/webpack/webpack'
 import { recursiveCopy } from '../lib/recursive-copy'
-import { shouldUseReactRoot } from '../server/config'
 
 export type SsgRoute = {
   initialRevalidateSeconds: number | false
@@ -160,8 +159,8 @@ export default async function build(
     setGlobal('distDir', distDir)
 
     // We enable concurrent features (Fizz-related rendering architecture) when
-    // using React 18 or experimental.
-    const hasReactRoot = shouldUseReactRoot()
+    // using React 18 or experimental and the developer hasn't opted out
+    const hasReactRoot = !!config.experimental.reactRoot
     const hasConcurrentFeatures = hasReactRoot
     const hasServerComponents =
       hasReactRoot && !!config.experimental.serverComponents

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -189,7 +189,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
   }
 
   const hasReactRoot = shouldUseReactRoot()
-  if (hasReactRoot) {
+  if (hasReactRoot && userConfig.experimental?.reactRoot !== false) {
     // users might not have the `experimental` key in their config
     result.experimental = result.experimental || {}
     result.experimental.reactRoot = true

--- a/test/integration/react-18-serial/app/next.config.js
+++ b/test/integration/react-18-serial/app/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  experimental: {
+    // Explicitly opt out of concurrent rendering
+    reactRoot: false,
+  },
+}

--- a/test/integration/react-18-serial/app/package.json
+++ b/test/integration/react-18-serial/app/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "dev": "yarn next dev",
+    "build": "yarn next build",
+    "start": "yarn next start"
+  },
+  "dependencies": {
+    "react": "*",
+    "react-dom": "*"
+  }
+}

--- a/test/integration/react-18-serial/app/pages/_document.js
+++ b/test/integration/react-18-serial/app/pages/_document.js
@@ -1,0 +1,36 @@
+import Document, { Head, Html, Main, NextScript } from 'next/document'
+
+export default class CustomDocument extends Document {
+  static async getInitialProps(ctx) {
+    let mainContentLength
+
+    const originalRenderPage = ctx.renderPage
+    // Keep renderPage synchronous since this integration test checks for
+    // serial rendering
+    ctx.renderPage = () => {
+      const result = originalRenderPage()
+      mainContentLength = result.html.length
+      return result
+    }
+
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps, mainContentLength }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <meta
+            name="test-main-content-length"
+            value={this.props.mainContentLength}
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}

--- a/test/integration/react-18-serial/app/pages/index.js
+++ b/test/integration/react-18-serial/app/pages/index.js
@@ -1,0 +1,12 @@
+import ReactDOM from 'react-dom'
+
+export default function Index() {
+  if (typeof window !== 'undefined') {
+    window.didHydrate = true
+  }
+  return (
+    <div>
+      <p id="react-dom-version">{ReactDOM.version}</p>
+    </div>
+  )
+}

--- a/test/integration/react-18-serial/test/basics.js
+++ b/test/integration/react-18-serial/test/basics.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+
+import webdriver from 'next-webdriver'
+import { renderViaHTTP } from 'next-test-utils'
+
+export default (context, env) => {
+  it('renders pages in serial', async () => {
+    const html = await renderViaHTTP(context.appPort, '/')
+    expect(html).toMatch(/<meta name="test-main-content-length" value="\d+"\/>/)
+  })
+
+  it('hydrates correctly for normal page', async () => {
+    const browser = await webdriver(context.appPort, '/')
+    expect(await browser.eval('window.didHydrate')).toBe(true)
+    expect(await browser.elementById('react-dom-version').text()).toMatch(/18/)
+  })
+}

--- a/test/integration/react-18-serial/test/index.test.js
+++ b/test/integration/react-18-serial/test/index.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+
+import { runDevSuite, runProdSuite } from 'next-test-utils'
+import basics from './basics'
+
+const appDir = join(__dirname, '../app')
+
+describe('Basics', () => {
+  runTests('react 18 with reactRoot set to false', basics)
+})
+
+function runTests(name, fn, opts) {
+  const suiteOptions = { ...opts, runTests: fn }
+  runDevSuite(name, appDir, suiteOptions)
+  runProdSuite(name, appDir, suiteOptions)
+}


### PR DESCRIPTION
Currently any website that uses React 18 causes `shouldUseReactRoot()` to return true, which forces `config.experimental.reactRoot` to be true and enables concurrent rendering. There are several libraries--often those that buffer up CSS used during rendering and emit it before streaming the response to the client--that rely on React's rendering to be synchronous. While those libraries will eventually need to be updated to support streaming and Suspense in some cases, they work with React 18 otherwise.

This commit lets websites disable concurrent features by explicitly setting `experimental.reactRoot = false` in next.config.js. If `experimental.reactRoot` is unspecified, then the existing default behavior still applies: `reactRoot` is true when using React 18+ or an experimental version and false otherwise. Production builds use the same resolved config object so future changes to this behavior will apply to both development and production.

Tested in a sample website that relies on synchronous React rendering and uses React 18. When `experimental.reactRoot` is false, the site renders. When it's true or not defined, the site expectedly fails to render (as was the case before this commit). Ran `next build` to make sure that production builds honor the same logic.

Added an integration test. Run with `node run-tests.js test/integration/react-18-serial/test/index.test.js`.

## Bug

- [ ] Related issues linked using `fixes #number` **This PR is the bug report**
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md` **N/A**