### PR TITLE
Fix missing `Content-Length` header from Image Optimization API

### DIFF
--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -621,6 +621,7 @@ export function sendResponse(
     contentSecurityPolicy
   )
   if (!result.finished) {
+    res.setHeader('Content-Length', Buffer.byteLength(buffer))
     res.end(buffer)
   }
 }

--- a/test/integration/image-optimizer/test/util.js
+++ b/test/integration/image-optimizer/test/util.js
@@ -74,6 +74,8 @@ export async function expectWidth(res, w) {
   const buffer = await res.buffer()
   const d = sizeOf(buffer)
   expect(d.width).toBe(w)
+  const lengthStr = res.headers.get('Content-Length')
+  expect(lengthStr).toBe(Buffer.byteLength(buffer).toString())
 }
 
 export const cleanImagesDir = async (ctx) => {
@@ -161,6 +163,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated.gif' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('content-type')).toContain('image/gif')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -177,6 +180,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('content-type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -193,6 +197,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated2.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('content-type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -209,6 +214,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated.webp' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('content-type')).toContain('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -227,6 +233,7 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
+      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toContain('image/svg+xml')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -284,6 +291,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toContain('image/jpeg')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -302,6 +310,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -320,6 +329,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toContain('image/jpeg')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -339,6 +349,7 @@ export function runTests(ctx) {
       const opts = { headers: { accept } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
+      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toContain('image/jpeg')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -441,6 +452,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/webp,*/*' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -458,6 +470,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/png' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -475,6 +488,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -492,6 +506,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/gif')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -509,6 +524,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/tiff')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -528,6 +544,7 @@ export function runTests(ctx) {
     }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -550,6 +567,7 @@ export function runTests(ctx) {
       }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
+      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/avif')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -584,6 +602,7 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
+      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/webp')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -607,6 +626,7 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
+      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/webp')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -995,6 +1015,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/bmp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -1022,6 +1043,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
+    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -1044,6 +1066,7 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/png' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
+      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/png')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`

--- a/test/integration/image-optimizer/test/util.js
+++ b/test/integration/image-optimizer/test/util.js
@@ -70,12 +70,13 @@ export async function fsToJson(dir, output = {}) {
   return output
 }
 
-export async function expectWidth(res, w) {
+export async function expectWidth(res, w, { expectAnimated = false } = {}) {
   const buffer = await res.buffer()
   const d = sizeOf(buffer)
   expect(d.width).toBe(w)
   const lengthStr = res.headers.get('Content-Length')
   expect(lengthStr).toBe(Buffer.byteLength(buffer).toString())
+  expect(isAnimated(buffer)).toBe(expectAnimated)
 }
 
 export const cleanImagesDir = async (ctx) => {
@@ -163,7 +164,6 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated.gif' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Length')).toBe('32880')
     expect(res.headers.get('content-type')).toContain('image/gif')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -173,14 +173,13 @@ export function runTests(ctx) {
     expect(res.headers.get('Content-Disposition')).toBe(
       `inline; filename="animated.gif"`
     )
-    expect(isAnimated(await res.buffer())).toBe(true)
+    await expectWidth(res, 50, { expectAnimated: true })
   })
 
   it('should maintain animated png', async () => {
     const query = { w: ctx.w, q: 90, url: '/animated.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Length')).toBe('63435')
     expect(res.headers.get('content-type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -190,14 +189,13 @@ export function runTests(ctx) {
     expect(res.headers.get('Content-Disposition')).toBe(
       `inline; filename="animated.png"`
     )
-    expect(isAnimated(await res.buffer())).toBe(true)
+    await expectWidth(res, 100, { expectAnimated: true })
   })
 
   it('should maintain animated png 2', async () => {
     const query = { w: ctx.w, q: 90, url: '/animated2.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Length')).toBe('550091')
     expect(res.headers.get('content-type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -207,14 +205,13 @@ export function runTests(ctx) {
     expect(res.headers.get('Content-Disposition')).toBe(
       `inline; filename="animated2.png"`
     )
-    expect(isAnimated(await res.buffer())).toBe(true)
+    await expectWidth(res, 1105, { expectAnimated: true })
   })
 
   it('should maintain animated webp', async () => {
     const query = { w: ctx.w, q: 90, url: '/animated.webp' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Length')).toBe('37342')
     expect(res.headers.get('content-type')).toContain('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -224,7 +221,7 @@ export function runTests(ctx) {
     expect(res.headers.get('Content-Disposition')).toBe(
       `inline; filename="animated.webp"`
     )
-    expect(isAnimated(await res.buffer())).toBe(true)
+    await expectWidth(res, 400, { expectAnimated: true })
   })
 
   if (ctx.dangerouslyAllowSVG) {
@@ -291,7 +288,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Length')).toBe('3381')
     expect(res.headers.get('Content-Type')).toContain('image/jpeg')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -310,7 +306,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    expect(res.headers.get('Content-Length')).toBe('2783')
     expect(res.headers.get('Content-Type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`

--- a/test/integration/image-optimizer/test/util.js
+++ b/test/integration/image-optimizer/test/util.js
@@ -163,7 +163,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated.gif' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
+    expect(res.headers.get('Content-Length')).toBe('32880')
     expect(res.headers.get('content-type')).toContain('image/gif')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -180,7 +180,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
+    expect(res.headers.get('Content-Length')).toBe('63435')
     expect(res.headers.get('content-type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -197,7 +197,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated2.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
+    expect(res.headers.get('Content-Length')).toBe('550091')
     expect(res.headers.get('content-type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -214,7 +214,7 @@ export function runTests(ctx) {
     const query = { w: ctx.w, q: 90, url: '/animated.webp' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
+    expect(res.headers.get('Content-Length')).toBe('37342')
     expect(res.headers.get('content-type')).toContain('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -233,7 +233,7 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
-      //expect(res.headers.get('Content-Length')).toBe(100)
+      expect(res.headers.get('Content-Length')).toBe('603')
       expect(res.headers.get('Content-Type')).toContain('image/svg+xml')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -291,7 +291,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
+    expect(res.headers.get('Content-Length')).toBe('3381')
     expect(res.headers.get('Content-Type')).toContain('image/jpeg')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -310,7 +310,7 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
+    expect(res.headers.get('Content-Length')).toBe('2783')
     expect(res.headers.get('Content-Type')).toContain('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -329,7 +329,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toContain('image/jpeg')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -339,6 +338,7 @@ export function runTests(ctx) {
     expect(res.headers.get('Content-Disposition')).toBe(
       `inline; filename="test.jpeg"`
     )
+    await expectWidth(res, ctx.w)
   })
 
   if (!ctx.isOutdatedSharp) {
@@ -349,7 +349,6 @@ export function runTests(ctx) {
       const opts = { headers: { accept } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
-      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toContain('image/jpeg')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -359,6 +358,7 @@ export function runTests(ctx) {
       expect(res.headers.get('Content-Disposition')).toBe(
         `inline; filename="test.jpeg"`
       )
+      await expectWidth(res, ctx.w)
     })
   }
 
@@ -452,7 +452,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/webp,*/*' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -470,7 +469,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/png' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -488,7 +486,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/png')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -506,7 +503,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/gif')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -524,7 +520,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/tiff')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -544,7 +539,6 @@ export function runTests(ctx) {
     }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -567,7 +561,6 @@ export function runTests(ctx) {
       }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
-      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/avif')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -602,7 +595,6 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
-      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/webp')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -626,7 +618,6 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
-      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/webp')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`
@@ -1015,7 +1006,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/bmp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -1043,7 +1033,6 @@ export function runTests(ctx) {
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
-    //expect(res.headers.get('Content-Length')).toBe(100)
     expect(res.headers.get('Content-Type')).toBe('image/webp')
     expect(res.headers.get('Cache-Control')).toBe(
       `public, max-age=0, must-revalidate`
@@ -1066,7 +1055,6 @@ export function runTests(ctx) {
       const opts = { headers: { accept: 'image/png' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
-      //expect(res.headers.get('Content-Length')).toBe(100)
       expect(res.headers.get('Content-Type')).toBe('image/png')
       expect(res.headers.get('Cache-Control')).toBe(
         `public, max-age=0, must-revalidate`


### PR DESCRIPTION
Fixes #35514 