### PR TITLE
Update `cms-kontent` example to action PR feedback

### DIFF
--- a/examples/cms-kontent/components/image.js
+++ b/examples/cms-kontent/components/image.js
@@ -1,8 +1,6 @@
 import NextImage from 'next/image'
 import { transformImageUrl } from '@kentico/kontent-delivery'
 
-const KONTENT_ASSET_HOSTNAME_REGEX = /.kc-usercontent.com$/
-
 const getLoader = (src) => {
   return srcIsKontentAsset(src) ? kontentImageLoader : undefined
 }
@@ -10,13 +8,13 @@ const getLoader = (src) => {
 const srcIsKontentAsset = (src) => {
   try {
     const { hostname } = new URL(src)
-    return KONTENT_ASSET_HOSTNAME_REGEX.test(hostname)
+    return hostname.endsWith('.kc-usercontent.com')
   } catch {
     return false
   }
 }
 
-const kontentImageLoader = ({ src, width, quality = 100 }) => {
+const kontentImageLoader = ({ src, width, quality = 75 }) => {
   return new transformImageUrl(src)
     .withWidth(width)
     .withQuality(quality)

--- a/examples/cms-kontent/package.json
+++ b/examples/cms-kontent/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "autoprefixer": "10.4.7",
     "postcss": "8.4.14",
-    "tailwindcss": "^3.0.15"
+    "tailwindcss": "^3.0.15",
+    "tslib": "2.4.0"
   }
 }


### PR DESCRIPTION
* Updates the `cms-kontent` example `Image` component to implement the
  suggested improvements from @styfle in #37188.
  * Simplifies the Kontent loader host checking.
  * Reduces the default image quality from `100` to `75`.
* Add `tslib` as a dev dependency to fix `Module not found: Can't resolve
  'tslib'` error when importing `transformImageUrl` in the `Image` component.
  * It looks like this might be a bug in v11 of the Kontent Delivery SDK,
    as it appears `tslib` needs to be included as a dependency, rather than
    a dev dependency.
  * I missed this originally as the example runs fine in the Next repo as the root
    `yarn.lock` has `tslib`. It's only when the example is used via
    `yarn create next-app` that the issue occurs.
  * We can likely remove this in future alongside an upgrade to the SDK package
    once this issue has been fixed and released there, ref:
    https://github.com/Kentico/kontent-delivery-sdk-js/issues/347

https://github.com/vercel/next.js/pull/37188

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`