### PR TITLE
Rename page -> entry in on-demand-entry-handler

### DIFF
--- a/packages/next/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/server/dev/on-demand-entry-handler.ts
@@ -398,34 +398,34 @@ export function onDemandEntryHandler({
       const isInsideAppDir =
         appDir && pagePathData.absolutePagePath.startsWith(appDir)
 
-      const addPageEntry = (
+      const addEntry = (
         compilerType: CompilerNameValues
       ): {
-        pageKey: string
+        entryKey: string
         newEntry: boolean
         shouldInvalidate: boolean
       } => {
-        const pageKey = `${compilerType}${pagePathData.page}`
+        const entryKey = `${compilerType}${pagePathData.page}`
 
-        if (entries[pageKey]) {
-          entries[pageKey].dispose = false
-          entries[pageKey].lastActiveTime = Date.now()
-          if (entries[pageKey].status === BUILT) {
+        if (entries[entryKey]) {
+          entries[entryKey].dispose = false
+          entries[entryKey].lastActiveTime = Date.now()
+          if (entries[entryKey].status === BUILT) {
             return {
-              pageKey,
+              entryKey,
               newEntry: false,
               shouldInvalidate: false,
             }
           }
 
           return {
-            pageKey,
+            entryKey,
             newEntry: false,
             shouldInvalidate: true,
           }
         }
 
-        entries[pageKey] = {
+        entries[entryKey] = {
           type: EntryTypes.ENTRY,
           absolutePagePath: pagePathData.absolutePagePath,
           request: pagePathData.absolutePagePath,
@@ -436,7 +436,7 @@ export function onDemandEntryHandler({
         }
 
         return {
-          pageKey,
+          entryKey: entryKey,
           newEntry: true,
           shouldInvalidate: true,
         }
@@ -447,10 +447,7 @@ export function onDemandEntryHandler({
         nextConfig,
       })
 
-      const added = new Map<
-        CompilerNameValues,
-        ReturnType<typeof addPageEntry>
-      >()
+      const added = new Map<CompilerNameValues, ReturnType<typeof addEntry>>()
 
       await runDependingOnPageType({
         page: pagePathData.page,
@@ -460,15 +457,15 @@ export function onDemandEntryHandler({
           if (isServerComponent || isInsideAppDir) {
             return
           }
-          added.set(COMPILER_NAMES.client, addPageEntry(COMPILER_NAMES.client))
+          added.set(COMPILER_NAMES.client, addEntry(COMPILER_NAMES.client))
         },
         onServer: () => {
-          added.set(COMPILER_NAMES.server, addPageEntry(COMPILER_NAMES.server))
+          added.set(COMPILER_NAMES.server, addEntry(COMPILER_NAMES.server))
         },
         onEdgeServer: () => {
           added.set(
             COMPILER_NAMES.edgeServer,
-            addPageEntry(COMPILER_NAMES.edgeServer)
+            addEntry(COMPILER_NAMES.edgeServer)
           )
         },
       })
@@ -489,9 +486,9 @@ export function onDemandEntryHandler({
 
       if (entriesThatShouldBeInvalidated.length > 0) {
         const invalidatePromises = entriesThatShouldBeInvalidated.map(
-          ({ pageKey }) => {
+          ({ entryKey }) => {
             return new Promise<void>((resolve, reject) => {
-              doneCallbacks!.once(pageKey, (err: Error) => {
+              doneCallbacks!.once(entryKey, (err: Error) => {
                 if (err) {
                   return reject(err)
                 }


### PR DESCRIPTION
Given that it's not just pages now I've renamed the entry handling.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
