### PR TITLE
Fix rsc test during deploy testing

### DIFF
--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -51,6 +51,7 @@ describe('app dir - react server components', () => {
 
   const { isNextDeploy, isNextDev } = global as any
   if (isNextDeploy) {
+    it('should skip tests for next-deploy', () => {})
     return
   }
 


### PR DESCRIPTION
This ensures we have one no-op test so the suite doesn't fail incorrectly. 

Fixes: https://github.com/vercel/next.js/runs/7283565452?check_suite_focus=true