### PR TITLE
Ensure history navigation is correct after query update

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -903,6 +903,8 @@ export default class Router implements BaseRouter {
       Object.assign<{}, TransitionOptions, TransitionOptions>({}, options, {
         shallow: options.shallow && this._shallow,
         locale: options.locale || this.defaultLocale,
+        // @ts-ignore internal value not exposed on types
+        _h: 0,
       }),
       forcedScroll
     )

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -50,6 +50,23 @@ describe('Middleware Rewrite', () => {
       }, /Welcome Page A/)
     })
 
+    it('should rewrite correctly when navigating via history after query update', async () => {
+      const browser = await webdriver(next.url, '/')
+      await browser.elementByCss('#override-with-internal-rewrite').click()
+      await check(() => {
+        return browser.eval('document.documentElement.innerHTML')
+      }, /Welcome Page A/)
+
+      await browser.refresh()
+      await browser.waitForCondition(`!!window.next.router.isReady`)
+      await browser.back()
+      await browser.waitForElementByCss('#override-with-internal-rewrite')
+      await browser.forward()
+      await check(() => {
+        return browser.eval('document.documentElement.innerHTML')
+      }, /Welcome Page A/)
+    })
+
     it('should return HTML/data correctly for pre-rendered page', async () => {
       for (const slug of [
         'first',

--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -68,6 +68,26 @@ describe('Production Usage', () => {
     await killApp(app)
   })
 
+  it('should navigate through history after query update', async () => {
+    const browser = await webdriver(appPort, '/')
+    await browser.eval('window.next.router.push("/about?a=b")')
+    await browser.waitForElementByCss('.about-page')
+    await browser.waitForCondition(`!!window.next.router.isReady`)
+
+    await browser.refresh()
+    await browser.waitForCondition(`!!window.next.router.isReady`)
+    await browser.back()
+    await browser.waitForElementByCss('.index-page')
+    await browser.forward()
+    await browser.waitForElementByCss('.about-page')
+    await browser.back()
+    await browser.waitForElementByCss('.index-page')
+    await browser.refresh()
+    await browser.waitForCondition(`!!window.next.router.isReady`)
+    await browser.forward()
+    await browser.waitForElementByCss('.about-page')
+  })
+
   it('should not show target deprecation warning', () => {
     expect(output).not.toContain(
       'The `target` config is deprecated and will be removed in a future version'


### PR DESCRIPTION
This fixes an issue with history navigations from the race condition check for query updating added in https://github.com/vercel/next.js/pull/37815 also adds regression tests with and without middleware to ensure this is working as expected. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: [slack thread](https://vercel.slack.com/archives/C017QMYC5FB/p1656373111055279)
