### PR TITLE
Fix failing switchable runtime deploy test

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -57,6 +57,7 @@ import {
   APP_PATH_ROUTES_MANIFEST,
   COMPILER_NAMES,
   APP_BUILD_MANIFEST,
+  FLIGHT_SERVER_CSS_MANIFEST,
 } from '../shared/lib/constants'
 import { getSortedRoutes, isDynamicRoute } from '../shared/lib/router/utils'
 import { __ApiPreviewProps } from '../server/api-utils'
@@ -708,6 +709,10 @@ export default async function build(
               ? [
                   path.join(SERVER_DIRECTORY, FLIGHT_MANIFEST + '.js'),
                   path.join(SERVER_DIRECTORY, FLIGHT_MANIFEST + '.json'),
+                  path.join(
+                    SERVER_DIRECTORY,
+                    FLIGHT_SERVER_CSS_MANIFEST + '.json'
+                  ),
                 ]
               : []),
             REACT_LOADABLE_MANIFEST,


### PR DESCRIPTION
This ensures we add the needed manifest for https://github.com/vercel/next.js/commit/b5aa571c71b8b3912bb96b78c359bfc9681833b4 in the `required-files-manifest`. No new test cases have been added as this was caught by the existing deploy test. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

x-ref: https://github.com/vercel/next.js/runs/7821226464?check_suite_focus=true#step:8:193