### PR TITLE
Add support for passing ref to next/link with new behavior enabled

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -119,322 +119,325 @@ function linkClicked(
   })
 }
 
-function Link(
-  props: React.PropsWithChildren<
-    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> &
-      LinkProps
-  >
-) {
-  const {
-    legacyBehavior = Boolean(process.env.__NEXT_NEW_LINK_BEHAVIOR) !== true,
-  } = props
-  if (process.env.NODE_ENV !== 'production') {
-    function createPropError(args: {
-      key: string
-      expected: string
-      actual: string
-    }) {
-      return new Error(
-        `Failed prop type: The prop \`${args.key}\` expects a ${args.expected} in \`<Link>\`, but got \`${args.actual}\` instead.` +
-          (typeof window !== 'undefined'
-            ? "\nOpen your browser's console to view the Component stack trace."
-            : '')
-      )
-    }
+type LinkPropsReal = React.PropsWithChildren<
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> &
+    LinkProps
+>
 
-    // TypeScript trick for type-guarding:
-    const requiredPropsGuard: Record<LinkPropsRequired, true> = {
-      href: true,
-    } as const
-    const requiredProps: LinkPropsRequired[] = Object.keys(
-      requiredPropsGuard
-    ) as LinkPropsRequired[]
-    requiredProps.forEach((key: LinkPropsRequired) => {
-      if (key === 'href') {
-        if (
-          props[key] == null ||
-          (typeof props[key] !== 'string' && typeof props[key] !== 'object')
-        ) {
-          throw createPropError({
-            key,
-            expected: '`string` or `object`',
-            actual: props[key] === null ? 'null' : typeof props[key],
-          })
-        }
-      } else {
-        // TypeScript trick for type-guarding:
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const _: never = key
-      }
-    })
-
-    // TypeScript trick for type-guarding:
-    const optionalPropsGuard: Record<LinkPropsOptional, true> = {
-      as: true,
-      replace: true,
-      scroll: true,
-      shallow: true,
-      passHref: true,
-      prefetch: true,
-      locale: true,
-      onClick: true,
-      onMouseEnter: true,
-      legacyBehavior: true,
-    } as const
-    const optionalProps: LinkPropsOptional[] = Object.keys(
-      optionalPropsGuard
-    ) as LinkPropsOptional[]
-    optionalProps.forEach((key: LinkPropsOptional) => {
-      const valType = typeof props[key]
-
-      if (key === 'as') {
-        if (props[key] && valType !== 'string' && valType !== 'object') {
-          throw createPropError({
-            key,
-            expected: '`string` or `object`',
-            actual: valType,
-          })
-        }
-      } else if (key === 'locale') {
-        if (props[key] && valType !== 'string') {
-          throw createPropError({
-            key,
-            expected: '`string`',
-            actual: valType,
-          })
-        }
-      } else if (key === 'onClick' || key === 'onMouseEnter') {
-        if (props[key] && valType !== 'function') {
-          throw createPropError({
-            key,
-            expected: '`function`',
-            actual: valType,
-          })
-        }
-      } else if (
-        key === 'replace' ||
-        key === 'scroll' ||
-        key === 'shallow' ||
-        key === 'passHref' ||
-        key === 'prefetch' ||
-        key === 'legacyBehavior'
-      ) {
-        if (props[key] != null && valType !== 'boolean') {
-          throw createPropError({
-            key,
-            expected: '`boolean`',
-            actual: valType,
-          })
-        }
-      } else {
-        // TypeScript trick for type-guarding:
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const _: never = key
-      }
-    })
-
-    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const hasWarned = React.useRef(false)
-    if (props.prefetch && !hasWarned.current) {
-      hasWarned.current = true
-      console.warn(
-        'Next.js auto-prefetches automatically based on viewport. The prefetch attribute is no longer needed. More: https://nextjs.org/docs/messages/prefetch-true-deprecated'
-      )
-    }
-  }
-
-  let children: React.ReactNode
-
-  const {
-    href: hrefProp,
-    as: asProp,
-    children: childrenProp,
-    prefetch: prefetchProp,
-    passHref,
-    replace,
-    shallow,
-    scroll,
-    locale,
-    onClick,
-    onMouseEnter,
-    ...restProps
-  } = props
-
-  children = childrenProp
-
-  if (legacyBehavior && typeof children === 'string') {
-    children = <a>{children}</a>
-  }
-
-  const p = prefetchProp !== false
-  const router = useRouter()
-
-  const { href, as } = React.useMemo(() => {
-    const [resolvedHref, resolvedAs] = resolveHref(router, hrefProp, true)
-    return {
-      href: resolvedHref,
-      as: asProp ? resolveHref(router, asProp) : resolvedAs || resolvedHref,
-    }
-  }, [router, hrefProp, asProp])
-
-  const previousHref = React.useRef<string>(href)
-  const previousAs = React.useRef<string>(as)
-
-  // This will return the first child, if multiple are provided it will throw an error
-  let child: any
-  if (legacyBehavior) {
-    if (process.env.NODE_ENV === 'development') {
-      if (onClick) {
-        console.warn(
-          `"onClick" was passed to <Link> with \`href\` of \`${hrefProp}\` but "legacyBehavior" was set. The legacy behavior requires onClick be set on the child of next/link`
-        )
-      }
-      if (onMouseEnter) {
-        console.warn(
-          `"onMouseEnter" was passed to <Link> with \`href\` of \`${hrefProp}\` but "legacyBehavior" was set. The legacy behavior requires onMouseEnter be set on the child of next/link`
-        )
-      }
-      try {
-        child = React.Children.only(children)
-      } catch (err) {
-        if (!children) {
-          throw new Error(
-            `No children were passed to <Link> with \`href\` of \`${hrefProp}\` but one child is required https://nextjs.org/docs/messages/link-no-children`
-          )
-        }
-        throw new Error(
-          `Multiple children were passed to <Link> with \`href\` of \`${hrefProp}\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children` +
+const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
+  (props, forwardedRef) => {
+    const {
+      legacyBehavior = Boolean(process.env.__NEXT_NEW_LINK_BEHAVIOR) !== true,
+    } = props
+    if (process.env.NODE_ENV !== 'production') {
+      function createPropError(args: {
+        key: string
+        expected: string
+        actual: string
+      }) {
+        return new Error(
+          `Failed prop type: The prop \`${args.key}\` expects a ${args.expected} in \`<Link>\`, but got \`${args.actual}\` instead.` +
             (typeof window !== 'undefined'
-              ? " \nOpen your browser's console to view the Component stack trace."
+              ? "\nOpen your browser's console to view the Component stack trace."
               : '')
         )
       }
-    } else {
-      child = React.Children.only(children)
-    }
-  }
 
-  const childRef: any =
-    legacyBehavior && child && typeof child === 'object' && child.ref
-
-  const [setIntersectionRef, isVisible, resetVisible] = useIntersection({
-    rootMargin: '200px',
-  })
-
-  const setRef = React.useCallback(
-    (el: Element) => {
-      // Before the link getting observed, check if visible state need to be reset
-      if (previousAs.current !== as || previousHref.current !== href) {
-        resetVisible()
-        previousAs.current = as
-        previousHref.current = href
-      }
-
-      setIntersectionRef(el)
-      if (legacyBehavior && childRef) {
-        if (typeof childRef === 'function') childRef(el)
-        else if (typeof childRef === 'object') {
-          childRef.current = el
+      // TypeScript trick for type-guarding:
+      const requiredPropsGuard: Record<LinkPropsRequired, true> = {
+        href: true,
+      } as const
+      const requiredProps: LinkPropsRequired[] = Object.keys(
+        requiredPropsGuard
+      ) as LinkPropsRequired[]
+      requiredProps.forEach((key: LinkPropsRequired) => {
+        if (key === 'href') {
+          if (
+            props[key] == null ||
+            (typeof props[key] !== 'string' && typeof props[key] !== 'object')
+          ) {
+            throw createPropError({
+              key,
+              expected: '`string` or `object`',
+              actual: props[key] === null ? 'null' : typeof props[key],
+            })
+          }
+        } else {
+          // TypeScript trick for type-guarding:
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const _: never = key
         }
-      }
-    },
-    [as, childRef, href, resetVisible, setIntersectionRef, legacyBehavior]
-  )
-  React.useEffect(() => {
-    const shouldPrefetch = isVisible && p && isLocalURL(href)
-    const curLocale =
-      typeof locale !== 'undefined' ? locale : router && router.locale
-    const isPrefetched =
-      prefetched[href + '%' + as + (curLocale ? '%' + curLocale : '')]
-    if (shouldPrefetch && !isPrefetched) {
-      prefetch(router, href, as, {
-        locale: curLocale,
       })
-    }
-  }, [as, href, isVisible, locale, p, router])
 
-  const childProps: {
-    onMouseEnter: React.MouseEventHandler
-    onClick: React.MouseEventHandler
-    href?: string
-    ref?: any
-  } = {
-    ref: setRef,
-    onClick: (e: React.MouseEvent) => {
-      if (process.env.NODE_ENV !== 'production') {
-        if (!e) {
-          throw new Error(
-            `Component rendered inside next/link has to pass click event to "onClick" prop.`
+      // TypeScript trick for type-guarding:
+      const optionalPropsGuard: Record<LinkPropsOptional, true> = {
+        as: true,
+        replace: true,
+        scroll: true,
+        shallow: true,
+        passHref: true,
+        prefetch: true,
+        locale: true,
+        onClick: true,
+        onMouseEnter: true,
+        legacyBehavior: true,
+      } as const
+      const optionalProps: LinkPropsOptional[] = Object.keys(
+        optionalPropsGuard
+      ) as LinkPropsOptional[]
+      optionalProps.forEach((key: LinkPropsOptional) => {
+        const valType = typeof props[key]
+
+        if (key === 'as') {
+          if (props[key] && valType !== 'string' && valType !== 'object') {
+            throw createPropError({
+              key,
+              expected: '`string` or `object`',
+              actual: valType,
+            })
+          }
+        } else if (key === 'locale') {
+          if (props[key] && valType !== 'string') {
+            throw createPropError({
+              key,
+              expected: '`string`',
+              actual: valType,
+            })
+          }
+        } else if (key === 'onClick' || key === 'onMouseEnter') {
+          if (props[key] && valType !== 'function') {
+            throw createPropError({
+              key,
+              expected: '`function`',
+              actual: valType,
+            })
+          }
+        } else if (
+          key === 'replace' ||
+          key === 'scroll' ||
+          key === 'shallow' ||
+          key === 'passHref' ||
+          key === 'prefetch' ||
+          key === 'legacyBehavior'
+        ) {
+          if (props[key] != null && valType !== 'boolean') {
+            throw createPropError({
+              key,
+              expected: '`boolean`',
+              actual: valType,
+            })
+          }
+        } else {
+          // TypeScript trick for type-guarding:
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const _: never = key
+        }
+      })
+
+      // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const hasWarned = React.useRef(false)
+      if (props.prefetch && !hasWarned.current) {
+        hasWarned.current = true
+        console.warn(
+          'Next.js auto-prefetches automatically based on viewport. The prefetch attribute is no longer needed. More: https://nextjs.org/docs/messages/prefetch-true-deprecated'
+        )
+      }
+    }
+
+    let children: React.ReactNode
+
+    const {
+      href: hrefProp,
+      as: asProp,
+      children: childrenProp,
+      prefetch: prefetchProp,
+      passHref,
+      replace,
+      shallow,
+      scroll,
+      locale,
+      onClick,
+      onMouseEnter,
+      ...restProps
+    } = props
+
+    children = childrenProp
+
+    if (legacyBehavior && typeof children === 'string') {
+      children = <a>{children}</a>
+    }
+
+    const p = prefetchProp !== false
+    const router = useRouter()
+
+    const { href, as } = React.useMemo(() => {
+      const [resolvedHref, resolvedAs] = resolveHref(router, hrefProp, true)
+      return {
+        href: resolvedHref,
+        as: asProp ? resolveHref(router, asProp) : resolvedAs || resolvedHref,
+      }
+    }, [router, hrefProp, asProp])
+
+    const previousHref = React.useRef<string>(href)
+    const previousAs = React.useRef<string>(as)
+
+    // This will return the first child, if multiple are provided it will throw an error
+    let child: any
+    if (legacyBehavior) {
+      if (process.env.NODE_ENV === 'development') {
+        if (onClick) {
+          console.warn(
+            `"onClick" was passed to <Link> with \`href\` of \`${hrefProp}\` but "legacyBehavior" was set. The legacy behavior requires onClick be set on the child of next/link`
           )
         }
+        if (onMouseEnter) {
+          console.warn(
+            `"onMouseEnter" was passed to <Link> with \`href\` of \`${hrefProp}\` but "legacyBehavior" was set. The legacy behavior requires onMouseEnter be set on the child of next/link`
+          )
+        }
+        try {
+          child = React.Children.only(children)
+        } catch (err) {
+          if (!children) {
+            throw new Error(
+              `No children were passed to <Link> with \`href\` of \`${hrefProp}\` but one child is required https://nextjs.org/docs/messages/link-no-children`
+            )
+          }
+          throw new Error(
+            `Multiple children were passed to <Link> with \`href\` of \`${hrefProp}\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children` +
+              (typeof window !== 'undefined'
+                ? " \nOpen your browser's console to view the Component stack trace."
+                : '')
+          )
+        }
+      } else {
+        child = React.Children.only(children)
       }
+    }
 
-      if (!legacyBehavior && typeof onClick === 'function') {
-        onClick(e)
+    const childRef: any = legacyBehavior
+      ? child && typeof child === 'object' && child.ref
+      : forwardedRef
+
+    const [setIntersectionRef, isVisible, resetVisible] = useIntersection({
+      rootMargin: '200px',
+    })
+
+    const setRef = React.useCallback(
+      (el: Element) => {
+        // Before the link getting observed, check if visible state need to be reset
+        if (previousAs.current !== as || previousHref.current !== href) {
+          resetVisible()
+          previousAs.current = as
+          previousHref.current = href
+        }
+
+        setIntersectionRef(el)
+        if (childRef) {
+          if (typeof childRef === 'function') childRef(el)
+          else if (typeof childRef === 'object') {
+            childRef.current = el
+          }
+        }
+      },
+      [as, childRef, href, resetVisible, setIntersectionRef]
+    )
+    React.useEffect(() => {
+      const shouldPrefetch = isVisible && p && isLocalURL(href)
+      const curLocale =
+        typeof locale !== 'undefined' ? locale : router && router.locale
+      const isPrefetched =
+        prefetched[href + '%' + as + (curLocale ? '%' + curLocale : '')]
+      if (shouldPrefetch && !isPrefetched) {
+        prefetch(router, href, as, {
+          locale: curLocale,
+        })
       }
-      if (
-        legacyBehavior &&
-        child.props &&
-        typeof child.props.onClick === 'function'
-      ) {
-        child.props.onClick(e)
-      }
-      if (!e.defaultPrevented) {
-        linkClicked(e, router, href, as, replace, shallow, scroll, locale)
-      }
-    },
-    onMouseEnter: (e: React.MouseEvent) => {
-      if (!legacyBehavior && typeof onMouseEnter === 'function') {
-        onMouseEnter(e)
-      }
-      if (
-        legacyBehavior &&
-        child.props &&
-        typeof child.props.onMouseEnter === 'function'
-      ) {
-        child.props.onMouseEnter(e)
-      }
-      if (isLocalURL(href)) {
-        prefetch(router, href, as, { priority: true })
-      }
-    },
+    }, [as, href, isVisible, locale, p, router])
+
+    const childProps: {
+      onMouseEnter: React.MouseEventHandler
+      onClick: React.MouseEventHandler
+      href?: string
+      ref?: any
+    } = {
+      ref: setRef,
+      onClick: (e: React.MouseEvent) => {
+        if (process.env.NODE_ENV !== 'production') {
+          if (!e) {
+            throw new Error(
+              `Component rendered inside next/link has to pass click event to "onClick" prop.`
+            )
+          }
+        }
+
+        if (!legacyBehavior && typeof onClick === 'function') {
+          onClick(e)
+        }
+        if (
+          legacyBehavior &&
+          child.props &&
+          typeof child.props.onClick === 'function'
+        ) {
+          child.props.onClick(e)
+        }
+        if (!e.defaultPrevented) {
+          linkClicked(e, router, href, as, replace, shallow, scroll, locale)
+        }
+      },
+      onMouseEnter: (e: React.MouseEvent) => {
+        if (!legacyBehavior && typeof onMouseEnter === 'function') {
+          onMouseEnter(e)
+        }
+        if (
+          legacyBehavior &&
+          child.props &&
+          typeof child.props.onMouseEnter === 'function'
+        ) {
+          child.props.onMouseEnter(e)
+        }
+        if (isLocalURL(href)) {
+          prefetch(router, href, as, { priority: true })
+        }
+      },
+    }
+
+    // If child is an <a> tag and doesn't have a href attribute, or if the 'passHref' property is
+    // defined, we specify the current 'href', so that repetition is not needed by the user
+    if (
+      !legacyBehavior ||
+      passHref ||
+      (child.type === 'a' && !('href' in child.props))
+    ) {
+      const curLocale =
+        typeof locale !== 'undefined' ? locale : router && router.locale
+
+      // we only render domain locales if we are currently on a domain locale
+      // so that locale links are still visitable in development/preview envs
+      const localeDomain =
+        router &&
+        router.isLocaleDomain &&
+        getDomainLocale(
+          as,
+          curLocale,
+          router && router.locales,
+          router && router.domainLocales
+        )
+
+      childProps.href =
+        localeDomain ||
+        addBasePath(addLocale(as, curLocale, router && router.defaultLocale))
+    }
+
+    return legacyBehavior ? (
+      React.cloneElement(child, childProps)
+    ) : (
+      <a {...restProps} {...childProps}>
+        {children}
+      </a>
+    )
   }
-
-  // If child is an <a> tag and doesn't have a href attribute, or if the 'passHref' property is
-  // defined, we specify the current 'href', so that repetition is not needed by the user
-  if (
-    !legacyBehavior ||
-    passHref ||
-    (child.type === 'a' && !('href' in child.props))
-  ) {
-    const curLocale =
-      typeof locale !== 'undefined' ? locale : router && router.locale
-
-    // we only render domain locales if we are currently on a domain locale
-    // so that locale links are still visitable in development/preview envs
-    const localeDomain =
-      router &&
-      router.isLocaleDomain &&
-      getDomainLocale(
-        as,
-        curLocale,
-        router && router.locales,
-        router && router.domainLocales
-      )
-
-    childProps.href =
-      localeDomain ||
-      addBasePath(addLocale(as, curLocale, router && router.defaultLocale))
-  }
-
-  return legacyBehavior ? (
-    React.cloneElement(child, childProps)
-  ) : (
-    <a {...restProps} {...childProps}>
-      {children}
-    </a>
-  )
-}
+)
 
 export default Link

--- a/test/e2e/new-link-behavior/typescript.test.ts
+++ b/test/e2e/new-link-behavior/typescript.test.ts
@@ -3,6 +3,7 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import path from 'path'
+import webdriver from 'next-webdriver'
 
 const appDir = path.join(__dirname, 'typescript')
 
@@ -14,6 +15,7 @@ describe('New Link Behavior', () => {
       files: {
         pages: new FileRef(path.join(appDir, 'pages')),
         'tsconfig.json': new FileRef(path.join(appDir, 'tsconfig.json')),
+        'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
       },
       dependencies: {
         typescript: '*',
@@ -30,5 +32,11 @@ describe('New Link Behavior', () => {
     const $a = $('a')
     expect($a.text()).toBe('Visit')
     expect($a.attr('href')).toBe('/test')
+  })
+
+  it('should apply ref on link', async () => {
+    const browser = await webdriver(next.url, `/ref`)
+    const text = await browser.elementByCss('#anchor-text').text()
+    expect(text).toBe('AnchorText: About')
   })
 })

--- a/test/e2e/new-link-behavior/typescript/next.config.js
+++ b/test/e2e/new-link-behavior/typescript/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  reactStrictMode: true,
+  experimental: {
+    newNextLinkBehavior: true,
+  },
+}

--- a/test/e2e/new-link-behavior/typescript/pages/index.tsx
+++ b/test/e2e/new-link-behavior/typescript/pages/index.tsx
@@ -73,6 +73,7 @@ export const ButtonLink: React.FC<ButtonLinkProps> = ({
       shallow={shallow}
       // Always passHref to the <a> component if it's defined.
       passHref={!!href}
+      legacyBehavior
     >
       <a>{children}</a>
     </NextLink>

--- a/test/e2e/new-link-behavior/typescript/pages/ref.tsx
+++ b/test/e2e/new-link-behavior/typescript/pages/ref.tsx
@@ -1,0 +1,21 @@
+import { useRef, useEffect, useState } from 'react'
+import Link from 'next/link'
+
+export default function Page() {
+  const ref = useRef<HTMLAnchorElement>()
+  const [anchorText, setAnchorText] = useState(null)
+
+  useEffect(() => {
+    const anchorElement = ref.current
+    setAnchorText(anchorElement?.textContent)
+  }, [])
+
+  return (
+    <>
+      {anchorText && <h1 id="anchor-text">AnchorText: {anchorText}</h1>}
+      <Link href="/about" ref={ref}>
+        About
+      </Link>
+    </>
+  )
+}


### PR DESCRIPTION
Found this case on the vercel.com app after running the codemod. A TypeScript error surfaced for `ref` on `next/link` as unsupported.

Current code:

```
const ref = useRef()

<Link href="/">
  <a ref={ref}>
    Home
  </a>
</Link>
```

Code after codemod:

```
const ref = useRef()

<Link href="/" ref={ref}> // Results in a TS error, also does not work as expected.
  Home
</Link>
```


This PR makes the code after running the codemod work.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
