### PR TITLE
Update flakey preview test

### DIFF
--- a/test/integration/prerender-preview/pages/index.js
+++ b/test/integration/prerender-preview/pages/index.js
@@ -34,7 +34,7 @@ export default function ({ hasProps, preview, previewData, random }) {
       >
         Reload static props
       </button>
-      <p id="router">{JSON.stringify(router)}</p>
+      <p id="router">{JSON.stringify({ isPreview: router.isPreview })}</p>
     </>
   )
 }


### PR DESCRIPTION
This test is causing a hydration error so the test isn't able to find the correct element, this corrects the hydration bug which should deflake this test. 

Fixes: https://github.com/vercel/next.js/runs/6767643290?check_suite_focus=true
Fixes: https://github.com/vercel/next.js/runs/6775907253?check_suite_focus=true