### PR TITLE
docs: add note about middleware being disabled

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -50,6 +50,9 @@ export const config = {
 }
 ```
 
+
+> **Note**: Middleware doesn't run when `useFileSystemPublicRoutes` is set to `false` in your `next.config.js`.
+
 ## Matching Paths
 
 Middleware will be invoked for **every route in your project**. The following is the execution order:


### PR DESCRIPTION
Found out while experimenting with middleware that it doesn't run when `useFileSystemPublicRoutes` is set to false. This PR adds a note about this.

https://github.com/vercel/next.js/blob/3eb9caeb6a81dc101beeefdc2046da0777761119/packages/next/server/router.ts#L229-L231

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
