### PR TITLE
test: ensure default output is correct

### DIFF
--- a/test/production/escheck-output/index.test.ts
+++ b/test/production/escheck-output/index.test.ts
@@ -1,0 +1,44 @@
+import { createNext } from 'e2e-utils'
+import execa from 'execa'
+import { NextInstance } from 'test/lib/next-modes/base'
+
+describe('ES Check default output', () => {
+  let next: NextInstance
+
+  afterEach(() => next.destroy())
+
+  it('should pass for ES5', async () => {
+    next = await createNext({
+      files: { 'pages/index.js': 'export default function Page() {}' },
+      dependencies: { 'es-check': '7.0.0' },
+    })
+
+    const res = await execa(
+      'pnpm',
+      ['es-check', 'es5', '.next/static/**/*.js'],
+      { cwd: next.testDir }
+    )
+
+    expect(res.stdout).toBe(
+      'info: ES-Check: there were no ES version matching errors!  🎉'
+    )
+  })
+
+  it('should pass for ES5 with SWC minify', async () => {
+    next = await createNext({
+      files: { 'pages/index.js': 'export default function Page() {}' },
+      dependencies: { 'es-check': '7.0.0' },
+      nextConfig: { swcMinify: true },
+    })
+
+    const res = await execa(
+      'pnpm',
+      ['es-check', 'es5', '.next/static/**/*.js'],
+      { cwd: next.testDir }
+    )
+
+    expect(res.stdout).toBe(
+      'info: ES-Check: there were no ES version matching errors!  🎉'
+    )
+  })
+})


### PR DESCRIPTION
So we don't regress on issues like #39090, #35913, #34629, #33314, etc.

Closes #35912

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
