### PR TITLE
Fix middleware + afterFiles SSG rewrite case

### DIFF
--- a/test/e2e/middleware-rewrites/app/next.config.js
+++ b/test/e2e/middleware-rewrites/app/next.config.js
@@ -16,6 +16,10 @@ module.exports = {
           source: '/afterfiles-rewrite',
           destination: '/ab-test/b',
         },
+        {
+          source: '/afterfiles-rewrite-ssg',
+          destination: '/fallback-true-blog/first',
+        },
       ],
       fallback: [],
     }

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -27,6 +27,30 @@ describe('Middleware Rewrite', () => {
   testsWithLocale('/fr')
 
   function tests() {
+    it('should have props for afterFiles rewrite to SSG page', async () => {
+      let browser = await webdriver(next.url, '/')
+      await browser.eval(`next.router.push("/afterfiles-rewrite-ssg")`)
+
+      await check(
+        () => browser.eval('next.router.isReady ? "yup": "nope"'),
+        'yup'
+      )
+      await check(
+        () => browser.eval('document.documentElement.innerHTML'),
+        /"slug":"first"/
+      )
+
+      browser = await webdriver(next.url, '/afterfiles-rewrite-ssg')
+      await check(
+        () => browser.eval('next.router.isReady ? "yup": "nope"'),
+        'yup'
+      )
+      await check(
+        () => browser.eval('document.documentElement.innerHTML'),
+        /"slug":"first"/
+      )
+    })
+
     it('should hard navigate on 404 for data request', async () => {
       const browser = await webdriver(next.url, '/')
       await browser.eval('window.beforeNav = 1')


### PR DESCRIPTION
This ensures we properly load props when updating query information or during a route transition when `afterFiles` rewrites are used alongside middleware for an SSG page. 

Deployment of reproduction with patch applied can be seen [here](https://middleware-missing-props-repro-bga080wtb-ijjk-testing.vercel.app/river/)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/38794