### PR TITLE
Ensure query params are populated correctly with middleware

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -34,6 +34,7 @@ import { ImageConfigContext } from '../shared/lib/image-config-context'
 import { ImageConfigComplete } from '../shared/lib/image-config'
 import { removeBasePath } from './remove-base-path'
 import { hasBasePath } from './has-base-path'
+import { match } from 'micromatch'
 
 const ReactDOM = process.env.__NEXT_REACT_ROOT
   ? require('react-dom/client')
@@ -112,15 +113,17 @@ class Container extends React.Component<{
         // it wasn't originally present
         initialData.page !== '/404' &&
         initialData.page !== '/_error' &&
-        (matchesMiddleware ||
-          initialData.isFallback ||
+        (initialData.isFallback ||
           (initialData.nextExport &&
             (isDynamicRoute(router.pathname) ||
               location.search ||
-              process.env.__NEXT_HAS_REWRITES)) ||
+              process.env.__NEXT_HAS_REWRITES ||
+              matchesMiddleware)) ||
           (initialData.props &&
             initialData.props.__N_SSG &&
-            (location.search || process.env.__NEXT_HAS_REWRITES)))
+            (location.search ||
+              process.env.__NEXT_HAS_REWRITES ||
+              matchesMiddleware)))
       ) {
         // update query on mount for exported pages
         router.replace(

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -34,7 +34,6 @@ import { ImageConfigContext } from '../shared/lib/image-config-context'
 import { ImageConfigComplete } from '../shared/lib/image-config'
 import { removeBasePath } from './remove-base-path'
 import { hasBasePath } from './has-base-path'
-import { match } from 'micromatch'
 
 const ReactDOM = process.env.__NEXT_REACT_ROOT
   ? require('react-dom/client')

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -2143,8 +2143,10 @@ function matchesMiddleware<T extends FetchDataOutput>(
         ? removeBasePath(asPathname)
         : asPathname
 
-      return !!items?.some(([regex]) => {
-        return new RegExp(regex).test(addLocale(cleanedAs, options.locale))
+      return !!items?.some(([regex, ssr]) => {
+        return (
+          !ssr && new RegExp(regex).test(addLocale(cleanedAs, options.locale))
+        )
       })
     }
   )

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -584,6 +584,7 @@ export default class Router implements BaseRouter {
   isReady: boolean
   isLocaleDomain: boolean
   isFirstPopStateEvent = true
+  _initialMatchesMiddlewarePromise: Promise<boolean>
 
   private state: Readonly<{
     route: string
@@ -709,6 +710,8 @@ export default class Router implements BaseRouter {
       isFallback,
     }
 
+    this._initialMatchesMiddlewarePromise = Promise.resolve(false)
+
     if (typeof window !== 'undefined') {
       // make sure "as" doesn't start with double slashes or else it can
       // throw an error as it's considered invalid
@@ -718,7 +721,7 @@ export default class Router implements BaseRouter {
         const options: TransitionOptions = { locale }
         const asPath = getURL()
 
-        matchesMiddleware({
+        this._initialMatchesMiddlewarePromise = matchesMiddleware({
           router: this,
           locale,
           asPath,
@@ -738,6 +741,7 @@ export default class Router implements BaseRouter {
             asPath,
             options
           )
+          return matches
         })
       }
 
@@ -1108,11 +1112,13 @@ export default class Router implements BaseRouter {
 
     // we don't attempt resolve asPath when we need to execute
     // middleware as the resolving will occur server-side
-    const isMiddlewareMatch = await matchesMiddleware({
-      asPath: as,
-      locale: nextState.locale,
-      router: this,
-    })
+    const isMiddlewareMatch =
+      !options.shallow &&
+      (await matchesMiddleware({
+        asPath: as,
+        locale: nextState.locale,
+        router: this,
+      }))
 
     if (!isMiddlewareMatch && shouldResolveHref && pathname !== '/_error') {
       ;(options as any)._shouldResolveHref = true
@@ -1234,10 +1240,12 @@ export default class Router implements BaseRouter {
         routeProps,
         locale: nextState.locale,
         isPreview: nextState.isPreview,
+        hasMiddleware: isMiddlewareMatch,
       })
 
-      if ('route' in routeInfo && routeInfo.route !== route) {
+      if ('route' in routeInfo && isMiddlewareMatch) {
         pathname = routeInfo.route || route
+        route = pathname
         query = Object.assign({}, routeInfo.query || {}, query)
 
         if (isDynamicRoute(pathname)) {
@@ -1534,6 +1542,7 @@ export default class Router implements BaseRouter {
     resolvedAs,
     routeProps,
     locale,
+    hasMiddleware,
     isPreview,
   }: {
     route: string
@@ -1541,6 +1550,7 @@ export default class Router implements BaseRouter {
     query: ParsedUrlQuery
     as: string
     resolvedAs: string
+    hasMiddleware?: boolean
     routeProps: RouteProperties
     locale: string | undefined
     isPreview: boolean
@@ -1552,10 +1562,14 @@ export default class Router implements BaseRouter {
      * for shallow routing purposes.
      */
     let route = requestedRoute
-
     try {
       let existingInfo: PrivateRouteInfo | undefined = this.components[route]
-      if (routeProps.shallow && existingInfo && this.route === route) {
+      if (
+        !hasMiddleware &&
+        routeProps.shallow &&
+        existingInfo &&
+        this.route === route
+      ) {
         return existingInfo
       }
 
@@ -1603,7 +1617,12 @@ export default class Router implements BaseRouter {
 
         // Check again the cache with the new destination.
         existingInfo = this.components[route]
-        if (routeProps.shallow && existingInfo && this.route === route) {
+        if (
+          routeProps.shallow &&
+          existingInfo &&
+          this.route === route &&
+          !hasMiddleware
+        ) {
           // If we have a match with the current route due to rewrite,
           // we can copy the existing information to the rewritten one.
           // Then, we return the information along with the matched route.
@@ -2120,13 +2139,12 @@ function matchesMiddleware<T extends FetchDataOutput>(
   return Promise.resolve(options.router.pageLoader.getMiddlewareList()).then(
     (items) => {
       const { pathname: asPathname } = parsePath(options.asPath)
-      const cleanedAs = removeLocale(
-        hasBasePath(asPathname) ? removeBasePath(asPathname) : asPathname,
-        options.locale
-      )
+      const cleanedAs = hasBasePath(asPathname)
+        ? removeBasePath(asPathname)
+        : asPathname
 
       return !!items?.some(([regex]) => {
-        return new RegExp(regex).test(cleanedAs)
+        return new RegExp(regex).test(addLocale(cleanedAs, options.locale))
       })
     }
   )
@@ -2214,6 +2232,7 @@ function getMiddlewareData<T extends FetchDataOutput>(
           )
 
           as = addBasePath(parsedSource.pathname)
+          parsedRewriteTarget.pathname = as
         }
 
         if (process.env.__NEXT_HAS_REWRITES) {
@@ -2228,6 +2247,7 @@ function getMiddlewareData<T extends FetchDataOutput>(
 
           if (result.matchedPage) {
             parsedRewriteTarget.pathname = result.parsedAs.pathname
+            as = parsedRewriteTarget.pathname
             Object.assign(parsedRewriteTarget.query, result.parsedAs.query)
           }
         }
@@ -2241,6 +2261,11 @@ function getMiddlewareData<T extends FetchDataOutput>(
               pages
             )
           : fsPathname
+
+        if (isDynamicRoute(resolvedHref)) {
+          const matches = getRouteMatcher(getRouteRegex(resolvedHref))(as)
+          Object.assign(parsedRewriteTarget.query, matches || {})
+        }
 
         return {
           type: 'rewrite' as const,

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -47,6 +47,12 @@ export async function middleware(request) {
     return NextResponse.next()
   }
 
+  if (url.pathname === '/to-ssg') {
+    url.pathname = '/ssg/hello'
+    url.searchParams.set('from', 'middleware')
+    return NextResponse.rewrite(url)
+  }
+
   if (url.pathname === '/sha') {
     url.pathname = '/shallow'
     return NextResponse.rewrite(url)

--- a/test/e2e/middleware-general/app/pages/ssg/[slug].js
+++ b/test/e2e/middleware-general/app/pages/ssg/[slug].js
@@ -1,13 +1,25 @@
 import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { useState } from 'react'
 
 export default function Page(props) {
   const router = useRouter()
+  const [asPath, setAsPath] = useState(
+    router.isReady ? router.asPath : router.href
+  )
+
+  useEffect(() => {
+    if (router.isReady) {
+      setAsPath(router.asPath)
+    }
+  }, [router.asPath, router.isReady])
+
   return (
     <>
       <p id="blog">/blog/[slug]</p>
       <p id="query">{JSON.stringify(router.query)}</p>
       <p id="pathname">{router.pathname}</p>
-      <p id="as-path">{router.asPath}</p>
+      <p id="as-path">{asPath}</p>
       <p id="props">{JSON.stringify(props)}</p>
     </>
   )
@@ -24,7 +36,7 @@ export function getStaticProps({ params }) {
 
 export function getStaticPaths() {
   return {
-    paths: ['/ssg/first'],
+    paths: ['/ssg/first', '/ssg/hello'],
     fallback: 'blocking',
   }
 }

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -133,6 +133,25 @@ describe('Middleware Runtime', () => {
     })
   }
 
+  it('should have correct query values for rewrite to ssg page', async () => {
+    const browser = await webdriver(next.url, '/to-ssg')
+    await browser.eval('window.beforeNav = 1')
+
+    await check(() => browser.elementByCss('body').text(), /\/to-ssg/)
+
+    expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
+      slug: 'hello',
+      from: 'middleware',
+    })
+    expect(
+      JSON.parse(await browser.elementByCss('#props').text()).params
+    ).toEqual({
+      slug: 'hello',
+    })
+    expect(await browser.elementByCss('#pathname').text()).toBe('/ssg/[slug]')
+    expect(await browser.elementByCss('#as-path').text()).toBe('/to-ssg')
+  })
+
   it('should have correct dynamic route params on client-transition to dynamic route', async () => {
     const browser = await webdriver(next.url, '/')
     await browser.eval('window.beforeNav = 1')

--- a/test/e2e/middleware-rewrites/app/pages/index.js
+++ b/test/e2e/middleware-rewrites/app/pages/index.js
@@ -64,3 +64,11 @@ export default function Home() {
     </div>
   )
 }
+
+export function getServerSideProps() {
+  return {
+    props: {
+      now: Date.now(),
+    },
+  }
+}

--- a/test/integration/dynamic-routing/test/middleware.test.js
+++ b/test/integration/dynamic-routing/test/middleware.test.js
@@ -1,19 +1,7 @@
 /* eslint-env jest */
-import './index.test'
-import fs from 'fs-extra'
-import { join } from 'path'
 
-const middlewarePath = join(__dirname, '../middleware.js')
+process.env.__MIDDLEWARE_TEST = '1'
 
-beforeAll(async () => {
-  await fs.writeFile(
-    middlewarePath,
-    `
-    import { NextResponse } from 'next/server'
-    export default function middleware() {
-      return NextResponse.next()
-    }
-  `
-  )
-})
-afterAll(() => fs.remove(middlewarePath))
+// run all existing tests from ./index.test.js with middleware
+// setup enabled via the above env variable
+require('./index.test')

--- a/test/integration/dynamic-routing/test/middleware.test.js
+++ b/test/integration/dynamic-routing/test/middleware.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+import './index.test'
+import fs from 'fs-extra'
+import { join } from 'path'
+
+const middlewarePath = join(__dirname, '../middleware.js')
+
+beforeAll(async () => {
+  await fs.writeFile(
+    middlewarePath,
+    `
+    import { NextResponse } from 'next/server'
+    export default function middleware() {
+      return NextResponse.next()
+    }
+  `
+  )
+})
+afterAll(() => fs.remove(middlewarePath))

--- a/test/integration/middleware-prefetch/tests/index.test.js
+++ b/test/integration/middleware-prefetch/tests/index.test.js
@@ -72,6 +72,7 @@ describe('Middleware Production Prefetch', () => {
         new URL(href).pathname.replace(/^\/_next\/data\/[^/]+/, '')
       )
       assert.deepEqual(mapped, [
+        '/index.json',
         '/made-up.json',
         '/ssg-page-2.json',
         '/ssg-page.json',


### PR DESCRIPTION
This ensures we properly trigger the query hydration when middleware is present as additional query values can be provided from middleware for static pages. This also adds more verbose test coverage for dynamic routing with middleware by adding a no-op middleware to our existing dynamic routing test suite. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/37753
Fixes: https://github.com/vercel/next.js/issues/37720
Fixes: https://github.com/vercel/next.js/issues/35227