### PR TITLE
Fix incorrect component cache for middleware cases

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1763,7 +1763,6 @@ export default class Router implements BaseRouter {
           // If we have a match with the current route due to rewrite,
           // we can copy the existing information to the rewritten one.
           // Then, we return the information along with the matched route.
-          this.components[requestedRoute] = { ...existingInfo, route }
           return { ...existingInfo, route }
         }
       }
@@ -1908,11 +1907,6 @@ export default class Router implements BaseRouter {
       routeInfo.resolvedAs = resolvedAs
       this.components[route] = routeInfo
 
-      // If the route was rewritten in the process of fetching data,
-      // we update the cache to allow hitting the same data for shallow requests.
-      if (route !== requestedRoute) {
-        this.components[requestedRoute] = { ...routeInfo, route }
-      }
       return routeInfo
     } catch (err) {
       return this.handleRouteInfoError(

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -27,6 +27,28 @@ describe('Middleware Rewrite', () => {
   testsWithLocale('/fr')
 
   function tests() {
+    it('should not mix component cache when navigating between dynamic routes', async () => {
+      const browser = await webdriver(next.url, '/param-1')
+
+      expect(await browser.eval('next.router.pathname')).toBe('/[param]')
+      expect(await browser.eval('next.router.query.param')).toBe('param-1')
+
+      await browser.eval(`next.router.push("/fallback-true-blog/first")`)
+      await check(
+        () => browser.eval('next.router.pathname'),
+        '/fallback-true-blog/[slug]'
+      )
+      expect(await browser.eval('next.router.query.slug')).toBe('first')
+      expect(await browser.eval('next.router.asPath')).toBe(
+        '/fallback-true-blog/first'
+      )
+
+      await browser.back()
+      await check(() => browser.eval('next.router.pathname'), '/[param]')
+      expect(await browser.eval('next.router.query.param')).toBe('param-1')
+      expect(await browser.eval('next.router.asPath')).toBe('/param-1')
+    })
+
     it('should have props for afterFiles rewrite to SSG page', async () => {
       let browser = await webdriver(next.url, '/')
       await browser.eval(`next.router.push("/afterfiles-rewrite-ssg")`)


### PR DESCRIPTION
This ensures we don't update the component cache incorrectly as the cache needs to be specific to the route and should not be mixed between routes. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1659060955506459)