### PR TITLE
Add missing closing curly bracket in compiler option example

### DIFF
--- a/docs/advanced-features/compiler.md
+++ b/docs/advanced-features/compiler.md
@@ -66,6 +66,7 @@ module.exports = {
       transpileTemplateLiterals?: boolean,
       // Not supported yet.
       pure?: boolean,
+    },
   },
 }
 ```


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
This PR adds a missing closing curly bracket in the compiler option example of the [Styled Components](https://nextjs.org/docs/advanced-features/compiler#styled-components).

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [X] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
