### PR TITLE
Fix URLPattern next/server export on deploy

### DIFF
--- a/packages/next/server.js
+++ b/packages/next/server.js
@@ -7,5 +7,6 @@ module.exports = {
     .userAgentFromString,
   userAgent: require('next/dist/server/web/spec-extension/user-agent')
     .userAgent,
-  URLPattern: global.URLPattern,
+  // eslint-disable-next-line no-undef
+  URLPattern: URLPattern,
 }


### PR DESCRIPTION
It seems webpack mangles the export when using `global` to reference it so this removes that. Our existing E2E tests caught this so no additional test has been added here. 

Fixes below error:

```sh
TypeError: s.URLPattern is not a constructor
    at middleware.js:7:4
    at webpack/bootstrap:21:0
    at .:6:18
    at webpack/bootstrap:21:0
    at node_modules/shared-package/index.js:1:0
    at node_modules/shared-package/index.js:1:0
    at webpack/runtime/jsonp chunk loading:34:0
    at middleware:middleware.js:1:17
````

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

