### PR TITLE
Extend contributing with add/deprecate examples guidelines

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -265,26 +265,28 @@ Below are the steps to add a new link:
 
 When you add an example to the [examples](examples) directory, please follow these guidelines to ensure high quality examples:
 
-- TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred)
-- Examples should not add custom ESLint configuration (we have specific templates for ESLint)
+- TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred as it's less to maintain). TypeScript helps eliminate a class of bugs, while also providing better developer experience, even for newcomers.
+- Examples should not add custom ESLint or Prettier configuration (we have specific templates for those)
 - If API routes aren't used in an example, they should be omitted
 - If an example exists for a certain library and you would like to showcase a specific feature of that library, the existing example should be updated (instead of adding a new example)
 - Package manager specific config should not be added (e.g. `resolutions` in `package.json`)
 - In `package.json` the version of `next` (and `eslint-config-next`) should be `latest`
 - In `package.json` the dependency versions should be up-to-date
 - Use `export default function` for page components and API Routes instead of `const`/`let` (The exception is if the page has `getInitialProps`, in which case [`NextPage`](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#typescript) could be useful)
+- TypeScript examples should not use `prop-types`
+- TypeScript `strict` mode should be set to `false` in `tsconfig.json`
+- Type definition files should be placed in the `interfaces` directory
 - CMS example directories should be prefixed with `cms-`
 - Example directories should not be prefixed with `with-`
+- Omit the `name` and `version` fields from your `package.json`
+- Ensure all your dependencies are up to date
+- Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image)
 - Make sure linting passes (you can run `pnpm lint-fix`)
 
 Also don’t forget to add a `README.md` file with the following format:
 
 - Replace `DIRECTORY_NAME` with the directory name you’re adding.
 - Fill in `Example Name` and `Description`.
-- Examples should be TypeScript first, if possible.
-- Omit the `name` and `version` fields from your `package.json`.
-- Ensure all your dependencies are up to date.
-- Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image).
 - To add additional installation instructions, please add it where appropriate.
 - To add additional notes, add `## Notes` section at the end.
 - Remove the `Deploy your own` section if your example can’t be immediately deployed to Vercel.
@@ -314,6 +316,16 @@ pnpm create next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
 ````
+
+## Deprecating examples
+
+Replace the app with just a `README.md` file.
+
+```markdown
+## Deprecated
+
+The main [blog-starter](/examples/blog-starter) example has been refactored to use TypeScript, so this example is deprecated.
+```
 
 ## Publishing
 

--- a/contributing.md
+++ b/contributing.md
@@ -265,22 +265,21 @@ Below are the steps to add a new link:
 
 When you add an example to the [examples](examples) directory, please follow these guidelines to ensure high quality examples:
 
-- TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred as it's less to maintain). TypeScript helps eliminate a class of bugs, while also providing better developer experience, even for newcomers.
-- Examples should not add custom ESLint or Prettier configuration (we have specific templates for those)
+- TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred as it's less to maintain). TypeScript helps eliminate a class of bugs while also providing better developer experience, even for newcomers.
+- Examples should not add custom ESLint or Prettier configurations (we have specific templates for those)
 - If API routes aren't used in an example, they should be omitted
 - If an example exists for a certain library and you would like to showcase a specific feature of that library, the existing example should be updated (instead of adding a new example)
 - Package manager specific config should not be added (e.g. `resolutions` in `package.json`)
 - In `package.json` the version of `next` (and `eslint-config-next`) should be `latest`
-- In `package.json` the dependency versions should be up-to-date
+- In `package.json` the dependency versions should be up-to-date, and accept new minor and patch versions (e.g. `^version`)
+- Omit the `name` and `version` fields from your `package.json`
 - Use `export default function` for page components and API Routes instead of `const`/`let` (The exception is if the page has `getInitialProps`, in which case [`NextPage`](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#typescript) could be useful)
 - TypeScript examples should not use `prop-types`
 - TypeScript `strict` mode should be set to `false` in `tsconfig.json`
-- Type definition files should be placed in the `interfaces` directory
+- Type definition files should be inside the `interfaces` directory. `.d.ts` modules should be in the root directory
 - CMS example directories should be prefixed with `cms-`
 - Example directories should not be prefixed with `with-`
-- Omit the `name` and `version` fields from your `package.json`
-- Ensure all your dependencies are up to date
-- Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image)
+- Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image) and [`next/link`](https://nextjs.org/docs/api-reference/next/link)
 - Make sure linting passes (you can run `pnpm lint-fix`)
 
 Also don’t forget to add a `README.md` file with the following format:

--- a/contributing.md
+++ b/contributing.md
@@ -318,7 +318,7 @@ Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&ut
 
 ## Deprecating examples
 
-Replace the app with just a `README.md` file.
+Replace the app with a `README.md` file. For example:
 
 ```markdown
 ## Deprecated

--- a/contributing.md
+++ b/contributing.md
@@ -275,10 +275,9 @@ When you add an example to the [examples](examples) directory, please follow the
 - Omit the `name` and `version` fields from your `package.json`
 - Use `export default function` for page components and API Routes instead of `const`/`let` (The exception is if the page has `getInitialProps`, in which case [`NextPage`](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#typescript) could be useful)
 - TypeScript examples should not use `prop-types`
-- Type definition files should be inside the `interfaces` directory. `.d.ts` modules should be in the root directory
 - CMS example directories should be prefixed with `cms-`
 - Example directories should not be prefixed with `with-`
-- Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image) and [`next/link`](https://nextjs.org/docs/api-reference/next/link)
+- Ensure you’re using [`next/image`](https://nextjs.org/docs/api-reference/next/image), and [`next/link`](https://nextjs.org/docs/api-reference/next/link), and [`next/script`](https://nextjs.org/docs/api-reference/next/script)
 - Make sure linting passes (you can run `pnpm lint-fix`)
 
 Also don’t forget to add a `README.md` file with the following format:
@@ -315,14 +314,22 @@ pnpm create next-app --example DIRECTORY_NAME DIRECTORY_NAME-app
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
 ````
 
-## Deprecating examples
+## Removing examples
 
-Replace the app with a `README.md` file. For example:
+When an example is deprecated or moved, the app should be replaced with a `README.md` file. For example:
 
 ```markdown
 ## Deprecated
 
-The main [blog-starter](/examples/blog-starter) example has been refactored to use TypeScript, so this example is deprecated.
+The main [<technology>](/examples/<technology>) example has been refactored to use TypeScript, so this example is deprecated.
+```
+
+```markdown
+## Moved
+
+The official example is maintained by the library authors outside of the Next.js repository:
+
+- [<Technology Example>](some-url)
 ```
 
 ## Publishing

--- a/contributing.md
+++ b/contributing.md
@@ -275,7 +275,6 @@ When you add an example to the [examples](examples) directory, please follow the
 - Omit the `name` and `version` fields from your `package.json`
 - Use `export default function` for page components and API Routes instead of `const`/`let` (The exception is if the page has `getInitialProps`, in which case [`NextPage`](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#typescript) could be useful)
 - TypeScript examples should not use `prop-types`
-- TypeScript `strict` mode should be set to `false` in `tsconfig.json`
 - Type definition files should be inside the `interfaces` directory. `.d.ts` modules should be in the root directory
 - CMS example directories should be prefixed with `cms-`
 - Example directories should not be prefixed with `with-`

--- a/contributing.md
+++ b/contributing.md
@@ -265,7 +265,7 @@ Below are the steps to add a new link:
 
 When you add an example to the [examples](examples) directory, please follow these guidelines to ensure high quality examples:
 
-- TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred as it's less to maintain). TypeScript helps eliminate a class of bugs while also providing better developer experience, even for newcomers.
+- TypeScript should be leveraged for new examples (no need for separate JavaScript and TypeScript examples, converting old JavaScript examples is preferred). TypeScript helps eliminate a class of bugs while providing a better developer experience, even for newcomers.
 - Examples should not add custom ESLint or Prettier configurations (we have specific templates for those)
 - If API routes aren't used in an example, they should be omitted
 - If an example exists for a certain library and you would like to showcase a specific feature of that library, the existing example should be updated (instead of adding a new example)


### PR DESCRIPTION
Extended the example contribution guidelines for consistency, and learnings I've made as a new contributor.

I also moved general guidelines out of the `README.md`-specific section.

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
