### PR TITLE
Include router in the app-next chunk

### DIFF
--- a/packages/next/client/app-next.js
+++ b/packages/next/client/app-next.js
@@ -1,5 +1,9 @@
 import { hydrate, version } from './app-index'
 
+// We have to include the router
+import { router } from './'
+console.log(router)
+
 window.next = {
   version,
   root: true,

--- a/packages/next/client/components/app-router.client.tsx
+++ b/packages/next/client/components/app-router.client.tsx
@@ -39,7 +39,7 @@ export default function AppRouter({ initialUrl, children }: any) {
   const [current, setCurrent] = React.useState(initialState)
   const appRouter = React.useMemo(() => {
     return {
-      prefetch: () => {},
+      prefetch: () => Promise.resolve(),
       replace: () => {},
       push: (url: string) => {
         previousUrlRef.current = current

--- a/test/e2e/app-dir/app/app/dashboard/index/page.server.js
+++ b/test/e2e/app-dir/app/app/dashboard/index/page.server.js
@@ -1,7 +1,12 @@
+import Link from 'next/link'
+
 export default function DashboardIndexPage() {
   return (
     <>
       <p>hello from root/dashboard/index</p>
+      <Link href="/dashboard/integrations" legacyBehavior={false}>
+        To Integrations
+      </Link>
     </>
   )
 }


### PR DESCRIPTION
The router module is explicitly excluded from client chunks except for main.js. However, that module is used by next/link. If we force it to be included in app-next the next/link hydration will now work.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
