### PR TITLE
add jest-environment-jsdom to dependencies

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -266,7 +266,7 @@ Since the release of [Next.js 12](https://nextjs.org/blog/next-12), Next.js now 
 To set up Jest, install `jest`, `jest-environment-jsdom`, `@testing-library/react`, `@testing-library/jest-dom`:
 
 ```bash
-npm install --save-dev jest jest-environment-jsdom @testing-library/react @testing-library/jest-dom
+npm install --save-dev jest jest-environment-jsdom @testing-library/react @testing-library/jest-dom jest-environment-jsdom
 ```
 
 Create a `jest.config.js` file in your project's root directory and add the following:


### PR DESCRIPTION
As of Jest 28 "jest-environment-jsdom" is no longer shipped by default, make sure to install it separately.

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
