### PR TITLE
Add ability to read domain from a different header for i18n on SSR

### DIFF
--- a/docs/advanced-features/i18n-routing.md
+++ b/docs/advanced-features/i18n-routing.md
@@ -97,7 +97,8 @@ module.exports = {
   i18n: {
     locales: ['en-US', 'fr', 'nl-NL', 'nl-BE'],
     defaultLocale: 'en-US',
-
+    // Note: the property allows NextJS to use a different host header (useful when nextjs server is behind a proxy).
+    // domainHeader: 'x-forwarded-host',
     domains: [
       {
         // Note: subdomains must be included in the domain value to be matched
@@ -128,6 +129,8 @@ For example if you have `pages/blog.js` the following urls will be available:
 - `example.fr/blog`
 - `example.nl/blog`
 - `example.nl/nl-BE/blog`
+
+In case your application is behind a proxy, you can use `domainHeader` set to `x-forwarded-host` (for example) in order for the server to use another domain header.
 
 ## Automatic Locale Detection
 

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -20,6 +20,7 @@ export type NextConfigComplete = Required<NextConfig> & {
 export interface I18NConfig {
   defaultLocale: string
   domains?: DomainLocale[]
+  trustProxy?: false
   localeDetection?: false
   locales: string[]
 }

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -19,8 +19,8 @@ export type NextConfigComplete = Required<NextConfig> & {
 
 export interface I18NConfig {
   defaultLocale: string
+  domainHeader?: string
   domains?: DomainLocale[]
-  trustProxy?: false
   localeDetection?: false
   locales: string[]
 }

--- a/packages/next/shared/lib/i18n/get-locale-metadata.ts
+++ b/packages/next/shared/lib/i18n/get-locale-metadata.ts
@@ -77,9 +77,9 @@ function getHostname(
   headers?: { [key: string]: string | string[] | undefined }
 ) {
   return (
-    (i18n.trustProxy &&
-      !Array.isArray(headers?.['x-forwarded-host']) &&
-      headers?.['x-forwarded-host']) ||
+    ((i18n.domainHeader &&
+      !Array.isArray(headers?.[i18n.domainHeader]) &&
+      headers?.[i18n.domainHeader]) as string | undefined) ||
     (!Array.isArray(headers?.host) && headers?.host) ||
     parsed.hostname
   )

--- a/packages/next/shared/lib/i18n/get-locale-metadata.ts
+++ b/packages/next/shared/lib/i18n/get-locale-metadata.ts
@@ -16,7 +16,10 @@ export function getLocaleMetadata(params: Params) {
   const { i18n } = params.nextConfig
   const { cookies, headers, nextConfig, url } = params
   const path = normalizeLocalePath(url.pathname, i18n.locales)
-  const domain = detectDomainLocale(i18n.domains, getHostname(url, headers))
+  const domain = detectDomainLocale(
+    i18n.domains,
+    getHostname(i18n, url, headers)
+  )
   const defaultLocale = domain?.defaultLocale || i18n.defaultLocale
   const preferredLocale = getAcceptPreferredLocale(i18n, headers)
   return {
@@ -69,10 +72,17 @@ function getAcceptPreferredLocale(
 }
 
 function getHostname(
+  i18n: I18NConfig,
   parsed: { hostname?: string | null },
   headers?: { [key: string]: string | string[] | undefined }
 ) {
-  return ((!Array.isArray(headers?.host) && headers?.host) || parsed.hostname)
+  return (
+    (i18n.trustProxy &&
+      !Array.isArray(headers?.['x-forwarded-host']) &&
+      headers?.['x-forwarded-host']) ||
+    (!Array.isArray(headers?.host) && headers?.host) ||
+    parsed.hostname
+  )
     ?.split(':')[0]
     .toLowerCase()
 }

--- a/test/integration/i18n-support/next.config.js
+++ b/test/integration/i18n-support/next.config.js
@@ -17,8 +17,8 @@ module.exports = {
       'do',
       'do-BE',
     ],
-    // trustProxy: true,
     defaultLocale: 'en-US',
+    // domainHeader: 'x-forwarded-host',
     domains: [
       {
         http: true,

--- a/test/integration/i18n-support/next.config.js
+++ b/test/integration/i18n-support/next.config.js
@@ -17,6 +17,7 @@ module.exports = {
       'do',
       'do-BE',
     ],
+    // trustProxy: true,
     defaultLocale: 'en-US',
     domains: [
       {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

So we moved from CSR to SSR, but we have hit the problem where our NextJS Server is behind a a reverse proxy. We cannot use 'domains', because either the 'host' header is not available or the 'host' header has the internal domain (see below).

How we use it:
pt.nextjs.com (public) ---> internal.nextjs.com (private)
en.nextjs.com (public) ---> internal.nextjs.com (private)
es.nextjs.com (public) ---> internal.nextjs.com (private)

Solution:
the i18n config now includes a `domainHeader` (undefined by default) which will tell nextjs what header to use for host resolution (has an additional header).

## Feature

- [X] Related issues linked using fixes #34553 and #34571
- [X] Integration tests added
- [X] Documentation added

## Documentation / Examples

- [X] Make sure the linting passes by running `yarn lint`
