### PR TITLE
fix: missing semicolon on Dockerfile

### DIFF
--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /app
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 # Omit --production flag for TypeScript devDependencies
 RUN \
-  if [ -f yarn.lock ] then yarn install --frozen-lockfile; \
-  elif [ -f package-lock.json ] then npm ci; \
-  elif [ -f pnpm-lock.yaml ] then yarn global add pnpm && pnpm i; \
+  if [ -f yarn.lock ]; then yarn install --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i; \
   else echo "Lockfile not found." && exit 1; \
   fi
 

--- a/examples/with-docker-compose/next-app/prod.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod.Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /app
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 # Omit --production flag for TypeScript devDependencies
 RUN \
-  if [ -f yarn.lock ] then yarn install --frozen-lockfile; \
-  elif [ -f package-lock.json ] then npm ci; \
-  elif [ -f pnpm-lock.yaml ] then yarn global add pnpm && pnpm i; \
+  if [ -f yarn.lock ]; then yarn install --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i; \
   else echo "Lockfile not found." && exit 1; \
   fi
 

--- a/examples/with-docker-multi-env/docker/development/Dockerfile
+++ b/examples/with-docker-multi-env/docker/development/Dockerfile
@@ -8,9 +8,9 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
-  if [ -f yarn.lock ] then yarn --frozen-lockfile;\
-  elif [ -f package-lock.json ] then npm ci;\
-  elif [ -f pnpm-lock.yaml ] then yarn global add pnpm && pnpm i;\
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile;\
+  elif [ -f package-lock.json ]; then npm ci;\
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i;\
   else echo "Lockfile not found." && exit 1;\
   fi
 

--- a/examples/with-docker-multi-env/docker/production/Dockerfile
+++ b/examples/with-docker-multi-env/docker/production/Dockerfile
@@ -8,9 +8,9 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
-  if [ -f yarn.lock ] then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ] then npm ci; \
-  elif [ -f pnpm-lock.yaml ] then yarn global add pnpm && pnpm i; \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i; \
   else echo "Lockfile not found." && exit 1; \
   fi
 

--- a/examples/with-docker-multi-env/docker/staging/Dockerfile
+++ b/examples/with-docker-multi-env/docker/staging/Dockerfile
@@ -8,9 +8,9 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
-  if [ -f yarn.lock ] then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ] then npm ci; \
-  elif [ -f pnpm-lock.yaml ] then yarn global add pnpm && pnpm i; \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i; \
   else echo "Lockfile not found." && exit 1; \
   fi
 


### PR DESCRIPTION
The commit https://github.com/vercel/next.js/commit/0a781dd67510b679db178b17e30a1a06bb912398 changes the docker examples to use `if..elif..else`

it is working fine tor the `with-docker` example, but not working for the `with-docker-compose` and `with-docker-multi-env` examples due to a missing semicolon.

Fix #39085

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
