### PR TITLE
enforce omitting `name` and `version`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -270,7 +270,7 @@ When you add an example to the [examples](examples) directory, don’t forget to
 - Replace `DIRECTORY_NAME` with the directory name you’re adding.
 - Fill in `Example Name` and `Description`.
 - Examples should be TypeScript first, if possible.
-- Do not add the `name` add `version` fields to your `package.json`.
+- Omit the `name` and `version` fields from your `package.json`.
 - Ensure all your dependencies are up to date.
 - Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image).
 - To add additional installation instructions, please add it where appropriate.

--- a/contributing.md
+++ b/contributing.md
@@ -270,7 +270,7 @@ When you add an example to the [examples](examples) directory, don’t forget to
 - Replace `DIRECTORY_NAME` with the directory name you’re adding.
 - Fill in `Example Name` and `Description`.
 - Examples should be TypeScript first, if possible.
-- You don’t need to add `name` or `version` in your `package.json`.
+- Do not add the `name` add `version` fields to your `package.json`.
 - Ensure all your dependencies are up to date.
 - Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image).
 - To add additional installation instructions, please add it where appropriate.


### PR DESCRIPTION
We have tests running on the examples repository that will fail if `name` or `version` is found in the `package.json`. We should make it more clear in the documentation to omit these fields.

@ijjk

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
