### PR TITLE
docs(api-routes): add new caveat

### DIFF
--- a/docs/api-routes/introduction.md
+++ b/docs/api-routes/introduction.md
@@ -59,6 +59,7 @@ For new projects, you can build your entire API with API Routes. If you have an 
 
 - API Routes [do not specify CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), meaning they are **same-origin only** by default. You can customize such behavior by wrapping the request handler with the [CORS middleware](/docs/api-routes/api-middlewares.md#connectexpress-middleware-support).
 - API Routes can't be used with [`next export`](/docs/advanced-features/static-html-export.md)
+- API Routes don't fully support file system interactions, such as reading files (https://github.com/vercel/next.js/discussions/32236). There are workarounds (https://github.com/vercel/next.js/discussions/32236#discussioncomment-2572290), but it's best to avoid interacting with the file system altogether.
 
 ## Related
 


### PR DESCRIPTION
Added caveat about the limited use of file system interactions in Next.js API Routes (see https://github.com/vercel/next.js/discussions/32236 for further reference)

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `yarn lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
