### PR TITLE
feat(css) add experimental webpack CSS support

### DIFF
--- a/packages/next/src/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/index.ts
@@ -563,6 +563,27 @@ export const css = curry(async function css(
     )
   }
 
+  if (ctx.experimental.webpackCssExperiment) {
+    fns.push(
+      loader({
+        oneOf: [
+          {
+            test: regexSassModules,
+            issuerLayer: ctx.hasAppDir ? APP_LAYER_RULE : PAGES_LAYER_RULE,
+            use: require.resolve('next/dist/compiled/sass-loader'),
+            type: 'css/module',
+          },
+          {
+            test: regexSassGlobal,
+            issuerLayer: ctx.hasAppDir ? APP_LAYER_RULE : PAGES_LAYER_RULE,
+            use: require.resolve('next/dist/compiled/sass-loader'),
+            type: 'css',
+          },
+        ],
+      })
+    )
+  }
+
   const fn = pipe(...fns)
   return fn(config)
 })

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -146,6 +146,7 @@ export interface ExperimentalConfig {
   // Use Record<string, unknown> as critters doesn't export its Option type
   // https://github.com/GoogleChromeLabs/critters/blob/a590c05f9197b656d2aeaae9369df2483c26b072/packages/critters/src/index.d.ts
   optimizeCss?: boolean | Record<string, unknown>
+  webpackCssExperiment?: boolean
   nextScriptWorkers?: boolean
   scrollRestoration?: boolean
   externalDir?: boolean

--- a/test/e2e/css-webpack-experiment/index.test.ts
+++ b/test/e2e/css-webpack-experiment/index.test.ts
@@ -1,0 +1,51 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import webdriver from 'next-webdriver'
+
+describe('CSS webpack Experiment', () => {
+  describe('with basic CSS', () => {
+    let next: NextInstance
+
+    beforeAll(async () => {
+      next = await createNext({
+        files: new FileRef(__dirname),
+        nextConfig: {
+          experimental: {
+            webpackCssExperiment: true,
+          },
+        },
+        dependencies: {
+          react: 'latest',
+          'react-dom': 'latest',
+          sass: 'latest',
+        },
+      })
+    })
+
+    afterAll(() => next.destroy())
+
+    it('should work with basic CSS', async () => {
+      const browser = await webdriver(next.url, `/`)
+      const element = await browser.elementByCss('p')
+      const color = await element.getComputedCss('color')
+
+      expect(color).toBe('rgb(0, 128, 0)')
+    })
+
+    it('should work with CSS modules', async () => {
+      const browser = await webdriver(next.url, `/css-modules`)
+      const element = await browser.elementByCss('p')
+      const color = await element.getComputedCss('color')
+
+      expect(color).toBe('rgb(255, 0, 0)')
+    })
+
+    it('should work with SASS', async () => {
+      const browser = await webdriver(next.url, `/sass`)
+      const element = await browser.elementByCss('p')
+      const color = await element.getComputedCss('color')
+
+      expect(color).toBe('rgb(0, 0, 255)')
+    })
+  })
+})

--- a/test/e2e/css-webpack-experiment/pages/_app.js
+++ b/test/e2e/css-webpack-experiment/pages/_app.js
@@ -1,0 +1,4 @@
+import '../styles/global.css'
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/test/e2e/css-webpack-experiment/pages/css-modules.js
+++ b/test/e2e/css-webpack-experiment/pages/css-modules.js
@@ -1,0 +1,4 @@
+import * as styles from '../styles/styles.module.css'
+export default function Page() {
+  return <p className={styles.hello}>hello world</p>
+}

--- a/test/e2e/css-webpack-experiment/pages/index.js
+++ b/test/e2e/css-webpack-experiment/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/css-webpack-experiment/pages/sass.js
+++ b/test/e2e/css-webpack-experiment/pages/sass.js
@@ -1,0 +1,4 @@
+import * as styles from '../styles/styles.module.sass'
+export default function Page() {
+  return <p className={styles.hello}>hello world</p>
+}

--- a/test/e2e/css-webpack-experiment/styles/global.css
+++ b/test/e2e/css-webpack-experiment/styles/global.css
@@ -1,0 +1,4 @@
+p {
+  color: green;
+  font-size: 2rem;
+}

--- a/test/e2e/css-webpack-experiment/styles/styles.module.css
+++ b/test/e2e/css-webpack-experiment/styles/styles.module.css
@@ -1,0 +1,3 @@
+.hello {
+  color: red;
+}

--- a/test/e2e/css-webpack-experiment/styles/styles.module.sass
+++ b/test/e2e/css-webpack-experiment/styles/styles.module.sass
@@ -1,0 +1,4 @@
+$color: blue
+
+.hello
+  color: $color


### PR DESCRIPTION
Hello, I propose some changes to enable the [webpack CSS experiment](https://webpack.js.org/configuration/experiments/#experimentscss).

The proposal is to add an experimental flag named `webpackCssExperiment` which, once enabled, replace the built-in CSS support from Next.js. I kept the warning message linking to https://nextjs.org/docs/messages/built-in-css-disabled as it's a CSS user config.

Tests have been added for basic CSS, CSS modules and SASS.

Notice: some features are not yet supported by webpack (media queries like `@media`, `@supports` and `@layer`, and `@import` rules) but PRs have been created to fix this (see [#15892](https://github.com/webpack/webpack/pull/15892), [#15812](https://github.com/webpack/webpack/pull/15812) or [#15818](https://github.com/webpack/webpack/pull/15818)).

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
