### PR TITLE
Handle rewriting WebSocket requests

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -119,6 +119,10 @@ export interface Options {
    * The port the server is running behind
    */
   port?: number
+  /**
+   * The HTTP Server that Next.js is running behind
+   */
+  httpServer?: import('http').Server
 }
 
 export interface BaseRequestHandler {
@@ -664,6 +668,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   public getRequestHandler(): BaseRequestHandler {
     return this.handleRequest.bind(this)
   }
+
+  protected async handleUpgrade(
+    _req: BaseNextRequest,
+    _socket: any,
+    _head?: any
+  ): Promise<void> {}
 
   public setAssetPrefix(prefix?: string): void {
     this.renderOpts.assetPrefix = prefix ? prefix.replace(/\/$/, '') : ''

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -84,10 +84,6 @@ const ReactDevOverlay = (props: any) => {
 
 export interface Options extends ServerOptions {
   /**
-   * The HTTP Server that Next.js is running behind
-   */
-  httpServer?: HTTPServer
-  /**
    * Tells of Next.js is running from the `next dev` command
    */
   isNextDevCommand?: boolean
@@ -629,6 +625,8 @@ export default class DevServer extends Server {
             )
           ) {
             this.hotReloader?.onHMR(req, socket, head)
+          } else {
+            this.handleUpgrade(req, socket, head)
           }
         })
       }

--- a/packages/next/server/lib/start-server.ts
+++ b/packages/next/server/lib/start-server.ts
@@ -39,6 +39,14 @@ export function startServer(opts: StartServerOptions) {
       }
     })
 
+    let upgradeHandler: any
+
+    if (!opts.dev) {
+      server.on('upgrade', (req, socket, upgrade) => {
+        upgradeHandler(req, socket, upgrade)
+      })
+    }
+
     server.on('listening', () => {
       const addr = server.address()
       const hostname =
@@ -55,6 +63,7 @@ export function startServer(opts: StartServerOptions) {
       })
 
       requestHandler = app.getRequestHandler()
+      upgradeHandler = app.getUpgradeHandler()
       resolve(app)
     })
 

--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -62,6 +62,15 @@ export class NextServer {
     }
   }
 
+  getUpgradeHandler() {
+    return async (req: IncomingMessage, socket: any, head: any) => {
+      const server = await this.getServer()
+      // @ts-expect-error we mark this as protected so it
+      // causes an error here
+      return server.handleUpgrade.apply(server, [req, socket, head])
+    }
+  }
+
   setAssetPrefix(assetPrefix: string) {
     if (this.server) {
       this.server.setAssetPrefix(assetPrefix)

--- a/packages/next/server/router.ts
+++ b/packages/next/server/router.ts
@@ -39,7 +39,8 @@ export type Route = {
     req: BaseNextRequest,
     res: BaseNextResponse,
     params: Params,
-    parsedUrl: NextUrlWithParsedQuery
+    parsedUrl: NextUrlWithParsedQuery,
+    upgradeHead?: any
   ) => Promise<RouteResult> | RouteResult
 }
 
@@ -130,7 +131,8 @@ export default class Router {
   async execute(
     req: BaseNextRequest,
     res: BaseNextResponse,
-    parsedUrl: NextUrlWithParsedQuery
+    parsedUrl: NextUrlWithParsedQuery,
+    upgradeHead?: any
   ): Promise<boolean> {
     if (this.seenRequests.has(req)) {
       throw new Error(
@@ -306,6 +308,11 @@ export default class Router {
       ]
 
       for (const testRoute of allRoutes) {
+        // only process rewrites for upgrade request
+        if (upgradeHead && testRoute.type !== 'rewrite') {
+          continue
+        }
+
         const originalPathname = parsedUrlUpdated.pathname as string
         const pathnameInfo = getNextPathnameInfo(originalPathname, {
           nextConfig: this.nextConfig,
@@ -388,7 +395,8 @@ export default class Router {
             req,
             res,
             newParams,
-            parsedUrlUpdated
+            parsedUrlUpdated,
+            upgradeHead
           )
 
           if (result.finished) {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -13,6 +13,11 @@ module.exports = {
             ]
           : []),
         {
+          source: '/to-websocket',
+          destination:
+            'http://localhost:__EXTERNAL_PORT__/_next/webpack-hmr?page=/about',
+        },
+        {
           source: '/to-nowhere',
           destination: 'http://localhost:12233',
         },


### PR DESCRIPTION
This ensures we properly handle rewrites when the request is a WebSocket request. This also adds an integration test to ensure it is working as expected in dev and production mode. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/32634
Closes: https://github.com/vercel/next.js/pull/38455