### PR TITLE
Update query/hash test for safari

### DIFF
--- a/test/integration/production/test/index.test.js
+++ b/test/integration/production/test/index.test.js
@@ -88,36 +88,41 @@ describe('Production Usage', () => {
     await browser.waitForElementByCss('.about-page')
   })
 
-  it.each([
-    { hash: '#hello?' },
-    { hash: '#?' },
-    { hash: '##' },
-    { hash: '##?' },
-    { hash: '##hello?' },
-    { hash: '##hello' },
-    { hash: '#hello?world' },
-    { search: '?hello=world', hash: '#a', query: { hello: 'world' } },
-    { search: '?hello', hash: '#a', query: { hello: '' } },
-    { search: '?hello=', hash: '#a', query: { hello: '' } },
-  ])(
-    'should handle query/hash correctly during query updating $hash $search',
-    async ({ hash, search, query }) => {
-      const browser = await webdriver(appPort, `/${search || ''}${hash || ''}`)
+  if (process.env.BROWSER_NAME !== 'safari') {
+    it.each([
+      { hash: '#hello?' },
+      { hash: '#?' },
+      { hash: '##' },
+      { hash: '##?' },
+      { hash: '##hello?' },
+      { hash: '##hello' },
+      { hash: '#hello?world' },
+      { search: '?hello=world', hash: '#a', query: { hello: 'world' } },
+      { search: '?hello', hash: '#a', query: { hello: '' } },
+      { search: '?hello=', hash: '#a', query: { hello: '' } },
+    ])(
+      'should handle query/hash correctly during query updating $hash $search',
+      async ({ hash, search, query }) => {
+        const browser = await webdriver(
+          appPort,
+          `/${search || ''}${hash || ''}`
+        )
 
-      await check(
-        () =>
-          browser.eval('window.next.router.isReady ? "ready" : "not ready"'),
-        'ready'
-      )
-      expect(await browser.eval('window.location.pathname')).toBe('/')
-      expect(await browser.eval('window.location.hash')).toBe(hash || '')
-      expect(await browser.eval('window.location.search')).toBe(search || '')
-      expect(await browser.eval('next.router.pathname')).toBe('/')
-      expect(
-        JSON.parse(await browser.eval('JSON.stringify(next.router.query)'))
-      ).toEqual(query || {})
-    }
-  )
+        await check(
+          () =>
+            browser.eval('window.next.router.isReady ? "ready" : "not ready"'),
+          'ready'
+        )
+        expect(await browser.eval('window.location.pathname')).toBe('/')
+        expect(await browser.eval('window.location.hash')).toBe(hash || '')
+        expect(await browser.eval('window.location.search')).toBe(search || '')
+        expect(await browser.eval('next.router.pathname')).toBe('/')
+        expect(
+          JSON.parse(await browser.eval('JSON.stringify(next.router.query)'))
+        ).toEqual(query || {})
+      }
+    )
+  }
 
   it('should not show target deprecation warning', () => {
     expect(output).not.toContain(


### PR DESCRIPTION
Seems browserstack isn't able to handle these URLs being sent to safari for testing so this skips them for that specific browser. 

Fixes: https://github.com/vercel/next.js/runs/7456408218?check_suite_focus=true
Fixes: https://github.com/vercel/next.js/runs/7456989980?check_suite_focus=true
