### PR TITLE
Replace `docker-compose` v1 command with `docker compose` v2

### DIFF
--- a/examples/with-docker-compose/.env
+++ b/examples/with-docker-compose/.env
@@ -1,5 +1,5 @@
 # DO NOT ADD SECRETS TO THIS FILE. This is a good place for defaults.
-# If you want to add secrets use `.env.production.local` instead, which is automatically detected by docker-compose.
+# If you want to add secrets use `.env.production.local` instead, which is automatically detected by docker compose.
 
 ENV_VARIABLE=production_server_only_variable
 NEXT_PUBLIC_ENV_VARIABLE=production_public_variable

--- a/examples/with-docker-compose/.env
+++ b/examples/with-docker-compose/.env
@@ -1,5 +1,5 @@
 # DO NOT ADD SECRETS TO THIS FILE. This is a good place for defaults.
-# If you want to add secrets use `.env.production.local` instead, which is automatically detected by `docker-compose`.
+# If you want to add secrets use `.env.production.local` instead, which is automatically detected by docker compose.
 
 ENV_VARIABLE=production_server_only_variable
 NEXT_PUBLIC_ENV_VARIABLE=production_public_variable

--- a/examples/with-docker-compose/.env
+++ b/examples/with-docker-compose/.env
@@ -1,5 +1,5 @@
 # DO NOT ADD SECRETS TO THIS FILE. This is a good place for defaults.
-# If you want to add secrets use `.env.production.local` instead, which is automatically detected by docker compose.
+# If you want to add secrets use `.env.production.local` instead, which is automatically detected by `docker-compose`.
 
 ENV_VARIABLE=production_server_only_variable
 NEXT_PUBLIC_ENV_VARIABLE=production_public_variable

--- a/examples/with-docker-compose/README.md
+++ b/examples/with-docker-compose/README.md
@@ -37,10 +37,10 @@ First, run the development server:
 docker network create my_network
 
 # Build dev using new BuildKit engine
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.dev.yml build --parallel
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.dev.yml build --parallel
 
 # Up dev
-docker-compose -f docker-compose.dev.yml up
+docker compose -f docker-compose.dev.yml up
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
@@ -59,10 +59,10 @@ First, run the production server (Final image approximately 110 MB).
 docker network create my_network
 
 # Build prod using new BuildKit engine
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.prod.yml build --parallel
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.prod.yml build --parallel
 
 # Up prod in detached mode
-docker-compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml up -d
 ```
 
 Alternatively, run the production server without without multistage builds (Final image approximately 1 GB).
@@ -73,10 +73,10 @@ Alternatively, run the production server without without multistage builds (Fina
 docker network create my_network
 
 # Build prod without multistage using new BuildKit engine
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.prod-without-multistage.yml build --parallel
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.prod-without-multistage.yml build --parallel
 
 # Up prod without multistage in detached mode
-docker-compose -f docker-compose.prod-without-multistage.yml up -d
+docker compose -f docker-compose.prod-without-multistage.yml up -d
 ```
 
 Open [http://localhost:3000](http://localhost:3000).

--- a/examples/with-docker-compose/README.md
+++ b/examples/with-docker-compose/README.md
@@ -37,10 +37,10 @@ First, run the development server:
 docker network create my_network
 
 # Build dev using new BuildKit engine
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.dev.yml build --parallel
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.dev.yml build --parallel
 
 # Up dev
-docker compose -f docker-compose.dev.yml up
+docker-compose -f docker-compose.dev.yml up
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
@@ -59,10 +59,10 @@ First, run the production server (Final image approximately 110 MB).
 docker network create my_network
 
 # Build prod using new BuildKit engine
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.prod.yml build --parallel
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.prod.yml build --parallel
 
 # Up prod in detached mode
-docker compose -f docker-compose.prod.yml up -d
+docker-compose -f docker-compose.prod.yml up -d
 ```
 
 Alternatively, run the production server without without multistage builds (Final image approximately 1 GB).
@@ -73,10 +73,10 @@ Alternatively, run the production server without without multistage builds (Fina
 docker network create my_network
 
 # Build prod without multistage using new BuildKit engine
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.prod-without-multistage.yml build --parallel
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.prod-without-multistage.yml build --parallel
 
 # Up prod without multistage in detached mode
-docker compose -f docker-compose.prod-without-multistage.yml up -d
+docker-compose -f docker-compose.prod-without-multistage.yml up -d
 ```
 
 Open [http://localhost:3000](http://localhost:3000).

--- a/examples/with-temporal/README.md
+++ b/examples/with-temporal/README.md
@@ -69,7 +69,7 @@ The Temporal Node SDK requires [Node `>= 14`, `node-gyp`, and Temporal Server](h
 In the Temporal Server docker directory:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 In the `next-temporal-app/` directory:

--- a/examples/with-temporal/README.md
+++ b/examples/with-temporal/README.md
@@ -69,7 +69,7 @@ The Temporal Node SDK requires [Node `>= 14`, `node-gyp`, and Temporal Server](h
 In the Temporal Server docker directory:
 
 ```bash
-docker compose up
+docker-compose up
 ```
 
 In the `next-temporal-app/` directory:


### PR DESCRIPTION
Replace legacy `docker-compose` command with `docker compose`  (no hyphen) in all examples https://github.com/vercel/next.js/pull/36283#pullrequestreview-946487627

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)