### PR TITLE
Update Jest config with SWC docs

### DIFF
--- a/docs/advanced-features/compiler.md
+++ b/docs/advanced-features/compiler.md
@@ -70,7 +70,7 @@ First, update to the latest version of Next.js: `npm install next@latest`. Then,
 const nextJest = require('next/jest')
 
 // Providing the path to your Next.js app which will enable loading next.config.js and .env files
-const createJestConfig = nextJest({ dir })
+const createJestConfig = nextJest({ dir: './' })
 
 // Any custom config you want to pass to Jest
 const customJestConfig = {


### PR DESCRIPTION
## Motivation/ Context
- When upgrading `next` from `11` to `12`, I followed [Upgrade guide from 11 => 12](https://nextjs.org/docs/upgrading#upgrading-from-11-to-12). I removed `.babelrc` to opt-in `SWC`. I thought that's all, but after removing `.babelrc`, Jest broke immediately. So I follow the guide https://nextjs.org/docs/advanced-features/compiler#jest to configure Jest to work with SWC. I copied the content of `jest.config.js` to my project but it does not work. The reason:
```diff
-const createJestConfig = nextJest({ dir }) // `dir` IS NOT DEFINED
+const createJestConfig = nextJest({ dir: './' }) // Should change to this. Sync with https://nextjs.org/docs/testing#setting-up-jest-with-the-rust-compiler
```
- This PR is to help others to configure Jest with SWC by copying code from the documentation site without encountering the same issue as I did.

## Documentation
- [x] Update the docs so users can just copy and paste when configuring Jest with SWC (Sync with https://nextjs.org/docs/testing#setting-up-jest-with-the-rust-compiler)
- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)

## Future work
- Since [Upgrade guide from 11 => 12](https://nextjs.org/docs/upgrading#upgrading-from-11-to-12) did not mention anything about Jest. If I remove `.babelrc` to opt-in SWC. The current Jest settings will crash (since it's using babel). We likely want to update the Upgrade guide to mention this cc: @leerob 