### PR TITLE
fix: ensure trailing slash on registry URL when fetching wasm fallback

### DIFF
--- a/packages/next/lib/download-wasm-swc.ts
+++ b/packages/next/lib/download-wasm-swc.ts
@@ -83,7 +83,7 @@ export async function downloadWasmSwc(
     try {
       const output = execSync('npm config get registry').toString().trim()
       if (output.startsWith('http')) {
-        registry = output
+        registry = output.endsWith('/') ? output : `${output}/`
       }
     } catch (_) {}
 


### PR DESCRIPTION
Fixes #39419

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
