### PR TITLE
Convert `i18n-routing` example to TypeScript

### DIFF
--- a/examples/i18n-routing/.gitignore
+++ b/examples/i18n-routing/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo

--- a/examples/i18n-routing/.gitignore
+++ b/examples/i18n-routing/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/i18n-routing/components/locale-switcher.tsx
+++ b/examples/i18n-routing/components/locale-switcher.tsx
@@ -4,7 +4,10 @@ import { useRouter } from 'next/router'
 export default function LocaleSwitcher() {
   const router = useRouter()
   const { locales, locale: activeLocale } = router
-  const otherLocales = locales.filter((locale) => locale !== activeLocale)
+
+  const otherLocales = (locales || []).filter(
+    (locale) => locale !== activeLocale
+  )
 
   return (
     <div>
@@ -15,7 +18,7 @@ export default function LocaleSwitcher() {
           return (
             <li key={locale}>
               <Link href={{ pathname, query }} as={asPath} locale={locale}>
-                <a>{locale}</a>
+                {locale}
               </Link>
             </li>
           )

--- a/examples/i18n-routing/next-env.d.ts
+++ b/examples/i18n-routing/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/i18n-routing/next-env.d.ts
+++ b/examples/i18n-routing/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/i18n-routing/next.config.js
+++ b/examples/i18n-routing/next.config.js
@@ -1,6 +1,13 @@
-module.exports = {
+// @ts-check
+
+/**
+ * @type {import('next').NextConfig}
+ **/
+const nextConfig = {
   i18n: {
     locales: ['en', 'fr', 'nl'],
     defaultLocale: 'en',
   },
 }
+
+module.exports = nextConfig

--- a/examples/i18n-routing/package.json
+++ b/examples/i18n-routing/package.json
@@ -7,7 +7,13 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.6.1",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
+    "typescript": "^4.7.4"
   }
 }

--- a/examples/i18n-routing/pages/gsp/[slug].tsx
+++ b/examples/i18n-routing/pages/gsp/[slug].tsx
@@ -1,8 +1,15 @@
+import type {
+  GetStaticProps,
+  GetStaticPaths,
+  InferGetStaticPropsType,
+} from 'next'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import LocaleSwitcher from '../../components/locale-switcher'
 
-export default function GspPage(props) {
+type GspPageProps = InferGetStaticPropsType<typeof getStaticProps>
+
+export default function GspPage(props: GspPageProps) {
   const router = useRouter()
   const { defaultLocale, isFallback, query } = router
 
@@ -20,25 +27,27 @@ export default function GspPage(props) {
 
       <LocaleSwitcher />
 
-      <Link href="/gsp">
-        <a>To getStaticProps page</a>
-      </Link>
+      <Link href="/gsp">To getStaticProps page</Link>
       <br />
 
-      <Link href="/gssp">
-        <a>To getServerSideProps page</a>
-      </Link>
+      <Link href="/gssp">To getServerSideProps page</Link>
       <br />
 
-      <Link href="/">
-        <a>To index page</a>
-      </Link>
+      <Link href="/">To index page</Link>
       <br />
     </div>
   )
 }
 
-export const getStaticProps = ({ locale, locales }) => {
+type Props = {
+  locale?: string
+  locales?: string[]
+}
+
+export const getStaticProps: GetStaticProps<Props> = async ({
+  locale,
+  locales,
+}) => {
   return {
     props: {
       locale,
@@ -47,7 +56,7 @@ export const getStaticProps = ({ locale, locales }) => {
   }
 }
 
-export const getStaticPaths = ({ locales }) => {
+export const getStaticPaths: GetStaticPaths = ({ locales = [] }) => {
   const paths = []
 
   for (const locale of locales) {

--- a/examples/i18n-routing/pages/gsp/index.tsx
+++ b/examples/i18n-routing/pages/gsp/index.tsx
@@ -1,8 +1,12 @@
+import type { GetStaticProps, InferGetStaticPropsType } from 'next'
+
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import LocaleSwitcher from '../../components/locale-switcher'
 
-export default function GspPage(props) {
+type GspPageProps = InferGetStaticPropsType<typeof getStaticProps>
+
+export default function GspPage(props: GspPageProps) {
   const router = useRouter()
   const { defaultLocale } = router
 
@@ -15,25 +19,27 @@ export default function GspPage(props) {
 
       <LocaleSwitcher />
 
-      <Link href="/gsp/first">
-        <a>To dynamic getStaticProps page</a>
-      </Link>
+      <Link href="/gsp/first">To dynamic getStaticProps page</Link>
       <br />
 
-      <Link href="/gssp">
-        <a>To getServerSideProps page</a>
-      </Link>
+      <Link href="/gssp">To getServerSideProps page</Link>
       <br />
 
-      <Link href="/">
-        <a>To index page</a>
-      </Link>
+      <Link href="/">To index page</Link>
       <br />
     </div>
   )
 }
 
-export const getStaticProps = ({ locale, locales }) => {
+type Props = {
+  locale?: string
+  locales?: string[]
+}
+
+export const getStaticProps: GetStaticProps<Props> = async ({
+  locale,
+  locales,
+}) => {
   return {
     props: {
       locale,

--- a/examples/i18n-routing/pages/gssp.tsx
+++ b/examples/i18n-routing/pages/gssp.tsx
@@ -1,8 +1,12 @@
+import type { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import LocaleSwitcher from '../components/locale-switcher'
 
-export default function GsspPage(props) {
+type GsspPageProps = InferGetServerSidePropsType<typeof getServerSideProps>
+
+export default function GsspPage(props: GsspPageProps) {
   const router = useRouter()
   const { defaultLocale } = router
 
@@ -15,25 +19,27 @@ export default function GsspPage(props) {
 
       <LocaleSwitcher />
 
-      <Link href="/gsp">
-        <a>To getStaticProps page</a>
-      </Link>
+      <Link href="/gsp">To getStaticProps page</Link>
       <br />
 
-      <Link href="/gsp/first">
-        <a>To dynamic getStaticProps page</a>
-      </Link>
+      <Link href="/gsp/first">To dynamic getStaticProps page</Link>
       <br />
 
-      <Link href="/">
-        <a>To index page</a>
-      </Link>
+      <Link href="/">To index page</Link>
       <br />
     </div>
   )
 }
 
-export const getServerSideProps = ({ locale, locales }) => {
+type Props = {
+  locale?: string
+  locales?: string[]
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  locale,
+  locales,
+}) => {
   return {
     props: {
       locale,

--- a/examples/i18n-routing/pages/index.tsx
+++ b/examples/i18n-routing/pages/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import LocaleSwitcher from '../components/locale-switcher'
 
-export default function IndexPage(props) {
+export default function IndexPage() {
   const router = useRouter()
   const { locale, locales, defaultLocale } = router
 
@@ -15,19 +15,13 @@ export default function IndexPage(props) {
 
       <LocaleSwitcher />
 
-      <Link href="/gsp">
-        <a>To getStaticProps page</a>
-      </Link>
+      <Link href="/gsp">To getStaticProps page</Link>
       <br />
 
-      <Link href="/gsp/first">
-        <a>To dynamic getStaticProps page</a>
-      </Link>
+      <Link href="/gsp/first">To dynamic getStaticProps page</Link>
       <br />
 
-      <Link href="/gssp">
-        <a>To getServerSideProps page</a>
-      </Link>
+      <Link href="/gssp">To getServerSideProps page</Link>
       <br />
     </div>
   )

--- a/examples/i18n-routing/tsconfig.json
+++ b/examples/i18n-routing/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Converted example to TypeScript to match Contribution docs.

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
