### PR TITLE
Fix rewrite/dynamic interpolation E2E cases

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -340,7 +340,10 @@ export function getUtils({
     }
   }
 
-  function normalizeDynamicRouteParams(params: ParsedUrlQuery) {
+  function normalizeDynamicRouteParams(
+    params: ParsedUrlQuery,
+    ignoreOptional?: boolean
+  ) {
     let hasValidParams = true
     if (!defaultRouteRegex) return { params, hasValidParams: false }
 
@@ -361,7 +364,10 @@ export function getUtils({
           })
         : value?.includes(defaultValue as string)
 
-      if (isDefaultValue || (typeof value === 'undefined' && !isOptional)) {
+      if (
+        isDefaultValue ||
+        (typeof value === 'undefined' && !(isOptional && ignoreOptional))
+      ) {
         hasValidParams = false
       }
 

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -1029,6 +1029,23 @@ describe('should set-up next', () => {
     const html = await res.text()
     const $ = cheerio.load(html)
     expect($('#slug-page').text()).toBe('[slug] page')
+    expect(JSON.parse($('#router').text()).query).toEqual({
+      slug: 'slug-1',
+    })
+
+    const res2 = await fetchViaHTTP(appPort, '/[slug]', undefined, {
+      headers: {
+        'x-matched-path': '/[slug]',
+      },
+      redirect: 'manual',
+    })
+
+    const html2 = await res2.text()
+    const $2 = cheerio.load(html2)
+    expect($2('#slug-page').text()).toBe('[slug] page')
+    expect(JSON.parse($2('#router').text()).query).toEqual({
+      slug: '[slug]',
+    })
   })
 
   it('should have correct asPath on dynamic SSG page correctly', async () => {


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/37646 fixing cases caught by E2E deploy tests. The changes here have been run against the deploy tests along with the builder fixtures as well to ensure we aren't regressing there. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/runs/6867919663?check_suite_focus=true