### PR TITLE
Simplify the logic for static flight response generation

### DIFF
--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -10,6 +10,7 @@ import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import {
   MIDDLEWARE_FLIGHT_MANIFEST,
   EDGE_RUNTIME_WEBPACK,
+  NEXT_CLIENT_SSR_ENTRY_SUFFIX,
 } from '../../../shared/lib/constants'
 import { clientComponentRegex } from '../loaders/utils'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
@@ -54,8 +55,6 @@ export class FlightManifestPlugin {
   }
 
   apply(compiler: any) {
-    const context = (this as any).context
-
     compiler.hooks.compilation.tap(
       PLUGIN_NAME,
       (compilation: any, { normalModuleFactory }: any) => {
@@ -74,138 +73,7 @@ export class FlightManifestPlugin {
     compiler.hooks.finishMake.tapAsync(
       PLUGIN_NAME,
       async (compilation: any, callback: any) => {
-        const promises: any = []
-
-        // For each SC server compilation entry, we need to create its corresponding
-        // client component entry.
-        for (const [name, entry] of compilation.entries.entries()) {
-          if (name === 'pages/_app.server') continue
-
-          // Check if the page entry is a server component or not.
-          const entryDependency = entry.dependencies?.[0]
-          const request = entryDependency?.request
-
-          if (request && entry.options?.layer === 'sc_server') {
-            const visited = new Set()
-            const clientComponentImports: string[] = []
-
-            function filterClientComponents(dependency: any) {
-              const module =
-                compilation.moduleGraph.getResolvedModule(dependency)
-              if (!module) return
-
-              if (visited.has(module.userRequest)) return
-              visited.add(module.userRequest)
-
-              if (clientComponentRegex.test(module.userRequest)) {
-                clientComponentImports.push(module.userRequest)
-              }
-
-              compilation.moduleGraph
-                .getOutgoingConnections(module)
-                .forEach((connection: any) => {
-                  filterClientComponents(connection.dependency)
-                })
-            }
-
-            // Traverse the module graph to find all client components.
-            filterClientComponents(entryDependency)
-
-            const entryModule =
-              compilation.moduleGraph.getResolvedModule(entryDependency)
-            const routeInfo = entryModule.buildInfo.route || {
-              page: denormalizePagePath(name.replace(/^pages/, '')),
-              absolutePagePath: entryModule.resource,
-            }
-
-            // Parse gSSP and gSP exports from the page source.
-            const pageStaticInfo = this.isEdgeServer
-              ? {}
-              : await getPageStaticInfo(
-                  routeInfo.absolutePagePath,
-                  {},
-                  this.dev
-                )
-
-            const clientLoader = `next-flight-client-entry-loader?${stringify({
-              modules: clientComponentImports,
-              runtime: this.isEdgeServer ? 'edge' : 'nodejs',
-              ssr: pageStaticInfo.ssr,
-              // Adding name here to make the entry key unique.
-              name,
-            })}!`
-
-            const bundlePath = 'pages' + normalizePagePath(routeInfo.page)
-
-            // Inject the entry to the client compiler.
-            if (this.dev) {
-              const pageKey = 'client' + routeInfo.page
-              if (!entries[pageKey]) {
-                entries[pageKey] = {
-                  bundlePath,
-                  absolutePagePath: routeInfo.absolutePagePath,
-                  clientLoader,
-                  dispose: false,
-                  lastActiveTime: Date.now(),
-                } as any
-                const invalidator = getInvalidator()
-                if (invalidator) {
-                  invalidator.invalidate()
-                }
-              }
-            } else {
-              injectedClientEntries.set(
-                bundlePath,
-                `next-client-pages-loader?${stringify({
-                  isServerComponent: true,
-                  page: denormalizePagePath(bundlePath.replace(/^pages/, '')),
-                  absolutePagePath: clientLoader,
-                })}!` + clientLoader
-              )
-            }
-
-            // Inject the entry to the server compiler.
-            const clientComponentEntryDep = (
-              webpack as any
-            ).EntryPlugin.createDependency(
-              clientLoader,
-              name + '.__sc_client__'
-            )
-            promises.push(
-              new Promise<void>((res, rej) => {
-                compilation.addEntry(
-                  context,
-                  clientComponentEntryDep,
-                  this.isEdgeServer
-                    ? {
-                        name: name + '.__sc_client__',
-                        library: {
-                          name: ['self._CLIENT_ENTRY'],
-                          type: 'assign',
-                        },
-                        runtime: EDGE_RUNTIME_WEBPACK,
-                        asyncChunks: false,
-                      }
-                    : {
-                        name: name + '.__sc_client__',
-                        runtime: 'webpack-runtime',
-                      },
-                  (err: any) => {
-                    if (err) {
-                      rej(err)
-                    } else {
-                      res()
-                    }
-                  }
-                )
-              })
-            )
-          }
-        }
-
-        Promise.all(promises)
-          .then(() => callback())
-          .catch(callback)
+        this.createClientEndpoints(compilation, callback)
       }
     )
 
@@ -219,6 +87,137 @@ export class FlightManifestPlugin {
         (assets: any) => this.createAsset(assets, compilation)
       )
     })
+  }
+
+  async createClientEndpoints(compilation: any, callback: () => void) {
+    const context = (this as any).context
+    const promises: any = []
+
+    // For each SC server compilation entry, we need to create its corresponding
+    // client component entry.
+    for (const [name, entry] of compilation.entries.entries()) {
+      if (name === 'pages/_app.server') continue
+
+      // Check if the page entry is a server component or not.
+      const entryDependency = entry.dependencies?.[0]
+      const request = entryDependency?.request
+
+      if (request && entry.options?.layer === 'sc_server') {
+        const visited = new Set()
+        const clientComponentImports: string[] = []
+
+        function filterClientComponents(dependency: any) {
+          const module = compilation.moduleGraph.getResolvedModule(dependency)
+          if (!module) return
+
+          if (visited.has(module.userRequest)) return
+          visited.add(module.userRequest)
+
+          if (clientComponentRegex.test(module.userRequest)) {
+            clientComponentImports.push(module.userRequest)
+          }
+
+          compilation.moduleGraph
+            .getOutgoingConnections(module)
+            .forEach((connection: any) => {
+              filterClientComponents(connection.dependency)
+            })
+        }
+
+        // Traverse the module graph to find all client components.
+        filterClientComponents(entryDependency)
+
+        const entryModule =
+          compilation.moduleGraph.getResolvedModule(entryDependency)
+        const routeInfo = entryModule.buildInfo.route || {
+          page: denormalizePagePath(name.replace(/^pages/, '')),
+          absolutePagePath: entryModule.resource,
+        }
+
+        // Parse gSSP and gSP exports from the page source.
+        const pageStaticInfo = this.isEdgeServer
+          ? {}
+          : await getPageStaticInfo(routeInfo.absolutePagePath, {}, this.dev)
+
+        const clientLoader = `next-flight-client-entry-loader?${stringify({
+          modules: clientComponentImports,
+          runtime: this.isEdgeServer ? 'edge' : 'nodejs',
+          ssr: pageStaticInfo.ssr,
+          // Adding name here to make the entry key unique.
+          name,
+        })}!`
+
+        const bundlePath = 'pages' + normalizePagePath(routeInfo.page)
+
+        // Inject the entry to the client compiler.
+        if (this.dev) {
+          const pageKey = 'client' + routeInfo.page
+          if (!entries[pageKey]) {
+            entries[pageKey] = {
+              bundlePath,
+              absolutePagePath: routeInfo.absolutePagePath,
+              clientLoader,
+              dispose: false,
+              lastActiveTime: Date.now(),
+            } as any
+            const invalidator = getInvalidator()
+            if (invalidator) {
+              invalidator.invalidate()
+            }
+          }
+        } else {
+          injectedClientEntries.set(
+            bundlePath,
+            `next-client-pages-loader?${stringify({
+              isServerComponent: true,
+              page: denormalizePagePath(bundlePath.replace(/^pages/, '')),
+              absolutePagePath: clientLoader,
+            })}!` + clientLoader
+          )
+        }
+
+        // Inject the entry to the server compiler.
+        const clientComponentEntryDep = (
+          webpack as any
+        ).EntryPlugin.createDependency(
+          clientLoader,
+          name + NEXT_CLIENT_SSR_ENTRY_SUFFIX
+        )
+        promises.push(
+          new Promise<void>((res, rej) => {
+            compilation.addEntry(
+              context,
+              clientComponentEntryDep,
+              this.isEdgeServer
+                ? {
+                    name: name + NEXT_CLIENT_SSR_ENTRY_SUFFIX,
+                    library: {
+                      name: ['self._CLIENT_ENTRY'],
+                      type: 'assign',
+                    },
+                    runtime: EDGE_RUNTIME_WEBPACK,
+                    asyncChunks: false,
+                  }
+                : {
+                    name: name + NEXT_CLIENT_SSR_ENTRY_SUFFIX,
+                    runtime: 'webpack-runtime',
+                  },
+              (err: any) => {
+                if (err) {
+                  rej(err)
+                } else {
+                  res()
+                }
+              }
+            )
+          })
+        )
+      }
+    }
+
+    Promise.all(promises)
+      .then(() => callback())
+      .catch(callback)
   }
 
   createAsset(assets: any, compilation: any) {

--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -10,6 +10,7 @@ import {
   MIDDLEWARE_FLIGHT_MANIFEST,
   MIDDLEWARE_MANIFEST,
   MIDDLEWARE_REACT_LOADABLE_MANIFEST,
+  NEXT_CLIENT_SSR_ENTRY_SUFFIX,
 } from '../../../shared/lib/constants'
 
 export interface MiddlewareManifest {
@@ -397,7 +398,11 @@ function getEntryFiles(entryFiles: string[], meta: EntryMetadata) {
             (file) =>
               file.startsWith('pages/') && !file.endsWith('.hot-update.js')
           )
-          .map((file) => 'server/' + file.replace('.js', '.__sc_client__.js'))
+          .map(
+            (file) =>
+              'server/' +
+              file.replace('.js', NEXT_CLIENT_SSR_ENTRY_SUFFIX + '.js')
+          )
       )
     }
 

--- a/packages/next/server/load-components.ts
+++ b/packages/next/server/load-components.ts
@@ -13,6 +13,7 @@ import {
   BUILD_MANIFEST,
   REACT_LOADABLE_MANIFEST,
   MIDDLEWARE_FLIGHT_MANIFEST,
+  NEXT_CLIENT_SSR_ENTRY_SUFFIX,
 } from '../shared/lib/constants'
 import { join } from 'path'
 import { requirePage, getPagePath } from './require'
@@ -69,7 +70,7 @@ export async function loadComponents(
   distDir: string,
   pathname: string,
   serverless: boolean,
-  serverComponents?: boolean,
+  hasServerComponents?: boolean,
   rootEnabled?: boolean
 ): Promise<LoadComponentsReturnType> {
   if (serverless) {
@@ -115,7 +116,7 @@ export async function loadComponents(
     Promise.resolve().then(() =>
       requirePage(pathname, distDir, serverless, rootEnabled)
     ),
-    serverComponents
+    hasServerComponents
       ? Promise.resolve().then(() =>
           requirePage('/_app.server', distDir, serverless, rootEnabled)
         )
@@ -126,23 +127,23 @@ export async function loadComponents(
     await Promise.all([
       require(join(distDir, BUILD_MANIFEST)),
       require(join(distDir, REACT_LOADABLE_MANIFEST)),
-      serverComponents
+      hasServerComponents
         ? require(join(distDir, 'server', MIDDLEWARE_FLIGHT_MANIFEST + '.json'))
         : null,
     ])
 
-  if (serverComponents) {
+  if (hasServerComponents) {
     try {
       // Make sure to also load the client entry in cache.
       await requirePage(
-        normalizePagePath(pathname) + '.__sc_client__',
+        normalizePagePath(pathname) + NEXT_CLIENT_SSR_ENTRY_SUFFIX,
         distDir,
         serverless,
         rootEnabled
       )
     } catch (_) {
-      // This page might not be a server component page, so there is no __sc_client__
-      // bundle to load.
+      // This page might not be a server component page, so there is no
+      // client entry to load.
     }
   }
 

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -350,8 +350,8 @@ function useFlightResponse({
           bootstrapped = true
           inlinedDataWriter.write(
             encodeText(
-              `<script>(self.__next_s=self.__next_s||[]).push(${escapeJSONForFlightScript(
-                [0, id]
+              `<script>(self.__next_s=self.__next_s||[]).push(${htmlEscapeJsonString(
+                JSON.stringify([0, id])
               )})</script>`
             )
           )
@@ -363,8 +363,8 @@ function useFlightResponse({
           const decodedValue = decodeText(value)
           inlinedDataWriter.write(
             encodeText(
-              `<script>(self.__next_s=self.__next_s||[]).push(${escapeJSONForFlightScript(
-                [1, id, decodedValue]
+              `<script>(self.__next_s=self.__next_s||[]).push(${htmlEscapeJsonString(
+                JSON.stringify([1, id, decodedValue])
               )})</script>`
             )
           )
@@ -378,10 +378,6 @@ function useFlightResponse({
     process()
   }
   return entry
-}
-
-function escapeJSONForFlightScript(input: unknown): string {
-  return htmlEscapeJsonString(JSON.stringify(input))
 }
 
 // Create the wrapper component for a Flight stream.

--- a/packages/next/server/view-render.tsx
+++ b/packages/next/server/view-render.tsx
@@ -98,56 +98,54 @@ function preloadDataFetchingRecord(
   return record
 }
 
-function createFlightHook() {
-  return (
-    writable: WritableStream<Uint8Array>,
-    id: string,
-    req: ReadableStream<Uint8Array>,
-    bootstrap: boolean
-  ) => {
-    let entry = rscCache.get(id)
-    if (!entry) {
-      const [renderStream, forwardStream] = readableStreamTee(req)
-      entry = createFromReadableStream(renderStream)
-      rscCache.set(id, entry)
+function useFlightResponse(
+  writable: WritableStream<Uint8Array>,
+  id: string,
+  req: ReadableStream<Uint8Array>
+) {
+  let entry = rscCache.get(id)
+  if (!entry) {
+    const [renderStream, forwardStream] = readableStreamTee(req)
+    entry = createFromReadableStream(renderStream)
+    rscCache.set(id, entry)
 
-      let bootstrapped = false
-      const forwardReader = forwardStream.getReader()
-      const writer = writable.getWriter()
-      function process() {
-        forwardReader.read().then(({ done, value }) => {
-          if (bootstrap && !bootstrapped) {
-            bootstrapped = true
-            writer.write(
-              encodeText(
-                `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify(
-                  [0, id]
-                )})</script>`
-              )
+    let bootstrapped = false
+    const forwardReader = forwardStream.getReader()
+    const writer = writable.getWriter()
+    function process() {
+      forwardReader.read().then(({ done, value }) => {
+        if (!bootstrapped) {
+          bootstrapped = true
+          writer.write(
+            encodeText(
+              `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify([
+                0,
+                id,
+              ])})</script>`
             )
-          }
-          if (done) {
-            rscCache.delete(id)
-            writer.close()
-          } else {
-            writer.write(
-              encodeText(
-                `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify(
-                  [1, id, decodeText(value)]
-                )})</script>`
-              )
+          )
+        }
+        if (done) {
+          rscCache.delete(id)
+          writer.close()
+        } else {
+          writer.write(
+            encodeText(
+              `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify([
+                1,
+                id,
+                decodeText(value),
+              ])})</script>`
             )
-            process()
-          }
-        })
-      }
-      process()
+          )
+          process()
+        }
+      })
     }
-    return entry
+    process()
   }
+  return entry
 }
-
-const useFlightResponse = createFlightHook()
 
 // Create the wrapper component for a Flight stream.
 function createServerComponentRenderer(
@@ -186,8 +184,7 @@ function createServerComponentRenderer(
     const response = useFlightResponse(
       writable,
       cachePrefix + ',' + id,
-      reqStream,
-      true
+      reqStream
     )
     const root = response.readRoot()
     rscCache.delete(id)

--- a/packages/next/server/view-render.tsx
+++ b/packages/next/server/view-render.tsx
@@ -18,6 +18,7 @@ import {
 } from './node-web-streams-helper'
 import { isDynamicRoute } from '../shared/lib/router/utils'
 import { tryGetPreviewData } from './api-utils/node'
+import { htmlEscapeJsonString } from './htmlescape'
 
 const ReactDOMServer = process.env.__NEXT_REACT_ROOT
   ? require('react-dom/server.browser')
@@ -118,10 +119,9 @@ function useFlightResponse(
           bootstrapped = true
           writer.write(
             encodeText(
-              `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify([
-                0,
-                id,
-              ])})</script>`
+              `<script>(self.__next_s=self.__next_s||[]).push(${htmlEscapeJsonString(
+                JSON.stringify([0, id])
+              )})</script>`
             )
           )
         }
@@ -131,11 +131,9 @@ function useFlightResponse(
         } else {
           writer.write(
             encodeText(
-              `<script>(self.__next_s=self.__next_s||[]).push(${JSON.stringify([
-                1,
-                id,
-                decodeText(value),
-              ])})</script>`
+              `<script>(self.__next_s=self.__next_s||[]).push(${htmlEscapeJsonString(
+                JSON.stringify([1, id, decodeText(value)])
+              )})</script>`
             )
           )
           process()

--- a/packages/next/shared/lib/constants.ts
+++ b/packages/next/shared/lib/constants.ts
@@ -27,6 +27,7 @@ export const CLIENT_STATIC_FILES_PATH = 'static'
 export const CLIENT_STATIC_FILES_RUNTIME = 'runtime'
 export const STRING_LITERAL_DROP_BUNDLE = '__NEXT_DROP_CLIENT_FILE__'
 export const NEXT_BUILTIN_DOCUMENT = '__NEXT_BUILTIN_DOCUMENT__'
+export const NEXT_CLIENT_SSR_ENTRY_SUFFIX = '.__sc_client__'
 
 // server/middleware-flight-manifest.js
 export const MIDDLEWARE_FLIGHT_MANIFEST = 'middleware-flight-manifest'


### PR DESCRIPTION
We used to generate the flight page data using a stream which is totally overhead because in that scenario we don't need to stream. This PR simplifies it to just use a string variable.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
