### PR TITLE
Handle getStaticPaths error inside worker to avoid serializing

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -862,117 +862,122 @@ export async function isPageStatic(
   traceExcludes?: string[]
 }> {
   const isPageStaticSpan = trace('is-page-static-utils', parentId)
-  return isPageStaticSpan.traceAsyncFn(async () => {
-    require('../shared/lib/runtime-config').setConfig(runtimeEnvConfig)
-    setHttpAgentOptions(httpAgentOptions)
+  return isPageStaticSpan
+    .traceAsyncFn(async () => {
+      require('../shared/lib/runtime-config').setConfig(runtimeEnvConfig)
+      setHttpAgentOptions(httpAgentOptions)
 
-    const mod = await loadComponents(distDir, page, serverless)
-    const Comp = mod.Component
+      const mod = await loadComponents(distDir, page, serverless)
+      const Comp = mod.Component
 
-    if (!Comp || !isValidElementType(Comp) || typeof Comp === 'string') {
-      throw new Error('INVALID_DEFAULT_EXPORT')
-    }
+      if (!Comp || !isValidElementType(Comp) || typeof Comp === 'string') {
+        throw new Error('INVALID_DEFAULT_EXPORT')
+      }
 
-    const hasGetInitialProps = !!(Comp as any).getInitialProps
-    const hasStaticProps = !!mod.getStaticProps
-    const hasStaticPaths = !!mod.getStaticPaths
-    const hasServerProps = !!mod.getServerSideProps
-    const hasLegacyServerProps = !!(await mod.ComponentMod
-      .unstable_getServerProps)
-    const hasLegacyStaticProps = !!(await mod.ComponentMod
-      .unstable_getStaticProps)
-    const hasLegacyStaticPaths = !!(await mod.ComponentMod
-      .unstable_getStaticPaths)
-    const hasLegacyStaticParams = !!(await mod.ComponentMod
-      .unstable_getStaticParams)
+      const hasGetInitialProps = !!(Comp as any).getInitialProps
+      const hasStaticProps = !!mod.getStaticProps
+      const hasStaticPaths = !!mod.getStaticPaths
+      const hasServerProps = !!mod.getServerSideProps
+      const hasLegacyServerProps = !!(await mod.ComponentMod
+        .unstable_getServerProps)
+      const hasLegacyStaticProps = !!(await mod.ComponentMod
+        .unstable_getStaticProps)
+      const hasLegacyStaticPaths = !!(await mod.ComponentMod
+        .unstable_getStaticPaths)
+      const hasLegacyStaticParams = !!(await mod.ComponentMod
+        .unstable_getStaticParams)
 
-    if (hasLegacyStaticParams) {
-      throw new Error(
-        `unstable_getStaticParams was replaced with getStaticPaths. Please update your code.`
-      )
-    }
+      if (hasLegacyStaticParams) {
+        throw new Error(
+          `unstable_getStaticParams was replaced with getStaticPaths. Please update your code.`
+        )
+      }
 
-    if (hasLegacyStaticPaths) {
-      throw new Error(
-        `unstable_getStaticPaths was replaced with getStaticPaths. Please update your code.`
-      )
-    }
+      if (hasLegacyStaticPaths) {
+        throw new Error(
+          `unstable_getStaticPaths was replaced with getStaticPaths. Please update your code.`
+        )
+      }
 
-    if (hasLegacyStaticProps) {
-      throw new Error(
-        `unstable_getStaticProps was replaced with getStaticProps. Please update your code.`
-      )
-    }
+      if (hasLegacyStaticProps) {
+        throw new Error(
+          `unstable_getStaticProps was replaced with getStaticProps. Please update your code.`
+        )
+      }
 
-    if (hasLegacyServerProps) {
-      throw new Error(
-        `unstable_getServerProps was replaced with getServerSideProps. Please update your code.`
-      )
-    }
+      if (hasLegacyServerProps) {
+        throw new Error(
+          `unstable_getServerProps was replaced with getServerSideProps. Please update your code.`
+        )
+      }
 
-    // A page cannot be prerendered _and_ define a data requirement. That's
-    // contradictory!
-    if (hasGetInitialProps && hasStaticProps) {
-      throw new Error(SSG_GET_INITIAL_PROPS_CONFLICT)
-    }
+      // A page cannot be prerendered _and_ define a data requirement. That's
+      // contradictory!
+      if (hasGetInitialProps && hasStaticProps) {
+        throw new Error(SSG_GET_INITIAL_PROPS_CONFLICT)
+      }
 
-    if (hasGetInitialProps && hasServerProps) {
-      throw new Error(SERVER_PROPS_GET_INIT_PROPS_CONFLICT)
-    }
+      if (hasGetInitialProps && hasServerProps) {
+        throw new Error(SERVER_PROPS_GET_INIT_PROPS_CONFLICT)
+      }
 
-    if (hasStaticProps && hasServerProps) {
-      throw new Error(SERVER_PROPS_SSG_CONFLICT)
-    }
+      if (hasStaticProps && hasServerProps) {
+        throw new Error(SERVER_PROPS_SSG_CONFLICT)
+      }
 
-    const pageIsDynamic = isDynamicRoute(page)
-    // A page cannot have static parameters if it is not a dynamic page.
-    if (hasStaticProps && hasStaticPaths && !pageIsDynamic) {
-      throw new Error(
-        `getStaticPaths can only be used with dynamic pages, not '${page}'.` +
-          `\nLearn more: https://nextjs.org/docs/routing/dynamic-routes`
-      )
-    }
+      const pageIsDynamic = isDynamicRoute(page)
+      // A page cannot have static parameters if it is not a dynamic page.
+      if (hasStaticProps && hasStaticPaths && !pageIsDynamic) {
+        throw new Error(
+          `getStaticPaths can only be used with dynamic pages, not '${page}'.` +
+            `\nLearn more: https://nextjs.org/docs/routing/dynamic-routes`
+        )
+      }
 
-    if (hasStaticProps && pageIsDynamic && !hasStaticPaths) {
-      throw new Error(
-        `getStaticPaths is required for dynamic SSG pages and is missing for '${page}'.` +
-          `\nRead more: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
-      )
-    }
+      if (hasStaticProps && pageIsDynamic && !hasStaticPaths) {
+        throw new Error(
+          `getStaticPaths is required for dynamic SSG pages and is missing for '${page}'.` +
+            `\nRead more: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
+        )
+      }
 
-    let prerenderRoutes: Array<string> | undefined
-    let encodedPrerenderRoutes: Array<string> | undefined
-    let prerenderFallback: boolean | 'blocking' | undefined
-    if (hasStaticProps && hasStaticPaths) {
-      ;({
-        paths: prerenderRoutes,
-        fallback: prerenderFallback,
-        encodedPaths: encodedPrerenderRoutes,
-      } = await buildStaticPaths(
-        page,
-        mod.getStaticPaths!,
-        configFileName,
-        locales,
-        defaultLocale
-      ))
-    }
+      let prerenderRoutes: Array<string> | undefined
+      let encodedPrerenderRoutes: Array<string> | undefined
+      let prerenderFallback: boolean | 'blocking' | undefined
+      if (hasStaticProps && hasStaticPaths) {
+        ;({
+          paths: prerenderRoutes,
+          fallback: prerenderFallback,
+          encodedPaths: encodedPrerenderRoutes,
+        } = await buildStaticPaths(
+          page,
+          mod.getStaticPaths!,
+          configFileName,
+          locales,
+          defaultLocale
+        ))
+      }
 
-    const isNextImageImported = (global as any).__NEXT_IMAGE_IMPORTED
-    const config: PageConfig = mod.pageConfig
-    return {
-      isStatic: !hasStaticProps && !hasGetInitialProps && !hasServerProps,
-      isHybridAmp: config.amp === 'hybrid',
-      isAmpOnly: config.amp === true,
-      prerenderRoutes,
-      prerenderFallback,
-      encodedPrerenderRoutes,
-      hasStaticProps,
-      hasServerProps,
-      isNextImageImported,
-      traceIncludes: config.unstable_includeFiles || [],
-      traceExcludes: config.unstable_excludeFiles || [],
-    }
-  })
+      const isNextImageImported = (global as any).__NEXT_IMAGE_IMPORTED
+      const config: PageConfig = mod.pageConfig
+      return {
+        isStatic: !hasStaticProps && !hasGetInitialProps && !hasServerProps,
+        isHybridAmp: config.amp === 'hybrid',
+        isAmpOnly: config.amp === true,
+        prerenderRoutes,
+        prerenderFallback,
+        encodedPrerenderRoutes,
+        hasStaticProps,
+        hasServerProps,
+        isNextImageImported,
+        traceIncludes: config.unstable_includeFiles || [],
+        traceExcludes: config.unstable_excludeFiles || [],
+      }
+    })
+    .catch((err) => {
+      console.error(err)
+      throw new Error(`Failed to collect page data for ${page}`)
+    })
 }
 
 export async function hasCustomGetInitialProps(

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -975,6 +975,9 @@ export async function isPageStatic(
       }
     })
     .catch((err) => {
+      if (err.message === 'INVALID_DEFAULT_EXPORT') {
+        throw err
+      }
       console.error(err)
       throw new Error(`Failed to collect page data for ${page}`)
     })


### PR DESCRIPTION
This ensures we don't throw an unserializable error inside of the static check workers and instead log the error inside of the worker and throw a controlled error. Integration tests ensuring this is handled properly for `getStaticProps` and `getStaticPaths` have been added. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/38324