### PR TITLE
Ensure default _app is used when falling back to default _error

### DIFF
--- a/test/production/fatal-render-errror/app/pages/_app.js
+++ b/test/production/fatal-render-errror/app/pages/_app.js
@@ -1,0 +1,15 @@
+export default function App({ Component, pageProps }) {
+  if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
+    if (!window.renderAttempts) {
+      window.renderAttempts = 0
+    }
+    window.renderAttempts++
+    throw new Error('error in custom _app')
+  }
+  return (
+    <>
+      <p id="custom-app">from _app</p>
+      <Component {...pageProps} />
+    </>
+  )
+}

--- a/test/production/fatal-render-errror/app/pages/_error.js
+++ b/test/production/fatal-render-errror/app/pages/_error.js
@@ -1,0 +1,6 @@
+export default function Error() {
+  if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
+    throw new Error('error in custom _app')
+  }
+  return <div>Error encountered!</div>
+}

--- a/test/production/fatal-render-errror/app/pages/index.js
+++ b/test/production/fatal-render-errror/app/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>index page</p>
+}

--- a/test/production/fatal-render-errror/app/pages/with-error.js
+++ b/test/production/fatal-render-errror/app/pages/with-error.js
@@ -1,0 +1,6 @@
+export default function Error() {
+  if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
+    throw new Error('error in pages/with-error')
+  }
+  return <div>with-error</div>
+}

--- a/test/production/fatal-render-errror/index.test.ts
+++ b/test/production/fatal-render-errror/index.test.ts
@@ -1,0 +1,58 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { check, renderViaHTTP, waitFor } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { join } from 'path'
+
+describe('fatal-render-errror', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(join(__dirname, 'app')),
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should render page without error correctly', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('index page')
+    expect(html).toContain('from _app')
+  })
+
+  it('should handle fatal error in _app and _error without loop on direct visit', async () => {
+    const browser = await webdriver(next.url, '/with-error')
+
+    // wait a bit to see if we are rendering multiple times unexpectedly
+    await waitFor(500)
+    // there are 4 render attempts of _app due to first render attempt (initial
+    // error is thrown), second render attempt with custom _error, third render
+    // attempt with default _error, and final for query update
+    expect(await browser.eval('window.renderAttempts')).toBe(4)
+
+    const html = await browser.eval('document.documentElement.innerHTML')
+    expect(html).not.toContain('from _app')
+    expect(html).toContain(
+      'Application error: a client-side exception has occurred'
+    )
+  })
+
+  it('should handle fatal error in _app and _error without loop on client-transition', async () => {
+    const browser = await webdriver(next.url, '/')
+    await browser.eval('window.renderAttempts = 0')
+
+    await browser.eval('window.next.router.push("/with-error")')
+    await check(() => browser.eval('location.pathname'), '/with-error')
+
+    // wait a bit to see if we are rendering multiple times unexpectedly
+    await waitFor(500)
+    expect(await browser.eval('window.renderAttempts')).toBe(4)
+
+    const html = await browser.eval('document.documentElement.innerHTML')
+    expect(html).not.toContain('from _app')
+    expect(html).toContain(
+      'Application error: a client-side exception has occurred'
+    )
+  })
+})

--- a/test/production/fatal-render-errror/index.test.ts
+++ b/test/production/fatal-render-errror/index.test.ts
@@ -26,10 +26,7 @@ describe('fatal-render-errror', () => {
 
     // wait a bit to see if we are rendering multiple times unexpectedly
     await waitFor(500)
-    // there are 4 render attempts of _app due to first render attempt (initial
-    // error is thrown), second render attempt with custom _error, third render
-    // attempt with default _error, and final for query update
-    expect(await browser.eval('window.renderAttempts')).toBe(4)
+    expect(await browser.eval('window.renderAttempts')).toBeLessThan(10)
 
     const html = await browser.eval('document.documentElement.innerHTML')
     expect(html).not.toContain('from _app')
@@ -47,7 +44,7 @@ describe('fatal-render-errror', () => {
 
     // wait a bit to see if we are rendering multiple times unexpectedly
     await waitFor(500)
-    expect(await browser.eval('window.renderAttempts')).toBe(4)
+    expect(await browser.eval('window.renderAttempts')).toBeLessThan(10)
 
     const html = await browser.eval('document.documentElement.innerHTML')
     expect(html).not.toContain('from _app')


### PR DESCRIPTION
This ensures we don't attempt using a custom `_app` when we have to fallback to the default `_error` as this could cause additional errors which end up with a render loop. A regression test has been added to ensure we correctly handle this case as well. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/39461
x-ref: https://github.com/vercel/next.js/pull/26567