### PR TITLE
Add exportPathMap config type/schema field

### DIFF
--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -30,7 +30,7 @@ import {
 } from '../shared/lib/constants'
 import loadConfig from '../server/config'
 import { isTargetLikeServerless } from '../server/utils'
-import { NextConfigComplete } from '../server/config-shared'
+import { ExportPathMap, NextConfigComplete } from '../server/config-shared'
 import { eventCliSession } from '../telemetry/events'
 import { hasNextSupport } from '../telemetry/ci-info'
 import { Telemetry } from '../telemetry/storage'
@@ -122,10 +122,6 @@ const createProgress = (total: number, label: string) => {
       console.log(newText)
     }
   }
-}
-
-type ExportPathMap = {
-  [page: string]: { page: string; query?: { [key: string]: string } }
 }
 
 interface ExportOptions {
@@ -318,7 +314,7 @@ export default async function exportApp(
           `No "exportPathMap" found in "${nextConfig.configFile}". Generating map from "./pages"`
         )
       }
-      nextConfig.exportPathMap = async (defaultMap: ExportPathMap) => {
+      nextConfig.exportPathMap = async (defaultMap) => {
         return defaultMap
       }
     }

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -391,6 +391,9 @@ const configSchema = {
       },
       type: 'object',
     },
+    exportPathMap: {
+      isFunction: true,
+    } as any,
     future: {
       additionalProperties: false,
       properties: {},

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -148,11 +148,26 @@ export interface ExperimentalConfig {
   largePageDataBytes?: number
 }
 
+export type ExportPathMap = {
+  [path: string]: { page: string; query?: Record<string, string | string[]> }
+}
+
 /**
  * Next configuration object
  * @see [configuration documentation](https://nextjs.org/docs/api-reference/next.config.js/introduction)
  */
 export interface NextConfig extends Record<string, any> {
+  exportPathMap?: (
+    defaultMap: ExportPathMap,
+    ctx: {
+      dev: boolean
+      dir: string
+      outDir: string | null
+      distDir: string
+      buildId: string
+    }
+  ) => Promise<ExportPathMap> | ExportPathMap
+
   /**
    * Internationalization configuration
    *


### PR DESCRIPTION
Adds missing config type/schema field for `exportPathMap`. 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/39170
x-ref: https://github.com/vercel/next.js/issues/38909#issuecomment-1199547828