### PR TITLE
Remove next-page-tester from testing.md

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -493,7 +493,6 @@ For further reading, you may find these resources helpful:
 
 The Next.js community has created packages and articles you may find helpful:
 
-- [next-page-tester](https://github.com/toomuchdesign/next-page-tester) for DOM Integration Testing.
 - [next-router-mock](https://github.com/scottrippey/next-router-mock) for Storybook.
 - [Test Preview Vercel Deploys with Cypress](https://glebbahmutov.com/blog/develop-preview-test/) by Gleb Bahmutov.
 


### PR DESCRIPTION
Next Page Tester has officially been deprecated.

https://github.com/next-page-tester/next-page-tester

https://github.com/next-page-tester/next-page-tester/issues/303

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
