### PR TITLE
Update .env HMR handling

### DIFF
--- a/packages/next-env/index.ts
+++ b/packages/next-env/index.ts
@@ -13,6 +13,7 @@ export type LoadedEnvFiles = Array<{
 let initialEnv: Env | undefined = undefined
 let combinedEnv: Env | undefined = undefined
 let cachedLoadedEnvFiles: LoadedEnvFiles = []
+let previousLoadedEnvFiles: LoadedEnvFiles = []
 
 type Log = {
   info: (...args: any[]) => void
@@ -49,7 +50,13 @@ export function processEnv(
 
       result = dotenvExpand(result)
 
-      if (result.parsed) {
+      if (
+        result.parsed &&
+        !previousLoadedEnvFiles.some(
+          (item) =>
+            item.contents === envFile.contents && item.path === envFile.path
+        )
+      ) {
         log.info(`Loaded env from ${path.join(dir || '', envFile.path)}`)
       }
 
@@ -88,6 +95,7 @@ export function loadEnvConfig(
     return { combinedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
   }
   process.env = Object.assign({}, initialEnv)
+  previousLoadedEnvFiles = cachedLoadedEnvFiles
   cachedLoadedEnvFiles = []
 
   const isTest = process.env.NODE_ENV === 'test'

--- a/test/integration/env-config/app/pages/another-global.js
+++ b/test/integration/env-config/app/pages/another-global.js
@@ -1,1 +1,3 @@
-export default () => <p>{process.env.NEXT_PUBLIC_HELLO_WORLD}</p>
+export default function Page() {
+  return <p>{process.env.NEXT_PUBLIC_HELLO_WORLD}</p>
+}

--- a/test/integration/env-config/app/pages/api/all.js
+++ b/test/integration/env-config/app/pages/api/all.js
@@ -27,7 +27,7 @@ const variables = [
   'NEXT_PUBLIC_HELLO_WORLD',
 ]
 
-export default async (req, res) => {
+export default async function handler(req, res) {
   const items = {
     nextConfigEnv: process.env.nextConfigEnv,
     nextConfigPublicEnv: process.env.nextConfigPublicEnv,

--- a/test/integration/env-config/app/pages/global.js
+++ b/test/integration/env-config/app/pages/global.js
@@ -1,1 +1,3 @@
-export default () => <p>{process.env.NEXT_PUBLIC_TEST_DEST}</p>
+export default function Page() {
+  return <p>{process.env.NEXT_PUBLIC_TEST_DEST}</p>
+}

--- a/test/integration/env-config/app/pages/index.js
+++ b/test/integration/env-config/app/pages/index.js
@@ -44,10 +44,12 @@ export async function getStaticProps() {
   }
 }
 
-export default ({ env }) => (
-  <>
-    <p>{JSON.stringify(env)}</p>
-    <div id="nextConfigEnv">{process.env.nextConfigEnv}</div>
-    <div id="nextConfigPublicEnv">{process.env.nextConfigPublicEnv}</div>
-  </>
-)
+export default function Page({ env }) {
+  return (
+    <>
+      <p>{JSON.stringify(env)}</p>
+      <div id="nextConfigEnv">{process.env.nextConfigEnv}</div>
+      <div id="nextConfigPublicEnv">{process.env.nextConfigPublicEnv}</div>
+    </>
+  )
+}

--- a/test/integration/env-config/app/pages/some-ssg.js
+++ b/test/integration/env-config/app/pages/some-ssg.js
@@ -44,10 +44,12 @@ export async function getStaticProps() {
   }
 }
 
-export default ({ env }) => (
-  <>
-    <p>{JSON.stringify(env)}</p>
-    <div id="nextConfigEnv">{process.env.nextConfigEnv}</div>
-    <div id="nextConfigPublicEnv">{process.env.nextConfigPublicEnv}</div>
-  </>
-)
+export default function Page({ env }) {
+  return (
+    <>
+      <p>{JSON.stringify(env)}</p>
+      <div id="nextConfigEnv">{process.env.nextConfigEnv}</div>
+      <div id="nextConfigPublicEnv">{process.env.nextConfigPublicEnv}</div>
+    </>
+  )
+}

--- a/test/integration/env-config/app/pages/some-ssp.js
+++ b/test/integration/env-config/app/pages/some-ssp.js
@@ -43,10 +43,12 @@ export async function getServerSideProps() {
   }
 }
 
-export default ({ env }) => (
-  <>
-    <p>{JSON.stringify(env)}</p>
-    <div id="nextConfigEnv">{process.env.nextConfigEnv}</div>
-    <div id="nextConfigPublicEnv">{process.env.nextConfigPublicEnv}</div>
-  </>
-)
+export default function Page({ env }) {
+  return (
+    <>
+      <p>{JSON.stringify(env)}</p>
+      <div id="nextConfigEnv">{process.env.nextConfigEnv}</div>
+      <div id="nextConfigPublicEnv">{process.env.nextConfigPublicEnv}</div>
+    </>
+  )
+}


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/38483 this ensures we HMR `NEXT_PUBLIC_` env values correctly and also updates to only log the env file we got updated values from. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
