### PR TITLE
Add docs about NEXT_DATA hydration 

### DIFF
--- a/docs/basic-features/data-fetching/get-static-props.md
+++ b/docs/basic-features/data-fetching/get-static-props.md
@@ -14,6 +14,10 @@ export async function getStaticProps(context) {
 }
 ```
 
+<div class="card">
+   Note that any props that are passed to the page component can be viewed on the client-side. Make sure that you don't pass any sensitive information like `auth-keys`.
+</div>
+
 ## When should I use getStaticProps?
 
 You should use `getStaticProps` if:


### PR DESCRIPTION
Missing documentation around `NEXT_DATA` hydration when using `getServerSideProps()`. This PR warn users that the result of getServerSideProps() / getStaticProps is also available on the client-side due to React Hydration so they should not use any sensitive information in the props.



## Bug

- [x] Related issues linked using [fixes number](https://github.com/vercel/documentation/issues/418)
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
