### PR TITLE
Add delay before exiting tests for log flushing

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -37,7 +37,10 @@ const cleanUpAndExit = async (code) => {
     await fs.remove(process.env.NEXT_TEST_STARTER)
   }
   console.log(`exiting with code ${code}`)
-  process.exit(code)
+
+  setTimeout(() => {
+    process.exit(code)
+  }, 1)
 }
 
 async function getTestTimings() {


### PR DESCRIPTION
This attempts moving the process.exit to the next tick to wait for the stdout/stderr logs have been flushed as we've seen test output get cut off here and there when a test fails

x-ref: https://github.com/vercel/next.js/runs/7612742424?check_suite_focus=true