### PR TITLE
Ensure rewrite query params with middleware are available in router

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1873,6 +1873,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     }
 
     if (
+      this.router.catchAllMiddleware &&
       !!ctx.req.headers['x-nextjs-data'] &&
       (!res.statusCode || res.statusCode === 200 || res.statusCode === 404)
     ) {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1238,13 +1238,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         'x-nextjs-matched-path',
         `${query.__nextLocale ? `/${query.__nextLocale}` : ''}${pathname}`
       )
-      // return empty JSON when not an SSG/SSP page and not an error
-      if (!(isSSG || hasServerProps)) {
-        res.setHeader('content-type', 'application/json')
-        res.body('{}')
-        res.send()
-        return null
-      }
     }
 
     // Don't delete query.__flight__ yet, it still needs to be used in renderToHTML later
@@ -1878,6 +1871,22 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       }
       return response
     }
+
+    if (
+      !!ctx.req.headers['x-nextjs-data'] &&
+      (!res.statusCode || res.statusCode === 200 || res.statusCode === 404)
+    ) {
+      res.setHeader(
+        'x-nextjs-matched-path',
+        `${query.__nextLocale ? `/${query.__nextLocale}` : ''}${pathname}`
+      )
+      res.statusCode = 200
+      res.setHeader('content-type', 'application/json')
+      res.body('{}')
+      res.send()
+      return null
+    }
+
     res.statusCode = 404
     return this.renderErrorToResponse(ctx, null)
   }

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -2200,7 +2200,14 @@ function getMiddlewareData<T extends FetchDataOutput>(
       ]).then(([pages, { __rewrites: rewrites }]: any) => {
         let as = parsedRewriteTarget.pathname
 
-        if (!rewriteHeader || isDynamicRoute(as)) {
+        if (
+          isDynamicRoute(as) ||
+          (!rewriteHeader &&
+            pages.includes(
+              normalizeLocalePath(removeBasePath(as), options.router.locales)
+                .pathname
+            ))
+        ) {
           const parsedSource = getNextPathnameInfo(
             parseRelativeUrl(source).pathname,
             { parseData: true }

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -59,11 +59,13 @@ export async function middleware(request) {
 
   if (url.pathname === '/rewrite-to-dynamic') {
     url.pathname = '/blog/from-middleware'
+    url.searchParams.set('some', 'middleware')
     return NextResponse.rewrite(url)
   }
 
   if (url.pathname === '/rewrite-to-config-rewrite') {
     url.pathname = '/rewrite-3'
+    url.searchParams.set('some', 'middleware')
     return NextResponse.rewrite(url)
   }
 

--- a/test/e2e/middleware-general/app/next.config.js
+++ b/test/e2e/middleware-general/app/next.config.js
@@ -16,11 +16,11 @@ module.exports = {
     return [
       {
         source: '/rewrite-1',
-        destination: '/ssr-page',
+        destination: '/ssr-page?from=config',
       },
       {
         source: '/rewrite-2',
-        destination: '/about/a',
+        destination: '/about/a?from=next-config',
       },
       {
         source: '/sha',
@@ -28,7 +28,7 @@ module.exports = {
       },
       {
         source: '/rewrite-3',
-        destination: '/blog/middleware-rewrite',
+        destination: '/blog/middleware-rewrite?hello=config',
       },
     ]
   },

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -158,6 +158,7 @@ describe('Middleware Runtime', () => {
 
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       slug: 'from-middleware',
+      some: 'middleware',
     })
     expect(
       JSON.parse(await browser.elementByCss('#props').text()).params
@@ -178,6 +179,8 @@ describe('Middleware Runtime', () => {
 
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       slug: 'middleware-rewrite',
+      hello: 'config',
+      some: 'middleware',
     })
     expect(
       JSON.parse(await browser.elementByCss('#props').text()).params
@@ -198,6 +201,7 @@ describe('Middleware Runtime', () => {
 
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       slug: 'middleware-rewrite',
+      hello: 'config',
     })
     expect(
       JSON.parse(await browser.elementByCss('#props').text()).params

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -212,6 +212,18 @@ describe('Middleware Runtime', () => {
     expect(await browser.elementByCss('#as-path').text()).toBe('/rewrite-3')
   })
 
+  it('should have correct route params for rewrite from config non-dynamic route', async () => {
+    const browser = await webdriver(next.url, '/')
+    await browser.eval('window.beforeNav = 1')
+    await browser.eval('window.next.router.push("/rewrite-1")')
+
+    await check(() => browser.elementByCss('body').text(), /Hello World/)
+
+    expect(await browser.eval('window.next.router.query')).toEqual({
+      from: 'config',
+    })
+  })
+
   it('should redirect the same for direct visit and client-transition', async () => {
     const res = await fetchViaHTTP(
       next.url,


### PR DESCRIPTION
This ensures query params from rewrites from middleware or `next.config.js` are properly populated in the router during client-transitions. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/37720