### PR TITLE
Fix invalid middleware regexp in manifest

### DIFF
--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -394,7 +394,7 @@ function getCreateAssets(params: {
       const { namedRegex } = getNamedMiddlewareRegex(page, {
         catchAll: !metadata.edgeSSR,
       })
-      const regexp = metadata?.edgeMiddleware?.matcherRegexp ?? namedRegex
+      const regexp = metadata?.edgeMiddleware?.matcherRegexp || namedRegex
 
       middlewareManifest.middleware[page] = {
         env: Array.from(metadata.env),

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1431,6 +1431,12 @@ function getMiddlewareMatcher(
     return stored
   }
 
+  if (typeof info.regexp !== 'string' || !info.regexp) {
+    throw new Error(
+      `Invariant: invalid regexp for middleware ${JSON.stringify(info)}`
+    )
+  }
+
   const matcher = getRouteMatcher({ re: new RegExp(info.regexp), groups: {} })
   MiddlewareMatcherCache.set(info, matcher)
   return matcher

--- a/test/integration/middleware-general/test/index.test.js
+++ b/test/integration/middleware-general/test/index.test.js
@@ -113,6 +113,22 @@ describe('Middleware Runtime', () => {
       })
     })
 
+    it('should have valid middleware field in manifest', async () => {
+      const manifest = await fs.readJSON(
+        join(context.appDir, '.next/server/middleware-manifest.json')
+      )
+      expect(manifest.middleware).toEqual({
+        '/': {
+          env: ['MIDDLEWARE_TEST'],
+          files: ['server/edge-runtime-webpack.js', 'server/middleware.js'],
+          name: 'middleware',
+          page: '/',
+          regexp: '^/.*$',
+          wasm: [],
+        },
+      })
+    })
+
     it('should have middleware warning during build', () => {
       expect(context.buildLogs.output).toContain(middlewareWarning)
     })


### PR DESCRIPTION
This fixes invalid `regexp` being output in the middleware manifest causing deployments to fail and invalid regex to be used for matching locally. Our E2E tests caught this after the canary publish although I have added additional integration tests to catch this earlier.  

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: https://github.com/vercel/next.js/pull/37177
Fixes: https://github.com/vercel/next.js/runs/6762816907?check_suite_focus=true