### PR TITLE
Fix asPath handling for data route revalidation in minimal mode

### DIFF
--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -56,6 +56,10 @@ describe('should set-up next', () => {
                 source: '/an-ssg-path',
                 destination: '/hello.txt',
               },
+              {
+                source: '/fallback-false/:path',
+                destination: '/hello.txt',
+              },
             ],
             afterFiles: [
               {
@@ -978,6 +982,35 @@ describe('should set-up next', () => {
     const $ = cheerio.load(html)
     expect($('#slug-page').text()).toBe('[slug] page')
     expect(JSON.parse($('#router').text()).asPath).toBe('/an-ssg-path')
+  })
+
+  it('should have correct asPath on dynamic SSG page fallback correctly', async () => {
+    const toCheck = [
+      {
+        pathname: '/fallback-false/first',
+        matchedPath: '/fallback-false/first',
+      },
+      {
+        pathname: '/fallback-false/first',
+        matchedPath: `/_next/data/${next.buildId}/fallback-false/first.json`,
+      },
+    ]
+    for (const check of toCheck) {
+      console.warn('checking', check)
+      const res = await fetchViaHTTP(appPort, check.pathname, undefined, {
+        headers: {
+          'x-matched-path': check.matchedPath,
+        },
+        redirect: 'manual',
+      })
+
+      const html = await res.text()
+      const $ = cheerio.load(html)
+      expect($('#page').text()).toBe('blog slug')
+      expect($('#asPath').text()).toBe('/fallback-false/first')
+      expect($('#pathname').text()).toBe('/fallback-false/[slug]')
+      expect(JSON.parse($('#query').text())).toEqual({ slug: 'first' })
+    }
   })
 
   it('should copy and read .env file', async () => {

--- a/test/production/required-server-files/pages/fallback-false/[slug].js
+++ b/test/production/required-server-files/pages/fallback-false/[slug].js
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router'
+
+export default function Page(props) {
+  const router = useRouter()
+
+  return (
+    <>
+      <p id="page">blog slug</p>
+      <p id="props">{JSON.stringify(props)}</p>
+      <p id="query">{JSON.stringify(router.query)}</p>
+      <p id="pathname">{router.pathname}</p>
+      <p id="asPath">{router.asPath}</p>
+    </>
+  )
+}
+
+export function getStaticProps({ params }) {
+  console.log({ blogSlug: true, params })
+
+  return {
+    props: {
+      random: Math.random() + Date.now(),
+      blogSlug: true,
+      params,
+    },
+    revalidate: 1,
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: ['/fallback-false/first', '/fallback-false/second'],
+    fallback: false,
+  }
+}


### PR DESCRIPTION
This fixes a failing test case noticed in our runtimes E2E tests that seemed flakey but was actually a race condition depending on which path revalidated first.  

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
