### PR TITLE
Update middleware matcher test for root

### DIFF
--- a/test/e2e/middleware-matcher/app/middleware.js
+++ b/test/e2e/middleware-matcher/app/middleware.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 
 export const config = {
   matcher: [
+    '/',
     '/with-middleware/:path*',
     '/another-middleware/:path*',
     // the below is testing special characters don't break the build

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -15,9 +15,9 @@ describe('Middleware can set the matcher in its config', () => {
   })
   afterAll(() => next.destroy())
 
-  it('does not add the header for root request', async () => {
+  it('does add the header for root request', async () => {
     const response = await fetchViaHTTP(next.url, '/')
-    expect(response.headers.get('X-From-Middleware')).toBeNull()
+    expect(response.headers.get('X-From-Middleware')).toBe('true')
     expect(await response.text()).toContain('root page')
   })
 
@@ -65,7 +65,7 @@ describe('Middleware can set the matcher in its config', () => {
     expect(response.headers.get('X-From-Middleware')).toBe('true')
   })
 
-  it('does not add the header for root data request', async () => {
+  it('does add the header for root data request', async () => {
     const response = await fetchViaHTTP(
       next.url,
       `/_next/data/${next.buildId}/index.json`,
@@ -77,7 +77,7 @@ describe('Middleware can set the matcher in its config', () => {
         message: 'Hello, world.',
       },
     })
-    expect(response.headers.get('X-From-Middleware')).toBeNull()
+    expect(response.headers.get('X-From-Middleware')).toBe('true')
   })
 
   it('should load matches in client manifest correctly', async () => {
@@ -172,6 +172,21 @@ describe('using a single matcher', () => {
     })
   })
   afterAll(() => next.destroy())
+
+  it('does not add the header for root request', async () => {
+    const response = await fetchViaHTTP(next.url, '/')
+    expect(response.headers.get('X-From-Middleware')).toBeFalsy()
+  })
+
+  it('does not add the header for root data request', async () => {
+    const response = await fetchViaHTTP(
+      next.url,
+      `/_next/data/${next.buildId}/index.json`,
+      undefined,
+      { headers: { 'x-nextjs-data': '1' } }
+    )
+    expect(response.headers.get('X-From-Middleware')).toBeFalsy()
+  })
 
   it('adds the header for a matched path', async () => {
     const response = await fetchViaHTTP(next.url, '/middleware/works')


### PR DESCRIPTION
This updates our middleware-matcher e2e tests to ensure we can correctly match `/` when it is defined as a matcher. This was already working locally with Next.js so no changes here but is fixed in the builder in the below PR. 


x-ref: https://github.com/vercel/vercel/pull/8005
x-ref: [slack thread](https://vercel.slack.com/archives/C0289CGVAR2/p1655946788395279?thread_ts=1655942747.319429&cid=C0289CGVAR2)

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

