### PR TITLE
Hoist styles for Route Announcer 📢

### DIFF
--- a/packages/next/client/route-announcer.tsx
+++ b/packages/next/client/route-announcer.tsx
@@ -1,7 +1,22 @@
 import React from 'react'
 import { useRouter } from './router'
 
-export function RouteAnnouncer() {
+const nextjsRouteAnnouncerStyles: React.CSSProperties = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  width: '1px',
+
+  // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+  whiteSpace: 'nowrap',
+  wordWrap: 'normal',
+}
+
+export const RouteAnnouncer = React.memo(() => {
   const { asPath } = useRouter()
   const [routeAnnouncement, setRouteAnnouncement] = React.useState('')
 
@@ -39,24 +54,11 @@ export function RouteAnnouncer() {
       aria-live="assertive" // Make the announcement immediately.
       id="__next-route-announcer__"
       role="alert"
-      style={{
-        border: 0,
-        clip: 'rect(0 0 0 0)',
-        height: '1px',
-        margin: '-1px',
-        overflow: 'hidden',
-        padding: 0,
-        position: 'absolute',
-        width: '1px',
-
-        // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
-        whiteSpace: 'nowrap',
-        wordWrap: 'normal',
-      }}
+      style={nextjsRouteAnnouncerStyles}
     >
       {routeAnnouncement}
     </p>
   )
-}
+})
 
 export default RouteAnnouncer

--- a/packages/next/client/route-announcer.tsx
+++ b/packages/next/client/route-announcer.tsx
@@ -16,7 +16,7 @@ const nextjsRouteAnnouncerStyles: React.CSSProperties = {
   wordWrap: 'normal',
 }
 
-export const RouteAnnouncer = React.memo(() => {
+export const RouteAnnouncer = () => {
   const { asPath } = useRouter()
   const [routeAnnouncement, setRouteAnnouncement] = React.useState('')
 
@@ -59,6 +59,6 @@ export const RouteAnnouncer = React.memo(() => {
       {routeAnnouncement}
     </p>
   )
-})
+}
 
 export default RouteAnnouncer


### PR DESCRIPTION
Hi,

- Remove inlined CSS style which have minor performance loss. And hoist it to top of the component.
> Each time you inline an object, React re-creates a new reference to this object on every render. This causes components that receive this object to treat it as a referentially different one which have some performance pitfalls.


_Extremely sorry if I made any mistakes :(_