### PR TITLE
Move styled-jsx type reference

### DIFF
--- a/docs/basic-features/typescript.md
+++ b/docs/basic-features/typescript.md
@@ -64,7 +64,7 @@ npm run dev
 
 You're now ready to start converting files from `.js` to `.tsx` and leveraging the benefits of TypeScript!
 
-> A file named `next-env.d.ts` will be created in the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. **You cannot remove it or edit it** as it can change at any time.
+> A file named `next-env.d.ts` will be created in the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. **You cannot remove it or edit it** as it can change at any time. As such this file should not be committed and should be ignored by version control.
 
 > TypeScript `strict` mode is turned off by default. When you feel comfortable with TypeScript, it's recommended to turn it on in your `tsconfig.json`.
 

--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="./types/global.d.ts" />
+/// <reference types="./types/global" />
 /// <reference path="./amp.d.ts" />
 /// <reference path="./app.d.ts" />
 /// <reference path="./config.d.ts" />
@@ -11,7 +11,7 @@
 /// <reference path="./router.d.ts" />
 /// <reference path="./script.d.ts" />
 /// <reference path="./server.d.ts" />
-/// <reference path="./dist/styled-jsx-types/global.d.ts" />
+/// <reference path="./dist/styled-jsx-types/global" />
 
 export { default } from './types'
 export * from './types'

--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="./types/global" />
+/// <reference types="./types/global.d.ts" />
 /// <reference path="./amp.d.ts" />
 /// <reference path="./app.d.ts" />
 /// <reference path="./config.d.ts" />
@@ -11,6 +11,7 @@
 /// <reference path="./router.d.ts" />
 /// <reference path="./script.d.ts" />
 /// <reference path="./server.d.ts" />
+/// <reference path="./dist/styled-jsx-types/global.d.ts" />
 
 export { default } from './types'
 export * from './types'

--- a/packages/next/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/lib/typescript/writeAppTypeDeclarations.ts
@@ -30,8 +30,6 @@ export async function writeAppTypeDeclarations(
   const content =
     '/// <reference types="next" />' +
     eol +
-    '/// <reference types="next/dist/styled-jsx-types/global" />' +
-    eol +
     (imageImportsEnabled
       ? '/// <reference types="next/image-types/global" />' + eol
       : '') +

--- a/test/unit/write-app-declarations.test.ts
+++ b/test/unit/write-app-declarations.test.ts
@@ -16,8 +16,6 @@ describe('find config', () => {
     const content =
       '/// <reference types="next" />' +
       eol +
-      '/// <reference types="next/dist/styled-jsx-types/global" />' +
-      eol +
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
@@ -39,8 +37,6 @@ describe('find config', () => {
     const content =
       '/// <reference types="next" />' +
       eol +
-      '/// <reference types="next/dist/styled-jsx-types/global" />' +
-      eol +
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
@@ -61,8 +57,6 @@ describe('find config', () => {
     const eol = os.EOL
     const content =
       '/// <reference types="next" />' +
-      eol +
-      '/// <reference types="next/dist/styled-jsx-types/global" />' +
       eol +
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/37902 this moves the reference to avoid a change in `next-env.d.ts`. Also updates our doc note on the `next-env.d.ts` file to be more explicit about it being ignored.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
