### PR TITLE
Update install native script

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -28,7 +28,7 @@ import fs from 'fs-extra'
           )
         ).version === nextVersion
       ) {
-        console.log(`@next/${pkg}@${nextVersion} already installed skipping`);
+        console.log(`@next/${pkg}@${nextVersion} already installed skipping`)
         return
       }
     }

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -9,11 +9,33 @@ import fs from 'fs-extra'
     )
     return
   }
+  let cwd = process.cwd()
+  const { version: nextVersion } = await fs.readJSON(
+    path.join(cwd, 'packages', 'next', 'package.json')
+  )
+
+  try {
+    // if installed swc package version matches monorepo version
+    // we can skip re-installing
+    for (const pkg of await fs.readdir(
+      path.join(cwd, 'node_modules', '@next')
+    )) {
+      if (
+        (
+          await fs.readJSON(
+            path.join(cwd, 'node_modules', '@next', pkg, 'package.json')
+          )
+        ).version === nextVersion
+      ) {
+        console.log(`@next/${pkg}@${nextVersion} already installed skipping`);
+        return
+      }
+    }
+  } catch (_) {}
 
   try {
     let tmpdir = path.join(os.tmpdir(), `next-swc-${Date.now()}`)
     await fs.ensureDir(tmpdir)
-    let cwd = process.cwd()
     let pkgJson = {
       name: 'dummy-package',
       version: '1.0.0',

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -21,6 +21,7 @@ import fs from 'fs-extra'
       path.join(cwd, 'node_modules', '@next')
     )) {
       if (
+        pkg.startsWith('swc-') &&
         (
           await fs.readJSON(
             path.join(cwd, 'node_modules', '@next', pkg, 'package.json')


### PR DESCRIPTION
This optimizes the `install-native` monorepo `postinstall` script a bit as it currently installs the swc binary after every install but it may already be present for the current version and can be skipped in that case. 