### PR TITLE
Add component wrapper in sizes documentation code snippet

### DIFF
--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -262,16 +262,17 @@ Second, the `sizes` property configures how `next/future/image` automatically ge
 For example, if you know your styling will cause an image to be full-width on mobile devices, in a 2-column layout on tablets, and a 3-column layout on desktop displays, you should include a sizes property such as the following:
 
 ```js
-import Image from 'next/image'
-;<div className="grid-element">
-  <Image
-    src="/example.png"
-    layout="fill"
-    sizes="(min-width: 75em) 33vw,
-            (min-width: 48em) 50vw,
-            100vw"
-  />
-</div>
+const Example = () => (
+  <div className="grid-element">
+    <Image
+      src="/example.png"
+      layout="fill"
+      sizes="(min-width: 75em) 33vw,
+              (min-width: 48em) 50vw,
+              100vw"
+    />
+  </div>
+)
 ```
 
 This example `sizes` could have a dramatic effect on performance metrics. Without the `33vw` sizes, the image selected from the server would be 3 times as wide as it needs to be. Because file size is proportional to the square of the width, without `sizes` the user would download an image that's 9 times larger than necessary.

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -262,6 +262,7 @@ Second, the `sizes` property configures how `next/future/image` automatically ge
 For example, if you know your styling will cause an image to be full-width on mobile devices, in a 2-column layout on tablets, and a 3-column layout on desktop displays, you should include a sizes property such as the following:
 
 ```js
+import Image from 'next/image'
 const Example = () => (
   <div className="grid-element">
     <Image

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -143,15 +143,17 @@ For example, if you know your styling will cause an image to be full-width on mo
 
 ```js
 import Image from 'next/image'
-;<div className="grid-element">
-  <Image
-    src="/example.png"
-    layout="fill"
-    sizes="(min-width: 75em) 33vw,
-            (min-width: 48em) 50vw,
-            100vw"
-  />
-</div>
+const Example = () => (
+  <div className="grid-element">
+    <Image
+      src="/example.png"
+      layout="fill"
+      sizes="(min-width: 75em) 33vw,
+              (min-width: 48em) 50vw,
+              100vw"
+    />
+  </div>
+)
 ```
 
 This example `sizes` could have a dramatic effect on performance metrics. Without the `33vw` sizes, the image selected from the server would be 3 times as wide as it needs to be. Because file size is proportional to the square of the width, without `sizes` the user would download an image that's 9 times larger than necessary.


### PR DESCRIPTION
This PR adds a function component wrapper to the example snippets in the new `sizes` docs section. This makes it consistent with the other snippets and should prevent a problem where an errant semicolon was getting inserted during commit.