### PR TITLE
Update config-schema for relay field to be less strict

### DIFF
--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -76,22 +76,6 @@ const configSchema = {
           ] as any,
         },
         relay: {
-          additionalProperties: false,
-          properties: {
-            artifactDirectory: {
-              minLength: 1,
-              type: 'string',
-            },
-            language: {
-              // automatic typing doesn't like enum
-              enum: ['flow', 'typescript'] as any,
-              type: 'string',
-            },
-            src: {
-              minLength: 1,
-              type: 'string',
-            },
-          },
           type: 'object',
         },
         removeConsole: {


### PR DESCRIPTION
There are additional keys allowed under the relay compiler config so this makes the schema validation less strict to prevent showing config warnings unnecessarily. 

Fixes: https://github.com/vercel/next.js/issues/38967

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

