### PR TITLE
bump styled-jsx to latest

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -72,7 +72,7 @@
     "@next/env": "12.1.6-canary.13",
     "caniuse-lite": "^1.0.30001332",
     "postcss": "8.4.5",
-    "styled-jsx": "5.0.1"
+    "styled-jsx": "5.0.2"
   },
   "peerDependencies": {
     "fibers": ">= 3.1.0",
@@ -153,7 +153,6 @@
     "@types/react-is": "16.7.1",
     "@types/semver": "7.3.1",
     "@types/send": "0.14.4",
-    "@types/styled-jsx": "2.2.8",
     "@types/text-table": "0.2.1",
     "@types/ua-parser-js": "0.7.36",
     "@types/uuid": "8.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5389,12 +5389,6 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/string-hash/-/string-hash-1.1.1.tgz#4c336e61d1e13ce2d3efaaa5910005fd080e106b"
 
-"@types/styled-jsx@2.2.8":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@types/styled-jsx/-/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
-  dependencies:
-    "@types/react" "*"
-
 "@types/tar@4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.3.tgz#e2cce0b8ff4f285293243f5971bd7199176ac489"
@@ -19918,10 +19912,10 @@ styled-jsx-plugin-postcss@3.0.2:
     postcss "^7.0.2"
     postcss-load-plugins "^2.3.0"
 
-styled-jsx@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.1.tgz#78fecbbad2bf95ce6cd981a08918ce4696f5fc80"
-  integrity sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==
+styled-jsx@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.2.tgz#ff230fd593b737e9e68b630a694d460425478729"
+  integrity sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
x-ref: https://github.com/coryetzkorn/twitter-algorithm/pull/2

* Bump styled-jsx to latest version (5.0.2), so that it could get dedup when user installs the styled-jsx manually
* Remove the legacy `@types/styled-jsx`