### PR TITLE
Fix mobile tests in with-playwright

### DIFF
--- a/examples/with-playwright/styles/Home.module.css
+++ b/examples/with-playwright/styles/Home.module.css
@@ -5,7 +5,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
 }
 
 .main {


### PR DESCRIPTION
I tried going through the testing docs on playwright (https://nextjs.org/docs/testing#playwright) and the test command failed for mobile browsers because the page has a fixed height and the link to `/about` is outside the viewport:

<img width="438" alt="image" src="https://user-images.githubusercontent.com/4278345/166948216-d2a5e15b-5414-4c4a-ab9a-c1d0c6eb2bb8.png">

The fix is from https://github.com/vercel/next.js/issues/31513

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
