### PR TITLE
feat: add linkTypes to next/link

### DIFF
--- a/packages/next/link.d.ts
+++ b/packages/next/link.d.ts
@@ -1,3 +1,4 @@
 import Link from './dist/client/link'
+export { LinkType } from './dist/shared/lib/router/router'
 export * from './dist/client/link'
 export default Link

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type {
+  LinkType,
   NextRouter,
   PrefetchOptions as RouterPrefetchOptions,
 } from '../shared/lib/router/router'
@@ -84,6 +85,11 @@ type InternalLinkProps = {
    * @see https://github.com/vercel/next.js/commit/489e65ed98544e69b0afd7e0cfc3f9f6c2b803b7
    */
   legacyBehavior?: boolean
+  /**
+   * Whitelist of locations this Link can navigate to. Avoid the use of Absolute and SchemeRelative to prevent open-redirects.
+   * @defaultValue `[LinkType.Absolute, LinkType.DomainRelative, LinkType.PageRelative, LinkType.Query, LinkType.Fragment]`
+   */
+  linkTypes?: LinkType[]
   /**
    * Optional event handler for when the mouse pointer is moved onto Link
    */
@@ -301,6 +307,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
         onMouseEnter: true,
         onTouchStart: true,
         legacyBehavior: true,
+        linkTypes: true,
       } as const
       const optionalProps: LinkPropsOptional[] = Object.keys(
         optionalPropsGuard
@@ -351,6 +358,14 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
               actual: valType,
             })
           }
+        } else if (key === 'linkTypes') {
+          if (props[key] != null && valType !== 'object') {
+            throw createPropError({
+              key,
+              expected: '`object`',
+              actual: valType,
+            })
+          }
         } else {
           // TypeScript trick for type-guarding:
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -386,6 +401,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       onTouchStart: onTouchStartProp,
       // @ts-expect-error this is inlined as a literal boolean not a string
       legacyBehavior = process.env.__NEXT_NEW_LINK_BEHAVIOR === false,
+      linkTypes,
       ...restProps
     } = props
 
@@ -445,7 +461,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       const [resolvedHref, resolvedAs] = resolveHref(
         pagesRouter,
         hrefProp,
-        true
+        true,
+        linkTypes
       )
 
       return {
@@ -454,7 +471,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
           ? resolveHref(pagesRouter, asProp)
           : resolvedAs || resolvedHref,
       }
-    }, [pagesRouter, hrefProp, asProp])
+    }, [pagesRouter, hrefProp, asProp, linkTypes])
 
     const previousHref = React.useRef<string>(href)
     const previousAs = React.useRef<string>(as)

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -669,6 +669,16 @@ const getCancelledHandler = ({
   return handleCancelled
 }
 
+/** A type of URL that an href can be. */
+export enum LinkType {
+  Absolute,
+  SchemeRelative,
+  DomainRelative,
+  PageRelative,
+  Query,
+  Fragment,
+}
+
 export default class Router implements BaseRouter {
   basePath: string
 

--- a/packages/next/src/shared/lib/router/utils/is-local-url.ts
+++ b/packages/next/src/shared/lib/router/utils/is-local-url.ts
@@ -1,14 +1,21 @@
-import { isAbsoluteUrl, getLocationOrigin } from '../../utils'
+import { getLocationOrigin, getLinkType } from '../../utils'
 import { hasBasePath } from '../../../../client/has-base-path'
+import { LinkType } from '../router'
 
 /**
  * Detects whether a given url is routable by the Next.js router (browser only).
  */
-export function isLocalURL(url: string): boolean {
+export function isLocalURL(
+  url: string,
+  linkType: LinkType = getLinkType(url)
+): boolean {
   // prevent a hydration mismatch on href for url with anchor refs
-  if (!isAbsoluteUrl(url)) return true
+  if (linkType !== LinkType.Absolute && linkType !== LinkType.SchemeRelative) {
+    return true
+  }
+
   try {
-    // absolute urls can be local if they are on the same origin
+    // absolute and scheme-relative urls can be local if they are on the same origin
     const locationOrigin = getLocationOrigin()
     const resolved = new URL(url, locationOrigin)
     return resolved.origin === locationOrigin && hasBasePath(resolved.pathname)

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -3,7 +3,7 @@ import type { ComponentType } from 'react'
 import type { DomainLocale } from '../../server/config'
 import type { Env } from '@next/env'
 import type { IncomingMessage, ServerResponse } from 'http'
-import type { NextRouter } from './router/router'
+import { LinkType, NextRouter } from './router/router'
 import type { ParsedUrlQuery } from 'querystring'
 import type { PreviewData } from 'next/types'
 import { COMPILER_NAMES } from './constants'
@@ -307,6 +307,16 @@ export function execOnce<T extends (...args: any[]) => ReturnType<T>>(
 // Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
 const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/
 export const isAbsoluteUrl = (url: string) => ABSOLUTE_URL_REGEX.test(url)
+
+export function getLinkType(url: string): LinkType {
+  if (url.startsWith('#')) return LinkType.Fragment
+  if (url.startsWith('?')) return LinkType.Query
+  if (url.startsWith('//')) return LinkType.SchemeRelative
+  if (/^\/(?!\/)/.test(url)) return LinkType.DomainRelative
+  if (isAbsoluteUrl(url)) return LinkType.Absolute
+
+  return LinkType.PageRelative
+}
 
 export function getLocationOrigin() {
   const { protocol, hostname, port } = window.location

--- a/test/integration/repeated-slashes/app/pages/invalid.js
+++ b/test/integration/repeated-slashes/app/pages/invalid.js
@@ -14,43 +14,47 @@ export default function Invalid() {
   return (
     <>
       <p id="invalid">invalid page</p>
-      <Link href="/another" as="//google.com" id="page-with-as-slashes">
-        to /another as //google.com
+      <Link href="/another" as="/vercel//next.js" id="page-with-as-slashes">
+        to /another as /vercel//next.js
       </Link>
       <br />
 
-      <Link href="//google.com" id="href-with-slashes">
-        to //google.com
+      <Link href="/vercel//next.js" id="href-with-slashes">
+        to /vercel//next.js
       </Link>
       <br />
 
-      <Link href="//google.com?hello=1" id="href-with-slashes-query">
-        to //google.com?hello=1
+      <Link href="/vercel//next.js?hello=1" id="href-with-slashes-query">
+        to /vercel//next.js?hello=1
       </Link>
       <br />
 
-      <Link href="//google.com#hello" id="href-with-slashes-hash">
-        to //google.com#hello
+      <Link href="/vercel//next.js#hello" id="href-with-slashes-hash">
+        to /vercel//next.js#hello
       </Link>
       <br />
 
-      <Link href="/another" as="\/\/google.com" id="page-with-as-backslashes">
-        to /another as \\/\\/google.com
+      <Link
+        href="/another"
+        as="\/vercel\/\/next.js"
+        id="page-with-as-backslashes"
+      >
+        to /another as \\/vercel\\/\\/next.js
       </Link>
       <br />
 
-      <Link href="\/\/google.com" id="href-with-backslashes">
-        to \\/\\/google.com
+      <Link href="\/vercel\/\/next.js" id="href-with-backslashes">
+        to \\/vercel\\/\\/next.js
       </Link>
       <br />
 
-      <Link href="\/\/google.com?hello=1" id="href-with-backslashes-query">
-        to \\/\\/google.com?hello=1
+      <Link href="\/vercel\/\/next.js?hello=1" id="href-with-backslashes-query">
+        to \\/vercel\\/\\/next.js?hello=1
       </Link>
       <br />
 
-      <Link href="\/\/google.com#hello" id="href-with-backslashes-hash">
-        to \\/\\/google.com#hello
+      <Link href="\/vercel\/\/next.js#hello" id="href-with-backslashes-hash">
+        to \\/vercel\\/\\/next.js#hello
       </Link>
       <br />
     </>

--- a/test/integration/repeated-slashes/test/index.test.js
+++ b/test/integration/repeated-slashes/test/index.test.js
@@ -93,21 +93,21 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
 
   it('should handle double slashes correctly', async () => {
     if (!isExport) {
-      const res = await fetchViaHTTP(appPort, '//google.com', undefined, {
+      const res = await fetchViaHTTP(appPort, '/vercel//next.js', undefined, {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
 
       const parsedUrl = url.parse(res.headers.get('location'), true)
-      expect(parsedUrl.pathname).toBe('/google.com')
+      expect(parsedUrl.pathname).toBe('/vercel/next.js')
       expect(parsedUrl.hostname).toBe('localhost')
       expect(parsedUrl.query).toEqual({})
     }
 
-    const browser = await webdriver(appPort, '//google.com')
+    const browser = await webdriver(appPort, '/vercel//next.js')
     await didNotReload(browser)
     expect(await browser.eval('window.location.pathname')).toBe(
-      isExport ? '//google.com' : '/google.com'
+      isExport ? '/vercel//next.js' : '/vercel/next.js'
     )
     expect(await browser.eval('window.location.search')).toBe('')
     expect(await browser.eval('window.location.hash')).toBe('')
@@ -120,7 +120,7 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
     if (!isExport) {
       const res = await fetchViaHTTP(
         appPort,
-        '//google.com',
+        '/vercel//next.js',
         { h: '1' },
         {
           redirect: 'manual',
@@ -128,15 +128,15 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       )
       expect(res.status).toBe(308)
       const parsedUrl = url.parse(res.headers.get('location'), true)
-      expect(parsedUrl.pathname).toBe('/google.com')
+      expect(parsedUrl.pathname).toBe('/vercel/next.js')
       expect(parsedUrl.hostname).toBe('localhost')
       expect(parsedUrl.query).toEqual({ h: '1' })
     }
 
-    const browser = await webdriver(appPort, '//google.com?h=1')
+    const browser = await webdriver(appPort, '/vercel//next.js?h=1')
     await didNotReload(browser)
     expect(await browser.eval('window.location.pathname')).toBe(
-      isExport ? '//google.com' : '/google.com'
+      isExport ? '/vercel//next.js' : '/vercel/next.js'
     )
     expect(await browser.eval('window.location.search')).toBe('?h=1')
     expect(await browser.eval('window.location.hash')).toBe('')
@@ -147,20 +147,20 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
 
   it('should handle double slashes correctly with hash', async () => {
     if (!isExport) {
-      const res = await fetchViaHTTP(appPort, '//google.com', undefined, {
+      const res = await fetchViaHTTP(appPort, '/vercel//next.js', undefined, {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
       const parsedUrl = url.parse(res.headers.get('location'), true)
-      expect(parsedUrl.pathname).toBe('/google.com')
+      expect(parsedUrl.pathname).toBe('/vercel/next.js')
       expect(parsedUrl.hostname).toBe('localhost')
       expect(parsedUrl.query).toEqual({})
     }
 
-    const browser = await webdriver(appPort, '//google.com#hello')
+    const browser = await webdriver(appPort, '/vercel//next.js#hello')
     await didNotReload(browser)
     expect(await browser.eval('window.location.pathname')).toBe(
-      isExport ? '//google.com' : '/google.com'
+      isExport ? '/vercel//next.js' : '/vercel/next.js'
     )
     expect(await browser.eval('window.location.hash')).toBe('#hello')
     expect(await browser.eval('window.location.search')).toBe('')
@@ -235,21 +235,21 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
 
   it('should handle backslashes correctly', async () => {
     if (!isExport) {
-      const res = await fetchViaHTTP(appPort, '/\\google.com', undefined, {
+      const res = await fetchViaHTTP(appPort, '/vercel//next.js', undefined, {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
       const parsedUrl = url.parse(res.headers.get('location'), true)
-      expect(parsedUrl.pathname).toBe('/google.com')
+      expect(parsedUrl.pathname).toBe('/vercel/next.js')
       expect(parsedUrl.hostname).toBe('localhost')
       expect(parsedUrl.query).toEqual({})
-      expect(await res.text()).toBe('/google.com')
+      expect(await res.text()).toBe('/vercel/next.js')
     }
 
-    const browser = await webdriver(appPort, '/\\google.com')
+    const browser = await webdriver(appPort, '/vercel//next.js')
     await didNotReload(browser)
     expect(await browser.eval('window.location.pathname')).toBe(
-      isExport ? '//google.com' : '/google.com'
+      isExport ? '/vercel//next.js' : '/vercel/next.js'
     )
     expect(await browser.eval('window.location.hash')).toBe('')
     expect(await browser.eval('window.location.search')).toBe('')
@@ -260,21 +260,23 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
 
   it('should handle mixed backslashes/forward slashes correctly', async () => {
     if (!isExport) {
-      const res = await fetchViaHTTP(appPort, '/\\/google.com', undefined, {
+      const res = await fetchViaHTTP(appPort, '/vercel/\\/next.js', undefined, {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
       const parsedUrl = url.parse(res.headers.get('location'), true)
-      expect(parsedUrl.pathname).toBe(isExport ? '//google.com' : '/google.com')
+      expect(parsedUrl.pathname).toBe(
+        isExport ? '/vercel//next.js' : '/vercel/next.js'
+      )
       expect(parsedUrl.hostname).toBe('localhost')
       expect(parsedUrl.query).toEqual({})
-      expect(await res.text()).toBe('/google.com')
+      expect(await res.text()).toBe('/vercel/next.js')
     }
 
-    const browser = await webdriver(appPort, '/\\/google.com#hello')
+    const browser = await webdriver(appPort, '/vercel/\\/next.js#hello')
     await didNotReload(browser)
     expect(await browser.eval('window.location.pathname')).toBe(
-      isExport ? '///google.com' : '/google.com'
+      isExport ? '/vercel///next.js' : '/vercel/next.js'
     )
     expect(await browser.eval('window.location.hash')).toBe('#hello')
     expect(await browser.eval('window.location.search')).toBe('')
@@ -289,12 +291,12 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       `/invalid${isExport ? '.html' : ''}`
     )
     const invalidHrefs = [
-      '//google.com',
-      '//google.com?hello=1',
-      '//google.com#hello',
-      '\\/\\/google.com',
-      '\\/\\/google.com?hello=1',
-      '\\/\\/google.com#hello',
+      '/vercel//next.js',
+      '/vercel//next.js?hello=1',
+      '/vercel//next.js#hello',
+      '\\/vercel\\/\\/next.js',
+      '\\/vercel\\/\\/next.js?hello=1',
+      '\\/vercel\\/\\/next.js#hello',
     ]
 
     for (const href of invalidHrefs) {
@@ -313,24 +315,24 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       {
         page: '/another',
         href: '/another',
-        as: '//google.com',
-        pathname: '/google.com',
+        as: '/vercel//next.js',
+        pathname: '/vercel/next.js',
       },
       {
         page: isPages404 ? '/404' : '/_error',
-        href: '//google.com',
-        pathname: '/google.com',
+        href: '/vercel//next.js',
+        pathname: '/vercel/next.js',
       },
       {
         page: isPages404 ? '/404' : '/_error',
-        href: '//google.com?hello=1',
-        pathname: '/google.com',
+        href: '/vercel//next.js?hello=1',
+        pathname: '/vercel/next.js',
         search: '?hello=1',
       },
       {
         page: isPages404 ? '/404' : '/_error',
-        href: '//google.com#hello',
-        pathname: '/google.com',
+        href: '/vercel//next.js#hello',
+        pathname: '/vercel/next.js',
         hash: '#hello',
       },
     ]) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `yarn lint`

## Relates Issues
* Proposal: https://github.com/vercel/next.js/discussions/37128
* Replaces https://github.com/vercel/next.js/issues/30947

---

* Explicitly handles schema-relative URLs rather than having it handled incidentally by merging slashes. Now it's rejected with a dedicated error message.
* Have a `linkTypes` property on `Link` to improve control/security.
  * Users can further limit what kind of URLs can be passed in, including absolute URLs.
  * Users can enable schema-relative URLs if they want to allow them.



> ```
> <a href="//example.com">Scheme-relative URL</a>
> ```
> — https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a

---

My initial solution can be found here for supporting schema-relative URLs can be found here:
https://github.com/vercel/next.js/pull/31119

It was rejected due to the risk of unintentional open-redirects. However, this is already possible with the current implementation with absolute URLs.

This is a middle-ground where the standard URL type can be supported, but users can also utilize finer control over what URL types can be passed. This improves security as users can lock things down further, also preventing absolute URLs too.