### PR TITLE
Move client entry chunk to non pages folder

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -26,7 +26,10 @@ import {
   MIDDLEWARE_FILENAME,
   SERVER_RUNTIME,
 } from '../lib/constants'
-import { EDGE_RUNTIME_WEBPACK } from '../shared/lib/constants'
+import {
+  EDGE_RUNTIME_WEBPACK,
+  NEXT_CLIENT_SSR_ENTRY_SUFFIX,
+} from '../shared/lib/constants'
 import prettyBytes from '../lib/pretty-bytes'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
@@ -1350,4 +1353,16 @@ export class NestedMiddlewareError extends Error {
         `Read More - https://nextjs.org/docs/messages/nested-middleware`
     )
   }
+}
+
+// `pages/index` -> `chunks/index.__sc_client__`
+// `/app/index` -> `chunks/index.__sc_client__`
+export function getClientEntryName(name: string) {
+  const pagePrefixes = ['pages/', 'app/']
+  let page = name
+  pagePrefixes.forEach((prefix) => {
+    prefix = page.startsWith('/') ? `/${prefix}` : prefix
+    page = page.startsWith(prefix) ? page.slice(prefix.length) : page
+  })
+  return path.join('chunks', `${page}${NEXT_CLIENT_SSR_ENTRY_SUFFIX}`)
 }

--- a/packages/next/build/webpack/loaders/next-flight-client-entry-loader.ts
+++ b/packages/next/build/webpack/loaders/next-flight-client-entry-loader.ts
@@ -1,18 +1,19 @@
 import { SERVER_RUNTIME } from '../../../lib/constants'
 
-export default async function transformSource(this: any): Promise<string> {
+export default function transformSource(this: any): string {
   let { modules, runtime, ssr } = this.getOptions()
   if (!Array.isArray(modules)) {
     modules = modules ? [modules] : []
   }
 
-  return (
+  const code =
     modules
       .map(
         (request: string) => `import(/* webpackMode: "eager" */ '${request}')`
       )
-      .join(';') +
+      .join(';\n') +
     `
+
     export const __next_rsc__ = {
       server: false,
       __webpack_require__
@@ -25,5 +26,5 @@ export default async function transformSource(this: any): Promise<string> {
       : ssr
       ? `export const __N_SSP = true;`
       : `export const __N_SSG = true;`)
-  )
+  return code
 }

--- a/packages/next/build/webpack/plugins/client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/client-entry-plugin.ts
@@ -1,9 +1,6 @@
 import { stringify } from 'querystring'
 import { webpack } from 'next/dist/compiled/webpack/webpack'
-import {
-  EDGE_RUNTIME_WEBPACK,
-  NEXT_CLIENT_SSR_ENTRY_SUFFIX,
-} from '../../../shared/lib/constants'
+import { EDGE_RUNTIME_WEBPACK } from '../../../shared/lib/constants'
 import { clientComponentRegex } from '../loaders/utils'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
 import { denormalizePagePath } from '../../../shared/lib/page-path/denormalize-page-path'
@@ -13,6 +10,7 @@ import {
 } from '../../../server/dev/on-demand-entry-handler'
 import { getPageStaticInfo } from '../../analysis/get-page-static-info'
 import { SERVER_RUNTIME } from '../../../lib/constants'
+import { getClientEntryName } from '../../utils'
 
 type Options = {
   dev: boolean
@@ -152,10 +150,7 @@ export class ClientEntryPlugin {
         // Inject the entry to the server compiler.
         const clientComponentEntryDep = (
           webpack as any
-        ).EntryPlugin.createDependency(
-          clientLoader,
-          name + NEXT_CLIENT_SSR_ENTRY_SUFFIX
-        )
+        ).EntryPlugin.createDependency(clientLoader, getClientEntryName(name))
         promises.push(
           new Promise<void>((res, rej) => {
             compilation.addEntry(
@@ -163,7 +158,7 @@ export class ClientEntryPlugin {
               clientComponentEntryDep,
               this.isEdgeServer
                 ? {
-                    name: name + NEXT_CLIENT_SSR_ENTRY_SUFFIX,
+                    name: getClientEntryName(name),
                     library: {
                       name: ['self._CLIENT_ENTRY'],
                       type: 'assign',
@@ -172,7 +167,7 @@ export class ClientEntryPlugin {
                     asyncChunks: false,
                   }
                 : {
-                    name: name + NEXT_CLIENT_SSR_ENTRY_SUFFIX,
+                    name: getClientEntryName(name),
                     runtime: 'webpack-runtime',
                   },
               (err: any) => {

--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -11,8 +11,8 @@ import {
   FLIGHT_MANIFEST,
   MIDDLEWARE_MANIFEST,
   MIDDLEWARE_REACT_LOADABLE_MANIFEST,
-  NEXT_CLIENT_SSR_ENTRY_SUFFIX,
 } from '../../../shared/lib/constants'
+import { getClientEntryName } from '../../utils'
 
 interface EdgeFunctionDefinition {
   env: string[]
@@ -539,9 +539,7 @@ function getEntryFiles(entryFiles: string[], meta: EntryMetadata) {
               file.startsWith('pages/') && !file.endsWith('.hot-update.js')
           )
           .map(
-            (file) =>
-              'server/' +
-              file.replace('.js', NEXT_CLIENT_SSR_ENTRY_SUFFIX + '.js')
+            (file) => `server/${getClientEntryName(file.replace('.js', ''))}.js`
           )
       )
     }

--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -115,13 +115,13 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
   // Here we output all traced assets and webpack chunks to a
   // ${page}.js.nft.json file
   async createTraceAssets(
-    compilation: any,
+    compilation: webpack5.Compilation,
     assets: any,
     span: Span,
     readlink: any,
     stat: any
   ) {
-    const outputPath = compilation.outputOptions.path
+    const outputPath = compilation.outputOptions.path!
 
     await span.traceChild('create-trace-assets').traceAsyncFn(async () => {
       const entryFilesMap = new Map<any, Set<string>>()
@@ -130,7 +130,6 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
 
       for (const entrypoint of compilation.entrypoints.values()) {
         const entryFiles = new Set<string>()
-
         for (const chunk of entrypoint
           .getEntrypointChunk()
           .getAllReferencedChunks()) {
@@ -474,7 +473,7 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
             // @ts-ignore TODO: Remove ignore when webpack 5 is stable
             stage: webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
           },
-          (assets: any, callback: any) => {
+          (assets, callback) => {
             this.createTraceAssets(
               compilation,
               assets,

--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -129,6 +129,11 @@ export class TraceEntryPointsPlugin implements webpack5.WebpackPluginInstance {
       const isTraceable = (file: string) => !file.endsWith('.wasm')
 
       for (const entrypoint of compilation.entrypoints.values()) {
+        // FIXME: fix the race condition that __sc_client__ files are not generated yet
+        // but tracing process is started
+        if (entrypoint.name?.includes('__sc_client__')) {
+          continue
+        }
         const entryFiles = new Set<string>()
         for (const chunk of entrypoint
           .getEntrypointChunk()

--- a/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -106,7 +106,7 @@ export class NextJsRequireCacheHotReloader implements WebpackPluginInstance {
       entries.forEach((page) => {
         const outputPath = path.join(
           compilation.outputOptions.path!,
-          getClientEntryName(page) + '.js'
+          page + '.js'
         )
         deleteCache(outputPath)
       })

--- a/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -69,11 +69,12 @@ export class NextJsRequireCacheHotReloader implements WebpackPluginInstance {
         ) {
           // Also clear the potential __sc_client__ cache.
           // @TODO: Investigate why the client ssr bundle isn't emitted as an asset here.
-          const page = targetPath.replace(outputPath, '').replace('.js', '')
-          const clientComponentsSSRTarget = path.join(
-            outputPath,
-            getClientEntryName(page) + '.js'
-          )
+          // Replace page entry path with chunk entry path
+          const page = targetPath.replace(outputPath, '').replace(/\.js$/, '')
+          const clientComponentsSSRTarget =
+            targetPath.slice(0, -(page + '.js').length) +
+            getClientEntryName(page) +
+            '.js'
 
           if (deleteCache(clientComponentsSSRTarget)) {
             this.currentOutputPathsWebpack5.add(clientComponentsSSRTarget)
@@ -105,7 +106,7 @@ export class NextJsRequireCacheHotReloader implements WebpackPluginInstance {
       entries.forEach((page) => {
         const outputPath = path.join(
           compilation.outputOptions.path!,
-          page + '.js'
+          getClientEntryName(page) + '.js'
         )
         deleteCache(outputPath)
       })

--- a/packages/next/server/load-components.ts
+++ b/packages/next/server/load-components.ts
@@ -13,6 +13,7 @@ import {
   BUILD_MANIFEST,
   REACT_LOADABLE_MANIFEST,
   FLIGHT_MANIFEST,
+  SERVER_DIRECTORY,
 } from '../shared/lib/constants'
 import { join } from 'path'
 import { requirePage, getPagePath } from './require'
@@ -113,6 +114,7 @@ export async function loadComponents(
     ),
   ])
 
+  const isServerComponent = !!ComponentMod.__next_rsc__
   const [buildManifest, reactLoadableManifest, serverComponentManifest] =
     await Promise.all([
       require(join(distDir, BUILD_MANIFEST)),
@@ -122,11 +124,11 @@ export async function loadComponents(
         : null,
     ])
 
-  if (hasServerComponents) {
+  if (hasServerComponents && isServerComponent) {
     try {
       // Make sure to also load the client entry in cache.
-      const name = getClientEntryName(normalizePagePath(pathname)) + '.js'
-      const chunkPath = join(distDir, 'server', name)
+      const name = getClientEntryName(normalizePagePath(pathname))
+      const chunkPath = join(distDir, SERVER_DIRECTORY, name)
       require(chunkPath)
     } catch (_) {
       // This page might not be a server component page, so there is no

--- a/packages/next/server/load-components.ts
+++ b/packages/next/server/load-components.ts
@@ -13,13 +13,13 @@ import {
   BUILD_MANIFEST,
   REACT_LOADABLE_MANIFEST,
   FLIGHT_MANIFEST,
-  NEXT_CLIENT_SSR_ENTRY_SUFFIX,
 } from '../shared/lib/constants'
 import { join } from 'path'
 import { requirePage, getPagePath } from './require'
 import { BuildManifest } from './get-page-files'
 import { interopDefault } from '../lib/interop-default'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
+import { getClientEntryName } from '../build/utils'
 
 export type ManifestItem = {
   id: number | string
@@ -125,12 +125,9 @@ export async function loadComponents(
   if (hasServerComponents) {
     try {
       // Make sure to also load the client entry in cache.
-      await requirePage(
-        normalizePagePath(pathname) + NEXT_CLIENT_SSR_ENTRY_SUFFIX,
-        distDir,
-        serverless,
-        appDirEnabled
-      )
+      const name = getClientEntryName(normalizePagePath(pathname)) + '.js'
+      const chunkPath = join(distDir, 'server', name)
+      require(chunkPath)
     } catch (_) {
       // This page might not be a server component page, so there is no
       // client entry to load.


### PR DESCRIPTION
Move `.next/server/pages/xxx.__sc_client__.js` chunks to `.next/server/chunks/xxx.__sc_client__.js` to avoid creating lambdas for them.

* Rename the chunk dist path, group them as a name mapping util
* Simplify the require call for those client entries (`requirePage` -> `require`)
* Add test