### PR TITLE
docs: remove eslint config link

### DIFF
--- a/docs/basic-features/eslint.md
+++ b/docs/basic-features/eslint.md
@@ -72,8 +72,6 @@ Recommended rule-sets from the following ESLint plugins are all used within `esl
 - [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks)
 - [`eslint-plugin-next`](https://www.npmjs.com/package/@next/eslint-plugin-next)
 
-You can see the full details of the shareable configuration in the [`eslint-config-next`](https://www.npmjs.com/package/eslint-config-next) package.
-
 This will take precedence over the configuration from `next.config.js`.
 
 ## ESLint Plugin


### PR DESCRIPTION
[Slack thread](https://vercel.slack.com/archives/C02UJ0QH45Q/p1656580818197009)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
