### PR TITLE
Update deployment docs to include China Solution

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -102,6 +102,7 @@ The following services support Next.js `v12+`. Below, you’ll find examples or 
 - [Heroku](https://elements.heroku.com/buildpacks/mars/heroku-nextjs)
 - [Railway](https://railway.app/new/starters/nextjs-prisma)
 - [Render](https://render.com/docs/deploy-nextjs-app)
+- [21YunBox](https://www.21cloudbox.com/solutions/how-to-deploy-nextjs-project-in-production-server.html)
 
 > **Note:** There are also managed platforms that allow you to use a Dockerfile as shown in the [example above](/docs/deployment.md#docker-image).
 
@@ -113,6 +114,8 @@ The following services support deploying Next.js using [`next export`](/docs/adv
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
 - [Firebase](https://github.com/vercel/next.js/tree/canary/examples/with-firebase-hosting)
 - [GitHub Pages](https://github.com/vercel/next.js/tree/canary/examples/github-pages)
+- [21YunBox](https://www.21cloudbox.com/solutions/how-to-deploy-nextjs-project-in-production-server.html)
+
 
 You can also manually deploy the [`next export`](/docs/advanced-features/static-html-export.md) output to any static hosting provider, often through your CI/CD pipeline like GitHub Actions, Jenkins, AWS CodeBuild, Circle CI, Azure Pipelines, and more.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,8 +114,6 @@ The following services support deploying Next.js using [`next export`](/docs/adv
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/)
 - [Firebase](https://github.com/vercel/next.js/tree/canary/examples/with-firebase-hosting)
 - [GitHub Pages](https://github.com/vercel/next.js/tree/canary/examples/github-pages)
-- [21YunBox](https://www.21cloudbox.com/solutions/how-to-deploy-nextjs-project-in-production-server.html)
-
 
 You can also manually deploy the [`next export`](/docs/advanced-features/static-html-export.md) output to any static hosting provider, often through your CI/CD pipeline like GitHub Actions, Jenkins, AWS CodeBuild, Circle CI, Azure Pipelines, and more.
 


### PR DESCRIPTION
I noticed many of the "Other Services" listed on this page do not provide service in China.

 I have updated the lists to include 21YunBox's Next.js China deployment guide/starter to the Other Services 'Managed Servers' and 'Static only' lists.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
