### PR TITLE
Improve `next/image` error message when `src` prop is missing

### DIFF
--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -375,21 +375,9 @@ export default function Image({
 
   if (process.env.NODE_ENV !== 'production') {
     if (!src) {
-      // React doesn't show the stack trace and there's no `src` to help identify which image,
-      // so we instead embed the error message into the image.
-      console.warn(
-        `Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
-          { width, height, quality, className, style }
-        )}`
-      )
-      const msg = `Missing \`src\` prop`
-      widthInt = Math.max(widthInt || 0, 200)
-      heightInt = Math.max(heightInt || 0, 200)
-      src =
-        'data:image/svg+xml;charset=utf-8,' +
-        encodeURIComponent(
-          `<svg xmlns="http://www.w3.org/2000/svg" width="${widthInt}" height="${heightInt}"><rect x="0" y="0" width="${widthInt}" height="${heightInt}" fill="red"/><text fill="#FFF" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">${msg}</text></svg>`
-        )
+      // React doesn't show the stack trace and there's
+      // no `src` to help identify which image, so we
+      // instead console.error(ref) during mount.
       unoptimized = true
     } else {
       if (typeof widthInt === 'undefined') {
@@ -663,6 +651,11 @@ const ImageElement = ({
         style={{ ...imgStyle, ...blurStyle }}
         ref={useCallback(
           (img: ImgElementWithDataProp) => {
+            if (process.env.NODE_ENV !== 'production') {
+              if (img && !srcString) {
+                console.error(`Image is missing required "src" property:`, img)
+              }
+            }
             if (img?.complete) {
               handleLoading(
                 img,

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -357,10 +357,6 @@ export default function Image({
   }
   src = typeof src === 'string' ? src : staticSrc
 
-  const widthInt = getInt(width)
-  const heightInt = getInt(height)
-  const qualityInt = getInt(quality)
-
   let isLazy =
     !priority && (loading === 'lazy' || typeof loading === 'undefined')
   if (src.startsWith('data:') || src.startsWith('blob:')) {
@@ -373,136 +369,151 @@ export default function Image({
   }
 
   const [blurComplete, setBlurComplete] = useState(false)
+  let widthInt = getInt(width)
+  let heightInt = getInt(height)
+  const qualityInt = getInt(quality)
 
   if (process.env.NODE_ENV !== 'production') {
     if (!src) {
-      throw new Error(
+      // Since react doesn't show the stack trace and we don't have a `src` to help identify the image with the error,
+      // we instead render an image with the error message embedded into the image
+      console.warn(
         `Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
-          { width, height, quality }
+          { width, height, quality, className, style }
         )}`
       )
-    }
-    if (typeof widthInt === 'undefined') {
-      throw new Error(
-        `Image with src "${src}" is missing required "width" property.`
-      )
-    } else if (isNaN(widthInt)) {
-      throw new Error(
-        `Image with src "${src}" has invalid "width" property. Expected a numeric value in pixels but received "${width}".`
-      )
-    }
-    if (typeof heightInt === 'undefined') {
-      throw new Error(
-        `Image with src "${src}" is missing required "height" property.`
-      )
-    } else if (isNaN(heightInt)) {
-      throw new Error(
-        `Image with src "${src}" has invalid "height" property. Expected a numeric value in pixels but received "${height}".`
-      )
-    }
-    if (!VALID_LOADING_VALUES.includes(loading)) {
-      throw new Error(
-        `Image with src "${src}" has invalid "loading" property. Provided "${loading}" should be one of ${VALID_LOADING_VALUES.map(
-          String
-        ).join(',')}.`
-      )
-    }
-    if (priority && loading === 'lazy') {
-      throw new Error(
-        `Image with src "${src}" has both "priority" and "loading='lazy'" properties. Only one should be used.`
-      )
-    }
-
-    if ('objectFit' in rest) {
-      throw new Error(
-        `Image with src "${src}" has unknown prop "objectFit". This style should be specified using the "style" attribute.`
-      )
-    }
-    if ('objectPosition' in rest) {
-      throw new Error(
-        `Image with src "${src}" has unknown prop "objectPosition". This style should be specified using the "style" attribute.`
-      )
-    }
-
-    if (placeholder === 'blur') {
-      if ((widthInt || 0) * (heightInt || 0) < 1600) {
-        warnOnce(
-          `Image with src "${src}" is smaller than 40x40. Consider removing the "placeholder='blur'" property to improve performance.`
+      const msg = `Missing \`src\` prop`
+      widthInt = widthInt || 200
+      heightInt = heightInt || 200
+      src =
+        'data:image/svg+xml;charset=utf-8,' +
+        encodeURIComponent(
+          `<svg xmlns="http://www.w3.org/2000/svg" width="${widthInt}" height="${heightInt}"><rect x="0" y="0" width="${widthInt}" height="${heightInt}" fill="red"/><text fill="#FFF" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">${msg}</text></svg>`
         )
-      }
-      if (!blurDataURL) {
-        const VALID_BLUR_EXT = ['jpeg', 'png', 'webp', 'avif'] // should match next-image-loader
-
+      unoptimized = true
+    } else {
+      if (typeof widthInt === 'undefined') {
         throw new Error(
-          `Image with src "${src}" has "placeholder='blur'" property but is missing the "blurDataURL" property.
-          Possible solutions:
-            - Add a "blurDataURL" property, the contents should be a small Data URL to represent the image
-            - Change the "src" property to a static import with one of the supported file types: ${VALID_BLUR_EXT.join(
-              ','
-            )}
-            - Remove the "placeholder" property, effectively no blur effect
-          Read more: https://nextjs.org/docs/messages/placeholder-blur-data-url`
+          `Image with src "${src}" is missing required "width" property.`
+        )
+      } else if (isNaN(widthInt)) {
+        throw new Error(
+          `Image with src "${src}" has invalid "width" property. Expected a numeric value in pixels but received "${width}".`
         )
       }
-    }
-    if ('ref' in rest) {
-      warnOnce(
-        `Image with src "${src}" is using unsupported "ref" property. Consider using the "onLoadingComplete" property instead.`
-      )
-    }
-
-    if (!unoptimized && loader !== defaultLoader) {
-      const urlStr = loader({
-        config,
-        src,
-        width: widthInt || 400,
-        quality: qualityInt || 75,
-      })
-      let url: URL | undefined
-      try {
-        url = new URL(urlStr)
-      } catch (err) {}
-      if (urlStr === src || (url && url.pathname === src && !url.search)) {
-        warnOnce(
-          `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.` +
-            `\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader-width`
+      if (typeof heightInt === 'undefined') {
+        throw new Error(
+          `Image with src "${src}" is missing required "height" property.`
+        )
+      } else if (isNaN(heightInt)) {
+        throw new Error(
+          `Image with src "${src}" has invalid "height" property. Expected a numeric value in pixels but received "${height}".`
         )
       }
-    }
+      if (!VALID_LOADING_VALUES.includes(loading)) {
+        throw new Error(
+          `Image with src "${src}" has invalid "loading" property. Provided "${loading}" should be one of ${VALID_LOADING_VALUES.map(
+            String
+          ).join(',')}.`
+        )
+      }
+      if (priority && loading === 'lazy') {
+        throw new Error(
+          `Image with src "${src}" has both "priority" and "loading='lazy'" properties. Only one should be used.`
+        )
+      }
 
-    if (
-      typeof window !== 'undefined' &&
-      !perfObserver &&
-      window.PerformanceObserver
-    ) {
-      perfObserver = new PerformanceObserver((entryList) => {
-        for (const entry of entryList.getEntries()) {
-          // @ts-ignore - missing "LargestContentfulPaint" class with "element" prop
-          const imgSrc = entry?.element?.src || ''
-          const lcpImage = allImgs.get(imgSrc)
-          if (
-            lcpImage &&
-            !lcpImage.priority &&
-            lcpImage.placeholder !== 'blur' &&
-            !lcpImage.src.startsWith('data:') &&
-            !lcpImage.src.startsWith('blob:')
-          ) {
-            // https://web.dev/lcp/#measure-lcp-in-javascript
-            warnOnce(
-              `Image with src "${lcpImage.src}" was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.` +
-                `\nRead more: https://nextjs.org/docs/api-reference/next/image#priority`
-            )
-          }
+      if ('objectFit' in rest) {
+        throw new Error(
+          `Image with src "${src}" has unknown prop "objectFit". This style should be specified using the "style" attribute.`
+        )
+      }
+      if ('objectPosition' in rest) {
+        throw new Error(
+          `Image with src "${src}" has unknown prop "objectPosition". This style should be specified using the "style" attribute.`
+        )
+      }
+
+      if (placeholder === 'blur') {
+        if ((widthInt || 0) * (heightInt || 0) < 1600) {
+          warnOnce(
+            `Image with src "${src}" is smaller than 40x40. Consider removing the "placeholder='blur'" property to improve performance.`
+          )
         }
-      })
-      try {
-        perfObserver.observe({
-          type: 'largest-contentful-paint',
-          buffered: true,
+        if (!blurDataURL) {
+          const VALID_BLUR_EXT = ['jpeg', 'png', 'webp', 'avif'] // should match next-image-loader
+
+          throw new Error(
+            `Image with src "${src}" has "placeholder='blur'" property but is missing the "blurDataURL" property.
+            Possible solutions:
+              - Add a "blurDataURL" property, the contents should be a small Data URL to represent the image
+              - Change the "src" property to a static import with one of the supported file types: ${VALID_BLUR_EXT.join(
+                ','
+              )}
+              - Remove the "placeholder" property, effectively no blur effect
+            Read more: https://nextjs.org/docs/messages/placeholder-blur-data-url`
+          )
+        }
+      }
+      if ('ref' in rest) {
+        warnOnce(
+          `Image with src "${src}" is using unsupported "ref" property. Consider using the "onLoadingComplete" property instead.`
+        )
+      }
+
+      if (!unoptimized && loader !== defaultLoader) {
+        const urlStr = loader({
+          config,
+          src,
+          width: widthInt || 400,
+          quality: qualityInt || 75,
         })
-      } catch (err) {
-        // Log error but don't crash the app
-        console.error(err)
+        let url: URL | undefined
+        try {
+          url = new URL(urlStr)
+        } catch (err) {}
+        if (urlStr === src || (url && url.pathname === src && !url.search)) {
+          warnOnce(
+            `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.` +
+              `\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader-width`
+          )
+        }
+      }
+
+      if (
+        typeof window !== 'undefined' &&
+        !perfObserver &&
+        window.PerformanceObserver
+      ) {
+        perfObserver = new PerformanceObserver((entryList) => {
+          for (const entry of entryList.getEntries()) {
+            // @ts-ignore - missing "LargestContentfulPaint" class with "element" prop
+            const imgSrc = entry?.element?.src || ''
+            const lcpImage = allImgs.get(imgSrc)
+            if (
+              lcpImage &&
+              !lcpImage.priority &&
+              lcpImage.placeholder !== 'blur' &&
+              !lcpImage.src.startsWith('data:') &&
+              !lcpImage.src.startsWith('blob:')
+            ) {
+              // https://web.dev/lcp/#measure-lcp-in-javascript
+              warnOnce(
+                `Image with src "${lcpImage.src}" was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.` +
+                  `\nRead more: https://nextjs.org/docs/api-reference/next/image#priority`
+              )
+            }
+          }
+        })
+        try {
+          perfObserver.observe({
+            type: 'largest-contentful-paint',
+            buffered: true,
+          })
+        } catch (err) {
+          // Log error but don't crash the app
+          console.error(err)
+        }
       }
     }
   }

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -375,16 +375,16 @@ export default function Image({
 
   if (process.env.NODE_ENV !== 'production') {
     if (!src) {
-      // Since react doesn't show the stack trace and we don't have a `src` to help identify the image with the error,
-      // we instead render an image with the error message embedded into the image
+      // React doesn't show the stack trace and there's no `src` to help identify which image,
+      // so we instead embed the error message into the image.
       console.warn(
         `Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
           { width, height, quality, className, style }
         )}`
       )
       const msg = `Missing \`src\` prop`
-      widthInt = widthInt || 200
-      heightInt = heightInt || 200
+      widthInt = Math.max(widthInt || 0, 200)
+      heightInt = Math.max(heightInt || 0, 200)
       src =
         'data:image/svg+xml;charset=utf-8,' +
         encodeURIComponent(

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -429,10 +429,6 @@ export default function Image({
   }
   src = typeof src === 'string' ? src : staticSrc
 
-  const widthInt = getInt(width)
-  const heightInt = getInt(height)
-  const qualityInt = getInt(quality)
-
   let isLazy =
     !priority && (loading === 'lazy' || typeof loading === 'undefined')
   if (src.startsWith('data:') || src.startsWith('blob:')) {
@@ -505,68 +501,83 @@ export default function Image({
     objectPosition,
   }
 
+  let widthInt = getInt(width)
+  let heightInt = getInt(height)
+  const qualityInt = getInt(quality)
+
   if (process.env.NODE_ENV !== 'production') {
     if (!src) {
-      throw new Error(
+      // Since react doesn't show the stack trace and we don't have a `src` to help identify the image with the error,
+      // we instead render an image with the error message embedded into the image
+      console.warn(
         `Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
-          { width, height, quality }
+          { width, height, quality, className, style }
         )}`
       )
-    }
-    if (!VALID_LAYOUT_VALUES.includes(layout)) {
-      if ((layout as any) === 'raw') {
+      const msg = `Missing \`src\` prop`
+      widthInt = widthInt || 200
+      heightInt = heightInt || 200
+      src =
+        'data:image/svg+xml;charset=utf-8,' +
+        encodeURIComponent(
+          `<svg xmlns="http://www.w3.org/2000/svg" width="${widthInt}" height="${heightInt}"><rect x="0" y="0" width="${widthInt}" height="${heightInt}" fill="red"/><text fill="#FFF" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">${msg}</text></svg>`
+        )
+      unoptimized = true
+    } else {
+      if (!VALID_LAYOUT_VALUES.includes(layout)) {
+        if ((layout as any) === 'raw') {
+          throw new Error(
+            `The layout="raw" experiment has been moved to a new module. Please import \`next/future/image\` instead.`
+          )
+        }
         throw new Error(
-          `The layout="raw" experiment has been moved to a new module. Please import \`next/future/image\` instead.`
+          `Image with src "${src}" has invalid "layout" property. Provided "${layout}" should be one of ${VALID_LAYOUT_VALUES.map(
+            String
+          ).join(',')}.`
         )
       }
-      throw new Error(
-        `Image with src "${src}" has invalid "layout" property. Provided "${layout}" should be one of ${VALID_LAYOUT_VALUES.map(
-          String
-        ).join(',')}.`
-      )
-    }
 
-    if (
-      (typeof widthInt !== 'undefined' && isNaN(widthInt)) ||
-      (typeof heightInt !== 'undefined' && isNaN(heightInt))
-    ) {
-      throw new Error(
-        `Image with src "${src}" has invalid "width" or "height" property. These should be numeric values.`
-      )
-    }
-    if (layout === 'fill' && (width || height)) {
-      warnOnce(
-        `Image with src "${src}" and "layout='fill'" has unused properties assigned. Please remove "width" and "height".`
-      )
-    }
-    if (!VALID_LOADING_VALUES.includes(loading)) {
-      throw new Error(
-        `Image with src "${src}" has invalid "loading" property. Provided "${loading}" should be one of ${VALID_LOADING_VALUES.map(
-          String
-        ).join(',')}.`
-      )
-    }
-    if (priority && loading === 'lazy') {
-      throw new Error(
-        `Image with src "${src}" has both "priority" and "loading='lazy'" properties. Only one should be used.`
-      )
-    }
-    if (sizes && layout !== 'fill' && layout !== 'responsive') {
-      warnOnce(
-        `Image with src "${src}" has "sizes" property but it will be ignored. Only use "sizes" with "layout='fill'" or "layout='responsive'"`
-      )
-    }
-    if (placeholder === 'blur') {
-      if (layout !== 'fill' && (widthInt || 0) * (heightInt || 0) < 1600) {
+      if (
+        (typeof widthInt !== 'undefined' && isNaN(widthInt)) ||
+        (typeof heightInt !== 'undefined' && isNaN(heightInt))
+      ) {
+        throw new Error(
+          `Image with src "${src}" has invalid "width" or "height" property. These should be numeric values.`
+        )
+      }
+      if (layout === 'fill' && (width || height)) {
         warnOnce(
-          `Image with src "${src}" is smaller than 40x40. Consider removing the "placeholder='blur'" property to improve performance.`
+          `Image with src "${src}" and "layout='fill'" has unused properties assigned. Please remove "width" and "height".`
         )
       }
-      if (!blurDataURL) {
-        const VALID_BLUR_EXT = ['jpeg', 'png', 'webp', 'avif'] // should match next-image-loader
-
+      if (!VALID_LOADING_VALUES.includes(loading)) {
         throw new Error(
-          `Image with src "${src}" has "placeholder='blur'" property but is missing the "blurDataURL" property.
+          `Image with src "${src}" has invalid "loading" property. Provided "${loading}" should be one of ${VALID_LOADING_VALUES.map(
+            String
+          ).join(',')}.`
+        )
+      }
+      if (priority && loading === 'lazy') {
+        throw new Error(
+          `Image with src "${src}" has both "priority" and "loading='lazy'" properties. Only one should be used.`
+        )
+      }
+      if (sizes && layout !== 'fill' && layout !== 'responsive') {
+        warnOnce(
+          `Image with src "${src}" has "sizes" property but it will be ignored. Only use "sizes" with "layout='fill'" or "layout='responsive'"`
+        )
+      }
+      if (placeholder === 'blur') {
+        if (layout !== 'fill' && (widthInt || 0) * (heightInt || 0) < 1600) {
+          warnOnce(
+            `Image with src "${src}" is smaller than 40x40. Consider removing the "placeholder='blur'" property to improve performance.`
+          )
+        }
+        if (!blurDataURL) {
+          const VALID_BLUR_EXT = ['jpeg', 'png', 'webp', 'avif'] // should match next-image-loader
+
+          throw new Error(
+            `Image with src "${src}" has "placeholder='blur'" property but is missing the "blurDataURL" property.
           Possible solutions:
             - Add a "blurDataURL" property, the contents should be a small Data URL to represent the image
             - Change the "src" property to a static import with one of the supported file types: ${VALID_BLUR_EXT.join(
@@ -574,80 +585,81 @@ export default function Image({
             )}
             - Remove the "placeholder" property, effectively no blur effect
           Read more: https://nextjs.org/docs/messages/placeholder-blur-data-url`
-        )
-      }
-    }
-    if ('ref' in rest) {
-      warnOnce(
-        `Image with src "${src}" is using unsupported "ref" property. Consider using the "onLoadingComplete" property instead.`
-      )
-    }
-
-    if (!unoptimized && loader !== defaultImageLoader) {
-      const urlStr = loader({
-        config,
-        src,
-        width: widthInt || 400,
-        quality: qualityInt || 75,
-      })
-      let url: URL | undefined
-      try {
-        url = new URL(urlStr)
-      } catch (err) {}
-      if (urlStr === src || (url && url.pathname === src && !url.search)) {
-        warnOnce(
-          `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.` +
-            `\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader-width`
-        )
-      }
-    }
-
-    if (style) {
-      let overwrittenStyles = Object.keys(style).filter(
-        (key) => key in layoutStyle
-      )
-      if (overwrittenStyles.length) {
-        warnOnce(
-          `Image with src ${src} is assigned the following styles, which are overwritten by automatically-generated styles: ${overwrittenStyles.join(
-            ', '
-          )}`
-        )
-      }
-    }
-
-    if (
-      typeof window !== 'undefined' &&
-      !perfObserver &&
-      window.PerformanceObserver
-    ) {
-      perfObserver = new PerformanceObserver((entryList) => {
-        for (const entry of entryList.getEntries()) {
-          // @ts-ignore - missing "LargestContentfulPaint" class with "element" prop
-          const imgSrc = entry?.element?.src || ''
-          const lcpImage = allImgs.get(imgSrc)
-          if (
-            lcpImage &&
-            !lcpImage.priority &&
-            lcpImage.placeholder !== 'blur' &&
-            !lcpImage.src.startsWith('data:') &&
-            !lcpImage.src.startsWith('blob:')
-          ) {
-            // https://web.dev/lcp/#measure-lcp-in-javascript
-            warnOnce(
-              `Image with src "${lcpImage.src}" was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.` +
-                `\nRead more: https://nextjs.org/docs/api-reference/next/image#priority`
-            )
-          }
+          )
         }
-      })
-      try {
-        perfObserver.observe({
-          type: 'largest-contentful-paint',
-          buffered: true,
+      }
+      if ('ref' in rest) {
+        warnOnce(
+          `Image with src "${src}" is using unsupported "ref" property. Consider using the "onLoadingComplete" property instead.`
+        )
+      }
+
+      if (!unoptimized && loader !== defaultImageLoader) {
+        const urlStr = loader({
+          config,
+          src,
+          width: widthInt || 400,
+          quality: qualityInt || 75,
         })
-      } catch (err) {
-        // Log error but don't crash the app
-        console.error(err)
+        let url: URL | undefined
+        try {
+          url = new URL(urlStr)
+        } catch (err) {}
+        if (urlStr === src || (url && url.pathname === src && !url.search)) {
+          warnOnce(
+            `Image with src "${src}" has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.` +
+              `\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader-width`
+          )
+        }
+      }
+
+      if (style) {
+        let overwrittenStyles = Object.keys(style).filter(
+          (key) => key in layoutStyle
+        )
+        if (overwrittenStyles.length) {
+          warnOnce(
+            `Image with src ${src} is assigned the following styles, which are overwritten by automatically-generated styles: ${overwrittenStyles.join(
+              ', '
+            )}`
+          )
+        }
+      }
+
+      if (
+        typeof window !== 'undefined' &&
+        !perfObserver &&
+        window.PerformanceObserver
+      ) {
+        perfObserver = new PerformanceObserver((entryList) => {
+          for (const entry of entryList.getEntries()) {
+            // @ts-ignore - missing "LargestContentfulPaint" class with "element" prop
+            const imgSrc = entry?.element?.src || ''
+            const lcpImage = allImgs.get(imgSrc)
+            if (
+              lcpImage &&
+              !lcpImage.priority &&
+              lcpImage.placeholder !== 'blur' &&
+              !lcpImage.src.startsWith('data:') &&
+              !lcpImage.src.startsWith('blob:')
+            ) {
+              // https://web.dev/lcp/#measure-lcp-in-javascript
+              warnOnce(
+                `Image with src "${lcpImage.src}" was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.` +
+                  `\nRead more: https://nextjs.org/docs/api-reference/next/image#priority`
+              )
+            }
+          }
+        })
+        try {
+          perfObserver.observe({
+            type: 'largest-contentful-paint',
+            buffered: true,
+          })
+        } catch (err) {
+          // Log error but don't crash the app
+          console.error(err)
+        }
       }
     }
   }

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -507,21 +507,11 @@ export default function Image({
 
   if (process.env.NODE_ENV !== 'production') {
     if (!src) {
-      // React doesn't show the stack trace and there's no `src` to help identify which image,
-      // so we instead embed the error message into the image.
-      console.warn(
-        `Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
-          { width, height, quality, className, style }
-        )}`
-      )
-      const msg = `Missing \`src\` prop`
-      widthInt = Math.max(widthInt || 0, 200)
-      heightInt = Math.max(heightInt || 0, 200)
-      src =
-        'data:image/svg+xml;charset=utf-8,' +
-        encodeURIComponent(
-          `<svg xmlns="http://www.w3.org/2000/svg" width="${widthInt}" height="${heightInt}"><rect x="0" y="0" width="${widthInt}" height="${heightInt}" fill="red"/><text fill="#FFF" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">${msg}</text></svg>`
-        )
+      // React doesn't show the stack trace and there's
+      // no `src` to help identify which image, so we
+      // instead console.error(ref) during mount.
+      widthInt = widthInt || 1
+      heightInt = heightInt || 1
       unoptimized = true
     } else {
       if (!VALID_LAYOUT_VALUES.includes(layout)) {
@@ -893,6 +883,11 @@ const ImageElement = ({
         style={{ ...imgStyle, ...blurStyle }}
         ref={useCallback(
           (img: ImgElementWithDataProp) => {
+            if (process.env.NODE_ENV !== 'production') {
+              if (img && !srcString) {
+                console.error(`Image is missing required "src" property:`, img)
+              }
+            }
             setIntersection(img)
             if (img?.complete) {
               handleLoading(

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -507,16 +507,16 @@ export default function Image({
 
   if (process.env.NODE_ENV !== 'production') {
     if (!src) {
-      // Since react doesn't show the stack trace and we don't have a `src` to help identify the image with the error,
-      // we instead render an image with the error message embedded into the image
+      // React doesn't show the stack trace and there's no `src` to help identify which image,
+      // so we instead embed the error message into the image.
       console.warn(
         `Image is missing required "src" property. Make sure you pass "src" in props to the \`next/image\` component. Received: ${JSON.stringify(
           { width, height, quality, className, style }
         )}`
       )
       const msg = `Missing \`src\` prop`
-      widthInt = widthInt || 200
-      heightInt = heightInt || 200
+      widthInt = Math.max(widthInt || 0, 200)
+      heightInt = Math.max(heightInt || 0, 200)
       src =
         'data:image/svg+xml;charset=utf-8,' +
         encodeURIComponent(

--- a/test/integration/image-component/base-path/test/index.test.js
+++ b/test/integration/image-component/base-path/test/index.test.js
@@ -386,10 +386,13 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/docs/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
-      expect(await getRedboxHeader(browser)).toContain(
-        'Image is missing required "src" property. Make sure you pass "src" in props to the `next/image` component. Received: {"width":200}'
-      )
+      expect(await hasRedbox(browser)).toBe(false)
+
+      await check(async () => {
+        return (await browser.log('browser'))
+          .map((log) => log.message)
+          .join('\n')
+      }, /Image is missing required "src" property/gm)
     })
 
     it('should show invalid src error', async () => {

--- a/test/integration/image-component/default/test/index.test.js
+++ b/test/integration/image-component/default/test/index.test.js
@@ -746,10 +746,13 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
-      expect(await getRedboxHeader(browser)).toContain(
-        'Image is missing required "src" property. Make sure you pass "src" in props to the `next/image` component. Received: {"width":200}'
-      )
+      expect(await hasRedbox(browser)).toBe(false)
+
+      await check(async () => {
+        return (await browser.log('browser'))
+          .map((log) => log.message)
+          .join('\n')
+      }, /Image is missing required "src" property/gm)
     })
 
     it('should show invalid src error', async () => {

--- a/test/integration/image-future/base-path/test/index.test.js
+++ b/test/integration/image-future/base-path/test/index.test.js
@@ -130,10 +130,13 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/docs/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
-      expect(await getRedboxHeader(browser)).toContain(
-        'Image is missing required "src" property. Make sure you pass "src" in props to the `next/image` component. Received: {"width":200}'
-      )
+      expect(await hasRedbox(browser)).toBe(false)
+
+      await check(async () => {
+        return (await browser.log('browser'))
+          .map((log) => log.message)
+          .join('\n')
+      }, /Image is missing required "src" property/gm)
     })
 
     it('should show invalid src error', async () => {

--- a/test/integration/image-future/default/test/index.test.js
+++ b/test/integration/image-future/default/test/index.test.js
@@ -605,10 +605,13 @@ function runTests(mode) {
     it('should show missing src error', async () => {
       const browser = await webdriver(appPort, '/missing-src')
 
-      expect(await hasRedbox(browser)).toBe(true)
-      expect(await getRedboxHeader(browser)).toContain(
-        'Image is missing required "src" property. Make sure you pass "src" in props to the `next/image` component. Received: {"width":200}'
-      )
+      expect(await hasRedbox(browser)).toBe(false)
+
+      await check(async () => {
+        return (await browser.log('browser'))
+          .map((log) => log.message)
+          .join('\n')
+      }, /Image is missing required "src" property/gm)
     })
 
     it('should show invalid src error', async () => {


### PR DESCRIPTION
Currently, when a user forgets the `src` prop on an image, an error is thrown. However that error doesn't include any of the the user's code in the stack trace, so its nearly impossible to figure out which image is the culprit if there are multiple images on the page.

Since this error only throws on demand when a page is visited during `next dev`, we can instead delay the error so it no longer prints on the server but prints on mount instead. At that point, we'll have the `<img>` element via ref and can print it to the web console with the stack trace.

- Fixes #23742 