### PR TITLE
fix(#38090): add missing `analyticsId` to config schema

### DIFF
--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -16,6 +16,9 @@ const configSchema = {
       },
       type: 'object',
     },
+    analyticsId: {
+      type: 'string',
+    },
     assetPrefix: {
       minLength: 1,
       type: 'string',

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -271,6 +271,15 @@ export interface NextConfig extends Record<string, any> {
   /** @see [Compression documentation](https://nextjs.org/docs/api-reference/next.config.js/compression) */
   compress?: boolean
 
+  /**
+   * The field should only be used when a Next.js project is not hosted on Vercel while using Vercel Analytics.
+   * Vercel provides zero-configuration analytics for Next.js projects hosted on Vercel.
+   *
+   * @default ''
+   * @see [Next.js Analytics](https://nextjs.org/analytics)
+   */
+  analyticsId?: string
+
   /** @see [Disabling x-powered-by](https://nextjs.org/docs/api-reference/next.config.js/disabling-x-powered-by) */
   poweredByHeader?: boolean
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes #38909

Add missing `analyticsId` to the `NextConfig` typescript definition and ajv schema.

The original issue would only affect Vercel's paid consumers who host the Next.js app on other platforms while using Vercel Analytics, where `analyticsId` is required to be added to `next.config.js`. 