### PR TITLE
Remove assertion in RouterContext

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -7,7 +7,6 @@ import {
   resolveHref,
 } from '../shared/lib/router/router'
 import { addLocale } from './add-locale'
-import { RouterContext } from '../shared/lib/router-context'
 import {
   AppRouterContext,
   AppRouterInstance,
@@ -15,6 +14,7 @@ import {
 import { useIntersection } from './use-intersection'
 import { getDomainLocale } from './get-domain-locale'
 import { addBasePath } from './add-base-path'
+import { useRouter } from './router'
 
 // @ts-ignore useTransition exist
 const hasUseTransition = typeof React.useTransition !== 'undefined'
@@ -317,7 +317,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
         // eslint-disable-next-line react-hooks/rules-of-hooks
         React.useTransition()
       : []
-    let router = React.useContext(RouterContext)
+    let router = useRouter()
 
     // TODO-APP: type error. Remove `as any`
     const appRouter = React.useContext(AppRouterContext) as any

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -130,7 +130,11 @@ export default singletonRouter as SingletonRouter
 export { default as withRouter } from './with-router'
 
 export function useRouter(): NextRouter {
-  return React.useContext(RouterContext)
+  const router = React.useContext(RouterContext)
+  if (router === null) {
+    throw Error('Cannot find RouterProvider')
+  }
+  return router
 }
 
 // INTERNAL APIS

--- a/packages/next/shared/lib/router-context.ts
+++ b/packages/next/shared/lib/router-context.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { NextRouter } from './router/router'
 
-export const RouterContext = React.createContext<NextRouter>(null as any)
+export const RouterContext = React.createContext<NextRouter | null>(null)
 
 if (process.env.NODE_ENV !== 'production') {
   RouterContext.displayName = 'RouterContext'

--- a/test/unit/link-rendering.test.ts
+++ b/test/unit/link-rendering.test.ts
@@ -2,15 +2,21 @@
 import React from 'react'
 import ReactDOM from 'react-dom/server'
 import Link from 'next/link'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import { NextRouter } from 'next/dist/shared/lib/router/router'
 
 describe('Link rendering', () => {
   it('should render Link on its own', async () => {
     const element = React.createElement(
-      Link,
-      {
-        href: '/my-path',
-      },
-      React.createElement('a', {}, 'to another page')
+      RouterContext.Provider,
+      { value: {} as NextRouter },
+      React.createElement(
+        Link,
+        {
+          href: '/my-path',
+        },
+        React.createElement('a', {}, 'to another page')
+      )
     )
     const html = ReactDOM.renderToString(element)
     expect(html).toMatchInlineSnapshot(


### PR DESCRIPTION
remove null as any assertion in RouterContext to prevent misuse.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
