### PR TITLE
Improve `next/link` error when `href` is missing/optional props invalid #38847

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -296,7 +296,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
           if (!_hrefProp) {
             console.error(
-              `<Link> is missing required "href" property. (Its type was \`${hrefType}\`):`,
+              `Link is missing required "href" property. (Its type was \`${hrefType}\`):`,
               el
             )
           } else if (!['string', 'object'].includes(hrefType)) {
@@ -320,12 +320,11 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
           const optionalProps: LinkPropsOptional[] = Object.keys(
             optionalPropsGuard
-          ) as LinkPropsOptional[]
+          ).filter((k) => k in props) as LinkPropsOptional[]
 
           for (const key of optionalProps) {
-            if (!props[key]) return
             const valType = typeof props[key]
-            if (key === 'as' || !['string', 'object'].includes(valType)) {
+            if (key === 'as' && !['string', 'object'].includes(valType)) {
               logPropError(key, valType, '`string` or `object`')
             } else if (key === 'locale' && valType !== 'string') {
               logPropError(key, valType, '`string`')

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -190,11 +190,9 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
             props[key] == null ||
             (typeof props[key] !== 'string' && typeof props[key] !== 'object')
           ) {
-            throw createPropError({
-              key,
-              expected: '`string` or `object`',
-              actual: props[key] === null ? 'null' : typeof props[key],
-            })
+            // React doesn't show the stack trace and there's
+            // no `href` to help identify which link, so we
+            // instead console.error(ref) during mount.
           }
         } else {
           // TypeScript trick for type-guarding:
@@ -284,7 +282,9 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     let children: React.ReactNode
 
     const {
-      href: hrefProp,
+      href: hrefProp = process.env.NODE_ENV !== 'production'
+        ? '/__NEXT_LINK_HREF_IS_MISSING_CHECK_THE_CONSOLE'
+        : undefined,
       as: asProp,
       children: childrenProp,
       prefetch: prefetchProp,
@@ -380,6 +380,12 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
     const setRef = React.useCallback(
       (el: Element) => {
+        if (
+          process.env.NODE_ENV !== 'production' &&
+          href === '/__NEXT_LINK_HREF_IS_MISSING_CHECK_THE_CONSOLE'
+        ) {
+          console.error(`<Link> is missing required "href" property:`, el)
+        }
         // Before the link getting observed, check if visible state need to be reset
         if (previousAs.current !== as || previousHref.current !== href) {
           resetVisible()

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -292,7 +292,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
             )
           }
 
-          const hrefType = _hrefProp == null ? 'null' : typeof _hrefProp
+          const hrefType = _hrefProp === null ? 'null' : typeof _hrefProp
 
           if (!_hrefProp) {
             console.error(

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -314,8 +314,8 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
             locale: true,
             onClick: true,
             onMouseEnter: true,
-            legacyBehavior: true,
             onTouchStart: true,
+            legacyBehavior: true,
           } as const
 
           const optionalProps: LinkPropsOptional[] = Object.keys(

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -20,9 +20,6 @@ import { addBasePath } from './add-base-path'
 const hasUseTransition = typeof React.useTransition !== 'undefined'
 
 type Url = string | UrlObject
-type RequiredKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
-}[keyof T]
 type OptionalKeys<T> = {
   [K in keyof T]-?: {} extends Pick<T, K> ? K : never
 }[keyof T]
@@ -62,7 +59,6 @@ type InternalLinkProps = {
 // TODO-APP: Include the full set of Anchor props
 // adding this to the publicly exported type currently breaks existing apps
 export type LinkProps = InternalLinkProps
-type LinkPropsRequired = RequiredKeys<LinkProps>
 type LinkPropsOptional = OptionalKeys<InternalLinkProps>
 
 const prefetched: { [cacheKey: string]: boolean } = {}

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -382,6 +382,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       (el: Element) => {
         if (
           process.env.NODE_ENV !== 'production' &&
+          el &&
           href === '/__NEXT_LINK_HREF_IS_MISSING_CHECK_THE_CONSOLE'
         ) {
           console.error(`<Link> is missing required "href" property:`, el)

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -164,110 +164,6 @@ type LinkPropsReal = React.PropsWithChildren<
 const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
   function LinkComponent(props, forwardedRef) {
     if (process.env.NODE_ENV !== 'production') {
-      function createPropError(args: {
-        key: string
-        expected: string
-        actual: string
-      }) {
-        return new Error(
-          `Failed prop type: The prop \`${args.key}\` expects a ${args.expected} in \`<Link>\`, but got \`${args.actual}\` instead.` +
-            (typeof window !== 'undefined'
-              ? "\nOpen your browser's console to view the Component stack trace."
-              : '')
-        )
-      }
-
-      // TypeScript trick for type-guarding:
-      const requiredPropsGuard: Record<LinkPropsRequired, true> = {
-        href: true,
-      } as const
-      const requiredProps: LinkPropsRequired[] = Object.keys(
-        requiredPropsGuard
-      ) as LinkPropsRequired[]
-      requiredProps.forEach((key: LinkPropsRequired) => {
-        if (key === 'href') {
-          if (
-            props[key] == null ||
-            (typeof props[key] !== 'string' && typeof props[key] !== 'object')
-          ) {
-            // React doesn't show the stack trace and there's
-            // no `href` to help identify which link, so we
-            // instead console.error(ref) during mount.
-          }
-        } else {
-          // TypeScript trick for type-guarding:
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const _: never = key
-        }
-      })
-
-      // TypeScript trick for type-guarding:
-      const optionalPropsGuard: Record<LinkPropsOptional, true> = {
-        as: true,
-        replace: true,
-        soft: true,
-        scroll: true,
-        shallow: true,
-        passHref: true,
-        prefetch: true,
-        locale: true,
-        onClick: true,
-        onMouseEnter: true,
-        legacyBehavior: true,
-      } as const
-      const optionalProps: LinkPropsOptional[] = Object.keys(
-        optionalPropsGuard
-      ) as LinkPropsOptional[]
-      optionalProps.forEach((key: LinkPropsOptional) => {
-        const valType = typeof props[key]
-
-        if (key === 'as') {
-          if (props[key] && valType !== 'string' && valType !== 'object') {
-            throw createPropError({
-              key,
-              expected: '`string` or `object`',
-              actual: valType,
-            })
-          }
-        } else if (key === 'locale') {
-          if (props[key] && valType !== 'string') {
-            throw createPropError({
-              key,
-              expected: '`string`',
-              actual: valType,
-            })
-          }
-        } else if (key === 'onClick' || key === 'onMouseEnter') {
-          if (props[key] && valType !== 'function') {
-            throw createPropError({
-              key,
-              expected: '`function`',
-              actual: valType,
-            })
-          }
-        } else if (
-          key === 'replace' ||
-          key === 'soft' ||
-          key === 'scroll' ||
-          key === 'shallow' ||
-          key === 'passHref' ||
-          key === 'prefetch' ||
-          key === 'legacyBehavior'
-        ) {
-          if (props[key] != null && valType !== 'boolean') {
-            throw createPropError({
-              key,
-              expected: '`boolean`',
-              actual: valType,
-            })
-          }
-        } else {
-          // TypeScript trick for type-guarding:
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const _: never = key
-        }
-      })
-
       // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const hasWarned = React.useRef(false)
@@ -282,9 +178,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     let children: React.ReactNode
 
     const {
-      href: hrefProp = process.env.NODE_ENV !== 'production'
-        ? '/__NEXT_LINK_HREF_IS_MISSING_CHECK_THE_CONSOLE'
-        : '',
+      href: _hrefProp,
       as: asProp,
       children: childrenProp,
       prefetch: prefetchProp,
@@ -299,6 +193,10 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
       legacyBehavior = Boolean(process.env.__NEXT_NEW_LINK_BEHAVIOR) !== true,
       ...restProps
     } = props
+    let hrefProp = _hrefProp
+    if (process.env.NODE_ENV !== 'production') {
+      hrefProp = '/__NEXT_LINK_HREF_IS_MISSING_CHECK_THE_CONSOLE'
+    }
 
     children = childrenProp
 
@@ -380,13 +278,72 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
     const setRef = React.useCallback(
       (el: Element) => {
-        if (
-          process.env.NODE_ENV !== 'production' &&
-          el &&
-          href === '/__NEXT_LINK_HREF_IS_MISSING_CHECK_THE_CONSOLE'
-        ) {
-          console.error(`<Link> is missing required "href" property:`, el)
+        if (process.env.NODE_ENV !== 'production' && el) {
+          function logPropError(key: string, actual: string, expected: string) {
+            console.error(
+              `Failed prop type on \`next/link\`: The prop \`${key}\` expects a ${expected} in \`Link\`, but got \`${actual}\` instead.`,
+              el
+            )
+          }
+
+          const hrefType = _hrefProp == null ? 'null' : typeof _hrefProp
+
+          if (!_hrefProp) {
+            console.error(
+              `<Link> is missing required "href" property. (Its type was \`${hrefType}\`):`,
+              el
+            )
+          } else if (!['string', 'object'].includes(hrefType)) {
+            logPropError('href', hrefType, '`string` or `object`')
+          }
+
+          const optionalPropsGuard: Record<LinkPropsOptional, true> = {
+            as: true,
+            replace: true,
+            soft: true,
+            scroll: true,
+            shallow: true,
+            passHref: true,
+            prefetch: true,
+            locale: true,
+            onClick: true,
+            onMouseEnter: true,
+            legacyBehavior: true,
+          } as const
+
+          const optionalProps: LinkPropsOptional[] = Object.keys(
+            optionalPropsGuard
+          ) as LinkPropsOptional[]
+
+          for (const key of optionalProps) {
+            if (!props[key]) return
+            const valType = typeof props[key]
+            if (key === 'as' || !['string', 'object'].includes(valType)) {
+              logPropError(key, valType, '`string` or `object`')
+            } else if (key === 'locale' && valType !== 'string') {
+              logPropError(key, valType, '`string`')
+            } else if (
+              ['onClick', 'onMouseEnter'].includes(key) &&
+              valType !== 'function'
+            ) {
+              logPropError(key, valType, '`function`')
+            } else if (
+              [
+                'replace',
+                'soft',
+                'scroll',
+                'shallow',
+                'passHref',
+                'prefetch',
+                'legacyBehavior',
+              ].includes(key) &&
+              valType !== 'boolean'
+            ) {
+              logPropError(key, valType, '`boolean`')
+            }
+          }
         }
+
         // Before the link getting observed, check if visible state need to be reset
         if (previousAs.current !== as || previousHref.current !== href) {
           resetVisible()

--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -284,7 +284,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
     const {
       href: hrefProp = process.env.NODE_ENV !== 'production'
         ? '/__NEXT_LINK_HREF_IS_MISSING_CHECK_THE_CONSOLE'
-        : undefined,
+        : '',
       as: asProp,
       children: childrenProp,
       prefetch: prefetchProp,

--- a/test/development/link-props/index.test.ts
+++ b/test/development/link-props/index.test.ts
@@ -1,0 +1,63 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { check, hasRedbox } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { BrowserInterface } from 'test/lib/browsers/base'
+
+describe('Link props', () => {
+  let next: NextInstance
+  let browser: BrowserInterface
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.js': `
+        import Link from 'next/link'
+        export default function Page() {
+          return <Link>Link</Link>
+        }
+        `,
+      },
+      dependencies: {},
+    })
+  })
+
+  beforeEach(async () => {
+    browser = await webdriver(next.url, '/')
+  })
+
+  afterAll(async () => {
+    await Promise.all([next.destroy(), browser.close()])
+  })
+
+  it('should show error in console when required `href` is missing', async () => {
+    expect(await hasRedbox(browser)).toBe(false)
+    await check(async () => {
+      return (await browser.log()).map((log) => log.message).join('\n')
+    }, /Link is missing required "href" property\. \(Its type was `undefined`\):/gm)
+  })
+
+  it('should show error in console when optional prop types are incorrect', async () => {
+    await next.patchFile(
+      'pages/index.js',
+      `import Link from 'next/link'
+      export default function Page() {
+        return <Link href='/' as={true} onTouchStart={true} locale={{}}>Link</Link>
+      }`
+    )
+    await browser.refresh()
+    expect(await hasRedbox(browser)).toBe(false)
+
+    await check(
+      async () => (await browser.log()).map((log) => log.message).join('\n'),
+      /Failed prop type on `next\/link`: The prop `as` expects a `string` or `object` in `Link`, but got `boolean` instead\./gm
+    )
+    await check(
+      async () => (await browser.log()).map((log) => log.message).join('\n'),
+      /Failed prop type on `next\/link`: The prop `onTouchStart` expects a `function` in `Link`, but got `boolean` instead\./gm
+    )
+    await check(
+      async () => (await browser.log()).map((log) => log.message).join('\n'),
+      /Failed prop type on `next\/link`: The prop `locale` expects a `string` in `Link`, but got `object` instead\./gm
+    )
+  })
+})


### PR DESCRIPTION
This is very similar to #23742, where we did not give a stack trace for `src` when it was missing from `next/image`.

This PR aims to do something similar to #38847 to fix #38965.

Instead of using the error-overlay to fail server-side, we wait until the component is mounted, so we can show the element in the console:
![image](https://user-images.githubusercontent.com/18369201/180777734-07168ea3-5937-4dcc-9637-d170caaab85a.png)


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
