### PR TITLE
Fix wrong conversion to JPEG instead of PNG when WEBP/AVIF is not supported (fixes images with alpha channels)

### DIFF
--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -379,7 +379,7 @@ export async function imageOptimizer(
   ) {
     contentType = upstreamType
   } else {
-    contentType = JPEG
+    contentType = PNG
   }
   try {
     let optimizedBuffer: Buffer | undefined


### PR DESCRIPTION
Change the fallback contentType from JPEG to PNG.
This way even if the unsupported contentType (webp/avif) has an alpha channel, it won't turn black.

Fixes #35674 

It's in direct relation and extension to a previously resolved issue #20794 fixed by PR #35190
