### PR TITLE
Ensure client cache keys match between prefetch and transition

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1363,9 +1363,9 @@ export default class Router implements BaseRouter {
             rewriteAs = localeResult.pathname
           }
           const routeRegex = getRouteRegex(pathname)
-          const routeMatch = getRouteMatcher(routeRegex)(rewriteAs)
+          const curRouteMatch = getRouteMatcher(routeRegex)(rewriteAs)
 
-          if (routeMatch) {
+          if (curRouteMatch) {
             Object.assign(query, routeMatch)
           }
         }

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1366,7 +1366,7 @@ export default class Router implements BaseRouter {
           const curRouteMatch = getRouteMatcher(routeRegex)(rewriteAs)
 
           if (curRouteMatch) {
-            Object.assign(query, routeMatch)
+            Object.assign(query, curRouteMatch)
           }
         }
       }


### PR DESCRIPTION
This ensures the data href used as the cache key for the client cache is consistent between prefetching and route transitions and adds regression tests with and without middleware in our dynamic routing test suite. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/C0289CGVAR2/p1656379310136979)