### PR TITLE
Fixing bug - Can't resolve 'prop-types'

### DIFF
--- a/examples/amp-first/package.json
+++ b/examples/amp-first/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "next": "latest",
+    "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }


### PR DESCRIPTION
## Bugfix

- Missing package dependency in package.json causing -> Can't resolve 'prop-types'