### PR TITLE
Handle dynamic routes / catchall routes in on-demand-entries

### DIFF
--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -15,7 +15,7 @@ import { serverComponentRegex } from '../../build/webpack/loaders/utils'
 import { getPageStaticInfo } from '../../build/analysis/get-page-static-info'
 import { isMiddlewareFile, isMiddlewareFilename } from '../../build/utils'
 import { PageNotFoundError } from '../../shared/lib/utils'
-import { FlightRouterState } from '../app-render'
+import { DynamicParamTypesShort, FlightRouterState } from '../app-render'
 
 function treePathToEntrypoint(
   segmentPath: string[],
@@ -38,6 +38,22 @@ function treePathToEntrypoint(
   return treePathToEntrypoint(childSegmentPath, path)
 }
 
+function convertDynamicParamTypeToSyntax(
+  dynamicParamTypeShort: DynamicParamTypesShort,
+  param: string
+) {
+  switch (dynamicParamTypeShort) {
+    case 'c':
+      return `[...${param}]`
+    case 'oc':
+      return `[[...${param}]]`
+    case 'd':
+      return `[${param}]`
+    default:
+      throw new Error('Unknown dynamic param type')
+  }
+}
+
 function getEntrypointsFromTree(
   tree: FlightRouterState,
   isFirst: boolean,
@@ -45,7 +61,9 @@ function getEntrypointsFromTree(
 ) {
   const [segment, parallelRoutes] = tree
 
-  const currentSegment = Array.isArray(segment) ? segment[0] : segment
+  const currentSegment = Array.isArray(segment)
+    ? convertDynamicParamTypeToSyntax(segment[2], segment[0])
+    : segment
 
   const currentPath = [...parentPath, currentSegment]
 


### PR DESCRIPTION
Ensures the on-demand entries ping does not return invalid when dynamic routes are used. There was a small bug with how the entrypoint path was constructed where it was missing tthe brackets. Downside to this is that the tree needs to hold the type of parameter in order to reverse-resolve the entrypoint that, tried to mimize that by using a short identifier
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
