### PR TITLE
Fix failing to set initial ISR cache item in new folder

### DIFF
--- a/packages/next/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/server/lib/incremental-cache/file-system-cache.ts
@@ -69,7 +69,9 @@ export default class FileSystemCache implements CacheHandler {
     })
 
     if (data?.kind === 'PAGE') {
-      await this.fs.writeFile(this.getFsPath(`${key}.html`), data.html)
+      const htmlPath = this.getFsPath(`${key}.html`)
+      await this.fs.mkdir(path.dirname(htmlPath))
+      await this.fs.writeFile(htmlPath, data.html)
       await this.fs.writeFile(
         this.getFsPath(`${key}.json`),
         JSON.stringify(data.pageData)

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1927,11 +1927,6 @@ describe('Prerender', () => {
       })
     }
 
-    // this should come very last
-    it('should not have attempted sending invalid payload', async () => {
-      expect(next.cliOutput).not.toContain('argument entity must be string')
-    })
-
     if ((global as any).isNextStart) {
       it('should of formatted build output correctly', () => {
         expect(next.cliOutput).toMatch(/○ \/normal/)
@@ -2321,6 +2316,25 @@ describe('Prerender', () => {
         expect(initialTime).not.toBe($2('#time').text())
       })
     }
+
+    it('should respond for catch-all deep folder', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        `/_next/data/${next.buildId}/catchall/first/second/third.json`
+      )
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('["first","second","third"]')
+    })
+
+    // this should come very last
+    it('should not fail to update incremental cache', async () => {
+      await waitFor(1000)
+      expect(next.cliOutput).not.toContain('Failed to update prerender cache')
+    })
+
+    it('should not have attempted sending invalid payload', async () => {
+      expect(next.cliOutput).not.toContain('argument entity must be string')
+    })
   }
   runTests((global as any).isNextDev, (global as any).isNextDeploy)
 })


### PR DESCRIPTION
This ensures we create any nested folders necessary when setting initial ISR cache entries with the filesystem cache. Also adds a regression test for this. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/38130