### PR TITLE
Optimize middleware regex handling

### DIFF
--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -161,19 +161,8 @@ function getMiddlewareRegExpStrings(matcherOrMatchers: unknown): string[] {
     throw new Error(`Invalid path matcher: ${matcher}`)
   }
 
-  // TODO: is the dataMatcher still needed now that we normalize this
-  // away while resolving routes
-  const dataMatcher = `/_next/data/:__nextjsBuildId__${matcher}.json`
-
-  const parsedDataRoute = tryToParsePath(dataMatcher)
-  if (parsedDataRoute.error) {
-    throw new Error(`Invalid data path matcher: ${dataMatcher}`)
-  }
-
-  const regexes = [parsedPage.regexStr, parsedDataRoute.regexStr].filter(
-    (x): x is string => !!x
-  )
-  if (regexes.length < 2) {
+  const regexes = [parsedPage.regexStr].filter((x): x is string => !!x)
+  if (regexes.length < 1) {
     throw new Error("Can't parse matcher")
   } else {
     return regexes

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -292,6 +292,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
   const server: webpack5.EntryObject = {}
   const client: webpack5.EntryObject = {}
   const nestedMiddleware: string[] = []
+  let middlewareRegex: string | undefined = undefined
 
   const getEntryHandler =
     (mappings: Record<string, string>, pagesType: 'app' | 'pages' | 'root') =>
@@ -344,6 +345,10 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
         isDev,
         page,
       })
+
+      if (isMiddlewareFile(page)) {
+        middlewareRegex = staticInfo.middleware?.pathMatcher?.source || '.*'
+      }
 
       runDependingOnPageType({
         page,
@@ -417,6 +422,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
     client,
     server,
     edgeServer,
+    middlewareRegex,
   }
 }
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -721,6 +721,7 @@ export default async function build(
           runWebpackSpan,
           target,
           appDir,
+          middlewareRegex: entrypoints.middlewareRegex,
         }
 
         const configs = await runWebpackSpan
@@ -2201,18 +2202,6 @@ export default async function build(
           'utf8'
         )
       }
-
-      await promises.writeFile(
-        path.join(
-          distDir,
-          CLIENT_STATIC_FILES_PATH,
-          buildId,
-          '_middlewareManifest.js'
-        ),
-        `self.__MIDDLEWARE_MANIFEST=${devalue(
-          middlewareManifest.clientInfo
-        )};self.__MIDDLEWARE_MANIFEST_CB&&self.__MIDDLEWARE_MANIFEST_CB()`
-      )
 
       const images = { ...config.images }
       const { deviceSizes, imageSizes } = images

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -331,6 +331,7 @@ export default async function getBaseWebpackConfig(
     runWebpackSpan,
     target = 'server',
     appDir,
+    middlewareRegex,
   }: {
     buildId: string
     config: NextConfigComplete
@@ -345,6 +346,7 @@ export default async function getBaseWebpackConfig(
     runWebpackSpan: Span
     target?: string
     appDir?: string
+    middlewareRegex?: string
   }
 ): Promise<webpack.Configuration> {
   const isClient = compilerType === 'client'
@@ -1465,6 +1467,9 @@ export default async function getBaseWebpackConfig(
             isEdgeServer ? 'edge' : 'nodejs'
           ),
         }),
+        'process.env.__NEXT_MIDDLEWARE_REGEX': JSON.stringify(
+          middlewareRegex || ''
+        ),
         'process.env.__NEXT_MANUAL_CLIENT_BASE_PATH': JSON.stringify(
           config.experimental.manualClientBasePath
         ),

--- a/packages/next/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/build-manifest-plugin.ts
@@ -224,13 +224,6 @@ export default class BuildManifestPlugin {
         const ssgManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_ssgManifest.js`
         assetMap.lowPriorityFiles.push(ssgManifestPath)
         assets[ssgManifestPath] = new sources.RawSource(srcEmptySsgManifest)
-
-        const srcEmptyMiddlewareManifest = `self.__MIDDLEWARE_MANIFEST=[];self.__MIDDLEWARE_MANIFEST_CB&&self.__MIDDLEWARE_MANIFEST_CB()`
-        const middlewareManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_middlewareManifest.js`
-        assetMap.lowPriorityFiles.push(middlewareManifestPath)
-        assets[middlewareManifestPath] = new sources.RawSource(
-          srcEmptyMiddlewareManifest
-        )
       }
 
       assetMap.pages = Object.keys(assetMap.pages)

--- a/packages/next/client/page-loader.ts
+++ b/packages/next/client/page-loader.ts
@@ -7,11 +7,7 @@ import { addLocale } from './add-locale'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { parseRelativeUrl } from '../shared/lib/router/utils/parse-relative-url'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
-import {
-  createRouteLoader,
-  getClientBuildManifest,
-  getMiddlewareManifest,
-} from './route-loader'
+import { createRouteLoader, getClientBuildManifest } from './route-loader'
 
 declare global {
   interface Window {
@@ -87,7 +83,11 @@ export default class PageLoader {
 
   getMiddlewareList() {
     if (process.env.NODE_ENV === 'production') {
-      return getMiddlewareManifest()
+      const middlewareRegex = process.env.__NEXT_MIDDLEWARE_REGEX
+      window.__MIDDLEWARE_MANIFEST = middlewareRegex
+        ? [[middlewareRegex, false]]
+        : []
+      return window.__MIDDLEWARE_MANIFEST
     } else {
       if (window.__DEV_MIDDLEWARE_MANIFEST) {
         return window.__DEV_MIDDLEWARE_MANIFEST

--- a/packages/next/client/route-loader.ts
+++ b/packages/next/client/route-loader.ts
@@ -232,28 +232,6 @@ export function getClientBuildManifest() {
   )
 }
 
-export function getMiddlewareManifest() {
-  if (self.__MIDDLEWARE_MANIFEST) {
-    return Promise.resolve(self.__MIDDLEWARE_MANIFEST)
-  }
-
-  const onMiddlewareManifest = new Promise<
-    [location: string, isSSR: boolean][]
-  >((resolve) => {
-    const cb = self.__MIDDLEWARE_MANIFEST_CB
-    self.__MIDDLEWARE_MANIFEST_CB = () => {
-      resolve(self.__MIDDLEWARE_MANIFEST!)
-      cb && cb()
-    }
-  })
-
-  return resolvePromiseWithTimeout(
-    onMiddlewareManifest,
-    MS_MAX_IDLE_DELAY,
-    markAssetError(new Error('Failed to load client middleware manifest'))
-  )
-}
-
 interface RouteFiles {
   scripts: (TrustedScriptURL | string)[]
   css: string[]

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1137,7 +1137,7 @@ export default class NextNodeServer extends BaseServer {
     onWarning?: (warning: Error) => void
   }): Promise<FetchEventResult | null> {
     middlewareBetaWarning()
-    const normalizedPathname = removeTrailingSlash(params.parsedUrl.pathname)
+    const normalizedPathname = removeTrailingSlash(params.parsed.pathname || '')
 
     // For middleware to "fetch" we must always provide an absolute URL
     const query = urlQueryToSearchParams(params.parsed.query).toString()
@@ -1269,7 +1269,7 @@ export default class NextNodeServer extends BaseServer {
         })
 
         parsedUrl.pathname = pathnameInfo.pathname
-        const normalizedPathname = removeTrailingSlash(parsedUrl.pathname)
+        const normalizedPathname = removeTrailingSlash(parsed.pathname || '')
         if (!middleware.some((m) => m.match(normalizedPathname))) {
           return { finished: false }
         }

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -2120,7 +2120,7 @@ function matchesMiddleware<T extends FetchDataOutput>(
         options.locale
       )
 
-      return items?.some(([regex]) => {
+      return !!items?.some(([regex]) => {
         return new RegExp(regex).test(cleanedAs)
       })
     }


### PR DESCRIPTION
This removes the need for loading the `_middlewareManifest` client bundle in favor of inlining the needed regex directly where needed as the data here is needed for query hydration so we don't want to wait on an additional chunk. This also optimizes the generated regex a bit as previously it was twice the size from including `_next/data` matching which should no longer be needed. 