### PR TITLE
test: merge rsc custom app cases

### DIFF
--- a/test/integration/react-streaming-and-server-components/test/index.test.js
+++ b/test/integration/react-streaming-and-server-components/test/index.test.js
@@ -5,7 +5,6 @@ import fs from 'fs-extra'
 
 import {
   fetchViaHTTP,
-  renderViaHTTP,
   nextBuild,
   runDevSuite,
   runProdSuite,
@@ -15,7 +14,6 @@ import {
   appDir,
   nativeModuleTestAppDir,
   appPage,
-  appServerPage,
   error500Page,
   nextConfig,
 } from './utils'
@@ -26,13 +24,6 @@ import streaming from './streaming'
 import basic from './basic'
 import runtime from './runtime'
 import { getNodeBuiltinModuleNotSupportedInEdgeRuntimeMessage } from 'next/dist/build/utils'
-
-const rscAppPage = `
-import Container from '../components/container.server'
-export default function App({children}) {
-  return <Container>{children}</Container>
-}
-`
 
 const appWithGlobalCss = `
 import '../styles.css'
@@ -184,19 +175,6 @@ const nodejsRuntimeBasicSuite = {
   },
 }
 
-const customAppPageSuite = {
-  runTests: (context) => {
-    it('should render container in app', async () => {
-      const indexHtml = await renderViaHTTP(context.appPort, '/')
-      const indexFlight = await renderViaHTTP(context.appPort, '/?__flight__=1')
-      expect(indexHtml).toContain('container-server')
-      expect(indexFlight).toContain('container-server')
-    })
-  },
-  beforeAll: () => appServerPage.write(rscAppPage),
-  afterAll: () => appServerPage.delete(),
-}
-
 const cssSuite = {
   runTests: css,
   beforeAll: () => appPage.write(appWithGlobalCss),
@@ -207,9 +185,6 @@ runDevSuite('Node.js runtime', appDir, nodejsRuntimeBasicSuite)
 runProdSuite('Node.js runtime', appDir, nodejsRuntimeBasicSuite)
 runDevSuite('Edge runtime', appDir, edgeRuntimeBasicSuite)
 runProdSuite('Edge runtime', appDir, edgeRuntimeBasicSuite)
-
-runDevSuite('Custom App', appDir, customAppPageSuite)
-runProdSuite('Custom App', appDir, customAppPageSuite)
 
 runDevSuite('CSS', appDir, cssSuite)
 runProdSuite('CSS', appDir, cssSuite)

--- a/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
+++ b/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
@@ -40,7 +40,7 @@ function flight(context) {
       expect(
         getOccurrence(
           flightResponse,
-          new RegExp(`"className":\s*"app-server-root"`, 'g')
+          new RegExp(`"className":\\s*"app-server-root"`, 'g')
         )
       ).toBe(1)
     })
@@ -58,7 +58,7 @@ function flight(context) {
     expect(
       getOccurrence(
         flightResponse,
-        new RegExp(`"className":\s*"app-server-root"`, 'g')
+        new RegExp(`"className":\\s*"app-server-root"`, 'g')
       )
     ).toBe(1)
   })

--- a/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
+++ b/test/integration/react-streaming-and-server-components/test/switchable-runtime.test.js
@@ -22,6 +22,48 @@ function splitLines(text) {
     .filter(Boolean)
 }
 
+function getOccurrence(text, matcher) {
+  return (text.match(matcher) || []).length
+}
+
+function flight(context) {
+  describe('flight response', () => {
+    it('should contain _app.server in flight response (node)', async () => {
+      const html = await renderViaHTTP(context.appPort, '/node-rsc')
+      const flightResponse = await renderViaHTTP(
+        context.appPort,
+        '/node-rsc?__flight__=1'
+      )
+      expect(
+        getOccurrence(html, new RegExp(`class="app-server-root"`, 'g'))
+      ).toBe(1)
+      expect(
+        getOccurrence(
+          flightResponse,
+          new RegExp(`"className":\s*"app-server-root"`, 'g')
+        )
+      ).toBe(1)
+    })
+  })
+
+  it('should contain _app.server in flight response (edge)', async () => {
+    const html = await renderViaHTTP(context.appPort, '/edge-rsc')
+    const flightResponse = await renderViaHTTP(
+      context.appPort,
+      '/edge-rsc?__flight__=1'
+    )
+    expect(
+      getOccurrence(html, new RegExp(`class="app-server-root"`, 'g'))
+    ).toBe(1)
+    expect(
+      getOccurrence(
+        flightResponse,
+        new RegExp(`"className":\s*"app-server-root"`, 'g')
+      )
+    ).toBe(1)
+  })
+}
+
 async function testRoute(appPort, url, { isStatic, isEdge, isRSC }) {
   const html1 = await renderViaHTTP(appPort, url)
   const renderedAt1 = +html1.match(/Time: (\d+)/)[1]
@@ -44,9 +86,8 @@ async function testRoute(appPort, url, { isStatic, isEdge, isRSC }) {
   const [rootClass, oppositeRootClass] = isRSC
     ? [rootClasses[0], rootClasses[1]]
     : [rootClasses[1], rootClasses[0]]
-  const appServerOccurrence =
-    html1.match(new RegExp(`class="${rootClass}"`, 'g')) || []
-  expect(appServerOccurrence.length).toBe(1)
+
+  expect(getOccurrence(html1, new RegExp(`class="${rootClass}"`, 'g'))).toBe(1)
   expect(html1).not.toContain(`"${oppositeRootClass}"`)
 }
 
@@ -66,6 +107,8 @@ describe('Switchable runtime (prod)', () => {
   afterAll(async () => {
     await killApp(context.server)
   })
+
+  flight(context)
 
   it('should build /static as a static page with the nodejs runtime', async () => {
     await testRoute(context.appPort, '/static', {
@@ -281,6 +324,7 @@ describe('Switchable runtime (dev)', () => {
     await killApp(context.server)
   })
 
+  flight(context)
   it('should support client side navigation to ssr rsc pages', async () => {
     let flightRequest = null
 

--- a/test/integration/react-streaming-and-server-components/test/utils.js
+++ b/test/integration/react-streaming-and-server-components/test/utils.js
@@ -8,7 +8,6 @@ export const nativeModuleTestAppDir = join(
   '../unsupported-native-module'
 )
 export const appPage = new File(join(appDir, 'pages/_app.js'))
-export const appServerPage = new File(join(appDir, 'pages/_app.server.js'))
 export const error500Page = new File(join(appDir, 'pages/500.js'))
 export const nextConfig = new File(join(appDir, 'next.config.js'))
 


### PR DESCRIPTION
the rsc & streaming test app is too big to build which is time consuming, move custom _app cases to switchable runtime test suite