### PR TITLE
Improve Middleware errors

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -349,7 +349,7 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
 
   if (process.env.NODE_ENV === 'development') {
     const {
-      getNodeError,
+      getServerError,
     } = require('next/dist/compiled/@next/react-dev-overlay/dist/client')
     // Server-side runtime errors need to be re-thrown on the client-side so
     // that the overlay is rendered.
@@ -368,15 +368,7 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
 
           error.name = initialErr!.name
           error.stack = initialErr!.stack
-
-          // Errors from the middleware are reported as client-side errors
-          // since the middleware is compiled using the client compiler
-          if (initialData.err && 'middleware' in initialData.err) {
-            throw error
-          }
-
-          const node = getNodeError(error)
-          throw node
+          throw getServerError(error, initialErr!.source)
         })
       }
       // We replaced the server-side error with a client-side error, and should

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -907,6 +907,7 @@ export default class HotReloader {
         rootDirectory: this.dir,
         stats: () => this.clientStats,
         serverStats: () => this.serverStats,
+        edgeServerStats: () => this.edgeServerStats,
       }),
     ]
   }

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -383,16 +383,16 @@ export default class DevServer extends Server {
 
         this.appPathRoutes = appPaths
         this.middleware = getSortedRoutes(routedMiddleware).map((page) => {
+          const middlewareRegex =
+            page === '/' && middlewareMatcher
+              ? { re: middlewareMatcher, groups: {} }
+              : getMiddlewareRegex(page, {
+                  catchAll: !ssrMiddleware.has(page),
+                })
           return {
-            match: getRouteMatcher(
-              page === '/' && middlewareMatcher
-                ? { re: middlewareMatcher, groups: {} }
-                : getMiddlewareRegex(page, {
-                    catchAll: !ssrMiddleware.has(page),
-                  })
-            ),
+            match: getRouteMatcher(middlewareRegex),
             page,
-            re: middlewareMatcher,
+            re: middlewareRegex.re,
             ssr: ssrMiddleware.has(page),
           }
         })

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -1,6 +1,5 @@
 import type { __ApiPreviewProps } from '../api-utils'
 import type { CustomRoutes } from '../../lib/load-custom-routes'
-import type { FetchEventResult } from '../web/types'
 import type { FindComponentsResult } from '../next-server'
 import type { LoadComponentsReturnType } from '../load-components'
 import type { Options as ServerOptions } from '../next-server'
@@ -52,6 +51,7 @@ import { loadDefaultErrorComponents } from '../load-components'
 import { DecodeError } from '../../shared/lib/utils'
 import {
   createOriginalStackFrame,
+  getErrorSource,
   getSourceById,
   parseStack,
 } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
@@ -646,34 +646,47 @@ export default class DevServer extends Server {
     response: BaseNextResponse
     parsedUrl: ParsedUrl
     parsed: UrlWithParsedQuery
-  }): Promise<FetchEventResult | null> {
+  }) {
     try {
       const result = await super.runMiddleware({
         ...params,
         onWarning: (warn) => {
-          this.logErrorWithOriginalStack(warn, 'warning', 'edge-server')
+          this.logErrorWithOriginalStack(warn, 'warning')
         },
       })
 
-      result?.waitUntil.catch((error) =>
-        this.logErrorWithOriginalStack(
-          error,
-          'unhandledRejection',
-          'edge-server'
-        )
-      )
+      if ('finished' in result) {
+        return result
+      }
+
+      result.waitUntil.catch((error) => {
+        this.logErrorWithOriginalStack(error, 'unhandledRejection')
+      })
       return result
     } catch (error) {
       if (error instanceof DecodeError) {
         throw error
       }
-      this.logErrorWithOriginalStack(error, undefined, 'edge-server')
+      this.logErrorWithOriginalStack(error)
       const err = getProperError(error)
       ;(err as any).middleware = true
       const { request, response, parsedUrl } = params
+
+      /**
+       * When there is a failure for an internal Next.js request from
+       * middleware we bypass the error without finishing the request
+       * so we can serve the required chunks to render the error.
+       */
+      if (
+        request.url.includes('/_next/static') ||
+        request.url.includes('/__nextjs_original-stack-frame')
+      ) {
+        return { finished: false }
+      }
+
       response.statusCode = 500
       this.renderError(err, request, response, parsedUrl.pathname)
-      return null
+      return { finished: true }
     }
   }
 
@@ -737,8 +750,7 @@ export default class DevServer extends Server {
 
   private async logErrorWithOriginalStack(
     err?: unknown,
-    type?: 'unhandledRejection' | 'uncaughtException' | 'warning',
-    stats: 'server' | 'edge-server' = 'server'
+    type?: 'unhandledRejection' | 'uncaughtException' | 'warning'
   ) {
     let usedOriginalStack = false
 
@@ -753,10 +765,18 @@ export default class DevServer extends Server {
             ''
           )
 
-          const compilation =
-            frame.file!.startsWith('(middleware)') && stats === 'server'
-              ? this.hotReloader?.serverStats?.compilation
-              : this.hotReloader?.edgeServerStats?.compilation
+          let compilation: any
+
+          const src = getErrorSource(err)
+          if (src === 'edge-server') {
+            compilation = this.hotReloader?.edgeServerStats?.compilation
+          } else if (src === 'server') {
+            compilation = this.hotReloader?.serverStats?.compilation
+          } else {
+            compilation = frame.file!.includes('(middleware)')
+              ? this.hotReloader?.edgeServerStats?.compilation
+              : this.hotReloader?.serverStats?.compilation
+          }
 
           const source = await getSourceById(
             !!frame.file?.startsWith(sep) || !!frame.file?.startsWith('file:'),

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -745,18 +745,18 @@ export default class DevServer extends Server {
     if (isError(err) && err.stack) {
       try {
         const frames = parseStack(err.stack!)
-        const frame = frames[0]
+        const frame = frames.find(({ file }) => !file?.startsWith('eval'))!
 
         if (frame.lineNumber && frame?.file) {
-          const compilation =
-            stats === 'server'
-              ? this.hotReloader?.serverStats?.compilation
-              : this.hotReloader?.edgeServerStats?.compilation
-
           const moduleId = frame.file!.replace(
             /^(webpack-internal:\/\/\/|file:\/\/)/,
             ''
           )
+
+          const compilation =
+            frame.file!.startsWith('(middleware)') && stats === 'server'
+              ? this.hotReloader?.serverStats?.compilation
+              : this.hotReloader?.edgeServerStats?.compilation
 
           const source = await getSourceById(
             !!frame.file?.startsWith(sep) || !!frame.file?.startsWith('file:'),

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1135,7 +1135,7 @@ export default class NextNodeServer extends BaseServer {
     parsedUrl: ParsedUrl
     parsed: UrlWithParsedQuery
     onWarning?: (warning: Error) => void
-  }): Promise<FetchEventResult | null> {
+  }) {
     middlewareBetaWarning()
     const normalizedPathname = removeTrailingSlash(params.parsed.pathname || '')
 
@@ -1233,6 +1233,7 @@ export default class NextNodeServer extends BaseServer {
 
     if (!result) {
       this.render404(params.request, params.response, params.parsed)
+      return { finished: true }
     } else {
       for (let [key, value] of allHeaders) {
         result.response.headers.set(key, value)
@@ -1274,7 +1275,7 @@ export default class NextNodeServer extends BaseServer {
           return { finished: false }
         }
 
-        let result: FetchEventResult | null = null
+        let result: Awaited<ReturnType<typeof this.runMiddleware>>
 
         try {
           result = await this.runMiddleware({
@@ -1302,8 +1303,8 @@ export default class NextNodeServer extends BaseServer {
           return { finished: true }
         }
 
-        if (result === null) {
-          return { finished: true }
+        if ('finished' in result) {
+          return result
         }
 
         if (result.response.headers.has('x-middleware-rewrite')) {

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -80,7 +80,6 @@ import {
 } from './node-web-streams-helper'
 import { ImageConfigContext } from '../shared/lib/image-config-context'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
-import { getErrorSource } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
 import { urlQueryToSearchParams } from '../shared/lib/router/utils/querystring'
 import { postProcessHTML } from './post-process'
 import { htmlEscapeJsonString } from './htmlescape'
@@ -1673,10 +1672,19 @@ export async function renderToHTML(
 }
 
 function errorToJSON(err: Error) {
+  let source: 'server' | 'edge-server' = 'server'
+
+  if (process.env.NEXT_RUNTIME !== 'edge') {
+    source =
+      require('next/dist/compiled/@next/react-dev-overlay/dist/middleware').getErrorSource(
+        err
+      ) || 'server'
+  }
+
   return {
     name: err.name,
+    source,
     message: stripAnsi(err.message),
-    source: getErrorSource(err) || 'server',
     stack: err.stack,
   }
 }

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -80,6 +80,7 @@ import {
 } from './node-web-streams-helper'
 import { ImageConfigContext } from '../shared/lib/image-config-context'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
+import { getErrorSource } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
 import { urlQueryToSearchParams } from '../shared/lib/router/utils/querystring'
 import { postProcessHTML } from './post-process'
 import { htmlEscapeJsonString } from './htmlescape'
@@ -1675,15 +1676,15 @@ function errorToJSON(err: Error) {
   return {
     name: err.name,
     message: stripAnsi(err.message),
+    source: getErrorSource(err) || 'server',
     stack: err.stack,
-    middleware: (err as any).middleware,
   }
 }
 
 function serializeError(
   dev: boolean | undefined,
   err: Error
-): Error & { statusCode?: number } {
+): Error & { statusCode?: number; source?: 'edge-server' | 'server' } {
   if (dev) {
     return errorToJSON(err)
   }

--- a/packages/next/server/web/sandbox/context.ts
+++ b/packages/next/server/web/sandbox/context.ts
@@ -1,5 +1,6 @@
 import type { Primitives } from 'next/dist/compiled/@edge-runtime/primitives'
 import type { WasmBinding } from '../../../build/webpack/loaders/get-module-build-info'
+import { getServerError } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
 import { EDGE_UNSUPPORTED_NODE_APIS } from '../../../shared/lib/constants'
 import { EdgeRuntime } from 'next/dist/compiled/edge-runtime'
 import { readFileSync, promises as fs } from 'fs'
@@ -116,7 +117,7 @@ async function createModuleContext(options: ModuleContextOptions) {
           warning.name = 'DynamicCodeEvaluationWarning'
           Error.captureStackTrace(warning, __next_eval__)
           warnedEvals.add(key)
-          options.onWarning(warning)
+          options.onWarning(getServerError(warning, 'edge-server'))
         }
         return fn()
       }

--- a/packages/next/server/web/sandbox/sandbox.ts
+++ b/packages/next/server/web/sandbox/sandbox.ts
@@ -1,8 +1,11 @@
-import type { WasmBinding } from '../../../build/webpack/loaders/get-module-build-info'
 import type { RequestData, FetchEventResult } from '../types'
+import type { WasmBinding } from '../../../build/webpack/loaders/get-module-build-info'
+import { getServerError } from 'next/dist/compiled/@next/react-dev-overlay/dist/middleware'
 import { getModuleContext } from './context'
 
-export async function run(params: {
+export const ErrorSource = Symbol('SandboxError')
+
+type RunnerFn = (params: {
   name: string
   env: string[]
   onWarning: (warn: Error) => void
@@ -10,7 +13,9 @@ export async function run(params: {
   request: RequestData
   useCache: boolean
   wasm: WasmBinding[]
-}): Promise<FetchEventResult> {
+}) => Promise<FetchEventResult>
+
+export const run = withTaggedErrors(async (params) => {
   const { runtime, evaluateInContext } = await getModuleContext({
     moduleName: params.name,
     onWarning: params.onWarning,
@@ -39,4 +44,22 @@ export async function run(params: {
   return runtime.context._ENTRIES[`middleware_${params.name}`].default({
     request: params.request,
   })
+})
+
+/**
+ * Decorates the runner function making sure all errors it can produce are
+ * tagged with `edge-server` so they can properly be rendered in dev.
+ */
+function withTaggedErrors(fn: RunnerFn): RunnerFn {
+  return (params) =>
+    fn(params)
+      .then((result) => ({
+        ...result,
+        waitUntil: result?.waitUntil?.catch((error) => {
+          throw getServerError(error, 'edge-server')
+        }),
+      }))
+      .catch((error) => {
+        throw getServerError(error, 'edge-server')
+      })
 }

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -92,7 +92,7 @@ export type NEXT_DATA = {
   autoExport?: boolean
   isFallback?: boolean
   dynamicIds?: (string | number)[]
-  err?: Error & { statusCode?: number }
+  err?: Error & { statusCode?: number; source?: 'server' | 'edge-server' }
   gsp?: boolean
   gssp?: boolean
   customServer?: boolean

--- a/packages/react-dev-overlay/src/client.ts
+++ b/packages/react-dev-overlay/src/client.ts
@@ -94,7 +94,7 @@ function onRefresh() {
 }
 
 export { getErrorByType } from './internal/helpers/getErrorByType'
-export { getNodeError } from './internal/helpers/nodeStackFrames'
+export { getServerError } from './internal/helpers/nodeStackFrames'
 export { default as ReactDevOverlay } from './internal/ReactDevOverlay'
 export {
   onBuildOk,

--- a/packages/react-dev-overlay/src/internal/container/Errors.tsx
+++ b/packages/react-dev-overlay/src/internal/container/Errors.tsx
@@ -15,7 +15,7 @@ import { LeftRightDialogHeader } from '../components/LeftRightDialogHeader'
 import { Overlay } from '../components/Overlay'
 import { Toast } from '../components/Toast'
 import { getErrorByType, ReadyRuntimeError } from '../helpers/getErrorByType'
-import { isNodeError } from '../helpers/nodeStackFrames'
+import { getErrorSource } from '../helpers/nodeStackFrames'
 import { noop as css } from '../helpers/noop-template'
 import { CloseIcon } from '../icons/CloseIcon'
 import { RuntimeError } from './RuntimeError'
@@ -240,7 +240,10 @@ export const Errors: React.FC<ErrorsProps> = function Errors({ errors }) {
     )
   }
 
-  const isServerError = isNodeError(activeError.error)
+  const isServerError = ['server', 'edge-server'].includes(
+    getErrorSource(activeError.error) || ''
+  )
+
   return (
     <Overlay>
       <Dialog

--- a/packages/react-dev-overlay/src/internal/helpers/getErrorByType.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/getErrorByType.ts
@@ -1,6 +1,6 @@
 import { TYPE_UNHANDLED_ERROR, TYPE_UNHANDLED_REJECTION } from '../bus'
 import { SupportedErrorEvent } from '../container/Errors'
-import { isNodeError } from './nodeStackFrames'
+import { getErrorSource } from './nodeStackFrames'
 import { getOriginalStackFrames, OriginalStackFrame } from './stack-frame'
 
 export type ReadyRuntimeError = {
@@ -22,8 +22,8 @@ export async function getErrorByType(
         runtime: true,
         error: event.reason,
         frames: await getOriginalStackFrames(
-          isNodeError(event.reason),
-          event.frames
+          event.frames,
+          getErrorSource(event.reason)
         ),
       }
     }

--- a/packages/react-dev-overlay/src/internal/helpers/nodeStackFrames.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/nodeStackFrames.ts
@@ -19,13 +19,16 @@ export function getFilesystemFrame(frame: StackFrame): StackFrame {
   return f
 }
 
-const symbolNodeError = Symbol('NextjsNodeError')
+const symbolError = Symbol('NextjsError')
 
-export function isNodeError(error: Error): boolean {
-  return symbolNodeError in error
+export function getErrorSource(error: Error): 'server' | 'edge-server' | null {
+  return (error as any)[symbolError] || null
 }
 
-export function getNodeError(error: Error): Error {
+export function getServerError(
+  error: Error,
+  type: 'edge-server' | 'server'
+): Error {
   let n: Error
   try {
     throw new Error(error.message)
@@ -56,10 +59,11 @@ export function getNodeError(error: Error): Error {
     n.stack = error.stack
   }
 
-  Object.defineProperty(n, symbolNodeError, {
+  Object.defineProperty(n, symbolError, {
     writable: false,
     enumerable: false,
     configurable: false,
+    value: type,
   })
   return n
 }

--- a/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
+++ b/packages/react-dev-overlay/src/internal/helpers/stack-frame.ts
@@ -31,21 +31,20 @@ export type OriginalStackFrame =
     }
 
 export function getOriginalStackFrames(
-  isServerSide: boolean,
-  frames: StackFrame[]
+  frames: StackFrame[],
+  type: 'server' | 'edge-server' | null
 ) {
-  return Promise.all(
-    frames.map((frame) => getOriginalStackFrame(isServerSide, frame))
-  )
+  return Promise.all(frames.map((frame) => getOriginalStackFrame(frame, type)))
 }
 
 export function getOriginalStackFrame(
-  isServerSide: boolean,
-  source: StackFrame
+  source: StackFrame,
+  type: 'server' | 'edge-server' | null
 ): Promise<OriginalStackFrame> {
   async function _getOriginalStackFrame(): Promise<OriginalStackFrame> {
     const params = new URLSearchParams()
-    params.append('isServerSide', String(isServerSide))
+    params.append('isServer', String(type === 'server'))
+    params.append('isEdgeServer', String(type === 'edge-server'))
     for (const key in source) {
       params.append(key, ((source as any)[key] ?? '').toString())
     }

--- a/packages/react-dev-overlay/src/middleware.ts
+++ b/packages/react-dev-overlay/src/middleware.ts
@@ -15,12 +15,15 @@ import type webpack from 'webpack'
 import { getRawSourceMap } from './internal/helpers/getRawSourceMap'
 import { launchEditor } from './internal/helpers/launchEditor'
 
+export { getErrorSource } from './internal/helpers/nodeStackFrames'
+export { getServerError } from './internal/helpers/nodeStackFrames'
 export { parseStack } from './internal/helpers/parseStack'
 
 export type OverlayMiddlewareOptions = {
   rootDirectory: string
   stats(): webpack.Stats | null
   serverStats(): webpack.Stats | null
+  edgeServerStats(): webpack.Stats | null
 }
 
 export type OriginalStackFrameResponse = {
@@ -212,7 +215,8 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
 
     if (pathname === '/__nextjs_original-stack-frame') {
       const frame = query as unknown as StackFrame & {
-        isServerSide: 'true' | 'false'
+        isEdgeServer: 'true' | 'false'
+        isServer: 'true' | 'false'
       }
       if (
         !(
@@ -226,7 +230,6 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
         return res.end()
       }
 
-      const isServerSide = frame.isServerSide === 'true'
       const moduleId: string = frame.file.replace(
         /^(webpack-internal:\/\/\/|file:\/\/)/,
         ''
@@ -234,9 +237,12 @@ function getOverlayMiddleware(options: OverlayMiddlewareOptions) {
 
       let source: Source
       try {
-        const compilation = isServerSide
-          ? options.serverStats()?.compilation
-          : options.stats()?.compilation
+        const compilation =
+          frame.isEdgeServer === 'true'
+            ? options.edgeServerStats()?.compilation
+            : frame.isServer === 'true'
+            ? options.serverStats()?.compilation
+            : options.stats()?.compilation
 
         source = await getSourceById(
           frame.file.startsWith('file:'),

--- a/test/integration/middleware-dev-errors/lib/unhandled.js
+++ b/test/integration/middleware-dev-errors/lib/unhandled.js
@@ -1,0 +1,3 @@
+setTimeout(() => {
+  throw new Error('This file asynchronously fails while loading')
+}, 10)

--- a/test/integration/middleware-dev-errors/lib/unparseable.js
+++ b/test/integration/middleware-dev-errors/lib/unparseable.js
@@ -1,0 +1,1 @@
+throw new Error('This file synchronously fails while loading')

--- a/test/integration/middleware-dev-errors/middleware.js
+++ b/test/integration/middleware-dev-errors/middleware.js
@@ -1,0 +1,1 @@
+// this will be populated by each test

--- a/test/integration/middleware-dev-errors/pages/index.js
+++ b/test/integration/middleware-dev-errors/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>A page</div>
+}

--- a/test/integration/middleware-dev-errors/pages/index.js
+++ b/test/integration/middleware-dev-errors/pages/index.js
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <div>A page</div>
+  return <div id="page-title">A page</div>
 }

--- a/test/integration/middleware-dev-errors/test/index.test.js
+++ b/test/integration/middleware-dev-errors/test/index.test.js
@@ -1,135 +1,244 @@
-import { writeFile } from 'fs-extra'
-import { fetchViaHTTP, findPort, killApp, launchApp } from 'next-test-utils'
+import {
+  fetchViaHTTP,
+  File,
+  findPort,
+  getRedboxSource,
+  hasRedbox,
+  killApp,
+  launchApp,
+} from 'next-test-utils'
 import { join } from 'path'
 import stripAnsi from 'strip-ansi'
+import webdriver from 'next-webdriver'
 
-describe('Middleware dev errors', () => {
-  const appDir = join(__dirname, '..')
-  const middlewareFile = join(appDir, 'middleware.js')
+const context = {
+  appDir: join(__dirname, '../'),
+  buildLogs: { output: '', stdout: '', stderr: '' },
+  logs: { output: '', stdout: '', stderr: '' },
+  middleware: new File(join(__dirname, '../middleware.js')),
+  page: new File(join(__dirname, '../pages/index.js')),
+}
 
-  afterEach(() =>
-    writeFile(middlewareFile, '// this will be populated by each test\n')
-  )
+describe('Middleware development errors', () => {
+  beforeEach(async () => {
+    context.logs = { output: '', stdout: '', stderr: '' }
+    context.appPort = await findPort()
+    context.app = await launchApp(context.appDir, context.appPort, {
+      env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
+      onStdout(msg) {
+        context.logs.output += msg
+        context.logs.stdout += msg
+      },
+      onStderr(msg) {
+        context.logs.output += msg
+        context.logs.stderr += msg
+      },
+    })
+  })
 
-  describe.each([
-    {
-      title: 'throwing synchronously during execution',
-      code: `export default function () {
-              throw new Error('boom')
-            }`,
-      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ Object.__WEBPACK_DEFAULT_EXPORT__ \\[as handler\\]
-Error: boom`,
-    },
-    {
-      title: 'throwing asynchronously during execution',
-      code: `import { NextResponse } from 'next/server'
-            async function throwError() {
-              throw new Error('async boom!')
-            }
-            export default function () {
-              throwError()
-              return NextResponse.next()
-            }`,
-      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ throwError
-Error: async boom!`,
-    },
-    {
-      title: 'running invalid dynamic code with eval',
-      code: `import { NextResponse } from 'next/server'
+  afterEach(() => {
+    context.middleware.restore()
+    context.page.restore()
+    if (context.app) {
+      killApp(context.app)
+    }
+  })
 
-                    export default function () {
-                      eval('test')
-                      return NextResponse.next()
-                    }`,
-      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval
-ReferenceError: test is not defined`,
-    },
-    {
-      title: 'running invalid dynamic code with Function constructor',
-      code: `import { NextResponse } from 'next/server'
+  describe('when middleware throws synchronously', () => {
+    beforeEach(() => {
+      context.middleware.write(`
+      export default function () {
+        throw new Error('boom')
+      }`)
+    })
 
-                    export default function () {
-                      new Function('test')()
-                      return NextResponse.next()
-                    }`,
-      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ Object.__WEBPACK_DEFAULT_EXPORT__ \\[as handler\\]
-ReferenceError: test is not defined`,
-    },
-    {
-      title: 'throwing error while loading middleware',
-      code: `import { NextResponse } from 'next/server'
+    it('logs the error correctly', async () => {
+      await fetchViaHTTP(context.appPort, '/')
+      const output = stripAnsi(context.logs.output)
+      expect(output).toMatch(
+        new RegExp(
+          `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ Object.__WEBPACK_DEFAULT_EXPORT__ \\[as handler\\]\nError: boom`,
+          'm'
+        )
+      )
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
+    })
+
+    it('renders the error correctly and recovers', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      expect(await hasRedbox(browser, true)).toBe(true)
+      context.middleware.write(`export default function () {}`)
+      await hasRedbox(browser, false)
+    })
+  })
+
+  describe('when middleware contains an unhandled rejection', () => {
+    beforeEach(() => {
+      context.middleware.write(`
+      import { NextResponse } from 'next/server'
+      async function throwError() {
+        throw new Error('async boom!')
+      }
+      export default function () {
+        throwError()
+        return NextResponse.next()
+      }`)
+    })
+
+    it('logs the error correctly', async () => {
+      await fetchViaHTTP(context.appPort, '/')
+      const output = stripAnsi(context.logs.output)
+      expect(output).toMatch(
+        new RegExp(
+          `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ throwError\nError: async boom!`,
+          'm'
+        )
+      )
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
+    })
+
+    it('does not render the error', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      expect(await hasRedbox(browser, false)).toBe(false)
+      expect(await browser.elementByCss('#page-title')).toBeTruthy()
+    })
+  })
+
+  describe('when running invalid dynamic code with eval', () => {
+    beforeEach(() => {
+      context.middleware.write(`
+      import { NextResponse } from 'next/server'
+      export default function () {
+        eval('test')
+        return NextResponse.next()
+      }`)
+    })
+
+    it('logs the error correctly', async () => {
+      await fetchViaHTTP(context.appPort, '/')
+      const output = stripAnsi(context.logs.output)
+      expect(output).toMatch(
+        new RegExp(
+          `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval\nReferenceError: test is not defined`,
+          'm'
+        )
+      )
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
+    })
+
+    it('renders the error correctly and recovers', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      expect(await hasRedbox(browser, true)).toBe(true)
+      expect(await getRedboxSource(browser)).toContain(`eval('test')`)
+      context.middleware.write(`export default function () {}`)
+      await hasRedbox(browser, false)
+    })
+  })
+
+  describe('when throwing while loading the module', () => {
+    beforeEach(() => {
+      context.middleware.write(`
+      import { NextResponse } from 'next/server'
                     throw new Error('booooom!')
                     export default function () {
                       return NextResponse.next()
-                    }`,
-      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ <unknown>
-Error: booooom!`,
-    },
-    {
-      title: 'throwing error while loading dependencies',
-      code: `import { NextResponse } from 'next/server'
-                    import './lib/unparseable'
+                    }`)
+    })
 
-                    export default function () {
-                      return NextResponse.next()
-                    }`,
-      expectedError: `error - \\(middleware\\)/lib/unparseable.js \\(\\d+:\\d+\\) @ <unknown>
-Error: This file synchronously fails while loading`,
-    },
-    {
-      title: 'with unhandled rejection during middleware loading',
-      code: `import { NextResponse } from 'next/server'
+    it('logs the error correctly', async () => {
+      await fetchViaHTTP(context.appPort, '/')
+      const output = stripAnsi(context.logs.output)
+      expect(output).toMatch(
+        new RegExp(
+          `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ <unknown>\nError: booooom!`,
+          'm'
+        )
+      )
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
+    })
+
+    it('renders the error correctly and recovers', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      expect(await hasRedbox(browser, true)).toBe(true)
+      expect(await getRedboxSource(browser)).toContain(
+        `throw new Error('booooom!')`
+      )
+      context.middleware.write(`export default function () {}`)
+      await hasRedbox(browser, false)
+    })
+  })
+
+  describe('when there is an unhandled rejection while loading the module', () => {
+    beforeEach(() => {
+      context.middleware.write(`
+      import { NextResponse } from 'next/server'
                 (async function(){
                   throw new Error('you shall see me')
                 })()
 
                 export default function () {
                   return NextResponse.next()
-                }`,
-      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval
-Error: you shall see me`,
-    },
-    {
-      title: 'with unhandled rejection during dependency loading',
-      code: `import { NextResponse } from 'next/server'
+                }`)
+    })
+
+    it('logs the error correctly', async () => {
+      await fetchViaHTTP(context.appPort, '/')
+      const output = stripAnsi(context.logs.output)
+      expect(output).toMatch(
+        new RegExp(
+          `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval\nError: you shall see me`,
+          'm'
+        )
+      )
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
+    })
+
+    it('does not render the error', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      expect(await hasRedbox(browser, false)).toBe(false)
+      expect(await browser.elementByCss('#page-title')).toBeTruthy()
+    })
+  })
+
+  describe('when there is an unhandled rejection while loading a dependency', () => {
+    beforeEach(() => {
+      context.middleware.write(`
+      import { NextResponse } from 'next/server'
                 import './lib/unhandled'
 
                 export default function () {
                   return NextResponse.next()
-                }`,
-      expectedError: `error - \\(middleware\\)/lib/unhandled.js \\(\\d+:\\d+\\) @ Timeout.eval \\[as _onTimeout\\]
-Error: This file asynchronously fails while loading`,
-    },
-  ])('given a middleware $title', ({ code, expectedError }) => {
-    let app = null
-    let port = 0
-    let output = ''
-
-    beforeAll(async () => {
-      await writeFile(middlewareFile, code)
-      port = await findPort()
-      app = await launchApp(appDir, port, {
-        env: {
-          __NEXT_TEST_WITH_DEVTOOL: 1,
-        },
-        onStdout(msg) {
-          output += msg
-        },
-        onStderr(msg) {
-          output += msg
-        },
-      })
+                }`)
     })
 
-    afterAll(() => killApp(app))
-
-    it('displays clean error in logs', async () => {
-      await fetchViaHTTP(port, '/')
-      output = stripAnsi(output)
-      expect(output).toMatch(new RegExp(expectedError, 'm'))
+    it('logs the error correctly', async () => {
+      await fetchViaHTTP(context.appPort, '/')
+      const output = stripAnsi(context.logs.output)
+      expect(output).toMatch(
+        new RegExp(
+          `error - \\(middleware\\)/lib/unhandled.js \\(\\d+:\\d+\\) @ Timeout.eval \\[as _onTimeout\\]\nError: This file asynchronously fails while loading`,
+          'm'
+        )
+      )
       expect(output).not.toContain(
         'webpack-internal:///(middleware)/./middleware.js'
       )
+    })
+
+    it('does not render the error', async () => {
+      const browser = await webdriver(context.appPort, '/')
+      expect(await hasRedbox(browser, false)).toBe(false)
+      expect(await browser.elementByCss('#page-title')).toBeTruthy()
     })
   })
 })

--- a/test/integration/middleware-dev-errors/test/index.test.js
+++ b/test/integration/middleware-dev-errors/test/index.test.js
@@ -1,0 +1,135 @@
+import { writeFile } from 'fs-extra'
+import { fetchViaHTTP, findPort, killApp, launchApp } from 'next-test-utils'
+import { join } from 'path'
+import stripAnsi from 'strip-ansi'
+
+describe('Middleware dev errors', () => {
+  const appDir = join(__dirname, '..')
+  const middlewareFile = join(appDir, 'middleware.js')
+
+  afterEach(() =>
+    writeFile(middlewareFile, '// this will be populated by each test\n')
+  )
+
+  describe.each([
+    {
+      title: 'throwing synchronously during execution',
+      code: `export default function () {
+              throw new Error('boom')
+            }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ Object.__WEBPACK_DEFAULT_EXPORT__ \\[as handler\\]
+Error: boom`,
+    },
+    {
+      title: 'throwing asynchronously during execution',
+      code: `import { NextResponse } from 'next/server'
+            async function throwError() {
+              throw new Error('async boom!')
+            }
+            export default function () {
+              throwError()
+              return NextResponse.next()
+            }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ throwError
+Error: async boom!`,
+    },
+    {
+      title: 'running invalid dynamic code with eval',
+      code: `import { NextResponse } from 'next/server'
+
+                    export default function () {
+                      eval('test')
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval
+ReferenceError: test is not defined`,
+    },
+    {
+      title: 'running invalid dynamic code with Function constructor',
+      code: `import { NextResponse } from 'next/server'
+
+                    export default function () {
+                      new Function('test')()
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ Object.__WEBPACK_DEFAULT_EXPORT__ \\[as handler\\]
+ReferenceError: test is not defined`,
+    },
+    {
+      title: 'throwing error while loading middleware',
+      code: `import { NextResponse } from 'next/server'
+                    throw new Error('booooom!')
+                    export default function () {
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ <unknown>
+Error: booooom!`,
+    },
+    {
+      title: 'throwing error while loading dependencies',
+      code: `import { NextResponse } from 'next/server'
+                    import './lib/unparseable'
+
+                    export default function () {
+                      return NextResponse.next()
+                    }`,
+      expectedError: `error - \\(middleware\\)/lib/unparseable.js \\(\\d+:\\d+\\) @ <unknown>
+Error: This file synchronously fails while loading`,
+    },
+    {
+      title: 'with unhandled rejection during middleware loading',
+      code: `import { NextResponse } from 'next/server'
+                (async function(){
+                  throw new Error('you shall see me')
+                })()
+
+                export default function () {
+                  return NextResponse.next()
+                }`,
+      expectedError: `error - \\(middleware\\)/middleware.js \\(\\d+:\\d+\\) @ eval
+Error: you shall see me`,
+    },
+    {
+      title: 'with unhandled rejection during dependency loading',
+      code: `import { NextResponse } from 'next/server'
+                import './lib/unhandled'
+
+                export default function () {
+                  return NextResponse.next()
+                }`,
+      expectedError: `error - \\(middleware\\)/lib/unhandled.js \\(\\d+:\\d+\\) @ Timeout.eval \\[as _onTimeout\\]
+Error: This file asynchronously fails while loading`,
+    },
+  ])('given a middleware $title', ({ code, expectedError }) => {
+    let app = null
+    let port = 0
+    let output = ''
+
+    beforeAll(async () => {
+      await writeFile(middlewareFile, code)
+      port = await findPort()
+      app = await launchApp(appDir, port, {
+        env: {
+          __NEXT_TEST_WITH_DEVTOOL: 1,
+        },
+        onStdout(msg) {
+          output += msg
+        },
+        onStderr(msg) {
+          output += msg
+        },
+      })
+    })
+
+    afterAll(() => killApp(app))
+
+    it('displays clean error in logs', async () => {
+      await fetchViaHTTP(port, '/')
+      output = stripAnsi(output)
+      expect(output).toMatch(new RegExp(expectedError, 'm'))
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
+    })
+  })
+})

--- a/test/integration/middleware-with-node.js-apis/test/index.test.ts
+++ b/test/integration/middleware-with-node.js-apis/test/index.test.ts
@@ -51,6 +51,7 @@ describe('Middleware using Node.js API', () => {
       output = ''
       appPort = await findPort()
       app = await launchApp(appDir, appPort, {
+        env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
         onStdout(msg) {
           output += msg
         },
@@ -65,7 +66,7 @@ describe('Middleware using Node.js API', () => {
     it.each([
       {
         api: 'Buffer',
-        error: `Cannot read properties of undefined (reading 'from')`,
+        error: `Cannot read property 'from' of undefined`,
       },
       ...unsupportedFunctions.map((api) => ({
         api,

--- a/test/integration/middleware-with-node.js-apis/test/index.test.ts
+++ b/test/integration/middleware-with-node.js-apis/test/index.test.ts
@@ -2,6 +2,7 @@
 
 import { remove } from 'fs-extra'
 import {
+  check,
   fetchViaHTTP,
   findPort,
   killApp,
@@ -80,10 +81,18 @@ describe('Middleware using Node.js API', () => {
       const res = await fetchViaHTTP(appPort, `/${api}`)
       await waitFor(500)
       expect(res.status).toBe(500)
-      expect(output)
-        .toContain(`NodejsRuntimeApiInMiddlewareWarning: You're using a Node.js API (${api}) which is not supported in the Edge Runtime that Middleware uses.
+      await check(
+        () =>
+          output.includes(`NodejsRuntimeApiInMiddlewareWarning: You're using a Node.js API (${api}) which is not supported in the Edge Runtime that Middleware uses.
 Learn more: https://nextjs.org/docs/api-reference/edge-runtime`)
-      expect(output).toContain(`TypeError: ${error}`)
+            ? 'success'
+            : output,
+        'success'
+      )
+      await check(
+        () => (output.includes(`TypeError: ${error}`) ? 'success' : output),
+        'success'
+      )
     })
   })
 

--- a/test/integration/middleware-with-node.js-apis/test/index.test.ts
+++ b/test/integration/middleware-with-node.js-apis/test/index.test.ts
@@ -67,7 +67,9 @@ describe('Middleware using Node.js API', () => {
     it.each([
       {
         api: 'Buffer',
-        error: `Cannot read property 'from' of undefined`,
+        error: process.version.startsWith('v16')
+          ? `Cannot read properties of undefined (reading 'from')`
+          : `Cannot read property 'from' of undefined`,
       },
       ...unsupportedFunctions.map((api) => ({
         api,


### PR DESCRIPTION
This PR brings the changes from #37659 and continues the work there to properly show errors from Middleware with the development overlay and the right trace. For this we update the package `react-dev-overlay` to accept as server errors also Edge errors taking the compiler stats on its middleware too in order to allow mapping errors.

This also brings self-recovery from middleware errors.