### PR TITLE
Expose test timings token for e2e tests

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -344,6 +344,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
+      TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -401,6 +402,7 @@ jobs:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
       NEXT_TEST_REACT_VERSION: ^17
+      TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -543,6 +545,7 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
+      TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -590,6 +593,7 @@ jobs:
       NEXT_TELEMETRY_DISABLED: 1
       NEXT_TEST_JOB: 1
       NEXT_TEST_REACT_VERSION: ^17
+      TEST_TIMINGS_TOKEN: ${{ secrets.TEST_TIMINGS_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/run-tests.js
+++ b/run-tests.js
@@ -287,20 +287,13 @@ async function main() {
           if (isFinalRun && hideOutput) {
             // limit out to last 64kb so that we don't
             // run out of log room in CI
-            let trimmedOutputSize = 0
-            const trimmedOutputLimit = 64 * 1024
             const trimmedOutput = []
 
             for (let i = outputChunks.length; i >= 0; i--) {
               const chunk = outputChunks[i]
               if (!chunk) continue
 
-              trimmedOutputSize += chunk.byteLength || chunk.length
               trimmedOutput.unshift(chunk)
-
-              if (trimmedOutputSize > trimmedOutputLimit) {
-                break
-              }
             }
             trimmedOutput.forEach((chunk) => process.stdout.write(chunk))
           }

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -243,12 +243,14 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
     try {
       browser = await webdriver(next.url, '/')
 
-      const predefinedWorkerScripts = await browser.eval(
-        `document.querySelectorAll('script[type="text/partytown"]').length`
-      )
-      expect(predefinedWorkerScripts).toEqual(1)
+      await check(async () => {
+        const predefinedWorkerScripts = await browser.eval(
+          `document.querySelectorAll('script[type="text/partytown"]').length`
+        )
+        return predefinedWorkerScripts + ''
+      }, '1')
 
-      // Partytown modifes type to "text/partytown-x" after it has been executed in the web worker
+      // Partytown modifies type to "text/partytown-x" after it has been executed in the web worker
       await check(async () => {
         const processedWorkerScripts = await browser.eval(
           `document.querySelectorAll('script[type="text/partytown-x"]').length`
@@ -275,10 +277,12 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
     try {
       browser = await webdriver(next.url, '/')
 
-      const predefinedWorkerScripts = await browser.eval(
-        `document.querySelectorAll('script[type="text/partytown"]').length`
-      )
-      expect(predefinedWorkerScripts).toEqual(1)
+      await check(async () => {
+        const predefinedWorkerScripts = await browser.eval(
+          `document.querySelectorAll('script[type="text/partytown"]').length`
+        )
+        return predefinedWorkerScripts + ''
+      }, '1')
 
       // Partytown modifes type to "text/partytown-x" after it has been executed in the web worker
       await check(async () => {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/37719 this exposes the test timings token to these jobs so that they can update timings for the e2e tests so we can split them better. This also removes the trimming of test output when a test fails as it can strip helpful context.  

Also updates test that flaked here https://github.com/vercel/next.js/runs/6921807080?check_suite_focus=true#step:8:728

x-ref: https://github.com/vercel/next.js/pull/37719