### PR TITLE
feat(next/jest): mock static imports of svg, image and others differently

### DIFF
--- a/packages/next/build/jest/__mocks__/fileMock.js
+++ b/packages/next/build/jest/__mocks__/fileMock.js
@@ -1,6 +1,2 @@
-module.exports = {
-  src: '/img.jpg',
-  height: 24,
-  width: 24,
-  blurDataURL: 'data:image/png;base64,imagedata',
-}
+// as jest suggested in https://jestjs.io/docs/webpack#handling-static-assets
+module.exports = 'test-file-stub'

--- a/packages/next/build/jest/__mocks__/imageMock.js
+++ b/packages/next/build/jest/__mocks__/imageMock.js
@@ -1,0 +1,7 @@
+// mock StaticImageData interface
+module.exports = {
+  src: '/mock-image.png',
+  height: 24,
+  width: 24,
+  blurDataURL: 'data:image/png;base64,imagedata',
+}

--- a/packages/next/build/jest/__mocks__/svgMock.js
+++ b/packages/next/build/jest/__mocks__/svgMock.js
@@ -1,0 +1,11 @@
+const React = require('react')
+
+// mock @svgr/webpack
+module.exports = (...props) => {
+  const svg = React.createElement('svg', {
+    fill: 'none',
+    xmlns: 'http://www.w3.org/2000/svg',
+    ...props[0],
+  })
+  return svg
+}

--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -92,13 +92,17 @@ export default function nextJest(options: { dir?: string } = {}) {
           // Handle CSS imports (without CSS modules)
           '^.+\\.(css|sass|scss)$': require.resolve('./__mocks__/styleMock.js'),
 
-          // Handle image imports
+          // Handle image imports as a StaticImageData-typed png image
           '^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp)$': require.resolve(
-            `./__mocks__/fileMock.js`
+            `./__mocks__/imageMock.js`
           ),
 
-          // Keep .svg to it's own rule to make overriding easy
-          '^.+\\.(svg)$': require.resolve(`./__mocks__/fileMock.js`),
+          // Handle svg imports as @svgr/webpack plugin handles
+          '^.+\\.(svg)$': require.resolve(`./__mocks__/svgMock.js`),
+
+          // Handle other files as jest suggested
+          '^.+\\.(eot|otf|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+            require.resolve(`./__mocks__/fileMock.js`),
 
           // custom config comes last to ensure the above rules are matched,
           // fixes the case where @pages/(.*) -> src/pages/$! doesn't break


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Related to #36230 , #35028 . (and PR #34350)

<br>

For now, every statically imported file gets mocked by a single [`fileMock.js`](https://github.com/vercel/next.js/blob/canary/packages/next/build/jest/__mocks__/fileMock.js).

```js
// (current) jest.config.js
moduleNameMapper = {
  '^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp)$': require.resolve(`./__mocks__/fileMock.js`),
  '^.+\\.(svg)$': require.resolve(`./__mocks__/fileMock.js`),
  ...
}
```
> https://github.com/vercel/next.js/blob/canary/packages/next/build/jest/jest.ts#L86-L107

```js
// (current) fileMock.js
module.exports = {
  src: '/img.jpg',
  height: 24,
  width: 24,
  blurDataURL: 'data:image/png;base64,imagedata',
}
```
> https://github.com/vercel/next.js/blob/canary/packages/next/build/jest/__mocks__/fileMock.js

<br>

As a result, In jest environment, every statically imported file will be mocked as a mock jpg file (to be specific, it is a [`StaticImageData`](https://github.com/vercel/next.js/blob/canary/packages/next/client/image.tsx#L92-L97)-typed object). But the thing is, in real world scenario, svg file doesn't get imported in a way that jpg or other image files do. Svg files gets imported by [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack) so that the import results of svg file and other images end up being different. You can observe this by simply do `console.log` both imported files.

| <img width="669" alt="image" src="https://user-images.githubusercontent.com/12558317/168417020-2a157c27-5898-41ac-b985-812054b1e02b.png"> | <img width="669" alt="image" src="https://user-images.githubusercontent.com/12558317/168417027-644f96ed-2802-46e3-a73b-ca2be63f0612.png"> |
| :-: | :-: |
| png file (StaticImageData-typed object) | svg file (a function) |

> In fact, next.js itself is treating svg and other images differently. (look [image-types](https://github.com/vercel/next.js/blob/canary/packages/next/image-types/global.d.ts#L4-L19))

<br>

So to make both svg file and other image files get imported properly under jest environment, `fileMock.js` should be split into each dedicated mock files as below.

```js
// (updated) jest.config.js
moduleNameMapper = {
  '\\.svg$': '<rootDir>/__mocks__/svgMock.js',
  '\\.(jpg|jpeg|png|gif|webp)$': '<rootDir>/__mocks__/imageMock.js',
  '\\.(eot|otf|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
  ...
}
```

```js
// (added) svgMock.js
const React = require('react');

module.exports = (...props) => {
  const svg = React.createElement('svg', {
    fill: 'none',
    xmlns: 'http://www.w3.org/2000/svg',
    ...props[0],
  });
  return svg;
};
```

```js
// (added) imageMock.js
module.exports = {
  src: '/mock-image.png',
  height: 24,
  width: 24,
  blurDataURL: 'data:image/png;base64,imagedata',
}
```

```js
// (modified) fileMock.js
module.exports = 'test-file-stub';
```

> `fileMock.js` doesn't have to be changed but it feels quite awkward for me to mock non-image files as a mock jpg file.

In `svgMock.js`, I tried to mimic the way how `@svgr/webpack` treats a svg file. If a svg file gets mocked in such way, now svg-as-component will work well in jest environment too. (ex. `<SvgFile width={10} height={20} />`).

<br>


## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
