### PR TITLE
Fix build-wasm CI job

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1414,7 +1414,7 @@ jobs:
 
   build-wasm:
     needs: build
-    # if: ${{ needs.build.outputs.isRelease == 'true' }}
+    if: ${{ needs.build.outputs.isRelease == 'true' }}
     strategy:
       matrix:
         target: [web, nodejs]

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1414,7 +1414,7 @@ jobs:
 
   build-wasm:
     needs: build
-    if: ${{ needs.build.outputs.isRelease == 'true' }}
+    # if: ${{ needs.build.outputs.isRelease == 'true' }}
     strategy:
       matrix:
         target: [web, nodejs]

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1418,7 +1418,7 @@ jobs:
     strategy:
       matrix:
         target: [web, nodejs]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/cache@v3
         id: restore-build


### PR DESCRIPTION
Updates to use a macos runner as it seems we are hitting a core dump error while optimizing the wasm binary on ubuntu. 

x-ref: https://github.com/vercel/next.js/runs/6579658792?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6579658710?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6575220783?check_suite_focus=true
x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1653380207301469)

potentially related: https://github.com/rustwasm/wasm-pack/issues/781