### PR TITLE
Change  invalid internal upstream image error code

### DIFF
--- a/packages/next/server/image-optimizer.ts
+++ b/packages/next/server/image-optimizer.ts
@@ -511,7 +511,7 @@ export async function imageOptimizer(
       }
     } else {
       throw new ImageError(
-        500,
+        400,
         'Unable to optimize image and unable to fallback to upstream image'
       )
     }

--- a/test/integration/image-optimizer/test/util.js
+++ b/test/integration/image-optimizer/test/util.js
@@ -766,7 +766,7 @@ export function runTests(ctx) {
     const query = { url, w: ctx.w, q: 39 }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
     expect(await res.text()).toBe(
       `Unable to optimize image and unable to fallback to upstream image`
     )


### PR DESCRIPTION
fixes #39312
this is more consistent with other errors
an invalid image should cause a validation error and not a server error

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`
