### PR TITLE
fix: support @import url in css with experimental.urlImports

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/loaders/file-resolve.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/file-resolve.ts
@@ -1,12 +1,8 @@
-export function cssFileResolve(
-  url: string,
-  _resourcePath: string,
-  urlImports: any
-) {
+export function cssFileResolve(url: string, _resourcePath: string) {
   if (url.startsWith('/')) {
     return false
   }
-  if (!urlImports && /^[a-z][a-z0-9+.-]*:/i.test(url)) {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) {
     return false
   }
   return true

--- a/packages/next/build/webpack/config/blocks/css/loaders/global.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/global.ts
@@ -31,9 +31,9 @@ export function getGlobalCssLoader(
       // Next.js controls CSS Modules eligibility:
       modules: false,
       url: (url: string, resourcePath: string) =>
-        cssFileResolve(url, resourcePath, ctx.experimental.urlImports),
+        cssFileResolve(url, resourcePath),
       import: (url: string, _: any, resourcePath: string) =>
-        cssFileResolve(url, resourcePath, ctx.experimental.urlImports),
+        cssFileResolve(url, resourcePath),
     },
   })
 

--- a/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
+++ b/packages/next/build/webpack/config/blocks/css/loaders/modules.ts
@@ -31,9 +31,9 @@ export function getCssModuleLoader(
       // Use CJS mode for backwards compatibility:
       esModule: false,
       url: (url: string, resourcePath: string) =>
-        cssFileResolve(url, resourcePath, ctx.experimental.urlImports),
+        cssFileResolve(url, resourcePath),
       import: (url: string, _: any, resourcePath: string) =>
-        cssFileResolve(url, resourcePath, ctx.experimental.urlImports),
+        cssFileResolve(url, resourcePath),
       modules: {
         // Do not transform class names (CJS mode backwards compatibility):
         exportLocalsConvention: 'asIs',

--- a/test/integration/url-imports/next.config.js
+++ b/test/integration/url-imports/next.config.js
@@ -2,6 +2,7 @@ module.exports = {
   experimental: {
     urlImports: [
       'http://localhost:12345/',
+      'https://cdn.jsdelivr.net',
       'https://github.com/vercel/next.js/raw/canary/',
     ],
   },

--- a/test/integration/url-imports/pages/_app.jsx
+++ b/test/integration/url-imports/pages/_app.jsx
@@ -1,0 +1,11 @@
+import '../styles/globals.css'
+
+function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <Component {...pageProps} />
+    </>
+  )
+}
+
+export default MyApp

--- a/test/integration/url-imports/styles/globals.css
+++ b/test/integration/url-imports/styles/globals.css
@@ -1,0 +1,17 @@
+@import url('https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css');
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/test/integration/url-imports/test/index.test.js
+++ b/test/integration/url-imports/test/index.test.js
@@ -102,8 +102,39 @@ describe(`Handle url imports`, () => {
               browser
                 .elementByCss('#static-css')
                 .getComputedCss('background-image'),
-            /^url\("http:\/\/localhost:\d+\/_next\/static\/media\/vercel\.[0-9a-f]{8}\.png"\)$/
+            `url("https://github.com/vercel/next.js/raw/canary/test/integration/url/public/vercel.png")`
           )
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it(`should support @import url in css`, async () => {
+        let browser
+        try {
+          browser = await webdriver(appPort, '/css')
+
+          let hasBootstrapCss = false
+
+          if (dev) {
+            hasBootstrapCss = await browser.eval(() => {
+              const styles = document.querySelectorAll('style')
+              return Boolean(
+                [...styles].find((style) =>
+                  style.innerHTML?.includes(
+                    `@import url('https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css')`
+                  )
+                )
+              )
+            })
+          } else {
+            hasBootstrapCss = await browser.eval(() => {
+              const style = getComputedStyle(document.body)
+              return style.getPropertyValue('--primary') === '#007bff'
+            })
+          }
+
+          expect(hasBootstrapCss).toBe(true)
         } finally {
           await browser.close()
         }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
fixes #37327 

Just move absolute urls in @import directly into the runtime code like `css-loader` does.

Currently, importing css directly in js like the following will still report an error:

```
import 'https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css'
```
> Using webpack + css-loader + style-loader directly will also have this problem.

I'm not quite sure if this usage is going to be supported, and if it is. We might need to change the [stringifyRequest](https://github.com/webpack-contrib/style-loader/blob/master/src/utils.js#L16) method in the `style-loader` and `css-loader`, so that their runtime files are resolved correctly, I tried to fix the error, but without success.



## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
