### PR TITLE
Add dark mode to Create Next App

### DIFF
--- a/packages/create-next-app/templates/default/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/styles/Home.module.css
@@ -114,3 +114,15 @@
     flex-direction: column;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .card, .footer {
+    border-color: #222;
+  }
+  .code {
+    background: #111;
+  }
+  .logo img {
+    filter: invert(1);
+  }
+}

--- a/packages/create-next-app/templates/default/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/styles/Home.module.css
@@ -116,7 +116,8 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .card, .footer {
+  .card,
+  .footer {
     border-color: #222;
   }
   .code {

--- a/packages/create-next-app/templates/default/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/styles/Home.module.css
@@ -66,15 +66,15 @@
 }
 
 .grid {
-  display: grid;
-  align-items: stretch;
-  gap: 2rem;
-  grid-template-columns: 1fr 1fr;
-  width: 100%;
-  max-width: 720px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  max-width: 800px;
 }
 
 .card {
+  margin: 1rem;
   padding: 1.5rem;
   text-align: left;
   color: inherit;
@@ -82,6 +82,7 @@
   border: 1px solid #eaeaea;
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
+  max-width: 300px;
 }
 
 .card:hover,
@@ -109,7 +110,8 @@
 
 @media (max-width: 600px) {
   .grid {
-    grid-template-columns: 1fr;
+    width: 100%;
+    flex-direction: column;
   }
 }
 

--- a/packages/create-next-app/templates/default/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/styles/Home.module.css
@@ -66,15 +66,15 @@
 }
 
 .grid {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  max-width: 800px;
+  display: grid;
+  align-items: stretch;
+  gap: 2rem;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
+  max-width: 720px;
 }
 
 .card {
-  margin: 1rem;
   padding: 1.5rem;
   text-align: left;
   color: inherit;
@@ -82,7 +82,6 @@
   border: 1px solid #eaeaea;
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
-  max-width: 300px;
 }
 
 .card:hover,
@@ -110,8 +109,7 @@
 
 @media (max-width: 600px) {
   .grid {
-    width: 100%;
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
 }
 

--- a/packages/create-next-app/templates/default/styles/globals.css
+++ b/packages/create-next-app/templates/default/styles/globals.css
@@ -14,3 +14,10 @@ a {
 * {
   box-sizing: border-box;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: white;
+    background: black;
+  }
+}

--- a/packages/create-next-app/templates/default/styles/globals.css
+++ b/packages/create-next-app/templates/default/styles/globals.css
@@ -16,6 +16,9 @@ a {
 }
 
 @media (prefers-color-scheme: dark) {
+  html {
+    color-scheme: dark;
+  }
   body {
     color: white;
     background: black;

--- a/packages/create-next-app/templates/typescript/styles/Home.module.css
+++ b/packages/create-next-app/templates/typescript/styles/Home.module.css
@@ -114,3 +114,15 @@
     flex-direction: column;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .card, .footer {
+    border-color: #222;
+  }
+  .code {
+    background: #111;
+  }
+  .logo img {
+    filter: invert(1);
+  }
+}

--- a/packages/create-next-app/templates/typescript/styles/Home.module.css
+++ b/packages/create-next-app/templates/typescript/styles/Home.module.css
@@ -116,7 +116,8 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .card, .footer {
+  .card,
+  .footer {
     border-color: #222;
   }
   .code {

--- a/packages/create-next-app/templates/typescript/styles/Home.module.css
+++ b/packages/create-next-app/templates/typescript/styles/Home.module.css
@@ -66,15 +66,15 @@
 }
 
 .grid {
-  display: grid;
-  align-items: stretch;
-  gap: 2rem;
-  grid-template-columns: 1fr 1fr;
-  width: 100%;
-  max-width: 720px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  max-width: 800px;
 }
 
 .card {
+  margin: 1rem;
   padding: 1.5rem;
   text-align: left;
   color: inherit;
@@ -82,6 +82,7 @@
   border: 1px solid #eaeaea;
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
+  max-width: 300px;
 }
 
 .card:hover,
@@ -109,7 +110,8 @@
 
 @media (max-width: 600px) {
   .grid {
-    grid-template-columns: 1fr;
+    width: 100%;
+    flex-direction: column;
   }
 }
 

--- a/packages/create-next-app/templates/typescript/styles/Home.module.css
+++ b/packages/create-next-app/templates/typescript/styles/Home.module.css
@@ -66,15 +66,15 @@
 }
 
 .grid {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  max-width: 800px;
+  display: grid;
+  align-items: stretch;
+  gap: 2rem;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
+  max-width: 720px;
 }
 
 .card {
-  margin: 1rem;
   padding: 1.5rem;
   text-align: left;
   color: inherit;
@@ -82,7 +82,6 @@
   border: 1px solid #eaeaea;
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
-  max-width: 300px;
 }
 
 .card:hover,
@@ -110,8 +109,7 @@
 
 @media (max-width: 600px) {
   .grid {
-    width: 100%;
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
 }
 

--- a/packages/create-next-app/templates/typescript/styles/globals.css
+++ b/packages/create-next-app/templates/typescript/styles/globals.css
@@ -14,3 +14,10 @@ a {
 * {
   box-sizing: border-box;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: white;
+    background: black;
+  }
+}

--- a/packages/create-next-app/templates/typescript/styles/globals.css
+++ b/packages/create-next-app/templates/typescript/styles/globals.css
@@ -16,6 +16,9 @@ a {
 }
 
 @media (prefers-color-scheme: dark) {
+  html {
+    color-scheme: dark;
+  }
   body {
     color: white;
     background: black;


### PR DESCRIPTION
Add dark mode to `default`/`typescript` CSS files in `create-next-app`

Given the reach of this template, are we ok using the following css strategies:

- ~~`display: grid` for core layout~~
- `filter: invert(1)` to handle logo in dark mode

Preview link
https://nextjs-darkmode.vercel.app/

Ref: [Slack thread](https://vercel.slack.com/archives/C8EAN8A94/p1657839597337459)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
