### PR TITLE
Convert `react-remove-properties` example to TypeScript

### DIFF
--- a/examples/react-remove-properties/README.md
+++ b/examples/react-remove-properties/README.md
@@ -1,6 +1,6 @@
 # React Remove Properties Example
 
-This example shows how to use the `reactRemoveProperties` config option to remove React properties.
+This example shows how to use the Next.js [reactRemoveProperties](https://nextjs.org/docs/advanced-features/compiler#remove-react-properties) config option to remove React properties.
 
 ## Deploy your own
 

--- a/examples/react-remove-properties/next.config.js
+++ b/examples/react-remove-properties/next.config.js
@@ -1,5 +1,10 @@
-module.exports = {
-  experimental: {
+// @ts-check
+
+/**
+ * @type {import('next').NextConfig}
+ **/
+const nextConfig = {
+  compiler: {
     reactRemoveProperties: true,
     // Or, specify a custom list of regular expressions to match properties to remove.
     // The regexes defined here are processed in Rust so the syntax is different from
@@ -7,3 +12,5 @@ module.exports = {
     // reactRemoveProperties: { properties: ['^data-custom$'] },
   },
 }
+
+module.exports = nextConfig

--- a/examples/react-remove-properties/package.json
+++ b/examples/react-remove-properties/package.json
@@ -7,7 +7,13 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.6.1",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
+    "typescript": "^4.7.4"
   }
 }

--- a/examples/react-remove-properties/pages/index.js
+++ b/examples/react-remove-properties/pages/index.js
@@ -1,9 +1,0 @@
-const Index = () => (
-  <div data-test-id="1" data-custom="1a">
-    <div data-custom="2">
-      <h1 data-testid="3">Hello World!</h1>
-    </div>
-  </div>
-)
-
-export default Index

--- a/examples/react-remove-properties/pages/index.tsx
+++ b/examples/react-remove-properties/pages/index.tsx
@@ -1,0 +1,9 @@
+export default function Index() {
+  return (
+    <div data-test-id="1" data-custom="1a">
+      <div data-custom="2">
+        <h1 data-testid="3">Hello World!</h1>
+      </div>
+    </div>
+  )
+}

--- a/examples/react-remove-properties/tsconfig.json
+++ b/examples/react-remove-properties/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Converted example to TypeScript to match Contribution docs.

- Moved `reactRemoveProperties` out of `experimental` into `compiler` to match docs https://nextjs.org/docs/advanced-features/compiler#remove-react-properties

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
