### PR TITLE
Convert `progressive-render` example to TypeScript

### DIFF
--- a/examples/progressive-render/components/Loading.tsx
+++ b/examples/progressive-render/components/Loading.tsx
@@ -4,6 +4,7 @@ export default function Loading() {
   return (
     <div>
       <h3>Loading...</h3>
+
       <style jsx>{`
         div {
           align-items: center;

--- a/examples/progressive-render/package.json
+++ b/examples/progressive-render/package.json
@@ -7,7 +7,13 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.6.1",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
+    "typescript": "^4.7.4"
   }
 }

--- a/examples/progressive-render/pages/index.tsx
+++ b/examples/progressive-render/pages/index.tsx
@@ -3,12 +3,15 @@ import Loading from '../components/Loading'
 
 function useMounted() {
   const [mounted, setMounted] = useState(false)
+
   useEffect(() => setMounted(true), [])
+
   return mounted
 }
 
 export default function HomePage() {
   const isMounted = useMounted()
+
   return (
     <main>
       <section>

--- a/examples/progressive-render/tsconfig.json
+++ b/examples/progressive-render/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Converted example to TypeScript to match Contribution docs.

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
