### PR TITLE
Ensure next-server tracing uses tracing root config

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1444,7 +1444,7 @@ export default async function build(
               } catch (_) {}
             }
 
-            const root = path.parse(dir).root
+            const root = config.experimental.outputFileTracingRoot || dir
             const toTrace = [require.resolve('next/dist/server/next-server')]
 
             // ensure we trace any dependencies needed for custom
@@ -1454,6 +1454,7 @@ export default async function build(
                 require.resolve(config.experimental.incrementalCacheHandlerPath)
               )
             }
+
             const serverResult = await nodeFileTrace(toTrace, {
               base: root,
               processCwd: dir,

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -103,6 +103,21 @@ describe('Production Usage', () => {
         file.includes('next/dist/server/send-payload/index.js')
       )
     ).toBe(true)
+    const repoRoot = join(__dirname, '../../../../')
+    expect(
+      serverTrace.files.some((file) => {
+        const fullPath = join(__dirname, '../.next', file)
+        if (!fullPath.startsWith(repoRoot)) {
+          console.error(`Found next-server trace file outside repo root`, {
+            repoRoot,
+            fullPath,
+            file,
+          })
+          return true
+        }
+        return false
+      })
+    ).toBe(false)
     expect(
       serverTrace.files.some((file) =>
         file.includes('next/dist/shared/lib/page-path/normalize-page-path.js')


### PR DESCRIPTION
As noticed in https://github.com/vercel/next.js/pull/37596 it seems we aren't locking the `next-server` tracing to the tracing root which can allow files outside of the folder to be included unexpectedly.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

