### PR TITLE
Fix chunk path resolution

### DIFF
--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -137,7 +137,10 @@ export class FlightManifestPlugin {
               chunks: appDir
                 ? chunk.ids.map((chunkId: string) => {
                     return (
-                      chunkId + ':' + chunk.name + (dev ? '' : '-' + chunk.hash)
+                      chunkId +
+                      ':' +
+                      (chunk.name || chunkId) +
+                      (dev ? '' : '-' + chunk.hash)
                     )
                   })
                 : [],

--- a/packages/next/client/app-next.js
+++ b/packages/next/client/app-next.js
@@ -14,7 +14,7 @@ const chunkFilenameMap = {}
 
 // eslint-disable-next-line no-undef
 __webpack_require__.u = (chunkId) => {
-  return getChunkScriptFilename(chunkId) || chunkFilenameMap[chunkId]
+  return chunkFilenameMap[chunkId] || getChunkScriptFilename(chunkId)
 }
 
 // Ignore the module ID transform in client.

--- a/test/e2e/app-dir/app/app/dashboard/index/lazy.client.js
+++ b/test/e2e/app-dir/app/app/dashboard/index/lazy.client.js
@@ -1,0 +1,7 @@
+export default function LazyComponent() {
+  return (
+    <>
+      <p>hello from lazy</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/dashboard/index/page.server.js
+++ b/test/e2e/app-dir/app/app/dashboard/index/page.server.js
@@ -1,7 +1,10 @@
+import { ClientComponent } from './test.client.js'
+
 export default function DashboardIndexPage() {
   return (
     <>
       <p>hello from app/dashboard/index</p>
+      <ClientComponent />
     </>
   )
 }

--- a/test/e2e/app-dir/app/app/dashboard/index/test.client.js
+++ b/test/e2e/app-dir/app/app/dashboard/index/test.client.js
@@ -1,0 +1,13 @@
+import { useState, lazy } from 'react'
+
+const Lazy = lazy(() => import('./lazy.client.js'))
+
+export function ClientComponent() {
+  let [state] = useState('client')
+  return (
+    <>
+      <Lazy />
+      <p className="hi">hello from modern the {state}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -62,6 +62,11 @@ describe('views dir', () => {
     expect(html).toContain('hello from app/dashboard/index')
   })
 
+  it('should load chunks generated via async import correctly', async () => {
+    const html = await renderViaHTTP(next.url, '/dashboard/index')
+    expect(html).toContain('hello from lazy')
+  })
+
   it('should include layouts when no direct parent layout', async () => {
     const html = await renderViaHTTP(next.url, '/dashboard/integrations')
     const $ = cheerio.load(html)


### PR DESCRIPTION
The `chunkFilenameMap` should take priority over the webpack built-in one here.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
