### PR TITLE
Pass nextRuntime in webpack context

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1820,6 +1820,11 @@ export default async function getBaseWebpackConfig(
       defaultLoaders,
       totalPages,
       webpack,
+      ...(isServer
+        ? {
+            nextRuntime: isEdgeRuntime ? 'edge' : 'nodejs',
+          }
+        : {}),
     })
 
     if (!webpackConfig) {

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -65,6 +65,8 @@ export interface WebpackConfigContext {
   totalPages: number
   /** The webpack configuration */
   webpack: any
+  /** The current server runtime */
+  nextRuntime?: 'nodejs' | 'edge'
 }
 
 export interface NextJsWebpackConfig {

--- a/test/production/react-18-streaming-ssr/index.test.ts
+++ b/test/production/react-18-streaming-ssr/index.test.ts
@@ -22,6 +22,23 @@ describe('react 18 streaming SSR in minimal mode', () => {
           serverComponents: true,
           runtime: 'nodejs',
         },
+        webpack(config, { nextRuntime }) {
+          const path = require('path')
+          const fs = require('fs')
+
+          const runtimeFilePath = path.join(__dirname, 'runtimes.txt')
+          let runtimeContent = ''
+
+          try {
+            runtimeContent = fs.readFileSync(runtimeFilePath, 'utf8')
+            runtimeContent += '\n'
+          } catch (_) {}
+
+          runtimeContent += nextRuntime || 'client'
+
+          fs.writeFileSync(runtimeFilePath, runtimeContent)
+          return config
+        },
       },
       dependencies: {
         react: '18.0.0',
@@ -32,6 +49,11 @@ describe('react 18 streaming SSR in minimal mode', () => {
   afterAll(() => {
     delete process.env.NEXT_PRIVATE_MINIMAL_MODE
     next.destroy()
+  })
+
+  it('should pass correct nextRuntime values', async () => {
+    const content = await next.readFile('runtimes.txt')
+    expect(content.split('\n').sort()).toEqual(['client', 'edge', 'nodejs'])
   })
 
   it('should generate html response by streaming correctly', async () => {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/36383 this also exposes the `nextRuntime` for the custom webpack function in `next.config.js` to allow differentiating between the environments. 

x-ref: https://vercel.slack.com/archives/CGU8HUTUH/p1647866770704939