### PR TITLE
fix(#37524): type hack for `interopClientDefaultExport`

### DIFF
--- a/packages/next/config.d.ts
+++ b/packages/next/config.d.ts
@@ -1,3 +1,4 @@
 import getConfig from './dist/shared/lib/runtime-config'
 export * from './dist/shared/lib/runtime-config'
 export default getConfig
+export = getConfig

--- a/packages/next/dynamic.d.ts
+++ b/packages/next/dynamic.d.ts
@@ -1,3 +1,4 @@
 import dynamic from './dist/shared/lib/dynamic'
 export * from './dist/shared/lib/dynamic'
 export default dynamic
+export = dynamic

--- a/packages/next/head.d.ts
+++ b/packages/next/head.d.ts
@@ -1,3 +1,4 @@
 import Head from './dist/shared/lib/head'
 export * from './dist/shared/lib/head'
 export default Head
+export = Head

--- a/packages/next/image.d.ts
+++ b/packages/next/image.d.ts
@@ -1,3 +1,4 @@
 import Image from './dist/client/image'
 export * from './dist/client/image'
 export default Image
+export = Image

--- a/packages/next/jest.d.ts
+++ b/packages/next/jest.d.ts
@@ -1,3 +1,4 @@
 import nextJest from './dist/build/jest/jest'
 export * from './dist/build/jest/jest'
 export default nextJest
+export = nextJest

--- a/packages/next/script.d.ts
+++ b/packages/next/script.d.ts
@@ -1,3 +1,4 @@
 import Script from './dist/client/script'
 export * from './dist/client/script'
 export default Script
+export = Script


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)

Fixes #37524.

Add `export =` to every type definition of pre-compiled file that has `interopClientDefaultExport` flag enabled.

Shout out to @Jack-Works for the idea, he is a true TypeScript master!