### PR TITLE
Optimize line breaks by increasing grid column width

### DIFF
--- a/packages/create-next-app/templates/default/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/styles/Home.module.css
@@ -66,15 +66,15 @@
 }
 
 .grid {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  max-width: 800px;
+  display: grid;
+  align-items: stretch;
+  gap: 2rem;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
+  max-width: 720px;
 }
 
 .card {
-  margin: 1rem;
   padding: 1.5rem;
   text-align: left;
   color: inherit;
@@ -82,7 +82,6 @@
   border: 1px solid #eaeaea;
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
-  max-width: 300px;
 }
 
 .card:hover,
@@ -110,8 +109,7 @@
 
 @media (max-width: 600px) {
   .grid {
-    width: 100%;
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
 }
 

--- a/packages/create-next-app/templates/typescript/styles/Home.module.css
+++ b/packages/create-next-app/templates/typescript/styles/Home.module.css
@@ -66,15 +66,15 @@
 }
 
 .grid {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  max-width: 800px;
+  display: grid;
+  align-items: stretch;
+  gap: 2rem;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
+  max-width: 720px;
 }
 
 .card {
-  margin: 1rem;
   padding: 1.5rem;
   text-align: left;
   color: inherit;
@@ -82,7 +82,6 @@
   border: 1px solid #eaeaea;
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
-  max-width: 300px;
 }
 
 .card:hover,
@@ -110,8 +109,7 @@
 
 @media (max-width: 600px) {
   .grid {
-    width: 100%;
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
This PR slightly enlarges grid boxes to optimize line breaks in `create-next-app`

This is done using `display: grid`—are we ok with the level of support for that?

Preview new layout
https://nextjs-darkmode.vercel.app/

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
