### PR TITLE
Update default gitignore templates

### DIFF
--- a/examples/active-class-name/.gitignore
+++ b/examples/active-class-name/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/amp-first/.gitignore
+++ b/examples/amp-first/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/amp-story/.gitignore
+++ b/examples/amp-story/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/amp/.gitignore
+++ b/examples/amp/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/analyze-bundles/.gitignore
+++ b/examples/analyze-bundles/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-apollo-server-and-client-auth/.gitignore
+++ b/examples/api-routes-apollo-server-and-client-auth/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-apollo-server-and-client/.gitignore
+++ b/examples/api-routes-apollo-server-and-client/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-apollo-server/.gitignore
+++ b/examples/api-routes-apollo-server/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-cors/.gitignore
+++ b/examples/api-routes-cors/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-graphql/.gitignore
+++ b/examples/api-routes-graphql/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-middleware/.gitignore
+++ b/examples/api-routes-middleware/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-rate-limit/.gitignore
+++ b/examples/api-routes-rate-limit/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes-rest/.gitignore
+++ b/examples/api-routes-rest/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/api-routes/.gitignore
+++ b/examples/api-routes/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/auth-with-stytch/.gitignore
+++ b/examples/auth-with-stytch/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/auth0/.gitignore
+++ b/examples/auth0/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/basic-css/.gitignore
+++ b/examples/basic-css/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/basic-export/.gitignore
+++ b/examples/basic-export/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/blog-starter/.gitignore
+++ b/examples/blog-starter/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/blog-with-comment/.gitignore
+++ b/examples/blog-with-comment/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/blog/.gitignore
+++ b/examples/blog/.gitignore
@@ -23,18 +23,17 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# nextra
-public/feed.xml
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts
+
+# nextra
+public/feed.xml

--- a/examples/catch-all-routes/.gitignore
+++ b/examples/catch-all-routes/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-agilitycms/.gitignore
+++ b/examples/cms-agilitycms/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-builder-io/.gitignore
+++ b/examples/cms-builder-io/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-buttercms/.gitignore
+++ b/examples/cms-buttercms/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-contentful/.gitignore
+++ b/examples/cms-contentful/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-cosmic/.gitignore
+++ b/examples/cms-cosmic/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-datocms/.gitignore
+++ b/examples/cms-datocms/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-drupal/.gitignore
+++ b/examples/cms-drupal/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-ghost/.gitignore
+++ b/examples/cms-ghost/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-graphcms/.gitignore
+++ b/examples/cms-graphcms/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-kontent/.gitignore
+++ b/examples/cms-kontent/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-makeswift/.gitignore
+++ b/examples/cms-makeswift/.gitignore
@@ -26,13 +26,11 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-plasmic/.gitignore
+++ b/examples/cms-plasmic/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-prepr/.gitignore
+++ b/examples/cms-prepr/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-prismic/.gitignore
+++ b/examples/cms-prismic/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-sanity/.gitignore
+++ b/examples/cms-sanity/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-storyblok/.gitignore
+++ b/examples/cms-storyblok/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-strapi/.gitignore
+++ b/examples/cms-strapi/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-takeshape/.gitignore
+++ b/examples/cms-takeshape/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-tina/.gitignore
+++ b/examples/cms-tina/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-umbraco-heartcore/.gitignore
+++ b/examples/cms-umbraco-heartcore/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/cms-wordpress/.gitignore
+++ b/examples/cms-wordpress/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/convex/.gitignore
+++ b/examples/convex/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-routes-proxying/.gitignore
+++ b/examples/custom-routes-proxying/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-server-actionhero/.gitignore
+++ b/examples/custom-server-actionhero/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-server-express/.gitignore
+++ b/examples/custom-server-express/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-server-fastify/.gitignore
+++ b/examples/custom-server-fastify/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-server-hapi/.gitignore
+++ b/examples/custom-server-hapi/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-server-koa/.gitignore
+++ b/examples/custom-server-koa/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-server-polka/.gitignore
+++ b/examples/custom-server-polka/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/custom-server-typescript/.gitignore
+++ b/examples/custom-server-typescript/.gitignore
@@ -13,7 +13,7 @@
 /out/
 
 # production
-/dist
+/build
 
 # misc
 .DS_Store
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/data-fetch/.gitignore
+++ b/examples/data-fetch/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/dynamic-routing/.gitignore
+++ b/examples/dynamic-routing/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/environment-variables/.gitignore
+++ b/examples/environment-variables/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/fast-refresh-demo/.gitignore
+++ b/examples/fast-refresh-demo/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/github-pages/.gitignore
+++ b/examples/github-pages/.gitignore
@@ -10,6 +10,7 @@
 
 # next.js
 /.next/
+/out/
 
 # production
 /build
@@ -22,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/head-elements/.gitignore
+++ b/examples/head-elements/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/headers/.gitignore
+++ b/examples/headers/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/hello-world-esm/.gitignore
+++ b/examples/hello-world-esm/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/hello-world/.gitignore
+++ b/examples/hello-world/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/i18n-routing/.gitignore
+++ b/examples/i18n-routing/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/image-component/.gitignore
+++ b/examples/image-component/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/layout-component/.gitignore
+++ b/examples/layout-component/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/markdoc/.gitignore
+++ b/examples/markdoc/.gitignore
@@ -20,7 +20,10 @@
 *.pem
 
 # debug
-*.log*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env*.local
@@ -30,3 +33,4 @@
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/middleware/.gitignore
+++ b/examples/middleware/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/modularize-imports/.gitignore
+++ b/examples/modularize-imports/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/nested-components/.gitignore
+++ b/examples/nested-components/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/next-forms/.gitignore
+++ b/examples/next-forms/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/progressive-render/.gitignore
+++ b/examples/progressive-render/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/progressive-web-app/.gitignore
+++ b/examples/progressive-web-app/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/react-remove-properties/.gitignore
+++ b/examples/react-remove-properties/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/redirects/.gitignore
+++ b/examples/redirects/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/remove-console/.gitignore
+++ b/examples/remove-console/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/reproduction-template/.gitignore
+++ b/examples/reproduction-template/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/rewrites/.gitignore
+++ b/examples/rewrites/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/script-component/.gitignore
+++ b/examples/script-component/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/ssr-caching/.gitignore
+++ b/examples/ssr-caching/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/styled-jsx-with-csp/.gitignore
+++ b/examples/styled-jsx-with-csp/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/svg-components/.gitignore
+++ b/examples/svg-components/.gitignore
@@ -23,17 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-pnpm-lock.yaml
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/using-preact/.gitignore
+++ b/examples/using-preact/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/using-router/.gitignore
+++ b/examples/using-router/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-ably/.gitignore
+++ b/examples/with-ably/.gitignore
@@ -27,7 +27,10 @@ yarn-error.log*
 
 # local env files
 .env*.local
-.env
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-absolute-imports/.gitignore
+++ b/examples/with-absolute-imports/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-algolia-react-instantsearch/.gitignore
+++ b/examples/with-algolia-react-instantsearch/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-ant-design/.gitignore
+++ b/examples/with-ant-design/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-aphrodite/.gitignore
+++ b/examples/with-aphrodite/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-apivideo-upload/.gitignore
+++ b/examples/with-apivideo-upload/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-apollo-and-redux/.gitignore
+++ b/examples/with-apollo-and-redux/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-apollo-neo4j-graphql/.gitignore
+++ b/examples/with-apollo-neo4j-graphql/.gitignore
@@ -17,14 +17,20 @@
 
 # misc
 .DS_Store
+*.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-apollo/.gitignore
+++ b/examples/with-apollo/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-app-layout/.gitignore
+++ b/examples/with-app-layout/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-atlaskit/.gitignore
+++ b/examples/with-atlaskit/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-aws-amplify-typescript/.gitignore
+++ b/examples/with-aws-amplify-typescript/.gitignore
@@ -23,33 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# Amplify
-amplify/\#current-cloud-backend
-amplify/.config/local-*
-amplify/logs
-amplify/mock-data
-amplify/backend/amplify-meta.json
-amplify/backend/awscloudformation
-amplify/backend/.temp
-dist/
-aws-exports.js
-awsconfiguration.json
-amplifyconfiguration.json
-amplifyconfiguration.dart
-amplify-build-config.json
-amplify-gradle-config.json
-amplifytools.xcconfig
-.secret-*
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-aws-amplify/.gitignore
+++ b/examples/with-aws-amplify/.gitignore
@@ -23,23 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# amplify
-amplify/\#current-cloud-backend
-amplify/.config/local-*
-amplify/backend/amplify-meta.json
-amplify/backend/awscloudformation
-build/
-dist/
-node_modules/
-aws-exports.js
-awsconfiguration.json
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-babel-macros/.gitignore
+++ b/examples/with-babel-macros/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-carbon-components/.gitignore
+++ b/examples/with-carbon-components/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-cerebral/.gitignore
+++ b/examples/with-cerebral/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-chakra-ui/.gitignore
+++ b/examples/with-chakra-ui/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-clerk/.gitignore
+++ b/examples/with-clerk/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-compiled-css/.gitignore
+++ b/examples/with-compiled-css/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-contentlayer/.gitignore
+++ b/examples/with-contentlayer/.gitignore
@@ -23,16 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-
-# Contentlayer
-.contentlayer
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-context-api/.gitignore
+++ b/examples/with-context-api/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-cookie-auth-fauna/.gitignore
+++ b/examples/with-cookie-auth-fauna/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-cookies-next/.gitignore
+++ b/examples/with-cookies-next/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-couchbase/.gitignore
+++ b/examples/with-couchbase/.gitignore
@@ -17,17 +17,20 @@
 
 # misc
 .DS_Store
+*.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
-# IDE Files
-.idea/
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-cssed/.gitignore
+++ b/examples/with-cssed/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# cssed compilation artifacts
-.*.module.css
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-custom-babel-config/.gitignore
+++ b/examples/with-custom-babel-config/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-cxs/.gitignore
+++ b/examples/with-cxs/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-cypress/.gitignore
+++ b/examples/with-cypress/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-deta-base/.gitignore
+++ b/examples/with-deta-base/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-docker-multi-env/.gitignore
+++ b/examples/with-docker-multi-env/.gitignore
@@ -23,16 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# lock files
-yarn.lock
-package-lock.json
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-docker/.gitignore
+++ b/examples/with-docker/.gitignore
@@ -23,16 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# lock files
-yarn.lock
-package-lock.json
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-draft-js/.gitignore
+++ b/examples/with-draft-js/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-dynamic-import/.gitignore
+++ b/examples/with-dynamic-import/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# TypeScript
+# typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-edgedb/.gitignore
+++ b/examples/with-edgedb/.gitignore
@@ -17,25 +17,20 @@
 
 # misc
 .DS_Store
-.vscode
 *.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# query builder
-dbschema/edgeql-js
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-elasticsearch/.gitignore
+++ b/examples/with-elasticsearch/.gitignore
@@ -2,6 +2,8 @@
 
 # dependencies
 /node_modules
+/.pnp
+.pnp.js
 
 # testing
 /coverage
@@ -15,14 +17,20 @@
 
 # misc
 .DS_Store
+*.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-electron-typescript/.gitignore
+++ b/examples/with-electron-typescript/.gitignore
@@ -9,12 +9,11 @@
 /coverage
 
 # next.js
-/renderer/.next/
-/renderer/out/
+/.next/
+/out/
 
 # production
-/main
-/dist
+/build
 
 # misc
 .DS_Store
@@ -24,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-electron/.gitignore
+++ b/examples/with-electron/.gitignore
@@ -9,11 +9,11 @@
 /coverage
 
 # next.js
-/renderer/.next/
-/renderer/out/
+/.next/
+/out/
 
 # production
-/dist
+/build
 
 # misc
 .DS_Store
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-emotion-swc/.gitignore
+++ b/examples/with-emotion-swc/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-emotion-vanilla/.gitignore
+++ b/examples/with-emotion-vanilla/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-emotion/.gitignore
+++ b/examples/with-emotion/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-env-from-next-config-js/.gitignore
+++ b/examples/with-env-from-next-config-js/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-eslint/.gitignore
+++ b/examples/with-eslint/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-expo-typescript/.gitignore
+++ b/examples/with-expo-typescript/.gitignore
@@ -1,37 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# @generated: @expo/next-adapter@2.1.9
-node_modules/**/*
-.expo/*
-npm-debug.*
-*.jks
-*.p8
-*.p12
-*.key
-*.mobileprovision
-*.orig.*
-web-build/
-web-report/
-/.expo/*
-# Expo Web
-/web-build/*
-# Expo Native
-*.jks
-*.p8
-*.p12
-*.key
-*.mobileprovision
-*.orig.*
-# Next.js
-/.next/*
-/out/
-# Next.js production
-/build/
-# Next.js dependencies
-/.pnp
-.pnp.js
-# @end @expo/next-adapter
-
 # dependencies
 /node_modules
 /.pnp
@@ -55,15 +23,14 @@ web-report/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-expo/.gitignore
+++ b/examples/with-expo/.gitignore
@@ -1,17 +1,4 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-# @generated: @expo/next-adapter@2.1.5
-node_modules/**/*
-.expo/*
-npm-debug.*
-*.jks
-*.p8
-*.p12
-*.key
-*.mobileprovision
-*.orig.*
-web-build/
-web-report/
-.next/*
 
 # dependencies
 /node_modules
@@ -36,12 +23,14 @@ web-report/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-facebook-pixel/.gitignore
+++ b/examples/with-facebook-pixel/.gitignore
@@ -17,14 +17,20 @@
 
 # misc
 .DS_Store
+*.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-fauna/.gitignore
+++ b/examples/with-fauna/.gitignore
@@ -23,14 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-.idea
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-fela/.gitignore
+++ b/examples/with-fela/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-filbert/.gitignore
+++ b/examples/with-filbert/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-fingerprintjs-pro/.gitignore
+++ b/examples/with-fingerprintjs-pro/.gitignore
@@ -26,13 +26,11 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-firebase-cloud-messaging/.gitignore
+++ b/examples/with-firebase-cloud-messaging/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-firebase-hosting/.gitignore
+++ b/examples/with-firebase-hosting/.gitignore
@@ -18,18 +18,19 @@
 # misc
 .DS_Store
 *.pem
-.firebase/
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-firebase/.gitignore
+++ b/examples/with-firebase/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-flow/.gitignore
+++ b/examples/with-flow/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-formspree/.gitignore
+++ b/examples/with-formspree/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-framer-motion/.gitignore
+++ b/examples/with-framer-motion/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-geist-ui/.gitignore
+++ b/examples/with-geist-ui/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-goober/.gitignore
+++ b/examples/with-goober/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-google-analytics-amp/.gitignore
+++ b/examples/with-google-analytics-amp/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-google-analytics/.gitignore
+++ b/examples/with-google-analytics/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-google-tag-manager/.gitignore
+++ b/examples/with-google-tag-manager/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-graphql-gateway/.gitignore
+++ b/examples/with-graphql-gateway/.gitignore
@@ -33,5 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-
-.mesh/
+next-env.d.ts

--- a/examples/with-graphql-hooks/.gitignore
+++ b/examples/with-graphql-hooks/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-graphql-react/.gitignore
+++ b/examples/with-graphql-react/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-grommet/.gitignore
+++ b/examples/with-grommet/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-gsap/.gitignore
+++ b/examples/with-gsap/.gitignore
@@ -4,7 +4,6 @@
 /node_modules
 /.pnp
 .pnp.js
-.prettierrc
 
 # testing
 /coverage
@@ -24,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-hls-js/.gitignore
+++ b/examples/with-hls-js/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-http2/.gitignore
+++ b/examples/with-http2/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-i18n-next-intl/.gitignore
+++ b/examples/with-i18n-next-intl/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-i18n-rosetta/.gitignore
+++ b/examples/with-i18n-rosetta/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-ionic-typescript/.gitignore
+++ b/examples/with-ionic-typescript/.gitignore
@@ -23,18 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# Ionic
-public/svg
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-iron-session/.gitignore
+++ b/examples/with-iron-session/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-jest-babel/.gitignore
+++ b/examples/with-jest-babel/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-jest/.gitignore
+++ b/examples/with-jest/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-joi/.gitignore
+++ b/examples/with-joi/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-jotai/.gitignore
+++ b/examples/with-jotai/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-kea/.gitignore
+++ b/examples/with-kea/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-knex/.gitignore
+++ b/examples/with-knex/.gitignore
@@ -17,14 +17,20 @@
 
 # misc
 .DS_Store
+*.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-linaria/.gitignore
+++ b/examples/with-linaria/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# Linaria
-.linaria-cache/
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-lingui/.gitignore
+++ b/examples/with-lingui/.gitignore
@@ -23,16 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# lingui
-locale/_build
-locale/*/*.js
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-loading/.gitignore
+++ b/examples/with-loading/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-magic/.gitignore
+++ b/examples/with-magic/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mantine/.gitignore
+++ b/examples/with-mantine/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mdbreact/.gitignore
+++ b/examples/with-mdbreact/.gitignore
@@ -5,7 +5,6 @@
 /.pnp
 .pnp.js
 
-/.idea
 # testing
 /coverage
 
@@ -24,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mdx-remote/.gitignore
+++ b/examples/with-mdx-remote/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mdx/.gitignore
+++ b/examples/with-mdx/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mobx-react-lite/.gitignore
+++ b/examples/with-mobx-react-lite/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mobx-state-tree-typescript/.gitignore
+++ b/examples/with-mobx-state-tree-typescript/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mobx-state-tree/.gitignore
+++ b/examples/with-mobx-state-tree/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mobx/.gitignore
+++ b/examples/with-mobx/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mocha/.gitignore
+++ b/examples/with-mocha/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mongodb-mongoose/.gitignore
+++ b/examples/with-mongodb-mongoose/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mongodb/.gitignore
+++ b/examples/with-mongodb/.gitignore
@@ -17,14 +17,20 @@
 
 # misc
 .DS_Store
+*.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mqtt-js/.gitignore
+++ b/examples/with-mqtt-js/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-msw/.gitignore
+++ b/examples/with-msw/.gitignore
@@ -7,7 +7,6 @@
 
 # testing
 /coverage
-public/mockServiceWorker.js
 
 # next.js
 /.next/
@@ -24,12 +23,14 @@ public/mockServiceWorker.js
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mux-video/.gitignore
+++ b/examples/with-mux-video/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-mysql/.gitignore
+++ b/examples/with-mysql/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-neo4j/.gitignore
+++ b/examples/with-neo4j/.gitignore
@@ -17,14 +17,20 @@
 
 # misc
 .DS_Store
+*.pem
 
 # debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-netlify-cms/.gitignore
+++ b/examples/with-netlify-cms/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-css/.gitignore
+++ b/examples/with-next-css/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-offline/.gitignore
+++ b/examples/with-next-offline/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-page-transitions/.gitignore
+++ b/examples/with-next-page-transitions/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-sass/.gitignore
+++ b/examples/with-next-sass/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-seo/.gitignore
+++ b/examples/with-next-seo/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-sitemap/.gitignore
+++ b/examples/with-next-sitemap/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-translate/.gitignore
+++ b/examples/with-next-translate/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-nhost-auth-realtime-graphql/.gitignore
+++ b/examples/with-nhost-auth-realtime-graphql/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-orbit-components/.gitignore
+++ b/examples/with-orbit-components/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-overmind/.gitignore
+++ b/examples/with-overmind/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-particles/.gitignore
+++ b/examples/with-particles/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-passport-and-next-connect/.gitignore
+++ b/examples/with-passport-and-next-connect/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-passport/.gitignore
+++ b/examples/with-passport/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-paste-typescript/.gitignore
+++ b/examples/with-paste-typescript/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-patternfly/.gitignore
+++ b/examples/with-patternfly/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-plausible/.gitignore
+++ b/examples/with-plausible/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-playwright/.gitignore
+++ b/examples/with-playwright/.gitignore
@@ -23,13 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
-test-results/
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-polyfills/.gitignore
+++ b/examples/with-polyfills/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-portals-ssr/.gitignore
+++ b/examples/with-portals-ssr/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-portals/.gitignore
+++ b/examples/with-portals/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-prefetching/.gitignore
+++ b/examples/with-prefetching/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-quill-js/.gitignore
+++ b/examples/with-quill-js/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-rbx-bulma-pro/.gitignore
+++ b/examples/with-rbx-bulma-pro/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-bootstrap/.gitignore
+++ b/examples/with-react-bootstrap/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-foundation/.gitignore
+++ b/examples/with-react-foundation/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.*local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-ga/.gitignore
+++ b/examples/with-react-ga/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-helmet/.gitignore
+++ b/examples/with-react-helmet/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-hook-form/.gitignore
+++ b/examples/with-react-hook-form/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-intl/.gitignore
+++ b/examples/with-react-intl/.gitignore
@@ -24,16 +24,14 @@ lang/.messages/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
-compiled-lang
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-jss/.gitignore
+++ b/examples/with-react-jss/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-md-typescript/.gitignore
+++ b/examples/with-react-md-typescript/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-md/.gitignore
+++ b/examples/with-react-md/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-multi-carousel/.gitignore
+++ b/examples/with-react-multi-carousel/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-native-web/.gitignore
+++ b/examples/with-react-native-web/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-toolbox/.gitignore
+++ b/examples/with-react-toolbox/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-react-with-styles/.gitignore
+++ b/examples/with-react-with-styles/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-reactstrap/.gitignore
+++ b/examples/with-reactstrap/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-realm-web/.gitignore
+++ b/examples/with-realm-web/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-reason-relay/.gitignore
+++ b/examples/with-reason-relay/.gitignore
@@ -23,15 +23,17 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
 
 # reason relay
 __generated__/

--- a/examples/with-reasonml-todo/.gitignore
+++ b/examples/with-reasonml-todo/.gitignore
@@ -28,12 +28,14 @@ lib/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-reasonml/.gitignore
+++ b/examples/with-reasonml/.gitignore
@@ -28,12 +28,14 @@ lib/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-rebass/.gitignore
+++ b/examples/with-rebass/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-recoil/.gitignore
+++ b/examples/with-recoil/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-redis/.gitignore
+++ b/examples/with-redis/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-redux-observable/.gitignore
+++ b/examples/with-redux-observable/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-redux-persist/.gitignore
+++ b/examples/with-redux-persist/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-redux-saga/.gitignore
+++ b/examples/with-redux-saga/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-redux-thunk/.gitignore
+++ b/examples/with-redux-thunk/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-redux-wrapper/.gitignore
+++ b/examples/with-redux-wrapper/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-redux/.gitignore
+++ b/examples/with-redux/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-reflexjs/.gitignore
+++ b/examples/with-reflexjs/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-reflux/.gitignore
+++ b/examples/with-reflux/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-relay-modern/.gitignore
+++ b/examples/with-relay-modern/.gitignore
@@ -23,16 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# relay
-__generated__/
-schema/schema.graphql
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-rematch/.gitignore
+++ b/examples/with-rematch/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-route-as-modal/.gitignore
+++ b/examples/with-route-as-modal/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-segment-analytics/.gitignore
+++ b/examples/with-segment-analytics/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-semantic-ui/.gitignore
+++ b/examples/with-semantic-ui/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-sentry/.gitignore
+++ b/examples/with-sentry/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-service-worker/.gitignore
+++ b/examples/with-service-worker/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-shallow-routing/.gitignore
+++ b/examples/with-shallow-routing/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-sitemap/.gitignore
+++ b/examples/with-sitemap/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-skynexui-components/.gitignore
+++ b/examples/with-skynexui-components/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-slate/.gitignore
+++ b/examples/with-slate/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-static-export/.gitignore
+++ b/examples/with-static-export/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-stencil/.gitignore
+++ b/examples/with-stencil/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-stitches/.gitignore
+++ b/examples/with-stitches/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-stomp/.gitignore
+++ b/examples/with-stomp/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-storybook-styled-jsx-scss/.gitignore
+++ b/examples/with-storybook-styled-jsx-scss/.gitignore
@@ -23,18 +23,17 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# Storybook
-/storybook-static
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts
+
+# Storybook
+/storybook-static

--- a/examples/with-storybook/.gitignore
+++ b/examples/with-storybook/.gitignore
@@ -23,18 +23,17 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# storybook
-storybook-static
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts
+
+# storybook
+storybook-static

--- a/examples/with-strict-csp/.gitignore
+++ b/examples/with-strict-csp/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-stripe-typescript/.gitignore
+++ b/examples/with-stripe-typescript/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-styled-components-babel/.gitignore
+++ b/examples/with-styled-components-babel/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-styled-components-rtl/.gitignore
+++ b/examples/with-styled-components-rtl/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-styled-components/.gitignore
+++ b/examples/with-styled-components/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-styled-jsx-plugins/.gitignore
+++ b/examples/with-styled-jsx-plugins/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-styled-jsx-scss/.gitignore
+++ b/examples/with-styled-jsx-scss/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-styled-jsx/.gitignore
+++ b/examples/with-styled-jsx/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-styletron/.gitignore
+++ b/examples/with-styletron/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-supabase-auth-realtime-db/.gitignore
+++ b/examples/with-supabase-auth-realtime-db/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-supertokens/.gitignore
+++ b/examples/with-supertokens/.gitignore
@@ -30,3 +30,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-tailwindcss-emotion/.gitignore
+++ b/examples/with-tailwindcss-emotion/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-tailwindcss/.gitignore
+++ b/examples/with-tailwindcss/.gitignore
@@ -26,13 +26,11 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-temporal/.gitignore
+++ b/examples/with-temporal/.gitignore
@@ -23,18 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
-# compiled files
-temporal/lib
-
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-tesfy/.gitignore
+++ b/examples/with-tesfy/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-three-js/.gitignore
+++ b/examples/with-three-js/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-typescript-graphql/.gitignore
+++ b/examples/with-typescript-graphql/.gitignore
@@ -23,15 +23,17 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
 
 # graphql-let
 .cache
@@ -41,6 +43,3 @@ yarn-error.log*
 
 lib/resolvers-types.ts
 lib/graphql-operations.ts
-
-# typescript
-*.tsbuildinfo

--- a/examples/with-typescript-types/.gitignore
+++ b/examples/with-typescript-types/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-typescript/.gitignore
+++ b/examples/with-typescript/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-typestyle/.gitignore
+++ b/examples/with-typestyle/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-unsplash/.gitignore
+++ b/examples/with-unsplash/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-unstated/.gitignore
+++ b/examples/with-unstated/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-urql/.gitignore
+++ b/examples/with-urql/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-userbase/.gitignore
+++ b/examples/with-userbase/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-vercel-fetch/.gitignore
+++ b/examples/with-vercel-fetch/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-videojs/.gitignore
+++ b/examples/with-videojs/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-vitest/.gitignore
+++ b/examples/with-vitest/.gitignore
@@ -23,15 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/with-web-worker/.gitignore
+++ b/examples/with-web-worker/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-webassembly/.gitignore
+++ b/examples/with-webassembly/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-why-did-you-render/.gitignore
+++ b/examples/with-why-did-you-render/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-xstate/.gitignore
+++ b/examples/with-xstate/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-yarn-workspaces/.gitignore
+++ b/examples/with-yarn-workspaces/.gitignore
@@ -9,7 +9,8 @@
 /coverage
 
 # next.js
-.next/
+/.next/
+/out/
 
 # production
 /build
@@ -22,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-yoga/.gitignore
+++ b/examples/with-yoga/.gitignore
@@ -30,3 +30,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-zones/.gitignore
+++ b/examples/with-zones/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-node_modules/
+/node_modules
 /.pnp
 .pnp.js
 
@@ -9,8 +9,8 @@ node_modules/
 /coverage
 
 # next.js
-.next/
-out/
+/.next/
+/out/
 
 # production
 /build
@@ -23,12 +23,14 @@ out/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-zustand/.gitignore
+++ b/examples/with-zustand/.gitignore
@@ -23,12 +23,14 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/packages/create-next-app/templates/default/gitignore
+++ b/packages/create-next-app/templates/default/gitignore
@@ -30,3 +30,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/packages/create-next-app/templates/typescript/gitignore
+++ b/packages/create-next-app/templates/typescript/gitignore
@@ -33,3 +33,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
This updates all of gitignore templates to include `next-env.d.ts` and updates the example ones to the current template content as well.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)

Closes: https://github.com/vercel/next.js/pull/39026
Closes: https://github.com/vercel/next.js/pull/38541