### PR TITLE
Move outputStandalone config

### DIFF
--- a/docs/advanced-features/output-file-tracing.md
+++ b/docs/advanced-features/output-file-tracing.md
@@ -18,7 +18,7 @@ Next.js' production server is also traced for its needed files and output at `.n
 
 To leverage the `.nft.json` files emitted to the `.next` output directory, you can read the list of files in each trace which are relative to the `.nft.json` file and then copy them to your deployment location.
 
-## Automatically Copying Traced Files (experimental)
+## Automatically Copying Traced Files
 
 Next.js can automatically create a `standalone` folder which copies only the necessary files for a production deployment including select files in `node_modules`.
 
@@ -26,9 +26,7 @@ To leverage this automatic copying you can enable it in your `next.config.js`:
 
 ```js
 module.exports = {
-  experimental: {
-    outputStandalone: true,
-  },
+  output: 'standalone',
 }
 ```
 

--- a/examples/with-docker-compose/next-app/next.config.js
+++ b/examples/with-docker-compose/next-app/next.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  experimental: {
-    outputStandalone: true,
-  },
+  output: 'standalone',
 }

--- a/examples/with-docker-multi-env/next.config.js
+++ b/examples/with-docker-multi-env/next.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  experimental: {
-    outputStandalone: true,
-  },
+  output: 'standalone',
 }

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -30,9 +30,7 @@ To add support for Docker to an existing project, just copy the `Dockerfile` int
 // next.config.js
 module.exports = {
   // ... rest of the configuration.
-  experimental: {
-    outputStandalone: true,
-  },
+  output: 'standalone',
 }
 ```
 

--- a/examples/with-docker/next.config.js
+++ b/examples/with-docker/next.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  experimental: {
-    outputStandalone: true,
-  },
+  output: 'standalone',
 }

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1640,7 +1640,7 @@ export default async function build(
       const outputFileTracingRoot =
         config.experimental.outputFileTracingRoot || dir
 
-      if (config.experimental.outputStandalone) {
+      if (config.output === 'standalone') {
         await nextBuildSpan
           .traceChild('copy-traced-files')
           .traceAsyncFn(async () => {
@@ -2235,7 +2235,7 @@ export default async function build(
         return Promise.reject(err)
       })
 
-      if (config.experimental.outputStandalone) {
+      if (config.output === 'standalone') {
         for (const file of [
           ...requiredServerFiles.files,
           path.join(config.distDir, SERVER_FILES_MANIFEST),

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -117,7 +117,6 @@ export interface ExperimentalConfig {
   fullySpecified?: boolean
   urlImports?: NonNullable<webpack5.Configuration['experiments']>['buildHttp']
   outputFileTracingRoot?: string
-  outputStandalone?: boolean
   images?: {
     layoutRaw: boolean
     remotePatterns: RemotePattern[]
@@ -449,6 +448,8 @@ export interface NextConfig extends Record<string, any> {
         }
   }
 
+  output?: 'standalone'
+
   /**
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.
    */
@@ -507,6 +508,7 @@ export const defaultConfig: NextConfig = {
   outputFileTracing: true,
   staticPageGenerationTimeout: 60,
   swcMinify: false,
+  output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   experimental: {
     // TODO: change default in next major release (current v12.1.5)
     legacyBrowsers: true,
@@ -539,7 +541,6 @@ export const defaultConfig: NextConfig = {
     serverComponents: false,
     fullySpecified: false,
     outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
-    outputStandalone: !!process.env.NEXT_PRIVATE_STANDALONE,
     images: {
       layoutRaw: false,
       remotePatterns: [],

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -534,6 +534,13 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     )
   }
 
+  if ((result.experimental as any).outputStandalone) {
+    Log.warn(
+      `experimental.outputStandalone has been renamed to "output: 'standalone'", please move the config.`
+    )
+    result.output = 'standalone'
+  }
+
   if (
     result.experimental?.outputFileTracingRoot &&
     !isAbsolute(result.experimental.outputFileTracingRoot)
@@ -546,11 +553,11 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     )
   }
 
-  if (result.experimental?.outputStandalone && !result.outputFileTracing) {
+  if (result.output === 'standalone' && !result.outputFileTracing) {
     Log.warn(
-      `experimental.outputStandalone requires outputFileTracing not be disabled please enable it to leverage the standalone build`
+      `"output: 'standalone'" requires outputFileTracing not be disabled please enable it to leverage the standalone build`
     )
-    result.experimental.outputStandalone = false
+    result.output = undefined
   }
 
   // TODO: Change defaultConfig type to NextConfigComplete

--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -423,10 +423,7 @@ export async function imageOptimizer(
       optimizedBuffer = await transformer.toBuffer()
       // End sharp transformation logic
     } else {
-      if (
-        showSharpMissingWarning &&
-        nextConfig.experimental?.outputStandalone
-      ) {
+      if (showSharpMissingWarning && nextConfig.output === 'standalone') {
         // TODO: should we ensure squoosh also works even though we don't
         // recommend it be used in production and this is a production feature
         console.error(

--- a/test/production/minimal-mode-response-cache/app/next.config.js
+++ b/test/production/minimal-mode-response-cache/app/next.config.js
@@ -1,7 +1,5 @@
 module.exports = {
-  experimental: {
-    outputStandalone: true,
-  },
+  output: 'standalone',
   trailingSlash: true,
   rewrites() {
     return {

--- a/test/production/pnpm-support/app-multi-page/next.config.js
+++ b/test/production/pnpm-support/app-multi-page/next.config.js
@@ -1,8 +1,8 @@
 const path = require('path')
 
 module.exports = {
+  output: 'standalone',
   experimental: {
-    outputStandalone: true,
     // pnpm virtual-store-dir is outside the app directory
     outputFileTracingRoot: path.resolve(__dirname, '../'),
   },

--- a/test/production/pnpm-support/app/next.config.js
+++ b/test/production/pnpm-support/app/next.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  experimental: {
-    outputStandalone: true,
-  },
+  output: 'standalone',
 }

--- a/test/production/pnpm-support/test/index.test.ts
+++ b/test/production/pnpm-support/test/index.test.ts
@@ -45,7 +45,7 @@ describe('pnpm support', () => {
     expect(html).toContain('Hello World')
   })
 
-  it('should execute client-side JS on each page in outputStandalone', async () => {
+  it('should execute client-side JS on each page in output: "standalone"', async () => {
     next = await createNext({
       files: {
         pages: new FileRef(path.join(__dirname, '..', 'app-multi-page/pages')),

--- a/test/production/required-server-files-i18n.test.ts
+++ b/test/production/required-server-files-i18n.test.ts
@@ -63,9 +63,7 @@ describe('should set-up next', () => {
         eslint: {
           ignoreDuringBuilds: true,
         },
-        experimental: {
-          outputStandalone: true,
-        },
+        output: 'standalone',
         async rewrites() {
           return [
             {

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -48,9 +48,7 @@ describe('should set-up next', () => {
         eslint: {
           ignoreDuringBuilds: true,
         },
-        experimental: {
-          outputStandalone: true,
-        },
+        output: 'standalone',
         async rewrites() {
           return {
             beforeFiles: [],

--- a/test/production/standalone-mode-and-optimizecss/index.test.ts
+++ b/test/production/standalone-mode-and-optimizecss/index.test.ts
@@ -25,8 +25,8 @@ describe('standalone mode and optimizeCss', () => {
       nextConfig: {
         experimental: {
           optimizeCss: true,
-          outputStandalone: true,
         },
+        output: 'standalone',
       },
       dependencies: {
         critters: 'latest',


### PR DESCRIPTION
As discussed this moves the `outputStandalone` config out of experimental to `output: 'standalone'`. 

