### PR TITLE
fix(next/build): disable next-swc crash reporting temporarily

### DIFF
--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -222,10 +222,12 @@ function loadNative() {
     // we can't rely on explicit manual initialization as similar to trace reporter.
     if (!swcCrashReporterFlushGuard) {
       // Crash reports in next-swc should be treated in the same way we treat telemetry to opt out.
+
+      /* TODO: temporarily disable initialization while confirming logistics.
       let telemetry = new Telemetry({ distDir: process.cwd() })
       if (telemetry.isEnabled) {
         swcCrashReporterFlushGuard = bindings.initCrashReporter?.()
-      }
+      }*/
     }
 
     nativeBindings = {

--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -8,7 +8,6 @@ import { eventSwcLoadFailure } from '../../telemetry/events/swc-load-failure'
 import { patchIncorrectLockfile } from '../../lib/patch-incorrect-lockfile'
 import { downloadWasmSwc } from '../../lib/download-wasm-swc'
 import { version as nextVersion } from 'next/package.json'
-import { Telemetry } from '../../telemetry/storage'
 
 const ArchName = arch()
 const PlatformName = platform()

--- a/packages/next/build/swc/index.js
+++ b/packages/next/build/swc/index.js
@@ -221,7 +221,6 @@ function loadNative() {
     // we can't rely on explicit manual initialization as similar to trace reporter.
     if (!swcCrashReporterFlushGuard) {
       // Crash reports in next-swc should be treated in the same way we treat telemetry to opt out.
-
       /* TODO: temporarily disable initialization while confirming logistics.
       let telemetry = new Telemetry({ distDir: process.cwd() })
       if (telemetry.isEnabled) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Temporarily disable sentry until clarifying few logistics questions.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
