### PR TITLE
Eagerly import the dev server from the CLI bin

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -11,6 +11,10 @@ import { getProjectDir } from '../lib/get-project-dir'
 import { CONFIG_FILES } from '../shared/lib/constants'
 import path from 'path'
 
+// Eagerly import the dev server here earlier, so it will be statically optimizable.
+// This makes bootup time faster.
+import '../server/dev/next-dev-server'
+
 const nextDev: cliCommand = (argv) => {
   const validArgs: arg.Spec = {
     // Types


### PR DESCRIPTION
Currently we are asynchronously and dynamically `require` the actual dev server module:

https://github.com/vercel/next.js/blob/f354f46b3fb37349122ab82c6aad3a5fb39ef5a2/packages/next/server/next.ts#L118-L120

However it is always needed by the dev server CLI. So here we can eagerly import the module initially, to give node and v8 more opportunities to analyze and optimize it. Here’s the comparison of the time spent between hitting enter and finishing the initial compilation, before/after:

![CleanShot 2022-06-02 at 18 09 11@2x](https://user-images.githubusercontent.com/3676859/171679878-13940396-8ddd-4bb5-a1de-34a3d239323d.png)

![CleanShot 2022-06-02 at 18 09 46@2x](https://user-images.githubusercontent.com/3676859/171679913-450a9c8b-f662-437d-856b-8adfcca69499.png)

Where we can see a ~40% improvement here.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
