### PR TITLE
typing: upgrade styled-jsx to remove workaround in build script

### DIFF
--- a/packages/next/index.d.ts
+++ b/packages/next/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="./types/global" />
-/// <reference path="./dist/styled-jsx/global.d.ts" />
+/// <reference path="./dist/styled-jsx/types/global.d.ts" />
 /// <reference path="./amp.d.ts" />
 /// <reference path="./app.d.ts" />
 /// <reference path="./config.d.ts" />

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -257,7 +257,7 @@
     "string-hash": "1.1.3",
     "string_decoder": "1.3.0",
     "strip-ansi": "6.0.0",
-    "styled-jsx": "5.0.2",
+    "styled-jsx": "5.0.3",
     "tar": "6.1.11",
     "taskr": "1.1.0",
     "terser": "5.14.1",

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -28,7 +28,7 @@ import type { UnwrapPromise } from '../lib/coalesced-function'
 import type { ReactReadableStream } from './node-web-streams-helper'
 
 import React from 'react'
-import { StyleRegistry, createStyleRegistry } from 'next/dist/styled-jsx'
+import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 import {
   GSP_NO_RETURNED_VALUE,
   GSSP_COMPONENT_MEMBER_ERROR,

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -28,7 +28,7 @@ import type { UnwrapPromise } from '../lib/coalesced-function'
 import type { ReactReadableStream } from './node-web-streams-helper'
 
 import React from 'react'
-import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
+import { StyleRegistry, createStyleRegistry } from 'next/dist/styled-jsx'
 import {
   GSP_NO_RETURNED_VALUE,
   GSSP_COMPONENT_MEMBER_ERROR,

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1959,7 +1959,6 @@ export async function compile(task, opts) {
       // we compile this each time so that fresh runtime data is pulled
       // before each publish
       'ncc_amp_optimizer',
-      'copy_styled_jsx_assets',
     ],
     opts
   )

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -58,7 +58,6 @@ export async function copy_styled_jsx_assets(task, opts) {
   await fs.ensureDir(outputDir)
 
   for (const file of typeFiles) {
-    // Port `declare module 'styled-jsx'` to `declare module 'next/dist/styled-jsx'`
     const fileNoExt = file.replace(/\.d\.ts/, '')
     const content = await fs.readFile(join(styledJsxPath, file), 'utf8')
     await fs.writeFile(join(outputDir, file), content)

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -53,13 +53,21 @@ export async function copy_styled_jsx_assets(task, opts) {
     cwd: styledJsxPath,
   })
   const outputDir = join(__dirname, 'dist/styled-jsx')
-  let typeReferences = ``
+  let typeReferences = ''
 
   await fs.ensureDir(outputDir)
 
   for (const file of typeFiles) {
+    // Port `declare module 'styled-jsx'` to `declare module 'next/dist/styled-jsx'`
     const fileNoExt = file.replace(/\.d\.ts/, '')
-    const content = await fs.readFile(join(styledJsxPath, file), 'utf8')
+    const content = (
+      await fs.readFile(join(styledJsxPath, file), 'utf8')
+    ).replace(
+      `declare module 'styled-jsx${
+        fileNoExt === 'index' ? '' : `/${fileNoExt}`
+      }'`,
+      `declare module 'next/dist/styled-jsx/${fileNoExt}'`
+    )
     await fs.writeFile(join(outputDir, file), content)
     typeReferences += `/// <reference types="./${fileNoExt}" />\n`
   }

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -60,14 +60,7 @@ export async function copy_styled_jsx_assets(task, opts) {
   for (const file of typeFiles) {
     // Port `declare module 'styled-jsx'` to `declare module 'next/dist/styled-jsx'`
     const fileNoExt = file.replace(/\.d\.ts/, '')
-    const content = (
-      await fs.readFile(join(styledJsxPath, file), 'utf8')
-    ).replace(
-      `declare module 'styled-jsx${
-        fileNoExt === 'index' ? '' : `/${fileNoExt}`
-      }'`,
-      `declare module 'next/dist/styled-jsx/${fileNoExt}'`
-    )
+    const content = await fs.readFile(join(styledJsxPath, file), 'utf8')
     await fs.writeFile(join(outputDir, file), content)
     typeReferences += `/// <reference types="./${fileNoExt}" />\n`
   }

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -53,18 +53,22 @@ export async function copy_styled_jsx_assets(task, opts) {
     cwd: styledJsxPath,
   })
   const outputDir = join(__dirname, 'dist/styled-jsx')
+  // Separate type files into different folders to avoid conflicts between
+  // dev dep `styled-jsx` and `next/dist/styled-jsx` for duplicated declare modules
+  const typesDir = join(outputDir, 'types')
   let typeReferences = ''
 
   await fs.ensureDir(outputDir)
+  await fs.ensureDir(typesDir)
 
   for (const file of typeFiles) {
     const fileNoExt = file.replace(/\.d\.ts/, '')
     const content = await fs.readFile(join(styledJsxPath, file), 'utf8')
-    await fs.writeFile(join(outputDir, file), content)
+    await fs.writeFile(join(typesDir, file), content)
     typeReferences += `/// <reference types="./${fileNoExt}" />\n`
   }
 
-  await fs.writeFile(join(outputDir, 'global.d.ts'), typeReferences)
+  await fs.writeFile(join(typesDir, 'global.d.ts'), typeReferences)
 
   for (const file of jsFiles) {
     const content = await fs.readFile(join(styledJsxPath, file), 'utf8')
@@ -1791,7 +1795,12 @@ export async function path_to_regexp(task, opts) {
 
 export async function precompile(task, opts) {
   await task.parallel(
-    ['browser_polyfills', 'path_to_regexp', 'copy_ncced'],
+    [
+      'browser_polyfills',
+      'path_to_regexp',
+      'copy_ncced',
+      'copy_styled_jsx_assets',
+    ],
     opts
   )
 }

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -44,7 +44,7 @@ export async function copy_regenerator_runtime(task, opts) {
 
 // eslint-disable-next-line camelcase
 export async function copy_styled_jsx_assets(task, opts) {
-  // we copy the styled-jsx types so that we can reference them
+  // we copy the styled-jsx assets and types so that we can reference them
   // in the next-env.d.ts file so it doesn't matter if the styled-jsx
   // package is hoisted out of Next.js' node_modules or not
   const styledJsxPath = dirname(require.resolve('styled-jsx/package.json'))
@@ -60,22 +60,7 @@ export async function copy_styled_jsx_assets(task, opts) {
   for (const file of typeFiles) {
     const fileNoExt = file.replace(/\.d\.ts/, '')
     const content = await fs.readFile(join(styledJsxPath, file), 'utf8')
-    const exportsIndex = content.indexOf('export')
-
-    let replacedContent =
-      `${content.substring(0, exportsIndex)}\n` +
-      `declare module 'styled-jsx${
-        file === 'index.d.ts' ? '' : '/' + fileNoExt
-      }' {
-        ${content.substring(exportsIndex)}
-      }`
-    if (file === 'index.d.ts') {
-      replacedContent = replacedContent
-        .replace(/export function StyleRegistry/g, 'export function IRegistry')
-        .replace(/StyleRegistry/g, 'IStyleRegistry')
-        .replace(/IRegistry/g, 'Registry')
-    }
-    await fs.writeFile(join(outputDir, file), replacedContent)
+    await fs.writeFile(join(outputDir, file), content)
     typeReferences += `/// <reference types="./${fileNoExt}" />\n`
   }
 

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -18,11 +18,6 @@ declare module 'next/dist/compiled/@next/react-refresh-utils/dist/ReactRefreshWe
   export = m
 }
 
-declare module 'next/dist/styled-jsx' {
-  import m from 'styled-jsx'
-  export = m
-}
-
 declare module 'next/dist/compiled/node-html-parser' {
   export * from 'node-html-parser'
 }

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -284,6 +284,11 @@ declare module 'next/dist/compiled/postcss-scss' {
   import m from 'postcss-scss'
   export = m
 }
+declare module 'next/dist/styled-jsx' {
+  import m from 'styled-jsx'
+  export = m
+}
+
 declare module 'next/dist/compiled/text-table' {
   function textTable(
     rows: Array<Array<{}>>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,7 +561,7 @@ importers:
       string_decoder: 1.3.0
       string-hash: 1.1.3
       strip-ansi: 6.0.0
-      styled-jsx: 5.0.2
+      styled-jsx: 5.0.3
       tar: 6.1.11
       taskr: 1.1.0
       terser: 5.14.1
@@ -750,7 +750,7 @@ importers:
       string_decoder: 1.3.0
       string-hash: 1.1.3
       strip-ansi: 6.0.0
-      styled-jsx: 5.0.2_@babel+core@7.18.0
+      styled-jsx: 5.0.3_@babel+core@7.18.0
       tar: 6.1.11
       taskr: 1.1.0
       terser: 5.14.1
@@ -20560,8 +20560,8 @@ packages:
       postcss-load-plugins: 2.3.0
     dev: true
 
-  /styled-jsx/5.0.2_@babel+core@7.18.0:
-    resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}
+  /styled-jsx/5.0.3_@babel+core@7.18.0:
+    resolution: {integrity: sha512-v82oihjxFj2WJtQiodZIDjJpnmVcE71HTCVylxdcQHU0ocnI0rGhJ0+5A3311NMQUx0KFJ+18RSHNlfIgcSU8g==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       '@babel/core': '*'


### PR DESCRIPTION
Improve styled-jsx types in next.js, previously there's no `declare module` for styled-jsx and there's type name conflicts in `styled-jsx/index.d.ts` and we use a rename hack to avoid the conflicts. Now styled-jsx 5.0.3 fixed those issues.

x-ref: https://github.com/vercel/styled-jsx/pull/805
