### PR TITLE
Fix interopDefault on jest object-proxy

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -117,7 +117,7 @@ module.exports = function (task) {
       if (output.map) {
         if (interopClientDefaultExport) {
           output.code += `
-if (typeof exports.default === 'function' || (typeof exports.default === 'object' && exports.default !== null)) {
+if ((typeof exports.default === 'function' || (typeof exports.default === 'object' && exports.default !== null)) && typeof exports.default.__esModule == 'undefined') {
   Object.defineProperty(exports.default, '__esModule', { value: true });
   Object.assign(exports.default, exports);
   module.exports = exports.default;

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -117,7 +117,7 @@ module.exports = function (task) {
       if (output.map) {
         if (interopClientDefaultExport) {
           output.code += `
-if ((typeof exports.default === 'function' || (typeof exports.default === 'object' && exports.default !== null)) && typeof exports.default.__esModule == 'undefined') {
+if ((typeof exports.default === 'function' || (typeof exports.default === 'object' && exports.default !== null)) && typeof exports.default.__esModule === 'undefined') {
   Object.defineProperty(exports.default, '__esModule', { value: true });
   Object.assign(exports.default, exports);
   module.exports = exports.default;

--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -21,10 +21,12 @@ describe('next/jest', () => {
             return <h1>Hello Dynamic</h1>;
           }
         `,
+        'styles/index.module.css': '.home { color: orange }',
         'pages/index.js': `
           import dynamic from "next/dynamic";
           import Image from "next/image";
           import img from "../public/vercel.svg";
+          import styles from "../styles/index.module.css";
 
           const Comp = dynamic(() => import("../components/comp"), {
             loading: () => <h1>Loading...</h1>,
@@ -35,7 +37,7 @@ describe('next/jest', () => {
               <Comp />
               <Image src={img} alt="logo" placeholder="blur"/>
               <Image src={img} alt="logo 2"/>
-              <p>hello world</p>
+              <p className={styles.home}>hello world</p>
             </>
           } 
         `,


### PR DESCRIPTION
This fixes the interop default from https://github.com/vercel/next.js/pull/36877 on the jest `object-proxy` as it currently causes the below error when running tests in our `with-jest` example:

```sh
    TypeError: 'get' on proxy: property '__esModule' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected 'true' but got 'false')
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: https://github.com/vercel/next.js/pull/36877