### PR TITLE
Fix document head with react 18

### DIFF
--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -1455,6 +1455,7 @@ export async function renderToHTML(
       let styles
       if (hasDocumentGetInitialProps) {
         styles = docProps.styles
+        head = docProps.head
       } else {
         styles = jsxStyleRegistry.styles()
         jsxStyleRegistry.flush()

--- a/test/e2e/next-head/app/pages/_document.js
+++ b/test/e2e/next-head/app/pages/_document.js
@@ -19,7 +19,7 @@ MyDocument.getInitialProps = async (context) => {
     ...initialProps,
     head: [
       ...(initialProps?.head ?? []),
-      <meta name="test-head-initial-props" content="hello" />
-    ]
+      <meta name="test-head-initial-props" content="hello" />,
+    ],
   }
 }

--- a/test/e2e/next-head/app/pages/_document.js
+++ b/test/e2e/next-head/app/pages/_document.js
@@ -1,4 +1,4 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
 
 export default function MyDocument() {
   return (
@@ -10,4 +10,16 @@ export default function MyDocument() {
       </body>
     </Html>
   )
+}
+
+MyDocument.getInitialProps = async (context) => {
+  const initialProps = await Document.getInitialProps(context)
+
+  return {
+    ...initialProps,
+    head: [
+      ...(initialProps?.head ?? []),
+      <meta name="test-head-initial-props" content="hello" />
+    ]
+  }
 }

--- a/test/e2e/next-head/index.test.ts
+++ b/test/e2e/next-head/index.test.ts
@@ -15,8 +15,8 @@ describe('should set-up next', () => {
         components: new FileRef(join(__dirname, 'app/components')),
       },
       dependencies: {
-        react: '17',
-        'react-dom': '17',
+        react: '18',
+        'react-dom': '18',
       },
     })
   })
@@ -61,5 +61,12 @@ describe('should set-up next', () => {
           .getAttribute('content')
       ).toBe('hello')
     }
+  })
+
+  it('should have current head tags from a _document getInitialProps', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    const $ = cheerio.load(html)
+
+    expect($(`meta[name="test-head-initial-props"]`).attr()['content']).toBe('hello')
   })
 })

--- a/test/e2e/next-head/index.test.ts
+++ b/test/e2e/next-head/index.test.ts
@@ -14,10 +14,6 @@ describe('should set-up next', () => {
         pages: new FileRef(join(__dirname, 'app/pages')),
         components: new FileRef(join(__dirname, 'app/components')),
       },
-      dependencies: {
-        react: '18',
-        'react-dom': '18',
-      },
     })
   })
   afterAll(() => next.destroy())

--- a/test/e2e/next-head/index.test.ts
+++ b/test/e2e/next-head/index.test.ts
@@ -67,6 +67,8 @@ describe('should set-up next', () => {
     const html = await renderViaHTTP(next.url, '/')
     const $ = cheerio.load(html)
 
-    expect($(`meta[name="test-head-initial-props"]`).attr()['content']).toBe('hello')
+    expect($(`meta[name="test-head-initial-props"]`).attr()['content']).toBe(
+      'hello'
+    )
   })
 })


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Fix custom head on getInitialProps works with React 18

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`