### PR TITLE
Remove the `hide-fouc` tags after hydration

### DIFF
--- a/packages/next/client/app-index.tsx
+++ b/packages/next/client/app-index.tsx
@@ -76,7 +76,6 @@ const getCacheKey = () => {
 }
 
 const encoder = new TextEncoder()
-const loadedCss: Set<string> = new Set()
 
 let initialServerDataBuffer: string[] | undefined = undefined
 let initialServerDataWriter: ReadableStreamDefaultController | undefined =
@@ -235,7 +234,7 @@ function ServerRoot({
     if (process.env.NODE_ENV === 'development') {
       onFlightCssLoaded?.()
     }
-  }, [])
+  }, [onFlightCssLoaded])
   const response = useInitialServerResponse(cacheKey)
   const root = response.readRoot()
   return root


### PR DESCRIPTION
The current timing (after chunk loaded) isn't accurate enough because React hydrates asynchronously.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
