### PR TITLE
chore: remove unused safari nomodule fix

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -925,10 +925,6 @@ export class NextScript extends Component<OriginProps> {
 
   context!: React.ContextType<typeof HtmlContext>
 
-  // Source: https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc
-  static safariNomoduleFix =
-    '!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();'
-
   getDynamicChunks(files: DocumentFiles) {
     return getDynamicChunks(this.context, this.props, files)
   }


### PR DESCRIPTION
`safariNomoduleFix` was first introduced back in the year 2019 (#7704) as a part of the `modern` experimental feature. The experiment is ended and the feature is removed a year later in #19275. However, the unused `safariNomoduleFix` is never removed, until now.