### PR TITLE
Fix compile time log after error

### DIFF
--- a/packages/next/build/output/store.ts
+++ b/packages/next/build/output/store.ts
@@ -88,7 +88,7 @@ store.subscribe((state) => {
         return
       }
     }
-
+    startTime = 0
     // Ensure traces are flushed after each compile in development mode
     flushAllTraces()
     teardownTraceSubscriber()


### PR DESCRIPTION
This fixes the compile timing showing longer than it should as we don't reset the compile start time when an error occurs. Added test for this log in our HMR test suite. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1655657412872879)