### PR TITLE
Remove url override from NextRequest

### DIFF
--- a/packages/next/server/web/spec-extension/request.ts
+++ b/packages/next/server/web/spec-extension/request.ts
@@ -53,10 +53,6 @@ export class NextRequest extends Request {
   public get ua() {
     throw new RemovedUAError()
   }
-
-  public get url() {
-    return this[INTERNALS].url.toString()
-  }
 }
 
 export interface RequestInit extends globalThis.RequestInit {

--- a/test/e2e/middleware-general/app/middleware.js
+++ b/test/e2e/middleware-general/app/middleware.js
@@ -238,7 +238,7 @@ export async function middleware(request) {
   response.headers.set('req-url-locale', request.nextUrl.locale)
   response.headers.set(
     'req-url-params',
-    url.pathname !== '/static' ? JSON.stringify(params(request.url)) : '{}'
+    url.pathname !== '/static' ? JSON.stringify(params(url)) : '{}'
   )
   return response
 }


### PR DESCRIPTION
Pretty much all other fields are extensions of the Request type, but `url` was overriding the standard Request url field. This is particularly bad because in an i18n setup Next.js normalizes the request URL and this made it impossible to access the true request.

If users want to access the normalized (ie. locale + locale-relative path) URL, they can use the `nextUrl()` getter.

See also discussion here: https://github.com/vercel/next.js/discussions/37754

---

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
