### PR TITLE
fix(next/config): update default config for the experimental

### DIFF
--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -544,7 +544,9 @@ export const defaultConfig: NextConfig = {
     images: {
       remotePatterns: [],
     },
+    swcTraceProfiling: false,
     forceSwcTransforms: false,
+    swcPlugins: [],
     largePageDataBytes: 128 * 1000, // 128KB by default
   },
 }

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -546,7 +546,7 @@ export const defaultConfig: NextConfig = {
     },
     swcTraceProfiling: false,
     forceSwcTransforms: false,
-    swcPlugins: [],
+    swcPlugins: undefined,
     largePageDataBytes: 128 * 1000, // 128KB by default
   },
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Minor fix to recent experimental configs. While the latest next.js includes support for those experimental features, currently it emits warnings like

```
You have defined experimental feature (swcPlugins) in next.config.js that does not exist in this version of Next.js
```

As validation checks the existence of default values even though config itself allows them to be optional. PR does not attempt to change validation logics, only amends it by having empty default values.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
