### PR TITLE
Set width and height to image placeholder on layout intrinsic

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -812,6 +812,8 @@ export default function Image({
                     padding: 0,
                   }}
                   alt=""
+                  width={widthInt}
+                  height={heightInt}
                   aria-hidden={true}
                   src={sizerSvgUrl}
                 />


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/39376
Since version 12.1.0 there was an update on the Image component which consists of removing the base64 encoding to the data url generated for the placeholder when using layout intrinsic, This causes lighthouse to throw "Image elements do not have explicit width and height" for the placeholder generated.

I think it would be better to explicitly set the height and width of the placeholder image generated to avoid this warning.