### PR TITLE
Convert `environment-variables` example to TypeScript

### DIFF
--- a/examples/environment-variables/.gitignore
+++ b/examples/environment-variables/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo

--- a/examples/environment-variables/.gitignore
+++ b/examples/environment-variables/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/environment-variables/environment.d.ts
+++ b/examples/environment-variables/environment.d.ts
@@ -1,0 +1,15 @@
+declare namespace NodeJS {
+  export interface ProcessEnv {
+    readonly ENV_VARIABLE: string
+    readonly NEXT_PUBLIC_ENV_VARIABLE: string
+
+    readonly DEVELOPMENT_ENV_VARIABLE: string
+    readonly NEXT_PUBLIC_DEVELOPMENT_ENV_VARIABLE: string
+
+    readonly ENV_LOCAL_VARIABLE: string
+    readonly NEXT_PUBLIC_ENV_LOCAL_VARIABLE: string
+
+    readonly PRODUCTION_ENV_VARIABLE: string
+    readonly NEXT_PUBLIC_PRODUCTION_ENV_VARIABLE: string
+  }
+}

--- a/examples/environment-variables/next-env.d.ts
+++ b/examples/environment-variables/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/environment-variables/next-env.d.ts
+++ b/examples/environment-variables/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/environment-variables/package.json
+++ b/examples/environment-variables/package.json
@@ -7,7 +7,13 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.6.1",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
+    "typescript": "^4.7.4"
   }
 }

--- a/examples/environment-variables/pages/index.tsx
+++ b/examples/environment-variables/pages/index.tsx
@@ -1,6 +1,13 @@
+import Link from 'next/link'
 import styles from '../styles.module.css'
 
-const Code = (p) => <code className={styles.inlineCode} {...p} />
+type CodeProps = {
+  children: React.ReactNode
+}
+
+const Code = ({ children }: CodeProps) => (
+  <code className={styles.inlineCode}>{children}</code>
+)
 
 const IndexPage = () => (
   <div className={styles.container}>
@@ -9,9 +16,9 @@ const IndexPage = () => (
       <hr className={styles.hr} />
       <p>
         In the table below you'll see how{' '}
-        <a href="https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser">
+        <Link href="https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser">
           environment variables can be exposed to the browser
-        </a>{' '}
+        </Link>{' '}
         with Next.js.
       </p>
       <p>

--- a/examples/environment-variables/tsconfig.json
+++ b/examples/environment-variables/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "environment.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Converted example to TypeScript to match Contribution docs.

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
