### PR TITLE
feat: Improve efficiency of unstable_onlyGenerated misses by returning empty 404

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1517,7 +1517,14 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           !hadCache &&
           !this.minimalMode
         ) {
-          await this.render404(req, res)
+          // Use a minimal 404 response to save bandwidth since it is only
+          // handled internally
+          res.statusCode = 404
+          res.setHeader(
+            'Cache-Control',
+            'no-cache, no-store, max-age=0, must-revalidate'
+          )
+          res.send()
           return null
         }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

I noticed with higher volumes of `unstable_onlyGenerated` revalidates, the bandwidth consumed by our 404 page started to grow quite a bit. Given that the 404 response is only used as a signal internally and this should never be user facing, it is more efficient to just return a 404 response, but not use the static 404 page.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
