### PR TITLE
Add caveat note about shallow routing with middleware

### DIFF
--- a/docs/routing/shallow-routing.md
+++ b/docs/routing/shallow-routing.md
@@ -61,3 +61,5 @@ router.push('/?counter=10', '/about?counter=10', { shallow: true })
 ```
 
 Since that's a new page, it'll unload the current page, load the new one and wait for data fetching even though we asked to do shallow routing.
+
+When shallow routing is used with middleware it will not ensure the new page matches the current page like previously done without middleware. This is due to middleware being able to rewrite dynamically and can't be verified client-side without a data fetch which is skipped with shallow, so a shallow route change must always be treated as shallow.


### PR DESCRIPTION
This adds a note about a caveat with shallow routing and middleware as previously when shallow was used but the route didn't match the new route being transitioned to the shallow flag would be ignored but this doesn't work with middleware. 

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)

Closes: https://github.com/vercel/next.js/issues/38595