### PR TITLE
Fix invalid warning for existing experimental flag

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -510,6 +510,7 @@ export const defaultConfig: NextConfig = {
   swcMinify: false,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   experimental: {
+    manualClientBasePath: false,
     // TODO: change default in next major release (current v12.1.5)
     legacyBrowsers: true,
     browsersListForSwc: false,

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import http from 'http'
 import webdriver from 'next-webdriver'
 import assert from 'assert'
-import { check, waitFor } from 'next-test-utils'
+import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 
 describe('manual-client-base-path', () => {
   if ((global as any).isNextDeploy) {
@@ -96,6 +96,11 @@ describe('manual-client-base-path', () => {
     } catch (err) {
       console.error(err)
     }
+  })
+
+  it('should not warn for flag in output', async () => {
+    await renderViaHTTP(next.url, '/')
+    expect(next.cliOutput).not.toContain('exist in this version of Next.js')
   })
 
   for (const [asPath, pathname, query] of [


### PR DESCRIPTION
This ensures we don't incorrectly warn for this flag not existing when it does. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1656214175381599?thread_ts=1656106212.752919&cid=CGU8HUTUH)