### PR TITLE
Ensure ENOENT error is not ignored when loading pages

### DIFF
--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -9,12 +9,12 @@ import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { ensureLeadingSlash } from '../../shared/lib/page-path/ensure-leading-slash'
 import { removePagePathTail } from '../../shared/lib/page-path/remove-page-path-tail'
-import { pageNotFoundError } from '../require'
 import { reportTrigger } from '../../build/output'
 import getRouteFromEntrypoint from '../get-route-from-entrypoint'
 import { serverComponentRegex } from '../../build/webpack/loaders/utils'
 import { MIDDLEWARE_FILE, MIDDLEWARE_FILENAME } from '../../lib/constants'
 import { getPageStaticInfo } from '../../build/analysis/get-page-static-info'
+import { PageNotFoundError } from '../../shared/lib/utils'
 
 export const ADDED = Symbol('added')
 export const BUILDING = Symbol('building')
@@ -375,7 +375,7 @@ async function findPagePathData(
     pagePath = await findPageFile(rootDir, normalizedPagePath, extensions)
 
     if (!pagePath) {
-      throw pageNotFoundError(normalizedPagePath)
+      throw new PageNotFoundError(normalizedPagePath)
     }
 
     const pageUrl = ensureLeadingSlash(
@@ -435,7 +435,7 @@ async function findPagePathData(
       page: normalizePathSep(page),
     }
   } else {
-    throw pageNotFoundError(normalizedPagePath)
+    throw new PageNotFoundError(normalizedPagePath)
   }
 }
 
@@ -444,6 +444,6 @@ function tryToNormalizePagePath(page: string) {
     return normalizePagePath(page)
   } catch (err) {
     console.error(err)
-    throw pageNotFoundError(page)
+    throw new PageNotFoundError(page)
   }
 }

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -2,7 +2,12 @@ import './node-polyfill-fetch'
 import './node-polyfill-web-streams'
 
 import type { Route } from './router'
-import { CacheFs, DecodeError, execOnce } from '../shared/lib/utils'
+import {
+  CacheFs,
+  DecodeError,
+  execOnce,
+  PageNotFoundError,
+} from '../shared/lib/utils'
 import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'
 import type RenderResult from './render-result'
 import type { FetchEventResult } from './web/types'
@@ -58,7 +63,7 @@ import BaseServer, {
   stringifyQuery,
   RoutingItem,
 } from './base-server'
-import { getPagePath, requireFontManifest, pageNotFoundError } from './require'
+import { getPagePath, requireFontManifest } from './require'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { loadComponents } from './load-components'
@@ -706,9 +711,9 @@ export default class NextNodeServer extends BaseServer {
           },
         }
       } catch (err) {
-        // we should only not throw if the error is a ENOENT
-        // when attempting to find the page path
-        if (isError(err) && !(err.code === 'ENOENT' && 'page' in err)) {
+        // we should only not throw if we failed to find the page
+        // in the pages-manifest
+        if (isError(err) && !(err instanceof PageNotFoundError)) {
           throw err
         }
       }
@@ -1046,12 +1051,12 @@ export default class NextNodeServer extends BaseServer {
     try {
       foundPage = denormalizePagePath(normalizePagePath(page))
     } catch (err) {
-      throw pageNotFoundError(page)
+      throw new PageNotFoundError(page)
     }
 
     let pageInfo = manifest.middleware[foundPage]
     if (!pageInfo) {
-      throw pageNotFoundError(foundPage)
+      throw new PageNotFoundError(foundPage)
     }
 
     return {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -706,7 +706,11 @@ export default class NextNodeServer extends BaseServer {
           },
         }
       } catch (err) {
-        if (isError(err) && err.code !== 'ENOENT') throw err
+        // we should only not throw if the error is a ENOENT
+        // when attempting to find the page path
+        if (isError(err) && !(err.code === 'ENOENT' && 'page' in err)) {
+          throw err
+        }
       }
     }
     return null

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -713,7 +713,7 @@ export default class NextNodeServer extends BaseServer {
       } catch (err) {
         // we should only not throw if we failed to find the page
         // in the pages-manifest
-        if (isError(err) && !(err instanceof PageNotFoundError)) {
+        if (!(err instanceof PageNotFoundError)) {
           throw err
         }
       }

--- a/packages/next/server/require.ts
+++ b/packages/next/server/require.ts
@@ -11,13 +11,7 @@ import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
-
-export function pageNotFoundError(page: string): Error {
-  const err: any = new Error(`Cannot find module for page: ${page}`)
-  err.code = 'ENOENT'
-  err.page = page
-  return err
-}
+import { PageNotFoundError } from '../shared/lib/utils'
 
 export function getPagePath(
   page: string,
@@ -48,7 +42,7 @@ export function getPagePath(
     page = denormalizePagePath(normalizePagePath(page))
   } catch (err) {
     console.error(err)
-    throw pageNotFoundError(page)
+    throw new PageNotFoundError(page)
   }
 
   const checkManifest = (manifest: PagesManifest) => {
@@ -76,7 +70,7 @@ export function getPagePath(
   }
 
   if (!pagePath) {
-    throw pageNotFoundError(page)
+    throw new PageNotFoundError(page)
   }
   return join(serverBuildPath, pagePath)
 }

--- a/packages/next/server/require.ts
+++ b/packages/next/server/require.ts
@@ -15,6 +15,7 @@ import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plug
 export function pageNotFoundError(page: string): Error {
   const err: any = new Error(`Cannot find module for page: ${page}`)
   err.code = 'ENOENT'
+  err.page = page
   return err
 }
 

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -403,6 +403,15 @@ export const ST =
 
 export class DecodeError extends Error {}
 export class NormalizeError extends Error {}
+export class PageNotFoundError extends Error {
+  code: string
+
+  constructor(page: string) {
+    super()
+    this.code = 'ENOENT'
+    this.message = `Cannot find module for page: ${page}`
+  }
+}
 
 export interface CacheFs {
   readFile(f: string): Promise<string>

--- a/test/integration/non-standard-node-env-warning/test/index.test.js
+++ b/test/integration/non-standard-node-env-warning/test/index.test.js
@@ -97,7 +97,7 @@ describe('Non-Standard NODE_ENV', () => {
         join(appDir, '.next/static', file),
         'utf8'
       )
-      if (content.match(/cannot find module/i)) {
+      if (content.match(/cannot find module(?! for page)/i)) {
         throw new Error(`${file} contains module not found error`)
       }
     }

--- a/test/production/enoent-during-require/index.test.ts
+++ b/test/production/enoent-during-require/index.test.ts
@@ -1,0 +1,55 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { check, renderViaHTTP } from 'next-test-utils'
+
+describe('ENOENT during require', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/_app.js': `
+          import App from 'next/app'
+          
+          if (typeof window === 'undefined') {
+            if (process.env.NEXT_PHASE !== 'phase-production-build') {
+              require('fs').readdirSync('non-existent-folder')
+            }
+          }
+          export default App
+        `,
+        'pages/index.js': `
+          export function getStaticProps() {
+            console.log('revalidate /')
+            
+            return {
+              props: {
+                now: Date.now()
+              },
+              revalidate: 1
+            }
+          }
+          
+          export default function Page() { 
+            return <p>hello world</p>
+          } 
+        `,
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should show ENOENT error correctly', async () => {
+    await check(async () => {
+      await renderViaHTTP(next.url, '/')
+      console.error(next.cliOutput)
+
+      return next.cliOutput.includes('non-existent-folder')
+        ? 'success'
+        : next.cliOutput
+    }, 'success')
+
+    expect(next.cliOutput).not.toContain('Cannot destructure property')
+  })
+})

--- a/test/unit/isolated/require-page.test.ts
+++ b/test/unit/isolated/require-page.test.ts
@@ -3,11 +3,8 @@
 import { join } from 'path'
 import { SERVER_DIRECTORY, CLIENT_STATIC_FILES_PATH } from 'next/constants'
 import { normalizePagePath } from 'next/dist/shared/lib/page-path/normalize-page-path'
-import {
-  requirePage,
-  getPagePath,
-  pageNotFoundError,
-} from 'next/dist/server/require'
+import { requirePage, getPagePath } from 'next/dist/server/require'
+import { PageNotFoundError } from 'next/dist/shared/lib/utils'
 
 const sep = '/'
 const distDir = join(__dirname, '_resolvedata')
@@ -23,7 +20,7 @@ describe('pageNotFoundError', () => {
   it('Should throw error with ENOENT code', () => {
     expect.assertions(1)
     try {
-      throw pageNotFoundError('test')
+      throw new PageNotFoundError('test')
     } catch (err) {
       // eslint-disable-next-line jest/no-try-expect
       expect(err.code).toBe('ENOENT')


### PR DESCRIPTION
This ensures we don't hide original `ENOENT` errors when they occur while requiring a page as we should only hide these when a 404 is occurring and the page lookup in the pages-manifest fails. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

