### PR TITLE
Migrate head side effects to hooks

### DIFF
--- a/packages/next/shared/lib/head.tsx
+++ b/packages/next/shared/lib/head.tsx
@@ -116,22 +116,13 @@ function unique() {
 
 /**
  *
- * @param headElements List of multiple <Head> instances
+ * @param headChildrenElements List of children of <Head>
  */
 function reduceComponents(
-  headElements: Array<React.ReactElement<any>>,
+  headChildrenElements: Array<React.ReactElement<any>>,
   props: WithInAmpMode
 ) {
-  return headElements
-    .reduce(
-      (list: React.ReactChild[], headElement: React.ReactElement<any>) => {
-        const headElementChildren = React.Children.toArray(
-          headElement.props.children
-        )
-        return list.concat(headElementChildren)
-      },
-      []
-    )
+  return headChildrenElements
     .reduce(onlyReactElement, [])
     .reverse()
     .concat(defaultHead(props.inAmpMode).reverse())

--- a/packages/next/shared/lib/side-effect.tsx
+++ b/packages/next/shared/lib/side-effect.tsx
@@ -28,8 +28,10 @@ export default function SideEffect(props: SideEffectProps) {
   if (typeof window === 'undefined') {
     headManager?.mountedInstances?.add(props.children)
     emitChange()
+    return null
   }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useLayoutEffect(() => {
     headManager?.mountedInstances?.add(props.children)
     return () => {
@@ -39,12 +41,14 @@ export default function SideEffect(props: SideEffectProps) {
 
   // Cache emitChange in headManager in layout effects and execute later in effects.
   // Since `useEffect` is async effects emitChange will only keep the latest results.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useLayoutEffect(() => {
     if (headManager) {
       headManager._pendingUpdate = emitChange
     }
   })
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (headManager && headManager._pendingUpdate) {
       headManager._pendingUpdate()

--- a/packages/next/shared/lib/side-effect.tsx
+++ b/packages/next/shared/lib/side-effect.tsx
@@ -13,6 +13,10 @@ type SideEffectProps = {
   children: React.ReactNode
 }
 
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? () => {} : useLayoutEffect
+const useIsomorphicEffect = typeof window === 'undefined' ? () => {} : useEffect
+
 export default function SideEffect(props: SideEffectProps) {
   const { headManager, reduceComponentsToState } = props
 
@@ -28,11 +32,9 @@ export default function SideEffect(props: SideEffectProps) {
   if (typeof window === 'undefined') {
     headManager?.mountedInstances?.add(props.children)
     emitChange()
-    return null
   }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     headManager?.mountedInstances?.add(props.children)
     return () => {
       headManager?.mountedInstances?.delete(props.children)
@@ -41,15 +43,13 @@ export default function SideEffect(props: SideEffectProps) {
 
   // Cache emitChange in headManager in layout effects and execute later in effects.
   // Since `useEffect` is async effects emitChange will only keep the latest results.
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (headManager) {
       headManager._pendingUpdate = emitChange
     }
   })
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  useEffect(() => {
+  useIsomorphicEffect(() => {
     if (headManager && headManager._pendingUpdate) {
       headManager._pendingUpdate()
       headManager._pendingUpdate = null

--- a/test/integration/client-navigation-a11y/next.config.js
+++ b/test/integration/client-navigation-a11y/next.config.js
@@ -1,2 +1,0 @@
-const path = require('path')
-module.exports = require(path.join(__dirname, '../../lib/with-react-17.js'))({})

--- a/test/integration/client-navigation-a11y/test/index.test.js
+++ b/test/integration/client-navigation-a11y/test/index.test.js
@@ -11,7 +11,6 @@ import { join } from 'path'
 
 const context = {}
 const appDir = join(__dirname, '../')
-const nodeArgs = ['-r', join(appDir, '../../lib/react-17-require-hook.js')]
 
 const navigateTo = async (browser, selector) =>
   await browser
@@ -32,7 +31,6 @@ describe('Client Navigation accessibility', () => {
     context.appPort = await findPort()
     context.server = await launchApp(appDir, context.appPort, {
       env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
-      nodeArgs,
     })
 
     const prerender = [

--- a/test/integration/client-navigation/pages/head-dynamic.js
+++ b/test/integration/client-navigation/pages/head-dynamic.js
@@ -1,0 +1,28 @@
+import Head from 'next/head'
+import React from 'react'
+
+function Foo() {
+  const [displayed, toggle] = React.useState(true)
+
+  return (
+    <>
+      {displayed ? (
+        <Head>
+          <title>B</title>
+        </Head>
+      ) : null}
+      <button onClick={() => toggle(!displayed)}>toggle</button>
+    </>
+  )
+}
+
+export default () => {
+  return (
+    <>
+      <Head>
+        <title>A</title>
+      </Head>
+      <Foo />
+    </>
+  )
+}

--- a/test/integration/client-navigation/test/index.test.js
+++ b/test/integration/client-navigation/test/index.test.js
@@ -1621,6 +1621,22 @@ describe('Client Navigation', () => {
         }
       }
     })
+
+    it('should update head when unmounting component', async () => {
+      let browser
+      try {
+        browser = await webdriver(context.appPort, '/head-dynamic')
+        expect(await browser.eval('document.title')).toBe('B')
+        await browser.elementByCss('button').click()
+        expect(await browser.eval('document.title')).toBe('A')
+        await browser.elementByCss('button').click()
+        expect(await browser.eval('document.title')).toBe('B')
+      } finally {
+        if (browser) {
+          await browser.close()
+        }
+      }
+    })
   })
 
   describe('foreign history manipulation', () => {


### PR DESCRIPTION
* rewrite head side effects component in hooks
* remove mapping from element to children in head manager since they're already the children of `<Head>`

When move `SideEffect` to hooks, the effects scheduling is earlier than life cycle. We're leverage layout effects and effects at the same time, always cache the latest head updating function in head manager in layout effects, and flush them in the effects. This could help get rid of the promises delaying approach in head manager.