### PR TITLE
fix "nextJest has no call signatures"

### DIFF
--- a/examples/with-jest/jest.config.js
+++ b/examples/with-jest/jest.config.js
@@ -1,4 +1,4 @@
-const nextJest = require('next/jest')
+const { nextJest } = require('next/jest')
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const nextJest = require('next/jest')
+const { nextJest } = require('next/jest')
 
 const createJestConfig = nextJest()
 

--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -42,7 +42,7 @@ const customJestConfig = {
 // createJestConfig is exported in this way to ensure that next/jest can load the Next.js config which is async
 module.exports = createJestConfig(customJestConfig)
 */
-export default function nextJest(options: { dir?: string } = {}) {
+export function nextJest(options: { dir?: string } = {}) {
   // createJestConfig
   return (customJestConfig?: any) => {
     // Function that is provided as the module.exports of jest.config.js
@@ -150,3 +150,4 @@ export default function nextJest(options: { dir?: string } = {}) {
     }
   }
 }
+export default nextJest

--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -29,7 +29,7 @@ function loadClosestPackageJson(dir: string, attempts = 1): any {
 
 /*
 // Usage in jest.config.js
-const nextJest = require('next/jest');
+const { nextJest } = require('next/jest');
 
 // Optionally provide path to Next.js app which will enable loading next.config.js and .env files
 const createJestConfig = nextJest({ dir })

--- a/packages/next/jest.d.ts
+++ b/packages/next/jest.d.ts
@@ -1,3 +1,1 @@
-import nextJest from './dist/build/jest/jest'
-export * from './dist/build/jest/jest'
-export default nextJest
+export { nextJest } from './dist/build/jest/jest'

--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -43,7 +43,7 @@ describe('next/jest', () => {
         `,
         'jest.config.js': `
           // jest.config.js
-          const nextJest = require('next/jest')
+          const { nextJest } = require('next/jest')
           
           const createJestConfig = nextJest({
             // Provide the path to your Next.js app to load next.config.js and .env files in your test environment

--- a/test/production/jest/relay/app/jest.config.js
+++ b/test/production/jest/relay/app/jest.config.js
@@ -1,4 +1,4 @@
-const nextJest = require('next/jest')
+const { nextJest } = require('next/jest')
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment

--- a/test/production/jest/remove-react-properties/app/jest.config.js
+++ b/test/production/jest/remove-react-properties/app/jest.config.js
@@ -1,4 +1,4 @@
-const nextJest = require('next/jest')
+const { nextJest } = require('next/jest')
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment


### PR DESCRIPTION
This expression is not callable.
  Type 'typeof import("/Users/devinrhode2/repos/my-app/node_modules/next/jest")' has no call signatures.ts(2349)

https://share.cleanshot.com/PQb1LfA0WKJTZVMlV5gl

https://share.cleanshot.com/qbZaNjFqqRXxd0fhmkgb

https://share.cleanshot.com/sOrhfVPg1KQvZmgacYht
