### PR TITLE
Migrate prerender lru cache into fs cache handler

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -353,8 +353,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     this.incrementalCache = new IncrementalCache({
       fs: this.getCacheFilesystem(),
       dev,
-      distDir: this.distDir,
-      pagesDir: join(this.serverDistDir, 'pages'),
+      serverDistDir: this.serverDistDir,
       maxMemoryCacheSize: this.nextConfig.experimental.isrMemoryCacheSize,
       flushToDisk: !minimalMode && this.nextConfig.experimental.isrFlushToDisk,
       getPrerenderManifest: () => {

--- a/packages/next/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/server/lib/incremental-cache/file-system-cache.ts
@@ -1,36 +1,83 @@
-import { CacheFs } from '../../../shared/lib/utils'
+import LRUCache from 'next/dist/compiled/lru-cache'
 import path from '../../../shared/lib/isomorphic/path'
-import type { CacheHandler, CacheHandlerContext } from './'
+import type { CacheHandler, CacheHandlerContext, CacheHandlerValue } from './'
 
 export default class FileSystemCache implements CacheHandler {
-  private flushToDisk?: boolean
-  private pagesDir: string
-  private fs: CacheFs
+  private fs: CacheHandlerContext['fs']
+  private flushToDisk?: CacheHandlerContext['flushToDisk']
+  private serverDistDir: CacheHandlerContext['serverDistDir']
+  private memoryCache?: LRUCache<string, CacheHandlerValue>
 
   constructor(ctx: CacheHandlerContext) {
-    this.flushToDisk = ctx.flushToDisk
-    this.pagesDir = ctx.pagesDir
     this.fs = ctx.fs
-  }
+    this.flushToDisk = ctx.flushToDisk
+    this.serverDistDir = ctx.serverDistDir
 
-  public async get(key: string) {
-    return this.fs.readFile(this.getSeedPath(key))
-  }
-  public async getMeta(key: string) {
-    const stat = await this.fs.stat(this.getSeedPath(key))
-    return {
-      mtime: stat.mtime.getTime(),
+    if (ctx.maxMemoryCacheSize) {
+      this.memoryCache = new LRUCache({
+        max: ctx.maxMemoryCacheSize,
+        length({ value }) {
+          if (!value) {
+            return 25
+          } else if (value.kind === 'REDIRECT') {
+            return JSON.stringify(value.props).length
+          } else if (value.kind === 'IMAGE') {
+            throw new Error('invariant image should not be incremental-cache')
+          }
+          // rough estimate of size of cache value
+          return value.html.length + JSON.stringify(value.pageData).length
+        },
+      })
     }
   }
 
-  public async set(key: string, data: string) {
-    if (!this.flushToDisk) return
-    const pathname = this.getSeedPath(key)
-    await this.fs.mkdir(path.dirname(pathname))
-    return this.fs.writeFile(pathname, data)
+  public async get(key: string) {
+    let data = this.memoryCache?.get(key)
+
+    // let's check the disk for seed data
+    if (!data) {
+      try {
+        const htmlPath = this.getFsPath(`${key}.html`)
+        const html = await this.fs.readFile(htmlPath)
+        const pageData = JSON.parse(
+          await this.fs.readFile(this.getFsPath(`${key}.json`))
+        )
+        const { mtime } = await this.fs.stat(htmlPath)
+
+        data = {
+          lastModified: mtime.getTime(),
+          value: {
+            kind: 'PAGE',
+            html,
+            pageData,
+          },
+        }
+        this.memoryCache?.set(key, data)
+      } catch (_) {
+        // unable to get data from disk
+      }
+    }
+    return data || null
   }
 
-  private getSeedPath(pathname: string): string {
-    return path.join(this.pagesDir, pathname)
+  public async set(key: string, data: CacheHandlerValue['value']) {
+    if (!this.flushToDisk) return
+
+    this.memoryCache?.set(key, {
+      value: data,
+      lastModified: Date.now(),
+    })
+
+    if (data?.kind === 'PAGE') {
+      await this.fs.writeFile(this.getFsPath(`${key}.html`), data.html)
+      await this.fs.writeFile(
+        this.getFsPath(`${key}.json`),
+        JSON.stringify(data.pageData)
+      )
+    }
+  }
+
+  private getFsPath(pathname: string): string {
+    return path.join(this.serverDistDir, 'pages', pathname)
   }
 }

--- a/packages/next/server/lib/incremental-cache/index.ts
+++ b/packages/next/server/lib/incremental-cache/index.ts
@@ -1,8 +1,6 @@
 import type { CacheFs } from '../../../shared/lib/utils'
 
 import FileSystemCache from './file-system-cache'
-import LRUCache from 'next/dist/compiled/lru-cache'
-import path from '../../../shared/lib/isomorphic/path'
 import { PrerenderManifest } from '../../../build'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
 import {
@@ -15,49 +13,49 @@ function toRoute(pathname: string): string {
 }
 
 export interface CacheHandlerContext {
-  flushToDisk?: boolean
-  pagesDir: string
-  distDir: string
-  dev?: boolean
   fs: CacheFs
+  dev?: boolean
+  flushToDisk?: boolean
+  serverDistDir: string
+  maxMemoryCacheSize?: number
+}
+
+export interface CacheHandlerValue {
+  lastModified?: number
+  value: IncrementalCacheValue | null
 }
 
 export class CacheHandler {
   // eslint-disable-next-line
   constructor(_ctx: CacheHandlerContext) {}
 
-  public async get(_key: string): Promise<string> {
-    return ''
-  }
-  public async getMeta(_key: string): Promise<{
-    // time in epoch e.g. Date.now()
-    mtime: number
-  }> {
+  public async get(_key: string): Promise<CacheHandlerValue | null> {
     return {} as any
   }
-  public async set(_key: string, _data: string): Promise<void> {}
+
+  public async set(
+    _key: string,
+    _data: IncrementalCacheValue | null
+  ): Promise<void> {}
 }
 
 export class IncrementalCache {
-  prerenderManifest: PrerenderManifest
-  cache?: LRUCache<string, IncrementalCacheEntry>
   dev?: boolean
   cacheHandler: CacheHandler
+  prerenderManifest: PrerenderManifest
 
   constructor({
     fs,
     dev,
-    distDir,
-    pagesDir,
     flushToDisk,
+    serverDistDir,
     maxMemoryCacheSize,
     getPrerenderManifest,
     incrementalCacheHandlerPath,
   }: {
     fs: CacheFs
     dev: boolean
-    distDir: string
-    pagesDir: string
+    serverDistDir: string
     flushToDisk?: boolean
     maxMemoryCacheSize?: number
     incrementalCacheHandlerPath?: string
@@ -69,38 +67,20 @@ export class IncrementalCache {
       cacheHandlerMod = require(incrementalCacheHandlerPath)
       cacheHandlerMod = cacheHandlerMod.default || cacheHandlerMod
     }
-    this.cacheHandler = new (cacheHandlerMod as typeof CacheHandler)({
-      dev,
-      distDir,
-      fs,
-      pagesDir,
-      flushToDisk,
-    })
-
-    this.dev = dev
-    this.prerenderManifest = getPrerenderManifest()
 
     if (process.env.__NEXT_TEST_MAX_ISR_CACHE) {
       // Allow cache size to be overridden for testing purposes
       maxMemoryCacheSize = parseInt(process.env.__NEXT_TEST_MAX_ISR_CACHE, 10)
     }
-
-    if (maxMemoryCacheSize) {
-      this.cache = new LRUCache({
-        max: maxMemoryCacheSize,
-        length({ value }) {
-          if (!value) {
-            return 25
-          } else if (value.kind === 'REDIRECT') {
-            return JSON.stringify(value.props).length
-          } else if (value.kind === 'IMAGE') {
-            throw new Error('invariant image should not be incremental-cache')
-          }
-          // rough estimate of size of cache value
-          return value.html.length + JSON.stringify(value.pageData).length
-        },
-      })
-    }
+    this.dev = dev
+    this.prerenderManifest = getPrerenderManifest()
+    this.cacheHandler = new (cacheHandlerMod as typeof CacheHandler)({
+      dev,
+      fs,
+      flushToDisk,
+      serverDistDir,
+      maxMemoryCacheSize,
+    })
   }
 
   private calculateRevalidate(
@@ -126,108 +106,55 @@ export class IncrementalCache {
     return revalidateAfter
   }
 
+  _getPathname(pathname: string) {
+    return normalizePagePath(pathname)
+  }
+
   // get data from cache if available
   async get(pathname: string): Promise<IncrementalCacheEntry | null> {
     if (this.dev) return null
-    pathname = normalizePagePath(pathname)
+    pathname = this._getPathname(pathname)
+    const cacheData = await this.cacheHandler.get(pathname)
 
-    let data = this.cache && this.cache.get(pathname)
-
-    // let's check the disk for seed data
-    if (!data) {
-      if (this.prerenderManifest.notFoundRoutes.includes(pathname)) {
-        const now = Date.now()
-        const revalidateAfter = this.calculateRevalidate(pathname, now)
-        data = {
-          value: null,
-          revalidateAfter: revalidateAfter !== false ? now : false,
-        }
+    if (cacheData) {
+      const revalidateAfter = this.calculateRevalidate(
+        pathname,
+        cacheData.lastModified || Date.now()
+      )
+      return {
+        revalidateAfter,
+        value: cacheData.value,
+        isStale:
+          revalidateAfter !== false && revalidateAfter < Date.now()
+            ? true
+            : undefined,
+        curRevalidate:
+          this.prerenderManifest.routes[toRoute(pathname)]
+            ?.initialRevalidateSeconds,
       }
-
-      try {
-        const htmlPath = `${pathname}.html`
-        const html = await this.cacheHandler.get(htmlPath)
-        const pageData = JSON.parse(
-          await this.cacheHandler.get(`${pathname}.json`)
-        )
-        const { mtime } = await this.cacheHandler.getMeta(htmlPath)
-
-        data = {
-          revalidateAfter: this.calculateRevalidate(pathname, mtime),
-          value: {
-            kind: 'PAGE',
-            html,
-            pageData,
-          },
-        }
-        if (this.cache) {
-          this.cache.set(pathname, data)
-        }
-      } catch (_) {
-        // unable to get data from disk
-      }
-    }
-    if (!data) {
-      return null
     }
 
     if (
-      data &&
-      data.revalidateAfter !== false &&
-      data.revalidateAfter < new Date().getTime()
+      !cacheData &&
+      this.prerenderManifest.notFoundRoutes.includes(pathname)
     ) {
-      data.isStale = true
+      return {
+        value: null,
+        revalidateAfter: this.calculateRevalidate(pathname, Date.now()),
+      }
     }
-
-    const manifestPath = toRoute(pathname)
-    const manifestEntry = this.prerenderManifest.routes[manifestPath]
-
-    if (data && manifestEntry) {
-      data.curRevalidate = manifestEntry.initialRevalidateSeconds
-    }
-    return data
+    return null
   }
 
   // populate the incremental cache with new data
-  async set(
-    pathname: string,
-    data: IncrementalCacheValue | null,
-    revalidateSeconds?: number | false
-  ) {
+  async set(pathname: string, data: IncrementalCacheValue | null) {
     if (this.dev) return
-    if (typeof revalidateSeconds !== 'undefined') {
-      this.prerenderManifest.routes[pathname] = {
-        dataRoute: path.posix.join(
-          '/_next/data',
-          `${normalizePagePath(pathname)}.json`
-        ),
-        srcRoute: null, // FIXME: provide actual source route, however, when dynamically appending it doesn't really matter
-        initialRevalidateSeconds: revalidateSeconds,
-      }
-    }
+    pathname = this._getPathname(pathname)
 
-    pathname = normalizePagePath(pathname)
-    if (this.cache) {
-      this.cache.set(pathname, {
-        revalidateAfter: this.calculateRevalidate(
-          pathname,
-          new Date().getTime()
-        ),
-        value: data,
-      })
-    }
-
-    if (data?.kind === 'PAGE') {
-      try {
-        await this.cacheHandler.set(`${pathname}.html`, data.html)
-        await this.cacheHandler.set(
-          `${pathname}.json`,
-          JSON.stringify(data.pageData)
-        )
-      } catch (error) {
-        // failed to set to cache handler
-        console.warn('Failed to update prerender files for', pathname, error)
-      }
+    try {
+      await this.cacheHandler.set(pathname, data)
+    } catch (error) {
+      console.warn('Failed to update prerender cache for', pathname, error)
     }
   }
 }


### PR DESCRIPTION
Continuation of https://github.com/vercel/next.js/pull/37258 this moves the LRU cache to the `file-system-cache` so that any different cache handlers don't need to disable the LRU cache as this may cause inconsistencies with some cache handlers that need to be the source of truth.  

