### PR TITLE
Fix copying local swc binary for pnpm test

### DIFF
--- a/test/integration/pnpm-support/test/index.test.js
+++ b/test/integration/pnpm-support/test/index.test.js
@@ -132,7 +132,7 @@ async function usingPnpmCreateNextApp(appDir, fn) {
 
     await fs.copy(
       path.join(__dirname, '../../../../packages/next-swc/native'),
-      path.join(tempAppDir, 'node_modules/next-swc/native')
+      path.join(tempAppDir, 'node_modules/@next/swc/native')
     )
 
     await fn(tempAppDir)


### PR DESCRIPTION
This fixes the test when a publish is done, seems it's been passing for a while by using the wasm fallback instead but this fails on a publish since the current version being published isn't available until after the test runs

x-ref: https://github.com/vercel/next.js/runs/6512721965?check_suite_focus=true