### PR TITLE
[docs] Avoid next config validation warning

### DIFF
--- a/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md
+++ b/docs/api-reference/next.config.js/cdn-support-with-asset-prefix.md
@@ -20,7 +20,7 @@ const isProd = process.env.NODE_ENV === 'production'
 
 module.exports = {
   // Use the CDN in production and localhost for development.
-  assetPrefix: isProd ? 'https://cdn.mydomain.com' : '',
+  assetPrefix: isProd ? 'https://cdn.mydomain.com' : undefined,
 }
 ```
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)

Next.js now validates next.config.js and setting `assetPath` to an empty string results in the following warning:

```
  {
    "instancePath": "/assetPrefix",
    "schemaPath": "#/properties/assetPrefix/minLength",
    "keyword": "minLength",
    "params": {
      "limit": 1
    },
    "message": "must NOT have fewer than 1 characters"
  }
```

This was raised in https://github.com/vercel/next.js/issues/39161#issuecomment-1200892600
