### PR TITLE
Enable @typescript-eslint/no-use-before-define variables,enums,typedefs,classes for  core files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,7 +69,7 @@
           "warn",
           {
             "functions": false,
-            "classes": true,
+            "classes": false,
             "variables": true,
             "enums": true,
             "typedefs": true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,8 +71,8 @@
             "functions": false,
             "classes": false,
             "variables": false,
-            "enums": false,
-            "typedefs": false
+            "enums": true,
+            "typedefs": true
           }
         ],
         "no-unused-vars": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -70,7 +70,7 @@
           {
             "functions": false,
             "classes": false,
-            "variables": false,
+            "variables": true,
             "enums": true,
             "typedefs": true
           }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,7 +69,7 @@
           "warn",
           {
             "functions": false,
-            "classes": false,
+            "classes": true,
             "variables": true,
             "enums": true,
             "typedefs": true

--- a/packages/next/build/analysis/extract-const-value.ts
+++ b/packages/next/build/analysis/extract-const-value.ts
@@ -15,6 +15,8 @@ import type {
   VariableDeclaration,
 } from '@swc/core'
 
+export class NoSuchDeclarationError extends Error {}
+
 /**
  * Extracts the value of an exported const variable named `exportedName`
  * (e.g. "export const config = { runtime: 'experimental-edge' }") from swc's AST.
@@ -138,7 +140,6 @@ export class UnsupportedValueError extends Error {
     this.path = codePath
   }
 }
-export class NoSuchDeclarationError extends Error {}
 
 function extractValue(node: Node, path?: string[]): any {
   if (isNullLiteral(node)) {

--- a/packages/next/build/analysis/extract-const-value.ts
+++ b/packages/next/build/analysis/extract-const-value.ts
@@ -15,8 +15,6 @@ import type {
   VariableDeclaration,
 } from '@swc/core'
 
-export class NoSuchDeclarationError extends Error {}
-
 /**
  * Extracts the value of an exported const variable named `exportedName`
  * (e.g. "export const config = { runtime: 'experimental-edge' }") from swc's AST.
@@ -140,6 +138,7 @@ export class UnsupportedValueError extends Error {
     this.path = codePath
   }
 }
+export class NoSuchDeclarationError extends Error {}
 
 function extractValue(node: Node, path?: string[]): any {
   if (isNullLiteral(node)) {

--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -226,6 +226,7 @@ function getMiddlewareRegExpStrings(
   }
 }
 
+let warnedAboutExperimentalEdgeApiFunctions = false
 function warnAboutExperimentalEdgeApiFunctions() {
   if (warnedAboutExperimentalEdgeApiFunctions) {
     return
@@ -233,8 +234,6 @@ function warnAboutExperimentalEdgeApiFunctions() {
   Log.warn(`You are using an experimental edge runtime, the API might change.`)
   warnedAboutExperimentalEdgeApiFunctions = true
 }
-
-let warnedAboutExperimentalEdgeApiFunctions = false
 
 const warnedUnsupportedValueMap = new Map<string, boolean>()
 function warnAboutUnsupportedValue(

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -319,6 +319,116 @@ function handleLoading(
   })
 }
 
+const ImageElement = ({
+  imgAttributes,
+  heightInt,
+  widthInt,
+  qualityInt,
+  className,
+  imgStyle,
+  blurStyle,
+  isLazy,
+  fill,
+  placeholder,
+  loading,
+  srcString,
+  config,
+  unoptimized,
+  loader,
+  onLoadingCompleteRef,
+  setBlurComplete,
+  setShowAltText,
+  onLoad,
+  onError,
+  noscriptSizes,
+  ...rest
+}: ImageElementProps) => {
+  loading = isLazy ? 'lazy' : loading
+  return (
+    <>
+      <img
+        {...rest}
+        {...imgAttributes}
+        width={widthInt}
+        height={heightInt}
+        decoding="async"
+        data-nimg={`future${fill ? '-fill' : ''}`}
+        className={className}
+        // @ts-ignore - TODO: upgrade to `@types/react@17`
+        loading={loading}
+        style={{ ...imgStyle, ...blurStyle }}
+        ref={useCallback(
+          (img: ImgElementWithDataProp) => {
+            if (process.env.NODE_ENV !== 'production') {
+              if (img && !srcString) {
+                console.error(`Image is missing required "src" property:`, img)
+              }
+            }
+            if (img?.complete) {
+              handleLoading(
+                img,
+                srcString,
+                placeholder,
+                onLoadingCompleteRef,
+                setBlurComplete
+              )
+            }
+          },
+          [srcString, placeholder, onLoadingCompleteRef, setBlurComplete]
+        )}
+        onLoad={(event) => {
+          const img = event.currentTarget as ImgElementWithDataProp
+          handleLoading(
+            img,
+            srcString,
+            placeholder,
+            onLoadingCompleteRef,
+            setBlurComplete
+          )
+          if (onLoad) {
+            onLoad(event)
+          }
+        }}
+        onError={(event) => {
+          // if the real image fails to load, this will ensure "alt" is visible
+          setShowAltText(true)
+          if (placeholder === 'blur') {
+            // If the real image fails to load, this will still remove the placeholder.
+            setBlurComplete(true)
+          }
+          if (onError) {
+            onError(event)
+          }
+        }}
+      />
+      {placeholder === 'blur' && (
+        <noscript>
+          <img
+            {...rest}
+            {...generateImgAttrs({
+              config,
+              src: srcString,
+              unoptimized,
+              width: widthInt,
+              quality: qualityInt,
+              sizes: noscriptSizes,
+              loader,
+            })}
+            width={widthInt}
+            height={heightInt}
+            decoding="async"
+            data-nimg={`future${fill ? '-fill' : ''}`}
+            style={imgStyle}
+            className={className}
+            // @ts-ignore - TODO: upgrade to `@types/react@17`
+            loading={loading}
+          />
+        </noscript>
+      )}
+    </>
+  )
+}
+
 export default function Image({
   src,
   sizes,
@@ -686,116 +796,6 @@ export default function Image({
           />
         </Head>
       ) : null}
-    </>
-  )
-}
-
-const ImageElement = ({
-  imgAttributes,
-  heightInt,
-  widthInt,
-  qualityInt,
-  className,
-  imgStyle,
-  blurStyle,
-  isLazy,
-  fill,
-  placeholder,
-  loading,
-  srcString,
-  config,
-  unoptimized,
-  loader,
-  onLoadingCompleteRef,
-  setBlurComplete,
-  setShowAltText,
-  onLoad,
-  onError,
-  noscriptSizes,
-  ...rest
-}: ImageElementProps) => {
-  loading = isLazy ? 'lazy' : loading
-  return (
-    <>
-      <img
-        {...rest}
-        {...imgAttributes}
-        width={widthInt}
-        height={heightInt}
-        decoding="async"
-        data-nimg={`future${fill ? '-fill' : ''}`}
-        className={className}
-        // @ts-ignore - TODO: upgrade to `@types/react@17`
-        loading={loading}
-        style={{ ...imgStyle, ...blurStyle }}
-        ref={useCallback(
-          (img: ImgElementWithDataProp) => {
-            if (process.env.NODE_ENV !== 'production') {
-              if (img && !srcString) {
-                console.error(`Image is missing required "src" property:`, img)
-              }
-            }
-            if (img?.complete) {
-              handleLoading(
-                img,
-                srcString,
-                placeholder,
-                onLoadingCompleteRef,
-                setBlurComplete
-              )
-            }
-          },
-          [srcString, placeholder, onLoadingCompleteRef, setBlurComplete]
-        )}
-        onLoad={(event) => {
-          const img = event.currentTarget as ImgElementWithDataProp
-          handleLoading(
-            img,
-            srcString,
-            placeholder,
-            onLoadingCompleteRef,
-            setBlurComplete
-          )
-          if (onLoad) {
-            onLoad(event)
-          }
-        }}
-        onError={(event) => {
-          // if the real image fails to load, this will ensure "alt" is visible
-          setShowAltText(true)
-          if (placeholder === 'blur') {
-            // If the real image fails to load, this will still remove the placeholder.
-            setBlurComplete(true)
-          }
-          if (onError) {
-            onError(event)
-          }
-        }}
-      />
-      {placeholder === 'blur' && (
-        <noscript>
-          <img
-            {...rest}
-            {...generateImgAttrs({
-              config,
-              src: srcString,
-              unoptimized,
-              width: widthInt,
-              quality: qualityInt,
-              sizes: noscriptSizes,
-              loader,
-            })}
-            width={widthInt}
-            height={heightInt}
-            decoding="async"
-            data-nimg={`future${fill ? '-fill' : ''}`}
-            style={imgStyle}
-            className={className}
-            // @ts-ignore - TODO: upgrade to `@types/react@17`
-            loading={loading}
-          />
-        </noscript>
-      )}
     </>
   )
 }

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -349,6 +349,120 @@ function handleLoading(
   })
 }
 
+const ImageElement = ({
+  imgAttributes,
+  heightInt,
+  widthInt,
+  qualityInt,
+  layout,
+  className,
+  imgStyle,
+  blurStyle,
+  isLazy,
+  placeholder,
+  loading,
+  srcString,
+  config,
+  unoptimized,
+  loader,
+  onLoadingCompleteRef,
+  setBlurComplete,
+  setIntersection,
+  onLoad,
+  onError,
+  isVisible,
+  noscriptSizes,
+  ...rest
+}: ImageElementProps) => {
+  loading = isLazy ? 'lazy' : loading
+  return (
+    <>
+      <img
+        {...rest}
+        {...imgAttributes}
+        decoding="async"
+        data-nimg={layout}
+        className={className}
+        style={{ ...imgStyle, ...blurStyle }}
+        ref={useCallback(
+          (img: ImgElementWithDataProp) => {
+            if (process.env.NODE_ENV !== 'production') {
+              if (img && !srcString) {
+                console.error(`Image is missing required "src" property:`, img)
+              }
+            }
+            setIntersection(img)
+            if (img?.complete) {
+              handleLoading(
+                img,
+                srcString,
+                layout,
+                placeholder,
+                onLoadingCompleteRef,
+                setBlurComplete
+              )
+            }
+          },
+          [
+            setIntersection,
+            srcString,
+            layout,
+            placeholder,
+            onLoadingCompleteRef,
+            setBlurComplete,
+          ]
+        )}
+        onLoad={(event) => {
+          const img = event.currentTarget as ImgElementWithDataProp
+          handleLoading(
+            img,
+            srcString,
+            layout,
+            placeholder,
+            onLoadingCompleteRef,
+            setBlurComplete
+          )
+          if (onLoad) {
+            onLoad(event)
+          }
+        }}
+        onError={(event) => {
+          if (placeholder === 'blur') {
+            // If the real image fails to load, this will still remove the placeholder.
+            setBlurComplete(true)
+          }
+          if (onError) {
+            onError(event)
+          }
+        }}
+      />
+      {(isLazy || placeholder === 'blur') && (
+        <noscript>
+          <img
+            {...rest}
+            {...generateImgAttrs({
+              config,
+              src: srcString,
+              unoptimized,
+              layout,
+              width: widthInt,
+              quality: qualityInt,
+              sizes: noscriptSizes,
+              loader,
+            })}
+            decoding="async"
+            data-nimg={layout}
+            style={imgStyle}
+            className={className}
+            // @ts-ignore - TODO: upgrade to `@types/react@17`
+            loading={loading}
+          />
+        </noscript>
+      )}
+    </>
+  )
+}
+
 export default function Image({
   src,
   sizes,
@@ -842,120 +956,6 @@ export default function Image({
           />
         </Head>
       ) : null}
-    </>
-  )
-}
-
-const ImageElement = ({
-  imgAttributes,
-  heightInt,
-  widthInt,
-  qualityInt,
-  layout,
-  className,
-  imgStyle,
-  blurStyle,
-  isLazy,
-  placeholder,
-  loading,
-  srcString,
-  config,
-  unoptimized,
-  loader,
-  onLoadingCompleteRef,
-  setBlurComplete,
-  setIntersection,
-  onLoad,
-  onError,
-  isVisible,
-  noscriptSizes,
-  ...rest
-}: ImageElementProps) => {
-  loading = isLazy ? 'lazy' : loading
-  return (
-    <>
-      <img
-        {...rest}
-        {...imgAttributes}
-        decoding="async"
-        data-nimg={layout}
-        className={className}
-        style={{ ...imgStyle, ...blurStyle }}
-        ref={useCallback(
-          (img: ImgElementWithDataProp) => {
-            if (process.env.NODE_ENV !== 'production') {
-              if (img && !srcString) {
-                console.error(`Image is missing required "src" property:`, img)
-              }
-            }
-            setIntersection(img)
-            if (img?.complete) {
-              handleLoading(
-                img,
-                srcString,
-                layout,
-                placeholder,
-                onLoadingCompleteRef,
-                setBlurComplete
-              )
-            }
-          },
-          [
-            setIntersection,
-            srcString,
-            layout,
-            placeholder,
-            onLoadingCompleteRef,
-            setBlurComplete,
-          ]
-        )}
-        onLoad={(event) => {
-          const img = event.currentTarget as ImgElementWithDataProp
-          handleLoading(
-            img,
-            srcString,
-            layout,
-            placeholder,
-            onLoadingCompleteRef,
-            setBlurComplete
-          )
-          if (onLoad) {
-            onLoad(event)
-          }
-        }}
-        onError={(event) => {
-          if (placeholder === 'blur') {
-            // If the real image fails to load, this will still remove the placeholder.
-            setBlurComplete(true)
-          }
-          if (onError) {
-            onError(event)
-          }
-        }}
-      />
-      {(isLazy || placeholder === 'blur') && (
-        <noscript>
-          <img
-            {...rest}
-            {...generateImgAttrs({
-              config,
-              src: srcString,
-              unoptimized,
-              layout,
-              width: widthInt,
-              quality: qualityInt,
-              sizes: noscriptSizes,
-              loader,
-            })}
-            decoding="async"
-            data-nimg={layout}
-            style={imgStyle}
-            className={className}
-            // @ts-ignore - TODO: upgrade to `@types/react@17`
-            loading={loading}
-          />
-        </noscript>
-      )}
     </>
   )
 }

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -289,18 +289,6 @@ export async function initialize(opts: { webpackHMR?: any } = {}): Promise<{
   return { assetPrefix: prefix }
 }
 
-const wrapApp =
-  (App: AppComponent) =>
-  (wrappedAppProps: Record<string, any>): JSX.Element => {
-    const appProps: AppProps = {
-      ...wrappedAppProps,
-      Component: CachedComponent,
-      err: initialData.err,
-      router,
-    }
-    return <AppContainer>{renderApp(App, appProps)}</AppContainer>
-  }
-
 export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
   let initialErr = initialData.err
 
@@ -407,6 +395,18 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
   if (window.__NEXT_PRELOADREADY) {
     await window.__NEXT_PRELOADREADY(initialData.dynamicIds)
   }
+
+  const wrapApp =
+    (App: AppComponent) =>
+    (wrappedAppProps: Record<string, any>): JSX.Element => {
+      const appProps: AppProps = {
+        ...wrappedAppProps,
+        Component: CachedComponent,
+        err: initialData.err,
+        router,
+      }
+      return <AppContainer>{renderApp(App, appProps)}</AppContainer>
+    }
 
   router = createRouter(initialData.page, initialData.query, asPath, {
     initialProps: initialData.props,

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -289,6 +289,18 @@ export async function initialize(opts: { webpackHMR?: any } = {}): Promise<{
   return { assetPrefix: prefix }
 }
 
+const wrapApp =
+  (App: AppComponent) =>
+  (wrappedAppProps: Record<string, any>): JSX.Element => {
+    const appProps: AppProps = {
+      ...wrappedAppProps,
+      Component: CachedComponent,
+      err: initialData.err,
+      router,
+    }
+    return <AppContainer>{renderApp(App, appProps)}</AppContainer>
+  }
+
 export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
   let initialErr = initialData.err
 
@@ -395,18 +407,6 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
   if (window.__NEXT_PRELOADREADY) {
     await window.__NEXT_PRELOADREADY(initialData.dynamicIds)
   }
-
-  const wrapApp =
-    (App: AppComponent) =>
-    (wrappedAppProps: Record<string, any>): JSX.Element => {
-      const appProps: AppProps = {
-        ...wrappedAppProps,
-        Component: CachedComponent,
-        err: initialData.err,
-        router,
-      }
-      return <AppContainer>{renderApp(App, appProps)}</AppContainer>
-    }
 
   router = createRouter(initialData.page, initialData.query, asPath, {
     initialProps: initialData.props,

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -80,6 +80,7 @@ let headManager: {
   getIsSsr?: () => boolean
 }
 let initialMatchesMiddleware = false
+let lastAppProps: AppProps
 
 let lastRenderReject: (() => void) | null
 let webpackHMR: any
@@ -395,6 +396,18 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
     await window.__NEXT_PRELOADREADY(initialData.dynamicIds)
   }
 
+  const wrapApp =
+    (App: AppComponent) =>
+    (wrappedAppProps: Record<string, any>): JSX.Element => {
+      const appProps: AppProps = {
+        ...wrappedAppProps,
+        Component: CachedComponent,
+        err: initialData.err,
+        router,
+      }
+      return <AppContainer>{renderApp(App, appProps)}</AppContainer>
+    }
+
   router = createRouter(initialData.page, initialData.query, asPath, {
     initialProps: initialData.props,
     pageLoader,
@@ -663,18 +676,6 @@ function renderApp(App: AppComponent, appProps: AppProps) {
   return <App {...appProps} />
 }
 
-const wrapApp =
-  (App: AppComponent) =>
-  (wrappedAppProps: Record<string, any>): JSX.Element => {
-    const appProps: AppProps = {
-      ...wrappedAppProps,
-      Component: CachedComponent,
-      err: initialData.err,
-      router,
-    }
-    return <AppContainer>{renderApp(App, appProps)}</AppContainer>
-  }
-
 let RSCComponent: (props: any) => JSX.Element
 if (process.env.__NEXT_RSC) {
   const getCacheKey = () => {
@@ -818,7 +819,6 @@ if (process.env.__NEXT_RSC) {
   }
 }
 
-let lastAppProps: AppProps
 function doRender(input: RenderRouteInfo): Promise<any> {
   let { App, Component, props, err, __N_RSC }: RenderRouteInfo = input
   let styleSheets: StyleSheetTuple[] | undefined =

--- a/packages/next/client/use-intersection.tsx
+++ b/packages/next/client/use-intersection.tsx
@@ -72,6 +72,9 @@ export function useIntersection<T extends Element>({
   return [setElement, visible, resetVisible]
 }
 
+const observers = new Map<Identifier, Observer>()
+const idList: Identifier[] = []
+
 function observe(
   element: Element,
   callback: ObserveCallback,
@@ -98,10 +101,6 @@ function observe(
     }
   }
 }
-
-const observers = new Map<Identifier, Observer>()
-
-const idList: Identifier[] = []
 
 function createObserver(options: UseIntersectionObserverInit): Observer {
   const id = {

--- a/packages/next/lib/is-serializable-props.ts
+++ b/packages/next/lib/is-serializable-props.ts
@@ -5,6 +5,16 @@ import {
 
 const regexpPlainIdentifier = /^[A-Za-z_$][A-Za-z0-9_$]*$/
 
+export class SerializableError extends Error {
+  constructor(page: string, method: string, path: string, message: string) {
+    super(
+      path
+        ? `Error serializing \`${path}\` returned from \`${method}\` in "${page}".\nReason: ${message}`
+        : `Error serializing props returned from \`${method}\` in "${page}".\nReason: ${message}`
+    )
+  }
+}
+
 export function isSerializableProps(
   page: string,
   method: string,
@@ -130,14 +140,4 @@ export function isSerializableProps(
   }
 
   return isSerializable(new Map(), input, '')
-}
-
-export class SerializableError extends Error {
-  constructor(page: string, method: string, path: string, message: string) {
-    super(
-      path
-        ? `Error serializing \`${path}\` returned from \`${method}\` in "${page}".\nReason: ${message}`
-        : `Error serializing props returned from \`${method}\` in "${page}".\nReason: ${message}`
-    )
-  }
 }

--- a/packages/next/lib/is-serializable-props.ts
+++ b/packages/next/lib/is-serializable-props.ts
@@ -5,16 +5,6 @@ import {
 
 const regexpPlainIdentifier = /^[A-Za-z_$][A-Za-z0-9_$]*$/
 
-export class SerializableError extends Error {
-  constructor(page: string, method: string, path: string, message: string) {
-    super(
-      path
-        ? `Error serializing \`${path}\` returned from \`${method}\` in "${page}".\nReason: ${message}`
-        : `Error serializing props returned from \`${method}\` in "${page}".\nReason: ${message}`
-    )
-  }
-}
-
 export function isSerializableProps(
   page: string,
   method: string,
@@ -140,4 +130,14 @@ export function isSerializableProps(
   }
 
   return isSerializable(new Map(), input, '')
+}
+
+export class SerializableError extends Error {
+  constructor(page: string, method: string, path: string, message: string) {
+    super(
+      path
+        ? `Error serializing \`${path}\` returned from \`${method}\` in "${page}".\nReason: ${message}`
+        : `Error serializing props returned from \`${method}\` in "${page}".\nReason: ${message}`
+    )
+  }
 }

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -346,77 +346,6 @@ function getScripts(
   })
 }
 
-/**
- * `Document` component handles the initial `document` markup and renders only on the server side.
- * Commonly used for implementing server side rendering for `css-in-js` libraries.
- */
-export default class Document<P = {}> extends Component<DocumentProps & P> {
-  /**
-   * `getInitialProps` hook returns the context object with the addition of `renderPage`.
-   * `renderPage` callback executes `React` rendering logic synchronously to support server-rendering wrappers
-   */
-  static getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
-    return ctx.defaultGetInitialProps(ctx)
-  }
-
-  render() {
-    return (
-      <Html>
-        <Head />
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    )
-  }
-}
-
-// Add a special property to the built-in `Document` component so later we can
-// identify if a user customized `Document` is used or not.
-const InternalFunctionDocument: DocumentType =
-  function InternalFunctionDocument() {
-    return (
-      <Html>
-        <Head />
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    )
-  }
-;(Document as any)[NEXT_BUILTIN_DOCUMENT] = InternalFunctionDocument
-
-export function Html(
-  props: React.DetailedHTMLProps<
-    React.HtmlHTMLAttributes<HTMLHtmlElement>,
-    HTMLHtmlElement
-  >
-) {
-  const {
-    inAmpMode,
-    docComponentsRendered,
-    locale,
-    scriptLoader,
-    __NEXT_DATA__,
-  } = useContext(HtmlContext)
-
-  docComponentsRendered.Html = true
-  handleDocumentScriptLoaderItems(scriptLoader, __NEXT_DATA__, props)
-
-  return (
-    <html
-      {...props}
-      lang={props.lang || locale || undefined}
-      amp={inAmpMode ? '' : undefined}
-      data-ampdevmode={
-        inAmpMode && process.env.NODE_ENV !== 'production' ? '' : undefined
-      }
-    />
-  )
-}
-
 function AmpStyles({
   styles,
 }: {
@@ -938,13 +867,6 @@ export class Head extends Component<HeadProps> {
   }
 }
 
-export function Main() {
-  const { docComponentsRendered } = useContext(HtmlContext)
-  docComponentsRendered.Main = true
-  // @ts-ignore
-  return <next-js-internal-body-render-target />
-}
-
 export class NextScript extends Component<OriginProps> {
   static contextType = HtmlContext
 
@@ -1104,6 +1026,84 @@ export class NextScript extends Component<OriginProps> {
       </>
     )
   }
+}
+
+/**
+ * `Document` component handles the initial `document` markup and renders only on the server side.
+ * Commonly used for implementing server side rendering for `css-in-js` libraries.
+ */
+export default class Document<P = {}> extends Component<DocumentProps & P> {
+  /**
+   * `getInitialProps` hook returns the context object with the addition of `renderPage`.
+   * `renderPage` callback executes `React` rendering logic synchronously to support server-rendering wrappers
+   */
+  static getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    return ctx.defaultGetInitialProps(ctx)
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+// Add a special property to the built-in `Document` component so later we can
+// identify if a user customized `Document` is used or not.
+const InternalFunctionDocument: DocumentType =
+  function InternalFunctionDocument() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+;(Document as any)[NEXT_BUILTIN_DOCUMENT] = InternalFunctionDocument
+
+export function Html(
+  props: React.DetailedHTMLProps<
+    React.HtmlHTMLAttributes<HTMLHtmlElement>,
+    HTMLHtmlElement
+  >
+) {
+  const {
+    inAmpMode,
+    docComponentsRendered,
+    locale,
+    scriptLoader,
+    __NEXT_DATA__,
+  } = useContext(HtmlContext)
+
+  docComponentsRendered.Html = true
+  handleDocumentScriptLoaderItems(scriptLoader, __NEXT_DATA__, props)
+
+  return (
+    <html
+      {...props}
+      lang={props.lang || locale || undefined}
+      amp={inAmpMode ? '' : undefined}
+      data-ampdevmode={
+        inAmpMode && process.env.NODE_ENV !== 'production' ? '' : undefined
+      }
+    />
+  )
+}
+
+export function Main() {
+  const { docComponentsRendered } = useContext(HtmlContext)
+  docComponentsRendered.Main = true
+  // @ts-ignore
+  return <next-js-internal-body-render-target />
 }
 
 function getAmpPath(ampPath: string, asPath: string): string {

--- a/packages/next/pages/_error.tsx
+++ b/packages/next/pages/_error.tsx
@@ -24,6 +24,46 @@ function _getInitialProps({
   return { statusCode }
 }
 
+const styles: { [k: string]: React.CSSProperties } = {
+  error: {
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
+    height: '100vh',
+    textAlign: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  desc: {
+    display: 'inline-block',
+    textAlign: 'left',
+    lineHeight: '49px',
+    height: '49px',
+    verticalAlign: 'middle',
+  },
+
+  h1: {
+    display: 'inline-block',
+    margin: 0,
+    marginRight: '20px',
+    padding: '0 23px 0 0',
+    fontSize: '24px',
+    fontWeight: 500,
+    verticalAlign: 'top',
+    lineHeight: '49px',
+  },
+
+  h2: {
+    fontSize: '14px',
+    fontWeight: 'normal',
+    lineHeight: '49px',
+    margin: 0,
+    padding: 0,
+  },
+}
+
 /**
  * `Error` component used for handling errors.
  */
@@ -93,44 +133,4 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
       </div>
     )
   }
-}
-
-const styles: { [k: string]: React.CSSProperties } = {
-  error: {
-    fontFamily:
-      '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", "Fira Sans", Avenir, "Helvetica Neue", "Lucida Grande", sans-serif',
-    height: '100vh',
-    textAlign: 'center',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-
-  desc: {
-    display: 'inline-block',
-    textAlign: 'left',
-    lineHeight: '49px',
-    height: '49px',
-    verticalAlign: 'middle',
-  },
-
-  h1: {
-    display: 'inline-block',
-    margin: 0,
-    marginRight: '20px',
-    padding: '0 23px 0 0',
-    fontSize: '24px',
-    fontWeight: 500,
-    verticalAlign: 'top',
-    lineHeight: '49px',
-  },
-
-  h2: {
-    fontSize: '14px',
-    fontWeight: 'normal',
-    lineHeight: '49px',
-    margin: 0,
-    padding: 0,
-  },
 }

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -141,6 +141,25 @@ type RequestContext = {
   renderOpts: RenderOptsPartial
 }
 
+class NoFallbackError extends Error {}
+
+// Internal wrapper around build errors at development
+// time, to prevent us from propagating or logging them
+export class WrappedBuildError extends Error {
+  innerError: Error
+
+  constructor(innerError: Error) {
+    super()
+    this.innerError = innerError
+  }
+}
+
+type ResponsePayload = {
+  type: 'html' | 'json'
+  body: RenderResult
+  revalidateOptions?: any
+}
+
 export default abstract class Server<ServerOptions extends Options = Options> {
   protected dir: string
   protected quiet: boolean
@@ -2139,22 +2158,3 @@ export function prepareServerlessUrl(
 }
 
 export { stringifyQuery } from './server-route-utils'
-
-class NoFallbackError extends Error {}
-
-// Internal wrapper around build errors at development
-// time, to prevent us from propagating or logging them
-export class WrappedBuildError extends Error {
-  innerError: Error
-
-  constructor(innerError: Error) {
-    super()
-    this.innerError = innerError
-  }
-}
-
-type ResponsePayload = {
-  type: 'html' | 'json'
-  body: RenderResult
-  revalidateOptions?: any
-}

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -573,40 +573,9 @@ export async function renderToHTML(
     isPreview,
     getRequestMeta(req, '__nextIsLocaleDomain')
   )
+
+  let scriptLoader: any = {}
   const jsxStyleRegistry = createStyleRegistry()
-  const ctx = {
-    err,
-    req: isAutoExport ? undefined : req,
-    res: isAutoExport ? undefined : res,
-    pathname,
-    query,
-    asPath,
-    locale: renderOpts.locale,
-    locales: renderOpts.locales,
-    defaultLocale: renderOpts.defaultLocale,
-    AppTree: (props: any) => {
-      return (
-        <AppContainerWithIsomorphicFiberStructure>
-          {renderPageTree(App, OriginComponent, { ...props, router })}
-        </AppContainerWithIsomorphicFiberStructure>
-      )
-    },
-    defaultGetInitialProps: async (
-      docCtx: DocumentContext,
-      options: { nonce?: string } = {}
-    ): Promise<DocumentInitialProps> => {
-      const enhanceApp = (AppComp: any) => {
-        return (props: any) => <AppComp {...props} />
-      }
-
-      const { html, head } = await docCtx.renderPage({ enhanceApp })
-      const styles = jsxStyleRegistry.styles({ nonce: options.nonce })
-      jsxStyleRegistry.flush()
-      return { html, head, styles }
-    },
-  }
-  let props: any
-
   const ampState = {
     ampFirst: pageConfig.amp === true,
     hasQuery: Boolean(query.amp),
@@ -615,10 +584,8 @@ export async function renderToHTML(
 
   // Disable AMP under the web environment
   const inAmpMode = process.env.NEXT_RUNTIME !== 'edge' && isInAmpMode(ampState)
-
-  const reactLoadableModules: string[] = []
-
   let head: JSX.Element[] = defaultHead(inAmpMode)
+  const reactLoadableModules: string[] = []
 
   let initialScripts: any = {}
   if (hasPageScripts) {
@@ -626,16 +593,6 @@ export async function renderToHTML(
       .concat(hasPageScripts())
       .filter((script: any) => script.props.strategy === 'beforeInteractive')
       .map((script: any) => script.props)
-  }
-
-  let scriptLoader: any = {}
-  const nextExport =
-    !isSSG && (renderOpts.nextExport || (dev && (isAutoExport || isFallback)))
-
-  const styledJsxFlushEffect = () => {
-    const styles = jsxStyleRegistry.styles()
-    jsxStyleRegistry.flush()
-    return <>{styles}</>
   }
 
   const AppContainer = ({ children }: { children: JSX.Element }) => (
@@ -698,6 +655,50 @@ export async function renderToHTML(
         </AppContainer>
       </>
     )
+  }
+
+  const ctx = {
+    err,
+    req: isAutoExport ? undefined : req,
+    res: isAutoExport ? undefined : res,
+    pathname,
+    query,
+    asPath,
+    locale: renderOpts.locale,
+    locales: renderOpts.locales,
+    defaultLocale: renderOpts.defaultLocale,
+    AppTree: (props: any) => {
+      return (
+        <AppContainerWithIsomorphicFiberStructure>
+          {renderPageTree(App, OriginComponent, { ...props, router })}
+        </AppContainerWithIsomorphicFiberStructure>
+      )
+    },
+    defaultGetInitialProps: async (
+      docCtx: DocumentContext,
+      options: { nonce?: string } = {}
+    ): Promise<DocumentInitialProps> => {
+      const enhanceApp = (AppComp: any) => {
+        return (props: any) => <AppComp {...props} />
+      }
+
+      const { html, head: renderPageHead } = await docCtx.renderPage({
+        enhanceApp,
+      })
+      const styles = jsxStyleRegistry.styles({ nonce: options.nonce })
+      jsxStyleRegistry.flush()
+      return { html, head: renderPageHead, styles }
+    },
+  }
+  let props: any
+
+  const nextExport =
+    !isSSG && (renderOpts.nextExport || (dev && (isAutoExport || isFallback)))
+
+  const styledJsxFlushEffect = () => {
+    const styles = jsxStyleRegistry.styles()
+    jsxStyleRegistry.flush()
+    return <>{styles}</>
   }
 
   props = await loadGetInitialProps(App, {
@@ -1299,7 +1300,7 @@ export async function renderToHTML(
       }
 
       const { docProps } = (documentInitialPropsRes as any) || {}
-      const documentElement = () => {
+      const documentElement = (htmlProps: any) => {
         if (process.env.NEXT_RUNTIME === 'edge') {
           return (Document as any)()
         } else {

--- a/packages/next/server/server-route-utils.ts
+++ b/packages/next/server/server-route-utils.ts
@@ -98,6 +98,34 @@ export const createHeaderRoute = ({
   }
 }
 
+// since initial query values are decoded by querystring.parse
+// we need to re-encode them here but still allow passing through
+// values from rewrites/redirects
+export const stringifyQuery = (req: BaseNextRequest, query: ParsedUrlQuery) => {
+  const initialQuery = getRequestMeta(req, '__NEXT_INIT_QUERY') || {}
+  const initialQueryValues: Array<string | string[]> =
+    Object.values(initialQuery)
+
+  return stringifyQs(query, undefined, undefined, {
+    encodeURIComponent(value) {
+      if (
+        value in initialQuery ||
+        initialQueryValues.some((initialQueryVal: string | string[]) => {
+          // `value` always refers to a query value, even if it's nested in an array
+          return Array.isArray(initialQueryVal)
+            ? initialQueryVal.includes(value)
+            : initialQueryVal === value
+        })
+      ) {
+        // Encode keys and values from initial query
+        return encodeURIComponent(value)
+      }
+
+      return value
+    },
+  })
+}
+
 export const createRedirectRoute = ({
   rule,
   restrictedRedirectPaths,
@@ -150,32 +178,4 @@ export const createRedirectRoute = ({
       }
     },
   }
-}
-
-// since initial query values are decoded by querystring.parse
-// we need to re-encode them here but still allow passing through
-// values from rewrites/redirects
-export const stringifyQuery = (req: BaseNextRequest, query: ParsedUrlQuery) => {
-  const initialQuery = getRequestMeta(req, '__NEXT_INIT_QUERY') || {}
-  const initialQueryValues: Array<string | string[]> =
-    Object.values(initialQuery)
-
-  return stringifyQs(query, undefined, undefined, {
-    encodeURIComponent(value) {
-      if (
-        value in initialQuery ||
-        initialQueryValues.some((initialQueryVal: string | string[]) => {
-          // `value` always refers to a query value, even if it's nested in an array
-          return Array.isArray(initialQueryVal)
-            ? initialQueryVal.includes(value)
-            : initialQueryVal === value
-        })
-      ) {
-        // Encode keys and values from initial query
-        return encodeURIComponent(value)
-      }
-
-      return value
-    },
-  })
 }

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -9,6 +9,31 @@ import { relativizeURL } from '../../shared/lib/router/utils/relativize-url'
 import { waitUntilSymbol } from './spec-extension/fetch-event'
 import { NextURL } from './next-url'
 
+class NextRequestHint extends NextRequest {
+  sourcePage: string
+
+  constructor(params: {
+    init: RequestInit
+    input: Request | string
+    page: string
+  }) {
+    super(params.input, params.init)
+    this.sourcePage = params.page
+  }
+
+  get request() {
+    throw new PageSignatureError({ page: this.sourcePage })
+  }
+
+  respondWith() {
+    throw new PageSignatureError({ page: this.sourcePage })
+  }
+
+  waitUntil() {
+    throw new PageSignatureError({ page: this.sourcePage })
+  }
+}
+
 export async function adapter(params: {
   handler: NextMiddleware
   page: string
@@ -204,29 +229,4 @@ function getUnsupportedModuleErrorMessage(module: string) {
   // warning: if you change these messages, you must adjust how react-dev-overlay's middleware detects modules not found
   return `The edge runtime does not support Node.js '${module}' module.
 Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime`
-}
-
-class NextRequestHint extends NextRequest {
-  sourcePage: string
-
-  constructor(params: {
-    init: RequestInit
-    input: Request | string
-    page: string
-  }) {
-    super(params.input, params.init)
-    this.sourcePage = params.page
-  }
-
-  get request() {
-    throw new PageSignatureError({ page: this.sourcePage })
-  }
-
-  respondWith() {
-    throw new PageSignatureError({ page: this.sourcePage })
-  }
-
-  waitUntil() {
-    throw new PageSignatureError({ page: this.sourcePage })
-  }
 }

--- a/packages/next/server/web/sandbox/context.ts
+++ b/packages/next/server/web/sandbox/context.ts
@@ -21,6 +21,13 @@ interface ModuleContext {
 }
 
 /**
+ * A Map of cached module contexts indexed by the module name. It allows
+ * to have a different cache scoped per module name or depending on the
+ * provided module key on creation.
+ */
+const moduleContexts = new Map<string, ModuleContext>()
+
+/**
  * For a given path a context, this function checks if there is any module
  * context that contains the path with an older content and, if that's the
  * case, removes the context from the cache.
@@ -36,13 +43,6 @@ export function clearModuleContext(path: string, content: Buffer | string) {
     }
   }
 }
-
-/**
- * A Map of cached module contexts indexed by the module name. It allows
- * to have a different cache scoped per module name or depending on the
- * provided module key on creation.
- */
-const moduleContexts = new Map<string, ModuleContext>()
 
 interface ModuleContextOptions {
   moduleName: string

--- a/packages/next/types/webpack.d.ts
+++ b/packages/next/types/webpack.d.ts
@@ -638,6 +638,10 @@ declare module 'webpack4' {
      */
     type Rule = RuleSetRule
 
+    abstract class Plugin {
+      apply(compiler: Compiler): void
+    }
+
     namespace Options {
       type Devtool =
         | 'eval'
@@ -1445,10 +1449,6 @@ declare module 'webpack4' {
     abstract class MultiWatching implements Watching {
       close(callback: () => void): void
       invalidate(): void
-    }
-
-    abstract class Plugin {
-      apply(compiler: Compiler): void
     }
 
     abstract class ResolvePlugin {

--- a/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
+++ b/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
@@ -50,6 +50,16 @@ function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
 
 type ErrorType = 'runtime' | 'build'
 
+const shouldPreventDisplay = (
+  errorType?: ErrorType | null,
+  preventType?: ErrorType[] | null
+) => {
+  if (!preventType || !errorType) {
+    return false
+  }
+  return preventType.includes(errorType)
+}
+
 const ReactDevOverlay: React.FunctionComponent = function ReactDevOverlay({
   children,
   preventDisplay,
@@ -113,16 +123,6 @@ const ReactDevOverlay: React.FunctionComponent = function ReactDevOverlay({
       ) : undefined}
     </React.Fragment>
   )
-}
-
-const shouldPreventDisplay = (
-  errorType?: ErrorType | null,
-  preventType?: ErrorType[] | null
-) => {
-  if (!preventType || !errorType) {
-    return false
-  }
-  return preventType.includes(errorType)
 }
 
 export default ReactDevOverlay


### PR DESCRIPTION
Follow-up to #39469. Didn't enable classes/functions yet, will follow up with a separate PR for those.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
