### PR TITLE
Remove `node-sass` optional peer dependency from `next`

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -79,15 +79,11 @@
   },
   "peerDependencies": {
     "fibers": ">= 3.1.0",
-    "node-sass": "^6.0.0 || ^7.0.0",
     "react": "^17.0.2 || ^18.0.0-0",
     "react-dom": "^17.0.2 || ^18.0.0-0",
     "sass": "^1.3.0"
   },
   "peerDependenciesMeta": {
-    "node-sass": {
-      "optional": true
-    },
     "sass": {
       "optional": true
     },

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -88,7 +88,6 @@ const externals = {
 
   // sass-loader
   // (also responsible for these dependencies in package.json)
-  'node-sass': 'node-sass',
   sass: 'sass',
   fibers: 'fibers',
 
@@ -1480,7 +1479,7 @@ export async function ncc_sass_loader(task, opts) {
   await fs.writeFile(
     utilsPath,
     originalContent.replace(
-      /require\.resolve\(["'](sass|node-sass)["']\)/g,
+      /require\.resolve\(["'](sass)["']\)/g,
       'eval("require").resolve("$1")'
     )
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19572,13 +19572,10 @@ packages:
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
       sass: ^1.3.0
       webpack: ^5.0.0
     peerDependenciesMeta:
       fibers:
-        optional: true
-      node-sass:
         optional: true
       sass:
         optional: true


### PR DESCRIPTION
Remove `node-sass` as an optional peer dependency of `sass-loader` in the `next` project. `node-sass` is deprecated, and there are no plans to finish adding support for Apple ARM. https://github.com/sass/node-sass/issues/3033 Replace with `sass`, which does not require any native dependencies.

Running `pnpm install` on an M1 Macbook (or other ARM64 device) stalls for over 1 minute, while pnpm waits for the `node-sass` postinstall script to timeout, before continuing.

```sh
node_modules/.pnpm/node-sass@7.0.1/node_modules/node-sass: Running install script, done in 789ms
node_modules/.pnpm/node-sass@7.0.1/node_modules/node-sass: Running postinstall script, done in 1m 7.1s # <--
```

x-ref: https://github.com/vercel/next.js/pull/39053#issuecomment-1196238344

How should I handle the `duplicate-sass` integration test? Can it simply be removed?