### PR TITLE
Fix swc jest pagesDir config

### DIFF
--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -51,11 +51,11 @@ export default function nextJest(options: { dir?: string } = {}) {
       let jsConfig
       let resolvedBaseUrl
       let isEsmProject = false
-      let pagesDir
+      let pagesDir: string | undefined
 
       if (options.dir) {
         const resolvedDir = resolve(options.dir)
-        pagesDir = findPagesDir(resolvedDir)
+        pagesDir = findPagesDir(resolvedDir).pages
         const packageConfig = loadClosestPackageJson(resolvedDir)
         isEsmProject = packageConfig.type === 'module'
 


### PR DESCRIPTION
This updates the `pagesDir` config for the new return shape updated in https://github.com/vercel/next.js/pull/36619, no additional tests were added as existing tests were failing from this. 

x-ref: https://github.com/vercel/next.js/runs/6257712883?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6257712805?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/pull/36619