### PR TITLE
Fix CSSM loader applying for both pages and app

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/build/webpack/config/blocks/css/index.ts
@@ -368,9 +368,13 @@ export const css = curry(async function css(
               sideEffects: true,
               test: regexCssGlobal,
               issuer: {
-                or: [
-                  { and: [ctx.rootDirectory, /\.(js|mjs|jsx|ts|tsx)$/] },
-                  regexClientEntry,
+                and: [
+                  {
+                    or: [
+                      { and: [ctx.rootDirectory, /\.(js|mjs|jsx|ts|tsx)$/] },
+                      regexClientEntry,
+                    ],
+                  },
                 ],
               },
               use: getGlobalCssLoader(ctx, lazyPostCSSInitializer),

--- a/packages/next/build/webpack/plugins/client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/client-entry-plugin.ts
@@ -87,8 +87,7 @@ export class ClientEntryPlugin {
             !rawRequest.startsWith('.') &&
             !rawRequest.startsWith('/')
               ? rawRequest
-              : // resourceResolveData.path doesn't contain the loader queries
-                mod.resourceResolveData?.path || mod.userRequest
+              : mod.resource || mod.userRequest
 
           if (visited.has(modRequest)) return
           visited.add(modRequest)

--- a/packages/next/build/webpack/plugins/client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/client-entry-plugin.ts
@@ -87,9 +87,9 @@ export class ClientEntryPlugin {
             !rawRequest.startsWith('.') &&
             !rawRequest.startsWith('/')
               ? rawRequest
-              : mod.resource || mod.userRequest
+              : mod.resourceResolveData?.path
 
-          if (visited.has(modRequest)) return
+          if (!modRequest || visited.has(modRequest)) return
           visited.add(modRequest)
 
           if (

--- a/packages/next/build/webpack/plugins/client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/client-entry-plugin.ts
@@ -87,7 +87,8 @@ export class ClientEntryPlugin {
             !rawRequest.startsWith('.') &&
             !rawRequest.startsWith('/')
               ? rawRequest
-              : mod.userRequest
+              : // resourceResolveData.path doesn't contain the loader queries
+                mod.resourceResolveData?.path || mod.userRequest
 
           if (visited.has(modRequest)) return
           visited.add(modRequest)

--- a/test/e2e/app-dir/app/pages/index.js
+++ b/test/e2e/app-dir/app/pages/index.js
@@ -1,8 +1,10 @@
 import Link from 'next/link'
+import styles from '../styles/shared.module.css'
+
 export default function Page(props) {
   return (
     <>
-      <p>hello from pages/index</p>
+      <p className={styles.content}>hello from pages/index</p>
       <Link href="/dashboard">Dashboard</Link>
     </>
   )

--- a/test/e2e/app-dir/app/styles/shared.module.css
+++ b/test/e2e/app-dir/app/styles/shared.module.css
@@ -1,0 +1,3 @@
+.content {
+  color: blueviolet;
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -23,6 +23,7 @@ describe('app dir', () => {
     next = await createNext({
       files: {
         public: new FileRef(path.join(__dirname, 'app/public')),
+        styles: new FileRef(path.join(__dirname, 'app/styles')),
         pages: new FileRef(path.join(__dirname, 'app/pages')),
         app: new FileRef(path.join(__dirname, 'app/app')),
         'next.config.js': new FileRef(


### PR DESCRIPTION
## Bug

x-ref: #38691

* Previous configured loader.issue results into a single function and will bail during next build, tune the rule set conditions to make it work for both pages and app dir
* prefer to use `mod.resourceResolveData?.path` instead of `mod.userRequest` since userRquest contains the applied loaders info

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
