### PR TITLE
Adding `priority` prop for `<Script />` component ⚡

### DIFF
--- a/docs/api-reference/next/script.md
+++ b/docs/api-reference/next/script.md
@@ -46,6 +46,15 @@ The loading strategy of the script.
 
 > **Note: `worker` is an experimental strategy that can only be used when enabled in `next.config.js`. See [Off-loading Scripts To A Web Worker](/docs/basic-features/script#off-loading-scripts-to-a-web-worker-experimental).**
 
+### priority
+
+A boolean value denoting if script need to be prioritized or not.
+> **Note: `priority` can't be used with the inlined scripts.**
+
+Next js will automatically determine weather script to be `preloadded` or `prefetched` using `strategy` prop.
+
+>Should only be used when the script is very important/urgent. Defaults to `false`.
+
 ### onLoad
 
 A method that returns additional JavaScript that should be executed once after the script has finished loading.

--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -214,7 +214,7 @@ function Script(props: ScriptProps): JSX.Element | null {
 
   const nextjsPriorityScriptPropsObj: { priorityType: "preload" | "prefetch", needPriority: boolean } = useMemo(() => {
     const nextjsPriorityType: 'preload' | 'prefetch' = strategy !== "lazyOnload" ? "preload" : "prefetch"
-    if (priority) {
+    if (!!(priority && src)) {
       return { needPriority: true, priorityType: nextjsPriorityType }
     } else {
       return { needPriority: false, priorityType: nextjsPriorityType }

--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -219,9 +219,9 @@ function Script(props: ScriptProps): JSX.Element | null {
     } else {
       return { needPriority: false, priorityType: nextjsPriorityType }
     }
-  }, [priority, strategy])
+  }, [priority, strategy, src])
 
-  return <NextjsPriorityScript {...nextjsPriorityScriptPropsObj} />
+  return <NextjsPriorityScript strategy={strategy} src={src} crossOrigin={restProps?.crossOrigin} {...nextjsPriorityScriptPropsObj} />
 }
 
 const NextjsPriorityScript = memo(({ needPriority, priorityType, strategy, src, crossOrigin }: NextjsPriorityScriptProps) => {

--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -221,7 +221,7 @@ function Script(props: ScriptProps): JSX.Element | null {
     }
   }, [priority, strategy, src])
 
-  return <NextjsPriorityScript strategy={strategy} src={src} crossOrigin={restProps?.crossOrigin} {...nextjsPriorityScriptPropsObj} />
+  return <NextjsPriorityScript {...nextjsPriorityScriptPropsObj} strategy={strategy} src={src} crossOrigin={restProps?.crossOrigin} />
 }
 
 const NextjsPriorityScript = memo(({ needPriority, priorityType, strategy, src, crossOrigin }: NextjsPriorityScriptProps) => {


### PR DESCRIPTION
### Adding `priority` prop for `<Script />` component for better loading performance (Inspired from `next/image`).

Hi, we can `preload` or `prefetch` the scripts by adding `priority` prop which helps to enhance the loading performance of the third-party scripts. 
We can `prefetch` the script if  `strategy` is `lazyOnLoad` or else we can `preload` the scripts.

---
TODOS
- [x] Code
- [x] Documentation
- [ ] Code Improvements (if needed)
- [ ] Testings

---

_Extremely sorry if I made any mistakes :(_