### PR TITLE
Fix `npm ci` issue when building from `Dockerfile`

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
-  [ -f yarn.lock ] && yarn --frozen-lockfile --prod || \
-  [ -f package-lock.json ] && npm ci || \
-  [ -f pnpm-lock.yaml ] && yarn global add pnpm && pnpm fetch --prod && pnpm i -r --offline --prod || \
+  ([ -f yarn.lock ] && yarn --frozen-lockfile --prod) || \
+  ([ -f package-lock.json ] && npm ci) || \
+  ([ -f pnpm-lock.yaml ] && yarn global add pnpm && pnpm fetch --prod && pnpm i -r --offline --prod) || \
   (echo "Lockfile not found." && exit 1)
 
 


### PR DESCRIPTION
## Bug

With the previous order of conditions, when building the `Dockerfile`, the build command would fail:

```
#12 100.9 npm ERR! code EUSAGE
#12 100.9 npm ERR!
#12 100.9 npm ERR! The `npm ci` command can only install with an existing package-lock.json or
#12 100.9 npm ERR! npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
#12 100.9 npm ERR! later to generate a package-lock.json file, then try again.
#12 100.9 npm ERR!
#12 100.9 npm ERR! Clean install a project
#12 100.9 npm ERR!
#12 100.9 npm ERR! Usage:
#12 100.9 npm ERR! npm ci
#12 100.9 npm ERR!
#12 100.9 npm ERR! Options:
#12 100.9 npm ERR! [--no-audit] [--foreground-scripts] [--ignore-scripts]
#12 100.9 npm ERR! [--script-shell <script-shell>]
#12 100.9 npm ERR!
#12 100.9 npm ERR! aliases: clean-install, ic, install-clean, isntall-clean
#12 100.9 npm ERR!
#12 100.9 npm ERR! Run "npm help ci" for more info
#12 100.9
#12 100.9 npm ERR! A complete log of this run can be found in:
#12 100.9 npm ERR!     /root/.npm/_logs/2022-07-24T18_55_34_319Z-debug-0.log
#12 100.9 Lockfile not found.
------
executor failed running [/bin/sh -c [ -f yarn.lock ] && yarn --frozen-lockfile --prod ||   [ -f package-lock.json ] && npm ci ||   [ -f pnpm-lock.yaml ] && yarn global add pnpm && pnpm fetch --prod && pnpm i -r --offline --prod ||   (echo "Lockfile not found." && exit 1)]: exit code: 1
```