### PR TITLE
Docs: Updated to solve issue presented in example

### DIFF
--- a/errors/link-multiple-children.md
+++ b/errors/link-multiple-children.md
@@ -29,7 +29,10 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <Link href="/about">
-      <a>To About</a>
+      <div>
+        <a>To About</a>
+        <a>Second To About</a>
+      </div>
     </Link>
   )
 }


### PR DESCRIPTION
Issue: Having read the documentation one is informed that the issue is that the `<Link>` tag can only accept one child however the example given is misleading.

In the example listed, the user requires two elements to be inside the link.
This models a real world application as many times a hyperlink may wrap several tags.

```js
import Link from 'next/link'

export default function Home() {
  return (
    <Link href="/about">
      <a>To About</a>
      <a>Second To About</a>
    </Link>
  )
}
```

The solution given however implies that in order to fix this issue, an element must be removed.

```js
import Link from 'next/link'

export default function Home() {
  return (
    <Link href="/about">
      <a>To About</a>
    </Link>
  )
}
```


Why is this a problem: This is a problem as the documentation does not truely solve the issue presented if the use case is required, eg. two elements within the link are mandatory. This may lead to further confusion especially for beginners or those new to error handling.


Solution: As the solution to the issue above is quite misleading and a better solution would be to wrap the elements within a parent tag such as `<div>` or `<span>` eg:

```js
import Link from 'next/link'

export default function Home() {
  return (
    <Link href="/about">
      <div>
        <a>To About</a>
        <a>Second To About</a>
      </div>
    </Link>
  )
}
```

This both solves the errors and remain true to solving the use case above.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
