### PR TITLE
fixed shouldResolveHref assignment in router change method

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -906,7 +906,7 @@ export default class Router implements BaseRouter {
     const shouldResolveHref =
       (options as any)._h ||
       (options as any)._shouldResolveHref ||
-      parsePath(url).pathname === parsePath(as).pathname
+      parsePath(url).pathname !== parsePath(as).pathname
 
     const nextState = {
       ...this.state,


### PR DESCRIPTION
Hi,

* I configured an app with `i18n` locales, `rewrites` and `redirects` in **next.config.js** properly
* I have a **Link** containing `as` prop different than `href`
* `rewrites` in next.config.js has the correct `".../:slug*"` **source** and **destination** assignments
* `as` and `href` are pointing out different subpaths _(may be called `slug`s)_
* When I click on the Link, it triggers `onClick`, `linkClicked` in the link.ts, and router `push` and router `change` in the router.ts respectively

In the `constructor` of the router.ts, `options._shouldResolveHref` has been set by **not-equal check of** `as` and `pathname`;

https://github.com/vercel/next.js/blob/808e558ade1b7563bf9ff8ed86d70dd3c7dba647/packages/next/shared/lib/router/router.ts#L728

But when I click the Link;

_the `constructor` of the router is not triggered (`options._shouldResolveHref` remains `undefined`),_

it triggers the router `change` method, but at the line 909, `shouldResolveHref` has been set as _`false`_ because of the **equality check of** `as` and `pathname (url)`;

https://github.com/vercel/next.js/blob/808e558ade1b7563bf9ff8ed86d70dd3c7dba647/packages/next/shared/lib/router/router.ts#L909

This causes the browser to download a file like;
".../_next/static/chunks/pages/{PAGE}/{SUBPAGE}.js"
with a 404 status code, and than **the app is recycled (refreshed completely)**.

But if the `shouldResolveHref` gets `true` (`as` not-equal to `href`), it downloads the correct file like;
".../_next/static/chunks/pages/{PAGE}/[slug].js"
and everything behaves as expected.

As a recap; if `as` and `href` are different for a Link, `shouldResolveHref` in the router `change` method has to be `true`, to continue the line below to work properly;

https://github.com/vercel/next.js/blob/808e558ade1b7563bf9ff8ed86d70dd3c7dba647/packages/next/shared/lib/router/router.ts#L1121

Thank you for your time and consideration.