### PR TITLE
Ensure older lockfile/invalid formats are handled

### DIFF
--- a/packages/next/lib/patch-incorrect-lockfile.ts
+++ b/packages/next/lib/patch-incorrect-lockfile.ts
@@ -19,15 +19,15 @@ export async function patchIncorrectLockfile(dir: string) {
   const content = await promises.readFile(lockfilePath, 'utf8')
   const lockfileParsed = JSON.parse(content)
 
-  const packageKeys = Object.keys(lockfileParsed.dependencies)
   const foundSwcPkgs = new Set()
-  const nextPkg = lockfileParsed.packages['node_modules/next']
+  const nextPkg = lockfileParsed.packages?.['node_modules/next']
 
   // if we don't find next in the package-lock we can't continue
   if (!nextPkg) {
     return
   }
   const nextVersion = nextPkg.version
+  const packageKeys = Object.keys(lockfileParsed.dependencies || {})
 
   const expectedSwcPkgs = Object.keys(nextPkg?.optionalDependencies).filter(
     (pkg) => pkg.startsWith('@next/swc-')

--- a/test/production/dependencies-can-use-env-vars-in-middlewares/index.test.ts
+++ b/test/production/dependencies-can-use-env-vars-in-middlewares/index.test.ts
@@ -40,11 +40,17 @@ describe('dependencies can use env vars in middlewares', () => {
             })
           }
         `,
+        // make sure invalid package-lock doesn't error
+        'package-lock.json': '{}',
       },
       dependencies: {},
     })
   })
   afterAll(() => next.destroy())
+
+  it('does not error from patching lockfile', () => {
+    expect(next.cliOutput).not.toContain('patch-incorrect-lockfile')
+  })
 
   it('parses the env vars correctly', async () => {
     const testDir = next.testDir


### PR DESCRIPTION
This ensures we gracefully handle lockfiles generated with npm v6 or older that don't have the packages field or when the content is invalid. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

