### PR TITLE
Ensure type check/link worker does not retry

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -2377,6 +2377,7 @@ function verifyTypeScriptSetup(
     {
       numWorkers,
       enableWorkerThreads,
+      maxRetries: 0,
     }
   ) as JestWorker & {
     verifyTypeScriptSetup: typeof import('../lib/verifyTypeScriptSetup').verifyTypeScriptSetup

--- a/packages/next/lib/verifyAndLint.ts
+++ b/packages/next/lib/verifyAndLint.ts
@@ -20,6 +20,7 @@ export async function verifyAndLint(
     const lintWorkers = new Worker(require.resolve('./eslint/runLintCheck'), {
       numWorkers,
       enableWorkerThreads,
+      maxRetries: 0,
     }) as Worker & {
       runLintCheck: typeof import('./eslint/runLintCheck').runLintCheck
     }

--- a/test/production/missing-dep-error/index.test.ts
+++ b/test/production/missing-dep-error/index.test.ts
@@ -1,0 +1,28 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+
+describe('missing-dep-error', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.tsx': `
+          export default function Page() { 
+            return <p>hello world</p>
+          } 
+        `,
+      },
+      skipStart: true,
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should only show error once', async () => {
+    await next.start().catch(() => {})
+    expect(
+      next.cliOutput.match(/It looks like you're trying to use TypeScript/g)
+        ?.length
+    ).toBe(1)
+  })
+})


### PR DESCRIPTION
This ensures we don't retry when the type check or lint worker fails as we want to give immediate feedback and retrying can slow this down quite a bit. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

