### PR TITLE
Fix example extraction when branch name contains slash

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -78,7 +78,7 @@ export function downloadAndExtractRepo(
     ),
     tar.extract(
       { cwd: root, strip: filePath ? filePath.split('/').length + 1 : 1 },
-      [`${name}-${branch}${filePath ? `/${filePath}` : ''}`]
+      [`${name}-${branch.replace(/\//, '-')}${filePath ? `/${filePath}` : ''}`]
     )
   )
 }

--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -78,7 +78,7 @@ export function downloadAndExtractRepo(
     ),
     tar.extract(
       { cwd: root, strip: filePath ? filePath.split('/').length + 1 : 1 },
-      [`${name}-${branch.replace(/\//, '-')}${filePath ? `/${filePath}` : ''}`]
+      [`${name}-${branch.replace(/\//g, '-')}${filePath ? `/${filePath}` : ''}`]
     )
   )
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Fixes #37138

I looked into adding an integration test, but I'm not sure it's possible without having a reliably persistent, slashed branch name to use in the test. Any suggestions to work around this?

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`
