### PR TITLE
Fix failing yarn PnP test from missing dependency

### DIFF
--- a/examples/with-styled-components-babel/package.json
+++ b/examples/with-styled-components-babel/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "17.0.24",
+    "@types/react": "^17.0.2",
     "@types/styled-components": "5.1.25",
     "babel-plugin-styled-components": "^1.12.0",
     "typescript": "4.6.3"


### PR DESCRIPTION
Fixes failing test from missing dependency that was most likely provided via a nested dependency previously. 

x-ref: https://github.com/vercel/next.js/pull/36513#issuecomment-1111090653
x-ref: https://github.com/vercel/next.js/runs/6195457073?check_suite_focus=true