### PR TITLE
chore: upgrade dependencies in Jest examples

### DIFF
--- a/examples/with-jest-babel/README.md
+++ b/examples/with-jest-babel/README.md
@@ -11,11 +11,11 @@ Quickly get started using [Create Next App](https://github.com/vercel/next.js/tr
 In your terminal, run the following command:
 
 ```bash
-npx create-next-app --example with-jest with-jest-app
+npx create-next-app --example with-jest-babel with-jest-babel-app
 # or
-yarn create next-app --example with-jest with-jest-app
+yarn create next-app --example with-jest-babel with-jest-babel-app
 # or
-pnpm create next-app -- --example with-jest with-jest-app
+pnpm create next-app -- --example with-jest-babel with-jest-babel-app
 ```
 
 ## Run Jest Tests

--- a/examples/with-jest-babel/package.json
+++ b/examples/with-jest-babel/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "lint": "next lint",
     "build": "next build",
     "start": "next start",
     "test": "jest --watch",
@@ -10,20 +9,18 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "5.16.1",
-    "@testing-library/react": "12.1.2",
-    "@testing-library/user-event": "13.5.0",
-    "@types/react": "17.0.37",
-    "babel-jest": "27.4.5",
-    "eslint": "8.5.0",
-    "eslint-config-next": "latest",
-    "eslint-plugin-testing-library": "5.0.1",
+    "@testing-library/jest-dom": "5.16.4",
+    "@testing-library/react": "13.2.0",
+    "@testing-library/user-event": "14.2.0",
+    "@types/react": "18.0.9",
+    "babel-jest": "28.1.0",
     "identity-obj-proxy": "3.0.0",
-    "jest": "27.4.5",
-    "typescript": "4.5.4"
+    "jest": "28.1.0",
+    "jest-environment-jsdom": "28.1.0",
+    "typescript": "4.6.4"
   }
 }

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -9,15 +9,16 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "5.16.1",
-    "@testing-library/react": "12.1.2",
-    "@testing-library/user-event": "13.5.0",
-    "@types/react": "17.0.38",
-    "jest": "27.4.5",
-    "typescript": "4.5.4"
+    "@testing-library/jest-dom": "5.16.4",
+    "@testing-library/react": "13.2.0",
+    "@testing-library/user-event": "14.2.0",
+    "@types/react": "18.0.9",
+    "jest": "28.1.0",
+    "jest-environment-jsdom": "28.1.0",
+    "typescript": "4.6.4"
   }
 }


### PR DESCRIPTION
Ref: https://github.com/vercel/next.js/issues/36842, https://github.com/vercel/next.js/pull/36632, https://github.com/vercel/next.js/pull/36787

Upgrading to Jest 28, and aligning Babel example with `with-jest`


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
