### PR TITLE
Fix next.config.js overwriting on deploy e2e test

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -178,9 +178,13 @@ export class NextInstance {
       }
     }
 
-    const nextConfigFile = Object.keys(this.files).find((file) =>
+    let nextConfigFile = Object.keys(this.files).find((file) =>
       file.startsWith('next.config.')
     )
+
+    if (await fs.pathExists(path.join(this.testDir, 'next.config.js'))) {
+      nextConfigFile = 'next.config.js'
+    }
 
     if (nextConfigFile && this.nextConfig) {
       throw new Error(


### PR DESCRIPTION
Noticed in https://github.com/vercel/next.js/pull/39257 that when using `new FileRef(path.join(__dirname, 'app'))` for E2E tests we fail to detect the existing `next.config.js` file so this ensures we correctly detect it when copying the entire app folder.