### PR TITLE
Ensure dangerouslyAllowSVG is passed correctly

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1571,6 +1571,7 @@ export default async function getBaseWebpackConfig(
           imageSizes: config.images.imageSizes,
           path: config.images.path,
           loader: config.images.loader,
+          dangerouslyAllowSVG: config.images.dangerouslyAllowSVG,
           experimentalUnoptimized: config?.experimental?.images?.unoptimized,
           experimentalFuture: config.experimental?.images?.allowFutureImage,
           ...(dev

--- a/test/integration/production/test/security.js
+++ b/test/integration/production/test/security.js
@@ -321,9 +321,8 @@ module.exports = (context) => {
         try {
           browser = await webdriver(context.appPort, '/svg-image')
           await browser.eval(`document.getElementById("img").scrollIntoView()`)
-          expect(
-            await browser.elementById('img').getAttribute('src')
-          ).toContain('xss.svg')
+          const src = await browser.elementById('img').getAttribute('src')
+          expect(src).toMatch(/_next\/image\?.*xss\.svg/)
           expect(await browser.elementById('msg').text()).toBe('safe')
           browser = await webdriver(
             context.appPort,


### PR DESCRIPTION
This ensures we pass the config correctly to the client so it can be enabled properly also updates the test to ensure it is working as expected. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/38968