### PR TITLE
Telemetry: track usage of 'experimental/nextScriptWorkers'

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1524,6 +1524,10 @@ export default async function build(
           invocationCount: config.experimental.optimizeCss ? 1 : 0,
         },
         {
+          featureName: 'experimental/nextScriptWorkers',
+          invocationCount: config.experimental.nextScriptWorkers ? 1 : 0,
+        },
+        {
           featureName: 'optimizeFonts',
           invocationCount: config.optimizeFonts ? 1 : 0,
         },

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -135,6 +135,7 @@ export type EventBuildFeatureUsage = {
     | 'next/script'
     | 'next/dynamic'
     | 'experimental/optimizeCss'
+    | 'experimental/nextScriptWorkers'
     | 'optimizeFonts'
     | 'swcLoader'
     | 'swcMinify'

--- a/test/integration/telemetry/next.config.next-script-workers
+++ b/test/integration/telemetry/next.config.next-script-workers
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    nextScriptWorkers: true
+  }
+}

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -647,6 +647,7 @@ describe('Telemetry CLI', () => {
     })
     const regex = /NEXT_BUILD_FEATURE_USAGE[\s\S]+?{([\s\S]+?)}/g
     regex.exec(stderr).pop() // optimizeCss
+    regex.exec(stderr).pop() // nextScriptWorkers
     regex.exec(stderr).pop() // build-lint
     const optimizeFonts = regex.exec(stderr).pop()
     expect(optimizeFonts).toContain(`"featureName": "optimizeFonts"`)
@@ -704,6 +705,7 @@ describe('Telemetry CLI', () => {
 
     const regex = /NEXT_BUILD_FEATURE_USAGE[\s\S]+?{([\s\S]+?)}/g
     regex.exec(stderr).pop() // optimizeCss
+    regex.exec(stderr).pop() // nextScriptWorkers
     regex.exec(stderr).pop() // build-lint
     regex.exec(stderr).pop() // optimizeFonts
     const swcLoader = regex.exec(stderr).pop()
@@ -759,6 +761,32 @@ describe('Telemetry CLI', () => {
     const optimizeCss = regex.exec(stderr).pop()
     expect(optimizeCss).toContain(`"featureName": "experimental/optimizeCss"`)
     expect(optimizeCss).toContain(`"invocationCount": 1`)
+  })
+
+  it('emits telemetry for usage of `nextScriptWorkers`', async () => {
+    await fs.rename(
+      path.join(appDir, 'next.config.next-script-workers'),
+      path.join(appDir, 'next.config.js')
+    )
+
+    const { stderr } = await nextBuild(appDir, [], {
+      stderr: true,
+      env: { NEXT_TELEMETRY_DEBUG: 1 },
+    })
+
+    await fs.rename(
+      path.join(appDir, 'next.config.js'),
+      path.join(appDir, 'next.config.next-script-workers')
+    )
+
+    const regex = /NEXT_BUILD_FEATURE_USAGE[\s\S]+?{([\s\S]+?)}/g
+    regex.exec(stderr).pop() // build-lint
+    regex.exec(stderr).pop() // optimizeCss
+    const nextScriptWorkers = regex.exec(stderr).pop()
+    expect(nextScriptWorkers).toContain(
+      `"featureName": "experimental/nextScriptWorkers"`
+    )
+    expect(nextScriptWorkers).toContain(`"invocationCount": 1`)
   })
 
   it('emits telemetry for usage of _middleware', async () => {


### PR DESCRIPTION
Track usage of the experimental `nextScriptWorkers` flag.

Backend PR: https://github.com/vercel/next-telemetry/pull/75

https://nextjs.org/docs/basic-features/script#off-loading-scripts-to-a-web-worker-experimental