### PR TITLE
Fix catchall rewrites for _next/data routes

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -734,6 +734,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         match: getPathMatch('/_next/data/:path*'),
         type: 'route',
         name: '_next/data catchall',
+        check: true,
         fn: async (req, res, params, _parsedUrl) => {
           // Make sure to 404 for /_next/data/ itself and
           // we also want to 404 if the buildId isn't correct

--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -222,7 +222,14 @@ export default class Router {
         this.catchAllMiddleware
       const allRoutes = [
         ...(middlewareCatchAllRoute
-          ? this.fsRoutes.filter((r) => r.name === '_next/data catchall')
+          ? this.fsRoutes
+              .filter((r) => r.name === '_next/data catchall')
+              .map((r) => {
+                return {
+                  ...r,
+                  check: false,
+                }
+              })
           : []),
         ...this.headers,
         ...this.redirects,

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -204,6 +204,10 @@ module.exports = {
           source: '/blog/about',
           destination: '/hello',
         },
+        {
+          source: '/overridden/:path*',
+          destination: '/overridden',
+        },
       ],
       beforeFiles: [
         {

--- a/test/integration/custom-routes/pages/overridden/[slug].js
+++ b/test/integration/custom-routes/pages/overridden/[slug].js
@@ -1,0 +1,18 @@
+export default function Page() {
+  return <p>/overriden/[slug]</p>
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}


### PR DESCRIPTION
This ensures we properly check the filesystem routes before resolving rewrites for `_next/data` routes to ensure we maintain previous behavior. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/38338