### PR TITLE
feat: router's key to public

### DIFF
--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -52,6 +52,7 @@ The following is the definition of the `router` object returned by both [`useRou
 - `domainLocales`: `Array<{domain, defaultLocale, locales}>` - Any configured domain locales.
 - `isReady`: `boolean` - Whether the router fields are updated client-side and ready for use. Should only be used inside of `useEffect` methods and not for conditionally rendering on the server. See related docs for use case with [automatically statically optimized pages](/docs/advanced-features/automatic-static-optimization.md)
 - `isPreview`: `boolean` - Whether the application is currently in [preview mode](/docs/advanced-features/preview-mode.md).
+- `key`: `string` - String uniquely representing the current history entry.
 
 > Using the `asPath` field may lead to a mismatch between client and server if the page is rendered using server-side rendering or [automatic static optimization](/docs/advanced-features/automatic-static-optimization.md). Avoid using `asPath` until the `isReady` field is `true`.
 

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -45,6 +45,7 @@ const urlPropertyFields = [
   'locales',
   'defaultLocale',
   'isReady',
+  'key',
   'isPreview',
   'isLocaleDomain',
   'domainLocales',

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -123,6 +123,7 @@ class ServerRouter implements NextRouter {
   domainLocales?: DomainLocale[]
   isPreview: boolean
   isLocaleDomain: boolean
+  key: string | null
 
   constructor(
     pathname: string,
@@ -151,6 +152,7 @@ class ServerRouter implements NextRouter {
     this.domainLocales = domainLocales
     this.isPreview = !!isPreview
     this.isLocaleDomain = !!isLocaleDomain
+    this.key = null
   }
 
   push(): any {

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -336,6 +336,7 @@ export type NextRouter = BaseRouter &
     | 'isFallback'
     | 'isReady'
     | 'isPreview'
+    | 'key'
   >
 
 export type PrefetchOptions = {
@@ -2243,6 +2244,10 @@ export default class Router implements BaseRouter {
 
   get isPreview(): boolean {
     return this.state.isPreview
+  }
+
+  get key(): string | null {
+    return this._key
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This is suggested to publish the history key in #34980 .
I also need this feature because I want to associate component's state and history and store them in storage.
Similar functionality is available in remix, and will be provided in the navigation-api being considered by the WICG.
https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationkey
https://github.com/WICG/navigation-api#the-current-entry

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
