### PR TITLE
Fix a couple flakey next-script and unoptimized image tests

### DIFF
--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -182,13 +182,7 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
     try {
       browser = await webdriver(next.url, '/')
 
-      const predefinedWorkerScripts = await browser.eval(
-        `document.querySelectorAll('script[type="text/partytown"]').length`
-      )
-
-      expect(predefinedWorkerScripts).toBeGreaterThan(0)
-
-      // Partytown modifes type to "text/partytown-x" after it has been executed in the web worker
+      // Partytown modifies type to "text/partytown-x" after it has been executed in the web worker
       await check(async () => {
         const processedWorkerScripts = await browser.eval(
           `document.querySelectorAll('script[type="text/partytown-x"]').length`
@@ -243,13 +237,6 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
     try {
       browser = await webdriver(next.url, '/')
 
-      await check(async () => {
-        const predefinedWorkerScripts = await browser.eval(
-          `document.querySelectorAll('script[type="text/partytown"]').length`
-        )
-        return predefinedWorkerScripts + ''
-      }, '1')
-
       // Partytown modifies type to "text/partytown-x" after it has been executed in the web worker
       await check(async () => {
         const processedWorkerScripts = await browser.eval(
@@ -277,14 +264,7 @@ describe('experimental.nextScriptWorkers: true with required Partytown dependenc
     try {
       browser = await webdriver(next.url, '/')
 
-      await check(async () => {
-        const predefinedWorkerScripts = await browser.eval(
-          `document.querySelectorAll('script[type="text/partytown"]').length`
-        )
-        return predefinedWorkerScripts + ''
-      }, '1')
-
-      // Partytown modifes type to "text/partytown-x" after it has been executed in the web worker
+      // Partytown modifies type to "text/partytown-x" after it has been executed in the web worker
       await check(async () => {
         const processedWorkerScripts = await browser.eval(
           `document.querySelectorAll('script[type="text/partytown-x"]').length`

--- a/test/integration/image-component/unoptimized/test/index.test.js
+++ b/test/integration/image-component/unoptimized/test/index.test.js
@@ -63,18 +63,21 @@ function runTests() {
         browser.eval(`document.getElementById("external-image").currentSrc`),
       /placeholder.com/
     )
-
-    expect(
-      await browser.elementById('internal-image').getAttribute('src')
-    ).toBe('/test.png')
-    expect(
-      await browser.elementById('static-image').getAttribute('src')
-    ).toMatch(/test(.*)jpg/)
-    expect(
-      await browser.elementById('external-image').getAttribute('src')
-    ).toBe('https://via.placeholder.com/800/000/FFF.png?text=test')
-    expect(await browser.elementById('eager-image').getAttribute('src')).toBe(
-      '/test.webp'
+    await check(
+      () => browser.elementById('internal-image').getAttribute('src'),
+      /test\.png/
+    )
+    await check(
+      () => browser.elementById('static-image').getAttribute('src'),
+      /test(.*)jpg/
+    )
+    await check(
+      () => browser.elementById('external-image').getAttribute('src'),
+      /https:\/\/via\.placeholder\.com\/800\/000\/FFF\.png\?text=test/
+    )
+    await check(
+      () => browser.elementById('eager-image').getAttribute('src'),
+      /test\.webp/
     )
 
     expect(


### PR DESCRIPTION
The predefined scripts check seems to be unreliable as we are racing the scripts initializing so this removes them in favor of just checking that the expected scripts do execute. Also adds check for some image tests.

x-ref: https://github.com/vercel/next.js/runs/6966093715?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6967524901?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6964491610?check_suite_focus=true
x-ref: https://github.com/vercel/next.js/runs/6965566326?check_suite_focus=true