### PR TITLE
[docs] Clarify "When does getStaticProps run" note

### DIFF
--- a/docs/basic-features/data-fetching/get-static-paths.md
+++ b/docs/basic-features/data-fetching/get-static-paths.md
@@ -37,9 +37,9 @@ You should use `getStaticPaths` if you’re statically pre-rendering pages that 
 
 `getStaticPaths` will only run during build in production, it will not be called during runtime. You can validate code written inside `getStaticPaths` is removed from the client-side bundle [with this tool](https://next-code-elimination.vercel.app/).
 
-- `getStaticProps` runs during `next build` for any `paths` returned during build
-- `getStaticProps` runs in the background when using `fallback: true`
-- `getStaticProps` is called before initial render when using `fallback: blocking`
+- `getStaticPaths` runs during `next build` for any `paths` returned during build
+- `getStaticPaths` runs in the background when using `fallback: true`
+- `getStaticPaths` is called before initial render when using `fallback: blocking`
 
 ## Where can I use getStaticPaths
 

--- a/docs/basic-features/data-fetching/get-static-paths.md
+++ b/docs/basic-features/data-fetching/get-static-paths.md
@@ -37,9 +37,11 @@ You should use `getStaticPaths` if you’re statically pre-rendering pages that 
 
 `getStaticPaths` will only run during build in production, it will not be called during runtime. You can validate code written inside `getStaticPaths` is removed from the client-side bundle [with this tool](https://next-code-elimination.vercel.app/).
 
-- `getStaticPaths` runs during `next build` for any `paths` returned during build
-- `getStaticPaths` runs in the background when using `fallback: true`
-- `getStaticPaths` is called before initial render when using `fallback: blocking`
+### How does getStaticProps run with regards to getStaticPaths
+
+- `getStaticProps` runs during `next build` for any `paths` returned during build
+- `getStaticProps` runs in the background when using `fallback: true`
+- `getStaticProps` is called before initial render when using `fallback: blocking`
 
 ## Where can I use getStaticPaths
 


### PR DESCRIPTION
Changed bullet points to say "getStaticPaths" instead of "getStaticProps".

Fixes https://github.com/vercel/next.js/issues/37288 

## Feature

- [x] Related issues linked using `fixes #number`
- [x] Documentation added

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
