### PR TITLE
Update x-nextjs-cache header in minimal mode

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1629,7 +1629,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       return null
     }
 
-    if (isSSG) {
+    if (isSSG && !this.minimalMode) {
       // set x-nextjs-cache header to match the header
       // we set for the image-optimizer
       res.setHeader(

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -188,6 +188,7 @@ describe('should set-up next', () => {
       redirect: 'manual',
     })
     expect(res.status).toBe(200)
+    expect(res.headers.get('x-nextjs-cache')).toBeFalsy()
     const $ = cheerio.load(await res.text())
     const props = JSON.parse($('#props').text())
     expect(props.gspCalls).toBeDefined()
@@ -201,6 +202,7 @@ describe('should set-up next', () => {
       }
     )
     expect(res2.status).toBe(200)
+    expect(res2.headers.get('x-nextjs-cache')).toBeFalsy()
     const { pageProps: props2 } = await res2.json()
     expect(props2.gspCalls).toBe(props.gspCalls)
 


### PR DESCRIPTION
This updates to skip setting the `x-nextjs-cache` header in minimal mode as the value will always be `MISS` since the incremental cache is disabled in this mode. 