### PR TITLE
refactor: add named export with existing default export

### DIFF
--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -30,6 +30,9 @@ function loadClosestPackageJson(dir: string, attempts = 1): any {
 /*
 // Usage in jest.config.js
 const nextJest = require('next/jest');
+// Usage in jest.config.js with @ts-check
+const { default: nextJest } = require('next/jest');
+const { nextJest } = require('next/jest');
 
 // Optionally provide path to Next.js app which will enable loading next.config.js and .env files
 const createJestConfig = nextJest({ dir })
@@ -42,7 +45,7 @@ const customJestConfig = {
 // createJestConfig is exported in this way to ensure that next/jest can load the Next.js config which is async
 module.exports = createJestConfig(customJestConfig)
 */
-export default function nextJest(options: { dir?: string } = {}) {
+export function nextJest(options: { dir?: string } = {}) {
   // createJestConfig
   return (customJestConfig?: any) => {
     // Function that is provided as the module.exports of jest.config.js
@@ -150,3 +153,5 @@ export default function nextJest(options: { dir?: string } = {}) {
     }
   }
 }
+
+export default nextJest

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -349,7 +349,8 @@ function handleLoading(
   })
 }
 
-export default function Image({
+export default Image
+export function Image({
   src,
   sizes,
   unoptimized = false,

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -137,7 +137,7 @@ type LinkPropsReal = React.PropsWithChildren<
     LinkProps
 >
 
-const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
+export const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
   function LinkComponent(props, forwardedRef) {
     if (process.env.NODE_ENV !== 'production') {
       function createPropError(args: {

--- a/packages/next/shared/lib/head.tsx
+++ b/packages/next/shared/lib/head.tsx
@@ -179,7 +179,7 @@ function reduceComponents(
  * This component injects elements to `<head>` of your page.
  * To avoid duplicated `tags` in `<head>` you can use the `key` property, which will make sure every tag is only rendered once.
  */
-function Head({ children }: { children: React.ReactNode }) {
+export function Head({ children }: { children: React.ReactNode }) {
   const ampState = useContext(AmpStateContext)
   const headManager = useContext(HeadManagerContext)
   return (

--- a/packages/next/shared/lib/loadable.js
+++ b/packages/next/shared/lib/loadable.js
@@ -260,7 +260,7 @@ class LoadableSubscription {
   }
 }
 
-function Loadable(opts) {
+export function Loadable(opts) {
   return createLoadableComponent(load, opts)
 }
 

--- a/packages/next/shared/lib/runtime-config.ts
+++ b/packages/next/shared/lib/runtime-config.ts
@@ -1,8 +1,8 @@
 let runtimeConfig: any
 
-export default () => {
-  return runtimeConfig
-}
+export const getConfig = () => runtimeConfig
+
+export default getConfig
 
 export function setConfig(configValue: any): void {
   runtimeConfig = configValue


### PR DESCRIPTION
## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

The PR is another attempt to resolve #37524.

Currently, almost all Next.js' essential exports are default export (using `export default`).
However, `export default` would become `exports.default` after pre-compilation to CommonJS.

To prevent the usage like `const { default: Image } = require('next/image')`, Next.js introduces a build flag `interopClientDefaultExport` in pre-compilation, which would manually assign `export.default` to `module.exports`:

https://github.com/vercel/next.js/blob/dc3bd761b463e385f4da361748b1e40615a56feb/packages/next/taskfile-swc.js#L118-L126

However, the workaround is transformer-based, thus when Next.js generates type definitions using `tsc`, the output `d.ts` doesn't include the `interopDefaultExport` information:

```jsx
// Enable TypeScript check for .js file using ts-check directive:
// @ts-check
const nextJest = require("next/jest");
nextJest(); // TypeScript will throw: This expression is not callable

const { default: nextJestDefault } = require("next/jest");
nextJestDefault(); // This works

const Image = require("next/image");
<>
  {/** TypeScript will throw:  JSX element type 'Image' does not have any construct or call signatures. */}
  <Image src="" />
</>

const { default: ImageDefault } = require("next/image");
<>
  {/** This works */}
  <Image src="" />
</>
```

Here is a minimum reproduction at codesandbox: https://codesandbox.io/s/trusting-goldwasser-6xn329?file=/index.jsx

> Not only do `.js` files have this issue, but also in `.ts` files without `allowSyntheticDefaultImports`. However, `allowSyntheticDefaultImports` is enabled by default in most cases, see https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports. 

Previously, I have tried to resolve the issue by manually adjusting `d.ts` files (see https://github.com/vercel/next.js/pull/37605), but the syntax is invalid and is not recognized by TypeScript.

In this PR I have tried a different approach, by making Next.js has both named export and default export:

```js
const nextJest = require("next/jest");
nextJest(); // This still works, while type-check would throw if "@ts-check" directive is used
```

```js
// @ts-check
const { nextJest } = require("next/jest");
nextJest(); // This will also work. And it will make type-check happy, too.
```

The change is backward compatible and will not break any existing Next.js project.