### PR TITLE
ci: dropping macos-10.15

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1441,7 +1441,7 @@ jobs:
     if: ${{ needs.build.outputs.isRelease == 'true' }}
     needs: build
     name: stable - x86_64-unknown-freebsd - node@16
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: tune mac network
         run: sudo sysctl -w net.link.generic.system.hwcksum_tx=0 && sudo sysctl -w net.link.generic.system.hwcksum_rx=0
@@ -1456,7 +1456,7 @@ jobs:
           rm -rf test
       - name: Build
         id: build
-        uses: vmactions/freebsd-vm@v0.1.6
+        uses: vmactions/freebsd-vm@v0.2.0
         env:
           DEBUG: napi:*
           RUSTUP_HOME: /usr/local/rustup


### PR DESCRIPTION
GitHub Action is sunsetting the `macos-10.15` runner and it will be removed by 8/30/22: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

Next.js only uses `macos-10.15` for building the freebsd version of the `next-swc` binary, and I have checked [`vmactions/freebsd-vm`](https://github.com/vmactions/freebsd-vm) does support `macos-12` (which requires `vmactions/freebsd-vm@0.2.0`).

I have updated the `runs-on` to `macos-12` and bumped `vmactions/freebsd-vm` to `0.2.0` in the PR.