### PR TITLE
Fix unnecessary flight render passes

### DIFF
--- a/packages/next/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -78,7 +78,7 @@ export default async function edgeSSRLoader(this: any) {
       buildId: ${JSON.stringify(buildId)},
     })
 
-    export default function rscMiddleware(opts) {
+    export default function(opts) {
       return adapter({
         ...opts,
         handler: render

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -180,13 +180,20 @@ function createServerComponentRenderer(
     globalThis.__next_chunk_load__ = () => Promise.resolve()
   }
 
-  const writable = transformStream.writable
-  const ServerComponentWrapper = (props: any) => {
-    const reqStream: ReadableStream<Uint8Array> = renderToReadableStream(
-      <ComponentToRender {...props} />,
-      serverComponentManifest
-    )
+  let RSCStream: ReadableStream<Uint8Array>
+  const createRSCStream = () => {
+    if (!RSCStream) {
+      RSCStream = renderToReadableStream(
+        <ComponentToRender />,
+        serverComponentManifest
+      )
+    }
+    return RSCStream
+  }
 
+  const writable = transformStream.writable
+  const ServerComponentWrapper = () => {
+    const reqStream = createRSCStream()
     const response = useFlightResponse(
       writable,
       cachePrefix,


### PR DESCRIPTION
Currently `renderToReadableStream` will be called whenever the component is re-rendered, but the result should actually be cached (per request).

Thanks to @sebmarkbage for pointing out.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
