### PR TITLE
docs: Replace debugWithChrome action with openExternally since "Debugger for Chrome" is deprecated

### DIFF
--- a/docs/advanced-features/debugging.md
+++ b/docs/advanced-features/debugging.md
@@ -37,7 +37,7 @@ Create a file named `.vscode/launch.json` at the root of your project with the f
       "serverReadyAction": {
         "pattern": "started server on .+, url: (https?://.+)",
         "uriFormat": "%s",
-        "action": "debugWithChrome"
+        "action": "openExternally"
       }
     }
   ]


### PR DESCRIPTION
The action `debugWithChrome` requires the [deprecated](https://code.visualstudio.com/docs/editor/debugging#_automatically-open-a-uri-when-debugging-a-server-program) "Debugger for Chrome" extension. This PR replaces it with `openExternally` which relies on built-in debugger.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
