### PR TITLE
Update some flaking tests for edge compiler and rsc

### DIFF
--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -25,15 +25,25 @@ describe('Edge compiler module exports preference', () => {
             })
           }
         `,
-        'node_modules/my-lib/package.json': JSON.stringify({
+        'my-lib/package.json': JSON.stringify({
           name: 'my-lib',
           version: '1.0.0',
           main: 'index.js',
           browser: 'browser.js',
         }),
-        'node_modules/my-lib/index.js': `module.exports = "Node.js"`,
-        'node_modules/my-lib/browser.js': `module.exports = "Browser"`,
+        'my-lib/index.js': `module.exports = "Node.js"`,
+        'my-lib/browser.js': `module.exports = "Browser"`,
       },
+      packageJson: {
+        scripts: {
+          setup: `cp -r ./my-lib ./node_modules`,
+          build: 'yarn setup && next build',
+          dev: 'yarn setup && next dev',
+          start: 'next start',
+        },
+      },
+      startCommand: (global as any).isNextDev ? 'yarn dev' : 'yarn start',
+      buildCommand: 'yarn build',
       dependencies: {},
     })
   })

--- a/test/integration/react-server-components/test/rsc.js
+++ b/test/integration/react-server-components/test/rsc.js
@@ -236,10 +236,13 @@ export default function (context, { runtime, env }) {
         expect(hasFlightRequest).toBe(false)
       }
       await browser.elementByCss(selector).click()
+
       // wait for re-hydration
-      await new Promise((res) => setTimeout(res, 1000))
       if (env === 'dev') {
-        expect(hasFlightRequest).toBe(true)
+        await check(
+          () => (hasFlightRequest ? 'success' : hasFlightRequest),
+          'success'
+        )
       }
       const refreshText = await browser.elementByCss(selector).text()
       expect(refreshText).toBe('next link')


### PR DESCRIPTION
Stabilizes some test failures noticed recently

x-ref: https://github.com/vercel/next.js/pull/38340#issuecomment-1175357638
x-ref: https://github.com/vercel/next.js/runs/7201957532?check_suite_focus=true