### PR TITLE
Fix unhandled rejections with edge runtime

### DIFF
--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -680,6 +680,11 @@ describe('Middleware Rewrite', () => {
         logs.every((log) => log.source === 'log' || log.source === 'info')
       ).toEqual(true)
     })
+
+    it('should not have unexpected errors', async () => {
+      expect(next.cliOutput).not.toContain('unhandledRejection')
+      expect(next.cliOutput).not.toContain('ECONNRESET')
+    })
   }
 
   function getCookieFromResponse(res, cookieName) {


### PR DESCRIPTION
This corrects some unhandledRejection errors showing when a connection is canceled with the edge runtime since the changes needed for https://github.com/vercel/next.js/commit/14463ddd10eb24c308c96df12874fb9862abefe4. This also adds a regression test to ensure we don't have these class of errors in our middleware tests. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: [slack thread](https://vercel.slack.com/archives/C03Q1UU3Z4H/p1658960102013969)