### PR TITLE
Allow passing FileRef directly to createNext

### DIFF
--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -111,9 +111,11 @@ if (typeof afterAll === 'function') {
  * to prevent relying on modules that shouldn't be
  */
 export async function createNext(opts: {
-  files: {
-    [filename: string]: string | FileRef
-  }
+  files:
+    | FileRef
+    | {
+        [filename: string]: string | FileRef
+      }
   dependencies?: {
     [name: string]: string
   }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -49,9 +49,11 @@ export class NextInstance {
     packageLockPath,
     env,
   }: {
-    files: {
-      [filename: string]: string | FileRef
-    }
+    files:
+      | FileRef
+      | {
+          [filename: string]: string | FileRef
+        }
     dependencies?: {
       [name: string]: string
     }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -16,9 +16,11 @@ export type PackageJson = {
   [key: string]: unknown
 }
 export class NextInstance {
-  protected files: {
-    [filename: string]: string | FileRef
-  }
+  protected files:
+    | FileRef
+    | {
+        [filename: string]: string | FileRef
+      }
   protected nextConfig?: NextConfig
   protected installCommand?: InstallCommand
   protected buildCommand?: string
@@ -148,15 +150,28 @@ export class NextInstance {
       require('console').log('created next.js install, writing test files')
     }
 
-    for (const filename of Object.keys(this.files)) {
-      const item = this.files[filename]
-      const outputfilename = path.join(this.testDir, filename)
+    if (this.files instanceof FileRef) {
+      // if a FileRef is passed directly to `files` we copy the
+      // entire folder to the test directory
+      const stats = await fs.stat(this.files.fsPath)
 
-      if (typeof item === 'string') {
-        await fs.ensureDir(path.dirname(outputfilename))
-        await fs.writeFile(outputfilename, item)
-      } else {
-        await fs.copy(item.fsPath, outputfilename)
+      if (!stats.isDirectory()) {
+        throw new Error(
+          `FileRef passed to "files" in "createNext" is not a directory ${this.files.fsPath}`
+        )
+      }
+      await fs.copy(this.files.fsPath, this.testDir)
+    } else {
+      for (const filename of Object.keys(this.files)) {
+        const item = this.files[filename]
+        const outputFilename = path.join(this.testDir, filename)
+
+        if (typeof item === 'string') {
+          await fs.ensureDir(path.dirname(outputFilename))
+          await fs.writeFile(outputFilename, item)
+        } else {
+          await fs.copy(item.fsPath, outputFilename)
+        }
       }
     }
 


### PR DESCRIPTION
As discussed here and there it would be easier for setting up new `createNext` tests to allow passing the directory with test files directly instead of listing them all out so this allows that by passing a `FileRef` directly to `files`.
