### PR TITLE
Remove extra yarn PnP example test

### DIFF
--- a/test/e2e/yarn-pnp/test/with-styled-components-babel.test.ts
+++ b/test/e2e/yarn-pnp/test/with-styled-components-babel.test.ts
@@ -1,5 +1,0 @@
-import { runTests } from './utils'
-
-describe('yarn PnP', () => {
-  runTests('with-styled-components-babel')
-})


### PR DESCRIPTION
Since this test seems to be failing here and there and we already have a TypeScript PnP test this removes this specific fixture

x-ref: https://github.com/vercel/next.js/runs/6197090560?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/pull/36516#issuecomment-1111203806