### PR TITLE
use dirname instead of process cwd for next dev watch files

### DIFF
--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -146,9 +146,10 @@ commands[command]()
 if (command === 'dev') {
   const { CONFIG_FILES } = require('../shared/lib/constants')
   const { watchFile } = require('fs')
+  const rootProjectDir = __dirname.replace('/node_modules/next/dist/bin', '')
 
   for (const CONFIG_FILE of CONFIG_FILES) {
-    watchFile(`${process.cwd()}/${CONFIG_FILE}`, (cur: any, prev: any) => {
+    watchFile(`${rootProjectDir}/${CONFIG_FILE}`, (cur: any, prev: any) => {
       if (cur.size > 0 || prev.size > 0) {
         console.log(
           `\n> Found a change in ${CONFIG_FILE}. Restart the server to see the changes in effect.`


### PR DESCRIPTION
Attempts to fix #36569

Get the application path from the next bin instead of the current directory.

Using a hardcoded string for the path because I didn't find a variable close to it in the codebase, but maybe there is a more elegant way of doing this.