### PR TITLE
Add `next-env.d.ts` to the `.gitignore` template of create-next-app

### DIFF
--- a/packages/create-next-app/templates/typescript/gitignore
+++ b/packages/create-next-app/templates/typescript/gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->


[The official document](https://nextjs.org/docs/basic-features/typescript#existing-projects) says about `next-env.d.ts`, "As such this file should not be committed and should be ignored by version control.". However, after executing `npx create-next-app --ts`, generated `.gitignore` omits `next-env.d.ts`. [Some developers](https://github.com/vercel/next.js/issues/26533#issuecomment-970427097) add `next-env.d.ts` to `.gitignore` manually. So, it would be better if the `.gitignore` template of create-next-app had `next-env.d.ts`.
Feel free to close if this change is wrong.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
