### PR TITLE
Remove unnecessary `<noscript>` from `next/future/image`

### DIFF
--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -677,7 +677,7 @@ const ImageElement = ({
           }
         }}
       />
-      {(isLazy || placeholder === 'blur') && (
+      {placeholder === 'blur' && (
         <noscript>
           <img
             {...rest}

--- a/test/integration/image-future/default/test/index.test.js
+++ b/test/integration/image-future/default/test/index.test.js
@@ -169,11 +169,9 @@ function runTests(mode) {
     const $html = cheerio.load(html)
 
     const els = [].slice.apply($html('img'))
-    expect(els.length).toBe(2)
+    expect(els.length).toBe(1)
 
-    const [el, noscriptEl] = els
-    expect(noscriptEl.attribs.src).toBeDefined()
-    expect(noscriptEl.attribs.srcset).toBeDefined()
+    const [el] = els
 
     expect(el.attribs.src).not.toBe('/truck.jpg')
     expect(el.attribs.srcset).not.toBe(

--- a/test/integration/image-future/noscript/pages/index.js
+++ b/test/integration/image-future/noscript/pages/index.js
@@ -9,13 +9,21 @@ const Page = () => {
   return (
     <div>
       <p>noscript images</p>
-      <Image id="basic-image" src="/basic-image.jpg" width={640} height={360} />
+      <Image id="basic-image" src="/basic.jpg" width={640} height={360} />
       <Image
         loader={myLoader}
         id="image-with-loader"
         src="/remote-image.jpg"
         width={640}
         height={360}
+      />
+      <Image
+        id="image-with-blur"
+        src="/blur.jpg"
+        width={640}
+        height={360}
+        placeholder="blur"
+        blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mMU/M9QDwADygGR4qH9qQAAAABJRU5ErkJggg=="
       />
     </div>
   )


### PR DESCRIPTION
We don't need to include `<noscript>` for `next/future/image` since it uses native lazy loading instead of the `IntersectionObserver` (https://github.com/vercel/next.js/pull/37927).

The only case when we still need `<noscript>` is for `placeholder="blur"` because it requires client-side JS to switch the from blur image to final image on load.