### PR TITLE
Add error for renaming of unstable_revalidate

### DIFF
--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -243,6 +243,13 @@ export async function apiResolver(
       }
     ) => revalidate(urlPath, opts || {}, req, apiContext)
 
+    // TODO: remove in next minor (current v12.2)
+    apiRes.unstable_revalidate = () => {
+      throw new Error(
+        `"unstable_revalidate" has been renamed to "revalidate" see more info here: https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation`
+      )
+    }
+
     const resolver = interopDefault(resolverModule)
     let wasPiped = false
 

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -256,6 +256,11 @@ export type NextApiResponse<T = any> = ServerResponse & {
   ) => NextApiResponse<T>
   clearPreviewData: () => NextApiResponse<T>
 
+  /**
+   * @deprecated `unstable_revalidate` has been renamed to `revalidate`
+   */
+  unstable_revalidate: () => void
+
   revalidate: (
     urlPath: string,
     opts?: {

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2048,7 +2048,7 @@ describe('Prerender', () => {
       })
 
       if (!(global as any).isNextDeploy) {
-        it.only('should show error about renaming unstable_revalidate', async () => {
+        it('should show error about renaming unstable_revalidate', async () => {
           const res = await fetchViaHTTP(next.url, '/api/manual-revalidate', {
             pathname: '/blog/first',
             deprecated: '1',

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -741,6 +741,20 @@ describe('Prerender', () => {
       expect(value).toMatch(/Hi \[third\] \[fourth\]/)
     })
 
+    if (!(global as any).isNextDeploy) {
+      it('should show error about renaming unstable_revalidate', async () => {
+        const res = await fetchViaHTTP(next.url, '/api/manual-revalidate', {
+          pathname: '/blog/first',
+          deprecated: '1',
+        })
+        expect(res.status).toBe(500)
+
+        expect(next.cliOutput).toContain(
+          '"unstable_revalidate" has been renamed to "revalidate"'
+        )
+      })
+    }
+
     if ((global as any).isNextStart) {
       // TODO: dev currently renders this page as blocking, meaning it shows the
       // server error instead of continuously retrying. Do we want to change this?
@@ -2046,20 +2060,6 @@ describe('Prerender', () => {
           'success'
         )
       })
-
-      if (!(global as any).isNextDeploy) {
-        it('should show error about renaming unstable_revalidate', async () => {
-          const res = await fetchViaHTTP(next.url, '/api/manual-revalidate', {
-            pathname: '/blog/first',
-            deprecated: '1',
-          })
-          expect(res.status).toBe(500)
-
-          expect(next.cliOutput).toContain(
-            '"unstable_revalidate" has been renamed to "revalidate"'
-          )
-        })
-      }
 
       it('should handle manual revalidate for fallback: blocking', async () => {
         const beforeRevalidate = Date.now()

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2047,6 +2047,20 @@ describe('Prerender', () => {
         )
       })
 
+      if (!(global as any).isNextDeploy) {
+        it.only('should show error about renaming unstable_revalidate', async () => {
+          const res = await fetchViaHTTP(next.url, '/api/manual-revalidate', {
+            pathname: '/blog/first',
+            deprecated: '1',
+          })
+          expect(res.status).toBe(500)
+
+          expect(next.cliOutput).toContain(
+            '"unstable_revalidate" has been renamed to "revalidate"'
+          )
+        })
+      }
+
       it('should handle manual revalidate for fallback: blocking', async () => {
         const beforeRevalidate = Date.now()
         const res = await fetchViaHTTP(

--- a/test/e2e/prerender/pages/api/manual-revalidate.js
+++ b/test/e2e/prerender/pages/api/manual-revalidate.js
@@ -1,4 +1,7 @@
 export default async function handler(req, res) {
+  if (req.query.deprecated) {
+    await res.unstable_revalidate(req.query.pathname)
+  }
   // WARNING: don't use user input in production
   // make sure to use trusted value for revalidating
   let revalidated = false


### PR DESCRIPTION
This adds an error mentioning the API for `unstable_revalidate` was renamed pointing to the documentation. 

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
