### PR TITLE
fix(amp): prevent empty 'style amp-custom' tag from appearing

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -446,6 +446,10 @@ function AmpStyles({
     })
   }
 
+  if (curStyles.length === 0) {
+    return null;
+  }
+
   /* Add custom styles before AMP styles to prevent accidental overrides */
   return (
     <style


### PR DESCRIPTION
When adding AMP support to a page or a set of pages, you'd likely want to add some styles to the page. If you try to manually add styles in the following—and only—way (`tailwindCss` being the stylesheet generated from the CLI at build time)
```html
<style
    amp-custom=""
    dangerouslySetInnerHTML={{
        __html: tailwindCss
    }}
></style>
``` 
it works but it doesn't prevent NextJS from adding its own `link amp-custom` (even if empty), causing an error that makes the whole AMP implementation fail: **The tag 'style amp-custom' appears more than once in the document.**

This PR fixes the issue, preventing the creation of an additional `style amp-custom`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
