### PR TITLE
fix(next/swc): set cache dir explicitly

### DIFF
--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -1,3 +1,5 @@
+import path from 'path'
+
 const nextDistPath =
   /(next[\\/]dist[\\/]shared[\\/]lib)|(next[\\/]dist[\\/]client)|(next[\\/]dist[\\/]pages)/
 
@@ -46,6 +48,7 @@ function getBaseSWCOptions({
   const plugins = (nextConfig?.experimental?.swcPlugins ?? [])
     .filter(Array.isArray)
     .map(([name, options]) => [require.resolve(name), options])
+
   return {
     jsc: {
       ...(resolvedBaseUrl && paths
@@ -59,6 +62,7 @@ function getBaseSWCOptions({
       experimental: {
         keepImportAssertions: true,
         plugins,
+        cacheRoot: path.join(nextConfig?.distDir ?? '.next', 'swc'),
       },
       transform: {
         // Enables https://github.com/swc-project/swc/blob/0359deb4841be743d73db4536d4a22ac797d7f65/crates/swc_ecma_ext_transforms/src/jest.rs

--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -1,5 +1,3 @@
-import path from 'path'
-
 const nextDistPath =
   /(next[\\/]dist[\\/]shared[\\/]lib)|(next[\\/]dist[\\/]client)|(next[\\/]dist[\\/]pages)/
 
@@ -33,6 +31,7 @@ function getBaseSWCOptions({
   nextConfig,
   resolvedBaseUrl,
   jsConfig,
+  swcCacheDir,
 }) {
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
@@ -62,7 +61,7 @@ function getBaseSWCOptions({
       experimental: {
         keepImportAssertions: true,
         plugins,
-        cacheRoot: path.join(nextConfig?.distDir ?? '.next', 'swc'),
+        cacheRoot: swcCacheDir,
       },
       transform: {
         // Enables https://github.com/swc-project/swc/blob/0359deb4841be743d73db4536d4a22ac797d7f65/crates/swc_ecma_ext_transforms/src/jest.rs
@@ -210,6 +209,7 @@ export function getLoaderSWCOptions({
   nextConfig,
   jsConfig,
   supportedBrowsers,
+  swcCacheDir,
   // This is not passed yet as "paths" resolving is handled by webpack currently.
   // resolvedBaseUrl,
 }) {
@@ -221,6 +221,7 @@ export function getLoaderSWCOptions({
     nextConfig,
     jsConfig,
     // resolvedBaseUrl,
+    swcCacheDir,
   })
 
   const isNextDist = nextDistPath.test(filename)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -480,6 +480,12 @@ export default async function getBaseWebpackConfig(
             supportedBrowsers: config.experimental.browsersListForSwc
               ? supportedBrowsers
               : undefined,
+            swcCacheDir: path.join(
+              dir,
+              config?.distDir ?? '.next',
+              'cache',
+              'swc'
+            ),
           },
         }
       : {

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -43,6 +43,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
     nextConfig,
     jsConfig,
     supportedBrowsers,
+    swcCacheDir,
   } = loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
 
@@ -56,6 +57,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
     nextConfig,
     jsConfig,
     supportedBrowsers,
+    swcCacheDir,
   })
 
   const programmaticOptions = {

--- a/test/integration/clean-distdir/test/index.test.js
+++ b/test/integration/clean-distdir/test/index.test.js
@@ -7,6 +7,7 @@ import { nextBuild } from 'next-test-utils'
 const appDir = join(__dirname, '../')
 const customFile = join(appDir, '.next/extra-file.txt')
 const cacheDir = join(appDir, '.next/cache')
+const swcCacheDir = join(appDir, '.next/cache/swc')
 const nextConfig = join(appDir, 'next.config.js')
 
 let nextConfigContent
@@ -18,6 +19,7 @@ async function checkFileWrite(existsAfterBuild) {
   expect(fs.existsSync(customFile)).toBe(existsAfterBuild)
   // `.next/cache` should be preserved in all cases
   expect(fs.existsSync(cacheDir)).toBe(true)
+  expect(fs.existsSync(swcCacheDir)).toBe(true)
 }
 
 const runTests = () => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR amends behavior of swc's cache by setting it explicitly under `distDir` from next.js config.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
