### PR TITLE
Remove unused `layoutRaw` config

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1519,7 +1519,6 @@ export default async function getBaseWebpackConfig(
           path: config.images.path,
           loader: config.images.loader,
           experimentalUnoptimized: config?.experimental?.images?.unoptimized,
-          experimentalLayoutRaw: config.experimental?.images?.layoutRaw,
           experimentalFuture: config.experimental?.images?.allowFutureImage,
           ...(dev
             ? {

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -118,7 +118,6 @@ export interface ExperimentalConfig {
   urlImports?: NonNullable<webpack5.Configuration['experiments']>['buildHttp']
   outputFileTracingRoot?: string
   images?: {
-    layoutRaw?: boolean
     remotePatterns?: RemotePattern[]
     unoptimized?: boolean
     allowFutureImage?: boolean
@@ -543,7 +542,6 @@ export const defaultConfig: NextConfig = {
     fullySpecified: false,
     outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
     images: {
-      layoutRaw: false,
       remotePatterns: [],
     },
     forceSwcTransforms: false,

--- a/test/integration/image-component/default/next.config.js
+++ b/test/integration/image-component/default/next.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  experimental: {
-    images: {
-      layoutRaw: true,
-    },
-  },
-}


### PR DESCRIPTION
Removes the `layoutRaw` experimental config which was forgotten in a previous PR #38006 