### PR TITLE
refactor: add named export in next/server

### DIFF
--- a/packages/next/server.js
+++ b/packages/next/server.js
@@ -14,4 +14,13 @@ if (typeof URLPattern !== 'undefined') {
   serverExports.URLPattern = URLPattern
 }
 
+// https://nodejs.org/api/esm.html#commonjs-namespaces
+// When importing CommonJS modules, the module.exports object is provided as the default export
 module.exports = serverExports
+
+// make import { xxx } from 'next/server' work
+exports.NextRequest = serverExports.NextRequest
+exports.NextResponse = serverExports.NextResponse
+exports.userAgentFromString = serverExports.userAgentFromString
+exports.userAgent = serverExports.userAgent
+exports.URLPattern = serverExports.URLPattern


### PR DESCRIPTION
## Bug
When using next/server in different environment ([vitest](https://vitest.dev/)), named import will have runtime error.

```tsx
import { NextRequest } from 'next/server'
// TypeError: NextRequest is not a constructor
const request = new NextRequest()
```
This is conflicted with current `server.d.ts` files.

## Alternative
* reverte current `server.js` to esm, them compiled it to cjs.


