### PR TITLE
Fix next/server being required during build

### DIFF
--- a/packages/next/server.js
+++ b/packages/next/server.js
@@ -1,4 +1,4 @@
-module.exports = {
+const serverExports = {
   NextRequest: require('next/dist/server/web/spec-extension/request')
     .NextRequest,
   NextResponse: require('next/dist/server/web/spec-extension/response')
@@ -7,6 +7,11 @@ module.exports = {
     .userAgentFromString,
   userAgent: require('next/dist/server/web/spec-extension/user-agent')
     .userAgent,
-  // eslint-disable-next-line no-undef
-  URLPattern: URLPattern,
 }
+
+if (typeof URLPattern !== 'undefined') {
+  // eslint-disable-next-line no-undef
+  serverExports.URLPattern = URLPattern
+}
+
+module.exports = serverExports

--- a/test/unit/web-runtime/next-server-node.test.ts
+++ b/test/unit/web-runtime/next-server-node.test.ts
@@ -1,0 +1,5 @@
+import 'next/dist/server/node-polyfill-fetch'
+
+it('should be able to require next/server outside edge', () => {
+  require('next/server')
+})


### PR DESCRIPTION
This ensures we gracefully handle `URLPattern` not being available when `next/server` is required e.g. during a build when analyzing pages. 

```sh
19:17:10.114 | info  - Collecting page data...
19:17:10.114 | ReferenceError: URLPattern is not defined
19:17:10.114 | at Object.<anonymous> (/vercel/path0/node_modules/next/server.js:11:15)
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

