### PR TITLE
Fix to remove webpack message per error

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -739,13 +739,6 @@ export default async function build(
         )
       }
 
-      const breakingChangeIndex = error.indexOf(
-        '\n\nBREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.'
-      )
-      if (breakingChangeIndex >= 0) {
-        error = error.slice(0, breakingChangeIndex)
-      }
-
       console.error(error)
       console.error()
 

--- a/packages/next/client/dev/error-overlay/format-webpack-messages.js
+++ b/packages/next/client/dev/error-overlay/format-webpack-messages.js
@@ -27,6 +27,9 @@ import stripAnsi from 'next/dist/compiled/strip-ansi'
 
 const friendlySyntaxErrorLabel = 'Syntax error:'
 
+const WEBPACK_BREAKING_CHANGE_POLYFILLS =
+  '\n\nBREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.'
+
 function isLikelyASyntaxError(message) {
   return stripAnsi(message).indexOf(friendlySyntaxErrorLabel) !== -1
 }
@@ -43,10 +46,17 @@ function formatMessage(message, verbose) {
             trace.originName
           )
       )
+
+    let body = message.message
+    const breakingChangeIndex = body.indexOf(WEBPACK_BREAKING_CHANGE_POLYFILLS)
+    if (breakingChangeIndex >= 0) {
+      body = body.slice(0, breakingChangeIndex)
+    }
+
     message =
       (message.moduleName ? stripAnsi(message.moduleName) + '\n' : '') +
       (message.file ? stripAnsi(message.file) + '\n' : '') +
-      message.message +
+      body +
       (message.details && verbose ? '\n' + message.details : '') +
       (filteredModuleTrace && filteredModuleTrace.length && verbose
         ? '\n\nImport trace for requested module:' +


### PR DESCRIPTION
Remove the webpack breaking change message per error since it can be contained in all errors and the current implementation causes to truncate other error messages

Follow up for https://github.com/vercel/next.js/pull/36190

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`