### PR TITLE
chore: Clean up imports and unused code

### DIFF
--- a/packages/next/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -47,10 +47,12 @@ export default async function edgeSSRLoader(this: any) {
     : null
 
   const transformed = `
-    import { adapter } from 'next/dist/server/web/adapter'
+    import { adapter, enhanceGlobals } from 'next/dist/server/web/adapter'
     import { getRender } from 'next/dist/build/webpack/loaders/next-edge-ssr-loader/render'
 
     import Document from ${stringifiedDocumentPath}
+
+    enhanceGlobals()
 
     const appMod = require(${stringifiedAppPath})
     const pageMod = require(${stringifiedPagePath})

--- a/packages/next/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -2,8 +2,7 @@ import type { NextConfig } from '../../../../server/config-shared'
 import type { DocumentType, AppType } from '../../../../shared/lib/utils'
 import type { BuildManifest } from '../../../../server/get-page-files'
 import type { ReactLoadableManifest } from '../../../../server/load-components'
-
-import { NextRequest } from '../../../../server/web/spec-extension/request'
+import type { NextRequest } from '../../../../server/web/spec-extension/request'
 
 import WebServer from '../../../../server/web-server'
 import {

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -9,6 +9,7 @@ import type {
   GetStaticProps,
 } from '../../../../types'
 import type { BaseNextRequest } from '../../../../server/base-http'
+import type { __ApiPreviewProps } from '../../../../server/api-utils'
 
 import { format as formatUrl, UrlWithParsedQuery, parse as parseUrl } from 'url'
 import { parse as parseQs, ParsedUrlQuery } from 'querystring'
@@ -20,7 +21,6 @@ import {
   matchHas,
   prepareDestination,
 } from '../../../../shared/lib/router/utils/prepare-destination'
-import { __ApiPreviewProps } from '../../../../server/api-utils'
 import { acceptLanguage } from '../../../../server/accept-header'
 import { detectLocaleCookie } from '../../../../shared/lib/i18n/detect-locale-cookie'
 import { detectDomainLocale } from '../../../../shared/lib/i18n/detect-domain-locale'

--- a/packages/next/lib/constants.ts
+++ b/packages/next/lib/constants.ts
@@ -3,17 +3,9 @@ import { join } from '../shared/lib/isomorphic/path'
 
 export const NEXT_PROJECT_ROOT = join(__dirname, '..', '..')
 export const NEXT_PROJECT_ROOT_DIST = join(NEXT_PROJECT_ROOT, 'dist')
-export const NEXT_PROJECT_ROOT_NODE_MODULES = join(
-  NEXT_PROJECT_ROOT,
-  'node_modules'
-)
 export const NEXT_PROJECT_ROOT_DIST_CLIENT = join(
   NEXT_PROJECT_ROOT_DIST,
   'client'
-)
-export const NEXT_PROJECT_ROOT_DIST_SERVER = join(
-  NEXT_PROJECT_ROOT_DIST,
-  'server'
 )
 
 // Regex for API routes

--- a/packages/next/server/node-web-streams-helper.ts
+++ b/packages/next/server/node-web-streams-helper.ts
@@ -222,21 +222,6 @@ export function createSuffixStream(
   })
 }
 
-export function createPrefixStream(
-  prefix: string
-): TransformStream<Uint8Array, Uint8Array> {
-  let prefixFlushed = false
-  return new TransformStream({
-    transform(chunk, controller) {
-      if (!prefixFlushed) {
-        controller.enqueue(encodeText(prefix))
-        prefixFlushed = true
-      }
-      controller.enqueue(chunk)
-    },
-  })
-}
-
 // Suffix after main body content - scripts before </body>,
 // but wait for the major chunks to be enqueued.
 export function createDeferredSuffixStream(

--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -5,12 +5,12 @@ import type {
   RouteMatch,
   Params,
 } from '../shared/lib/router/utils/route-matcher'
+import type { RouteHas } from '../lib/load-custom-routes'
 
 import { getNextInternalQuery, NextUrlWithParsedQuery } from './request-meta'
 import { getPathMatch } from '../shared/lib/router/utils/path-match'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
-import { RouteHas } from '../lib/load-custom-routes'
 import { matchHas } from '../shared/lib/router/utils/prepare-destination'
 import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import { getRequestMeta } from './request-meta'

--- a/packages/next/server/utils.ts
+++ b/packages/next/server/utils.ts
@@ -40,8 +40,6 @@ export function stripInternalQueries(query: NextParsedUrlQuery) {
   delete query.__props__
   // routing
   delete query.__flight_router_state_tree__
-
-  return query
 }
 
 // When react version is >= 18 opt-in using reactRoot

--- a/packages/next/server/web/spec-extension/cookies.ts
+++ b/packages/next/server/web/spec-extension/cookies.ts
@@ -1,5 +1,6 @@
+import type { CookieSerializeOptions } from '../types'
+
 import cookie from 'next/dist/compiled/cookie'
-import { CookieSerializeOptions } from '../types'
 
 type GetWithOptionsOutput = {
   value: string | undefined


### PR DESCRIPTION
A small refactor PR to convert some imports to type imports, as well as removing a couple of unused exports.

The Edge SSR loader is also missing the global process injection (`enhanceGlobals`).

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
