### PR TITLE
ci: use recommended major version  `vmactions/freebsd-vm@v0`

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1463,7 +1463,7 @@ jobs:
           rm -rf test
       - name: Build
         id: build
-        uses: vmactions/freebsd-vm@v0.2.0
+        uses: vmactions/freebsd-vm@v0
         env:
           DEBUG: napi:*
           RUSTUP_HOME: /usr/local/rustup


### PR DESCRIPTION
[`vmactions/freebsd-vm`](https://github.com/vmactions/freebsd-vm) is now recommending specifying the major version (i.e. `vmactions/freebsd-vm@v0`), as I quote:

> The latest major version is: `v0`, which is the most recommended to use.
