### PR TITLE
Update to use HEAD request for On-Demand ISR

### DIFF
--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -316,6 +316,7 @@ async function revalidate(
   try {
     if (context.trustHostHeader) {
       const res = await fetch(`https://${req.headers.host}${urlPath}`, {
+        method: 'HEAD',
         headers: {
           ...revalidateHeaders,
           cookie: req.headers.cookie || '',

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2002,6 +2002,62 @@ describe('Prerender', () => {
       })
     }
 
+    if (!isDev) {
+      it('should handle manual revalidate for fallback: blocking', async () => {
+        const beforeRevalidate = Date.now()
+        const res = await fetchViaHTTP(
+          next.url,
+          '/blocking-fallback/test-manual-1'
+        )
+        await waitForCacheWrite(
+          '/blocking-fallback/test-manual-1',
+          beforeRevalidate
+        )
+        const html = await res.text()
+        const $ = cheerio.load(html)
+        const initialTime = $('#time').text()
+
+        expect(res.headers.get('x-nextjs-cache')).toMatch(/MISS/)
+        expect($('p').text()).toMatch(/Post:.*?test-manual-1/)
+
+        const res2 = await fetchViaHTTP(
+          next.url,
+          '/blocking-fallback/test-manual-1'
+        )
+        const html2 = await res2.text()
+        const $2 = cheerio.load(html2)
+        const cacheHeader = isDeploy ? 'x-vercel-cache' : 'x-nextjs-cache'
+
+        expect(res2.headers.get(cacheHeader)).toMatch(/(HIT|STALE)/)
+        expect(initialTime).toBe($2('#time').text())
+
+        const res3 = await fetchViaHTTP(
+          next.url,
+          '/api/manual-revalidate',
+          {
+            pathname: '/blocking-fallback/test-manual-1',
+          },
+          { redirect: 'manual' }
+        )
+
+        expect(res3.status).toBe(200)
+        const revalidateData = await res3.json()
+        expect(revalidateData.revalidated).toBe(true)
+
+        await check(async () => {
+          const res4 = await fetchViaHTTP(
+            next.url,
+            '/blocking-fallback/test-manual-1'
+          )
+          const html4 = await res4.text()
+          const $4 = cheerio.load(html4)
+          expect($4('#time').text()).not.toBe(initialTime)
+          expect(res4.headers.get(cacheHeader)).toMatch(/(HIT|STALE)/)
+          return 'success'
+        }, 'success')
+      })
+    }
+
     if (!isDev && !isDeploy) {
       it('should automatically reset cache TTL when an error occurs and build cache was available', async () => {
         await next.patchFile('error.txt', 'yes')
@@ -2054,56 +2110,6 @@ describe('Prerender', () => {
               : next.cliOutput,
           'success'
         )
-      })
-
-      it('should handle manual revalidate for fallback: blocking', async () => {
-        const beforeRevalidate = Date.now()
-        const res = await fetchViaHTTP(
-          next.url,
-          '/blocking-fallback/test-manual-1'
-        )
-        await waitForCacheWrite(
-          '/blocking-fallback/test-manual-1',
-          beforeRevalidate
-        )
-        const html = await res.text()
-        const $ = cheerio.load(html)
-        const initialTime = $('#time').text()
-
-        expect(res.headers.get('x-nextjs-cache')).toMatch(/MISS/)
-        expect($('p').text()).toMatch(/Post:.*?test-manual-1/)
-
-        const res2 = await fetchViaHTTP(
-          next.url,
-          '/blocking-fallback/test-manual-1'
-        )
-        const html2 = await res2.text()
-        const $2 = cheerio.load(html2)
-
-        expect(res2.headers.get('x-nextjs-cache')).toMatch(/(HIT|STALE)/)
-        expect(initialTime).toBe($2('#time').text())
-
-        const res3 = await fetchViaHTTP(
-          next.url,
-          '/api/manual-revalidate',
-          {
-            pathname: '/blocking-fallback/test-manual-1',
-          },
-          { redirect: 'manual' }
-        )
-
-        expect(res3.status).toBe(200)
-        const revalidateData = await res3.json()
-        expect(revalidateData.revalidated).toBe(true)
-
-        const res4 = await fetchViaHTTP(
-          next.url,
-          '/blocking-fallback/test-manual-1'
-        )
-        const html4 = await res4.text()
-        const $4 = cheerio.load(html4)
-        expect($4('#time').text()).not.toBe(initialTime)
-        expect(res4.headers.get('x-nextjs-cache')).toMatch(/(HIT|STALE)/)
       })
 
       it('should not manual revalidate for fallback: blocking with onlyGenerated if not generated', async () => {


### PR DESCRIPTION
This updates the internal request used for On-Demand ISR when deployed to use a `HEAD` request to reduce bandwidth usage as noted in https://github.com/vercel/next.js/pull/38952 this also updates our On-Demand ISR E2E test to run for deploy mode. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
