### PR TITLE
Enable concurrent mode by default in app-render

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -413,7 +413,6 @@ export async function renderToHTMLOrFlight(
     buildManifest,
     serverComponentManifest,
     supportsDynamicHTML,
-    runtime,
     ComponentMod,
   } = renderOpts
 
@@ -1046,11 +1045,9 @@ export async function renderToHTMLOrFlight(
       },
     })
 
-    const hasConcurrentFeatures = !!runtime
-
     return await continueFromInitialStream(renderStream, {
       dataStream: serverComponentsInlinedTransformStream?.readable,
-      generateStaticHTML: generateStaticHTML || !hasConcurrentFeatures,
+      generateStaticHTML: generateStaticHTML,
       flushEffectHandler,
       flushEffectsToHead: true,
       initialStylesheets,

--- a/test/e2e/app-dir/app-rendering/next.config.js
+++ b/test/e2e/app-dir/app-rendering/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    runtime: 'nodejs',
     serverComponents: true,
   },
 }

--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    runtime: 'nodejs',
     serverComponents: true,
     legacyBrowsers: false,
     browsersListForSwc: true,

--- a/test/e2e/app-dir/rsc-basic/next.config.js
+++ b/test/e2e/app-dir/rsc-basic/next.config.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   experimental: {
     appDir: true,
-    runtime: 'nodejs',
     serverComponents: true,
   },
 }


### PR DESCRIPTION
Concurrent mode is always enabled in app-render, it's not relying on runtime option yet

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

