### PR TITLE
Update to latest version of turbo

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -8,7 +8,7 @@ name: Build, test, and deploy
 
 env:
   NAPI_CLI_VERSION: 2.7.0
-  TURBO_VERSION: 1.3.1
+  TURBO_VERSION: 1.3.2-canary.1
   RUST_TOOLCHAIN: nightly-2022-02-23
   PNPM_VERSION: 7.2.1
 

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -6,7 +6,7 @@ name: Generate Pull Request Stats
 
 env:
   NAPI_CLI_VERSION: 2.7.0
-  TURBO_VERSION: 1.3.1
+  TURBO_VERSION: 1.3.2-canary.1
   RUST_TOOLCHAIN: nightly-2022-02-23
   PNPM_VERSION: 7.2.1
 

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "taskr": "1.1.0",
     "tree-kill": "1.2.2",
     "tsec": "0.2.1",
-    "turbo": "1.3.1",
+    "turbo": "1.3.2-canary.1",
     "typescript": "4.6.3",
     "wait-port": "0.2.2",
     "webpack": "link:node_modules/webpack5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,7 +159,7 @@ importers:
       taskr: 1.1.0
       tree-kill: 1.2.2
       tsec: 0.2.1
-      turbo: 1.3.1
+      turbo: 1.3.2-canary.1
       typescript: 4.6.3
       wait-port: 0.2.2
       webpack: link:node_modules/webpack5
@@ -313,7 +313,7 @@ importers:
       taskr: 1.1.0
       tree-kill: 1.2.2
       tsec: 0.2.1_5yr6raq5qir6dqmptdaiz6dy4a
-      turbo: 1.3.1
+      turbo: 1.3.2-canary.1
       typescript: 4.6.3
       wait-port: 0.2.2
       webpack: link:node_modules/webpack5
@@ -21363,137 +21363,137 @@ packages:
       safe-buffer: 5.2.0
     dev: true
 
-  /turbo-android-arm64/1.3.1:
-    resolution: {integrity: sha512-JcnZh9tLbZDpKaXaao/s/k4qXt3TbNEc1xEYYXurVWnqiMueGeS7QAtThVB85ZSqzj7djk+ngSrZabPy5RG25Q==}
+  /turbo-android-arm64/1.3.2-canary.1:
+    resolution: {integrity: sha512-XIX6/7iy7jT8/U3FSmN4HUxNk2/HAeFcYL2A7Vh0wGQ7aVJAqItYxV5Iawf49lokdmdxQnJnttQ2TRIEKH1ITg==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-64/1.3.1:
-    resolution: {integrity: sha512-TIGDradVFoGck86VIuM38KaDeNxdKaP2ti93UpQeFw26ZhPIeTAa6wUgnz4DQP6bjIvQmXlYJ16ETZb4tFYygg==}
+  /turbo-darwin-64/1.3.2-canary.1:
+    resolution: {integrity: sha512-h1Dd6qx8L2FZG86zWgafEgw6JwuWI2hla4PNXP/jiLEp7QuALGONJ2jdwNmsuBj0+q47eQjY9Q1tZtVvnY/iKA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.3.1:
-    resolution: {integrity: sha512-aLBq8KiMMmop7uKBkvDt/y+eER2UzxZyUzh1KWcZ7DZB5tFZnknEUyf2qggY2vd2WcDVfQ1EUjZ0MFxhhVaVzA==}
+  /turbo-darwin-arm64/1.3.2-canary.1:
+    resolution: {integrity: sha512-zM5BHkxHJltKK6isJilVL7L3dlYa6WF5VPfYOAekYor3u2ZhNsgFLGom+YXz22LD/csP2giRGokREObA7q0YJQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-64/1.3.1:
-    resolution: {integrity: sha512-BOr/ifmxjlBeuDkDQLUJtzqzXQ2zPHHcI14U9Ys+z4Mza1uzQn/oSJqQvU5RuyRBVai7noMrpPS7QuKtDz0Cyg==}
+  /turbo-freebsd-64/1.3.2-canary.1:
+    resolution: {integrity: sha512-ZepqMN1relzuqr3g16wh0bXVKoBKzEivkGh1NVm87sDE5nvwLuB9lOCnxg89xb31PdJAyVr5UGeqVE5SfYltww==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-arm64/1.3.1:
-    resolution: {integrity: sha512-bHPZjK4xnGLz6/oxl5XmWhdYOdtBMSadrGhptWSZ0wBGNn/gQzDTeZAkQeqhh25AD0eM1hzDe8QUz8GlS43lrA==}
+  /turbo-freebsd-arm64/1.3.2-canary.1:
+    resolution: {integrity: sha512-gL/U8Su+GjvdI2yon+revsRFi/GfB/CdWGvDzdsore4eO1/V1DiACDRJDzf+/gvNdUzoD3cwbpiKGFuaZ7wVow==}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-32/1.3.1:
-    resolution: {integrity: sha512-c5okimusfvivu9wS8MKSr+rXpQAV+M4TyR9JX+spIK8B1I7AjfECAqiK2D5WFWO1bQ33bUAuxXOEpUuLpgEm+g==}
+  /turbo-linux-32/1.3.2-canary.1:
+    resolution: {integrity: sha512-8jxYYI4q2AHODKgO1XQ7KL7ufRFfGT4phi0JPs4KilaYEgNvDGSIDr2d8BHPVJr3exlb884ZcAW1tm+0t0WCog==}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.3.1:
-    resolution: {integrity: sha512-O0pNX+N5gbmRcyZT+jsCPUNCN3DpIZHqNN35j7MT5nr0IkZa83CGbZnrEc+7Qws//jFJ26EngqD/JyRB2E8nwQ==}
+  /turbo-linux-64/1.3.2-canary.1:
+    resolution: {integrity: sha512-uCHCQ1HZdns78hr2Z6N3zZwFrUYJdyYRIPWj12TwvtTEErTARAcKvtWV9mQkkXvzkkmUDHJoTsSl5cIyhtoreg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm/1.3.1:
-    resolution: {integrity: sha512-f+r6JIwv/7ylxxJtgVi8cVw+6oNoD/r1IMTU6ejH8bfyMZZko4kkNwH9VYribQ44KDkJEgzdltnzFG5f6Hz10g==}
+  /turbo-linux-arm/1.3.2-canary.1:
+    resolution: {integrity: sha512-xEp/twlTo8Q5TaMz3g7UCtbPdO/VZS0ugAZ2egmbBpkEIdSQ7wjME8z7cgjK/Wc2l9y0BEuA/mc/ndmO43LaNw==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.3.1:
-    resolution: {integrity: sha512-D6+1MeS/x+/VCCooHPU4NIpB8qI/eW70eMRA79bqTPaxxluP0g2CaxXgucco05P51YtNsSxeVcH7X76iadON6Q==}
+  /turbo-linux-arm64/1.3.2-canary.1:
+    resolution: {integrity: sha512-5JjIQTuDo5RALnKvxPholfljiWxVwhyUpBm8xYNMtufR8CmbkjsNZgNGm8cyFXl3syHdLOhL/PsCpeVaiWDlUw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-mips64le/1.3.1:
-    resolution: {integrity: sha512-yL64jgwVCziOpBcdpMxIsczkgwwOvmaqKObFKWyCNlk/LOl5NKODLwXEaryLaALtpwUAoS4ltMSI64gKqmLrOA==}
+  /turbo-linux-mips64le/1.3.2-canary.1:
+    resolution: {integrity: sha512-oOZD03ZyfOxifgi3YAAbtcnZtCA6fpsc2/y6R5sm9jRpXlia7PCbQLiV4H1UWCfmsQzUsLCTTZmO+D8K2rjymg==}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-ppc64le/1.3.1:
-    resolution: {integrity: sha512-tjnM+8RosykS1lBpOPLDXGOz/Po2h796ty17uBd7IFslWPOI16a/akFOFoLH8PCiGGJMe3CYgRhEKn4sPWNxFA==}
+  /turbo-linux-ppc64le/1.3.2-canary.1:
+    resolution: {integrity: sha512-JtFMPdO+N6lYCFO7gN042CdzQPWvF2ow77Hv1oOpVkyU2X9seK73XHmv+15dan92/flslZLFAW8T93kiXfsJug==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-32/1.3.1:
-    resolution: {integrity: sha512-Snnv+TVigulqwK6guHKndMlrLw88NXj8BtHRGrEksPR0QkyuHlwLf+tHYB4HmvpUl4W9lnXQf4hsljWP64BEdw==}
+  /turbo-windows-32/1.3.2-canary.1:
+    resolution: {integrity: sha512-xDi61dm5CbLGpi2nu20+fWcl7IcSayqQYtQNztVqyAv9TpP84gzItuETOxwNyK7BivZ0BTMuVhtVUfc44ZxG+A==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.3.1:
-    resolution: {integrity: sha512-gLeohHG07yIhON1Pp0YNE00i/yzip2GFhkA6HdJaK95uE5bKULpqxuO414hOS/WzGwrGVXBKCImfe24XXh5T+Q==}
+  /turbo-windows-64/1.3.2-canary.1:
+    resolution: {integrity: sha512-uj4RVdVXIffTOeozFk8df+hgLUOZInkFvUTJ9jEKSNR/9zF9QXz7EkeQF8Cq+f840W7zNMDxciGBls3SWWTX0w==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.3.1:
-    resolution: {integrity: sha512-0MWcHLvYgs/qdcoTFZ55nu8HhrpeiwXEMw9cbNfgqTlzy3OsrAsovYEJFyQ8KSxeploiD+QJlCdvhxx+5C0tlA==}
+  /turbo-windows-arm64/1.3.2-canary.1:
+    resolution: {integrity: sha512-rtU97ntfMRIr3IscaB3VwCxXCb60CkaM35NdTM3Yr+5H8UplmzQt1iBV8+Zc8/JO5YDfWD82dGZKVw4Oou+f2w==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.3.1:
-    resolution: {integrity: sha512-DXckoGKlZgvTn/PrHpBI/57aeXR7tfyPf2dK+4LmBczt24ELA3o6eYHeA7KzfpSYhB2LE9qveYFQ6mJ1OzGjjg==}
+  /turbo/1.3.2-canary.1:
+    resolution: {integrity: sha512-qrSrKjkKDn7afDMz++RXg84sXBmd+CprnmJNNQq7l1Ao0eOPRpe//uh4JsULgjxYHHLeB2Re1fJ02HF282Kaww==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-android-arm64: 1.3.1
-      turbo-darwin-64: 1.3.1
-      turbo-darwin-arm64: 1.3.1
-      turbo-freebsd-64: 1.3.1
-      turbo-freebsd-arm64: 1.3.1
-      turbo-linux-32: 1.3.1
-      turbo-linux-64: 1.3.1
-      turbo-linux-arm: 1.3.1
-      turbo-linux-arm64: 1.3.1
-      turbo-linux-mips64le: 1.3.1
-      turbo-linux-ppc64le: 1.3.1
-      turbo-windows-32: 1.3.1
-      turbo-windows-64: 1.3.1
-      turbo-windows-arm64: 1.3.1
+      turbo-android-arm64: 1.3.2-canary.1
+      turbo-darwin-64: 1.3.2-canary.1
+      turbo-darwin-arm64: 1.3.2-canary.1
+      turbo-freebsd-64: 1.3.2-canary.1
+      turbo-freebsd-arm64: 1.3.2-canary.1
+      turbo-linux-32: 1.3.2-canary.1
+      turbo-linux-64: 1.3.2-canary.1
+      turbo-linux-arm: 1.3.2-canary.1
+      turbo-linux-arm64: 1.3.2-canary.1
+      turbo-linux-mips64le: 1.3.2-canary.1
+      turbo-linux-ppc64le: 1.3.2-canary.1
+      turbo-windows-32: 1.3.2-canary.1
+      turbo-windows-64: 1.3.2-canary.1
+      turbo-windows-arm64: 1.3.2-canary.1
     dev: true
 
   /tweetnacl/0.14.5:


### PR DESCRIPTION
Updates to latest turbo which includes patches for cached files. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02CDC2ALJH/p1657767763630359?thread_ts=1657757803.039099&cid=C02CDC2ALJH)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
