### PR TITLE
allow for parallel builds

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -147,6 +147,7 @@ export interface ExperimentalConfig {
   }
   swcPlugins?: Array<[string, Record<string, unknown>]>
   largePageDataBytes?: number
+  parallelBuilds?: boolean
 }
 
 /**


### PR DESCRIPTION
Our CI is strong enough to handle parallel builds, allowing for them could potentially optimize our build times. I added a flag to the experimental config `parallelBuilds` to enable parallel webpack builds.
