### PR TITLE
Ensure .client.tsx/.ts/.jsx Client Components can be imported

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -58,6 +58,7 @@ import { withoutRSCExtensions } from './utils'
 import browserslist from 'next/dist/compiled/browserslist'
 import loadJsConfig from './load-jsconfig'
 import { loadBindings } from './swc'
+import { clientComponentRegex } from './webpack/loaders/utils'
 
 const watchOptions = Object.freeze({
   aggregateTimeout: 5,
@@ -1311,7 +1312,7 @@ export default async function getBaseWebpackConfig(
                   },
                 },
                 {
-                  test: /(\.client\.(js|cjs|mjs))$|\/next\/(link|image|future\/image|head|script)/,
+                  test: clientComponentRegex,
                   issuerLayer: 'sc_server',
                   use: {
                     loader: 'next-flight-client-loader',

--- a/packages/next/build/webpack/loaders/utils.ts
+++ b/packages/next/build/webpack/loaders/utils.ts
@@ -3,6 +3,7 @@ const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif']
 const nextClientComponents = [
   'link',
   'image',
+  // TODO-APP: check if this affects the regex
   'future/image',
   'head',
   'script',

--- a/packages/next/build/webpack/loaders/utils.ts
+++ b/packages/next/build/webpack/loaders/utils.ts
@@ -1,6 +1,13 @@
 export const defaultJsFileExtensions = ['js', 'mjs', 'jsx', 'ts', 'tsx']
 const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif']
-const nextClientComponents = ['link', 'image', 'head', 'script', 'dynamic']
+const nextClientComponents = [
+  'link',
+  'image',
+  'future/image',
+  'head',
+  'script',
+  'dynamic',
+]
 
 const NEXT_BUILT_IN_CLIENT_RSC_REGEX = new RegExp(
   `[\\\\/]next[\\\\/](${nextClientComponents.join('|')})\\.js$`

--- a/test/e2e/app-dir/app/app/dashboard/client-comp.client.jsx
+++ b/test/e2e/app-dir/app/app/dashboard/client-comp.client.jsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export default function ClientComp() {
+  const [state, setState] = useState({})
+  useEffect(() => {
+    setState({ test: 'HELLOOOO' })
+  }, [])
+  return (
+    <>
+      <p>Hello</p>
+      {state.test}
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/dashboard/page.server.js
+++ b/test/e2e/app-dir/app/app/dashboard/page.server.js
@@ -1,8 +1,10 @@
+import ClientComp from './client-comp.client'
 export default function DashboardPage(props) {
   return (
     <>
       <p className="p">hello from app/dashboard</p>
       <p className="green">this is green</p>
+      <ClientComp />
     </>
   )
 }


### PR DESCRIPTION
Currently .client.ts / .client.tsx / .client.jsx throws an error as they're handled as server components incorrectly.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
