### PR TITLE
Fixes `beforeInteractive` scripts failing in custom document

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -816,7 +816,7 @@ export default async function getBaseWebpackConfig(
       }
 
       const notExternalModules =
-        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|constants|dynamic)$)|string-hash$)/
+        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|constants|dynamic|script)$)|string-hash$)/
       if (notExternalModules.test(request)) {
         return
       }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -12,7 +12,7 @@ import type {
 import { BuildManifest, getPageFiles } from '../server/get-page-files'
 import { cleanAmpPath } from '../server/utils'
 import { htmlEscapeJsonString } from '../server/htmlescape'
-import Script, { ScriptProps } from '../client/script'
+import { ScriptProps } from '../client/script'
 import isError from '../lib/is-error'
 
 import { HtmlContext } from '../shared/lib/html-context'
@@ -605,7 +605,7 @@ export class Head extends Component<
     const filteredChildren: ReactNode[] = []
 
     React.Children.forEach(children, (child: any) => {
-      if (child.type === Script) {
+      if (typeof child.type === 'function' && child.type.name === 'Script') {
         if (child.props.strategy === 'beforeInteractive') {
           scriptLoader.beforeInteractive = (
             scriptLoader.beforeInteractive || []

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -12,7 +12,7 @@ import type {
 import { BuildManifest, getPageFiles } from '../server/get-page-files'
 import { cleanAmpPath } from '../server/utils'
 import { htmlEscapeJsonString } from '../server/htmlescape'
-import { ScriptProps } from '../client/script'
+import Script, { ScriptProps } from '../client/script'
 import isError from '../lib/is-error'
 
 import { HtmlContext } from '../shared/lib/html-context'
@@ -605,7 +605,7 @@ export class Head extends Component<
     const filteredChildren: ReactNode[] = []
 
     React.Children.forEach(children, (child: any) => {
-      if (typeof child.type === 'function' && child.type.name === 'Script') {
+      if (child.type === Script) {
         if (child.props.strategy === 'beforeInteractive') {
           scriptLoader.beforeInteractive = (
             scriptLoader.beforeInteractive || []


### PR DESCRIPTION
- Fixes #36997
- Fixes #31275

@janicklas-ralph Any idea why tests were passing while this check was failing? Can we add a stronger test for this?

