### PR TITLE
fix: correct the next config optimizeCss type

### DIFF
--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -333,7 +333,14 @@ const configSchema = {
           type: 'boolean',
         },
         optimizeCss: {
-          type: 'boolean',
+          oneOf: [
+            {
+              type: 'boolean',
+            },
+            {
+              type: 'object',
+            },
+          ] as any,
         },
         outputFileTracingRoot: {
           minLength: 1,

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -94,7 +94,10 @@ export interface ExperimentalConfig {
   isrFlushToDisk?: boolean
   workerThreads?: boolean
   pageEnv?: boolean
-  optimizeCss?: boolean
+  // optimizeCss can be boolean or critters' option object
+  // Use Record<string, unknown> as critters doesn't export its Option type
+  // https://github.com/GoogleChromeLabs/critters/blob/a590c05f9197b656d2aeaae9369df2483c26b072/packages/critters/src/index.d.ts
+  optimizeCss?: boolean | Record<string, unknown>
   nextScriptWorkers?: boolean
   scrollRestoration?: boolean
   externalDir?: boolean


### PR DESCRIPTION
`experimental.optimizeCss` from `next.config.js` can be an object containing the critters' option:

https://github.com/vercel/next.js/blob/70a53e0789c7e361f12139db6e124a5bb1d2afd9/packages/next/server/post-process.ts#L224-L232

The PR corrects the ajv schema and the type definition of `experimental.optimizeCss`.