### PR TITLE
Update nullish router to use optional operator

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -83,7 +83,7 @@ function prefetch(
   const curLocale =
     options && typeof options.locale !== 'undefined'
       ? options.locale
-      : router && router.locale
+      : router?.locale
 
   // Join on an invalid URI character
   prefetched[href + '%' + as + (curLocale ? '%' + curLocale : '')] = true
@@ -399,8 +399,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     )
     React.useEffect(() => {
       const shouldPrefetch = isVisible && p && isLocalURL(href)
-      const curLocale =
-        typeof locale !== 'undefined' ? locale : router && router.locale
+      const curLocale = typeof locale !== 'undefined' ? locale : router?.locale
       const isPrefetched =
         prefetched[href + '%' + as + (curLocale ? '%' + curLocale : '')]
       if (shouldPrefetch && !isPrefetched) {
@@ -475,8 +474,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       passHref ||
       (child.type === 'a' && !('href' in child.props))
     ) {
-      const curLocale =
-        typeof locale !== 'undefined' ? locale : router && router.locale
+      const curLocale = typeof locale !== 'undefined' ? locale : router?.locale
 
       // we only render domain locales if we are currently on a domain locale
       // so that locale links are still visitable in development/preview envs
@@ -487,7 +485,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
       childProps.href =
         localeDomain ||
-        addBasePath(addLocale(as, curLocale, router && router.defaultLocale))
+        addBasePath(addLocale(as, curLocale, router?.defaultLocale))
     }
 
     return legacyBehavior ? (


### PR DESCRIPTION
Concise expression using optional operator. ([RouterContext allows null through assertion.](https://github.com/vercel/next.js/pull/38876))

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
