### PR TITLE
Update blog-starter-typescript README.md

### DIFF
--- a/examples/blog-starter-typescript/README.md
+++ b/examples/blog-starter-typescript/README.md
@@ -23,7 +23,7 @@ npx create-next-app --example blog-starter-typescript blog-starter-typescript-ap
 # or
 yarn create next-app --example blog-starter-typescript blog-starter-typescript-app
 # or
-pnpm create next-app --example blog-starter-typescript blog-starter-typescript-app
+pnpx create-next-app --example blog-starter-typescript blog-starter-typescript-app
 ```
 
 Your blog should be up and running on [http://localhost:3000](http://localhost:3000)! If it doesn't work, post on [GitHub discussions](https://github.com/vercel/next.js/discussions).


### PR DESCRIPTION
The pnpm command wasn't working as it was a typo, changed to `pnpx` and `create-next-app` and now the example works in a terminal

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
