### PR TITLE
fix: ensure hidden iframe apps render in development mode

### DIFF
--- a/packages/next/client/dev/fouc.ts
+++ b/packages/next/client/dev/fouc.ts
@@ -1,12 +1,24 @@
-// This wrapper function is used to avoid raising a Trusted Types violation.
-const safeSetTimeout = (callback: () => void) => setTimeout(callback)
+// This wrapper function is used to safely select the best available function
+// to schedule removal of the no-FOUC styles workaround. requestAnimationFrame
+// is the ideal choice, but when used in iframes, there are no guarantees that
+// the callback will actually be called, which could stall the promise returned
+// from displayContent.
+//
+// See: https://www.vector-logic.com/blog/posts/on-request-animation-frame-and-embedded-iframes
+const safeCallbackQueue = (callback: () => void) => {
+  if (window.requestAnimationFrame && window.self === window.top) {
+    window.requestAnimationFrame(callback)
+  } else {
+    window.setTimeout(callback)
+  }
+}
 
 // This function is used to remove Next.js' no-FOUC styles workaround for using
 // `style-loader` in development. It must be called before hydration, or else
 // rendering won't have the correct computed values in effects.
 export function displayContent(): Promise<void> {
   return new Promise((resolve) => {
-    ;(window.requestAnimationFrame || safeSetTimeout)(function () {
+    safeCallbackQueue(function () {
       for (
         var x = document.querySelectorAll('[data-next-hide-fouc]'),
           i = x.length;


### PR DESCRIPTION
## Description
fixes #39340 

The PR template was trimmed to only include the relevant fields for this PR. Please read the full bug description and my inline comments below for full context on this issue.

## Bug
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
  - Believe me, I made an honest attempt to test this... I almost got there, but in the end, I'm not so sure the test will provide much value. Given the nature of this bug being browser dependent, and not a hard-documented behavior of `requestAnimationFrame`, I think any test that gets written could quickly become a false positive anyways. Given that the `fouc` code is already untested (as far as I could tell), I think this is a fair fix-without-test. I'm 100% open to suggestions here though.
  - The test setup I _did_ have going was a `development` test using a `createNext` app that had two pages. The first was a page with a hidden iframe that links to the 2nd page under a different domain (e.g. `url.replace('localhost', '127.0.0.1')` to force the cross origin aspect of the bug). The problem with the test is that I wasn't able to reproduce it in playwright chromium (so test could easily be a false positive), and the other issue was that the interface for the browser has no methods that allow access to iframe elements, making verifying the bug difficult. I could add it to the interface and implement it for both playwright/selenium, but it seems like a lot for such specific issue.
- [ ] Errors have helpful link attached, see `contributing.md`
  - No error now, but any thoughts on creating an `opts.beforeRender` timeout that could trigger an error/warning if the `opts.beforeRender` promise doesn't resolve within X seconds? That way I could provide a link to a full description on what's occurring in this scenario. I dug through tons of minified code to find the origin of this issue, so hoping to save others trouble here.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
