### PR TITLE
Add dev/start timing to PR stats

### DIFF
--- a/.github/actions/next-stats-action/src/run/collect-stats.js
+++ b/.github/actions/next-stats-action/src/run/collect-stats.js
@@ -35,6 +35,7 @@ module.exports = async function collectStats(
     (hasPagesToFetch || hasPagesToBench)
   ) {
     const port = await getPort()
+    const startTime = Date.now()
     const child = spawn(statsConfig.appStartCommand, {
       cwd: curDir,
       env: {
@@ -44,14 +45,35 @@ module.exports = async function collectStats(
     })
     let exitCode = null
     let logStderr = true
-    child.stdout.on('data', (data) => process.stdout.write(data))
+
+    let serverReadyResolve
+    let serverReadyResolved = false
+    const serverReadyPromise = new Promise((resolve) => {
+      serverReadyResolve = resolve
+    })
+
+    child.stdout.on('data', (data) => {
+      if (data.toString().includes('started server') && !serverReadyResolved) {
+        serverReadyResolved = true
+        serverReadyResolve()
+      }
+      process.stdout.write(data)
+    })
     child.stderr.on('data', (data) => logStderr && process.stderr.write(data))
 
     child.on('exit', (code) => {
+      if (!serverReadyResolved) {
+        serverReadyResolve()
+        serverReadyResolved = true
+      }
       exitCode = code
     })
-    // give app a second to start up
-    await new Promise((resolve) => setTimeout(() => resolve(), 1500))
+
+    await serverReadyPromise
+    if (!orderedStats['General']) {
+      orderedStats['General'] = {}
+    }
+    orderedStats['General']['server start time (ms)'] = Date.now() - startTime
 
     if (exitCode !== null) {
       throw new Error(

--- a/.github/actions/next-stats-action/src/run/collect-stats.js
+++ b/.github/actions/next-stats-action/src/run/collect-stats.js
@@ -73,7 +73,8 @@ module.exports = async function collectStats(
     if (!orderedStats['General']) {
       orderedStats['General'] = {}
     }
-    orderedStats['General']['server start time (ms)'] = Date.now() - startTime
+    orderedStats['General']['nextStartReadyDuration (ms)'] =
+      Date.now() - startTime
 
     if (exitCode !== null) {
       throw new Error(

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const fs = require('fs-extra')
+const getPort = require('get-port')
 const glob = require('../util/glob')
 const exec = require('../util/exec')
 const logger = require('../util/logger')

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -158,6 +158,7 @@ async function runConfigs(
       curStats.General.buildDurationCached = Date.now() - secondBuildStart
 
       if (statsConfig.appDevCommand) {
+        const port = await getPort()
         const startTime = Date.now()
         const child = exec.spawn(statsConfig.appDevCommand, {
           cwd: statsAppDir,

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -156,6 +156,57 @@ async function runConfigs(
         env: yarnEnvValues,
       })
       curStats.General.buildDurationCached = Date.now() - secondBuildStart
+
+      if (statsConfig.appDevCommand) {
+        const startTime = Date.now()
+        const child = exec.spawn(statsConfig.appDevCommand, {
+          cwd: statsAppDir,
+          env: {
+            PORT: port,
+          },
+          stdio: 'pipe',
+        })
+
+        let serverReadyResolve
+        let serverReadyResolved = false
+        const serverReadyPromise = new Promise((resolve) => {
+          serverReadyResolve = resolve
+        })
+
+        child.stdout.on('data', (data) => {
+          if (
+            data.toString().includes('started server') &&
+            !serverReadyResolved
+          ) {
+            serverReadyResolved = true
+            serverReadyResolve()
+          }
+          process.stdout.write(data)
+        })
+        child.stderr.on('data', (data) => process.stderr.write(data))
+
+        child.on('exit', (code) => {
+          if (!serverReadyResolved) {
+            serverReadyResolve()
+            serverReadyResolved = true
+          }
+          exitCode = code
+        })
+
+        setTimeout(() => {
+          if (!serverReadyResolved) {
+            child.kill()
+          }
+        }, 3 * 1000)
+
+        await serverReadyPromise
+        child.kill()
+
+        if (!curStats['General']) {
+          curStats['General'] = {}
+        }
+        curStats['General']['dev start time (ms)'] = Date.now() - startTime
+      }
     }
 
     logger(`Finished running: ${config.title}`)

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -79,9 +79,9 @@ async function runConfigs(
       }
 
       const collectedStats = await collectStats(config, statsConfig)
-      curStats = {
-        ...curStats,
-        ...collectedStats,
+
+      for (const key of Object.keys(collectedStats)) {
+        curStats[key] = Object.assign({}, curStats[key], collectedStats[key])
       }
 
       const applyRenames = (renames, stats) => {
@@ -204,10 +204,7 @@ async function runConfigs(
         await serverReadyPromise
         child.kill()
 
-        if (!curStats['General']) {
-          curStats['General'] = {}
-        }
-        curStats['General']['dev start time (ms)'] = Date.now() - startTime
+        curStats['General']['nextDevReadyDuration'] = Date.now() - startTime
       }
     }
 

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -68,6 +68,7 @@ module.exports = {
   commentReleaseHeading: 'Stats from current release',
   appBuildCommand: 'NEXT_TELEMETRY_DISABLED=1 yarn next build',
   appStartCommand: 'NEXT_TELEMETRY_DISABLED=1 yarn next start --port $PORT',
+  appDevCommand: 'NEXT_TELEMETRY_DISABLED=1 yarn next --port $PORT',
   mainRepo: 'vercel/next.js',
   mainBranch: 'canary',
   autoMergeMain: true,


### PR DESCRIPTION
This adds tracking of CLI startup time for `next dev` and `next start` so we can track this over time. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1657548925308059?thread_ts=1656613729.838999&cid=C03KAR5DCKC)

