### PR TITLE
test: disable the rsc flaky test temporarily

### DIFF
--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -360,7 +360,8 @@ describe('app dir - react server components', () => {
     )
   })
 
-  it('should support partial hydration with inlined server data in browser', async () => {
+  // disable this flaky test
+  it.skip('should support partial hydration with inlined server data in browser', async () => {
     // Should end up with "next_streaming_data".
     const browser = await webdriver(next.url, '/partial-hydration', {
       waitHydration: false,


### PR DESCRIPTION
disable flaky test for now. the page cache wasn't busted on the 2nd visit

x-ref: https://github.com/vercel/next.js/runs/7433146709?check_suite_focus=true
