### PR TITLE
skip rsc tests for react 17 e2e

### DIFF
--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -50,12 +50,12 @@ describe('app dir - react server components', () => {
   afterAll(() => next.destroy())
 
   const { isNextDeploy, isNextDev } = global as any
-  if (isNextDeploy) {
-    it('should skip tests for next-deploy', () => {})
+  const isReact17 = process.env.NEXT_TEST_REACT_VERSION === '^17'
+  if (isNextDeploy || isReact17) {
+    it('should skip tests for next-deploy and react 17', () => {})
     return
   }
 
-  // TODO: support RSC index route
   it('should render server components correctly', async () => {
     const homeHTML = await renderViaHTTP(next.url, '/', null, {
       headers: {


### PR DESCRIPTION
Fix flaky rsc test in react 17 e2e tests

x-ref: https://github.com/vercel/next.js/runs/7285946966?check_suite_focus=true