### PR TITLE
Update matched path params priority

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -351,6 +351,7 @@ export function getUtils({
       // on the parsed params, this is used to signal if we need
       // to parse x-now-route-matches or not
       const defaultValue = defaultRouteMatches![key]
+      const isOptional = defaultRouteRegex!.groups[key].optional
 
       const isDefaultValue = Array.isArray(defaultValue)
         ? defaultValue.some((defaultVal) => {
@@ -360,14 +361,14 @@ export function getUtils({
           })
         : value?.includes(defaultValue as string)
 
-      if (isDefaultValue || typeof value === 'undefined') {
+      if (isDefaultValue || (typeof value === 'undefined' && !isOptional)) {
         hasValidParams = false
       }
 
       // non-provided optional values should be undefined so normalize
       // them to undefined
       if (
-        defaultRouteRegex!.groups[key].optional &&
+        isOptional &&
         (!value ||
           (Array.isArray(value) &&
             value.length === 1 &&

--- a/packages/next/lib/download-wasm-swc.ts
+++ b/packages/next/lib/download-wasm-swc.ts
@@ -107,9 +107,13 @@ export async function downloadWasmSwc(
   const cacheFiles = await fs.promises.readdir(cacheDirectory)
 
   if (cacheFiles.length > MAX_VERSIONS_TO_CACHE) {
-    cacheFiles.sort()
+    cacheFiles.sort((a, b) => {
+      if (a.length < b.length) return -1
+      return a.localeCompare(b)
+    })
 
-    for (let i = MAX_VERSIONS_TO_CACHE - 1; i++; i < cacheFiles.length) {
+    // prune oldest versions in cache
+    for (let i = 0; i++; i < cacheFiles.length - MAX_VERSIONS_TO_CACHE) {
       await fs.promises
         .unlink(path.join(cacheDirectory, cacheFiles[i]))
         .catch(() => {})

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -457,6 +457,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           if (urlPathname.startsWith(`/_next/data/`)) {
             parsedUrl.query.__nextDataReq = '1'
           }
+          const normalizedUrlPath = this.stripNextDataPath(urlPathname)
           matchedPath = this.stripNextDataPath(matchedPath, false)
 
           if (this.nextConfig.i18n) {
@@ -512,9 +513,20 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           if (pageIsDynamic) {
             let params: ParsedUrlQuery | false = {}
 
-            const paramsResult = utils.normalizeDynamicRouteParams(
+            let paramsResult = utils.normalizeDynamicRouteParams(
               parsedUrl.query
             )
+
+            if (!paramsResult.hasValidParams) {
+              // we favor matching against req.url although if there's a
+              // rewrite and it's SSR we use the x-matched-path instead
+              let matcherRes = utils.dynamicRouteMatcher?.(normalizedUrlPath)
+
+              if (!matcherRes) {
+                matcherRes = utils.dynamicRouteMatcher?.(matchedPath)
+              }
+              paramsResult = utils.normalizeDynamicRouteParams(matcherRes || {})
+            }
 
             if (paramsResult.hasValidParams) {
               params = paramsResult.params
@@ -529,8 +541,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
               if (opts.locale) {
                 parsedUrl.query.__nextLocale = opts.locale
               }
-            } else {
-              params = utils.dynamicRouteMatcher!(matchedPath) || {}
             }
 
             if (params) {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -530,9 +530,16 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
             if (paramsResult.hasValidParams) {
               params = paramsResult.params
-            } else if (req.headers['x-now-route-matches']) {
+            }
+
+            if (
+              req.headers['x-now-route-matches'] &&
+              (!paramsResult.hasValidParams ||
+                (isDynamicRoute(matchedPath) &&
+                  isDynamicRoute(normalizedUrlPath)))
+            ) {
               const opts: Record<string, string> = {}
-              params = utils.getParamsFromRouteMatches(
+              const routeParams = utils.getParamsFromRouteMatches(
                 req,
                 opts,
                 parsedUrl.query.__nextLocale || ''
@@ -540,6 +547,11 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
               if (opts.locale) {
                 parsedUrl.query.__nextLocale = opts.locale
+              }
+              paramsResult = utils.normalizeDynamicRouteParams(routeParams)
+
+              if (paramsResult.hasValidParams) {
+                params = paramsResult.params
               }
             }
 

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -456,6 +456,17 @@ interface FetchDataOutput {
   text: string
 }
 
+interface FetchNextDataParams {
+  dataHref: string
+  isServerRender: boolean
+  parseJSON: boolean | undefined
+  hasMiddleware?: boolean
+  inflightCache: NextDataCache
+  persistCache: boolean
+  isPrefetch: boolean
+  isBackground?: boolean
+}
+
 function fetchNextData({
   dataHref,
   inflightCache,
@@ -464,15 +475,8 @@ function fetchNextData({
   isServerRender,
   parseJSON,
   persistCache,
-}: {
-  dataHref: string
-  isServerRender: boolean
-  parseJSON: boolean | undefined
-  hasMiddleware?: boolean
-  inflightCache: NextDataCache
-  persistCache: boolean
-  isPrefetch: boolean
-}): Promise<FetchDataOutput> {
+  isBackground,
+}: FetchNextDataParams): Promise<FetchDataOutput> {
   const { href: cacheKey } = new URL(dataHref, window.location.href)
   const getData = (params?: { method?: 'HEAD' | 'GET' }) =>
     fetchRetry(dataHref, isServerRender ? 3 : 1, {
@@ -560,18 +564,11 @@ function fetchNextData({
       })
 
   if (inflightCache[cacheKey] !== undefined) {
-    // we kick off a HEAD request in the background
-    // when a non-prefetch request is made to signal revalidation
-    if (!isPrefetch && persistCache && !backgroundCache[cacheKey]) {
-      backgroundCache[cacheKey] = getData({ method: 'HEAD' })
-        .catch(() => {})
-        .then(() => {
-          delete backgroundCache[cacheKey]
-        })
-    }
     return inflightCache[cacheKey]
   }
-  return (inflightCache[cacheKey] = getData())
+  return (inflightCache[cacheKey] = getData(
+    isBackground ? { method: 'HEAD' } : {}
+  ))
 }
 
 function tryToParseAsJSON(text: string) {
@@ -1573,22 +1570,23 @@ export default class Router implements BaseRouter {
           ? existingInfo
           : undefined
 
+      const fetchNextDataParams: FetchNextDataParams = {
+        dataHref: this.pageLoader.getDataHref({
+          href: formatWithValidation({ pathname, query }),
+          skipInterpolation: true,
+          asPath: resolvedAs,
+          locale,
+        }),
+        hasMiddleware: true,
+        isServerRender: this.isSsr,
+        parseJSON: true,
+        inflightCache: this.sdc,
+        persistCache: !isPreview,
+        isPrefetch: false,
+      }
+
       const data = await withMiddlewareEffects({
-        fetchData: () =>
-          fetchNextData({
-            dataHref: this.pageLoader.getDataHref({
-              href: formatWithValidation({ pathname, query }),
-              skipInterpolation: true,
-              asPath: resolvedAs,
-              locale,
-            }),
-            hasMiddleware: true,
-            isServerRender: this.isSsr,
-            parseJSON: true,
-            inflightCache: this.sdc,
-            persistCache: !isPreview,
-            isPrefetch: false,
-          }),
+        fetchData: () => fetchNextData(fetchNextDataParams),
         asPath: resolvedAs,
         locale: locale,
         router: this,
@@ -1632,13 +1630,6 @@ export default class Router implements BaseRouter {
             __N_RSC: !!res.mod.__next_rsc__,
           })
         ))
-
-      // TODO: we only bust the data cache for SSP routes
-      // although middleware can skip cache per request with
-      // x-middleware-cache: no-cache
-      if (routeInfo.__N_SSP && data?.dataHref) {
-        delete this.sdc[data?.dataHref]
-      }
 
       if (process.env.NODE_ENV !== 'production') {
         const { isValidElementType } = require('next/dist/compiled/react-is')
@@ -1699,6 +1690,29 @@ export default class Router implements BaseRouter {
           ),
         }
       })
+
+      // Only bust the data cache for SSP routes although
+      // middleware can skip cache per request with
+      // x-middleware-cache: no-cache as well
+      if (routeInfo.__N_SSP && fetchNextDataParams.dataHref) {
+        const cacheKey = new URL(
+          fetchNextDataParams.dataHref,
+          window.location.href
+        ).href
+        delete this.sdc[cacheKey]
+      }
+
+      // we kick off a HEAD request in the background
+      // when a non-prefetch request is made to signal revalidation
+      if (!this.isPreview && routeInfo.__N_SSG) {
+        fetchNextData(
+          Object.assign({}, fetchNextDataParams, {
+            isBackground: true,
+            persistCache: false,
+            inflightCache: backgroundCache,
+          })
+        ).catch(() => {})
+      }
 
       if (routeInfo.__N_RSC) {
         props.pageProps = Object.assign(props.pageProps, {

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1674,7 +1674,7 @@ export default class Router implements BaseRouter {
               isServerRender: this.isSsr,
               parseJSON: true,
               inflightCache: this.sdc,
-              persistCache: !!routeInfo.__N_SSG && !isPreview,
+              persistCache: !isPreview,
               isPrefetch: false,
             }))
 
@@ -1906,8 +1906,8 @@ export default class Router implements BaseRouter {
           isServerRender: this.isSsr,
           parseJSON: true,
           inflightCache: this.sdc,
-          persistCache: false,
-          isPrefetch: false,
+          persistCache: !this.isPreview,
+          isPrefetch: true,
         }),
       asPath: asPath,
       locale: locale,

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1704,7 +1704,11 @@ export default class Router implements BaseRouter {
 
       // we kick off a HEAD request in the background
       // when a non-prefetch request is made to signal revalidation
-      if (!this.isPreview && routeInfo.__N_SSG) {
+      if (
+        !this.isPreview &&
+        routeInfo.__N_SSG &&
+        process.env.NODE_ENV !== 'development'
+      ) {
         fetchNextData(
           Object.assign({}, fetchNextDataParams, {
             isBackground: true,

--- a/test/integration/middleware-prefetch/tests/index.test.js
+++ b/test/integration/middleware-prefetch/tests/index.test.js
@@ -71,7 +71,11 @@ describe('Middleware Production Prefetch', () => {
       const mapped = hrefs.map((href) =>
         new URL(href).pathname.replace(/^\/_next\/data\/[^/]+/, '')
       )
-      assert.deepEqual(mapped, ['/ssg-page.json'])
+      assert.deepEqual(mapped, [
+        '/made-up.json',
+        '/ssg-page-2.json',
+        '/ssg-page.json',
+      ])
       return 'yes'
     }, 'yes')
   })

--- a/test/integration/required-server-files-ssr-404/test/index.test.js
+++ b/test/integration/required-server-files-ssr-404/test/index.test.js
@@ -533,7 +533,7 @@ describe('Required Server Files', () => {
   })
 
   it('should match the root dynamic page correctly', async () => {
-    const res = await fetchViaHTTP(appPort, '/index', undefined, {
+    const res = await fetchViaHTTP(appPort, '/slug-1', undefined, {
       headers: {
         'x-matched-path': '/[slug]',
       },

--- a/test/production/required-server-files-i18n.test.ts
+++ b/test/production/required-server-files-i18n.test.ts
@@ -448,7 +448,7 @@ describe('should set-up next', () => {
 
     const html3 = await renderViaHTTP(
       appPort,
-      '/catch-all/[[..rest]]',
+      '/catch-all/[[...rest]]',
       undefined,
       {
         headers: {
@@ -732,7 +732,7 @@ describe('should set-up next', () => {
   })
 
   it('should match the root dyanmic page correctly', async () => {
-    const res = await fetchViaHTTP(appPort, '/index', undefined, {
+    const res = await fetchViaHTTP(appPort, '/slug-1', undefined, {
       headers: {
         'x-matched-path': '/[slug]',
       },

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -494,6 +494,59 @@ describe('should set-up next', () => {
     expect(data2.random).not.toBe(data.random)
   })
 
+  it('should favor valid route params over routes-matches', async () => {
+    const html = await renderViaHTTP(appPort, '/fallback/first', undefined, {
+      headers: {
+        'x-matched-path': '/fallback/first',
+        'x-now-route-matches': '1=fallback%2ffirst',
+      },
+    })
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+
+    expect($('#fallback').text()).toBe('fallback page')
+    expect($('#slug').text()).toBe('first')
+    expect(data.hello).toBe('world')
+
+    const html2 = await renderViaHTTP(appPort, `/fallback/second`, undefined, {
+      headers: {
+        'x-matched-path': '/fallback/[slug]',
+        'x-now-route-matches': '1=fallback%2fsecond',
+      },
+    })
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect($2('#fallback').text()).toBe('fallback page')
+    expect($2('#slug').text()).toBe('second')
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.random).not.toBe(data.random)
+  })
+
+  it('should favor valid route params over routes-matches optional', async () => {
+    const html = await renderViaHTTP(appPort, '/optional-ssg', undefined, {
+      headers: {
+        'x-matched-path': '/optional-ssg',
+        'x-now-route-matches': '1=optional-ssg',
+      },
+    })
+    const $ = cheerio.load(html)
+    const data = JSON.parse($('#props').text())
+    expect(data.params).toEqual({})
+
+    const html2 = await renderViaHTTP(appPort, `/optional-ssg`, undefined, {
+      headers: {
+        'x-matched-path': '/optional-ssg',
+        'x-now-route-matches': '1=optional-ssg%2fanother',
+      },
+    })
+    const $2 = cheerio.load(html2)
+    const data2 = JSON.parse($2('#props').text())
+
+    expect(isNaN(data2.random)).toBe(false)
+    expect(data2.params).toEqual({})
+  })
+
   it('should return data correctly with x-matched-path', async () => {
     const res = await fetchViaHTTP(
       appPort,
@@ -569,7 +622,7 @@ describe('should set-up next', () => {
 
     const html3 = await renderViaHTTP(
       appPort,
-      '/catch-all/[[..rest]]',
+      '/catch-all/[[...rest]]',
       undefined,
       {
         headers: {
@@ -966,7 +1019,7 @@ describe('should set-up next', () => {
   })
 
   it('should match the root dynamic page correctly', async () => {
-    const res = await fetchViaHTTP(appPort, '/index', undefined, {
+    const res = await fetchViaHTTP(appPort, '/slug-1', undefined, {
       headers: {
         'x-matched-path': '/[slug]',
       },


### PR DESCRIPTION
This ensures we use the correct dynamic route params favoring params from the URL/matched-path over route-matches. This also ensures we properly cache `_next/data` requests client side when the page is not a `getServerSideProps` page. 

x-ref: https://github.com/vercel/next.js/pull/37574

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
