### PR TITLE
Remove un-helpful error in with-sentry example

### DIFF
--- a/examples/with-sentry/pages/_error.js
+++ b/examples/with-sentry/pages/_error.js
@@ -14,7 +14,7 @@ const MyError = ({ statusCode, hasGetInitialPropsRun, err }) => {
   return <NextErrorComponent statusCode={statusCode} />
 }
 
-MyError.getInitialProps = async ({ res, err, asPath }) => {
+MyError.getInitialProps = async ({ res, err }) => {
   const errorInitialProps = await NextErrorComponent.getInitialProps({
     res,
     err,
@@ -48,13 +48,8 @@ MyError.getInitialProps = async ({ res, err, asPath }) => {
   }
 
   // If this point is reached, getInitialProps was called without any
-  // information about what the error might be. This is unexpected and may
-  // indicate a bug introduced in Next.js, so record it in Sentry
-  Sentry.captureException(
-    new Error(`_error.js getInitialProps missing data at path: ${asPath}`)
-  )
-  await Sentry.flush(2000)
-
+  // information about what the error might be. This can be caused by
+  // a falsy value being thrown e.g. throw undefined
   return errorInitialProps
 }
 


### PR DESCRIPTION
The error reported here is unclear and un-helpful so we shouldn't be recommending to report this by default. 

x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1652466540356879) 

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
