### PR TITLE
Add param names into the tree

### DIFF
--- a/packages/next/client/components/app-router.client.tsx
+++ b/packages/next/client/components/app-router.client.tsx
@@ -161,13 +161,6 @@ export default function AppRouter({
   }, [])
 
   useEffect(() => {
-    console.log(
-      'UPDATE URL',
-      pushRef.pendingPush ? 'push' : 'replace',
-      pushRef.mpaNavigation ? 'MPA' : '',
-      tree
-    )
-
     if (pushRef.mpaNavigation) {
       window.location.href = canonicalUrl
       return

--- a/packages/next/client/components/app-router.client.tsx
+++ b/packages/next/client/components/app-router.client.tsx
@@ -213,10 +213,6 @@ export default function AppRouter({
     }
   }, [onPopState])
 
-  React.useEffect(() => {
-    window.history.replaceState({ tree: initialTree }, '')
-  }, [initialTree])
-
   return (
     <PathnameContext.Provider value={pathname}>
       <QueryContext.Provider value={query}>

--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -253,11 +253,6 @@ export default function OuterLayoutRouter({
 
   // This relates to the segments in the current router
   // tree[1].children[0] refers to tree.children.segment in the data format
-  try {
-    tree[1][parallelRouterKey][0]
-  } catch (err) {
-    debugger
-  }
   const treeSegment = tree[1][parallelRouterKey][0]
   const childPropSegment = Array.isArray(childProp.segment)
     ? childProp.segment[1]

--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -126,7 +126,6 @@ export function InnerLayoutRouter({
     // TODO: remove ''
     const refetchTree = walkAddRefetch(['', ...segmentPath], fullTree)
 
-    console.log('FETCHING IN RENDER', { childNode, segmentPath, path })
     const data = fetchServerResponse(new URL(url, location.origin), refetchTree)
     childNodes.set(path, {
       data,
@@ -175,12 +174,6 @@ export function InnerLayoutRouter({
     }
 
     if (!fastPath) {
-      console.log('NOT FAST PATH', {
-        childNode,
-        segmentPath,
-        path,
-        flightData,
-      })
       // For push we can set data in the cache
 
       // segmentPath from the server does not match the layout's segmentPath
@@ -200,7 +193,6 @@ export function InnerLayoutRouter({
 
   // TODO: double check users can't return null in a component that will kick in here
   if (!childNode.subTreeData) {
-    console.log('No subtree data', { childNode, segmentPath, path })
     throw createInfinitePromise()
   }
 

--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -68,7 +68,7 @@ export function InnerLayoutRouter({
     childNodes.set(path, {
       data: null,
       subTreeData: childProp.current,
-      parallelRoutes: new Map([[parallelRouterKey, new Map()]]),
+      parallelRoutes: new Map(),
     })
     childProp.current = null
     // In the above case childNode was set on childNodes, so we have to get it from the cacheNodes again.
@@ -128,7 +128,7 @@ export function InnerLayoutRouter({
     childNodes.set(path, {
       data,
       subTreeData: null,
-      parallelRoutes: new Map([[parallelRouterKey, new Map()]]),
+      parallelRoutes: new Map(),
     })
     // In the above case childNode was set on childNodes, so we have to get it from the cacheNodes again.
     childNode = childNodes.get(path)

--- a/packages/next/client/components/match-segments.ts
+++ b/packages/next/client/components/match-segments.ts
@@ -1,0 +1,20 @@
+import { Segment } from '../../server/app-render'
+
+export const matchSegment = (
+  existingSegment: Segment,
+  segment: Segment
+): boolean => {
+  // Common case: segment is just a string
+  if (typeof existingSegment === 'string' && typeof segment === 'string') {
+    return existingSegment === segment
+  }
+
+  // Dynamic parameter case: segment is an array with param/value. Both param and value are compared.
+  if (Array.isArray(existingSegment) && Array.isArray(segment)) {
+    return (
+      existingSegment[0] === segment[0] && existingSegment[1] === segment[1]
+    )
+  }
+
+  return false
+}

--- a/packages/next/client/components/reducer.ts
+++ b/packages/next/client/components/reducer.ts
@@ -275,7 +275,6 @@ export function reducer(
         }
       }
 ): AppRouterState {
-  console.log('ACTION', action)
   if (action.type === 'restore') {
     const { url, historyState } = action.payload
     const href = url.pathname + url.search + url.hash
@@ -353,7 +352,6 @@ export function reducer(
           state.cache,
           segments.slice(1),
           () => {
-            console.log('FETCHING IN CACHE DATA FILL')
             return fetchServerResponse(url, optimisticTree)
           }
         )
@@ -371,7 +369,6 @@ export function reducer(
       }
 
       if (!cache.data) {
-        console.log('FETCHING IN NOT OPTIMISTIC')
         cache.data = fetchServerResponse(url, state.tree)
       }
       const flightData = cache.data.readRoot()

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -22,6 +22,7 @@ import { tryGetPreviewData } from './api-utils/node'
 import { htmlEscapeJsonString } from './htmlescape'
 import { stripInternalQueries } from './utils'
 import { NextApiRequestCookies } from './api-utils'
+import { matchSegment } from '../client/components/match-segments'
 
 const ReactDOMServer = process.env.__NEXT_REACT_ROOT
   ? require('react-dom/server.browser')
@@ -245,6 +246,8 @@ function createServerComponentRenderer(
   return ServerComponentWrapper
 }
 
+export type Segment = string | [param: string, value: string]
+
 type LoaderTree = [
   segment: string,
   parallelRoutes: { [parallelRouterKey: string]: LoaderTree },
@@ -256,7 +259,7 @@ type LoaderTree = [
 ]
 
 export type FlightRouterState = [
-  segment: string,
+  segment: Segment,
   parallelRoutes: { [parallelRouterKey: string]: FlightRouterState },
   url?: string,
   refresh?: 'refetch'
@@ -266,11 +269,11 @@ export type FlightSegmentPath =
   | any[]
   // Looks somewhat like this
   | [
-      segment: string,
+      segment: Segment,
       parallelRouterKey: string,
-      segment: string,
+      segment: Segment,
       parallelRouterKey: string,
-      segment: string,
+      segment: Segment,
       parallelRouterKey: string
     ]
 
@@ -278,18 +281,21 @@ export type FlightDataPath =
   | any[]
   // Looks somewhat like this
   | [
-      segment: string,
+      segment: Segment,
       parallelRoute: string,
-      segment: string,
+      segment: Segment,
       parallelRoute: string,
-      segment: string,
+      segment: Segment,
       parallelRoute: string,
       tree: FlightRouterState,
       subTreeData: React.ReactNode
     ]
 
 export type FlightData = Array<FlightDataPath> | string
-export type ChildProp = { current: React.ReactNode; segment: string }
+export type ChildProp = {
+  current: React.ReactNode
+  segment: Segment
+}
 
 export async function renderToHTML(
   req: IncomingMessage,
@@ -395,7 +401,7 @@ export async function renderToHTML(
     const dynamicParam = getDynamicParamFromSegment(segment)
 
     const segmentTree: FlightRouterState = [
-      dynamicParam ? dynamicParam.value : segment,
+      dynamicParam ? [dynamicParam.param, dynamicParam.value] : segment,
       {},
     ]
 
@@ -459,7 +465,9 @@ export async function renderToHTML(
         }
       : parentParams
 
-    const actualSegment = segmentParam ? segmentParam.value : segment
+    const actualSegment = segmentParam
+      ? [segmentParam.param, segmentParam.value]
+      : segment
 
     // This happens outside of rendering in order to eagerly kick off data fetching for layouts / the page further down
     const parallelRouteComponents = Object.keys(parallelRoutes).reduce(
@@ -482,7 +490,7 @@ export async function renderToHTML(
         const childProp: ChildProp = {
           current: <ChildComponent />,
           segment: childSegmentParam
-            ? childSegmentParam.value
+            ? [childSegmentParam.param, childSegmentParam.value]
             : parallelRoutes[currentValue][0],
         }
 
@@ -621,7 +629,9 @@ export async function renderToHTML(
       const parallelRoutesKeys = Object.keys(parallelRoutes)
 
       const segmentParam = getDynamicParamFromSegment(segment)
-      const actualSegment = segmentParam ? segmentParam.value : segment
+      const actualSegment = segmentParam
+        ? [segmentParam.param, segmentParam.value]
+        : segment
 
       const currentParams = segmentParam
         ? {
@@ -632,7 +642,7 @@ export async function renderToHTML(
 
       const renderComponentsOnThisLevel =
         !flightRouterState ||
-        actualSegment !== flightRouterState[0] ||
+        !matchSegment(actualSegment, flightRouterState[0]) ||
         // Last item in the tree
         parallelRoutesKeys.length === 0 ||
         // Explicit refresh

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -629,7 +629,7 @@ export async function renderToHTML(
       const parallelRoutesKeys = Object.keys(parallelRoutes)
 
       const segmentParam = getDynamicParamFromSegment(segment)
-      const actualSegment = segmentParam
+      const actualSegment: Segment = segmentParam
         ? [segmentParam.param, segmentParam.value]
         : segment
 


### PR DESCRIPTION
- Remove cache value that was incorrectly nested deeper
- Remove extra useEffect (already applied during hydration based on the `useReducer` input)
- Add dynamic parameter name into the tree

Follow-up to #37551, cleans up some code and prepares for catch-all and optional catch-all routes.
