### PR TITLE
Fixed links to supabase examples

### DIFF
--- a/examples/with-supabase-auth-realtime-db/README.md
+++ b/examples/with-supabase-auth-realtime-db/README.md
@@ -15,7 +15,7 @@ Please file feedback and issues over on the [Supabase GitHub org](https://github
 ## More Supabase examples
 
 - [Next.js Subscription Payments Starter](https://github.com/vercel/nextjs-subscription-payments)
-- [Next.js Slack Clone](https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone)
-- [Next.js Todo List](https://github.com/supabase/supabase/tree/master/examples/nextjs-todo-list)
-- [Next.js Live Tracker Map](https://github.com/supabase/supabase/tree/master/examples/nextjs-live-tracker-map)
+- [Next.js Slack Clone](https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone)
+- [Next.js Todo List](https://github.com/supabase/supabase/tree/master/examples/todo-list)
+- [Next.js Live Tracker Map](https://github.com/supabase/supabase/tree/master/examples/with-leaflet)
 - [And many more...](https://github.com/supabase/supabase/tree/master/examples)


### PR DESCRIPTION
Corrected links to supabase examples in the `with-supabase-auth-realtime-db/README.md`

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
