### PR TITLE
docs: clarify that `matcher` needs to be constant values

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -86,7 +86,7 @@ export const config = {
 }
 ```
 
-> **Note:** The `matcher` values need to be constants so they can be analyzed at build-time. Non-static values will be ignored.
+> **Note:** The `matcher` values need to be constants so they can be statically analyzed at build-time. Dynamic values such as variables will be ignored.
 
 ### Conditional Statements
 

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -86,6 +86,8 @@ export const config = {
 }
 ```
 
+> **Note:** The `matcher` values need to be constants so they can be analyzed at build-time. Non-static values will be ignored.
+
 ### Conditional Statements
 
 ```typescript


### PR DESCRIPTION
Ref: #38461, #37346

As [introduced](https://github.com/vercel/next.js/pull/37177/files#diff-7ec7f47987bd890b5b47f6cf101398cd22fa37f874348d70036f85309a040c92
) in #37177, we statically analyze the `matcher` values, so we should make it clear.


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
