### PR TITLE
Update @types/node-fetch to latest

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -147,7 +147,7 @@
     "@types/lodash.curry": "4.1.6",
     "@types/lru-cache": "5.1.0",
     "@types/micromatch": "4.0.2",
-    "@types/node-fetch": "2.3.4",
+    "@types/node-fetch": "2.6.1",
     "@types/path-to-regexp": "1.7.0",
     "@types/react": "16.9.17",
     "@types/react-dom": "16.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5216,11 +5216,13 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@2.3.4":
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.3.4.tgz#a46fc4fe9f94b491bf551b6bb7f0f493b9bacd1a"
+"@types/node-fetch@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
+  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
   dependencies:
     "@types/node" "*"
+    form-data "^3.0.0"
 
 "@types/node@*", "@types/node@13.11.0", "@types/node@>= 8":
   version "13.11.0"


### PR DESCRIPTION
Currently, if you try the following code while developing with Next.js inside Middleware:

```ts
const url = new URL(MY_URL)
const res = await fetch(url)
```

The app will work as expected, and so will the dom types for TS 4.5+. However when running `next build` or `tsc` typescript fails with:

<img width="837" alt="image" src="https://user-images.githubusercontent.com/4278345/168647502-06b8b223-e0cf-4e8b-9a82-cdac51748789.png">

The types for `node-fetch` have been updated to include `URL` so this PR updates the dependency to fix it.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
