### PR TITLE
Tweak styled-jsx type declarations

### DIFF
--- a/test/production/typescript-basic/app/pages/index.tsx
+++ b/test/production/typescript-basic/app/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { type PageConfig } from 'next'
+import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 
 export const config: PageConfig = {}
 

--- a/test/production/typescript-basic/app/pages/index.tsx
+++ b/test/production/typescript-basic/app/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { type PageConfig } from 'next'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 
 export const config: PageConfig = {}


### PR DESCRIPTION
This fixes an issue with our `declare module` for `styled-jsx` and `react` conflicting causing the type to be ignored. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

