### PR TITLE
Avoid anonymous function in next/link

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -125,7 +125,7 @@ type LinkPropsReal = React.PropsWithChildren<
 >
 
 const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
-  function Link(props, forwardedRef) {
+  function LinkComponent(props, forwardedRef) {
     const {
       legacyBehavior = Boolean(process.env.__NEXT_NEW_LINK_BEHAVIOR) !== true,
     } = props

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -125,7 +125,7 @@ type LinkPropsReal = React.PropsWithChildren<
 >
 
 const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
-  (props, forwardedRef) => {
+  function Link(props, forwardedRef) {
     const {
       legacyBehavior = Boolean(process.env.__NEXT_NEW_LINK_BEHAVIOR) !== true,
     } = props


### PR DESCRIPTION
Avoid anonymous function in `next/link` so DevTools show `Link` instead of `Anonymous`:

Before:

![Screenshot_20220524_123016](https://user-images.githubusercontent.com/20753323/170018947-2d9bdd58-5311-4bba-ab6b-4dc9547092f6.png)

After:

![Screenshot_20220524_122946](https://user-images.githubusercontent.com/20753323/170018968-2993a24a-5518-4de1-b7a4-75cc6d6562f2.png)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
