### PR TITLE
feat: Added scroll position restoration on reload

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -99,7 +99,7 @@ class Container extends React.Component<{
   }
 
   componentDidMount() {
-    this.scrollToHash()
+    this.scrollToHashOrRestore()
 
     // We need to replace the router state if:
     // - the page was (auto) exported and has a query string or search (hash)
@@ -158,20 +158,26 @@ class Container extends React.Component<{
   }
 
   componentDidUpdate() {
-    this.scrollToHash()
+    this.scrollToHashOrRestore()
   }
 
-  scrollToHash() {
-    let { hash } = location
-    hash = hash && hash.substring(1)
-    if (!hash) return
+  scrollToHashOrRestore() {
+    const scrollPosition = router.lastScrollPosition()
 
-    const el: HTMLElement | null = document.getElementById(hash)
-    if (!el) return
+    if (scrollPosition) {
+      window.scrollTo(scrollPosition.x, scrollPosition.y)
+    } else {
+      let { hash } = location
+      hash = hash && hash.substring(1)
+      if (!hash) return
 
-    // If we call scrollIntoView() in here without a setTimeout
-    // it won't scroll properly.
-    setTimeout(() => el.scrollIntoView(), 0)
+      const el: HTMLElement | null = document.getElementById(hash)
+      if (!el) return
+
+      // If we call scrollIntoView() in here without a setTimeout
+      // it won't scroll properly.
+      setTimeout(() => el.scrollIntoView(), 0)
+    }
   }
 
   render() {

--- a/test/e2e/reload-scroll-backforward-restoration/index.test.ts
+++ b/test/e2e/reload-scroll-backforward-restoration/index.test.ts
@@ -39,7 +39,7 @@ describe('reload-scroll-back-restoration', () => {
     expect(scrollPositionMemories[0].x).not.toBe(0)
     expect(scrollPositionMemories[0].y).not.toBe(0)
 
-    await browser.eval(`window.next.router.push('/1')`)
+    await browser.eval(`window.next.router.push('/1?test=test')`)
     await browser.eval(() => document.querySelector('#link').scrollIntoView())
     scrollPositionMemories.push({
       x: Math.floor(await browser.eval(() => window.scrollX)),
@@ -71,6 +71,23 @@ describe('reload-scroll-back-restoration', () => {
     await check(async () => {
       const isReady = await browser.eval('next.router.isReady')
       return isReady ? 'success' : isReady
+    }, 'success')
+
+    // check restore value on reload
+    await check(
+      () => browser.eval(() => document.documentElement.innerHTML),
+      /router ready/
+    )
+    await check(async () => {
+      assert.equal(
+        scrollPositionMemories[1].x,
+        Math.floor(await browser.eval(() => window.scrollX))
+      )
+      assert.equal(
+        scrollPositionMemories[1].y,
+        Math.floor(await browser.eval(() => window.scrollY))
+      )
+      return 'success'
     }, 'success')
 
     // check restore value on history index: 0
@@ -113,7 +130,7 @@ describe('reload-scroll-back-restoration', () => {
     expect(scrollPositionMemories[0].x).not.toBe(0)
     expect(scrollPositionMemories[0].y).not.toBe(0)
 
-    await browser.eval(`window.next.router.push('/1')`)
+    await browser.eval(`window.next.router.push('/1?test=test')`)
     await browser.eval(() => document.querySelector('#link').scrollIntoView())
     scrollPositionMemories.push({
       x: Math.floor(await browser.eval(() => window.scrollX)),
@@ -152,6 +169,23 @@ describe('reload-scroll-back-restoration', () => {
     await check(async () => {
       const isReady = await browser.eval('next.router.isReady')
       return isReady ? 'success' : isReady
+    }, 'success')
+
+    // check restore value on reload
+    await check(
+      () => browser.eval(() => document.documentElement.innerHTML),
+      /router ready/
+    )
+    await check(async () => {
+      assert.equal(
+        scrollPositionMemories[1].x,
+        Math.floor(await browser.eval(() => window.scrollX))
+      )
+      assert.equal(
+        scrollPositionMemories[1].y,
+        Math.floor(await browser.eval(() => window.scrollY))
+      )
+      return 'success'
     }, 'success')
 
     // check restore value on history index: 2

--- a/test/e2e/reload-scroll-backforward-restoration/pages/[id].js
+++ b/test/e2e/reload-scroll-backforward-restoration/pages/[id].js
@@ -5,11 +5,14 @@ import { useRouter } from 'next/router'
 const Page = ({ id }) => {
   const router = useRouter()
   const [ready, setReady] = useState(false)
+  const [routeChangeComplete, setRouteChangeComplete] = useState(false)
   useEffect(() => {
     router.events.on('routeChangeComplete', () => {
-      setReady(true)
+      setRouteChangeComplete(true)
     })
-  }, [router, ready, setReady])
+
+    setReady(true)
+  }, [router, routeChangeComplete, setRouteChangeComplete])
 
   return (
     <>
@@ -20,7 +23,8 @@ const Page = ({ id }) => {
           background: 'blue',
         }}
       />
-      <p>{ready ? 'routeChangeComplete' : 'loading'}</p>
+      <p>{ready ? 'router ready' : 'loading'}</p>
+      <p>{routeChangeComplete ? 'routeChangeComplete' : 'loading'}</p>
       <Link href={`/${id + 1}`}>
         <a
           id="link"


### PR DESCRIPTION
if `experimental.scrollRestoration = true`, reloading always resets the scroll position.
This pull request keeps the last `key` and `as` in session storage and restores the scroll position based on them when reloading.
This is more like browser behavior.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
