### PR TITLE
Extract and refactor `getPageStaticInfo`

### DIFF
--- a/packages/next/build/analysis/extract-const-value.ts
+++ b/packages/next/build/analysis/extract-const-value.ts
@@ -1,0 +1,189 @@
+import type {
+  ArrayExpression,
+  BooleanLiteral,
+  ExportDeclaration,
+  Identifier,
+  KeyValueProperty,
+  Module,
+  Node,
+  NullLiteral,
+  NumericLiteral,
+  ObjectExpression,
+  StringLiteral,
+  VariableDeclaration,
+} from '@swc/core'
+
+/**
+ * Extracts the value of an exported const variable named `exportedName`
+ * (e.g. "export const config = { runtime: 'edge' }") from swc's AST.
+ * The value must be one of (or throws UnsupportedValueError):
+ *   - string
+ *   - boolean
+ *   - number
+ *   - null
+ *   - undefined
+ *   - array containing values listed in this list
+ *   - object containing values listed in this list
+ *
+ * Throws NoSuchDeclarationError if the declaration is not found.
+ */
+export function extractExportedConstValue(
+  module: Module,
+  exportedName: string
+): any {
+  for (const moduleItem of module.body) {
+    if (!isExportDeclaration(moduleItem)) {
+      continue
+    }
+
+    const declaration = moduleItem.declaration
+    if (!isVariableDeclaration(declaration)) {
+      continue
+    }
+
+    if (declaration.kind !== 'const') {
+      continue
+    }
+
+    for (const decl of declaration.declarations) {
+      if (
+        isIdentifier(decl.id) &&
+        decl.id.value === exportedName &&
+        decl.init
+      ) {
+        return extractValue(decl.init)
+      }
+    }
+  }
+
+  throw new NoSuchDeclarationError()
+}
+
+/**
+ * A wrapper on top of `extractExportedConstValue` that returns undefined
+ * instead of throwing when the thrown error is known.
+ */
+export function tryToExtractExportedConstValue(
+  module: Module,
+  exportedName: string
+) {
+  try {
+    return extractExportedConstValue(module, exportedName)
+  } catch (error) {
+    if (
+      error instanceof UnsupportedValueError ||
+      error instanceof NoSuchDeclarationError
+    ) {
+      return undefined
+    }
+  }
+}
+
+function isExportDeclaration(node: Node): node is ExportDeclaration {
+  return node.type === 'ExportDeclaration'
+}
+
+function isVariableDeclaration(node: Node): node is VariableDeclaration {
+  return node.type === 'VariableDeclaration'
+}
+
+function isIdentifier(node: Node): node is Identifier {
+  return node.type === 'Identifier'
+}
+
+function isBooleanLiteral(node: Node): node is BooleanLiteral {
+  return node.type === 'BooleanLiteral'
+}
+
+function isNullLiteral(node: Node): node is NullLiteral {
+  return node.type === 'NullLiteral'
+}
+
+function isStringLiteral(node: Node): node is StringLiteral {
+  return node.type === 'StringLiteral'
+}
+
+function isNumericLiteral(node: Node): node is NumericLiteral {
+  return node.type === 'NumericLiteral'
+}
+
+function isArrayExpression(node: Node): node is ArrayExpression {
+  return node.type === 'ArrayExpression'
+}
+
+function isObjectExpression(node: Node): node is ObjectExpression {
+  return node.type === 'ObjectExpression'
+}
+
+function isKeyValueProperty(node: Node): node is KeyValueProperty {
+  return node.type === 'KeyValueProperty'
+}
+
+class UnsupportedValueError extends Error {}
+class NoSuchDeclarationError extends Error {}
+
+function extractValue(node: Node): any {
+  if (isNullLiteral(node)) {
+    return null
+  } else if (isBooleanLiteral(node)) {
+    // e.g. true / false
+    return node.value
+  } else if (isStringLiteral(node)) {
+    // e.g. "abc"
+    return node.value
+  } else if (isNumericLiteral(node)) {
+    // e.g. 123
+    return node.value
+  } else if (isIdentifier(node)) {
+    switch (node.value) {
+      case 'undefined':
+        return undefined
+      default:
+        throw new UnsupportedValueError()
+    }
+  } else if (isArrayExpression(node)) {
+    // e.g. [1, 2, 3]
+    const arr = []
+    for (const elem of node.elements) {
+      if (elem) {
+        if (elem.spread) {
+          // e.g. [ ...a ]
+          throw new UnsupportedValueError()
+        }
+
+        arr.push(extractValue(elem.expression))
+      } else {
+        // e.g. [1, , 2]
+        //         ^^
+        arr.push(undefined)
+      }
+    }
+    return arr
+  } else if (isObjectExpression(node)) {
+    // e.g. { a: 1, b: 2 }
+    const obj: any = {}
+    for (const prop of node.properties) {
+      if (!isKeyValueProperty(prop)) {
+        // e.g. { ...a }
+        throw new UnsupportedValueError()
+      }
+
+      let key
+      if (isIdentifier(prop.key)) {
+        // e.g. { a: 1, b: 2 }
+        key = prop.key.value
+      } else if (isStringLiteral(prop.key)) {
+        // e.g. { "a": 1, "b": 2 }
+        key = prop.key.value
+      } else {
+        throw new UnsupportedValueError()
+      }
+
+      obj[key] = extractValue(prop.value)
+    }
+
+    return obj
+  } else {
+    throw new UnsupportedValueError()
+  }
+}

--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -1,0 +1,119 @@
+import type { PageRuntime } from '../../server/config-shared'
+import type { NextConfig } from '../../server/config-shared'
+import { tryToExtractExportedConstValue } from './extract-const-value'
+import { parseModule } from './parse-module'
+import { promises as fs } from 'fs'
+
+export interface PageStaticInfo {
+  runtime?: PageRuntime
+  ssg?: boolean
+  ssr?: boolean
+}
+
+/**
+ * For a given pageFilePath and nextConfig, if the config supports it, this
+ * function will read the file and return the runtime that should be used.
+ * It will look into the file content only if the page *requires* a runtime
+ * to be specified, that is, when gSSP or gSP is used.
+ * Related discussion: https://github.com/vercel/next.js/discussions/34179
+ */
+export async function getPageStaticInfo(params: {
+  nextConfig: Partial<NextConfig>
+  pageFilePath: string
+  isDev?: boolean
+}): Promise<PageStaticInfo> {
+  const { isDev, pageFilePath, nextConfig } = params
+
+  const fileContent = (await tryToReadFile(pageFilePath, !isDev)) || ''
+  if (/runtime|getStaticProps|getServerSideProps/.test(fileContent)) {
+    const swcAST = await parseModule(pageFilePath, fileContent)
+    const { ssg, ssr } = checkExports(swcAST)
+    const config = tryToExtractExportedConstValue(swcAST, 'config') || {}
+    if (config?.runtime === 'edge') {
+      return {
+        runtime: config.runtime,
+        ssr: ssr,
+        ssg: ssg,
+      }
+    }
+
+    // For Node.js runtime, we do static optimization.
+    if (config?.runtime === 'nodejs') {
+      return {
+        runtime: ssr || ssg ? config.runtime : undefined,
+        ssr: ssr,
+        ssg: ssg,
+      }
+    }
+
+    // When the runtime is required because there is ssr or ssg we fallback
+    if (ssr || ssg) {
+      return {
+        runtime: nextConfig.experimental?.runtime,
+        ssr: ssr,
+        ssg: ssg,
+      }
+    }
+  }
+
+  return { ssr: false, ssg: false }
+}
+
+/**
+ * Receives a parsed AST from SWC and checks if it belongs to a module that
+ * requires a runtime to be specified. Those are:
+ *   - Modules with `export function getStaticProps | getServerSideProps`
+ *   - Modules with `export { getStaticProps | getServerSideProps } <from ...>`
+ */
+function checkExports(swcAST: any) {
+  if (Array.isArray(swcAST?.body)) {
+    try {
+      for (const node of swcAST.body) {
+        if (
+          node.type === 'ExportDeclaration' &&
+          node.declaration?.type === 'FunctionDeclaration' &&
+          ['getStaticProps', 'getServerSideProps'].includes(
+            node.declaration.identifier?.value
+          )
+        ) {
+          return {
+            ssg: node.declaration.identifier.value === 'getStaticProps',
+            ssr: node.declaration.identifier.value === 'getServerSideProps',
+          }
+        }
+
+        if (node.type === 'ExportNamedDeclaration') {
+          const values = node.specifiers.map(
+            (specifier: any) =>
+              specifier.type === 'ExportSpecifier' &&
+              specifier.orig?.type === 'Identifier' &&
+              specifier.orig?.value
+          )
+
+          return {
+            ssg: values.some((value: any) =>
+              ['getStaticProps'].includes(value)
+            ),
+            ssr: values.some((value: any) =>
+              ['getServerSideProps'].includes(value)
+            ),
+          }
+        }
+      }
+    } catch (err) {}
+  }
+
+  return { ssg: false, ssr: false }
+}
+
+async function tryToReadFile(filePath: string, shouldThrow: boolean) {
+  try {
+    return await fs.readFile(filePath, {
+      encoding: 'utf8',
+    })
+  } catch (error) {
+    if (shouldThrow) {
+      throw error
+    }
+  }
+}

--- a/packages/next/build/analysis/parse-module.ts
+++ b/packages/next/build/analysis/parse-module.ts
@@ -1,0 +1,15 @@
+import LRUCache from 'next/dist/compiled/lru-cache'
+import { withPromiseCache } from '../../lib/with-promise-cache'
+import { createHash } from 'crypto'
+import { parse } from '../swc'
+
+/**
+ * Parses a module with SWC using an LRU cache where the parsed module will
+ * be indexed by a sha of its content holding up to 500 entries.
+ */
+export const parseModule = withPromiseCache(
+  new LRUCache<string, any>({ max: 500 }),
+  async (filename: string, content: string) =>
+    parse(content, { isModule: 'unknown', filename }).catch(() => null),
+  (_, content) => createHash('sha1').update(content).digest('hex')
+)

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -1,12 +1,11 @@
 import type { ClientPagesLoaderOptions } from './webpack/loaders/next-client-pages-loader'
 import type { MiddlewareLoaderOptions } from './webpack/loaders/next-middleware-loader'
 import type { MiddlewareSSRLoaderQuery } from './webpack/loaders/next-middleware-ssr-loader'
-import type { NextConfigComplete, NextConfig } from '../server/config-shared'
+import type { NextConfigComplete } from '../server/config-shared'
 import type { PageRuntime } from '../server/config-shared'
 import type { ServerlessLoaderQuery } from './webpack/loaders/next-serverless-loader'
 import type { webpack5 } from 'next/dist/compiled/webpack/webpack'
 import type { LoadedEnvFiles } from '@next/env'
-import fs from 'fs'
 import chalk from 'next/dist/compiled/chalk'
 import { posix, join } from 'path'
 import { stringify } from 'querystring'
@@ -29,7 +28,7 @@ import {
 import { __ApiPreviewProps } from '../server/api-utils'
 import { isTargetLikeServerless } from '../server/utils'
 import { warn } from './output/log'
-import { parse } from '../build/swc'
+import { getPageStaticInfo } from './analysis/get-page-static-info'
 import { isServerComponentPage, withoutRSCExtensions } from './utils'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
@@ -135,129 +134,6 @@ export function createPagesMapping({
     '/_document': `${root}/_document`,
     ...(hasServerComponents ? { '/_app.server': `${root}/_app.server` } : {}),
     ...pages,
-  }
-}
-
-type PageStaticInfo = { runtime?: PageRuntime; ssr?: boolean; ssg?: boolean }
-
-const cachedPageStaticInfo = new Map<string, [number, PageStaticInfo]>()
-
-// @TODO: We should limit the maximum concurrency of this function as there
-// could be thousands of pages existing.
-export async function getPageStaticInfo(
-  pageFilePath: string,
-  nextConfig: Partial<NextConfig>,
-  isDev?: boolean
-): Promise<PageStaticInfo> {
-  const globalRuntime = nextConfig.experimental?.runtime
-  const cached = cachedPageStaticInfo.get(pageFilePath)
-  if (cached) {
-    return cached[1]
-  }
-
-  let pageContent: string
-  try {
-    pageContent = await fs.promises.readFile(pageFilePath, {
-      encoding: 'utf8',
-    })
-  } catch (err) {
-    if (!isDev) throw err
-    return {}
-  }
-
-  // When gSSP or gSP is used, this page requires an execution runtime. If the
-  // page config is not present, we fallback to the global runtime. Related
-  // discussion:
-  // https://github.com/vercel/next.js/discussions/34179
-  let isRuntimeRequired: boolean = false
-  let pageRuntime: PageRuntime = undefined
-  let ssr = false
-  let ssg = false
-
-  // Since these configurations should always be static analyzable, we can
-  // skip these cases that "runtime" and "gSP", "gSSP" are not included in the
-  // source code.
-  if (/runtime|getStaticProps|getServerSideProps/.test(pageContent)) {
-    try {
-      const { body } = await parse(pageContent, {
-        filename: pageFilePath,
-        isModule: 'unknown',
-      })
-
-      for (const node of body) {
-        const { type, declaration } = node
-        if (type === 'ExportDeclaration') {
-          // Match `export const config`
-          const valueNode = declaration?.declarations?.[0]
-          if (valueNode?.id?.value === 'config') {
-            const props = valueNode.init.properties
-            const runtimeKeyValue = props.find(
-              (prop: any) => prop.key.value === 'runtime'
-            )
-            const runtime = runtimeKeyValue?.value?.value
-            pageRuntime =
-              runtime === 'edge' || runtime === 'nodejs' ? runtime : pageRuntime
-          } else if (declaration?.type === 'FunctionDeclaration') {
-            // Match `export function getStaticProps | getServerSideProps`
-            const identifier = declaration.identifier?.value
-            if (
-              identifier === 'getStaticProps' ||
-              identifier === 'getServerSideProps'
-            ) {
-              isRuntimeRequired = true
-              ssg = identifier === 'getStaticProps'
-              ssr = identifier === 'getServerSideProps'
-            }
-          }
-        } else if (type === 'ExportNamedDeclaration') {
-          // Match `export { getStaticProps | getServerSideProps } <from '../..'>`
-          const { specifiers } = node
-          for (const specifier of specifiers) {
-            const { orig } = specifier
-            const hasDataFetchingExports =
-              specifier.type === 'ExportSpecifier' &&
-              orig?.type === 'Identifier' &&
-              (orig?.value === 'getStaticProps' ||
-                orig?.value === 'getServerSideProps')
-            if (hasDataFetchingExports) {
-              isRuntimeRequired = true
-              ssg = orig.value === 'getStaticProps'
-              ssr = orig.value === 'getServerSideProps'
-              break
-            }
-          }
-        }
-      }
-    } catch (err) {}
-  }
-
-  if (!pageRuntime) {
-    if (isRuntimeRequired) {
-      pageRuntime = globalRuntime
-    }
-  } else {
-    // For Node.js runtime, we do static optimization.
-    if (!isRuntimeRequired && pageRuntime === 'nodejs') {
-      pageRuntime = undefined
-    }
-  }
-
-  const info = {
-    runtime: pageRuntime,
-    ssr,
-    ssg,
-  }
-  cachedPageStaticInfo.set(pageFilePath, [Date.now(), info])
-  return info
-}
-
-export function invalidatePageRuntimeCache(
-  pageFilePath: string,
-  safeTime: number
-) {
-  const cached = cachedPageStaticInfo.get(pageFilePath)
-  if (cached && cached[0] < safeTime) {
-    cachedPageStaticInfo.delete(pageFilePath)
   }
 }
 
@@ -457,10 +333,15 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
 
       const isServerComponent = serverComponentRegex.test(absolutePagePath)
 
+      const staticInfo = await getPageStaticInfo({
+        nextConfig: config,
+        pageFilePath,
+        isDev,
+      })
+
       runDependingOnPageType({
         page,
-        pageRuntime: (await getPageStaticInfo(pageFilePath, config, isDev))
-          .runtime,
+        pageRuntime: staticInfo.runtime,
         onClient: () => {
           if (isServerComponent) {
             // We skip the initial entries for server component pages and let the

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -76,11 +76,8 @@ import {
 } from '../telemetry/events'
 import { Telemetry } from '../telemetry/storage'
 import { runCompiler } from './compiler'
-import {
-  createEntrypoints,
-  createPagesMapping,
-  getPageStaticInfo,
-} from './entries'
+import { getPageStaticInfo } from './analysis/get-page-static-info'
+import { createEntrypoints, createPagesMapping } from './entries'
 import { generateBuildId } from './generate-build-id'
 import { isWriteable } from './is-writeable'
 import * as Log from './output/log'
@@ -1088,9 +1085,14 @@ export default async function build(
                   p.startsWith(actualPage + '.') ||
                   p.startsWith(actualPage + '/index.')
               )
+
               const pageRuntime = pagePath
-                ? (await getPageStaticInfo(join(pagesDir, pagePath), config))
-                    .runtime
+                ? (
+                    await getPageStaticInfo({
+                      pageFilePath: join(pagesDir, pagePath),
+                      nextConfig: config,
+                    })
+                  ).runtime
                 : undefined
 
               if (hasServerComponents && pagePath) {

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -47,7 +47,7 @@ import { Sema } from 'next/dist/compiled/async-sema'
 import { MiddlewareManifest } from './webpack/plugins/middleware-plugin'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
-import { getPageStaticInfo } from './entries'
+import { getPageStaticInfo } from './analysis/get-page-static-info'
 
 const { builtinModules } = require('module')
 const RESERVED_PAGE = /^\/(_app|_error|_document|api(\/|$))/
@@ -1302,9 +1302,14 @@ export async function isEdgeRuntimeCompiled(
     }
   }
 
+  const staticInfo = await getPageStaticInfo({
+    pageFilePath: module.resource,
+    nextConfig: config,
+  })
+
   // Check the page runtime as well since we cannot detect the runtime from
   // compilation when it's for the client part of edge function
-  return (await getPageStaticInfo(module.resource, config)).runtime === 'edge'
+  return staticInfo.runtime === 'edge'
 }
 
 export function getNodeBuiltinModuleNotSupportedInEdgeRuntimeMessage(

--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -19,7 +19,7 @@ import {
   getInvalidator,
   entries,
 } from '../../../server/dev/on-demand-entry-handler'
-import { getPageStaticInfo } from '../../entries'
+import { getPageStaticInfo } from '../../analysis/get-page-static-info'
 
 // This is the module that will be used to anchor all client references to.
 // I.e. it will have all the client files as async deps from this point on.
@@ -137,7 +137,11 @@ export class FlightManifestPlugin {
         // Parse gSSP and gSP exports from the page source.
         const pageStaticInfo = this.isEdgeServer
           ? {}
-          : await getPageStaticInfo(routeInfo.absolutePagePath, {}, this.dev)
+          : await getPageStaticInfo({
+              pageFilePath: routeInfo.absolutePagePath,
+              nextConfig: {},
+              isDev: this.dev,
+            })
 
         const clientLoader = `next-flight-client-entry-loader?${stringify({
           modules: clientComponentImports,

--- a/packages/next/lib/with-promise-cache.ts
+++ b/packages/next/lib/with-promise-cache.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-redeclare */
+interface Cache<K, V> {
+  set(key: K, value: V, maxAge?: number): boolean
+  get(key: K): V | undefined
+  del(key: K): void
+}
+
+export function withPromiseCache<K, V>(
+  cache: Cache<K, Promise<V>>,
+  fn: (value: K) => Promise<V>
+): (value: K) => Promise<V>
+export function withPromiseCache<T extends any[], K, V>(
+  cache: Cache<K, Promise<V>>,
+  fn: (...values: T) => Promise<V>,
+  getKey: (...values: T) => K
+): (...values: T) => Promise<V>
+export function withPromiseCache<T extends any[], K, V>(
+  cache: Cache<K, Promise<V>>,
+  fn: (...values: T) => Promise<V>,
+  getKey?: (...values: T) => K
+): (...values: T) => Promise<V> {
+  return (...values: T) => {
+    const key = getKey ? getKey(...values) : values[0]
+    let p = cache.get(key)
+    if (!p) {
+      p = fn(...values)
+      p.catch(() => cache.del(key))
+      cache.set(key, p)
+    }
+    return p
+  }
+}

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -43,7 +43,7 @@ import { Span, trace } from '../../trace'
 import { getProperError } from '../../lib/is-error'
 import ws from 'next/dist/compiled/ws'
 import { promises as fs } from 'fs'
-import { getPageStaticInfo } from '../../build/entries'
+import { getPageStaticInfo } from '../../build/analysis/get-page-static-info'
 import { serverComponentRegex } from '../../build/webpack/loaders/utils'
 import { stringify } from 'querystring'
 
@@ -566,11 +566,14 @@ export default class HotReloader {
             const isServerComponent =
               serverComponentRegex.test(absolutePagePath)
 
+            const staticInfo = await getPageStaticInfo({
+              pageFilePath: absolutePagePath,
+              nextConfig: this.config,
+            })
+
             runDependingOnPageType({
               page,
-              pageRuntime: (
-                await getPageStaticInfo(absolutePagePath, this.config)
-              ).runtime,
+              pageRuntime: staticInfo.runtime,
               onEdgeServer: () => {
                 if (!isEdgeServerCompilation) return
                 entries[pageKey].status = BUILDING

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -65,10 +65,7 @@ import {
 import { getSortedRoutes, isDynamicRoute } from '../../shared/lib/router/utils'
 import { runDependingOnPageType } from '../../build/entries'
 import { NodeNextResponse, NodeNextRequest } from '../base-http/node'
-import {
-  getPageStaticInfo,
-  invalidatePageRuntimeCache,
-} from '../../build/entries'
+import { getPageStaticInfo } from '../../build/analysis/get-page-static-info'
 import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 import { normalizeViewPath } from '../../shared/lib/router/utils/view-paths'
 import { MIDDLEWARE_FILE } from '../../lib/constants'
@@ -345,11 +342,14 @@ export default class DevServer extends Server {
             continue
           }
 
-          invalidatePageRuntimeCache(fileName, meta.safeTime)
+          const staticInfo = await getPageStaticInfo({
+            pageFilePath: fileName,
+            nextConfig: this.nextConfig,
+          })
+
           runDependingOnPageType({
             page: pageName,
-            pageRuntime: (await getPageStaticInfo(fileName, this.nextConfig))
-              .runtime,
+            pageRuntime: staticInfo.runtime,
             onClient: () => {},
             onServer: () => {},
             onEdgeServer: () => {

--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -3,7 +3,7 @@ import type { webpack5 as webpack } from 'next/dist/compiled/webpack/webpack'
 import type { NextConfigComplete } from '../config-shared'
 import { EventEmitter } from 'events'
 import { findPageFile } from '../lib/find-page-file'
-import { getPageStaticInfo, runDependingOnPageType } from '../../build/entries'
+import { runDependingOnPageType } from '../../build/entries'
 import { join, posix } from 'path'
 import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
@@ -14,6 +14,7 @@ import { reportTrigger } from '../../build/output'
 import getRouteFromEntrypoint from '../get-route-from-entrypoint'
 import { serverComponentRegex } from '../../build/webpack/loaders/utils'
 import { MIDDLEWARE_FILE, MIDDLEWARE_FILENAME } from '../../lib/constants'
+import { getPageStaticInfo } from '../../build/analysis/get-page-static-info'
 
 export const ADDED = Symbol('added')
 export const BUILDING = Symbol('building')
@@ -236,11 +237,14 @@ export function onDemandEntryHandler({
         })
       }
 
+      const staticInfo = await getPageStaticInfo({
+        pageFilePath: pagePathData.absolutePagePath,
+        nextConfig,
+      })
+
       const promises = runDependingOnPageType({
         page: pagePathData.page,
-        pageRuntime: (
-          await getPageStaticInfo(pagePathData.absolutePagePath, nextConfig)
-        ).runtime,
+        pageRuntime: staticInfo.runtime,
         onClient: () => addPageEntry('client'),
         onServer: () => addPageEntry('server'),
         onEdgeServer: () => addPageEntry('edge-server'),

--- a/test/unit/parse-page-runtime.test.ts
+++ b/test/unit/parse-page-runtime.test.ts
@@ -1,4 +1,4 @@
-import { getPageStaticInfo } from 'next/dist/build/entries'
+import { getPageStaticInfo } from 'next/dist/build/analysis/get-page-static-info'
 import { join } from 'path'
 
 const fixtureDir = join(__dirname, 'fixtures')
@@ -11,52 +11,52 @@ function createNextConfig(runtime?: 'edge' | 'nodejs') {
 
 describe('parse page runtime config', () => {
   it('should parse nodejs runtime correctly', async () => {
-    const { runtime } = await getPageStaticInfo(
-      join(fixtureDir, 'page-runtime/nodejs-ssr.js'),
-      createNextConfig()
-    )
+    const { runtime } = await getPageStaticInfo({
+      pageFilePath: join(fixtureDir, 'page-runtime/nodejs-ssr.js'),
+      nextConfig: createNextConfig(),
+    })
     expect(runtime).toBe('nodejs')
   })
 
   it('should parse static runtime correctly', async () => {
-    const { runtime } = await getPageStaticInfo(
-      join(fixtureDir, 'page-runtime/nodejs.js'),
-      createNextConfig()
-    )
+    const { runtime } = await getPageStaticInfo({
+      pageFilePath: join(fixtureDir, 'page-runtime/nodejs.js'),
+      nextConfig: createNextConfig(),
+    })
     expect(runtime).toBe(undefined)
   })
 
   it('should parse edge runtime correctly', async () => {
-    const { runtime } = await getPageStaticInfo(
-      join(fixtureDir, 'page-runtime/edge.js'),
-      createNextConfig()
-    )
+    const { runtime } = await getPageStaticInfo({
+      pageFilePath: join(fixtureDir, 'page-runtime/edge.js'),
+      nextConfig: createNextConfig(),
+    })
     expect(runtime).toBe('edge')
   })
 
   it('should return undefined if no runtime is specified', async () => {
-    const { runtime } = await getPageStaticInfo(
-      join(fixtureDir, 'page-runtime/static.js'),
-      createNextConfig()
-    )
+    const { runtime } = await getPageStaticInfo({
+      pageFilePath: join(fixtureDir, 'page-runtime/static.js'),
+      nextConfig: createNextConfig(),
+    })
     expect(runtime).toBe(undefined)
   })
 })
 
 describe('fallback to the global runtime configuration', () => {
   it('should fallback when gSP is defined and exported', async () => {
-    const { runtime } = await getPageStaticInfo(
-      join(fixtureDir, 'page-runtime/fallback-with-gsp.js'),
-      createNextConfig('edge')
-    )
+    const { runtime } = await getPageStaticInfo({
+      pageFilePath: join(fixtureDir, 'page-runtime/fallback-with-gsp.js'),
+      nextConfig: createNextConfig('edge'),
+    })
     expect(runtime).toBe('edge')
   })
 
   it('should fallback when gSP is re-exported from other module', async () => {
-    const { runtime } = await getPageStaticInfo(
-      join(fixtureDir, 'page-runtime/fallback-re-export-gsp.js'),
-      createNextConfig('edge')
-    )
+    const { runtime } = await getPageStaticInfo({
+      pageFilePath: join(fixtureDir, 'page-runtime/fallback-re-export-gsp.js'),
+      nextConfig: createNextConfig('edge'),
+    })
     expect(runtime).toBe('edge')
   })
 })


### PR DESCRIPTION
This PR refactors the way we extract static information for a page in order to check if it has SSG, SSR and what's the configured runtime. It includes generic util `extractExportedConstValue` that allows to read an arbitrary exported `const` and it is used for reading the exposed runtime configuration.

It also revamps the cache to use a new util `withPromiseCache` that is used to wrap the function that parses the AST of a file using SWC. It indexes items using a `sha1` of the file content in a LRU cache with a size of `500` and no TTL. This removes the requirement to purge the cache imperatively from the dev server.

This is in preparation to have a new function that will extract the `export const config = {}` object in **middleware** so that we can bring in configuration options without having to have specific AST parsing logic.