### PR TITLE
Update flakey next-script tests

### DIFF
--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -2,7 +2,7 @@ import webdriver from 'next-webdriver'
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { BrowserInterface } from 'test/lib/browsers/base'
-import { waitFor } from 'next-test-utils'
+import { check } from 'next-test-utils'
 
 describe('beforeInteractive', () => {
   let next: NextInstance
@@ -188,14 +188,13 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
 
       expect(predefinedWorkerScripts).toBeGreaterThan(0)
 
-      await waitFor(1000)
-
       // Partytown modifes type to "text/partytown-x" after it has been executed in the web worker
-      const processedWorkerScripts = await browser.eval(
-        `document.querySelectorAll('script[type="text/partytown-x"]').length`
-      )
-
-      expect(processedWorkerScripts).toBeGreaterThan(0)
+      await check(async () => {
+        const processedWorkerScripts = await browser.eval(
+          `document.querySelectorAll('script[type="text/partytown-x"]').length`
+        )
+        return processedWorkerScripts > 0 ? 'success' : processedWorkerScripts
+      }, 'success')
     } finally {
       if (browser) await browser.close()
     }
@@ -249,13 +248,13 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
       )
       expect(predefinedWorkerScripts).toEqual(1)
 
-      await waitFor(1000)
-
       // Partytown modifes type to "text/partytown-x" after it has been executed in the web worker
-      const processedWorkerScripts = await browser.eval(
-        `document.querySelectorAll('script[type="text/partytown-x"]').length`
-      )
-      expect(processedWorkerScripts).toEqual(1)
+      await check(async () => {
+        const processedWorkerScripts = await browser.eval(
+          `document.querySelectorAll('script[type="text/partytown-x"]').length`
+        )
+        return processedWorkerScripts + ''
+      }, '1')
 
       const text = await browser.elementById('text').text()
       expect(text).toBe('abc')
@@ -281,13 +280,13 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
       )
       expect(predefinedWorkerScripts).toEqual(1)
 
-      await waitFor(1000)
-
       // Partytown modifes type to "text/partytown-x" after it has been executed in the web worker
-      const processedWorkerScripts = await browser.eval(
-        `document.querySelectorAll('script[type="text/partytown-x"]').length`
-      )
-      expect(processedWorkerScripts).toEqual(1)
+      await check(async () => {
+        const processedWorkerScripts = await browser.eval(
+          `document.querySelectorAll('script[type="text/partytown-x"]').length`
+        )
+        return processedWorkerScripts + ''
+      }, '1')
 
       const text = await browser.elementById('text').text()
       expect(text).toBe('abcd')


### PR DESCRIPTION
This updates a few next-script tests to use `check` instead of `waitFor` to make them more stable as they have flaked here and there. 

x-ref: https://github.com/vercel/next.js/runs/6862392941?check_suite_focus=true

