### PR TITLE
Small code improvements

### DIFF
--- a/packages/next/trace/trace.ts
+++ b/packages/next/trace/trace.ts
@@ -1,7 +1,7 @@
 import { SpanId } from './shared'
 import { reporter } from './report'
 
-const NUM_OF_MICROSEC_IN_SEC = BigInt('1000')
+const NUM_OF_MICROSEC_IN_NANOSEC = BigInt('1000')
 let count = 0
 const getId = () => {
   count++
@@ -58,12 +58,12 @@ export class Span {
   // a float64 in both JSON and JavaScript.
   stop(stopTime?: bigint) {
     const end: bigint = stopTime || process.hrtime.bigint()
-    const duration = (end - this._start) / NUM_OF_MICROSEC_IN_SEC
+    const duration = (end - this._start) / NUM_OF_MICROSEC_IN_NANOSEC
     this.status = SpanStatus.Stopped
     if (duration > Number.MAX_SAFE_INTEGER) {
       throw new Error(`Duration is too long to express as float64: ${duration}`)
     }
-    const timestamp = this._start / NUM_OF_MICROSEC_IN_SEC
+    const timestamp = this._start / NUM_OF_MICROSEC_IN_NANOSEC
     reporter.report(
       this.name,
       Number(duration),


### PR DESCRIPTION
Two small things noticed today. When calling `getDependencies` concurrently (which is happening right now) the cache doesn't work as it's after the `await`, so here we move it to cache the promise instead. Also `NUM_OF_MICROSEC_IN_SEC` isn't accurate and it should be `NANOSEC` actually.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
