### PR TITLE
Convert `styled-jsx-with-csp` example to TypeScript

### DIFF
--- a/examples/styled-jsx-with-csp/package.json
+++ b/examples/styled-jsx-with-csp/package.json
@@ -6,9 +6,15 @@
     "start": "next start"
   },
   "dependencies": {
-    "nanoid": "3.1.21",
-    "next": "^12.0.7",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "nanoid": "^4.0.0",
+    "next": "latest",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.6.2",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
+    "typescript": "^4.7.4"
   }
 }

--- a/examples/styled-jsx-with-csp/pages/_app.jsx
+++ b/examples/styled-jsx-with-csp/pages/_app.jsx
@@ -1,6 +1,0 @@
-const CustomApp = ({ Component, pageProps }) => <Component {...pageProps} />
-
-//  Disable static optimization to always server render, making nonce unique on every request
-CustomApp.getInitialProps = () => ({})
-
-export default CustomApp

--- a/examples/styled-jsx-with-csp/pages/_app.tsx
+++ b/examples/styled-jsx-with-csp/pages/_app.tsx
@@ -1,0 +1,8 @@
+import type { AppProps } from 'next/app'
+
+export default function CustomApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}
+
+//  Disable static optimization to always server render, making nonce unique on every request
+CustomApp.getInitialProps = () => ({})

--- a/examples/styled-jsx-with-csp/pages/_document.tsx
+++ b/examples/styled-jsx-with-csp/pages/_document.tsx
@@ -1,7 +1,16 @@
-import Document, { Html, Head, Main, NextScript } from 'next/document'
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+} from 'next/document'
 import { nanoid } from 'nanoid'
+
 class CustomDocument extends Document {
-  static async getInitialProps(ctx) {
+  public props: any
+
+  static async getInitialProps(ctx: DocumentContext) {
     const nonce = nanoid()
     const docProps = await ctx.defaultGetInitialProps(ctx, { nonce })
 
@@ -15,7 +24,8 @@ class CustomDocument extends Document {
       contentSecurityPolicy = `default-src 'self'; style-src 'unsafe-inline'; script-src 'self' 'unsafe-eval';`
     }
 
-    ctx.res.setHeader('Content-Security-Policy', contentSecurityPolicy)
+    ctx.res?.setHeader('Content-Security-Policy', contentSecurityPolicy)
+
     return { ...docProps, nonce }
   }
 

--- a/examples/styled-jsx-with-csp/pages/index.tsx
+++ b/examples/styled-jsx-with-csp/pages/index.tsx
@@ -1,20 +1,22 @@
 import { useState } from 'react'
 
-const ClientSideComponent = () => (
-  <>
-    <style jsx>
-      {`
-        .title {
-          font-size: 24px;
-          color: green;
-        }
-      `}
-    </style>
-    <p className="title">This is rendered on client-side</p>
-  </>
-)
+function ClientSideComponent() {
+  return (
+    <>
+      <style jsx>
+        {`
+          .title {
+            font-size: 24px;
+            color: green;
+          }
+        `}
+      </style>
+      <p className="title">This is rendered on client-side</p>
+    </>
+  )
+}
 
-const Home = () => {
+export default function Home() {
   const [isVisible, setVisibility] = useState(false)
 
   const toggleVisibility = () => {
@@ -36,5 +38,3 @@ const Home = () => {
     </>
   )
 }
-
-export default Home

--- a/examples/styled-jsx-with-csp/tsconfig.json
+++ b/examples/styled-jsx-with-csp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Converted example to TypeScript to match Contribution docs.

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
