### PR TITLE
Update `router.prefetch` documentation to include `locale` option

### DIFF
--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -256,6 +256,8 @@ router.prefetch(url, as)
 
 - `url` - The URL to prefetch, including explicit routes (e.g. `/dashboard`) and dynamic routes (e.g. `/product/[id]`)
 - `as` - Optional decorator for `url`. Before Next.js 9.5.3 this was used to prefetch dynamic routes, check our [previous docs](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes) to see how it worked
+- `options` - Optional object with the following configuration options:
+  - `locale` - The active locale is automatically prepended. `locale` allows for providing a different locale. When `false` `url` has to include the locale as the default behavior is disabled.
 
 #### Usage
 

--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -248,16 +248,16 @@ export default function Page() {
 
 Prefetch pages for faster client-side transitions. This method is only useful for navigations without [`next/link`](/docs/api-reference/next/link.md), as `next/link` takes care of prefetching pages automatically.
 
-> This is a production only feature. Next.js doesn't prefetch pages on development.
+> This is a production only feature. Next.js doesn't prefetch pages in development.
 
 ```jsx
-router.prefetch(url, as)
+router.prefetch(url, as, options)
 ```
 
 - `url` - The URL to prefetch, including explicit routes (e.g. `/dashboard`) and dynamic routes (e.g. `/product/[id]`)
 - `as` - Optional decorator for `url`. Before Next.js 9.5.3 this was used to prefetch dynamic routes, check our [previous docs](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes) to see how it worked
-- `options` - Optional object with the following configuration options:
-  - `locale` - The active locale is automatically prepended. `locale` allows for providing a different locale. When `false` `url` has to include the locale as the default behavior is disabled.
+- `options` - Optional object with the following allowed fields:
+  - `locale` - allows providing a different locale from the active one. If `false`, `url` has to include the locale as the active locale won't be used.
 
 #### Usage
 


### PR DESCRIPTION
Includes some basic documentation for setting the locale as an option within `router.prefetch`. I was quite confused when I was looking to use this feature recently and couldn't see it in the docs. 

Wording is adapted from: https://github.com/vercel/next.js/blob/a6bc38799addf17434bcced2e4f3dcd24a3ff3e6/docs/api-reference/next/link.md?plain=1#L64

There is also an undocumented `priority` boolean option described in the typescript types however having just tested it, it doesn't seem to have any effect so perhaps it's not ready for documentation and I have left it out.

## Feature


- [x] Documentation added

