### PR TITLE
Fix : when link child is react componet will cause warning #20434 #7915

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -520,7 +520,11 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     }
 
     return legacyBehavior ? (
-      React.cloneElement(child, childProps)
+      typeof child.type === 'string' ? (
+        React.cloneElement(child, childProps)
+      ) : (
+        child
+      )
     ) : (
       <a {...restProps} {...childProps}>
         {children}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
