### PR TITLE
Show large-page-data warnings only once per page for production mode

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -970,24 +970,30 @@ export class NextScript extends Component<OriginProps> {
     const { __NEXT_DATA__, largePageDataBytes } = context
     try {
       const data = JSON.stringify(__NEXT_DATA__)
-      const bytes =
-        process.env.NEXT_RUNTIME === 'edge'
-          ? new TextEncoder().encode(data).buffer.byteLength
-          : Buffer.from(data).byteLength
-      const prettyBytes = require('../lib/pretty-bytes').default
 
-      if (largePageDataBytes && bytes > largePageDataBytes) {
-        console.warn(
-          `Warning: data for page "${__NEXT_DATA__.page}"${
-            __NEXT_DATA__.page === context.dangerousAsPath
-              ? ''
-              : ` (path "${context.dangerousAsPath}")`
-          } is ${prettyBytes(
-            bytes
-          )} which exceeds the threshold of ${prettyBytes(
-            largePageDataBytes
-          )}, this amount of data can reduce performance.\nSee more info here: https://nextjs.org/docs/messages/large-page-data`
-        )
+      if (
+        process.env.NODE_ENV === 'development' ||
+        !(__NEXT_DATA__.gssp || __NEXT_DATA__.gip)
+      ) {
+        const bytes =
+          process.env.NEXT_RUNTIME === 'edge'
+            ? new TextEncoder().encode(data).buffer.byteLength
+            : Buffer.from(data).byteLength
+        const prettyBytes = require('../lib/pretty-bytes').default
+
+        if (largePageDataBytes && bytes > largePageDataBytes) {
+          console.warn(
+            `Warning: data for page "${__NEXT_DATA__.page}"${
+              __NEXT_DATA__.page === context.dangerousAsPath
+                ? ''
+                : ` (path "${context.dangerousAsPath}")`
+            } is ${prettyBytes(
+              bytes
+            )} which exceeds the threshold of ${prettyBytes(
+              largePageDataBytes
+            )}, this amount of data can reduce performance.\nSee more info here: https://nextjs.org/docs/messages/large-page-data`
+          )
+        }
       }
 
       return htmlEscapeJsonString(data)

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -945,6 +945,8 @@ export function Main() {
   return <next-js-internal-body-render-target />
 }
 
+const largePageDataWarnings = new Map<string, boolean>()
+
 export class NextScript extends Component<OriginProps> {
   static contextType = HtmlContext
 
@@ -971,10 +973,7 @@ export class NextScript extends Component<OriginProps> {
     try {
       const data = JSON.stringify(__NEXT_DATA__)
 
-      if (
-        process.env.NODE_ENV === 'development' ||
-        !(__NEXT_DATA__.gssp || __NEXT_DATA__.gip)
-      ) {
+      if (!largePageDataWarnings.get(__NEXT_DATA__.page)) {
         const bytes =
           process.env.NEXT_RUNTIME === 'edge'
             ? new TextEncoder().encode(data).buffer.byteLength
@@ -982,6 +981,9 @@ export class NextScript extends Component<OriginProps> {
         const prettyBytes = require('../lib/pretty-bytes').default
 
         if (largePageDataBytes && bytes > largePageDataBytes) {
+          if (process.env.NODE_ENV === 'production') {
+            largePageDataWarnings.set(__NEXT_DATA__.page, true)
+          }
           console.warn(
             `Warning: data for page "${__NEXT_DATA__.page}"${
               __NEXT_DATA__.page === context.dangerousAsPath


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [X] Related issues linked using fixes #37264
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

#37264 PR causes a warning log to accumulate for every server-side render request that exceeds the recommended bytes.
In this case, too much log data is accumulated in docker's stdout or log management system or something like that.

This PR works as follows:
- Addresses potential issues with Next.js user systems by showing only one warning per request per page in production mode.