### PR TITLE
Fix broken link for no-script-in-document-page error.

### DIFF
--- a/errors/manifest.json
+++ b/errors/manifest.json
@@ -569,7 +569,7 @@
         {
           "path": "/errors/no-script-in-document-page.md",
           "redirect": {
-            "destination": "/errors/no-script-in-document"
+            "destination": "/docs/messages/no-script-in-document"
           }
         },
         {


### PR DESCRIPTION
Going to https://nextjs.org/docs/messages/no-script-in-document-page incorrectly redirects to https://nextjs.org/errors/no-script-in-document.