### PR TITLE
Fix some casing of "On-Demand ISR"

### DIFF
--- a/docs/api-reference/data-fetching/get-static-paths.md
+++ b/docs/api-reference/data-fetching/get-static-paths.md
@@ -10,7 +10,7 @@ description: API reference for `getStaticPaths`. Learn how to fetch data and gen
 | Version | Changes |
 | ------- | ------- |
 
-| `v12.1.0` | [On-demand Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md#on-demand-revalidation-beta) added (Beta). |
+| `v12.1.0` | [On-Demand Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md#on-demand-revalidation-beta) added (Beta). |
 | `v9.5.0` | Stable [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md) |
 | `v9.3.0` | `getStaticPaths` introduced. |
 

--- a/docs/api-reference/data-fetching/get-static-props.md
+++ b/docs/api-reference/data-fetching/get-static-props.md
@@ -10,7 +10,7 @@ description: API reference for `getStaticProps`. Learn how to use `getStaticProp
 | Version | Changes |
 | ------- | ------- |
 
-| `v12.1.0` | [On-demand Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md#on-demand-revalidation-beta) added (Beta). |
+| `v12.1.0` | [On-Demand Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md#on-demand-revalidation-beta) added (Beta). |
 | `v10.0.0` | `locale`, `locales`, `defaultLocale`, and `notFound` options added. |
 | `v10.0.0` | `fallback: 'blocking'` return option added. |
 | `v9.5.0` | Stable [Incremental Static Regeneration](/docs/basic-features/data-fetching/incremental-static-regeneration.md) |

--- a/docs/basic-features/data-fetching/incremental-static-regeneration.md
+++ b/docs/basic-features/data-fetching/incremental-static-regeneration.md
@@ -18,7 +18,7 @@ description: 'Learn how to create or update static pages at runtime with Increme
 
 | Version   | Changes                                                                                 |
 | --------- | --------------------------------------------------------------------------------------- |
-| `v12.1.0` | On-demand ISR added (Beta).                                                             |
+| `v12.1.0` | On-Demand ISR added (Beta).                                                             |
 | `v12.0.0` | [Bot-aware ISR fallback](https://nextjs.org/blog/next-12#bot-aware-isr-fallback) added. |
 | `v9.5.0`  | Base Path added.                                                                        |
 
@@ -91,7 +91,7 @@ When a request is made to a path that hasn’t been generated, Next.js will serv
 
 If you set a `revalidate` time of `60`, all visitors will see the same generated version of your site for one minute. The only way to invalidate the cache is from someone visiting that page after the minute has passed.
 
-Starting with `v12.1.0`, Next.js supports on-demand Incremental Static Regeneration to manually purge the Next.js cache for a specific page. This makes it easier to update your site when:
+Starting with `v12.1.0`, Next.js supports On-Demand Incremental Static Regeneration to manually purge the Next.js cache for a specific page. This makes it easier to update your site when:
 
 - Content from your headless CMS is created or updated
 - Ecommerce metadata changes (price, description, category, reviews, etc.)
@@ -130,7 +130,7 @@ export default async function handler(req, res) {
 
 [View our demo](https://on-demand-isr.vercel.app) to see on-demand revalidation in action and provide feedback.
 
-### Testing on-demand ISR during development
+### Testing on-Demand ISR during development
 
 When running locally with `next dev`, `getStaticProps` is invoked on every request. To verify your on-demand ISR configuration is correct, you will need to create a [production build](/docs/api-reference/cli.md#build) and start the [production server](/docs/api-reference/cli.md#production):
 


### PR DESCRIPTION
This normalizes some casing of "On-Demand ISR" following our https://title.sh convention. 

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
