### PR TITLE
Ensure cache-control is correct when returning redirect

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1717,6 +1717,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         return null
       }
     } else if (cachedData.kind === 'REDIRECT') {
+      if (revalidateOptions) {
+        setRevalidateHeaders(res, revalidateOptions)
+      }
       if (isDataReq) {
         return {
           type: 'json',

--- a/test/production/required-server-files/pages/optional-ssg/[[...rest]].js
+++ b/test/production/required-server-files/pages/optional-ssg/[[...rest]].js
@@ -1,4 +1,42 @@
 export const getStaticProps = ({ params }) => {
+  console.log('getStaticProps /optional-ssg/[[...rest]]', params)
+
+  switch (params.rest?.[0]) {
+    case 'redirect-1': {
+      return {
+        redirect: { destination: '/somewhere', permanent: false },
+      }
+    }
+    case 'redirect-2': {
+      return {
+        redirect: { destination: '/somewhere-else', permanent: false },
+        revalidate: 5,
+      }
+    }
+    case 'not-found-1': {
+      return {
+        notFound: true,
+      }
+    }
+    case 'not-found-2': {
+      return {
+        notFound: true,
+        revalidate: 5,
+      }
+    }
+    case 'props-no-revalidate': {
+      return {
+        props: {
+          random: Math.random(),
+          params: params || null,
+        },
+      }
+    }
+    default: {
+      break
+    }
+  }
+
   return {
     props: {
       random: Math.random(),


### PR DESCRIPTION
This ensures we set the revalidate cache headers correctly when returning `redirect` from `getStaticProps`, regression tests covering this have also been added. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: [slack thread](https://vercel.slack.com/archives/C01Q935TWKT/p1655996505940399?thread_ts=1655979053.001019&cid=C01Q935TWKT)