### PR TITLE
Feature: Allow user to set `rewriteSecure: false` for rewrites function in next configs

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -512,8 +512,10 @@ export default class NextNodeServer extends BaseServer {
     parsedUrl.search = stringifyQuery(req, query)
 
     const target = formatUrl(parsedUrl)
+    const secure = this.nextConfig.rewriteSecure
     const proxy = new HttpProxy({
       target,
+      secure,
       changeOrigin: true,
       ignorePath: true,
       xfwd: true,


### PR DESCRIPTION
There are a lot of people got this `UNABLE_TO_VERIFY_LEAF_SIGNATURE` error when using rewrites function to external https url: https://github.com/vercel/next.js/search?q=unable+to+verify+the+first+certificate (and more if you google it...
We should add an option for users to ignore this error during development. Like this one proposed: https://github.com/vercel/next.js/discussions/28334

Then user can set `rewriteSecure: false` in `next.config.js` file to ignore this type of error.
