### PR TITLE
Add next-env.d.ts to default gitignore.

### DIFF
--- a/packages/create-next-app/templates/typescript/gitignore
+++ b/packages/create-next-app/templates/typescript/gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+next-end.d.ts
 
 # production
 /build

--- a/packages/create-next-app/templates/typescript/gitignore
+++ b/packages/create-next-app/templates/typescript/gitignore
@@ -11,7 +11,7 @@
 # next.js
 /.next/
 /out/
-next-end.d.ts
+next-env.d.ts
 
 # production
 /build


### PR DESCRIPTION
As per the docs:

<img width="705" alt="image" src="https://user-images.githubusercontent.com/1926652/181024885-12fde4f6-2865-45f9-84dc-04321ac21e2a.png">

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Documentation added
- [x] Telemetry added. In case of a feature if it's used or not.
- [x] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
