### PR TITLE
Update contributing doc and PR template for examples

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -268,10 +268,12 @@ Below are the steps to add a new link:
 When you add an example to the [examples](examples) directory, please follow these guidelines to ensure high quality examples:
 
 - TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples)
-- Examples should not add custom eslint configuration (we have specific templates for eslint)
+- Examples should not add custom ESLint configuration (we have specific templates for ESLint)
 - If API routes aren't used in an example, they should be omitted
 - If an example exists for a certain library and you would like to showcase a specific feature of that library, the existing example should be updated (instead of adding a new example)
 - Package manager specific config should not be added (e.g. `resolutions` in `package.json`)
+- In `package.json` the version of `next` (and `eslint-config-next`) should be `latest`
+- In `package.json` the dependency versions should be up-to-date
 
 Also don’t forget to add a `README.md` file with the following format:
 


### PR DESCRIPTION
Follow-up on https://github.com/vercel/next.js/pull/37193

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
