### PR TITLE
Fix check for optimistic routing and handle loading in server-patch

### DIFF
--- a/packages/next/client/components/reducer.ts
+++ b/packages/next/client/components/reducer.ts
@@ -154,27 +154,28 @@ const canOptimisticallyRender = (
 ): boolean => {
   const segment = segments[0]
   const isLastSegment = segments.length === 1
-
   const [existingSegment, existingParallelRoutes, , , loadingMarker] =
     flightRouterState
+  // If the segments mismatch we can't resolve deeper into the tree
+  const segmentMatches = matchSegment(existingSegment, segment)
+
+  // If the segment mismatches we can't assume this level has loading
+  if (!segmentMatches) {
+    return false
+  }
 
   const hasLoading = loadingMarker === 'loading'
-
   // If the tree path holds at least one loading.js it will be optimistic
   if (hasLoading) {
     return true
   }
-
   // Above already catches the last segment case where `hasLoading` is true, so in this case it would always be `false`.
   if (isLastSegment) {
     return false
   }
 
-  // If the segments mismatch we can't resolve deeper into the tree
-  const segmentMatches = matchSegment(existingSegment, segment)
-
   // If the existingParallelRoutes does not have a `children` parallelRouteKey we can't resolve deeper into the tree
-  if (!segmentMatches || !existingParallelRoutes.children) {
+  if (!existingParallelRoutes.children) {
     return hasLoading
   }
 
@@ -188,9 +189,9 @@ const canOptimisticallyRender = (
 const createOptimisticTree = (
   segments: string[],
   flightRouterState: FlightRouterState | null,
-  isFirstSegment: boolean,
+  _isFirstSegment: boolean,
   parentRefetch: boolean,
-  href?: string
+  _href?: string
 ): FlightRouterState => {
   const [existingSegment, existingParallelRoutes] = flightRouterState || [
     null,
@@ -232,10 +233,11 @@ const createOptimisticTree = (
     result[3] = 'refetch'
   }
 
+  // TODO-APP: Revisit
   // Add url into the tree
-  if (isFirstSegment) {
-    result[2] = href
-  }
+  // if (isFirstSegment) {
+  //   result[2] = href
+  // }
 
   // Copy the loading flag from existing tree
   if (flightRouterState && flightRouterState[4]) {
@@ -250,15 +252,16 @@ const walkTreeWithFlightDataPath = (
   flightRouterState: FlightRouterState,
   treePatch: FlightRouterState
 ): FlightRouterState => {
-  const [segment, parallelRoutes, url] = flightRouterState
+  const [segment, parallelRoutes /* , url */] = flightRouterState
 
   // Root refresh
   if (flightSegmentPath.length === 1) {
     const tree: FlightRouterState = [...treePatch]
 
-    if (url) {
-      tree[2] = url
-    }
+    // TODO-APP: revisit
+    // if (url) {
+    //   tree[2] = url
+    // }
 
     return tree
   }
@@ -286,13 +289,14 @@ const walkTreeWithFlightDataPath = (
     },
   ]
 
-  if (url) {
-    tree[2] = url
-  }
+  // TODO-APP: Revisit
+  // if (url) {
+  //   tree[2] = url
+  // }
 
   // Copy loading flag
-  if (flightSegmentPath[4]) {
-    tree[4] = flightSegmentPath[4]
+  if (flightRouterState[4]) {
+    tree[4] = flightRouterState[4]
   }
 
   return tree


### PR DESCRIPTION
Fixes two bugs:
- `isOptimisticTree` would be `true` for routes that don't have loading state when they're on the same level of segment. This is no longer the case.
- `server-patch` is meant to copy over the `loading` marker but it read from the wrong variable.


Kudos @delbaoliveira who highlighted navigation broke between same-level segments.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
