### PR TITLE
Add .swc/ to .gitignore in examples/ and CNA template files

### DIFF
--- a/examples/active-class-name/.gitignore
+++ b/examples/active-class-name/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/active-class-name/.gitignore
+++ b/examples/active-class-name/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/amp-first/.gitignore
+++ b/examples/amp-first/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/amp-first/.gitignore
+++ b/examples/amp-first/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/amp-story/.gitignore
+++ b/examples/amp-story/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/amp-story/.gitignore
+++ b/examples/amp-story/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/amp/.gitignore
+++ b/examples/amp/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/amp/.gitignore
+++ b/examples/amp/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/analyze-bundles/.gitignore
+++ b/examples/analyze-bundles/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/analyze-bundles/.gitignore
+++ b/examples/analyze-bundles/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-apollo-server-and-client-auth/.gitignore
+++ b/examples/api-routes-apollo-server-and-client-auth/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-apollo-server-and-client-auth/.gitignore
+++ b/examples/api-routes-apollo-server-and-client-auth/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-apollo-server-and-client/.gitignore
+++ b/examples/api-routes-apollo-server-and-client/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-apollo-server-and-client/.gitignore
+++ b/examples/api-routes-apollo-server-and-client/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-apollo-server/.gitignore
+++ b/examples/api-routes-apollo-server/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-apollo-server/.gitignore
+++ b/examples/api-routes-apollo-server/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-cors/.gitignore
+++ b/examples/api-routes-cors/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-cors/.gitignore
+++ b/examples/api-routes-cors/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-graphql/.gitignore
+++ b/examples/api-routes-graphql/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-graphql/.gitignore
+++ b/examples/api-routes-graphql/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-middleware/.gitignore
+++ b/examples/api-routes-middleware/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-middleware/.gitignore
+++ b/examples/api-routes-middleware/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-rate-limit/.gitignore
+++ b/examples/api-routes-rate-limit/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-rate-limit/.gitignore
+++ b/examples/api-routes-rate-limit/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes-rest/.gitignore
+++ b/examples/api-routes-rest/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes-rest/.gitignore
+++ b/examples/api-routes-rest/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/api-routes/.gitignore
+++ b/examples/api-routes/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/api-routes/.gitignore
+++ b/examples/api-routes/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/auth-with-stytch/.gitignore
+++ b/examples/auth-with-stytch/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/auth-with-stytch/.gitignore
+++ b/examples/auth-with-stytch/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/auth0/.gitignore
+++ b/examples/auth0/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/auth0/.gitignore
+++ b/examples/auth0/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/basic-css/.gitignore
+++ b/examples/basic-css/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/basic-css/.gitignore
+++ b/examples/basic-css/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/basic-export/.gitignore
+++ b/examples/basic-export/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/basic-export/.gitignore
+++ b/examples/basic-export/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/blog-starter-typescript/.gitignore
+++ b/examples/blog-starter-typescript/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/blog-starter-typescript/.gitignore
+++ b/examples/blog-starter-typescript/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/blog-starter/.gitignore
+++ b/examples/blog-starter/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/blog-starter/.gitignore
+++ b/examples/blog-starter/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/blog-with-comment/.gitignore
+++ b/examples/blog-with-comment/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/blog-with-comment/.gitignore
+++ b/examples/blog-with-comment/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -36,4 +36,4 @@ yarn-error.log*
 public/feed.xml
 
 # cache
-*.swc/
+.swc/

--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 .vercel
 
 public/feed.xml
+
+# cache
+*.swc/

--- a/examples/catch-all-routes/.gitignore
+++ b/examples/catch-all-routes/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/catch-all-routes/.gitignore
+++ b/examples/catch-all-routes/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-agilitycms/.gitignore
+++ b/examples/cms-agilitycms/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-agilitycms/.gitignore
+++ b/examples/cms-agilitycms/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-builder-io/.gitignore
+++ b/examples/cms-builder-io/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-builder-io/.gitignore
+++ b/examples/cms-builder-io/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-buttercms/.gitignore
+++ b/examples/cms-buttercms/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-buttercms/.gitignore
+++ b/examples/cms-buttercms/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-contentful/.gitignore
+++ b/examples/cms-contentful/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-contentful/.gitignore
+++ b/examples/cms-contentful/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-cosmic/.gitignore
+++ b/examples/cms-cosmic/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-cosmic/.gitignore
+++ b/examples/cms-cosmic/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-datocms/.gitignore
+++ b/examples/cms-datocms/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-datocms/.gitignore
+++ b/examples/cms-datocms/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-drupal/.gitignore
+++ b/examples/cms-drupal/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-drupal/.gitignore
+++ b/examples/cms-drupal/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-ghost/.gitignore
+++ b/examples/cms-ghost/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-ghost/.gitignore
+++ b/examples/cms-ghost/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-graphcms/.gitignore
+++ b/examples/cms-graphcms/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-graphcms/.gitignore
+++ b/examples/cms-graphcms/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-kontent/.gitignore
+++ b/examples/cms-kontent/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-kontent/.gitignore
+++ b/examples/cms-kontent/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-makeswift/.gitignore
+++ b/examples/cms-makeswift/.gitignore
@@ -38,4 +38,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-makeswift/.gitignore
+++ b/examples/cms-makeswift/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/cms-plasmic/.gitignore
+++ b/examples/cms-plasmic/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-plasmic/.gitignore
+++ b/examples/cms-plasmic/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/cms-prepr/.gitignore
+++ b/examples/cms-prepr/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-prepr/.gitignore
+++ b/examples/cms-prepr/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-prismic/.gitignore
+++ b/examples/cms-prismic/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-prismic/.gitignore
+++ b/examples/cms-prismic/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-sanity/.gitignore
+++ b/examples/cms-sanity/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-sanity/.gitignore
+++ b/examples/cms-sanity/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-storyblok/.gitignore
+++ b/examples/cms-storyblok/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-storyblok/.gitignore
+++ b/examples/cms-storyblok/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-strapi/.gitignore
+++ b/examples/cms-strapi/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-strapi/.gitignore
+++ b/examples/cms-strapi/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-takeshape/.gitignore
+++ b/examples/cms-takeshape/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-takeshape/.gitignore
+++ b/examples/cms-takeshape/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-tina/.gitignore
+++ b/examples/cms-tina/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-tina/.gitignore
+++ b/examples/cms-tina/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-umbraco-heartcore/.gitignore
+++ b/examples/cms-umbraco-heartcore/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-umbraco-heartcore/.gitignore
+++ b/examples/cms-umbraco-heartcore/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/cms-wordpress/.gitignore
+++ b/examples/cms-wordpress/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/cms-wordpress/.gitignore
+++ b/examples/cms-wordpress/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/convex/.gitignore
+++ b/examples/convex/.gitignore
@@ -40,4 +40,4 @@ convex/_generated
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/convex/.gitignore
+++ b/examples/convex/.gitignore
@@ -38,3 +38,6 @@ convex/_generated
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/custom-routes-proxying/.gitignore
+++ b/examples/custom-routes-proxying/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/custom-routes-proxying/.gitignore
+++ b/examples/custom-routes-proxying/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/custom-server-actionhero/.gitignore
+++ b/examples/custom-server-actionhero/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/custom-server-actionhero/.gitignore
+++ b/examples/custom-server-actionhero/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/custom-server-express/.gitignore
+++ b/examples/custom-server-express/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/custom-server-express/.gitignore
+++ b/examples/custom-server-express/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/custom-server-fastify/.gitignore
+++ b/examples/custom-server-fastify/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/custom-server-fastify/.gitignore
+++ b/examples/custom-server-fastify/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/custom-server-hapi/.gitignore
+++ b/examples/custom-server-hapi/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/custom-server-hapi/.gitignore
+++ b/examples/custom-server-hapi/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/custom-server-koa/.gitignore
+++ b/examples/custom-server-koa/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/custom-server-koa/.gitignore
+++ b/examples/custom-server-koa/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/custom-server-polka/.gitignore
+++ b/examples/custom-server-polka/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/custom-server-polka/.gitignore
+++ b/examples/custom-server-polka/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/custom-server-typescript/.gitignore
+++ b/examples/custom-server-typescript/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/custom-server-typescript/.gitignore
+++ b/examples/custom-server-typescript/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/data-fetch/.gitignore
+++ b/examples/data-fetch/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/data-fetch/.gitignore
+++ b/examples/data-fetch/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/dynamic-routing/.gitignore
+++ b/examples/dynamic-routing/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/dynamic-routing/.gitignore
+++ b/examples/dynamic-routing/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/environment-variables/.gitignore
+++ b/examples/environment-variables/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/environment-variables/.gitignore
+++ b/examples/environment-variables/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/fast-refresh-demo/.gitignore
+++ b/examples/fast-refresh-demo/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/fast-refresh-demo/.gitignore
+++ b/examples/fast-refresh-demo/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/github-pages/.gitignore
+++ b/examples/github-pages/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/github-pages/.gitignore
+++ b/examples/github-pages/.gitignore
@@ -33,4 +33,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/head-elements/.gitignore
+++ b/examples/head-elements/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/head-elements/.gitignore
+++ b/examples/head-elements/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/headers/.gitignore
+++ b/examples/headers/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/headers/.gitignore
+++ b/examples/headers/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/hello-world-esm/.gitignore
+++ b/examples/hello-world-esm/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/hello-world-esm/.gitignore
+++ b/examples/hello-world-esm/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/hello-world/.gitignore
+++ b/examples/hello-world/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/hello-world/.gitignore
+++ b/examples/hello-world/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/i18n-routing/.gitignore
+++ b/examples/i18n-routing/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/i18n-routing/.gitignore
+++ b/examples/i18n-routing/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/image-component/.gitignore
+++ b/examples/image-component/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/image-component/.gitignore
+++ b/examples/image-component/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/layout-component/.gitignore
+++ b/examples/layout-component/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/layout-component/.gitignore
+++ b/examples/layout-component/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/markdoc/.gitignore
+++ b/examples/markdoc/.gitignore
@@ -30,3 +30,6 @@
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/markdoc/.gitignore
+++ b/examples/markdoc/.gitignore
@@ -32,4 +32,4 @@
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/modularize-imports/.gitignore
+++ b/examples/modularize-imports/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/modularize-imports/.gitignore
+++ b/examples/modularize-imports/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/nested-components/.gitignore
+++ b/examples/nested-components/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/nested-components/.gitignore
+++ b/examples/nested-components/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/next-forms/.gitignore
+++ b/examples/next-forms/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/next-forms/.gitignore
+++ b/examples/next-forms/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/page-transitions/.gitignore
+++ b/examples/page-transitions/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/page-transitions/.gitignore
+++ b/examples/page-transitions/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/parameterized-routing/.gitignore
+++ b/examples/parameterized-routing/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/parameterized-routing/.gitignore
+++ b/examples/parameterized-routing/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/progressive-render/.gitignore
+++ b/examples/progressive-render/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/progressive-render/.gitignore
+++ b/examples/progressive-render/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/progressive-web-app/.gitignore
+++ b/examples/progressive-web-app/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/progressive-web-app/.gitignore
+++ b/examples/progressive-web-app/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/react-remove-properties/.gitignore
+++ b/examples/react-remove-properties/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/react-remove-properties/.gitignore
+++ b/examples/react-remove-properties/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/redirects/.gitignore
+++ b/examples/redirects/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/redirects/.gitignore
+++ b/examples/redirects/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/remove-console/.gitignore
+++ b/examples/remove-console/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/remove-console/.gitignore
+++ b/examples/remove-console/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/reproduction-template/.gitignore
+++ b/examples/reproduction-template/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/reproduction-template/.gitignore
+++ b/examples/reproduction-template/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/rewrites/.gitignore
+++ b/examples/rewrites/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/rewrites/.gitignore
+++ b/examples/rewrites/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/script-component/.gitignore
+++ b/examples/script-component/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/script-component/.gitignore
+++ b/examples/script-component/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/ssr-caching/.gitignore
+++ b/examples/ssr-caching/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/ssr-caching/.gitignore
+++ b/examples/ssr-caching/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/styled-jsx-with-csp/.gitignore
+++ b/examples/styled-jsx-with-csp/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/styled-jsx-with-csp/.gitignore
+++ b/examples/styled-jsx-with-csp/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/svg-components/.gitignore
+++ b/examples/svg-components/.gitignore
@@ -37,3 +37,6 @@ pnpm-lock.yaml
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/svg-components/.gitignore
+++ b/examples/svg-components/.gitignore
@@ -39,4 +39,4 @@ pnpm-lock.yaml
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/using-preact/.gitignore
+++ b/examples/using-preact/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/using-preact/.gitignore
+++ b/examples/using-preact/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/using-router/.gitignore
+++ b/examples/using-router/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/using-router/.gitignore
+++ b/examples/using-router/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-ably/.gitignore
+++ b/examples/with-ably/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-ably/.gitignore
+++ b/examples/with-ably/.gitignore
@@ -33,4 +33,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-absolute-imports/.gitignore
+++ b/examples/with-absolute-imports/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-absolute-imports/.gitignore
+++ b/examples/with-absolute-imports/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-algolia-react-instantsearch/.gitignore
+++ b/examples/with-algolia-react-instantsearch/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-algolia-react-instantsearch/.gitignore
+++ b/examples/with-algolia-react-instantsearch/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-ant-design/.gitignore
+++ b/examples/with-ant-design/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-ant-design/.gitignore
+++ b/examples/with-ant-design/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-aphrodite/.gitignore
+++ b/examples/with-aphrodite/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-aphrodite/.gitignore
+++ b/examples/with-aphrodite/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-apollo-and-redux/.gitignore
+++ b/examples/with-apollo-and-redux/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-apollo-and-redux/.gitignore
+++ b/examples/with-apollo-and-redux/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-apollo-neo4j-graphql/.gitignore
+++ b/examples/with-apollo-neo4j-graphql/.gitignore
@@ -30,4 +30,4 @@ yarn-error.log*
 .env.production.local
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-apollo-neo4j-graphql/.gitignore
+++ b/examples/with-apollo-neo4j-graphql/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# cache
+*.swc/

--- a/examples/with-apollo/.gitignore
+++ b/examples/with-apollo/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-apollo/.gitignore
+++ b/examples/with-apollo/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-app-layout/.gitignore
+++ b/examples/with-app-layout/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-app-layout/.gitignore
+++ b/examples/with-app-layout/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-atlaskit/.gitignore
+++ b/examples/with-atlaskit/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-atlaskit/.gitignore
+++ b/examples/with-atlaskit/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-aws-amplify-typescript/.gitignore
+++ b/examples/with-aws-amplify-typescript/.gitignore
@@ -55,4 +55,4 @@ amplifytools.xcconfig
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-aws-amplify-typescript/.gitignore
+++ b/examples/with-aws-amplify-typescript/.gitignore
@@ -53,3 +53,6 @@ amplifytools.xcconfig
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-aws-amplify/.gitignore
+++ b/examples/with-aws-amplify/.gitignore
@@ -43,3 +43,6 @@ dist/
 node_modules/
 aws-exports.js
 awsconfiguration.json
+
+# cache
+*.swc/

--- a/examples/with-aws-amplify/.gitignore
+++ b/examples/with-aws-amplify/.gitignore
@@ -45,4 +45,4 @@ aws-exports.js
 awsconfiguration.json
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-babel-macros/.gitignore
+++ b/examples/with-babel-macros/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-babel-macros/.gitignore
+++ b/examples/with-babel-macros/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-carbon-components/.gitignore
+++ b/examples/with-carbon-components/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-carbon-components/.gitignore
+++ b/examples/with-carbon-components/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-cerebral/.gitignore
+++ b/examples/with-cerebral/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-cerebral/.gitignore
+++ b/examples/with-cerebral/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-chakra-ui/.gitignore
+++ b/examples/with-chakra-ui/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-chakra-ui/.gitignore
+++ b/examples/with-chakra-ui/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-clerk/.gitignore
+++ b/examples/with-clerk/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-clerk/.gitignore
+++ b/examples/with-clerk/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-compiled-css/.gitignore
+++ b/examples/with-compiled-css/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-compiled-css/.gitignore
+++ b/examples/with-compiled-css/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-contentlayer/.gitignore
+++ b/examples/with-contentlayer/.gitignore
@@ -38,4 +38,4 @@ yarn-error.log*
 .contentlayer
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-contentlayer/.gitignore
+++ b/examples/with-contentlayer/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # Contentlayer
 .contentlayer
+
+# cache
+*.swc/

--- a/examples/with-context-api/.gitignore
+++ b/examples/with-context-api/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-context-api/.gitignore
+++ b/examples/with-context-api/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-cookie-auth-fauna/.gitignore
+++ b/examples/with-cookie-auth-fauna/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-cookie-auth-fauna/.gitignore
+++ b/examples/with-cookie-auth-fauna/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-cookie-auth/.gitignore
+++ b/examples/with-cookie-auth/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-cookie-auth/.gitignore
+++ b/examples/with-cookie-auth/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-couchbase/.gitignore
+++ b/examples/with-couchbase/.gitignore
@@ -33,4 +33,4 @@ yarn-error.log*
 .idea/
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-couchbase/.gitignore
+++ b/examples/with-couchbase/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # IDE Files
 .idea/
+
+# cache
+*.swc/

--- a/examples/with-cssed/.gitignore
+++ b/examples/with-cssed/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 .*.module.css
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-cssed/.gitignore
+++ b/examples/with-cssed/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # cssed compilation artifacts
 .*.module.css
+
+# cache
+*.swc/

--- a/examples/with-custom-babel-config/.gitignore
+++ b/examples/with-custom-babel-config/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-custom-babel-config/.gitignore
+++ b/examples/with-custom-babel-config/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-cxs/.gitignore
+++ b/examples/with-cxs/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-cxs/.gitignore
+++ b/examples/with-cxs/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-cypress/.gitignore
+++ b/examples/with-cypress/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-cypress/.gitignore
+++ b/examples/with-cypress/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-deta-base/.gitignore
+++ b/examples/with-deta-base/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-deta-base/.gitignore
+++ b/examples/with-deta-base/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-docker-compose/.gitignore
+++ b/examples/with-docker-compose/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-docker-compose/.gitignore
+++ b/examples/with-docker-compose/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-docker-multi-env/.gitignore
+++ b/examples/with-docker-multi-env/.gitignore
@@ -38,4 +38,4 @@ yarn.lock
 package-lock.json
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-docker-multi-env/.gitignore
+++ b/examples/with-docker-multi-env/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # lock files
 yarn.lock
 package-lock.json
+
+# cache
+*.swc/

--- a/examples/with-docker/.gitignore
+++ b/examples/with-docker/.gitignore
@@ -38,4 +38,4 @@ yarn.lock
 package-lock.json
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-docker/.gitignore
+++ b/examples/with-docker/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # lock files
 yarn.lock
 package-lock.json
+
+# cache
+*.swc/

--- a/examples/with-dotenv/.gitignore
+++ b/examples/with-dotenv/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-dotenv/.gitignore
+++ b/examples/with-dotenv/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-draft-js/.gitignore
+++ b/examples/with-draft-js/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-draft-js/.gitignore
+++ b/examples/with-draft-js/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-dynamic-import/.gitignore
+++ b/examples/with-dynamic-import/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-dynamic-import/.gitignore
+++ b/examples/with-dynamic-import/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-edgedb/.gitignore
+++ b/examples/with-edgedb/.gitignore
@@ -41,4 +41,4 @@ dbschema/edgeql-js
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-edgedb/.gitignore
+++ b/examples/with-edgedb/.gitignore
@@ -39,3 +39,6 @@ dbschema/edgeql-js
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-elasticsearch/.gitignore
+++ b/examples/with-elasticsearch/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# cache
+*.swc/

--- a/examples/with-elasticsearch/.gitignore
+++ b/examples/with-elasticsearch/.gitignore
@@ -28,4 +28,4 @@ yarn-error.log*
 .env.production.local
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-electron-typescript/.gitignore
+++ b/examples/with-electron-typescript/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-electron-typescript/.gitignore
+++ b/examples/with-electron-typescript/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-electron/.gitignore
+++ b/examples/with-electron/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-electron/.gitignore
+++ b/examples/with-electron/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-emotion-swc/.gitignore
+++ b/examples/with-emotion-swc/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-emotion-swc/.gitignore
+++ b/examples/with-emotion-swc/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-emotion-vanilla/.gitignore
+++ b/examples/with-emotion-vanilla/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-emotion-vanilla/.gitignore
+++ b/examples/with-emotion-vanilla/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-emotion/.gitignore
+++ b/examples/with-emotion/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-emotion/.gitignore
+++ b/examples/with-emotion/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-env-from-next-config-js/.gitignore
+++ b/examples/with-env-from-next-config-js/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-env-from-next-config-js/.gitignore
+++ b/examples/with-env-from-next-config-js/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-eslint/.gitignore
+++ b/examples/with-eslint/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-eslint/.gitignore
+++ b/examples/with-eslint/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-expo-typescript/.gitignore
+++ b/examples/with-expo-typescript/.gitignore
@@ -67,3 +67,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-expo-typescript/.gitignore
+++ b/examples/with-expo-typescript/.gitignore
@@ -69,4 +69,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-expo/.gitignore
+++ b/examples/with-expo/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-expo/.gitignore
+++ b/examples/with-expo/.gitignore
@@ -47,4 +47,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-facebook-pixel/.gitignore
+++ b/examples/with-facebook-pixel/.gitignore
@@ -30,4 +30,4 @@ yarn-error.log*
 .env.production.local
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-facebook-pixel/.gitignore
+++ b/examples/with-facebook-pixel/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# cache
+*.swc/

--- a/examples/with-fauna/.gitignore
+++ b/examples/with-fauna/.gitignore
@@ -36,4 +36,4 @@ yarn-error.log*
 .idea
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-fauna/.gitignore
+++ b/examples/with-fauna/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 .vercel
 
 .idea
+
+# cache
+*.swc/

--- a/examples/with-fela/.gitignore
+++ b/examples/with-fela/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-fela/.gitignore
+++ b/examples/with-fela/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-filbert/.gitignore
+++ b/examples/with-filbert/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-filbert/.gitignore
+++ b/examples/with-filbert/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-fingerprintjs-pro/.gitignore
+++ b/examples/with-fingerprintjs-pro/.gitignore
@@ -38,4 +38,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-fingerprintjs-pro/.gitignore
+++ b/examples/with-fingerprintjs-pro/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-firebase-authentication-serverless/.gitignore
+++ b/examples/with-firebase-authentication-serverless/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-firebase-authentication-serverless/.gitignore
+++ b/examples/with-firebase-authentication-serverless/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-firebase-authentication/.gitignore
+++ b/examples/with-firebase-authentication/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-firebase-authentication/.gitignore
+++ b/examples/with-firebase-authentication/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-firebase-cloud-messaging/.gitignore
+++ b/examples/with-firebase-cloud-messaging/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-firebase-cloud-messaging/.gitignore
+++ b/examples/with-firebase-cloud-messaging/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-firebase-hosting/.gitignore
+++ b/examples/with-firebase-hosting/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-firebase-hosting/.gitignore
+++ b/examples/with-firebase-hosting/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-firebase/.gitignore
+++ b/examples/with-firebase/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-firebase/.gitignore
+++ b/examples/with-firebase/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-flow/.gitignore
+++ b/examples/with-flow/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-flow/.gitignore
+++ b/examples/with-flow/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-formspree/.gitignore
+++ b/examples/with-formspree/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-formspree/.gitignore
+++ b/examples/with-formspree/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-framer-motion/.gitignore
+++ b/examples/with-framer-motion/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-framer-motion/.gitignore
+++ b/examples/with-framer-motion/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-geist-ui/.gitignore
+++ b/examples/with-geist-ui/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-geist-ui/.gitignore
+++ b/examples/with-geist-ui/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-glamorous/.gitignore
+++ b/examples/with-glamorous/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-glamorous/.gitignore
+++ b/examples/with-glamorous/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-global-stylesheet-simple/.gitignore
+++ b/examples/with-global-stylesheet-simple/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-global-stylesheet-simple/.gitignore
+++ b/examples/with-global-stylesheet-simple/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-global-stylesheet/.gitignore
+++ b/examples/with-global-stylesheet/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-global-stylesheet/.gitignore
+++ b/examples/with-global-stylesheet/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-goober/.gitignore
+++ b/examples/with-goober/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-goober/.gitignore
+++ b/examples/with-goober/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-google-analytics-amp/.gitignore
+++ b/examples/with-google-analytics-amp/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-google-analytics-amp/.gitignore
+++ b/examples/with-google-analytics-amp/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-google-analytics/.gitignore
+++ b/examples/with-google-analytics/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-google-analytics/.gitignore
+++ b/examples/with-google-analytics/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-google-tag-manager/.gitignore
+++ b/examples/with-google-tag-manager/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-google-tag-manager/.gitignore
+++ b/examples/with-google-tag-manager/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-graphql-gateway/.gitignore
+++ b/examples/with-graphql-gateway/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 .mesh/
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-graphql-gateway/.gitignore
+++ b/examples/with-graphql-gateway/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 *.tsbuildinfo
 
 .mesh/
+
+# cache
+*.swc/

--- a/examples/with-graphql-hooks/.gitignore
+++ b/examples/with-graphql-hooks/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-graphql-hooks/.gitignore
+++ b/examples/with-graphql-hooks/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-graphql-react/.gitignore
+++ b/examples/with-graphql-react/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-graphql-react/.gitignore
+++ b/examples/with-graphql-react/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-grommet/.gitignore
+++ b/examples/with-grommet/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-grommet/.gitignore
+++ b/examples/with-grommet/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-gsap/.gitignore
+++ b/examples/with-gsap/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-gsap/.gitignore
+++ b/examples/with-gsap/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-hls-js/.gitignore
+++ b/examples/with-hls-js/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-hls-js/.gitignore
+++ b/examples/with-hls-js/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-http2/.gitignore
+++ b/examples/with-http2/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-http2/.gitignore
+++ b/examples/with-http2/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-i18n-next-intl/.gitignore
+++ b/examples/with-i18n-next-intl/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-i18n-next-intl/.gitignore
+++ b/examples/with-i18n-next-intl/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-i18n-rosetta/.gitignore
+++ b/examples/with-i18n-rosetta/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-i18n-rosetta/.gitignore
+++ b/examples/with-i18n-rosetta/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-ionic-typescript/.gitignore
+++ b/examples/with-ionic-typescript/.gitignore
@@ -40,4 +40,4 @@ public/svg
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-ionic-typescript/.gitignore
+++ b/examples/with-ionic-typescript/.gitignore
@@ -38,3 +38,6 @@ public/svg
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-iron-session/.gitignore
+++ b/examples/with-iron-session/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-iron-session/.gitignore
+++ b/examples/with-iron-session/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-jest-babel/.gitignore
+++ b/examples/with-jest-babel/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-jest-babel/.gitignore
+++ b/examples/with-jest-babel/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-jest/.gitignore
+++ b/examples/with-jest/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-jest/.gitignore
+++ b/examples/with-jest/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-joi/.gitignore
+++ b/examples/with-joi/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-joi/.gitignore
+++ b/examples/with-joi/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-jotai/.gitignore
+++ b/examples/with-jotai/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-jotai/.gitignore
+++ b/examples/with-jotai/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-kea/.gitignore
+++ b/examples/with-kea/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-kea/.gitignore
+++ b/examples/with-kea/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-knex/.gitignore
+++ b/examples/with-knex/.gitignore
@@ -30,4 +30,4 @@ yarn-error.log*
 .env.production.local
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-knex/.gitignore
+++ b/examples/with-knex/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# cache
+*.swc/

--- a/examples/with-linaria/.gitignore
+++ b/examples/with-linaria/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 .linaria-cache/
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-linaria/.gitignore
+++ b/examples/with-linaria/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # Linaria
 .linaria-cache/
+
+# cache
+*.swc/

--- a/examples/with-lingui/.gitignore
+++ b/examples/with-lingui/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # lingui
 locale/_build
 locale/*/*.js
+
+# cache
+*.swc/

--- a/examples/with-lingui/.gitignore
+++ b/examples/with-lingui/.gitignore
@@ -38,4 +38,4 @@ locale/_build
 locale/*/*.js
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-loading/.gitignore
+++ b/examples/with-loading/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-loading/.gitignore
+++ b/examples/with-loading/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-magic/.gitignore
+++ b/examples/with-magic/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-magic/.gitignore
+++ b/examples/with-magic/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mantine/.gitignore
+++ b/examples/with-mantine/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mantine/.gitignore
+++ b/examples/with-mantine/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-markdown/.gitignore
+++ b/examples/with-markdown/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-markdown/.gitignore
+++ b/examples/with-markdown/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-material-ui/.gitignore
+++ b/examples/with-material-ui/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-material-ui/.gitignore
+++ b/examples/with-material-ui/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mdbreact/.gitignore
+++ b/examples/with-mdbreact/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mdbreact/.gitignore
+++ b/examples/with-mdbreact/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mdx-remote/.gitignore
+++ b/examples/with-mdx-remote/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mdx-remote/.gitignore
+++ b/examples/with-mdx-remote/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mdx/.gitignore
+++ b/examples/with-mdx/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mdx/.gitignore
+++ b/examples/with-mdx/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mobx-react-lite/.gitignore
+++ b/examples/with-mobx-react-lite/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mobx-react-lite/.gitignore
+++ b/examples/with-mobx-react-lite/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mobx-state-tree-typescript/.gitignore
+++ b/examples/with-mobx-state-tree-typescript/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-mobx-state-tree-typescript/.gitignore
+++ b/examples/with-mobx-state-tree-typescript/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mobx-state-tree/.gitignore
+++ b/examples/with-mobx-state-tree/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mobx-state-tree/.gitignore
+++ b/examples/with-mobx-state-tree/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mobx/.gitignore
+++ b/examples/with-mobx/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mobx/.gitignore
+++ b/examples/with-mobx/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mocha/.gitignore
+++ b/examples/with-mocha/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mocha/.gitignore
+++ b/examples/with-mocha/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mongodb-mongoose/.gitignore
+++ b/examples/with-mongodb-mongoose/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mongodb-mongoose/.gitignore
+++ b/examples/with-mongodb-mongoose/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mongodb/.gitignore
+++ b/examples/with-mongodb/.gitignore
@@ -30,4 +30,4 @@ yarn-error.log*
 .env.production.local
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mongodb/.gitignore
+++ b/examples/with-mongodb/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# cache
+*.swc/

--- a/examples/with-mqtt-js/.gitignore
+++ b/examples/with-mqtt-js/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mqtt-js/.gitignore
+++ b/examples/with-mqtt-js/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-msw/.gitignore
+++ b/examples/with-msw/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-msw/.gitignore
+++ b/examples/with-msw/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mux-video/.gitignore
+++ b/examples/with-mux-video/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mux-video/.gitignore
+++ b/examples/with-mux-video/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-mysql/.gitignore
+++ b/examples/with-mysql/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-mysql/.gitignore
+++ b/examples/with-mysql/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-neo4j/.gitignore
+++ b/examples/with-neo4j/.gitignore
@@ -30,4 +30,4 @@ yarn-error.log*
 .env.production.local
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-neo4j/.gitignore
+++ b/examples/with-neo4j/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# cache
+*.swc/

--- a/examples/with-netlify-cms/.gitignore
+++ b/examples/with-netlify-cms/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-netlify-cms/.gitignore
+++ b/examples/with-netlify-cms/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-css/.gitignore
+++ b/examples/with-next-css/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-css/.gitignore
+++ b/examples/with-next-css/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-i18next/.gitignore
+++ b/examples/with-next-i18next/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-i18next/.gitignore
+++ b/examples/with-next-i18next/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-offline/.gitignore
+++ b/examples/with-next-offline/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-offline/.gitignore
+++ b/examples/with-next-offline/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-page-transitions/.gitignore
+++ b/examples/with-next-page-transitions/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-page-transitions/.gitignore
+++ b/examples/with-next-page-transitions/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-routes/.gitignore
+++ b/examples/with-next-routes/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-routes/.gitignore
+++ b/examples/with-next-routes/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-sass/.gitignore
+++ b/examples/with-next-sass/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-sass/.gitignore
+++ b/examples/with-next-sass/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-seo/.gitignore
+++ b/examples/with-next-seo/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-seo/.gitignore
+++ b/examples/with-next-seo/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-sitemap/.gitignore
+++ b/examples/with-next-sitemap/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-next-sitemap/.gitignore
+++ b/examples/with-next-sitemap/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-next-translate/.gitignore
+++ b/examples/with-next-translate/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-next-translate/.gitignore
+++ b/examples/with-next-translate/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-nhost-auth-realtime-graphql/.gitignore
+++ b/examples/with-nhost-auth-realtime-graphql/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-nhost-auth-realtime-graphql/.gitignore
+++ b/examples/with-nhost-auth-realtime-graphql/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-now-env/.gitignore
+++ b/examples/with-now-env/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-now-env/.gitignore
+++ b/examples/with-now-env/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-orbit-components/.gitignore
+++ b/examples/with-orbit-components/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-orbit-components/.gitignore
+++ b/examples/with-orbit-components/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-overmind/.gitignore
+++ b/examples/with-overmind/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-overmind/.gitignore
+++ b/examples/with-overmind/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-particles/.gitignore
+++ b/examples/with-particles/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-particles/.gitignore
+++ b/examples/with-particles/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-passport-and-next-connect/.gitignore
+++ b/examples/with-passport-and-next-connect/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-passport-and-next-connect/.gitignore
+++ b/examples/with-passport-and-next-connect/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-passport/.gitignore
+++ b/examples/with-passport/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-passport/.gitignore
+++ b/examples/with-passport/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-paste-typescript/.gitignore
+++ b/examples/with-paste-typescript/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-paste-typescript/.gitignore
+++ b/examples/with-paste-typescript/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-patternfly/.gitignore
+++ b/examples/with-patternfly/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-patternfly/.gitignore
+++ b/examples/with-patternfly/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-plausible/.gitignore
+++ b/examples/with-plausible/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-plausible/.gitignore
+++ b/examples/with-plausible/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-playwright/.gitignore
+++ b/examples/with-playwright/.gitignore
@@ -35,4 +35,4 @@ yarn-error.log*
 test-results/
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-playwright/.gitignore
+++ b/examples/with-playwright/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 # vercel
 .vercel
 test-results/
+
+# cache
+*.swc/

--- a/examples/with-polyfills/.gitignore
+++ b/examples/with-polyfills/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-polyfills/.gitignore
+++ b/examples/with-polyfills/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-portals-ssr/.gitignore
+++ b/examples/with-portals-ssr/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-portals-ssr/.gitignore
+++ b/examples/with-portals-ssr/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-portals/.gitignore
+++ b/examples/with-portals/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-portals/.gitignore
+++ b/examples/with-portals/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-prefetching/.gitignore
+++ b/examples/with-prefetching/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-prefetching/.gitignore
+++ b/examples/with-prefetching/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-pretty-url-routing/.gitignore
+++ b/examples/with-pretty-url-routing/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-pretty-url-routing/.gitignore
+++ b/examples/with-pretty-url-routing/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-quill-js/.gitignore
+++ b/examples/with-quill-js/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-quill-js/.gitignore
+++ b/examples/with-quill-js/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-rbx-bulma-pro/.gitignore
+++ b/examples/with-rbx-bulma-pro/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-rbx-bulma-pro/.gitignore
+++ b/examples/with-rbx-bulma-pro/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-bootstrap/.gitignore
+++ b/examples/with-react-bootstrap/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-bootstrap/.gitignore
+++ b/examples/with-react-bootstrap/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-foundation/.gitignore
+++ b/examples/with-react-foundation/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-react-foundation/.gitignore
+++ b/examples/with-react-foundation/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-ga/.gitignore
+++ b/examples/with-react-ga/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-ga/.gitignore
+++ b/examples/with-react-ga/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-helmet/.gitignore
+++ b/examples/with-react-helmet/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-helmet/.gitignore
+++ b/examples/with-react-helmet/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-hook-form/.gitignore
+++ b/examples/with-react-hook-form/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-hook-form/.gitignore
+++ b/examples/with-react-hook-form/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-intl/.gitignore
+++ b/examples/with-react-intl/.gitignore
@@ -37,3 +37,6 @@ compiled-lang
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-react-intl/.gitignore
+++ b/examples/with-react-intl/.gitignore
@@ -39,4 +39,4 @@ compiled-lang
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-jss/.gitignore
+++ b/examples/with-react-jss/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-jss/.gitignore
+++ b/examples/with-react-jss/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-md-typescript/.gitignore
+++ b/examples/with-react-md-typescript/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-react-md-typescript/.gitignore
+++ b/examples/with-react-md-typescript/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-md/.gitignore
+++ b/examples/with-react-md/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-md/.gitignore
+++ b/examples/with-react-md/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-multi-carousel/.gitignore
+++ b/examples/with-react-multi-carousel/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-multi-carousel/.gitignore
+++ b/examples/with-react-multi-carousel/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-native-web/.gitignore
+++ b/examples/with-react-native-web/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-native-web/.gitignore
+++ b/examples/with-react-native-web/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-toolbox/.gitignore
+++ b/examples/with-react-toolbox/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-toolbox/.gitignore
+++ b/examples/with-react-toolbox/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-react-with-styles/.gitignore
+++ b/examples/with-react-with-styles/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-react-with-styles/.gitignore
+++ b/examples/with-react-with-styles/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-reactstrap/.gitignore
+++ b/examples/with-reactstrap/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-reactstrap/.gitignore
+++ b/examples/with-reactstrap/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-realm-web/.gitignore
+++ b/examples/with-realm-web/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-realm-web/.gitignore
+++ b/examples/with-realm-web/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-reason-relay/.gitignore
+++ b/examples/with-reason-relay/.gitignore
@@ -41,4 +41,4 @@ lib/
 *.bs.js
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-reason-relay/.gitignore
+++ b/examples/with-reason-relay/.gitignore
@@ -39,3 +39,6 @@ schema/schema.graphql
 lib/
 .merlin
 *.bs.js
+
+# cache
+*.swc/

--- a/examples/with-reasonml-todo/.gitignore
+++ b/examples/with-reasonml-todo/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-reasonml-todo/.gitignore
+++ b/examples/with-reasonml-todo/.gitignore
@@ -39,4 +39,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-reasonml/.gitignore
+++ b/examples/with-reasonml/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-reasonml/.gitignore
+++ b/examples/with-reasonml/.gitignore
@@ -39,4 +39,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-rebass/.gitignore
+++ b/examples/with-rebass/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-rebass/.gitignore
+++ b/examples/with-rebass/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-recoil/.gitignore
+++ b/examples/with-recoil/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-recoil/.gitignore
+++ b/examples/with-recoil/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-redis/.gitignore
+++ b/examples/with-redis/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-redis/.gitignore
+++ b/examples/with-redis/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-redux-observable/.gitignore
+++ b/examples/with-redux-observable/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-redux-observable/.gitignore
+++ b/examples/with-redux-observable/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-redux-persist/.gitignore
+++ b/examples/with-redux-persist/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-redux-persist/.gitignore
+++ b/examples/with-redux-persist/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-redux-saga/.gitignore
+++ b/examples/with-redux-saga/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-redux-saga/.gitignore
+++ b/examples/with-redux-saga/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-redux-thunk/.gitignore
+++ b/examples/with-redux-thunk/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-redux-thunk/.gitignore
+++ b/examples/with-redux-thunk/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-redux-wrapper/.gitignore
+++ b/examples/with-redux-wrapper/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-redux-wrapper/.gitignore
+++ b/examples/with-redux-wrapper/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-redux/.gitignore
+++ b/examples/with-redux/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-redux/.gitignore
+++ b/examples/with-redux/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-reflexjs/.gitignore
+++ b/examples/with-reflexjs/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-reflexjs/.gitignore
+++ b/examples/with-reflexjs/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-reflux/.gitignore
+++ b/examples/with-reflux/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-reflux/.gitignore
+++ b/examples/with-reflux/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-relay-modern/.gitignore
+++ b/examples/with-relay-modern/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # relay
 __generated__/
 schema/schema.graphql
+
+# cache
+*.swc/

--- a/examples/with-relay-modern/.gitignore
+++ b/examples/with-relay-modern/.gitignore
@@ -38,4 +38,4 @@ __generated__/
 schema/schema.graphql
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-rematch/.gitignore
+++ b/examples/with-rematch/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-rematch/.gitignore
+++ b/examples/with-rematch/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-route-as-modal/.gitignore
+++ b/examples/with-route-as-modal/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-route-as-modal/.gitignore
+++ b/examples/with-route-as-modal/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-segment-analytics/.gitignore
+++ b/examples/with-segment-analytics/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-segment-analytics/.gitignore
+++ b/examples/with-segment-analytics/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-semantic-ui/.gitignore
+++ b/examples/with-semantic-ui/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-semantic-ui/.gitignore
+++ b/examples/with-semantic-ui/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-sentry-simple/.gitignore
+++ b/examples/with-sentry-simple/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-sentry-simple/.gitignore
+++ b/examples/with-sentry-simple/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-sentry/.gitignore
+++ b/examples/with-sentry/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-sentry/.gitignore
+++ b/examples/with-sentry/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-service-worker/.gitignore
+++ b/examples/with-service-worker/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-service-worker/.gitignore
+++ b/examples/with-service-worker/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-shallow-routing/.gitignore
+++ b/examples/with-shallow-routing/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-shallow-routing/.gitignore
+++ b/examples/with-shallow-routing/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-sitemap/.gitignore
+++ b/examples/with-sitemap/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-sitemap/.gitignore
+++ b/examples/with-sitemap/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-skynexui-components/.gitignore
+++ b/examples/with-skynexui-components/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-skynexui-components/.gitignore
+++ b/examples/with-skynexui-components/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-slate/.gitignore
+++ b/examples/with-slate/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-slate/.gitignore
+++ b/examples/with-slate/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-static-export/.gitignore
+++ b/examples/with-static-export/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-static-export/.gitignore
+++ b/examples/with-static-export/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-stencil/.gitignore
+++ b/examples/with-stencil/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-stencil/.gitignore
+++ b/examples/with-stencil/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-stitches/.gitignore
+++ b/examples/with-stitches/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-stitches/.gitignore
+++ b/examples/with-stitches/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-stomp/.gitignore
+++ b/examples/with-stomp/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-stomp/.gitignore
+++ b/examples/with-stomp/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-storybook-styled-jsx-scss/.gitignore
+++ b/examples/with-storybook-styled-jsx-scss/.gitignore
@@ -38,3 +38,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-storybook-styled-jsx-scss/.gitignore
+++ b/examples/with-storybook-styled-jsx-scss/.gitignore
@@ -40,4 +40,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-storybook/.gitignore
+++ b/examples/with-storybook/.gitignore
@@ -40,4 +40,4 @@ storybook-static
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-storybook/.gitignore
+++ b/examples/with-storybook/.gitignore
@@ -38,3 +38,6 @@ storybook-static
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-strict-csp-hash/.gitignore
+++ b/examples/with-strict-csp-hash/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-strict-csp-hash/.gitignore
+++ b/examples/with-strict-csp-hash/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-strict-csp/.gitignore
+++ b/examples/with-strict-csp/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-strict-csp/.gitignore
+++ b/examples/with-strict-csp/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-stripe-typescript/.gitignore
+++ b/examples/with-stripe-typescript/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-stripe-typescript/.gitignore
+++ b/examples/with-stripe-typescript/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styled-components-babel/.gitignore
+++ b/examples/with-styled-components-babel/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-styled-components-babel/.gitignore
+++ b/examples/with-styled-components-babel/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styled-components-rtl/.gitignore
+++ b/examples/with-styled-components-rtl/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-styled-components-rtl/.gitignore
+++ b/examples/with-styled-components-rtl/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styled-components/.gitignore
+++ b/examples/with-styled-components/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-styled-components/.gitignore
+++ b/examples/with-styled-components/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styled-jsx-plugins/.gitignore
+++ b/examples/with-styled-jsx-plugins/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-styled-jsx-plugins/.gitignore
+++ b/examples/with-styled-jsx-plugins/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styled-jsx-postcss/.gitignore
+++ b/examples/with-styled-jsx-postcss/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-styled-jsx-postcss/.gitignore
+++ b/examples/with-styled-jsx-postcss/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styled-jsx-scss/.gitignore
+++ b/examples/with-styled-jsx-scss/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-styled-jsx-scss/.gitignore
+++ b/examples/with-styled-jsx-scss/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styled-jsx/.gitignore
+++ b/examples/with-styled-jsx/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-styled-jsx/.gitignore
+++ b/examples/with-styled-jsx/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-styletron/.gitignore
+++ b/examples/with-styletron/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-styletron/.gitignore
+++ b/examples/with-styletron/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-supabase-auth-realtime-db/.gitignore
+++ b/examples/with-supabase-auth-realtime-db/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-supabase-auth-realtime-db/.gitignore
+++ b/examples/with-supabase-auth-realtime-db/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-supertokens/.gitignore
+++ b/examples/with-supertokens/.gitignore
@@ -32,4 +32,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-supertokens/.gitignore
+++ b/examples/with-supertokens/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-sw-precache/.gitignore
+++ b/examples/with-sw-precache/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-sw-precache/.gitignore
+++ b/examples/with-sw-precache/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-tailwindcss-emotion/.gitignore
+++ b/examples/with-tailwindcss-emotion/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-tailwindcss-emotion/.gitignore
+++ b/examples/with-tailwindcss-emotion/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-tailwindcss/.gitignore
+++ b/examples/with-tailwindcss/.gitignore
@@ -38,4 +38,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-tailwindcss/.gitignore
+++ b/examples/with-tailwindcss/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-temporal/.gitignore
+++ b/examples/with-temporal/.gitignore
@@ -38,3 +38,6 @@ temporal/lib
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-temporal/.gitignore
+++ b/examples/with-temporal/.gitignore
@@ -40,4 +40,4 @@ temporal/lib
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-tesfy/.gitignore
+++ b/examples/with-tesfy/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-tesfy/.gitignore
+++ b/examples/with-tesfy/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-three-js/.gitignore
+++ b/examples/with-three-js/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-three-js/.gitignore
+++ b/examples/with-three-js/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-typescript-graphql/.gitignore
+++ b/examples/with-typescript-graphql/.gitignore
@@ -44,3 +44,6 @@ lib/graphql-operations.ts
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-typescript-graphql/.gitignore
+++ b/examples/with-typescript-graphql/.gitignore
@@ -46,4 +46,4 @@ lib/graphql-operations.ts
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-typescript-types/.gitignore
+++ b/examples/with-typescript-types/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-typescript-types/.gitignore
+++ b/examples/with-typescript-types/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-typescript/.gitignore
+++ b/examples/with-typescript/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-typescript/.gitignore
+++ b/examples/with-typescript/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-typestyle/.gitignore
+++ b/examples/with-typestyle/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-typestyle/.gitignore
+++ b/examples/with-typestyle/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-universal-configuration-build-time/.gitignore
+++ b/examples/with-universal-configuration-build-time/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-universal-configuration-build-time/.gitignore
+++ b/examples/with-universal-configuration-build-time/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-universal-configuration-runtime/.gitignore
+++ b/examples/with-universal-configuration-runtime/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-universal-configuration-runtime/.gitignore
+++ b/examples/with-universal-configuration-runtime/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-unsplash/.gitignore
+++ b/examples/with-unsplash/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-unsplash/.gitignore
+++ b/examples/with-unsplash/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-unstated/.gitignore
+++ b/examples/with-unstated/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-unstated/.gitignore
+++ b/examples/with-unstated/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-urql/.gitignore
+++ b/examples/with-urql/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-urql/.gitignore
+++ b/examples/with-urql/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-userbase/.gitignore
+++ b/examples/with-userbase/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-userbase/.gitignore
+++ b/examples/with-userbase/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-vercel-fetch/.gitignore
+++ b/examples/with-vercel-fetch/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-vercel-fetch/.gitignore
+++ b/examples/with-vercel-fetch/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-videojs/.gitignore
+++ b/examples/with-videojs/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-videojs/.gitignore
+++ b/examples/with-videojs/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-vitest/.gitignore
+++ b/examples/with-vitest/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+*.swc/

--- a/examples/with-vitest/.gitignore
+++ b/examples/with-vitest/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-web-worker/.gitignore
+++ b/examples/with-web-worker/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-web-worker/.gitignore
+++ b/examples/with-web-worker/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-webassembly/.gitignore
+++ b/examples/with-webassembly/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-webassembly/.gitignore
+++ b/examples/with-webassembly/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-why-did-you-render/.gitignore
+++ b/examples/with-why-did-you-render/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-why-did-you-render/.gitignore
+++ b/examples/with-why-did-you-render/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-xstate/.gitignore
+++ b/examples/with-xstate/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-xstate/.gitignore
+++ b/examples/with-xstate/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-yarn-workspaces/.gitignore
+++ b/examples/with-yarn-workspaces/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-yarn-workspaces/.gitignore
+++ b/examples/with-yarn-workspaces/.gitignore
@@ -33,4 +33,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-yoga/.gitignore
+++ b/examples/with-yoga/.gitignore
@@ -32,4 +32,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-yoga/.gitignore
+++ b/examples/with-yoga/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-zones/.gitignore
+++ b/examples/with-zones/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-zones/.gitignore
+++ b/examples/with-zones/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/examples/with-zustand/.gitignore
+++ b/examples/with-zustand/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+*.swc/

--- a/examples/with-zustand/.gitignore
+++ b/examples/with-zustand/.gitignore
@@ -34,4 +34,4 @@ yarn-error.log*
 .vercel
 
 # cache
-*.swc/
+.swc/

--- a/packages/create-next-app/templates/default/gitignore
+++ b/packages/create-next-app/templates/default/gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# cache
+.swc/

--- a/packages/create-next-app/templates/typescript/gitignore
+++ b/packages/create-next-app/templates/typescript/gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# cache
+.swc/


### PR DESCRIPTION
Added `./swc` to all of the Example's `.gitignore` files and the Create Next App template `gitignore` files.

Noticed that an empty `./swc` directory was created after running `yarn dev` after creating a new Next.js app from `create-next-app` and `create-next-app --typescript` respectively.

Followed the same convention from [PR #36790](https://github.com/vercel/next.js/pull/36790/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) where it added the support experimental swc plugins. 