### PR TITLE
Normalize font optimization snapshot to reduce flakes

### DIFF
--- a/test/integration/font-optimization/test/index.test.js
+++ b/test/integration/font-optimization/test/index.test.js
@@ -208,13 +208,20 @@ describe('Font Optimization', () => {
               encoding: 'utf-8',
             })
           )
+          const normalizeContent = (content) => {
+            return content.replace(/\/v[\d]{1,}\//g, '/v0/')
+          }
           const testCss = {}
           testJson.forEach((fontDefinition) => {
-            testCss[fontDefinition.url] = fontDefinition.content
+            testCss[fontDefinition.url] = normalizeContent(
+              fontDefinition.content
+            )
           })
           const snapshotCss = {}
           snapshotJson.forEach((fontDefinition) => {
-            snapshotCss[fontDefinition.url] = fontDefinition.content
+            snapshotCss[fontDefinition.url] = normalizeContent(
+              fontDefinition.content
+            )
           })
 
           expect(testCss).toStrictEqual(snapshotCss)


### PR DESCRIPTION
This aims to remove the need to update the test snapshot every time the font version changes by normalizing the content. 

x-ref:  https://github.com/vercel/next.js/runs/6202902088?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6202819426?check_suite_focus=true