### PR TITLE
Add string children case for newNextLinkBehavior codemod

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/new-link/link-string.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/new-link/link-string.input.js
@@ -1,0 +1,8 @@
+import Link from 'next/link'
+export default function Page() {
+    return (
+        <Link href="/about">
+            Link
+        </Link>
+    );
+}

--- a/packages/next-codemod/transforms/__testfixtures__/new-link/link-string.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/new-link/link-string.output.js
@@ -1,0 +1,8 @@
+import Link from 'next/link'
+export default function Page() {
+    return (
+        <Link href="/about">
+            Link
+        </Link>
+    );
+}

--- a/packages/next-codemod/transforms/__tests__/new-link.test.js
+++ b/packages/next-codemod/transforms/__tests__/new-link.test.js
@@ -8,7 +8,8 @@ const fixtures = [
   'add-legacy-behavior',
   'excludes-links-with-legacybehavior-prop',
   'children-interpolation',
-  'spread-props'
+  'spread-props',
+  'link-string'
 ]
 
 for (const fixture of fixtures) {

--- a/packages/next-codemod/transforms/new-link.ts
+++ b/packages/next-codemod/transforms/new-link.ts
@@ -36,6 +36,19 @@ export default function transformer(file: FileInfo, api: API) {
         if ($link.size() === 0) {
           return
         }
+
+        const linkChildrenNodes = $link.get('children')
+
+        // Text-only link children are already correct with the new behavior
+        // `next/link` would previously auto-wrap typeof 'string' children already
+        if (
+          linkChildrenNodes.value &&
+          linkChildrenNodes.value.length === 1 &&
+          linkChildrenNodes.value[0].type === 'JSXText'
+        ) {
+          return
+        }
+
         // Direct child elements referenced
         const $childrenElements = $link.childElements()
         const $childrenWithA = $childrenElements.filter((childPath) => {


### PR DESCRIPTION
Found this while running the codemod on the vercel.com app, it ended up adding `oldBehavior` to links with string content only.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
