### PR TITLE
Add module ID hash plugin for server components

### DIFF
--- a/packages/next/build/webpack/plugins/flight-id-hash-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-id-hash-plugin.ts
@@ -1,0 +1,64 @@
+// https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
+const cyrb53 = function (str: string, seed = 0x71421) {
+  let h1 = 0xdeadbeef ^ seed,
+    h2 = 0x41c6ce57 ^ seed
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0)
+}
+
+export class FlightIdHashPlugin {
+  apply(compiler: any) {
+    const usedIds = new Set()
+    const idMap = new Map()
+
+    compiler.hooks.compilation.tap('FlightIdHashPlugin', (compilation: any) => {
+      compilation.hooks.moduleIds.tap('FlightIdHashPlugin', (modules: any) => {
+        const chunkGraph = compilation.chunkGraph
+        const filteredModules = Array.from(modules).filter((m: any) => {
+          if (!m.needId) return false
+          if (chunkGraph.getNumberOfModuleChunks(m) === 0) return false
+          return chunkGraph.getModuleId(module) === null
+        })
+
+        for (const module of filteredModules) {
+          let request = (module as any).request || ''
+
+          // Remove resource queries and the loader prefix.
+          const flightClientEntry = request.split(
+            'next-flight-client-loader.js!'
+          )
+          if (flightClientEntry[1]) {
+            request = flightClientEntry[1]
+          }
+
+          let id
+          if (idMap.has(request)) {
+            id = idMap.get(request)
+          } else {
+            id = cyrb53(request)
+            while (usedIds.has(id)) id++
+            idMap.set(request, id)
+            usedIds.add(id)
+          }
+
+          // We will have to add a special query to differenciate the two module IDs.
+          if (flightClientEntry[1]) {
+            chunkGraph.setModuleId(module, id.toString(36) + '?sc_client')
+          } else {
+            chunkGraph.setModuleId(module, id.toString(36))
+          }
+        }
+      })
+    })
+  }
+}

--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -230,11 +230,7 @@ export class FlightManifestPlugin {
         // TODO: Hook into deps instead of the target module.
         // That way we know by the type of dep whether to include.
         // It also resolves conflicts when the same module is in multiple chunks.
-        if (
-          !resource ||
-          !clientComponentRegex.test(resource) ||
-          !clientComponentRegex.test(id)
-        ) {
+        if (!resource || !clientComponentRegex.test(resource)) {
           return
         }
 
@@ -255,7 +251,7 @@ export class FlightManifestPlugin {
         moduleExportedKeys.forEach((name) => {
           if (!moduleExports[name]) {
             moduleExports[name] = {
-              id: id.replace(/^\(sc_server\)\//, ''),
+              id,
               name,
               chunks: [],
             }
@@ -268,14 +264,10 @@ export class FlightManifestPlugin {
         const chunkModules =
           compilation.chunkGraph.getChunkModulesIterable(chunk)
         for (const mod of chunkModules) {
-          let modId = compilation.chunkGraph.getModuleId(mod)
+          let modId = '' + compilation.chunkGraph.getModuleId(mod)
 
-          if (typeof modId !== 'string') continue
-
-          // Remove resource queries.
-          modId = modId.split('?')[0]
-          // Remove the loader prefix.
-          modId = modId.split('next-flight-client-loader.js!')[1] || modId
+          // Remove the special query added in flight-id-hash-plugin.
+          modId = modId.replace(/\?sc_client$/, '')
 
           recordModule(modId, chunk, mod)
           // If this is a concatenation, register each child to the parent ID.


### PR DESCRIPTION
We currently use the request of the module as the module ID in the webpack bundle, which is usually the filepath. This ensures that two different builds (server/client) always have consistent module IDs, so webpack can load the specific module from another bundle.

However this has two downsides, one is the JS bundle and flight manifest size increase, and also it includes some unnecessary filesystem information (dir path for each client module source) in the client bundle.

In this PR we are using a plugin to hash the filename to make it still deterministic and consistent across builds, instead of using `named` module IDs.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
