### PR TITLE
Improve element detection further

### DIFF
--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -42,15 +42,9 @@ function createInfinitePromise() {
   return infinitePromise
 }
 
-function isInViewport(element: HTMLElement) {
+function topOfElementInViewport(element: HTMLElement) {
   const rect = element.getBoundingClientRect()
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <=
-      (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  )
+  return rect.top >= 0
 }
 
 export function InnerLayoutRouter({
@@ -84,7 +78,7 @@ export function InnerLayoutRouter({
       focusRef.focus = false
       focusAndScrollRef.current.focus()
       // Only scroll into viewport when the layout is not visible currently.
-      if (!isInViewport(focusAndScrollRef.current)) {
+      if (!topOfElementInViewport(focusAndScrollRef.current)) {
         focusAndScrollRef.current.scrollIntoView()
       }
     }


### PR DESCRIPTION
Follow-up to #38682. Instead of checking if the full element is in the viewport we only check if the top of the element is in the viewport. If it is not we have to scroll back up in cases of navigating between items in the same layout for example.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
