### PR TITLE
chore: TS improvments

### DIFF
--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -137,6 +137,12 @@ export function useRouter(): NextRouter {
 // -------------
 // (do not use following exports inside the app)
 
+/**
+ * Create a router and assign it as the singleton instance.
+ * This is used in client side when we are initializing the app.
+ * This should **not** be used inside the server.
+ * @internal
+ */
 export function createRouter(
   ...args: ConstructorParameters<typeof Router>
 ): Router {
@@ -147,7 +153,10 @@ export function createRouter(
   return singletonRouter.router
 }
 
-// This function is used to create the `withRouter` router instance
+/**
+ * This function is used to create the `withRouter` router instance
+ * @internal
+ */
 export function makePublicRouterInstance(router: Router): NextRouter {
   const scopedRouter = router as any
   const instance = {} as any

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -5,10 +5,6 @@ import type { NextRouter } from '../shared/lib/router/router'
 import { RouterContext } from '../shared/lib/router-context'
 import isError from '../lib/is-error'
 
-type ClassArguments<T> = T extends new (...args: infer U) => any ? U : any
-
-type RouterArgs = ClassArguments<typeof Router>
-
 type SingletonRouterBase = {
   router: Router | null
   readyCallbacks: Array<() => any>
@@ -141,10 +137,9 @@ export function useRouter(): NextRouter {
 // -------------
 // (do not use following exports inside the app)
 
-// Create a router and assign it as the singleton instance.
-// This is used in client side when we are initializing the app.
-// This should **not** be used inside the server.
-export function createRouter(...args: RouterArgs): Router {
+export function createRouter(
+  ...args: ConstructorParameters<typeof Router>
+): Router {
   singletonRouter.router = new Router(...args)
   singletonRouter.readyCallbacks.forEach((cb) => cb())
   singletonRouter.readyCallbacks = []

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "ES2017",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "stripInternal": true
   },
   "exclude": ["dist", "./*.d.ts", "future/*.d.ts", "image-types/global.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "amp-test-utils": ["test/lib/amp-test-utils"],
       "next-webdriver": ["test/lib/next-webdriver"],
       "e2e-utils": ["test/lib/e2e-utils"]
-    }
+    },
+    "stripInternal": true
   },
   "include": [
     "test/jest.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,7 @@
       "amp-test-utils": ["test/lib/amp-test-utils"],
       "next-webdriver": ["test/lib/next-webdriver"],
       "e2e-utils": ["test/lib/e2e-utils"]
-    },
-    "stripInternal": true
+    }
   },
   "include": [
     "test/jest.d.ts",


### PR DESCRIPTION
I noticed our internal comments about exported functions that should not be used in application code.

TSDoc has the [`@internal`](https://tsdoc.org/pages/tags/internal/) option that can be used together with TS's [`stripInternal: true` compiler option](https://www.typescriptlang.org/tsconfig/#stripInternal), hiding these from inferred types:

Before:
![image](https://user-images.githubusercontent.com/18369201/180011847-5d754629-e2f6-4fef-ab18-916174ef006d.png)
After:
![image](https://user-images.githubusercontent.com/18369201/180011951-ee8b1a9d-f0a7-4603-9532-d0e6b08f5ac8.png)

It would also be great to use `/**/` comments instead of `//` when documenting methods/properties/functions, as these can be picked up by the editor when referring to these, so someone new to the codebase will hopefully have to jump around less to get some useful comments.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
