### PR TITLE
Refactor incremental cache to be extensible

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -83,6 +83,8 @@ export interface ExperimentalConfig {
   browsersListForSwc?: boolean
   manualClientBasePath?: boolean
   newNextLinkBehavior?: boolean
+  // custom path to a cache handler to use
+  incrementalCacheHandlerPath?: string
   disablePostcssPresetEnv?: boolean
   swcMinify?: boolean
   swcFileReading?: boolean

--- a/packages/next/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/server/lib/incremental-cache/file-system-cache.ts
@@ -1,5 +1,5 @@
 import { CacheFs } from '../../../shared/lib/utils'
-import path from 'path'
+import path from '../../../shared/lib/isomorphic/path'
 import type { CacheHandler, CacheHandlerContext } from './'
 
 export default class FileSystemCache implements CacheHandler {

--- a/packages/next/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/server/lib/incremental-cache/file-system-cache.ts
@@ -1,0 +1,36 @@
+import { CacheFs } from '../../../shared/lib/utils'
+import path from 'path'
+import type { CacheHandler, CacheHandlerContext } from './'
+
+export default class FileSystemCache implements CacheHandler {
+  private flushToDisk?: boolean
+  private pagesDir: string
+  private fs: CacheFs
+
+  constructor(ctx: CacheHandlerContext) {
+    this.flushToDisk = ctx.flushToDisk
+    this.pagesDir = ctx.pagesDir
+    this.fs = ctx.fs
+  }
+
+  public async get(key: string) {
+    return this.fs.readFile(this.getSeedPath(key))
+  }
+  public async getMeta(key: string) {
+    const stat = await this.fs.stat(this.getSeedPath(key))
+    return {
+      mtime: stat.mtime.getTime(),
+    }
+  }
+
+  public async set(key: string, data: string) {
+    if (!this.flushToDisk) return
+    const pathname = this.getSeedPath(key)
+    await this.fs.mkdir(path.dirname(pathname))
+    return this.fs.writeFile(pathname, data)
+  }
+
+  private getSeedPath(pathname: string): string {
+    return path.join(this.pagesDir, pathname)
+  }
+}

--- a/packages/next/server/lib/incremental-cache/index.ts
+++ b/packages/next/server/lib/incremental-cache/index.ts
@@ -1,5 +1,6 @@
 import type { CacheFs } from '../../../shared/lib/utils'
 
+import FileSystemCache from './file-system-cache'
 import LRUCache from 'next/dist/compiled/lru-cache'
 import path from '../../../shared/lib/isomorphic/path'
 import { PrerenderManifest } from '../../../build'
@@ -62,12 +63,13 @@ export class IncrementalCache {
     incrementalCacheHandlerPath?: string
     getPrerenderManifest: () => PrerenderManifest
   }) {
-    if (!incrementalCacheHandlerPath) {
-      incrementalCacheHandlerPath = require.resolve('./file-system-cache')
+    let cacheHandlerMod: any = FileSystemCache
+
+    if (incrementalCacheHandlerPath) {
+      cacheHandlerMod = require(incrementalCacheHandlerPath)
+      cacheHandlerMod = cacheHandlerMod.default || cacheHandlerMod
     }
-    const cacheHandlerMod = require(incrementalCacheHandlerPath)
-    this.cacheHandler = new ((cacheHandlerMod.default ||
-      cacheHandlerMod) as typeof CacheHandler)({
+    this.cacheHandler = new (cacheHandlerMod as typeof CacheHandler)({
       dev,
       distDir,
       fs,


### PR DESCRIPTION
This refactors the `incremental-cache` and moves the file-system cache handling to it's own cache handler allowing it to be replaced by a custom cache handler (experimental). 

Closes: https://github.com/vercel/next.js/pull/22619

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
