### PR TITLE
docs: Rename API middlewares title in sidebar

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -143,7 +143,7 @@
               "path": "/docs/api-routes/dynamic-api-routes.md"
             },
             {
-              "title": "API Middlewares",
+              "title": "Request Helpers",
               "path": "/docs/api-routes/request-helpers.md"
             },
             {


### PR DESCRIPTION
Based on the PR #39407, the sidebar title for API middlewares is changed from "API Middlewares" to "Request Helpers".

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->


## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
