### PR TITLE
little improvements type in client router

### DIFF
--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -85,9 +85,11 @@ urlPropertyFields.forEach((field) => {
 })
 
 coreMethodFields.forEach((field) => {
-  const router = getRouter()
   Object.defineProperty(singletonRouter, field, {
-    value: router[field],
+    get() {
+      const router = getRouter()
+      return router[field]
+    },
   })
 })
 
@@ -179,9 +181,11 @@ export function makePublicRouterInstance(router: Router): NextRouter {
   instance.events = Router.events
 
   coreMethodFields.forEach((field) => {
-    Object.defineProperty(instance, field, {
-      value: scopedRouter[field],
-    })
+    instance[field] = (...args: any[]) => {
+      // Explicitly distinguishes from any
+      const scopedField = scopedRouter[field]
+      return (scopedField as any)(...args)
+    }
   })
 
   return instance

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -15,9 +15,10 @@ export { Router }
 
 export type { NextRouter }
 
+type InternalSingletonRouter = SingletonRouterBase & Partial<NextRouter>
 export type SingletonRouter = SingletonRouterBase & NextRouter
 
-const singletonRouter: SingletonRouterBase = {
+const singletonRouter: InternalSingletonRouter = {
   router: null, // holds the actual router instance
   readyCallbacks: [],
   ready(cb: () => void) {
@@ -85,12 +86,11 @@ urlPropertyFields.forEach((field) => {
 })
 
 coreMethodFields.forEach((field) => {
-  Object.defineProperty(singletonRouter, field, {
-    get() {
-      const router = getRouter()
-      return router[field]
-    },
-  })
+  // We don't really know the types here, so we add them later instead
+  singletonRouter[field] = (...args: any[]) => {
+    const router = getRouter()
+    return (router[field] as any)(...args)
+  }
 })
 
 routerEvents.forEach((event) => {

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -172,6 +172,7 @@ export function makePublicRouterInstance(router: Router): NextRouter {
       })
       continue
     }
+
     Object.defineProperty(instance, property, {
       value: scopedRouter[property],
     })
@@ -182,9 +183,8 @@ export function makePublicRouterInstance(router: Router): NextRouter {
 
   coreMethodFields.forEach((field) => {
     instance[field] = (...args: any[]) => {
-      // Explicitly distinguishes from any
-      const scopedField = scopedRouter[field]
-      return (scopedField as any)(...args)
+      // Explicitly distinguishes from 'scopedRouter' any
+      return (scopedRouter[field] as any)(...args)
     }
   })
 

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -169,12 +169,16 @@ export function makePublicRouterInstance(router: Router): NextRouter {
           Array.isArray(scopedRouter[property]) ? [] : {},
           scopedRouter[property]
         ), // makes sure query is not stateful
+        configurable: true,
+        enumerable: true,
       })
       continue
     }
 
     Object.defineProperty(instance, property, {
       value: scopedRouter[property],
+      configurable: true,
+      enumerable: true,
     })
   }
 


### PR DESCRIPTION
Hi! I made type inference little improvements in client router.
It's not perfect, but it does make some improvements by making it possible to infer the router type. (now, all routers do not use `any`)

If someone use the wrong property, can realize it

|in using wrong property|before (inference impossible)|after|
|---|---|---|
| <img width="189" alt="image" src="https://user-images.githubusercontent.com/41747333/181074358-35c55a1d-1c47-4372-b2ff-481beb4eec5b.png"> |<img width="451" alt="image" src="https://user-images.githubusercontent.com/41747333/181074055-53dda8e3-6435-414f-8896-ce75f3cf5aba.png">|  <img width="444" alt="image" src="https://user-images.githubusercontent.com/41747333/181073891-1f240681-5638-44a8-aaff-c51fe33513c6.png">|

I try to improve this router gradually!

How about this?

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
