### PR TITLE
fix: add missing hyphens in code example

### DIFF
--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -26,9 +26,9 @@ You can create a TypeScript project with [`create-next-app`](https://nextjs.org/
 ```
 npx create-next-app@latest --ts
 # or
-yarn create next-app --typescript
+yarn create-next-app --typescript
 # or
-pnpm create next-app -- --ts
+pnpm create-next-app -- --ts
 ```
 
 ## Existing projects


### PR DESCRIPTION
Update to fix incorrect code example https://nextjs.org/docs/basic-features/typescript page.