### PR TITLE
add reactOnRecoverableError to next.config.js

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1547,6 +1547,8 @@ export default async function getBaseWebpackConfig(
         'process.env.__NEXT_I18N_SUPPORT': JSON.stringify(!!config.i18n),
         'process.env.__NEXT_I18N_DOMAINS': JSON.stringify(config.i18n?.domains),
         'process.env.__NEXT_ANALYTICS_ID': JSON.stringify(config.analyticsId),
+        'process.env.__NEXT_REACT_ONRECOVERABLE_ERROR':
+          config.reactOnRecoverableError,
         ...(isNodeServer || isEdgeServer
           ? {
               // Fix bad-actors in the npm ecosystem (e.g. `node-formidable`)

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -553,7 +553,15 @@ function renderReactElement(
   if (process.env.__NEXT_REACT_ROOT) {
     if (!reactRoot) {
       // Unlike with createRoot, you don't need a separate root.render() call here
-      reactRoot = ReactDOM.hydrateRoot(domEl, reactEl)
+      reactRoot = ReactDOM.hydrateRoot(
+        domEl,
+        reactEl,
+        Boolean(process.env.__NEXT_REACT_ONRECOVERABLE_ERROR)
+          ? {
+              onRecoverableError: process.env.__NEXT_REACT_ONRECOVERABLE_ERROR,
+            }
+          : undefined
+      )
       // TODO: Remove shouldHydrate variable when React 18 is stable as it can depend on `reactRoot` existing
       shouldHydrate = false
     } else {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This allows users to pass a custom function to `ReactDOM.hydrateRoot`'s `onRecoverableError` option.

I previously spoke to @gnoff about this. We need this to migrate all legacy Blitz framework users to Next.js + Blitz 2.0 toolkit. We need it because [we are forcing rendering of Suspense fallbacks](https://github.com/blitz-js/blitz/blob/main/packages/blitz-rpc/src/data-client/react-query.tsx#L102-L105) on the server for our queries. Currently that results in the below error overlay. We can bypass that for our use case by using a custom `onRecoverableError` function.

This is a critical blocker for our blitz -> nextjs migration, so we'd love to ship this soon if possible :)

![image](https://user-images.githubusercontent.com/8813276/176711316-c10ec59d-2f9e-455a-b6ed-16d133fc4151.png)

## Feature

User can define the custom `onRecoverableError` in next.config.js like this:
```ts
module.exports = {
  reactOnRecoverableError: (...args) => {
    console.error(...args)
  }
}
```

This API & implementation was not previously discussed, so I'm expecting some discussion about it. Once we're happy with it, I'll add relevant tests and docs.

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`


