### PR TITLE
Add section about migrating from `next/image` to `next/future/image`

### DIFF
--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -60,7 +60,10 @@ Although `layout` is not available, you can migrate `next/image` to `next/future
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-return <Image src={img} />
+
+function Page() {
+  return <Image src={img} />
+}
 ```
 
 </td>
@@ -69,8 +72,11 @@ return <Image src={img} />
 ```jsx
 import Image from 'next/future/image'
 import img from '../img.png'
+
 const css = { maxWidth: '100%', height: 'auto' }
-return <Image src={img} style={css} />
+function Page() {
+  return <Image src={img} style={css} />
+}
 ```
 
 </td>
@@ -82,7 +88,10 @@ return <Image src={img} style={css} />
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-return <Image src={img} layout="responsive" />
+
+function Page() {
+  return <Image src={img} layout="responsive" />
+}
 ```
 
 </td>
@@ -91,8 +100,11 @@ return <Image src={img} layout="responsive" />
 ```jsx
 import Image from 'next/future/image'
 import img from '../img.png'
+
 const css = { width: '100%', height: 'auto' }
-return <Image src={img} sizes="100vw" style={css} />
+function Page() {
+  return <Image src={img} sizes="100vw" style={css} />
+}
 ```
 
 </td>
@@ -104,7 +116,10 @@ return <Image src={img} sizes="100vw" style={css} />
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-return <Image src={img} layout="fill" />
+
+function Page() {
+  return <Image src={img} layout="fill" />
+}
 ```
 
 </td>
@@ -113,7 +128,10 @@ return <Image src={img} layout="fill" />
 ```jsx
 import Image from 'next/future/image'
 import img from '../img.png'
-return <Image src={img} sizes="100vw" fill />
+
+function Page() {
+  return <Image src={img} sizes="100vw" fill />
+}
 ```
 
 </td>
@@ -125,7 +143,10 @@ return <Image src={img} sizes="100vw" fill />
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-return <Image src={img} layout="fixed" />
+
+function Page() {
+  return <Image src={img} layout="fixed" />
+}
 ```
 
 </td>
@@ -134,7 +155,10 @@ return <Image src={img} layout="fixed" />
 ```jsx
 import Image from 'next/future/image'
 import img from '../img.png'
-return <Image src={img} />
+
+function Page() {
+  return <Image src={img} />
+}
 ```
 
 </td>

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -45,25 +45,41 @@ Compared to `next/image`, the new `next/future/image` component has the followin
 
 Although `layout` is not available, you can migrate `next/image` to `next/future/image` using a few props. The following is a comparison of the two components:
 
-**intrinsic: next/image**
+<table>
+<thead>
+  <tr>
+    <th>next/image</th>
+    <th>next/future/image</th>
+  </tr>
+</thead>
+<tbody>
+
+<tr>
+<td>
 
 ```jsx
 <ImageLegacy src={src} />
 ```
 
-**intrinsic: next/future/image**
+</td>
+<td>
 
 ```jsx
 <ImageFuture src={src} style={{ maxWidth: '100%', height: 'auto' }} />
 ```
 
-**responsive: next/image**
+</td>
+</tr>
+
+<tr>
+<td>
 
 ```jsx
 <ImageLegacy src={src} layout="responsive" />
 ```
 
-**responsive: next/future/image**
+</td>
+<td>
 
 ```jsx
 <ImageFuture
@@ -73,29 +89,45 @@ Although `layout` is not available, you can migrate `next/image` to `next/future
 />
 ```
 
-**fill: next/image**
+</td>
+</tr>
+
+<tr>
+<td>
 
 ```jsx
 <ImageLegacy src={src} layout="fill" />
 ```
 
-**fill: next/future/image**
+</td>
+<td>
 
 ```jsx
 <ImageFuture src={src} sizes="100vw" fill />
 ```
 
-**fixed: next/image**
+</td>
+</tr>
+
+<tr>
+<td>
 
 ```jsx
 <ImageLegacy src={src} layout="fixed" />
 ```
 
-**fixed: next/future/image**
+</td>
+<td>
 
 ```jsx
 <ImageFuture src={src} />
 ```
+
+</td>
+</tr>
+
+</tbody>
+</table>
 
 You can also use `className` instead of `style`.
 

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -60,7 +60,7 @@ Although `layout` is not available, you can migrate `next/image` to `next/future
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-;<Image src={img} />
+return <Image src={img} />
 ```
 
 </td>
@@ -70,7 +70,7 @@ import img from '../img.png'
 import Image from 'next/future/image'
 import img from '../img.png'
 const css = { maxWidth: '100%', height: 'auto' }
-;<Image src={img} style={css} />
+return <Image src={img} style={css} />
 ```
 
 </td>
@@ -82,7 +82,7 @@ const css = { maxWidth: '100%', height: 'auto' }
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-;<Image src={img} layout="responsive" />
+return <Image src={img} layout="responsive" />
 ```
 
 </td>
@@ -92,7 +92,7 @@ import img from '../img.png'
 import Image from 'next/future/image'
 import img from '../img.png'
 const css = { width: '100%', height: 'auto' }
-;<Image src={img} sizes="100vw" style={css} />
+return <Image src={img} sizes="100vw" style={css} />
 ```
 
 </td>
@@ -104,7 +104,7 @@ const css = { width: '100%', height: 'auto' }
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-;<Image src={img} layout="fill" />
+return <Image src={img} layout="fill" />
 ```
 
 </td>
@@ -113,7 +113,7 @@ import img from '../img.png'
 ```jsx
 import Image from 'next/future/image'
 import img from '../img.png'
-;<Image src={img} sizes="100vw" fill />
+return <Image src={img} sizes="100vw" fill />
 ```
 
 </td>
@@ -125,7 +125,7 @@ import img from '../img.png'
 ```jsx
 import Image from 'next/image'
 import img from '../img.png'
-;<Image src={img} layout="fixed" />
+return <Image src={img} layout="fixed" />
 ```
 
 </td>
@@ -134,7 +134,7 @@ import img from '../img.png'
 ```jsx
 import Image from 'next/future/image'
 import img from '../img.png'
-;<ImageFuture src={img} />
+return <Image src={img} />
 ```
 
 </td>

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -30,6 +30,8 @@ module.exports = {
 }
 ```
 
+## Comparison
+
 Compared to `next/image`, the new `next/future/image` component has the following changes:
 
 - Renders a single `<img>` without `<div>` or `<span>` wrappers
@@ -39,12 +41,63 @@ Compared to `next/image`, the new `next/future/image` component has the followin
 - Removes `loader` config in favor of [`loader`](#loader) prop
 - Note: the [`onError`](#onerror) prop might behave differently
 
-The default layout for `next/image` was `intrinsic`, which would shrink the `width` if the image was larger than it's container. Since no styles are automatically applied to `next/future/image`, you'll need to add the following CSS to achieve the same behavior:
+## Migration
 
-```css
-max-width: 100%;
-height: auto;
+Although `layout` is not available, you can migrate `next/image` to `next/future/image` using a few props. The following is a comparison of the two components:
+
+**intrinsic: next/image**
+
+```jsx
+<ImageLegacy src={src} />
 ```
+
+**intrinsic: next/future/image**
+
+```jsx
+<ImageFuture src={src} style={{ maxWidth: '100%', height: 'auto' }} />
+```
+
+**responsive: next/image**
+
+```jsx
+<ImageLegacy src={src} layout="responsive" />
+```
+
+**responsive: next/future/image**
+
+```jsx
+<ImageFuture
+  src={src}
+  sizes="100vw"
+  style={{ width: '100%', height: 'auto' }}
+/>
+```
+
+**fill: next/image**
+
+```jsx
+<ImageLegacy src={src} layout="fill" />
+```
+
+**fill: next/future/image**
+
+```jsx
+<ImageFuture src={src} sizes="100vw" fill />
+```
+
+**fixed: next/image**
+
+```jsx
+<ImageLegacy src={src} layout="fixed" />
+```
+
+**fixed: next/future/image**
+
+```jsx
+<ImageFuture src={src} />
+```
+
+You can also use `className` instead of `style`.
 
 ## Required Props
 

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -58,35 +58,19 @@ Although `layout` is not available, you can migrate `next/image` to `next/future
 <td>
 
 ```jsx
-<ImageLegacy src={src} />
+import Image from 'next/image'
+import img from '../img.png'
+;<Image src={img} />
 ```
 
 </td>
 <td>
 
 ```jsx
-<ImageFuture src={src} style={{ maxWidth: '100%', height: 'auto' }} />
-```
-
-</td>
-</tr>
-
-<tr>
-<td>
-
-```jsx
-<ImageLegacy src={src} layout="responsive" />
-```
-
-</td>
-<td>
-
-```jsx
-<ImageFuture
-  src={src}
-  sizes="100vw"
-  style={{ width: '100%', height: 'auto' }}
-/>
+import Image from 'next/future/image'
+import img from '../img.png'
+const css = { maxWidth: '100%', height: 'auto' }
+;<Image src={img} style={css} />
 ```
 
 </td>
@@ -96,14 +80,19 @@ Although `layout` is not available, you can migrate `next/image` to `next/future
 <td>
 
 ```jsx
-<ImageLegacy src={src} layout="fill" />
+import Image from 'next/image'
+import img from '../img.png'
+;<Image src={img} layout="responsive" />
 ```
 
 </td>
 <td>
 
 ```jsx
-<ImageFuture src={src} sizes="100vw" fill />
+import Image from 'next/future/image'
+import img from '../img.png'
+const css = { width: '100%', height: 'auto' }
+;<Image src={img} sizes="100vw" style={css} />
 ```
 
 </td>
@@ -113,14 +102,39 @@ Although `layout` is not available, you can migrate `next/image` to `next/future
 <td>
 
 ```jsx
-<ImageLegacy src={src} layout="fixed" />
+import Image from 'next/image'
+import img from '../img.png'
+;<Image src={img} layout="fill" />
 ```
 
 </td>
 <td>
 
 ```jsx
-<ImageFuture src={src} />
+import Image from 'next/future/image'
+import img from '../img.png'
+;<Image src={img} sizes="100vw" fill />
+```
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+```jsx
+import Image from 'next/image'
+import img from '../img.png'
+;<Image src={img} layout="fixed" />
+```
+
+</td>
+<td>
+
+```jsx
+import Image from 'next/future/image'
+import img from '../img.png'
+;<ImageFuture src={img} />
 ```
 
 </td>


### PR DESCRIPTION
This expands on the previous PR #38978 with a section on migrating