### PR TITLE
Make dev watch ignore more specific

### DIFF
--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -266,7 +266,7 @@ export default class DevServer extends Server {
       })
 
       const wp = (this.webpackWatcher = new Watchpack({
-        ignored: /(node_modules|\.next)/,
+        ignored: /([/\\]node_modules[/\\]|[/\\]\.next[/\\]|[/\\]\.git[/\\])/,
       }))
       const pages = [this.pagesDir]
       const app = this.appDir ? [this.appDir] : []

--- a/test/integration/api-support/pages/api/auth/[...nextauth].js
+++ b/test/integration/api-support/pages/api/auth/[...nextauth].js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.json({ from: 'auth' })
+}

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -26,6 +26,14 @@ let mode
 let app
 
 function runTests(dev = false) {
+  it('should respond from /api/auth/[...nextauth] correctly', async () => {
+    const res = await fetchViaHTTP(appPort, '/api/auth/signin', undefined, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ from: 'auth' })
+  })
+
   it('should handle 204 status correctly', async () => {
     const res = await fetchViaHTTP(appPort, '/api/status-204', undefined, {
       redirect: 'manual',


### PR DESCRIPTION
This fixes the case where we were incorrectly ignoring the next-auth API endpoint since it matched the `.next` watch ignore and also adds a test case to ensure we match this route correctly. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/39495