### PR TITLE
Ensure special chars in middleware matcher is handled

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -164,8 +164,12 @@ export function getEdgeServerEntry(opts: {
     const loaderParams: MiddlewareLoaderOptions = {
       absolutePagePath: opts.absolutePagePath,
       page: opts.page,
-      matcherRegexp:
-        opts.middleware?.pathMatcher && opts.middleware.pathMatcher.source,
+      // pathMatcher can have special characters that break the loader params
+      // parsing so we base64 encode/decode the string
+      matcherRegexp: Buffer.from(
+        (opts.middleware?.pathMatcher && opts.middleware.pathMatcher.source) ||
+          ''
+      ).toString('base64'),
     }
 
     return `next-middleware-loader?${stringify(loaderParams)}!`

--- a/packages/next/build/webpack/loaders/next-middleware-loader.ts
+++ b/packages/next/build/webpack/loaders/next-middleware-loader.ts
@@ -9,8 +9,15 @@ export type MiddlewareLoaderOptions = {
 }
 
 export default function middlewareLoader(this: any) {
-  const { absolutePagePath, page, matcherRegexp }: MiddlewareLoaderOptions =
-    this.getOptions()
+  const {
+    absolutePagePath,
+    page,
+    matcherRegexp: base64MatcherRegex,
+  }: MiddlewareLoaderOptions = this.getOptions()
+  const matcherRegexp = Buffer.from(
+    base64MatcherRegex || '',
+    'base64'
+  ).toString()
   const stringifiedPagePath = stringifyRequest(this, absolutePagePath)
   const buildInfo = getModuleBuildInfo(this._module)
   buildInfo.nextEdgeMiddleware = {

--- a/test/e2e/middleware-matcher/app/middleware.js
+++ b/test/e2e/middleware-matcher/app/middleware.js
@@ -1,7 +1,12 @@
 import { NextResponse } from 'next/server'
 
 export const config = {
-  matcher: ['/with-middleware/:path*', '/another-middleware/:path*'],
+  matcher: [
+    '/with-middleware/:path*',
+    '/another-middleware/:path*',
+    // the below is testing special characters don't break the build
+    '/_sites/:path((?![^/]*\\.json$)[^/]+$)',
+  ],
 }
 
 export default (req) => {


### PR DESCRIPTION
Fixes webpack failing to parse the loader params from special characters being included in the `matcherRegex` value.

```sh
Module not found: Error: Can't resolve '%5B%5E%2F%5D*%5C.json%24)%5B%5E%2F%5D%2B%24))%5B%5C%2F%23%5C%3F%5D%3F%24' in 
```

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/C0289CGVAR2/p1655942747319429)