### PR TITLE
Add invariant with debug information when failing to load static file

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -22,6 +22,7 @@ import {
   NormalizeError,
   DecodeError,
   normalizeRepeatedSlashes,
+  MissingStaticPage,
 } from '../shared/lib/utils'
 import type { PreviewData } from 'next/types'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
@@ -1856,6 +1857,26 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       }
     } catch (error) {
       const err = getProperError(error)
+
+      if (error instanceof MissingStaticPage) {
+        console.error(
+          'Invariant: failed to load static page',
+          JSON.stringify(
+            {
+              page,
+              url: ctx.req.url,
+              matchedPath: ctx.req.headers['x-matched-path'],
+              initUrl: getRequestMeta(ctx.req, '__NEXT_INIT_URL'),
+              didRewrite: getRequestMeta(ctx.req, '_nextDidRewrite'),
+              rewroteUrl: getRequestMeta(ctx.req, '_nextRewroteUrl'),
+            },
+            null,
+            2
+          )
+        )
+        throw err
+      }
+
       if (err instanceof NoFallbackError && bubbleNoFallback) {
         throw err
       }

--- a/packages/next/server/require.ts
+++ b/packages/next/server/require.ts
@@ -11,7 +11,7 @@ import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
-import { PageNotFoundError } from '../shared/lib/utils'
+import { PageNotFoundError, MissingStaticPage } from '../shared/lib/utils'
 
 export function getPagePath(
   page: string,
@@ -90,7 +90,9 @@ export function requirePage(
     appDirEnabled
   )
   if (pagePath.endsWith('.html')) {
-    return promises.readFile(pagePath, 'utf8')
+    return promises.readFile(pagePath, 'utf8').catch((err) => {
+      throw new MissingStaticPage(page, err.message)
+    })
   }
   return require(pagePath)
 }

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -413,6 +413,13 @@ export class PageNotFoundError extends Error {
   }
 }
 
+export class MissingStaticPage extends Error {
+  constructor(page: string, message: string) {
+    super()
+    this.message = `Failed to load static file for page: ${page} ${message}`
+  }
+}
+
 export class MiddlewareNotFoundError extends Error {
   code: string
   constructor() {

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -138,6 +138,24 @@ describe('should set-up next', () => {
     if (server) await killApp(server)
   })
 
+  it('should show invariant when an automatic static page is requested', async () => {
+    const toRename = `standalone/.next/server/pages/auto-static.html`
+    await next.renameFile(toRename, `${toRename}.bak`)
+
+    try {
+      const res = await fetchViaHTTP(appPort, '/auto-static', undefined, {
+        headers: {
+          'x-matched-path': '/auto-static',
+        },
+      })
+
+      expect(res.status).toBe(500)
+      await check(() => stderr, /Invariant: failed to load static page/)
+    } finally {
+      await next.renameFile(`${toRename}.bak`, toRename)
+    }
+  })
+
   it.each([
     {
       case: 'redirect no revalidate',

--- a/test/production/required-server-files/pages/auto-static.js
+++ b/test/production/required-server-files/pages/auto-static.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>automatic static page</p>
+}


### PR DESCRIPTION
This adds an invariant with a proper error stack when we fail to load a static file that is expected to be present. An integration test has been added to ensure the invariant is triggered correctly. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/CLDDX2Y0G/p1656355021729869?thread_ts=1656316024.211829&cid=CLDDX2Y0G)