### PR TITLE
Add clarification about webpack requirement in MDX steup

### DIFF
--- a/docs/advanced-features/using-mdx.md
+++ b/docs/advanced-features/using-mdx.md
@@ -64,6 +64,8 @@ The following steps outline how to setup `@next/mdx` in your Next.js project:
      - package.json
    ```
 
+> **Note**: When installing `MDX` packages, you might get a warning message that requires webpack to be installed as a peer dependency. This can be ignored since Next.js already comes with webpack bundled in.
+
 ## Using Components, Layouts and Custom Elements
 
 You can now import a React component directly inside your MDX page:


### PR DESCRIPTION
Add clarification about ignoring the warning message about installing webpack as peer dependency during MDX setup. Because Next.js already has webpack bundled in. 

## Bug

- [x] Related issues linked using `fixes #36600 `
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #36600`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature, if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
