### PR TITLE
Update usage paragraph of next/script `onLoad`

### DIFF
--- a/docs/api-reference/next/script.md
+++ b/docs/api-reference/next/script.md
@@ -73,3 +73,29 @@ export default function Home() {
   )
 }
 ```
+
+### onError
+
+A method that executes if the script fails to load.
+
+> **Note: `onError` can't be used with the `beforeInteractive` loading strategy.**
+
+The following is an example of how to use the `onError` property:
+
+```jsx
+import Script from 'next/script'
+
+export default function Home() {
+  return (
+    <>
+      <Script
+        id="will-fail"
+        src="https://example.com/non-existant-script.js"
+        onError={(e) => {
+          console.error('Script failed to load', e)
+        }}
+      />
+    </>
+  )
+}
+```

--- a/docs/basic-features/script.md
+++ b/docs/basic-features/script.md
@@ -250,7 +250,7 @@ There are two limitations to be aware of when using the Script component for inl
 
 ### Executing Code After Loading (`onLoad`)
 
-Some third-party scripts require users to run JavaScript code after the script has finished loading in order to instantiate content or call a function. If you are loading a script with either `beforeInteractive` or `afterInteractive` as a loading strategy, you can execute code after it has loaded using the `onLoad` property:
+Some third-party scripts require users to run JavaScript code after the script has finished loading in order to instantiate content or call a function. If you are loading a script with either `afterInteractive` or `lazyOnload` as a loading strategy, you can execute code after it has loaded using the `onLoad` property:
 
 ```jsx
 import { useState } from 'react'

--- a/docs/basic-features/script.md
+++ b/docs/basic-features/script.md
@@ -250,6 +250,8 @@ There are two limitations to be aware of when using the Script component for inl
 
 ### Executing Code After Loading (`onLoad`)
 
+> **Note: Both `onLoad` and `onError` can't be used with the `beforeInteractive` loading strategy.**
+
 Some third-party scripts require users to run JavaScript code after the script has finished loading in order to instantiate content or call a function. If you are loading a script with either `afterInteractive` or `lazyOnload` as a loading strategy, you can execute code after it has loaded using the `onLoad` property:
 
 ```jsx
@@ -272,8 +274,6 @@ export default function Home() {
   )
 }
 ```
-
-> **Note: `onLoad` can't be used with the `beforeInteractive` loading strategy.**
 
 Sometimes it is helpful to catch when a script fails to load. These errors can be handled with the `onError` property:
 


### PR DESCRIPTION
Changing the paragraph to not include `beforeInteractive` as one of the possible use cases of `onLoad`.

*Update:* Added docs for `onError` in the API reference of `next/script`.

@housseindjirdeh does `onError` also has the same limitation or is this only for `onLoad`?

Closes https://github.com/vercel/next.js/issues/33402

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
