### PR TITLE
chore(middleware): improves stack traces in dev mode

### DIFF
--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -738,18 +738,18 @@ export default class DevServer extends Server {
     if (isError(err) && err.stack) {
       try {
         const frames = parseStack(err.stack!)
-        const frame = frames[0]
+        const frame = frames.find(({ file }) => !file?.startsWith('eval'))!
 
         if (frame.lineNumber && frame?.file) {
-          const compilation =
-            stats === 'server'
-              ? this.hotReloader?.serverStats?.compilation
-              : this.hotReloader?.edgeServerStats?.compilation
-
           const moduleId = frame.file!.replace(
             /^(webpack-internal:\/\/\/|file:\/\/)/,
             ''
           )
+
+          const compilation =
+            frame.file!.startsWith('(middleware)') && stats === 'server'
+              ? this.hotReloader?.serverStats?.compilation
+              : this.hotReloader?.edgeServerStats?.compilation
 
           const source = await getSourceById(
             !!frame.file?.startsWith(sep) || !!frame.file?.startsWith('file:'),

--- a/test/integration/middleware-dev-errors/lib/unhandled.js
+++ b/test/integration/middleware-dev-errors/lib/unhandled.js
@@ -1,0 +1,3 @@
+setTimeout(() => {
+  throw new Error('This file asynchronously fails while loading')
+}, 10)

--- a/test/integration/middleware-dev-errors/lib/unparseable.js
+++ b/test/integration/middleware-dev-errors/lib/unparseable.js
@@ -1,0 +1,1 @@
+throw new Error('This file synchronously fails while loading')

--- a/test/integration/middleware-dev-errors/middleware.js
+++ b/test/integration/middleware-dev-errors/middleware.js
@@ -1,0 +1,1 @@
+// this will be populated by each test

--- a/test/integration/middleware-dev-errors/pages/index.js
+++ b/test/integration/middleware-dev-errors/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>A page</div>
+}

--- a/test/integration/middleware-dev-errors/test/index.test.js
+++ b/test/integration/middleware-dev-errors/test/index.test.js
@@ -1,0 +1,135 @@
+import { writeFile } from 'fs-extra'
+import { fetchViaHTTP, findPort, killApp, launchApp } from 'next-test-utils'
+import { join } from 'path'
+import stripAnsi from 'strip-ansi'
+
+describe('Middleware dev errors', () => {
+  const appDir = join(__dirname, '..')
+  const middlewareFile = join(appDir, 'middleware.js')
+
+  afterEach(() =>
+    writeFile(middlewareFile, '// this will be populated by each test\n')
+  )
+
+  describe.each([
+    {
+      title: 'throwing synchronously during execution',
+      code: `export default function () {
+              throw new Error('boom')
+            }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ Object.__WEBPACK_DEFAULT_EXPORT__ \\[as handler\\]
+Error: boom`,
+    },
+    {
+      title: 'throwing asynchronously during execution',
+      code: `import { NextResponse } from 'next/server'
+            async function throwError() {
+              throw new Error('async boom!')
+            }
+            export default function () {
+              throwError()
+              return NextResponse.next()
+            }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ throwError
+Error: async boom!`,
+    },
+    {
+      title: 'running invalid dynamic code with eval',
+      code: `import { NextResponse } from 'next/server'
+
+                    export default function () {
+                      eval('test')
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval
+ReferenceError: test is not defined`,
+    },
+    {
+      title: 'running invalid dynamic code with Function constructor',
+      code: `import { NextResponse } from 'next/server'
+
+                    export default function () {
+                      new Function('test')()
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ Object.__WEBPACK_DEFAULT_EXPORT__ \\[as handler\\]
+ReferenceError: test is not defined`,
+    },
+    {
+      title: 'throwing error while loading middleware',
+      code: `import { NextResponse } from 'next/server'
+                    throw new Error('booooom!')
+                    export default function () {
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ <unknown>
+Error: booooom!`,
+    },
+    {
+      title: 'throwing error while loading dependencies',
+      code: `import { NextResponse } from 'next/server'
+                    import './lib/unparseable'
+
+                    export default function () {
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/lib/unparseable.js \\(\\d+:\\d+\\) @ <unknown>
+Error: This file synchronously fails while loading`,
+    },
+    {
+      title: 'with unhandled rejection during middleware loading',
+      code: `import { NextResponse } from 'next/server'
+                (async function(){
+                  throw new Error('you shall see me')
+                })()
+
+                export default function () {
+                  return NextResponse.next()
+                }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval
+Error: you shall see me`,
+    },
+    {
+      title: 'with unhandled rejection during dependency loading',
+      code: `import { NextResponse } from 'next/server'
+                import './lib/unhandled'
+
+                export default function () {
+                  return NextResponse.next()
+                }`,
+      expectedError: `error - \\(middleware\\)/lib/unhandled.js \\(\\d+:\\d+\\) @ Timeout.eval \\[as _onTimeout\\]
+Error: This file asynchronously fails while loading`,
+    },
+  ])('given a middleware $title', ({ code, expectedError }) => {
+    let app = null
+    let port = 0
+    let output = ''
+
+    beforeAll(async () => {
+      await writeFile(middlewareFile, code)
+      port = await findPort()
+      app = await launchApp(appDir, port, {
+        env: {
+          __NEXT_TEST_WITH_DEVTOOL: 1,
+        },
+        onStdout(msg) {
+          output += msg
+        },
+        onStderr(msg) {
+          output += msg
+        },
+      })
+    })
+
+    afterAll(() => killApp(app))
+
+    it('displays clean error in logs', async () => {
+      await fetchViaHTTP(port, '/')
+      output = stripAnsi(output)
+      expect(output).toMatch(new RegExp(expectedError, 'm'))
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## What's in there?

In `dev` mode, when running code on the server side, like for `getServerSideProps()`, Next adjusts caught exceptions to gracefully display them in the console logs.

This mechanism is also used for Middleware code, and works for:
- throwing synchronously during execution
- throwing error while loading middleware file (or deps)

However, it does not work for:
- errors thrown asynchronously when loading middleware file (or deps)
- asynchronous errors during execution
- error in dynamic code (although it can not be built, it could be ran in dev)

In such case, we see cryptic stack traces, such as:
![image](https://user-images.githubusercontent.com/186268/173333268-b1654f5f-6b0f-4b4a-ad5d-1d538fcda7b6.png)

## How to reproduce

This PR contains several examples in tests. An iconic one:
```js
import { NextResponse } from 'next/server'
async function throwError() {
  throw new Error('async boom!')
}

export default function () {
  throwError()
  return NextResponse.next()
}
```

## Notes to reviewers

When running dynamic code, the stack trace first frame always starts with `eval`, while the second stack trace starts with `webpack-internal:///(middleware)` (which triggers stack trace sanitization). We must skip them.

Finally, for unhandled rejections, `stats` variable does not contain `'server'`, which may load the wrong compilation.
I had to use the first frame file to load the correct compilation.

