### PR TITLE
Update edge blob asset e2e test

### DIFF
--- a/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
+++ b/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
@@ -9,6 +9,12 @@ import type { MiddlewareManifest } from 'next/build/webpack/plugins/middleware-p
 describe('Edge Compiler can import asset assets', () => {
   let next: NextInstance
 
+  // TODO: remove after this is supported for deploy
+  if ((global as any).isNextDeploy) {
+    it('should skip for deploy for now', () => {})
+    return
+  }
+
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, './app')),


### PR DESCRIPTION
This test isn't yet expected to work on deploy so this skips it for now. 

x-ref: https://github.com/vercel/next.js/runs/7439533482?check_suite_focus=true

