### PR TITLE
Add bug report field to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -41,6 +41,12 @@ body:
       description: A clear and concise description of what you expected to happen.
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Link to reproduction
+      description: A link to a https://stackblitz.com/ or git repo with a minimal reproduction. Minimal reproductions should be created from a create-next-app starter and include only relevant changes to cause the issue if possible.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: To Reproduce


### PR DESCRIPTION
As discussed with @balazsorban44  this adds a required field for a reproduction link to the issue 

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
