### PR TITLE
Fix resolving dynamic routes when on returns a redirect

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1830,8 +1830,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       // Ensure a request to the URL /accounts/[id] will be treated as a dynamic
       // route correctly and not loaded immediately without parsing params.
       if (!isDynamicRoute(page)) {
-        const result = await this.renderPageComponent(ctx, bubbleNoFallback)
-        if (result) return result
+        return await this.renderPageComponent(ctx, bubbleNoFallback)
       }
 
       if (this.dynamicRoutes) {
@@ -1841,7 +1840,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             continue
           }
           page = dynamicRoute.page
-          const result = await this.renderPageComponent(
+          return await this.renderPageComponent(
             {
               ...ctx,
               pathname: page,
@@ -1852,7 +1851,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             },
             bubbleNoFallback
           )
-          if (result) return result
         }
       }
     } catch (error) {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1815,7 +1815,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         }
       }
     }
-    return null
+    return false
   }
 
   private async renderToResponse(
@@ -1830,7 +1830,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       // Ensure a request to the URL /accounts/[id] will be treated as a dynamic
       // route correctly and not loaded immediately without parsing params.
       if (!isDynamicRoute(page)) {
-        return await this.renderPageComponent(ctx, bubbleNoFallback)
+        const result = await this.renderPageComponent(ctx, bubbleNoFallback)
+        if (result !== false) return result
       }
 
       if (this.dynamicRoutes) {
@@ -1840,7 +1841,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             continue
           }
           page = dynamicRoute.page
-          return await this.renderPageComponent(
+          const result = await this.renderPageComponent(
             {
               ...ctx,
               pathname: page,
@@ -1851,6 +1852,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             },
             bubbleNoFallback
           )
+          if (result !== false) return result
         }
       }
     } catch (error) {

--- a/test/production/required-server-files.test.ts
+++ b/test/production/required-server-files.test.ts
@@ -138,6 +138,33 @@ describe('should set-up next', () => {
     if (server) await killApp(server)
   })
 
+  it('should resolve correctly when a redirect is returned', async () => {
+    const toRename = `standalone/.next/server/pages/route-resolving/[slug]/[project].html`
+    await next.renameFile(toRename, `${toRename}.bak`)
+    try {
+      const res = await fetchViaHTTP(
+        appPort,
+        '/route-resolving/import/first',
+        undefined,
+        {
+          redirect: 'manual',
+          headers: {
+            'x-matched-path': '/route-resolving/import/[slug]',
+          },
+        }
+      )
+      expect(res.status).toBe(307)
+      expect(new URL(res.headers.get('location'), 'http://n').pathname).toBe(
+        '/somewhere'
+      )
+
+      await waitFor(3000)
+      expect(stderr).not.toContain('ENOENT')
+    } finally {
+      await next.renameFile(`${toRename}.bak`, toRename)
+    }
+  })
+
   it('should show invariant when an automatic static page is requested', async () => {
     const toRename = `standalone/.next/server/pages/auto-static.html`
     await next.renameFile(toRename, `${toRename}.bak`)

--- a/test/production/required-server-files/pages/route-resolving/[slug]/[project].js
+++ b/test/production/required-server-files/pages/route-resolving/[slug]/[project].js
@@ -1,0 +1,3 @@
+export default function Page(props) {
+  return <p>/[slug]/[project]</p>
+}

--- a/test/production/required-server-files/pages/route-resolving/import/[slug].js
+++ b/test/production/required-server-files/pages/route-resolving/import/[slug].js
@@ -1,0 +1,19 @@
+export default function Page(props) {
+  return <p>/import/[slug]</p>
+}
+
+export function getStaticProps() {
+  return {
+    redirect: {
+      destination: '/somewhere',
+      permanent: false,
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: true,
+  }
+}


### PR DESCRIPTION
This fixes the case where we are resolving dynamic routes and the render result is `null` since it was already handled we attempt to continue resolving dynamic routes which can cause the request to fail. This was changed slightly in https://github.com/vercel/next.js/pull/37897 and it seems we didn't have any test cases covering this already.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/CLDDX2Y0G/p1656316024211829)
x-ref: https://github.com/vercel/next.js/pull/37897