### PR TITLE
Improve before and after migration table

### DIFF
--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -45,35 +45,7 @@ Compared to `next/image`, the new `next/future/image` component has the followin
 
 Although `layout` is not available, you can migrate `next/image` to `next/future/image` using a few props. The following is a comparison of the two components:
 
-| `next/image` (Before)              | `next/future/image` (After)                                                 |
-| --------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------- | --------------------- |
-| ```import Image from 'next/image'
-import img from '../img.png'
-
-function Page() {
-  return <Image src={img} />
-}``` | ```import Image from 'next/future/image'
-import img from '../img.png'
-
-const css = { maxWidth: '100%', height: 'auto' }
-function Page() {
-  return <Image src={img} style={css} />
-}``` |
-| `fixed`               | Sized to `width` and `height` exactly                    |
-| `responsive`          | Scale to fit width of container                          |
-| `fill`                | Grow in both X and Y axes to fill container              |
-
-<table>
-<thead>
-  <tr>
-    <th>next/image</th>
-    <th>next/future/image</th>
-  </tr>
-</thead>
-<tbody>
-
-<tr>
-<td>
+### With `next/image` (*Before*)
 
 ```jsx
 import Image from 'next/image'
@@ -84,8 +56,7 @@ function Page() {
 }
 ```
 
-</td>
-<td>
+### With `next/future/image` (*After*)
 
 ```jsx
 import Image from 'next/future/image'
@@ -97,11 +68,7 @@ function Page() {
 }
 ```
 
-</td>
-</tr>
-
-<tr>
-<td>
+### With `next/image` (*Before*)
 
 ```jsx
 import Image from 'next/image'
@@ -112,8 +79,7 @@ function Page() {
 }
 ```
 
-</td>
-<td>
+### With `next/future/image` (*After*)
 
 ```jsx
 import Image from 'next/future/image'
@@ -125,11 +91,7 @@ function Page() {
 }
 ```
 
-</td>
-</tr>
-
-<tr>
-<td>
+### With `next/image` (*Before*)
 
 ```jsx
 import Image from 'next/image'
@@ -140,8 +102,7 @@ function Page() {
 }
 ```
 
-</td>
-<td>
+### With `next/future/image` (*After*)
 
 ```jsx
 import Image from 'next/future/image'
@@ -152,11 +113,7 @@ function Page() {
 }
 ```
 
-</td>
-</tr>
-
-<tr>
-<td>
+### With `next/image` (*Before*)
 
 ```jsx
 import Image from 'next/image'
@@ -167,8 +124,7 @@ function Page() {
 }
 ```
 
-</td>
-<td>
+### With `next/future/image` (*After*)
 
 ```jsx
 import Image from 'next/future/image'
@@ -178,12 +134,6 @@ function Page() {
   return <Image src={img} />
 }
 ```
-
-</td>
-</tr>
-
-</tbody>
-</table>
 
 You can also use `className` instead of `style`.
 

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -45,7 +45,7 @@ Compared to `next/image`, the new `next/future/image` component has the followin
 
 Although `layout` is not available, you can migrate `next/image` to `next/future/image` using a few props. The following is a comparison of the two components:
 
-### With `next/image` (Before)
+#### before: `next/image`
 
 ```jsx
 import Image from 'next/image'
@@ -56,7 +56,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (After)
+#### after: `next/future/image`
 
 ```jsx
 import Image from 'next/future/image'
@@ -68,7 +68,7 @@ function Page() {
 }
 ```
 
-### With `next/image` (Before)
+#### before: `next/image`
 
 ```jsx
 import Image from 'next/image'
@@ -79,7 +79,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (After)
+#### after: `next/future/image`
 
 ```jsx
 import Image from 'next/future/image'
@@ -91,7 +91,7 @@ function Page() {
 }
 ```
 
-### With `next/image` (Before)
+#### before: `next/image`
 
 ```jsx
 import Image from 'next/image'
@@ -102,7 +102,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (After)
+#### after: `next/future/image`
 
 ```jsx
 import Image from 'next/future/image'
@@ -113,7 +113,7 @@ function Page() {
 }
 ```
 
-### With `next/image` (Before)
+#### before: `next/image`
 
 ```jsx
 import Image from 'next/image'
@@ -124,7 +124,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (After)
+#### after: `next/future/image`
 
 ```jsx
 import Image from 'next/future/image'

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -45,7 +45,7 @@ Compared to `next/image`, the new `next/future/image` component has the followin
 
 Although `layout` is not available, you can migrate `next/image` to `next/future/image` using a few props. The following is a comparison of the two components:
 
-### With `next/image` (*Before*)
+### With `next/image` (Before)
 
 ```jsx
 import Image from 'next/image'
@@ -56,7 +56,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (*After*)
+### With `next/future/image` (After)
 
 ```jsx
 import Image from 'next/future/image'
@@ -68,7 +68,7 @@ function Page() {
 }
 ```
 
-### With `next/image` (*Before*)
+### With `next/image` (Before)
 
 ```jsx
 import Image from 'next/image'
@@ -79,7 +79,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (*After*)
+### With `next/future/image` (After)
 
 ```jsx
 import Image from 'next/future/image'
@@ -91,7 +91,7 @@ function Page() {
 }
 ```
 
-### With `next/image` (*Before*)
+### With `next/image` (Before)
 
 ```jsx
 import Image from 'next/image'
@@ -102,7 +102,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (*After*)
+### With `next/future/image` (After)
 
 ```jsx
 import Image from 'next/future/image'
@@ -113,7 +113,7 @@ function Page() {
 }
 ```
 
-### With `next/image` (*Before*)
+### With `next/image` (Before)
 
 ```jsx
 import Image from 'next/image'
@@ -124,7 +124,7 @@ function Page() {
 }
 ```
 
-### With `next/future/image` (*After*)
+### With `next/future/image` (After)
 
 ```jsx
 import Image from 'next/future/image'

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -45,6 +45,24 @@ Compared to `next/image`, the new `next/future/image` component has the followin
 
 Although `layout` is not available, you can migrate `next/image` to `next/future/image` using a few props. The following is a comparison of the two components:
 
+| `next/image` (Before)              | `next/future/image` (After)                                                 |
+| --------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------- | --------------------- |
+| ```import Image from 'next/image'
+import img from '../img.png'
+
+function Page() {
+  return <Image src={img} />
+}``` | ```import Image from 'next/future/image'
+import img from '../img.png'
+
+const css = { maxWidth: '100%', height: 'auto' }
+function Page() {
+  return <Image src={img} style={css} />
+}``` |
+| `fixed`               | Sized to `width` and `height` exactly                    |
+| `responsive`          | Scale to fit width of container                          |
+| `fill`                | Grow in both X and Y axes to fill container              |
+
 <table>
 <thead>
   <tr>


### PR DESCRIPTION
The [comparison table for migration](https://nextjs.org/docs/api-reference/next/future/image#migration) to `next/future/image` looks odd layout-wise. The issue was brought up via this [Slack thread](https://vercel.slack.com/archives/C02F56A54LU/p1660040275310949).

This PR makes this improvement.

### New implementation

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/12712988/183631902-6850836b-cb4e-44ea-909f-ba353725be15.png">


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
