### PR TITLE
Fix eslint-config-next peer dep issue

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -21,7 +21,6 @@
   },
   "peerDependencies": {
     "eslint": "^7.23.0 || ^8.0.0",
-    "next": ">=10.2.0",
     "typescript": ">=3.3.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
It seems `npm` fails to resolve the `next` `peerDependencies` field for `eslint-config-next` and this field isn't necessarily needed so this removes it to ensure upgrading doesn't require the `--force` flag.  

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/pull/38008#discussion_r906629793