### PR TITLE
chore: remove git.io

### DIFF
--- a/packages/next/server/lib/squoosh/impl.ts
+++ b/packages/next/server/lib/squoosh/impl.ts
@@ -7,7 +7,7 @@ type EncoderKey = keyof typeof supportedFormats
 // Fixed in Node.js 16.5.0 and newer.
 // See https://github.com/nodejs/node/pull/39337
 // Eventually, remove this delay when engines is updated.
-// See https://git.io/JCTr0
+// See https://github.com/vercel/next.js/blob/1bcc923439f495a1717421e06af7e64c6003072c/packages/next/package.json#L249-L251
 const FIXED_VERSION = '16.5.0'
 const DELAY_MS = 1000
 let _promise: Promise<void> | undefined


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
