### PR TITLE
Fix incorrect asPath with fallback rewrite in minimal mode

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/index.ts
@@ -105,19 +105,15 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
 
         import { getApiHandler } from 'next/dist/build/webpack/loaders/next-serverless-loader/api-handler'
 
-        const combinedRewrites = Array.isArray(routesManifest.rewrites)
-          ? routesManifest.rewrites
-          : []
-
-        if (!Array.isArray(routesManifest.rewrites)) {
-          combinedRewrites.push(...routesManifest.rewrites.beforeFiles)
-          combinedRewrites.push(...routesManifest.rewrites.afterFiles)
-          combinedRewrites.push(...routesManifest.rewrites.fallback)
-        }
+        const rewrites = Array.isArray(routesManifest.rewrites)
+          ? {
+            afterFiles: routesManifest.rewrites
+          }
+          : routesManifest.rewrites
 
         const apiHandler = getApiHandler({
           pageModule: require(${stringifyRequest(this, absolutePagePath)}),
-          rewrites: combinedRewrites,
+          rewrites: rewrites,
           i18n: ${i18n || 'undefined'},
           page: "${page}",
           basePath: "${basePath}",
@@ -166,15 +162,11 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
       export let config = compMod['confi' + 'g'] || (compMod.then && compMod.then(mod => mod['confi' + 'g'])) || {}
       export const _app = App
 
-      const combinedRewrites = Array.isArray(routesManifest.rewrites)
-        ? routesManifest.rewrites
-        : []
-
-      if (!Array.isArray(routesManifest.rewrites)) {
-        combinedRewrites.push(...routesManifest.rewrites.beforeFiles)
-        combinedRewrites.push(...routesManifest.rewrites.afterFiles)
-        combinedRewrites.push(...routesManifest.rewrites.fallback)
-      }
+      const rewrites = Array.isArray(routesManifest.rewrites)
+        ? {
+          afterFiles: routesManifest.rewrites
+        }
+        : routesManifest.rewrites
 
       const { renderReqToHTML, render } = getPageHandler({
         pageModule: compMod,
@@ -202,7 +194,7 @@ const nextServerlessLoader: webpack.loader.Loader = function () {
         buildManifest,
         reactLoadableManifest,
 
-        rewrites: combinedRewrites,
+        rewrites: rewrites,
         i18n: ${i18n || 'undefined'},
         page: "${page}",
         buildId: "${buildId}",

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -96,16 +96,6 @@ export function getUtils({
     parsedUrl: UrlWithParsedQuery
   ) {
     const rewriteParams = {}
-    const addRewriteType =
-      (type: string) =>
-      (
-        _r: Rewrite
-      ): Rewrite & { type: 'beforeFiles' | 'afterFiles' | 'fallback' } => {
-        const r = _r as any
-        r.type = type
-        return r
-      }
-
     let fsPathname = parsedUrl.pathname
 
     const matchesPage = () => {

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -124,6 +124,11 @@ export function getUtils({
           query: parsedUrl.query,
         })
 
+        // if the rewrite destination is external break rewrite chain
+        if (parsedDestination.protocol) {
+          return true
+        }
+
         Object.assign(rewriteParams, destQuery, params)
         Object.assign(parsedUrl.query, parsedDestination.query)
         delete (parsedDestination as any).query
@@ -169,7 +174,7 @@ export function getUtils({
       checkRewrite(rewrite)
     }
 
-    if (!matchesPage()) {
+    if (fsPathname !== page) {
       let finished = false
 
       for (const rewrite of rewrites.afterFiles || []) {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -480,18 +480,12 @@ export default abstract class Server {
         }
 
         const pageIsDynamic = isDynamicRoute(srcPathname)
-        const combinedRewrites: Rewrite[] = []
-
-        combinedRewrites.push(...this.customRoutes.rewrites.beforeFiles)
-        combinedRewrites.push(...this.customRoutes.rewrites.afterFiles)
-        combinedRewrites.push(...this.customRoutes.rewrites.fallback)
-
         const utils = getUtils({
           pageIsDynamic,
           page: srcPathname,
           i18n: this.nextConfig.i18n,
           basePath: this.nextConfig.basePath,
-          rewrites: combinedRewrites,
+          rewrites: this.customRoutes.rewrites,
         })
 
         try {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -8,7 +8,6 @@ import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plu
 import type { NextConfig, NextConfigComplete } from './config-shared'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import type { ParsedUrlQuery } from 'querystring'
-import type { Rewrite } from '../lib/load-custom-routes'
 import type { RenderOpts, RenderOptsPartial } from './render'
 import type { ResponseCacheEntry, ResponseCacheValue } from './response-cache'
 import type { UrlWithParsedQuery } from 'url'

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -479,6 +479,15 @@ export default abstract class Server {
           srcPathname = denormalizePagePath(srcPathname)
         }
 
+        if (!isDynamicRoute(srcPathname) && !this.hasPage(srcPathname)) {
+          for (const dynamicRoute of this.dynamicRoutes || []) {
+            if (dynamicRoute.match(srcPathname)) {
+              srcPathname = dynamicRoute.page
+              break
+            }
+          }
+        }
+
         const pageIsDynamic = isDynamicRoute(srcPathname)
         const utils = getUtils({
           pageIsDynamic,

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -49,20 +49,29 @@ describe('should set-up next', () => {
           outputStandalone: true,
         },
         async rewrites() {
-          return [
-            {
-              source: '/some-catch-all/:path*',
-              destination: '/',
-            },
-            {
-              source: '/to-dynamic/post-2',
-              destination: '/dynamic/post-2?hello=world',
-            },
-            {
-              source: '/to-dynamic/:path',
-              destination: '/dynamic/:path',
-            },
-          ]
+          return {
+            beforeFiles: [],
+            fallback: [
+              {
+                source: '/an-ssg-path',
+                destination: '/hello.txt',
+              },
+            ],
+            afterFiles: [
+              {
+                source: '/some-catch-all/:path*',
+                destination: '/',
+              },
+              {
+                source: '/to-dynamic/post-2',
+                destination: '/dynamic/post-2?hello=world',
+              },
+              {
+                source: '/to-dynamic/:path',
+                destination: '/dynamic/:path',
+              },
+            ],
+          }
         },
       },
     })
@@ -691,6 +700,7 @@ describe('should set-up next', () => {
     expect(res.status).toBe(200)
     const $ = cheerio.load(await res.text())
     expect($('#resolved-url').text()).toBe('/dynamic/post-2')
+    expect(JSON.parse($('#router').text()).asPath).toBe('/to-dynamic/post-2')
   })
 
   it('should have correct resolvedUrl from dynamic route', async () => {
@@ -874,6 +884,20 @@ describe('should set-up next', () => {
     const html = await res.text()
     const $ = cheerio.load(html)
     expect($('#slug-page').text()).toBe('[slug] page')
+  })
+
+  it('should have correct asPath on dynamic SSG page correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/an-ssg-path', undefined, {
+      headers: {
+        'x-matched-path': '/[slug]',
+      },
+      redirect: 'manual',
+    })
+
+    const html = await res.text()
+    const $ = cheerio.load(html)
+    expect($('#slug-page').text()).toBe('[slug] page')
+    expect(JSON.parse($('#router').text()).asPath).toBe('/an-ssg-path')
   })
 
   it('should copy and read .env file', async () => {

--- a/test/production/required-server-files/pages/[slug]/index.js
+++ b/test/production/required-server-files/pages/[slug]/index.js
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router'
+
 export const getStaticProps = () => {
   return {
     props: {
@@ -14,5 +16,11 @@ export const getStaticPaths = () => {
 }
 
 export default function Page(props) {
-  return <p id="slug-page">[slug] page</p>
+  const router = useRouter()
+  return (
+    <>
+      <p id="slug-page">[slug] page</p>
+      <p id="router">{JSON.stringify(router)}</p>
+    </>
+  )
 }


### PR DESCRIPTION
This continues off of the change in https://github.com/vercel/next.js/pull/36368 and ensures a fallback rewrite does not influence the `asPath` as these are only matched when a filesystem or dynamic route aren't matched. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: https://github.com/vercel/next.js/pull/36368