### PR TITLE
fix: ignore  test file for the no-server-import-in-page rule

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
+++ b/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
@@ -19,7 +19,10 @@ module.exports = {
         if (
           filename.startsWith('middleware.') ||
           filename.startsWith(`${path.sep}middleware.`) ||
-          filename.startsWith(`${path.posix.sep}middleware.`)
+          filename.startsWith(`${path.posix.sep}middleware.`) ||
+          filename.includes(`${path.sep}__tests__${path.sep}`) ||
+          filename.includes(`${path.posix.sep}__tests__${path.posix.sep}`) ||
+          /\.(test|spec)\.(js|mjs|cjs|ts|mts|cts|jsx|tsx)$/.test(filename)
         ) {
           return
         }

--- a/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
+++ b/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
@@ -51,6 +51,26 @@ ruleTester.run('no-server-import-in-page', rule, {
     `,
       filename: 'middleware.page.tsx',
     },
+    {
+      code: `import "jest";
+      import { NextRequest } from "next/server";
+      
+      describe("example", () => {
+        it("should pass", () => {});
+      });
+      `,
+      filename: `${path.sep}__tests__${path.sep}test.ts`,
+    },
+    {
+      code: `import "jest";
+      import { NextRequest } from "next/server";
+      
+      describe("example", () => {
+        it("should pass", () => {});
+      });
+      `,
+      filename: 'test/example.spec.jsx',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
fixes #37309 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
