### PR TITLE
Clarify .env* environment variable priority

### DIFF
--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -155,31 +155,12 @@ export default async () => {
 Environment variables are looked up in the following places, in order, stopping once the variable is found.
 
 1. `process.env`
-1. `.env.$(NODE_ENV).local` (Not in 
-1. `.env.local` (Not checked when `NODE_ENV` is `test`.
+1. `.env.$(NODE_ENV).local`
+1. `.env.local` (Not checked when `NODE_ENV` is `test`.)
 1. `.env.$(NODE_ENV)`
 1. `.env`
 
-For example, if you define a variable in both `.env.local` and `.env`, the value in `.env.local` will be used.
+For example, if `NODE_ENV` is `development` and you define a variable in both `.env.development.local` and `.env`, the value in `.env.development.local` will be used.
 
-`NODE_ENV=production`
 
-1. `.env.production.local`
-1. `.env.local`
-1. `.env.production`
-1. `.env`
-
-`NODE_ENV=development`
-
-1. `.env.development.local`
-1. `.env.local`
-1. `.env.development`
-1. `.env`
-
-`NODE_ENV=test`
-
-1. `.env.test.local`
-1. `.env.test`
-1. `.env`
-
-> **Note:** `.env.local` is not loaded when `NODE_ENV=test`.
+> **Note:** The allowed values for `NODE_ENV` are `production`, `development` and `test`.

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -152,7 +152,15 @@ export default async () => {
 
 ## Environment Variable Load Order
 
-Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources. The sources are ordered in descending priority, so environment variables from source (4) are loaded first, then 3 will override, then 2 will override, and finally 1 has the highest priority and will override all others. In all environments, the existing system `env` has the highest priority and is not overridden.
+Environment variables are looked up in the following places, in order, stopping once the variable is found.
+
+1. `process.env`
+1. `.env.$(NODE_ENV).local` (Not in 
+1. `.env.local` (Not checked when `NODE_ENV` is `test`.
+1. `.env.$(NODE_ENV)`
+1. `.env`
+
+For example, if you define a variable in both `.env.local` and `.env`, the value in `.env.local` will be used.
 
 `NODE_ENV=production`
 

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -152,7 +152,7 @@ export default async () => {
 
 ## Environment Variable Load Order
 
-Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources with descending priority. In all environments, the existing system `env` has the highest priority and is not overridden.
+Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources with descending priority. This means that the lowest priority (4) is loaded first, then 3 will override, then 2 will override, and finally 1 has the highest priority and will override all others. In all environments, the existing system `env` has the highest priority and is not overridden.
 
 `NODE_ENV=production`
 

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -152,7 +152,7 @@ export default async () => {
 
 ## Environment Variable Load Order
 
-Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources with descending priority. In all environments, the existing `env` has the highest priority and is not overridden.
+Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources with descending priority. In all environments, the existing system `env` has the highest priority and is not overridden.
 
 `NODE_ENV=production`
 

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -152,7 +152,7 @@ export default async () => {
 
 ## Environment Variable Load Order
 
-Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources with descending priority. This means that the lowest priority (4) is loaded first, then 3 will override, then 2 will override, and finally 1 has the highest priority and will override all others. In all environments, the existing system `env` has the highest priority and is not overridden.
+Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources. The sources are ordered in descending priority, so environment variables from source (4) are loaded first, then 3 will override, then 2 will override, and finally 1 has the highest priority and will override all others. In all environments, the existing system `env` has the highest priority and is not overridden.
 
 `NODE_ENV=production`
 

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -162,5 +162,4 @@ Environment variables are looked up in the following places, in order, stopping 
 
 For example, if `NODE_ENV` is `development` and you define a variable in both `.env.development.local` and `.env`, the value in `.env.development.local` will be used.
 
-
 > **Note:** The allowed values for `NODE_ENV` are `production`, `development` and `test`.

--- a/docs/basic-features/environment-variables.md
+++ b/docs/basic-features/environment-variables.md
@@ -152,7 +152,7 @@ export default async () => {
 
 ## Environment Variable Load Order
 
-Depending on the environment (as set by `NODE_ENV`), Environment Variables are loaded from the following sources in top-to-bottom order. In all environments, the existing `env` is not overridden by following sources:
+Depending on the environment (as set by `NODE_ENV`), Environment Variables are defined from the following sources with descending priority. In all environments, the existing `env` has the highest priority and is not overridden.
 
 `NODE_ENV=production`
 


### PR DESCRIPTION
Clarify that the environment variables are ordered in descending priority and that the existing system environment is not overridden.

fixes https://github.com/vercel/next.js/issues/36966

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
