### PR TITLE
feat(next/swc): support experimental coverage instrument

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -1109,12 +1109,12 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.1",
  "rayon",
  "serde",
 ]
@@ -1152,6 +1152,16 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "istanbul-oxide"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36315bd6d9ced11b0abffad052120f3f8b49211e6ed6d025c8d11781445f7546"
+dependencies = [
+ "indexmap",
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -1504,7 +1514,7 @@ dependencies = [
  "serde",
  "swc_cached",
  "swc_ecma_transforms_testing",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "testing",
 ]
 
@@ -1590,12 +1600,13 @@ dependencies = [
  "styled_components",
  "styled_jsx",
  "swc",
+ "swc-coverage-instrument",
  "swc_atoms",
  "swc_cached",
  "swc_common",
  "swc_ecma_loader",
  "swc_ecma_transforms_testing",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "swc_emotion",
  "swc_plugin_runner",
  "testing",
@@ -1625,7 +1636,7 @@ dependencies = [
  "swc_bundler",
  "swc_common",
  "swc_ecma_loader",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "swc_node_base",
  "swc_plugin_runner",
  "tracing",
@@ -2867,7 +2878,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_transforms_testing",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "testing",
  "tracing",
 ]
@@ -2881,7 +2892,7 @@ dependencies = [
  "swc_css",
  "swc_css_prefixer",
  "swc_ecma_transforms_testing",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "testing",
  "tracing",
 ]
@@ -2960,13 +2971,31 @@ dependencies = [
  "swc_ecma_transforms_optimization",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
  "swc_plugin_runner",
  "swc_timer",
  "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc-coverage-instrument"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e3252d736fa76c88b7c1d217c699ffa0e4f1664819381aabc11e5c03b73ce2"
+dependencies = [
+ "istanbul-oxide",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_quote",
+ "swc_ecmascript 0.167.0",
  "tracing",
 ]
 
@@ -3381,6 +3410,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_quote"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eba886449eabbaf684a8b895fc8fb45beea27866afc08eb693ec5695a6cd33c"
+dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_quote_macros",
+ "swc_ecma_utils",
+]
+
+[[package]]
+name = "swc_ecma_quote_macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f027387858d08e906b7988694d64e0d1165cfcfa1b87f7c78b084fa4af97c060"
+dependencies = [
+ "anyhow",
+ "pmutil",
+ "proc-macro2",
+ "quote",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_macros_common",
+ "syn",
+]
+
+[[package]]
 name = "swc_ecma_testing"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,6 +3730,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecmascript"
+version = "0.167.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3f448a7c49540d33a45ed59f4ca6189d4d0ff7edf14181e27f1a9c91c4b135"
+dependencies = [
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "swc_emotion"
 version = "0.10.0"
 dependencies = [
@@ -3684,7 +3756,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_transforms_testing",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "swc_trace_macro",
  "testing",
  "tracing",
@@ -4379,7 +4451,7 @@ dependencies = [
  "serde_json",
  "swc",
  "swc_common",
- "swc_ecmascript",
+ "swc_ecmascript 0.164.0",
  "swc_plugin_runner",
  "tracing",
  "wasm-bindgen",

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -33,6 +33,7 @@ swc_ecma_loader = { version = "0.30.2", features = ["node", "lru"] }
 swc_ecmascript = { version = "0.164.0", features = ["codegen", "minifier", "optimization", "parser", "react", "transforms", "typescript", "utils", "visit"] }
 swc_plugin_runner = { version = "0.56.0", optional = true, default-features = false }
 swc_cached = "0.1.1"
+swc-coverage-instrument = "0.0.7"
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 wasmer = { version = "2.3.0", optional = true, default-features = false }
 wasmer-wasi = { version = "2.3.0", optional = true, default-features = false }

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -10,6 +10,7 @@ use next_swc::{
 };
 use std::path::PathBuf;
 use swc_common::{chain, comments::SingleThreadedComments, FileName, Mark};
+use swc_coverage_instrument::create_coverage_instrumentation_visitor;
 use swc_ecma_transforms_testing::{test, test_fixture};
 use swc_ecmascript::{
     parser::{EsConfig, Syntax},
@@ -204,6 +205,24 @@ fn shake_exports_fixture_default(input: PathBuf) {
             shake_exports(ShakeExportsConfig {
                 ignore: vec![String::from("default").into()],
             })
+        },
+        &input,
+        &output,
+    );
+}
+
+#[fixture("tests/fixture/coverage-instrument/input.js")]
+fn coverage_instrument_simple_default(input: PathBuf) {
+    let output = input.parent().unwrap().join("output.js");
+    test_fixture(
+        syntax(),
+        &|tr| {
+            swc_ecmascript::visit::as_folder(create_coverage_instrumentation_visitor(
+                tr.cm.clone(),
+                tr.comments.clone(),
+                Default::default(),
+                "anon".to_string(),
+            ))
         },
         &input,
         &output,

--- a/packages/next-swc/crates/core/tests/fixture/coverage-instrument/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/coverage-instrument/input.js
@@ -1,0 +1,6 @@
+function* x() { yield 1; yield 2; };
+var k;
+output = 0;
+for (k of x()) {
+  output += k;
+}

--- a/packages/next-swc/crates/core/tests/fixture/coverage-instrument/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/coverage-instrument/output.js
@@ -1,0 +1,130 @@
+function cov_473891610594984201() {
+    var path = "anon";
+    var hash = "13293363232410732979";
+    var global = new ((function(){}).constructor)("return this")();
+    var gcv = "__coverage__";
+    var coverageData = {
+        all: false,
+        path: "anon",
+        statementMap: {
+            "0": {
+                start: {
+                    line: 1,
+                    column: 16
+                },
+                end: {
+                    line: 1,
+                    column: 24
+                }
+            },
+            "1": {
+                start: {
+                    line: 1,
+                    column: 25
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            "2": {
+                start: {
+                    line: 3,
+                    column: 0
+                },
+                end: {
+                    line: 3,
+                    column: 11
+                }
+            },
+            "3": {
+                start: {
+                    line: 4,
+                    column: 0
+                },
+                end: {
+                    line: 6,
+                    column: 1
+                }
+            },
+            "4": {
+                start: {
+                    line: 5,
+                    column: 2
+                },
+                end: {
+                    line: 5,
+                    column: 14
+                }
+            }
+        },
+        fnMap: {
+            "0": {
+                name: "x",
+                decl: {
+                    start: {
+                        line: 1,
+                        column: 10
+                    },
+                    end: {
+                        line: 1,
+                        column: 11
+                    }
+                },
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 14
+                    },
+                    end: {
+                        line: 1,
+                        column: 35
+                    }
+                },
+                line: 1
+            }
+        },
+        branchMap: {},
+        s: {
+            "0": 0,
+            "1": 0,
+            "2": 0,
+            "3": 0,
+            "4": 0
+        },
+        f: {
+            "0": 0
+        },
+        b: {},
+        _coverageSchema: "11020577277169172593",
+        hash: "13293363232410732979"
+    };
+    var coverage = global[gcv] || (global[gcv] = {});
+    if (!coverage[path] || coverage[path].hash !== hash) {
+        coverage[path] = coverageData;
+    }
+    var actualCoverage = coverage[path];
+    {
+        cov_473891610594984201 = function() {
+            return actualCoverage;
+        };
+    }
+    return actualCoverage;
+}
+cov_473891610594984201();
+function* x() {
+    cov_473891610594984201().f[0]++;
+    cov_473891610594984201().s[0]++;
+    yield 1;
+    cov_473891610594984201().s[1]++;
+    yield 2;
+}
+;
+var k;
+cov_473891610594984201().s[2]++;
+output = 0;
+cov_473891610594984201().s[3]++;
+for (k of x()){
+    cov_473891610594984201().s[4]++;
+    output += k;
+}

--- a/packages/next-swc/crates/core/tests/full.rs
+++ b/packages/next-swc/crates/core/tests/full.rs
@@ -63,6 +63,7 @@ fn test(input: &Path, minify: bool) {
                 shake_exports: None,
                 emotion: Some(assert_json("{}")),
                 modularize_imports: None,
+                coverage_instrument: None,
             };
 
             let options = options.patch(&fm);

--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -114,6 +114,7 @@ function getBaseSWCOptions({
     modularizeImports: nextConfig?.experimental?.modularizeImports,
     relay: nextConfig?.compiler?.relay,
     emotion: getEmotionOptions(nextConfig, development),
+    coverageInstrument: getCoverageInstrumentOptions(nextConfig),
   }
 }
 
@@ -154,6 +155,15 @@ function getEmotionOptions(nextConfig, development) {
       ? nextConfig?.experimental?.emotion?.sourceMap ?? true
       : false,
   }
+}
+
+function getCoverageInstrumentOptions(nextConfig) {
+  const options = nextConfig?.experimental?.swcInstrumentCoverage
+  if (!options) {
+    return
+  }
+
+  return options === true ? {} : options
 }
 
 export function getJestSWCOptions({

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -146,6 +146,14 @@ export interface ExperimentalConfig {
   }
   swcPlugins?: Array<[string, Record<string, unknown>]>
   largePageDataBytes?: number
+  swcInstrumentCoverage?:
+    | boolean
+    | {
+        coverageVariable?: string
+        compact?: boolean
+        reportLogic?: boolean
+        ignoreClassMethods?: Array<string>
+      }
 }
 
 /**
@@ -549,6 +557,7 @@ export const defaultConfig: NextConfig = {
     forceSwcTransforms: false,
     swcPlugins: undefined,
     largePageDataBytes: 128 * 1000, // 128KB by default
+    swcInstrumentCoverage: false,
   },
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Related to https://github.com/vercel/next.js/discussions/30529 , https://github.com/vercel/next.js/discussions/30174

This PR enables an experimental next.js configuration to enable coverage instrumentation via next-swc. 
Currently configuration itself is not being used yet other than if user manually opt in, may need some thought if there are places we may want to enable this depends on the running context (next/jest maybe). However, as a first step user opt-in able path should be good.

All of the actual implementation is based on near direct port from istanbul (https://github.com/istanbuljs/istanbuljs), which results transform behaves as similar as it can, while there aren't some identical behavior due to differences of ast visitor architecture between swc to babel. At least, current transform passes all the fixtures from istanbuljs.

The implementation itself along with test lives in https://github.com/kwonoj/swc-coverage-instrument. It contains main visitor (which this PR uses) written isomorphic can support wasm / native both, as well as a swc wasm plugin package. Depends on the discussion, codes may move into upstream swc's plugin repository (https://github.com/swc-project/plugins).

Enabling instrumentation can be controlled via next.config.js's `experimental` flag:

```
{
 ...
 experimental: true | {
   swcInstrumentCoverage: {
        coverageVariable?: string
        compact?: boolean
        reportLogic?: boolean
        ignoreClassMethods?: Array<string>
   }
 }
}
```

`swcInstrumentCoverage` is a subset of istanbul's [instrumentation options] (https://github.com/istanbuljs/istanbuljs/blob/a743b8442e977f0c77ffa282eed7ac84ca200d1f/packages/istanbul-lib-instrument/src/instrumenter.js#L16-L27=) which current visitor implementation can support. I expect there'll be feedback to either amend or improve behaviors.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
