### PR TITLE
Update rewrite destination for flakey rewrite tests

### DIFF
--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -222,7 +222,7 @@ module.exports = {
         },
         {
           source: '/overridden',
-          destination: 'https://vercel.com',
+          destination: 'https://example.vercel.sh',
         },
         {
           source: '/nfl/:path*',

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -89,13 +89,13 @@ const runTests = (isDev = false) => {
       console.error('Invalid response', html)
     }
     expect(res.status).toBe(200)
-    expect(html).toContain('Vercel')
+    expect(html).toContain('Example Domain')
 
     const browser = await webdriver(appPort, '/nav')
     await browser.elementByCss('#to-before-files-overridden').click()
     await check(
       () => browser.eval('document.documentElement.innerHTML'),
-      /Vercel/
+      /Example Domain/
     )
   })
 
@@ -1768,7 +1768,7 @@ const runTests = (isDev = false) => {
               source: '/old-blog/:path*',
             },
             {
-              destination: 'https://vercel.com',
+              destination: 'https://example.vercel.sh',
               regex: normalizeRegEx('^\\/overridden(?:\\/)?$'),
               source: '/overridden',
             },

--- a/test/integration/middleware/core/pages/rewrites/_middleware.js
+++ b/test/integration/middleware/core/pages/rewrites/_middleware.js
@@ -12,7 +12,9 @@ export async function middleware(request) {
   ) {
     const isExternal = url.searchParams.get('override') === 'external'
     return NextResponse.rewrite(
-      isExternal ? 'https://vercel.com' : new URL('/rewrites/a', request.url)
+      isExternal
+        ? 'https://example.vercel.sh'
+        : new URL('/rewrites/a', request.url)
     )
   }
 

--- a/test/integration/middleware/core/pages/rewrites/_middleware.js
+++ b/test/integration/middleware/core/pages/rewrites/_middleware.js
@@ -54,7 +54,7 @@ export async function middleware(request) {
   }
 
   if (url.pathname === '/rewrites/rewrite-me-to-vercel') {
-    return NextResponse.rewrite('https://vercel.com')
+    return NextResponse.rewrite('https://example.vercel.sh')
   }
 
   if (url.pathname === '/rewrites/clear-query-params') {

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -260,13 +260,13 @@ function rewriteTests(log, locale = '') {
     )
 
     expect(res.status).toBe(200)
-    expect(await res.text()).toContain('Vercel')
+    expect(await res.text()).toContain('Example Domain')
 
     const browser = await webdriver(context.appPort, `${locale}/rewrites`)
     await browser.elementByCss('#override-with-external-rewrite').click()
     await check(
       () => browser.eval('document.documentElement.innerHTML'),
-      /Vercel/
+      /Example Domain/
     )
     await check(
       () => browser.eval('window.location.pathname'),

--- a/test/integration/middleware/core/test/index.test.js
+++ b/test/integration/middleware/core/test/index.test.js
@@ -474,12 +474,9 @@ function rewriteTests(log, locale = '') {
       `${locale}/rewrites/rewrite-me-to-vercel`
     )
     const html = await res.text()
-    const $ = cheerio.load(html)
     // const browser = await webdriver(context.appPort, '/rewrite-me-to-vercel')
     // TODO: running this to chech the window.location.pathname hangs for some reason;
-    expect($('head > title').text()).toBe(
-      'Develop. Preview. Ship. For the best frontend teams – Vercel'
-    )
+    expect(html).toContain('Example Domain')
   })
 
   it(`${locale} should rewrite without hard navigation`, async () => {


### PR DESCRIPTION
These tests occasionally flake due to the network in GitHub actions so this uses a simpler test deployment which should hopefully reduce flakes. 

x-ref: https://github.com/vercel/next.js/pull/36518#issuecomment-1111215997