### PR TITLE
Update codeowners image pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 
 # Image Component (@styfle)
 
+/**/*image*                                                  @timneutkens @ijjk @shuding @styfle
 /**/*image*/**                                               @timneutkens @ijjk @shuding @styfle
 /packages/next/client/use-intersection.tsx                   @timneutkens @ijjk @shuding @styfle
 /packages/next/server/lib/squoosh/                           @timneutkens @ijjk @shuding @styfle


### PR DESCRIPTION
Fixes the GitHub CODEOWNERS pattern matching which previously missed adding me to #36611 