### PR TITLE
chore(examples): require `WORDPRESS_API_URL` to include `/graphql`

### DIFF
--- a/examples/cms-wordpress/lib/api.js
+++ b/examples/cms-wordpress/lib/api.js
@@ -10,7 +10,7 @@ async function fetchAPI(query = '', { variables } = {}) {
   }
 
   // WPGraphQL Plugin must be enabled
-  const res = await fetch(`${API_URL}/graphql`, {
+  const res = await fetch(API_URL, {
     headers,
     method: 'POST',
     body: JSON.stringify({


### PR DESCRIPTION
Fixes #38749

Since we are calling it `API_URL`, it sounds more correct to require including the `/graphql` rather than making `WORDPRESS_API_URL` be just the root domain in https://github.com/vercel/next.js/blob/54f87245dc8a181759a3c8065a35c7fbb1d1d329/examples/cms-wordpress/README.md?plain=1#L96


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
