### PR TITLE
Honor NEXT_MANUAL_SIG_HANDLE flag in standalone mode

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1219,8 +1219,11 @@ const http = require('http')
 const path = require('path')
 
 // Make sure commands gracefully respect termination signals (e.g. from Docker)
-process.on('SIGTERM', () => process.exit(0))
-process.on('SIGINT', () => process.exit(0))
+// Allow the graceful termination to be manually configurable
+if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
+  process.on('SIGTERM', () => process.exit(0))
+  process.on('SIGINT', () => process.exit(0))
+}
 
 let handler
 


### PR DESCRIPTION
Ensures we check for the `NEXT_MANUAL_SIG_HANDLE` env variable when setting up SIG process listeners the same as we do when not in standalone mode. 

Fixes: https://github.com/vercel/next.js/issues/38298