### PR TITLE
docs: Add React 18 streaming to Edge Runtime use cases

### DIFF
--- a/docs/api-reference/edge-runtime.md
+++ b/docs/api-reference/edge-runtime.md
@@ -4,7 +4,7 @@ description: The Next.js Edge Runtime is based on standard Web APIs. Learn more 
 
 # Edge Runtime
 
-The Next.js Edge Runtime is based on standard Web APIs, which is used by [Middleware](/docs/middleware.md) and [Edge API Routes](/docs/api-routes/edge-api-routes.md).
+The Next.js Edge Runtime is based on standard Web APIs, which is used by [Middleware](/docs/middleware.md), [Edge API Routes](/docs/api-routes/edge-api-routes.md) and [React 18's streaming feature](/docs/advanced-features/react-18/overview.md).
 
 ## Network APIs
 


### PR DESCRIPTION
Besides the existing use cases (Middleware & Edge API Routes), the Edge Runtime is also used for React 18's streaming feature. This change adds this use case.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->


## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
