### PR TITLE
fix: respond with 405 to page requests in `next dev`

### DIFF
--- a/test/e2e/page-respond-with-405-on-post/index.test.ts
+++ b/test/e2e/page-respond-with-405-on-post/index.test.ts
@@ -1,0 +1,24 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { fetchViaHTTP } from 'next-test-utils'
+
+describe('Page respond with 405 on POST', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.js': 'export default function Page() {}',
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should work', async () => {
+    const res = await fetchViaHTTP(next.url, '/', undefined, {
+      method: 'POST',
+    })
+    expect(res.status).toBe(405)
+  })
+})

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -113,6 +113,13 @@ export function renderViaHTTP(appPort, pathname, query, opts) {
   return fetchViaHTTP(appPort, pathname, query, opts).then((res) => res.text())
 }
 
+/**
+ * @param {number|string} appPort
+ * @param {string} [pathname]
+ * @param {string} [query]
+ * @param {RequestInit} opts
+ * @returns {Response}
+ */
 export function fetchViaHTTP(appPort, pathname, query, opts) {
   const url = `${pathname}${
     typeof query === 'string' ? query : query ? `?${qs.stringify(query)}` : ''

--- a/test/lib/next-test-utils.js
+++ b/test/lib/next-test-utils.js
@@ -117,7 +117,7 @@ export function renderViaHTTP(appPort, pathname, query, opts) {
  * @param {number|string} appPort
  * @param {string} [pathname]
  * @param {string} [query]
- * @param {RequestInit} opts
+ * @param {RequestInit} [opts]
  * @returns {Response}
  */
 export function fetchViaHTTP(appPort, pathname, query, opts) {


### PR DESCRIPTION
Fixes #38863

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
