### PR TITLE
docs: update instructions for pnpm 7.1.1

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,8 +35,8 @@ If you want to start with a TypeScript project you can use the `--typescript` fl
 npx create-next-app@latest --typescript
 # or
 yarn create next-app --typescript
-# or (the extra '--' is expected and tells pnpm to pass the args down)
-pnpm create next-app -- --typescript
+# or
+pnpm create next-app --typescript
 ```
 
 After the installation is complete:


### PR DESCRIPTION
Arguments are now passed to the next-app by default since [pnpm 7.1.1](https://github.com/pnpm/pnpm/releases/tag/v7.1.1)

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
