### PR TITLE
Ensure we hard navigate for failed _next/data with middleware

### DIFF
--- a/test/e2e/middleware-rewrites/app/middleware.js
+++ b/test/e2e/middleware-rewrites/app/middleware.js
@@ -13,6 +13,12 @@ export async function middleware(request) {
     return NextResponse.next()
   }
 
+  if (url.pathname.includes('/to/some/404/path')) {
+    return NextResponse.next({
+      'x-matched-path': '/404',
+    })
+  }
+
   if (url.pathname.includes('/fallback-true-blog/rewritten')) {
     request.nextUrl.pathname = '/about'
     return NextResponse.rewrite(request.nextUrl)

--- a/test/e2e/middleware-rewrites/app/pages/404.js
+++ b/test/e2e/middleware-rewrites/app/pages/404.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <p>custom 404 page</p>
+}

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -27,7 +27,7 @@ describe('Middleware Rewrite', () => {
   testsWithLocale('/fr')
 
   function tests() {
-    it.only('should hard navigate on 404 for data request', async () => {
+    it('should hard navigate on 404 for data request', async () => {
       const browser = await webdriver(next.url, '/')
       await browser.eval('window.beforeNav = 1')
       await browser.eval(`next.router.push("/to/some/404/path")`)

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -27,6 +27,18 @@ describe('Middleware Rewrite', () => {
   testsWithLocale('/fr')
 
   function tests() {
+    it.only('should hard navigate on 404 for data request', async () => {
+      const browser = await webdriver(next.url, '/')
+      await browser.eval('window.beforeNav = 1')
+      await browser.eval(`next.router.push("/to/some/404/path")`)
+      await check(
+        () => browser.eval('document.documentElement.innerHTML'),
+        /custom 404 page/
+      )
+      expect(await browser.eval('location.pathname')).toBe('/to/some/404/path')
+      expect(await browser.eval('window.beforeNav')).not.toBe(1)
+    })
+
     // TODO: middleware effect headers aren't available here
     it.skip('includes the locale in rewrites by default', async () => {
       const res = await fetchViaHTTP(next.url, `/rewrite-me-to-about`)


### PR DESCRIPTION
This ensures we properly hard navigate when `_next/data` returns a 404 and removes the previous check that tolerated this as we have addressed the referenced TODO. This also adds an e2e test for this case. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/39006
x-ref: https://github.com/vercel/next.js/issues/38239