### PR TITLE
fix: don't use optional chaining in ESLint rule

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-img-element.js
+++ b/packages/eslint-plugin-next/lib/rules/no-img-element.js
@@ -22,7 +22,13 @@ module.exports = {
           return
         }
 
-        if (node.parent?.parent?.openingElement?.name?.name === 'picture') {
+        if (
+          node.parent &&
+          node.parent.openingElement &&
+          node.parent.parent.openingElement &&
+          node.parent.parent.openingElement.name &&
+          node.parent.parent.openingElement.name.name === 'picture'
+        ) {
           return
         }
 


### PR DESCRIPTION
Fixes #38530

Should we consider adding a build-step to lint rules to be able to use TS/modern JS?

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
