### PR TITLE
Update Safari 10 test to no longer wait for modern Safari

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -859,7 +859,7 @@ jobs:
   testSafariOld:
     name: Test Safari 10.1 (nav)
     runs-on: ubuntu-latest
-    needs: [build, testSafari, build-native-test]
+    needs: [build, build-native-test]
     env:
       BROWSERSTACK: true
       LEGACY_SAFARI: true


### PR DESCRIPTION
The Safari 10 job no longer needs to wait for the modern Safari job as modern Safari is no longer leveraging browserstack so we don't have to worry about getting queued with both running. 