### PR TITLE
fix(next/swc): handle call args reference in styled-components template literal

### DIFF
--- a/packages/next-swc/crates/styled_components/src/visitors/transpile_css_prop/transpile.rs
+++ b/packages/next-swc/crates/styled_components/src/visitors/transpile_css_prop/transpile.rs
@@ -656,11 +656,8 @@ where
             Expr::Lit(_) => true,
             Expr::Ident(id) if is_top_level_ident(id) => {
                 if let Expr::Call(CallExpr { args, .. }) = expr {
-                    args.iter().all(|arg| {
-                        let direct_access = is_direct_access(&*arg.expr, is_top_level_ident);
-
-                        direct_access
-                    })
+                    args.iter()
+                        .all(|arg| -> bool { is_direct_access(&*arg.expr, is_top_level_ident) })
                 } else {
                     true
                 }

--- a/packages/next-swc/crates/styled_components/src/visitors/transpile_css_prop/transpile.rs
+++ b/packages/next-swc/crates/styled_components/src/visitors/transpile_css_prop/transpile.rs
@@ -248,12 +248,12 @@ impl VisitMut for TranspileCssProp {
                                 .take()
                                 .into_iter()
                                 .fold(vec![], |mut acc, mut expr| {
-                                    if expr.is_fn_expr() || expr.is_arrow() {
-                                        acc.push(expr);
-                                        return acc;
-                                    } else if is_direct_access(&expr, &|id| {
-                                        self.is_top_level_ident(id)
-                                    }) {
+                                    if expr.is_fn_expr()
+                                        || expr.is_arrow()
+                                        || is_direct_access(&expr, &|id| {
+                                            self.is_top_level_ident(id)
+                                        })
+                                    {
                                         acc.push(expr);
                                         return acc;
                                     }
@@ -651,7 +651,7 @@ fn is_direct_access<F>(expr: &Expr, is_top_level_ident: &F) -> bool
 where
     F: Fn(&Ident) -> bool,
 {
-    if let Some(root) = trace_root_value(&expr) {
+    if let Some(root) = trace_root_value(expr) {
         match root {
             Expr::Lit(_) => true,
             Expr::Ident(id) if is_top_level_ident(id) => {

--- a/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/code.js
+++ b/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/code.js
@@ -266,6 +266,9 @@ function Home() {
   return (
     <div
       css={css`
+      /* direct */
+      ${myCss(2)}
+      /* indirect */
       ${myCss(x)}
   `}
     />

--- a/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/code.js
+++ b/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/code.js
@@ -214,3 +214,52 @@ const ObjectPropWithSpread = () => {
     />
   )
 }
+
+
+const id = x => x
+
+const LocalCallInterpolation = p => {
+  const color = 'red'
+
+  return (
+    <p
+      css={`
+        color: ${id(color)};
+      `}
+    >
+      H
+    </p>
+  )
+}
+
+const LocalCallCssHelperProp = p => {
+  const color = 'red'
+
+  return (
+    <p
+      css={css`
+        color: ${id(color)};
+      `}
+    >
+      H
+    </p>
+  )
+}
+
+// issue #38914
+function Home() {
+  const { x } = { x: 4 };
+
+  return (
+    <div
+      css={css`
+      // ReferenceError: x is not defined
+      ${myCss(x)}
+  `}
+    />
+  );
+}
+
+const myCss = x => css`
+  margin: ${x}px;
+`;

--- a/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/code.js
+++ b/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/code.js
@@ -232,6 +232,19 @@ const LocalCallInterpolation = p => {
   )
 }
 
+const LocalCallInterpolation2 = () => {
+  return (
+    <p
+      css={`
+        /* direct call */
+        color: ${id('red')};
+      `}
+    >
+      H
+    </p>
+  )
+}
+
 const LocalCallCssHelperProp = p => {
   const color = 'red'
 
@@ -253,7 +266,6 @@ function Home() {
   return (
     <div
       css={css`
-      // ReferenceError: x is not defined
       ${myCss(x)}
   `}
     />

--- a/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/output.js
+++ b/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/output.js
@@ -224,5 +224,8 @@ var _StyledP16 = _styled("p")`
         color: ${(p)=>p.$_css16};
       `;
 var _StyledDiv2 = _styled("div")`
+      /* direct */
+      ${myCss(2)}
+      /* indirect */
       ${(p)=>p.$_css17}
   `;

--- a/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/output.js
+++ b/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/output.js
@@ -120,15 +120,42 @@ const ObjectPropMixedInputs = (p)=>{
     </_StyledP13>;
 };
 const ObjectPropWithSpread = ()=>{
-    const css = {
+    const css1 = {
         color: 'red'
     };
     const playing = true;
-    return <_StyledDiv $_css13={css} $_css14={playing ? {
+    return <_StyledDiv $_css13={css1} $_css14={playing ? {
         opacity: 0,
         bottom: '-100px'
     } : {}}/>;
 };
+const id = (x)=>x;
+const LocalCallInterpolation = (p)=>{
+    const color = 'red';
+    return <_StyledP14 $_css15={id(color)}>
+
+      H
+
+    </_StyledP14>;
+};
+const LocalCallCssHelperProp = (p)=>{
+    const color = 'red';
+    return <_StyledP15 $_css16={id(color)}>
+
+      H
+
+    </_StyledP15>;
+};
+// issue #38914
+function Home() {
+    const { x  } = {
+        x: 4
+    };
+    return <_StyledDiv2 $_css17={myCss(x)}/>;
+}
+const myCss = (x)=>css`
+  margin: ${x}px;
+`;
 var _StyledP = _styled("p")`flex: 1;`;
 var _StyledP2 = _styled("p")`
       flex: 1;
@@ -179,3 +206,13 @@ var _StyledDiv = _styled("div")((p)=>({
         ...p.$_css13,
         ...p.$_css14
     }));
+var _StyledP14 = _styled("p")`
+        color: ${(p)=>p.$_css15};
+      `;
+var _StyledP15 = _styled("p")`
+        color: ${(p)=>p.$_css16};
+      `;
+var _StyledDiv2 = _styled("div")`
+      // ReferenceError: x is not defined
+      ${(p)=>p.$_css17}
+  `;

--- a/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/output.js
+++ b/packages/next-swc/crates/styled_components/tests/fixtures/transpile-css-prop/output.js
@@ -138,13 +138,20 @@ const LocalCallInterpolation = (p)=>{
 
     </_StyledP14>;
 };
-const LocalCallCssHelperProp = (p)=>{
-    const color = 'red';
-    return <_StyledP15 $_css16={id(color)}>
+const LocalCallInterpolation2 = ()=>{
+    return <_StyledP15 >
 
       H
 
     </_StyledP15>;
+};
+const LocalCallCssHelperProp = (p)=>{
+    const color = 'red';
+    return <_StyledP16 $_css16={id(color)}>
+
+      H
+
+    </_StyledP16>;
 };
 // issue #38914
 function Home() {
@@ -210,9 +217,12 @@ var _StyledP14 = _styled("p")`
         color: ${(p)=>p.$_css15};
       `;
 var _StyledP15 = _styled("p")`
+        /* direct call */
+        color: ${id('red')};
+      `;
+var _StyledP16 = _styled("p")`
         color: ${(p)=>p.$_css16};
       `;
 var _StyledDiv2 = _styled("div")`
-      // ReferenceError: x is not defined
       ${(p)=>p.$_css17}
   `;


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] fixes #38914 
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
