### PR TITLE
Fix Docker example

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -6,11 +6,12 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+# Omit --prod flag for TypeScript devDependencies
 RUN \
-  [ -f yarn.lock ] && yarn --frozen-lockfile --prod || \
-  [ -f package-lock.json ] && npm ci || \
-  [ -f pnpm-lock.yaml ] && yarn global add pnpm && pnpm fetch --prod && pnpm i -r --offline --prod || \
-  (echo "Lockfile not found." && exit 1)
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile --prod; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm fetch --prod && pnpm i -r --offline --prod; \
+  else (echo "Lockfile not found." && exit 1); fi;
 
 
 # Rebuild the source code only when needed
@@ -45,7 +46,7 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 
-# Automatically leverage output traces to reduce image size 
+# Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static


### PR DESCRIPTION
Ciao! 
I'm trying to use the [with-docker example](https://github.com/vercel/next.js/tree/canary/examples/with-docker) inside my projects, but when I run the command `docker build -t nextjs-docker .` - as reported in the guide - the following error appeared:

![immagine](https://user-images.githubusercontent.com/15154851/181272456-d2cbfab7-5732-4972-ad52-767e0db7c25b.png)

linked to this step:

```shell
# Install dependencies based on the preferred package manager
COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
RUN \
  [ -f yarn.lock ] && yarn --frozen-lockfile --prod || \
  [ -f package-lock.json ] && npm ci || \
  [ -f pnpm-lock.yaml ] && yarn global add pnpm && pnpm fetch --prod && pnpm i -r --offline --prod || \
  (echo "Lockfile not found." && exit 1)
```

I then proceeded to find a solution that could work without upsetting the logic and, seeing that it was giving me some problems with Typescript, I added a reference readjusted based on [this example](https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose/next-app/prod.Dockerfile) . 


I hope I was helpful...
And thank you for the work you are doing!
