### PR TITLE
Extract router utils to common functions

### DIFF
--- a/packages/next/client/add-base-path.ts
+++ b/packages/next/client/add-base-path.ts
@@ -1,0 +1,14 @@
+import { addPathPrefix } from '../shared/lib/router/utils/add-path-prefix'
+import { normalizePathTrailingSlash } from './normalize-trailing-slash'
+
+const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+
+export function addBasePath(path: string, required?: boolean): string {
+  if (process.env.__NEXT_MANUAL_CLIENT_BASE_PATH) {
+    if (!required) {
+      return path
+    }
+  }
+
+  return normalizePathTrailingSlash(addPathPrefix(path, basePath))
+}

--- a/packages/next/client/add-locale.ts
+++ b/packages/next/client/add-locale.ts
@@ -1,0 +1,11 @@
+import type { addLocale as Fn } from '../shared/lib/router/utils/add-locale'
+import { normalizePathTrailingSlash } from './normalize-trailing-slash'
+
+export const addLocale: typeof Fn = (path, ...args) => {
+  if (process.env.__NEXT_I18N_SUPPORT) {
+    return normalizePathTrailingSlash(
+      require('../shared/lib/router/utils/add-locale').addLocale(path, ...args)
+    )
+  }
+  return path
+}

--- a/packages/next/client/detect-domain-locale.ts
+++ b/packages/next/client/detect-domain-locale.ts
@@ -1,0 +1,9 @@
+import type { detectDomainLocale as Fn } from '../shared/lib/i18n/detect-domain-locale'
+
+export const detectDomainLocale: typeof Fn = (...args) => {
+  if (process.env.__NEXT_I18N_SUPPORT) {
+    return require('../shared/lib/i18n/detect-domain-locale').detectDomainLocale(
+      ...args
+    )
+  }
+}

--- a/packages/next/client/get-domain-locale.ts
+++ b/packages/next/client/get-domain-locale.ts
@@ -1,6 +1,6 @@
 import type { DomainLocale } from '../server/config'
-import { normalizeLocalePath } from './normalize-locale-path'
-import { detectDomainLocale } from './detect-domain-locale'
+import type { normalizeLocalePath as NormalizeFn } from './normalize-locale-path'
+import type { detectDomainLocale as DetectFn } from './detect-domain-locale'
 
 const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 
@@ -11,6 +11,11 @@ export function getDomainLocale(
   domainLocales?: DomainLocale[]
 ) {
   if (process.env.__NEXT_I18N_SUPPORT) {
+    const normalizeLocalePath: typeof NormalizeFn =
+      require('./normalize-locale-path').normalizeLocalePath
+    const detectDomainLocale: typeof DetectFn =
+      require('./detect-domain-locale').detectDomainLocale
+
     const target = locale || normalizeLocalePath(path, locales).detectedLocale
     const domain = detectDomainLocale(domainLocales, undefined, target)
     if (domain) {

--- a/packages/next/client/get-domain-locale.ts
+++ b/packages/next/client/get-domain-locale.ts
@@ -1,0 +1,25 @@
+import type { DomainLocale } from '../server/config'
+import { normalizeLocalePath } from './normalize-locale-path'
+import { detectDomainLocale } from './detect-domain-locale'
+
+const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+
+export function getDomainLocale(
+  path: string,
+  locale?: string | false,
+  locales?: string[],
+  domainLocales?: DomainLocale[]
+) {
+  if (process.env.__NEXT_I18N_SUPPORT) {
+    const target = locale || normalizeLocalePath(path, locales).detectedLocale
+    const domain = detectDomainLocale(domainLocales, undefined, target)
+    if (domain) {
+      const proto = `http${domain.http ? '' : 's'}://`
+      const finalLocale = target === domain.defaultLocale ? '' : `/${target}`
+      return `${proto}${domain.domain}${basePath}${finalLocale}${path}`
+    }
+    return false
+  } else {
+    return false
+  }
+}

--- a/packages/next/client/has-base-path.ts
+++ b/packages/next/client/has-base-path.ts
@@ -1,0 +1,7 @@
+import { pathHasPrefix } from '../shared/lib/router/utils/path-has-prefix'
+
+const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+
+export function hasBasePath(path: string): boolean {
+  return pathHasPrefix(path, basePath)
+}

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -8,8 +8,6 @@ import type Router from '../shared/lib/router/router'
 import {
   AppComponent,
   AppProps,
-  delBasePath,
-  hasBasePath,
   PrivateRouteInfo,
 } from '../shared/lib/router/router'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
@@ -35,6 +33,8 @@ import { getProperError } from '../lib/is-error'
 import { RefreshContext } from './streaming/refresh'
 import { ImageConfigContext } from '../shared/lib/image-config-context'
 import { ImageConfigComplete } from '../shared/lib/image-config'
+import { removeBasePath } from './remove-base-path'
+import { hasBasePath } from './has-base-path'
 
 const ReactDOM = process.env.__NEXT_REACT_ROOT
   ? require('react-dom/client')
@@ -206,7 +206,7 @@ export async function initialize(opts: { webpackHMR?: any } = {}): Promise<{
 
   // make sure not to attempt stripping basePath for 404s
   if (hasBasePath(asPath)) {
-    asPath = delBasePath(asPath)
+    asPath = removeBasePath(asPath)
   }
 
   if (process.env.__NEXT_I18N_SUPPORT) {

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { UrlObject } from 'url'
 import {
-  addBasePath,
-  getDomainLocale,
   isLocalURL,
   NextRouter,
   PrefetchOptions,
@@ -12,6 +10,8 @@ import { addLocale } from './add-locale'
 import { RouterContext } from '../shared/lib/router-context'
 import { AppRouterContext } from '../shared/lib/app-router-context'
 import { useIntersection } from './use-intersection'
+import { getDomainLocale } from './get-domain-locale'
+import { addBasePath } from './add-base-path'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -422,12 +422,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       const localeDomain =
         router &&
         router.isLocaleDomain &&
-        getDomainLocale(
-          as,
-          curLocale,
-          router && router.locales,
-          router && router.domainLocales
-        )
+        getDomainLocale(as, curLocale, router.locales, router.domainLocales)
 
       childProps.href =
         localeDomain ||

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { UrlObject } from 'url'
 import {
   addBasePath,
-  addLocale,
   getDomainLocale,
   isLocalURL,
   NextRouter,
   PrefetchOptions,
   resolveHref,
 } from '../shared/lib/router/router'
+import { addLocale } from './add-locale'
 import { RouterContext } from '../shared/lib/router-context'
 import { AppRouterContext } from '../shared/lib/app-router-context'
 import { useIntersection } from './use-intersection'

--- a/packages/next/client/normalize-locale-path.ts
+++ b/packages/next/client/normalize-locale-path.ts
@@ -1,0 +1,11 @@
+import type { normalizeLocalePath as Fn } from '../shared/lib/i18n/normalize-locale-path'
+
+export const normalizeLocalePath: typeof Fn = (pathname, locales) => {
+  if (process.env.__NEXT_I18N_SUPPORT) {
+    return require('../shared/lib/i18n/normalize-locale-path').normalizeLocalePath(
+      pathname,
+      locales
+    )
+  }
+  return { pathname, detectedLocale: undefined }
+}

--- a/packages/next/client/normalize-trailing-slash.ts
+++ b/packages/next/client/normalize-trailing-slash.ts
@@ -1,17 +1,25 @@
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
+import { parsePath } from '../shared/lib/router/utils/parse-path'
 
 /**
  * Normalizes the trailing slash of a path according to the `trailingSlash` option
  * in `next.config.js`.
  */
-export const normalizePathTrailingSlash = process.env.__NEXT_TRAILING_SLASH
-  ? (path: string): string => {
-      if (/\.[^/]+\/?$/.test(path)) {
-        return removeTrailingSlash(path)
-      } else if (path.endsWith('/')) {
-        return path
-      } else {
-        return path + '/'
-      }
+export const normalizePathTrailingSlash = (path: string) => {
+  if (!path.startsWith('/')) {
+    return path
+  }
+
+  const { pathname, query, hash } = parsePath(path)
+  if (process.env.__NEXT_TRAILING_SLASH) {
+    if (/\.[^/]+\/?$/.test(pathname)) {
+      return `${removeTrailingSlash(pathname)}${query}${hash}`
+    } else if (pathname.endsWith('/')) {
+      return `${pathname}${query}${hash}`
+    } else {
+      return `${pathname}/${query}${hash}`
     }
-  : removeTrailingSlash
+  }
+
+  return `${removeTrailingSlash(pathname)}${query}${hash}`
+}

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react'
 import type { RouteLoader } from './route-loader'
-import { addBasePath, interpolateAs } from '../shared/lib/router/router'
+import { addBasePath } from './add-base-path'
+import { interpolateAs } from '../shared/lib/router/router'
 import getAssetPathFromRoute from '../shared/lib/router/utils/get-asset-path-from-route'
 import { addLocale } from './add-locale'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -1,11 +1,8 @@
 import type { ComponentType } from 'react'
 import type { RouteLoader } from './route-loader'
-import {
-  addBasePath,
-  addLocale,
-  interpolateAs,
-} from '../shared/lib/router/router'
+import { addBasePath, interpolateAs } from '../shared/lib/router/router'
 import getAssetPathFromRoute from '../shared/lib/router/utils/get-asset-path-from-route'
+import { addLocale } from './add-locale'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { parseRelativeUrl } from '../shared/lib/router/utils/parse-relative-url'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'

--- a/packages/next/client/remove-base-path.ts
+++ b/packages/next/client/remove-base-path.ts
@@ -1,0 +1,15 @@
+import { hasBasePath } from './has-base-path'
+
+const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+
+export function removeBasePath(path: string): string {
+  if (process.env.__NEXT_MANUAL_CLIENT_BASE_PATH) {
+    if (!hasBasePath(path)) {
+      return path
+    }
+  }
+
+  path = path.slice(basePath.length)
+  if (!path.startsWith('/')) path = `/${path}`
+  return path
+}

--- a/packages/next/client/remove-locale.ts
+++ b/packages/next/client/remove-locale.ts
@@ -1,0 +1,18 @@
+import { parsePath } from '../shared/lib/router/utils/parse-path'
+
+export function removeLocale(path: string, locale?: string) {
+  if (process.env.__NEXT_I18N_SUPPORT) {
+    const { pathname } = parsePath(path)
+    const pathLower = pathname.toLowerCase()
+    const localeLower = locale?.toLowerCase()
+
+    return locale &&
+      (pathLower.startsWith(`/${localeLower}/`) ||
+        pathLower === `/${localeLower}`)
+      ? `${pathname.length === locale.length + 1 ? `/` : ``}${path.slice(
+          locale.length + 1
+        )}`
+      : path
+  }
+  return path
+}

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -42,6 +42,7 @@ import { pathHasPrefix } from './utils/path-has-prefix'
 import { parsePath } from './utils/parse-path'
 import { addPathPrefix } from './utils/add-path-prefix'
 import { addLocale } from '../../../client/add-locale'
+import { removeLocale } from '../../../client/remove-locale'
 
 declare global {
   interface Window {
@@ -130,22 +131,6 @@ export function getDomainLocale(
   } else {
     return false
   }
-}
-
-export function delLocale(path: string, locale?: string) {
-  if (process.env.__NEXT_I18N_SUPPORT) {
-    const { pathname } = parsePath(path)
-    const pathLower = pathname.toLowerCase()
-    const localeLower = locale && locale.toLowerCase()
-
-    return locale &&
-      (pathLower.startsWith('/' + localeLower + '/') ||
-        pathLower === '/' + localeLower)
-      ? (pathname.length === locale.length + 1 ? '/' : '') +
-          path.slice(locale.length + 1)
-      : path
-  }
-  return path
 }
 
 export function hasBasePath(path: string): boolean {
@@ -1038,7 +1023,7 @@ export default class Router implements BaseRouter {
         this.defaultLocale
       )
     )
-    const cleanedAs = delLocale(
+    const cleanedAs = removeLocale(
       hasBasePath(as) ? delBasePath(as) : as,
       nextState.locale
     )
@@ -1167,7 +1152,7 @@ export default class Router implements BaseRouter {
       return false
     }
 
-    resolvedAs = delLocale(delBasePath(resolvedAs), nextState.locale)
+    resolvedAs = removeLocale(delBasePath(resolvedAs), nextState.locale)
 
     /**
      * If the route update was triggered for client-side hydration and
@@ -1773,7 +1758,7 @@ export default class Router implements BaseRouter {
       if (rewritesResult.externalDest) {
         return
       }
-      resolvedAs = delLocale(delBasePath(rewritesResult.asPath), this.locale)
+      resolvedAs = removeLocale(delBasePath(rewritesResult.asPath), this.locale)
 
       if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
         // if this directly matches a page we need to update the href to
@@ -1915,7 +1900,7 @@ export default class Router implements BaseRouter {
     isPreview: boolean
   }): Promise<PreflightEffect> {
     const { pathname: asPathname } = parsePath(options.as)
-    const cleanedAs = delLocale(
+    const cleanedAs = removeLocale(
       hasBasePath(asPathname) ? delBasePath(asPathname) : asPathname,
       options.locale
     )

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -37,6 +37,7 @@ import resolveRewrites from './utils/resolve-rewrites'
 import { getRouteMatcher } from './utils/route-matcher'
 import { getRouteRegex, getMiddlewareRegex } from './utils/route-regex'
 import { formatWithValidation } from './utils/format-url'
+import { detectDomainLocale } from '../../../client/detect-domain-locale'
 
 declare global {
   interface Window {
@@ -96,13 +97,6 @@ export type HistoryState =
   | null
   | { __N: false }
   | ({ __N: true; key: string } & NextHistoryState)
-
-let detectDomainLocale: typeof import('../i18n/detect-domain-locale').detectDomainLocale
-
-if (process.env.__NEXT_I18N_SUPPORT) {
-  detectDomainLocale =
-    require('../i18n/detect-domain-locale').detectDomainLocale
-}
 
 const basePath = (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
 

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -41,6 +41,7 @@ import { detectDomainLocale } from '../../../client/detect-domain-locale'
 import { pathHasPrefix } from './utils/path-has-prefix'
 import { parsePath } from './utils/parse-path'
 import { addPathPrefix } from './utils/add-path-prefix'
+import { addLocale } from '../../../client/add-locale'
 
 declare global {
   interface Window {
@@ -131,28 +132,6 @@ export function getDomainLocale(
   }
 }
 
-export function addLocale(
-  path: string,
-  locale?: string | false,
-  defaultLocale?: string
-) {
-  if (process.env.__NEXT_I18N_SUPPORT) {
-    if (locale && locale !== defaultLocale) {
-      const pathLower = parsePath(path).pathname.toLowerCase()
-      if (
-        !pathHasPrefix(pathLower, `/${locale.toLowerCase()}`) &&
-        !pathHasPrefix(pathLower, '/api')
-      ) {
-        const { pathname, query, hash } = parsePath(
-          addPathPrefix(path, `/${locale}`)
-        )
-        return `${normalizePathTrailingSlash(pathname)}${query}${hash}`
-      }
-    }
-  }
-  return path
-}
-
 export function delLocale(path: string, locale?: string) {
   if (process.env.__NEXT_I18N_SUPPORT) {
     const { pathname } = parsePath(path)
@@ -179,9 +158,8 @@ export function addBasePath(path: string, required?: boolean): string {
       return path
     }
   }
-  // we only add the basepath on relative urls
-  const { pathname, query, hash } = parsePath(addPathPrefix(path, basePath))
-  return `${normalizePathTrailingSlash(pathname)}${query}${hash}`
+
+  return normalizePathTrailingSlash(addPathPrefix(path, basePath))
 }
 
 export function delBasePath(path: string): string {

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -38,6 +38,7 @@ import { getRouteMatcher } from './utils/route-matcher'
 import { getRouteRegex, getMiddlewareRegex } from './utils/route-regex'
 import { formatWithValidation } from './utils/format-url'
 import { detectDomainLocale } from '../../../client/detect-domain-locale'
+import { pathHasPrefix } from './utils/path-has-prefix'
 import { parsePath } from './utils/parse-path'
 
 declare global {
@@ -118,11 +119,6 @@ function addPathPrefix(path: string, prefix?: string) {
   )
 }
 
-function hasPathPrefix(path: string, prefix: string) {
-  path = parsePath(path).pathname
-  return path === prefix || path.startsWith(prefix + '/')
-}
-
 export function getDomainLocale(
   path: string,
   locale?: string | false,
@@ -157,8 +153,8 @@ export function addLocale(
       const localeLower = locale.toLowerCase()
 
       if (
-        !hasPathPrefix(pathLower, '/' + localeLower) &&
-        !hasPathPrefix(pathLower, '/api')
+        !pathHasPrefix(pathLower, '/' + localeLower) &&
+        !pathHasPrefix(pathLower, '/api')
       ) {
         return addPathPrefix(path, '/' + locale)
       }
@@ -184,7 +180,7 @@ export function delLocale(path: string, locale?: string) {
 }
 
 export function hasBasePath(path: string): boolean {
-  return hasPathPrefix(path, basePath)
+  return pathHasPrefix(path, basePath)
 }
 
 export function addBasePath(path: string, required?: boolean): string {

--- a/packages/next/shared/lib/router/utils/parse-path.ts
+++ b/packages/next/shared/lib/router/utils/parse-path.ts
@@ -10,7 +10,10 @@ export function parsePath(path: string) {
   if (queryIndex > -1 || hashIndex > -1) {
     return {
       pathname: path.substring(0, queryIndex > -1 ? queryIndex : hashIndex),
-      query: queryIndex > -1 ? path.substring(queryIndex, hashIndex) : '',
+      query:
+        queryIndex > -1
+          ? path.substring(queryIndex, hashIndex > -1 ? hashIndex : undefined)
+          : '',
       hash: hashIndex > -1 ? path.slice(hashIndex) : '',
     }
   }

--- a/packages/next/shared/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/shared/lib/router/utils/resolve-rewrites.ts
@@ -1,11 +1,11 @@
-import { ParsedUrlQuery } from 'querystring'
+import type { ParsedUrlQuery } from 'querystring'
 import { getPathMatch } from './path-match'
 import { matchHas, prepareDestination } from './prepare-destination'
 import { Rewrite } from '../../../../lib/load-custom-routes'
 import { removeTrailingSlash } from './remove-trailing-slash'
 import { normalizeLocalePath } from '../../i18n/normalize-locale-path'
+import { removeBasePath } from '../../../../client/remove-base-path'
 import { parseRelativeUrl } from './parse-relative-url'
-import { delBasePath } from '../router'
 
 export default function resolveRewrites(
   asPath: string,
@@ -29,7 +29,7 @@ export default function resolveRewrites(
   let externalDest = false
   let parsedAs = parseRelativeUrl(asPath)
   let fsPathname = removeTrailingSlash(
-    normalizeLocalePath(delBasePath(parsedAs.pathname), locales).pathname
+    normalizeLocalePath(removeBasePath(parsedAs.pathname), locales).pathname
   )
   let resolvedHref
 
@@ -83,7 +83,7 @@ export default function resolveRewrites(
       Object.assign(query, destRes.parsedDestination.query)
 
       fsPathname = removeTrailingSlash(
-        normalizeLocalePath(delBasePath(asPath), locales).pathname
+        normalizeLocalePath(removeBasePath(asPath), locales).pathname
       )
 
       if (pages.includes(fsPathname)) {

--- a/test/unit/router-add-base-path.test.ts
+++ b/test/unit/router-add-base-path.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { addBasePath } from 'next/dist/shared/lib/router/router'
+import { addBasePath } from 'next/dist/client/add-base-path'
 
 describe('router addBasePath', () => {
   it('should add basePath correctly when no basePath', () => {


### PR DESCRIPTION
This PR refactors routing utils used by the client into isolated files within `./client` that makes explicit it purpose. It embraces a pattern where we have some logic that is used in the server and we create a specific file for client where we use env variables to tree-shake the logic we know we won't need. This allows for consumers of those utils to simply import without worrying about the bundle.

For example, `detectDomainLocale` is defined for the server but it is only needed in the client when `process.env.__NEXT_I18N_SUPPORT` is truthy. Therefore there is a file `client/detect-domain-locale` such as:

```typescript
import type { detectDomainLocale as Fn } from '../shared/lib/i18n/detect-domain-locale'

export const detectDomainLocale: typeof Fn = (...args) => {
  if (process.env.__NEXT_I18N_SUPPORT) {
    return require('../shared/lib/i18n/detect-domain-locale').detectDomainLocale(
      ...args
    )
  }
}
```

This allows to include the code only when required and keeps traceability from Typescript with the type import. This pattern is repeated for a few utilities that deal with pathnames.