### PR TITLE
Fix shallow routing with rewrites/middleware

### DIFF
--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -41,6 +41,11 @@ export async function middleware(request) {
     return NextResponse.next()
   }
 
+  if (url.pathname === '/sha') {
+    url.pathname = '/shallow'
+    return NextResponse.rewrite(url)
+  }
+
   if (url.pathname.startsWith('/fetch-user-agent-default')) {
     try {
       const apiRoute = new URL(url)

--- a/test/e2e/middleware-general/app/next.config.js
+++ b/test/e2e/middleware-general/app/next.config.js
@@ -22,6 +22,10 @@ module.exports = {
         source: '/rewrite-2',
         destination: '/about/a',
       },
+      {
+        source: '/sha',
+        destination: '/shallow',
+      },
     ]
   },
 }

--- a/test/e2e/middleware-general/app/pages/shallow.js
+++ b/test/e2e/middleware-general/app/pages/shallow.js
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export default function Shallow({ message }) {
+  const { pathname, query } = useRouter()
+  return (
+    <div>
+      <ul>
+        <li id="message-contents">{message}</li>
+        <li>
+          <Link href="/sha?hello=world" shallow>
+            <a id="shallow-link">Shallow link to /shallow?hello=world</a>
+          </Link>
+        </li>
+        <li>
+          <Link href="/sha?hello=goodbye">
+            <a id="deep-link">Deep link to /shallo?hello=goodbye</a>
+          </Link>
+        </li>
+        <li>
+          <h1 id="pathname">
+            Current path: <code>{pathname}</code>
+          </h1>
+        </li>
+        <li>
+          <h2 id="query" data-query-hello={query.hello}>
+            Current query: <code>{JSON.stringify(query)}</code>
+          </h2>
+        </li>
+      </ul>
+    </div>
+  )
+}
+
+let i = 0
+
+export const getServerSideProps = () => {
+  return {
+    props: {
+      message: `Random: ${++i}${Math.random()}`,
+    },
+  }
+}

--- a/test/e2e/middleware-general/app/pages/shallow.js
+++ b/test/e2e/middleware-general/app/pages/shallow.js
@@ -9,12 +9,12 @@ export default function Shallow({ message }) {
         <li id="message-contents">{message}</li>
         <li>
           <Link href="/sha?hello=world" shallow>
-            <a id="shallow-link">Shallow link to /shallow?hello=world</a>
+            <a id="shallow-link">Shallow link to ?hello=world</a>
           </Link>
         </li>
         <li>
           <Link href="/sha?hello=goodbye">
-            <a id="deep-link">Deep link to /shallo?hello=goodbye</a>
+            <a id="deep-link">Deep link to ?hello=goodbye</a>
           </Link>
         </li>
         <li>

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -386,6 +386,34 @@ describe('Middleware Runtime', () => {
     await browser.waitForElementByCss('.refreshed')
     expect(await browser.eval('window.__SAME_PAGE')).toBeUndefined()
   })
+
+  it('allows shallow linking with middleware', async () => {
+    const browser = await webdriver(next.url, '/sha')
+    const getMessageContents = () =>
+      browser.elementById('message-contents').text()
+    const ssrMessage = await getMessageContents()
+    const requests: string[] = []
+
+    browser.on('request', (x) => {
+      requests.push(x.url())
+    })
+
+    browser.elementById('deep-link').click()
+    browser.waitForElementByCss('[data-query-hello="goodbye"]')
+    const deepLinkMessage = await getMessageContents()
+    expect(deepLinkMessage).not.toEqual(ssrMessage)
+
+    // Changing the route with a shallow link should not cause a server request
+    browser.elementById('shallow-link').click()
+    browser.waitForElementByCss('[data-query-hello="world"]')
+    expect(await getMessageContents()).toEqual(deepLinkMessage)
+
+    // Check that no server requests were made to ?hello=world,
+    // as it's a shallow request.
+    expect(requests).toEqual([
+      `${next.url}/_next/data/${next.buildId}/en/sha.json?hello=goodbye`,
+    ])
+  })
 })
 
 function readMiddlewareJSON(response) {


### PR DESCRIPTION
Shallow route changes did not work for rewritten pages when Middleware
was used, and made hard refreshes, although it was possible with static rewrites.

This happened because the router has a manifest of the static rewrites,
allowing static rewrites to map the route before comparing with the
local cache.

Middleware rewrites are dynamic and happening on the server, so we
can't send a manifest easily. This means that we need to propagate
the rewrites from the data requests into the components cache in
the router to make sure we have cache hits and don't miss.

This commit does exactly that and adds a test to verify that it works.

This fixes #37072 and fixes #31680

_Note:_ there's one thing that is somewhat an issue though: if the first
page the user lands on is a rewritten page, and will try to make a
shallow navigation to the same page--we will make a `fetch` request.
This is because we don't have any client cache of the `rewrite` we just
had.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
