### PR TITLE
Add libc field to swc packages

### DIFF
--- a/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-gnu/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "arm64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "main": "next-swc.linux-arm64-gnu.node",
   "files": [
     "next-swc.linux-arm64-gnu.node"

--- a/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-arm64-musl/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "arm64"
   ],
+  "libc": [
+    "musl"
+  ],
   "main": "next-swc.linux-arm64-musl.node",
   "files": [
     "next-swc.linux-arm64-musl.node"

--- a/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-gnu/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "main": "next-swc.linux-x64-gnu.node",
   "files": [
     "next-swc.linux-x64-gnu.node"

--- a/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
+++ b/packages/next-swc/crates/napi/npm/linux-x64-musl/package.json
@@ -7,6 +7,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "musl"
+  ],
   "main": "next-swc.linux-x64-musl.node",
   "files": [
     "next-swc.linux-x64-musl.node"


### PR DESCRIPTION
This adds the new `libc` field to our swc packages to help package managers detect which package is relevant better as this is available in newer versions of pnpm, yarn, and cnpm 

x-ref: https://github.com/pnpm/pnpm/issues/4454 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
