### PR TITLE
Add middleware size stats

### DIFF
--- a/test/.stats-app/middleware.js
+++ b/test/.stats-app/middleware.js
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export default async function middleware() {
+  return NextResponse.next()
+}

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -31,6 +31,10 @@ const clientGlobs = [
     name: 'Rendered Page Sizes',
     globs: ['fetched-pages/**/*.html'],
   },
+  {
+    name: 'Middleware size',
+    globs: ['.next/server/middleware*', '.next/server/edge-runtime-webpack.js'],
+  },
 ]
 
 const renames = [


### PR DESCRIPTION
This will allow us to track base middleware size in our PR stats. 