### PR TITLE
Revert "Change getStaticProps to getStaticPaths in getStaticPaths docs"

### DIFF
--- a/docs/basic-features/data-fetching/get-static-paths.md
+++ b/docs/basic-features/data-fetching/get-static-paths.md
@@ -37,9 +37,9 @@ You should use `getStaticPaths` if you’re statically pre-rendering pages that 
 
 `getStaticPaths` will only run during build in production, it will not be called during runtime. You can validate code written inside `getStaticPaths` is removed from the client-side bundle [with this tool](https://next-code-elimination.vercel.app/).
 
-- `getStaticPaths` runs during `next build` for any `paths` returned during build
-- `getStaticPaths` runs in the background when using `fallback: true`
-- `getStaticPaths` is called before initial render when using `fallback: blocking`
+- `getStaticProps` runs during `next build` for any `paths` returned during build
+- `getStaticProps` runs in the background when using `fallback: true`
+- `getStaticProps` is called before initial render when using `fallback: blocking`
 
 ## Where can I use getStaticPaths
 


### PR DESCRIPTION
This change was un-necessary and `getStaticProps` was correct here so this reverts the change. 

Reverts vercel/next.js#36403