### PR TITLE
chore: clarify CLI network errors

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -93,7 +93,7 @@ export async function createApp({
           `1. Your spelling of example ${chalk.red(
             `"${example}"`
           )} might be incorrect.\n`,
-          `2. You might not be connected to the internet.`
+          `2. You might not be connected to the internet or you are behind a proxy.`
         )
         process.exit(1)
       }

--- a/packages/next/cli/next-info.ts
+++ b/packages/next/cli/next-info.ts
@@ -76,12 +76,15 @@ const nextInfo: cliCommand = async (argv) => {
         Read more - https://nextjs.org/docs/messages/opening-an-issue`
       )
     }
-  } catch {
+  } catch (e) {
     console.warn(
       `${chalk.yellow(
         chalk.bold('warn')
-      )}  - Failed to fetch latest canary version. Visit https://github.com/vercel/next.js/releases. Detected "${installedRelease}".
-      Make sure to try the latest canary version (\`npm install next@canary\`) to confirm the issue still exists before creating a new issue.
+      )}  - Failed to fetch latest canary version. (Reason: ${
+        (e as Error).message
+      }.)
+      Detected "${installedRelease}". Visit https://github.com/vercel/next.js/releases.
+      Make sure to try the latest canary version (eg.: \`npm install next@canary\`) to confirm the issue still exists before creating a new issue.
       Read more - https://nextjs.org/docs/messages/opening-an-issue`
     )
   }


### PR DESCRIPTION
Makes it easier to detect why a network error occurred with the CLI or `next info`, based on https://github.com/vercel/next.js/issues/36344

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
