### PR TITLE
fix(packages/next): trace json reporter write stream completion

### DIFF
--- a/packages/next/trace/report/to-json.ts
+++ b/packages/next/trace/report/to-json.ts
@@ -84,9 +84,12 @@ class RotatingWriteStream {
         throw err
       }
     }
+
     this.size = 0
-    this.createWriteStream()
     this.rotatePromise = undefined
+    this.drainPromise = undefined
+
+    this.createWriteStream()
   }
   async write(data: string): Promise<void> {
     if (this.rotatePromise) await this.rotatePromise
@@ -99,10 +102,7 @@ class RotatingWriteStream {
     if (!this.writeStream.write(data, 'utf8')) {
       if (this.drainPromise === undefined) {
         this.drainPromise = new Promise<void>((resolve, _reject) => {
-          this.writeStream.once('drain', () => {
-            this.drainPromise = undefined
-            resolve()
-          })
+          this.writeStream.once('drain', resolve)
         })
       }
       await this.drainPromise


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

When running the build more than once in the same process, the event loop is blocked when used with `await` the promise never resolves on the second run!

Then we reset the `drainPromise` by running `rotate` and creating a new writeStream instance.

Scenario

```ts
import build from 'next/dist/build/index.js'

  await build() // Finished
  await build() // Finished but blocked the event loop
  console.log("show me") // Is not executed
```

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
