### PR TITLE
Add final newline to package-lock.json

### DIFF
--- a/packages/next/lib/patch-incorrect-lockfile.ts
+++ b/packages/next/lib/patch-incorrect-lockfile.ts
@@ -87,7 +87,7 @@ export async function patchIncorrectLockfile(dir: string) {
 
       await promises.writeFile(
         lockfilePath,
-        JSON.stringify(lockfileParsed, null, 2)
+        `${JSON.stringify(lockfileParsed, null, 2)}\n`
       )
       Log.warn(
         'Lockfile was successfully patched, please run "npm install" to ensure @next/swc dependencies are downloaded'


### PR DESCRIPTION
This aligns the output with what npm outputs. Without this change,
Next.js causes unwanted changes in package-lock.json.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
