### PR TITLE
Enable html post optimization for react 18

### DIFF
--- a/packages/next/server/node-web-streams-helper.ts
+++ b/packages/next/server/node-web-streams-helper.ts
@@ -86,18 +86,18 @@ export function decodeText(input?: Uint8Array, textDecoder?: TextDecoder) {
     : new TextDecoder().decode(input)
 }
 
-export function createBufferedTransformStream(): TransformStream<
-  Uint8Array,
-  Uint8Array
-> {
+export function createBufferedTransformStream(
+  transform: (v: string) => string | Promise<string> = (v) => v
+): TransformStream<Uint8Array, Uint8Array> {
   let bufferedString = ''
   let pendingFlush: Promise<void> | null = null
 
   const flushBuffer = (controller: TransformStreamDefaultController) => {
     if (!pendingFlush) {
       pendingFlush = new Promise((resolve) => {
-        setTimeout(() => {
-          controller.enqueue(encodeText(bufferedString))
+        setTimeout(async () => {
+          const buffered = await transform(bufferedString)
+          controller.enqueue(encodeText(buffered))
           bufferedString = ''
           pendingFlush = null
           resolve()

--- a/packages/next/server/post-process.ts
+++ b/packages/next/server/post-process.ts
@@ -1,5 +1,4 @@
 import type { RenderOpts } from './render'
-import type { FontManifest } from './font-utils'
 import { parse, HTMLElement } from 'next/dist/compiled/node-html-parser'
 import { OPTIMIZED_FONT_PROVIDERS } from '../shared/lib/constants'
 import { nonNullable } from '../lib/non-nullable'

--- a/packages/next/server/post-process.ts
+++ b/packages/next/server/post-process.ts
@@ -180,7 +180,7 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
 
 async function postOptimizeHTML(
   pathname: string,
-  html: string,
+  content: string,
   renderOpts: RenderOpts,
   { inAmpMode, hybridAmp }: { inAmpMode: boolean; hybridAmp: boolean }
 ) {
@@ -242,10 +242,10 @@ async function postOptimizeHTML(
 
   for (const postProcessor of postProcessors) {
     if (postProcessor) {
-      html = await postProcessor(html)
+      content = await postProcessor(content)
     }
   }
-  return html
+  return content
 }
 
 // Initialization
@@ -257,4 +257,4 @@ registerPostProcessor(
   (options) => options.optimizeFonts || process.env.__NEXT_OPTIMIZE_FONTS
 )
 
-export { processHTML, postOptimizeHTML }
+export { postOptimizeHTML }

--- a/packages/next/server/post-process.ts
+++ b/packages/next/server/post-process.ts
@@ -9,7 +9,6 @@ let getFontDefinitionFromManifest:
   | undefined
 
 if (process.env.NEXT_RUNTIME !== 'edge') {
-  require('./node-polyfill-web-streams')
   optimizeAmp = require('./optimize-amp').default
   getFontDefinitionFromManifest =
     require('./font-utils').getFontDefinitionFromManifest

--- a/packages/next/server/post-process.ts
+++ b/packages/next/server/post-process.ts
@@ -1,7 +1,20 @@
+import type { RenderOpts } from './render'
+import type { FontManifest } from './font-utils'
 import { parse, HTMLElement } from 'next/dist/compiled/node-html-parser'
-import { OPTIMIZED_FONT_PROVIDERS } from './constants'
+import { OPTIMIZED_FONT_PROVIDERS } from '../shared/lib/constants'
+import { nonNullable } from '../lib/non-nullable'
 
-// const MIDDLEWARE_TIME_BUDGET = parseInt(process.env.__POST_PROCESS_MIDDLEWARE_TIME_BUDGET || '', 10) || 10
+let optimizeAmp: typeof import('./optimize-amp').default | undefined
+let getFontDefinitionFromManifest:
+  | typeof import('./font-utils').getFontDefinitionFromManifest
+  | undefined
+
+if (process.env.NEXT_RUNTIME !== 'edge') {
+  require('./node-polyfill-web-streams')
+  optimizeAmp = require('./optimize-amp').default
+  getFontDefinitionFromManifest =
+    require('./font-utils').getFontDefinitionFromManifest
+}
 
 type postProcessOptions = {
   optimizeFonts: boolean
@@ -165,6 +178,76 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
   }
 }
 
+async function postOptimizeHTML(
+  pathname: string,
+  html: string,
+  renderOpts: RenderOpts,
+  { inAmpMode, hybridAmp }: { inAmpMode: boolean; hybridAmp: boolean }
+) {
+  const postProcessors: Array<(html: string) => Promise<string>> = [
+    process.env.NEXT_RUNTIME !== 'edge' && inAmpMode
+      ? async (html: string) => {
+          html = await optimizeAmp!(html, renderOpts.ampOptimizerConfig)
+          if (!renderOpts.ampSkipValidation && renderOpts.ampValidator) {
+            await renderOpts.ampValidator(html, pathname)
+          }
+          return html
+        }
+      : null,
+    process.env.NEXT_RUNTIME !== 'edge' && process.env.__NEXT_OPTIMIZE_FONTS
+      ? async (html: string) => {
+          const createFontDefinitionGetter =
+            (fontManifest?: FontManifest) =>
+            (url: string): string => {
+              if (fontManifest) {
+                return getFontDefinitionFromManifest!(url, fontManifest)
+              }
+              return ''
+            }
+          return await processHTML(
+            html,
+            {
+              getFontDefinition: createFontDefinitionGetter(
+                renderOpts.fontManifest
+              ),
+            },
+            {
+              optimizeFonts: renderOpts.optimizeFonts,
+            }
+          )
+        }
+      : null,
+    process.env.NEXT_RUNTIME !== 'edge' && renderOpts.optimizeCss
+      ? async (html: string) => {
+          // eslint-disable-next-line import/no-extraneous-dependencies
+          const Critters = require('critters')
+          const cssOptimizer = new Critters({
+            ssrMode: true,
+            reduceInlineStyles: false,
+            path: renderOpts.distDir,
+            publicPath: `${renderOpts.assetPrefix}/_next/`,
+            preload: 'media',
+            fonts: false,
+            ...renderOpts.optimizeCss,
+          })
+          return await cssOptimizer.process(html)
+        }
+      : null,
+    inAmpMode || hybridAmp
+      ? async (html: string) => {
+          return html.replace(/&amp;amp=1/g, '&amp=1')
+        }
+      : null,
+  ].filter(nonNullable)
+
+  for (const postProcessor of postProcessors) {
+    if (postProcessor) {
+      html = await postProcessor(html)
+    }
+  }
+  return html
+}
+
 // Initialization
 registerPostProcessor(
   'Inline-Fonts',
@@ -174,4 +257,4 @@ registerPostProcessor(
   (options) => options.optimizeFonts || process.env.__NEXT_OPTIMIZE_FONTS
 )
 
-export default processHTML
+export { processHTML, postOptimizeHTML }

--- a/packages/next/server/post-process.ts
+++ b/packages/next/server/post-process.ts
@@ -178,7 +178,7 @@ class FontOptimizerMiddleware implements PostProcessMiddleware {
   }
 }
 
-async function postOptimizeHTML(
+async function postProcessHTML(
   pathname: string,
   content: string,
   renderOpts: RenderOpts,
@@ -196,21 +196,18 @@ async function postOptimizeHTML(
       : null,
     process.env.NEXT_RUNTIME !== 'edge' && process.env.__NEXT_OPTIMIZE_FONTS
       ? async (html: string) => {
-          const createFontDefinitionGetter =
-            (fontManifest?: FontManifest) =>
-            (url: string): string => {
-              if (fontManifest) {
-                return getFontDefinitionFromManifest!(url, fontManifest)
-              }
-              return ''
+          const getFontDefinition = (url: string): string => {
+            if (renderOpts.fontManifest) {
+              return getFontDefinitionFromManifest!(
+                url,
+                renderOpts.fontManifest
+              )
             }
+            return ''
+          }
           return await processHTML(
             html,
-            {
-              getFontDefinition: createFontDefinitionGetter(
-                renderOpts.fontManifest
-              ),
-            },
+            { getFontDefinition },
             {
               optimizeFonts: renderOpts.optimizeFonts,
             }
@@ -257,4 +254,4 @@ registerPostProcessor(
   (options) => options.optimizeFonts || process.env.__NEXT_OPTIMIZE_FONTS
 )
 
-export { postOptimizeHTML }
+export { postProcessHTML }

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -83,7 +83,7 @@ import { FlushEffectsContext } from '../shared/lib/flush-effects'
 import { interopDefault } from '../lib/interop-default'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { urlQueryToSearchParams } from '../shared/lib/router/utils/querystring'
-import { postOptimizeHTML } from './post-process'
+import { postProcessHTML } from './post-process'
 
 let tryGetPreviewData: typeof import('./api-utils/node').tryGetPreviewData
 let warn: typeof import('../build/output/log').warn
@@ -1742,7 +1742,7 @@ export async function renderToHTML(
   }
 
   const postOptimize = (html: string) =>
-    postOptimizeHTML(pathname, html, renderOpts, { inAmpMode, hybridAmp })
+    postProcessHTML(pathname, html, renderOpts, { inAmpMode, hybridAmp })
 
   if (generateStaticHTML) {
     const html = await streamToString(chainStreams(streams))

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -465,7 +465,6 @@ export async function renderToHTML(
     ampPath = '',
     pageConfig = {},
     buildManifest,
-    fontManifest,
     reactLoadableManifest,
     ErrorDebug,
     getStaticProps,
@@ -1740,6 +1739,7 @@ export async function renderToHTML(
 
   const postOptimize = (html: string) =>
     postOptimizeHTML(pathname, html, renderOpts, { inAmpMode, hybridAmp })
+
   if (generateStaticHTML) {
     const html = await streamToString(chainStreams(streams))
     const optimizedHtml = await postOptimize(html)

--- a/test/integration/amphtml-custom-optimizer/next.config.js
+++ b/test/integration/amphtml-custom-optimizer/next.config.js
@@ -1,5 +1,4 @@
-const path = require('path')
-module.exports = require(path.join(__dirname, '../../lib/with-react-17.js'))({
+module.exports = {
   experimental: {
     amp: {
       optimizer: {
@@ -10,4 +9,4 @@ module.exports = require(path.join(__dirname, '../../lib/with-react-17.js'))({
       skipValidation: true,
     },
   },
-})
+}

--- a/test/integration/amphtml-custom-optimizer/test/index.test.js
+++ b/test/integration/amphtml-custom-optimizer/test/index.test.js
@@ -12,19 +12,14 @@ import {
 let app
 let appPort
 const appDir = join(__dirname, '../')
-const nodeArgs = ['-r', join(appDir, '../../lib/react-17-require-hook.js')]
 
 describe('AMP Custom Optimizer', () => {
   it('should build and start for static page', async () => {
-    const { code } = await nextBuild(appDir, undefined, {
-      nodeArgs,
-    })
+    const { code } = await nextBuild(appDir)
     expect(code).toBe(0)
 
     appPort = await findPort()
-    app = await nextStart(appDir, appPort, {
-      nodeArgs,
-    })
+    app = await nextStart(appDir, appPort)
 
     const html = await renderViaHTTP(appPort, '/')
     await killApp(app)
@@ -39,11 +34,11 @@ describe('AMP Custom Optimizer', () => {
   })
 
   it('should build and start for dynamic page', async () => {
-    const { code } = await nextBuild(appDir, undefined, { nodeArgs })
+    const { code } = await nextBuild(appDir)
     expect(code).toBe(0)
 
     appPort = await findPort()
-    app = await nextStart(appDir, appPort, { nodeArgs })
+    app = await nextStart(appDir, appPort)
 
     const html = await renderViaHTTP(appPort, '/dynamic')
     await killApp(app)

--- a/test/integration/amphtml/next.config.js
+++ b/test/integration/amphtml/next.config.js
@@ -1,5 +1,4 @@
-const path = require('path')
-module.exports = require(path.join(__dirname, '../../lib/with-react-17.js'))({
+module.exports = {
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
@@ -8,4 +7,4 @@ module.exports = require(path.join(__dirname, '../../lib/with-react-17.js'))({
     canonicalBase: 'http://localhost:1234',
   },
   // edit here
-})
+}

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -18,7 +18,6 @@ import webdriver from 'next-webdriver'
 import { join } from 'path'
 
 const appDir = join(__dirname, '../')
-const nodeArgs = ['-r', join(appDir, '../../lib/react-17-require-hook.js')]
 let appPort
 let app
 
@@ -36,14 +35,11 @@ describe('AMP Usage', () => {
       const result = await nextBuild(appDir, undefined, {
         stdout: true,
         stderr: true,
-        nodeArgs,
       })
       output = result.stdout + result.stderr
 
       appPort = context.appPort = await findPort()
-      app = await nextStart(appDir, context.appPort, {
-        nodeArgs,
-      })
+      app = await nextStart(appDir, context.appPort)
     })
     afterAll(async () => {
       await rename(
@@ -276,7 +272,6 @@ describe('AMP Usage', () => {
         onStderr(msg) {
           inspectPayload += msg
         },
-        nodeArgs,
       })
 
       await renderViaHTTP(dynamicAppPort, '/only-amp')
@@ -301,7 +296,6 @@ describe('AMP Usage', () => {
         onStderr(msg) {
           output += msg
         },
-        nodeArgs,
       })
     })
 
@@ -549,7 +543,6 @@ describe('AMP Usage', () => {
         onStderr(msg) {
           inspectPayload += msg
         },
-        nodeArgs,
       })
 
       await renderViaHTTP(dynamicAppPort, '/invalid-amp')

--- a/test/integration/app-document/next.config.js
+++ b/test/integration/app-document/next.config.js
@@ -1,4 +1,1 @@
-const path = require('path')
-module.exports = require(path.join(__dirname, '../../lib/with-react-17.js'))({
-  crossOrigin: 'anonymous',
-})
+module.exports = { crossOrigin: 'anonymous' }

--- a/test/integration/app-document/pages/_document.js
+++ b/test/integration/app-document/pages/_document.js
@@ -38,7 +38,7 @@ export default class MyDocument extends Document {
       }
     }
 
-    const result = ctx.renderPage(options)
+    const result = await ctx.renderPage(options)
 
     return {
       ...result,

--- a/test/integration/app-document/test/index.test.js
+++ b/test/integration/app-document/test/index.test.js
@@ -28,10 +28,6 @@ describe('Document and App', () => {
     context.server = await launchApp(join(__dirname, '../'), context.appPort, {
       onStdout: collectOutput,
       onStderr: collectOutput,
-      nodeArgs: [
-        '-r',
-        join(__dirname, '../../../lib/react-17-require-hook.js'),
-      ],
     })
 
     // pre-build all pages at the start

--- a/test/integration/critical-css/next.config.js
+++ b/test/integration/critical-css/next.config.js
@@ -1,1 +1,0 @@
-module.exports = { experimental: { optimizeCss: true } }

--- a/test/integration/critical-css/test/index.test.js
+++ b/test/integration/critical-css/test/index.test.js
@@ -14,7 +14,6 @@ import fs from 'fs-extra'
 const glob = promisify(globOrigig)
 const appDir = join(__dirname, '../')
 const nextConfig = join(appDir, 'next.config.js')
-const nodeArgs = ['-r', join(appDir, '../../lib/react-17-require-hook.js')]
 let appPort
 let app
 
@@ -68,13 +67,9 @@ describe('CSS optimization for SSR apps', () => {
     if (fs.pathExistsSync(join(appDir, '.next'))) {
       await fs.remove(join(appDir, '.next'))
     }
-    await nextBuild(appDir, undefined, {
-      nodeArgs,
-    })
+    await nextBuild(appDir)
     appPort = await findPort()
-    app = await nextStart(appDir, appPort, {
-      nodeArgs,
-    })
+    app = await nextStart(appDir, appPort)
   })
   afterAll(async () => {
     await killApp(app)
@@ -90,13 +85,9 @@ describe('Font optimization for emulated serverless apps', () => {
       `module.exports = { target: 'experimental-serverless-trace', experimental: {optimizeCss: true} }`,
       'utf8'
     )
-    await nextBuild(appDir, undefined, {
-      nodeArgs,
-    })
+    await nextBuild(appDir)
     appPort = await findPort()
-    app = await nextStart(appDir, appPort, {
-      nodeArgs,
-    })
+    app = await nextStart(appDir, appPort)
   })
   afterAll(async () => {
     await killApp(app)

--- a/test/integration/font-optimization/fixtures/with-google/next.config.js
+++ b/test/integration/font-optimization/fixtures/with-google/next.config.js
@@ -1,7 +1,1 @@
-const path = require('path')
-module.exports = require(path.join(
-  __dirname,
-  '../../../../lib/with-react-17.js'
-))({
-  cleanDistDir: false,
-})
+module.exports = { cleanDistDir: false }

--- a/test/integration/font-optimization/fixtures/with-typekit/next.config.js
+++ b/test/integration/font-optimization/fixtures/with-typekit/next.config.js
@@ -1,7 +1,3 @@
-const path = require('path')
-module.exports = require(path.join(
-  __dirname,
-  '../../../../lib/with-react-17.js'
-))({
+module.exports = {
   cleanDistDir: false,
-})
+}

--- a/test/integration/font-optimization/test/index.test.js
+++ b/test/integration/font-optimization/test/index.test.js
@@ -15,10 +15,6 @@ import {
 import webdriver from 'next-webdriver'
 
 const fixturesDir = join(__dirname, '..', 'fixtures')
-const nodeArgs = [
-  '-r',
-  join(__dirname, '../../../lib/react-17-require-hook.js'),
-]
 
 const fsExists = (file) =>
   fs
@@ -229,9 +225,7 @@ describe('Font Optimization', () => {
 
         // Re-run build to check if it works when build is cached
         it('should work when build is cached', async () => {
-          await nextBuild(appDir, undefined, {
-            nodeArgs,
-          })
+          await nextBuild(appDir)
           const testJson = JSON.parse(
             await fs.readFile(builtPage('font-manifest.json'), {
               encoding: 'utf-8',
@@ -246,13 +240,9 @@ describe('Font Optimization', () => {
           if (fs.pathExistsSync(join(appDir, '.next'))) {
             await fs.remove(join(appDir, '.next'))
           }
-          await nextBuild(appDir, undefined, {
-            nodeArgs,
-          })
+          await nextBuild(appDir)
           appPort = await findPort()
-          app = await nextStart(appDir, appPort, {
-            nodeArgs,
-          })
+          app = await nextStart(appDir, appPort)
           builtServerPagesDir = join(appDir, '.next', 'server')
           builtPage = (file) => join(builtServerPagesDir, file)
         })
@@ -266,19 +256,12 @@ describe('Font Optimization', () => {
         beforeAll(async () => {
           await fs.writeFile(
             nextConfig,
-            `
-            const path = require('path')
-            module.exports = require(path.join(__dirname, '../../../../lib/with-react-17.js'))({ target: 'serverless', cleanDistDir: false })
-            `,
+            `module.exports = ({ target: 'serverless', cleanDistDir: false })`,
             'utf8'
           )
-          await nextBuild(appDir, undefined, {
-            nodeArgs,
-          })
+          await nextBuild(appDir)
           appPort = await findPort()
-          app = await nextStart(appDir, appPort, {
-            nodeArgs,
-          })
+          app = await nextStart(appDir, appPort)
           builtServerPagesDir = join(appDir, '.next', 'serverless')
           builtPage = (file) => join(builtServerPagesDir, file)
         })
@@ -295,19 +278,12 @@ describe('Font Optimization', () => {
         beforeAll(async () => {
           await fs.writeFile(
             nextConfig,
-            `
-            const path = require('path')
-            module.exports = require(path.join(__dirname, '../../../../lib/with-react-17.js'))({ target: 'experimental-serverless-trace', cleanDistDir: false })
-            `,
+            `module.exports = ({ target: 'experimental-serverless-trace', cleanDistDir: false })`,
             'utf8'
           )
-          await nextBuild(appDir, undefined, {
-            nodeArgs,
-          })
+          await nextBuild(appDir)
           appPort = await findPort()
-          app = await startServerlessEmulator(appDir, appPort, {
-            nodeArgs,
-          })
+          app = await startServerlessEmulator(appDir, appPort)
           builtServerPagesDir = join(appDir, '.next', 'serverless')
           builtPage = (file) => join(builtServerPagesDir, file)
         })
@@ -320,18 +296,14 @@ describe('Font Optimization', () => {
 
       describe('Font optimization for unreachable font definitions.', () => {
         beforeAll(async () => {
-          await nextBuild(appDir, undefined, {
-            nodeArgs,
-          })
+          await nextBuild(appDir)
           await fs.writeFile(
             join(appDir, '.next', 'server', 'font-manifest.json'),
             '[]',
             'utf8'
           )
           appPort = await findPort()
-          app = await nextStart(appDir, appPort, {
-            nodeArgs,
-          })
+          app = await nextStart(appDir, appPort)
           builtServerPagesDir = join(appDir, '.next', 'serverless')
           builtPage = (file) => join(builtServerPagesDir, file)
         })


### PR DESCRIPTION
Follow up for #35888 to re-enable more test, and re-enable post processors after #36792 has better support for document.gIP with react 18. Apply post-pocessing when the the shell chunk is fully buffered.

re-enabled integration tests for react 18:
- amphtml
- amphtml-custom-optimizer
- app-document
- font-optimization

Fixes #35835


## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

