### PR TITLE
fix: Create relative URLs only on server

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1804,10 +1804,12 @@ export default async function getBaseWebpackConfig(
       : undefined,
   }
 
-  webpack5Config.module!.parser = {
-    javascript: {
-      url: 'relative',
-    },
+  if (isEdgeServer || isNodeServer) {
+    webpack5Config.module!.parser = {
+      javascript: {
+        url: 'relative',
+      },
+    }
   }
   webpack5Config.module!.generator = {
     asset: {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Only apply `url: "relative"` webpack [config](https://webpack.js.org/configuration/module/#moduleparserjavascripturl) on the server, so that browser urls can work in all contexts (including Web Workers).

fixes #39350 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
