### PR TITLE
Update to skip middleware for unstable_revalidate

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -24,7 +24,7 @@ import type {
 
 import fs from 'fs'
 import { join, relative, resolve, sep } from 'path'
-import { IncomingMessage, request, ServerResponse } from 'http'
+import { IncomingMessage, ServerResponse } from 'http'
 import React from 'react'
 import { addRequestMeta, getRequestMeta } from './request-meta'
 

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -36,6 +36,12 @@ const params = (url) => {
 export async function middleware(request) {
   const url = request.nextUrl
 
+  if (request.headers.get('x-prerender-revalidate')) {
+    const res = NextResponse.next()
+    res.headers.set('x-middleware', 'hi')
+    return res
+  }
+
   // this is needed for tests to get the BUILD_ID
   if (url.pathname.startsWith('/_next/static/__BUILD_ID')) {
     return NextResponse.next()

--- a/test/e2e/middleware-general/app/pages/ssg/[slug].js
+++ b/test/e2e/middleware-general/app/pages/ssg/[slug].js
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router'
+
+export default function Page(props) {
+  const router = useRouter()
+  return (
+    <>
+      <p id="blog">/blog/[slug]</p>
+      <p id="query">{JSON.stringify(router.query)}</p>
+      <p id="pathname">{router.pathname}</p>
+      <p id="as-path">{router.asPath}</p>
+      <p id="props">{JSON.stringify(props)}</p>
+    </>
+  )
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      now: Date.now(),
+      params,
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: ['/ssg/first'],
+    fallback: 'blocking',
+  }
+}

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -116,6 +116,21 @@ describe('Middleware Runtime', () => {
         )
       }
     })
+
+    it('should not run middleware for on-demand revalidate', async () => {
+      const bypassToken = (
+        await fs.readJSON(join(next.testDir, '.next/prerender-manifest.json'))
+      ).preview.previewModeId
+
+      const res = await fetchViaHTTP(next.url, '/ssg/first', undefined, {
+        headers: {
+          'x-prerender-revalidate': bypassToken,
+        },
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-middleware')).toBeFalsy()
+      expect(res.headers.get('x-nextjs-cache')).toBe('REVALIDATED')
+    })
   }
 
   it('should have correct dynamic route params on client-transition to dynamic route', async () => {


### PR DESCRIPTION
This updates to skip `middleware` when processing on-demand revalidate from the `unstable_revalidate` helper. The request is still validated and the exact path should still be passed to `unstable_revalidate` preventing the need from relying on any rewrites for the revalidate to occur.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: https://github.com/vercel/next.js/issues/35523