### PR TITLE
Update usage of example.com -> example.vercel.sh

### DIFF
--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -757,7 +757,9 @@ describe('basePath', () => {
           .waitForElementByCss('#other-page-title')
 
         const eventLog = await browser.eval('window._getEventLog()')
-        expect(eventLog).toEqual([
+        expect(
+          eventLog.filter((item) => item[1]?.endsWith('/other-page'))
+        ).toEqual([
           ['routeChangeStart', `${basePath}/other-page`, { shallow: false }],
           ['beforeHistoryChange', `${basePath}/other-page`, { shallow: false }],
           ['routeChangeComplete', `${basePath}/other-page`, { shallow: false }],

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -38,7 +38,7 @@ describe('basePath', () => {
             },
             {
               source: '/rewrite-no-basepath',
-              destination: 'https://example.com',
+              destination: 'https://example.vercel.sh',
               basePath: false,
             },
             {

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -131,7 +131,7 @@ export async function middleware(request) {
     const response = {}
 
     try {
-      await fetch('https://example.com', { signal })
+      await fetch('https://example.vercel.sh', { signal })
     } catch (err) {
       response.error = {
         name: err.name,

--- a/test/production/required-server-files/pages/api/optional/[[...rest]].js
+++ b/test/production/required-server-files/pages/api/optional/[[...rest]].js
@@ -4,6 +4,6 @@ export default async (req, res) => {
     url: req.url,
     query: req.query,
     // make sure fetch if polyfilled
-    example: await fetch('https://example.com').then((res) => res.text()),
+    example: await fetch('https://example.vercel.sh').then((res) => res.text()),
   })
 }

--- a/test/production/required-server-files/pages/fallback/[slug].js
+++ b/test/production/required-server-files/pages/fallback/[slug].js
@@ -12,7 +12,7 @@ export const getStaticProps = ({ params }) => {
 
 export const getStaticPaths = async () => {
   // make sure fetch if polyfilled
-  await fetch('https://example.com').then((res) => res.text())
+  await fetch('https://example.vercel.sh').then((res) => res.text())
 
   return {
     paths: ['/fallback/first'],

--- a/test/production/required-server-files/pages/gssp.js
+++ b/test/production/required-server-files/pages/gssp.js
@@ -24,7 +24,9 @@ export async function getServerSideProps({ res }) {
       data,
       random: Math.random(),
       // make sure fetch if polyfilled
-      example: await fetch('https://example.com').then((res) => res.text()),
+      example: await fetch('https://example.vercel.sh').then((res) =>
+        res.text()
+      ),
     },
   }
 }


### PR DESCRIPTION
Seems we still have some usage of `example.com` in our tests which is very flakey so this updates to use `example.vercel.sh` instead. 

x-ref: https://github.com/vercel/next.js/runs/6838713646?check_suite_focus=true#step:8:240