### PR TITLE
Ensure locale redirects are not applied in minimal mode

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -617,7 +617,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         }
       }
 
-      if (defaultLocale) {
+      if (!this.minimalMode && defaultLocale) {
         const redirect = getLocaleRedirect({
           defaultLocale,
           domainLocale,

--- a/test/production/required-server-files-i18n.test.ts
+++ b/test/production/required-server-files-i18n.test.ts
@@ -135,6 +135,27 @@ describe('should set-up next', () => {
     if (server) await killApp(server)
   })
 
+  it('should not apply locale redirect in minimal mode', async () => {
+    const res = await fetchViaHTTP(appPort, '/', undefined, {
+      redirect: 'manual',
+      headers: {
+        'accept-language': 'fr',
+      },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('index page')
+
+    const resCookie = await fetchViaHTTP(appPort, '/', undefined, {
+      redirect: 'manual',
+      headers: {
+        'accept-language': 'en',
+        cookie: 'NEXT_LOCALE=fr',
+      },
+    })
+    expect(resCookie.status).toBe(200)
+    expect(await resCookie.text()).toContain('index page')
+  })
+
   it('should output required-server-files manifest correctly', async () => {
     expect(requiredFilesManifest.version).toBe(1)
     expect(Array.isArray(requiredFilesManifest.files)).toBe(true)


### PR DESCRIPTION
This ensures we don't apply locale redirects in minimal mode as this should occur at the edge level when minimal mode is enabled. 

Fixes: [slack thread](https://vercel.slack.com/archives/C03SYBLBY1E/p1660069961896559?thread_ts=1659565964.021089&cid=C03SYBLBY1E)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

