### PR TITLE
Remove previous query param deleting warning

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1369,12 +1369,6 @@ export default class NextNodeServer extends BaseServer {
           const parsedDestination = parseUrl(rewritePath)
           const newUrl = parsedDestination.pathname
 
-          // TODO: remove after next minor version current `v12.0.9`
-          this.warnIfQueryParametersWereDeleted(
-            parsedUrl.query,
-            parsedDestination.query
-          )
-
           if (
             parsedDestination.protocol &&
             (parsedDestination.port
@@ -1438,26 +1432,6 @@ export default class NextNodeServer extends BaseServer {
 
   protected getRoutesManifest() {
     return require(join(this.distDir, ROUTES_MANIFEST))
-  }
-
-  // TODO: remove after next minor version current `v12.0.9`
-  private warnIfQueryParametersWereDeleted(
-    incoming: ParsedUrlQuery,
-    rewritten: ParsedUrlQuery
-  ): void {
-    const incomingQuery = urlQueryToSearchParams(incoming)
-    const rewrittenQuery = urlQueryToSearchParams(rewritten)
-
-    const missingKeys = [...incomingQuery.keys()].filter((key) => {
-      return !rewrittenQuery.has(key)
-    })
-
-    if (missingKeys.length > 0) {
-      Log.warn(
-        `Query params are no longer automatically merged for rewrites in middleware, see more info here: https://nextjs.org/docs/messages/deleting-query-params-in-middlewares`
-      )
-      this.warnIfQueryParametersWereDeleted = () => {}
-    }
   }
 
   private async runEdgeFunctionApiEndpoint(params: {

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -169,19 +169,6 @@ describe('Middleware Rewrite', () => {
       }, 'success')
     })
 
-    if (!(global as any).isNextDeploy) {
-      // runtime logs aren't currently available for deploy test
-      it(`warns about a query param deleted`, async () => {
-        await fetchViaHTTP(next.url, `/clear-query-params`, {
-          a: '1',
-          allowed: 'kept',
-        })
-        expect(next.cliOutput).toContain(
-          'Query params are no longer automatically merged for rewrites in middleware'
-        )
-      })
-    }
-
     it('should allow to opt-out prefetch caching', async () => {
       const browser = await webdriver(next.url, '/')
       await browser.addCookie({ name: 'about-bypass', value: '1' })


### PR DESCRIPTION
This warning can be removed now as we are past the version we noted removing it in. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
