### PR TITLE
Update delayed test output handling

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -269,15 +269,15 @@ async function main() {
           },
         }
       )
-      const handleOutput = (chunk) => {
+      const handleOutput = (type) => (chunk) => {
         if (hideOutput) {
-          outputChunks.push(chunk)
+          outputChunks.push({ type, chunk })
         } else {
           process.stderr.write(chunk)
         }
       }
-      child.stdout.on('data', handleOutput)
-      child.stderr.on('data', handleOutput)
+      child.stdout.on('data', handleOutput('stdout'))
+      child.stderr.on('data', handleOutput('stderr'))
 
       children.add(child)
 
@@ -287,15 +287,13 @@ async function main() {
           if (isFinalRun && hideOutput) {
             // limit out to last 64kb so that we don't
             // run out of log room in CI
-            const trimmedOutput = []
-
-            for (let i = outputChunks.length; i >= 0; i--) {
-              const chunk = outputChunks[i]
-              if (!chunk) continue
-
-              trimmedOutput.unshift(chunk)
-            }
-            trimmedOutput.forEach((chunk) => process.stdout.write(chunk))
+            outputChunks.forEach(({ type, chunk }) => {
+              if (type === 'stdout') {
+                process.stdout.write(chunk)
+              } else {
+                process.stderr.write(chunk)
+              }
+            })
           }
           return reject(
             new Error(


### PR DESCRIPTION
This updates the delayed test output handling to write to the correct output type and removes un-necessary handling from when the output was trimmed to a max length.

x-ref: https://github.com/vercel/next.js/runs/7543450465?check_suite_focus=true

