### PR TITLE
Fix Edge SSR routes

### DIFF
--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -382,12 +382,13 @@ export default class DevServer extends Server {
             page: pageName,
             pageRuntime: staticInfo.runtime,
             onClient: () => {},
-            onServer: () => {},
+            onServer: () => {
+              routedPages.push(pageName)
+            },
             onEdgeServer: () => {
               edgeRoutesSet.add(pageName)
             },
           })
-          routedPages.push(pageName)
         }
 
         if (envChange) {

--- a/test/e2e/switchable-runtime/pages/edge/[id].js
+++ b/test/e2e/switchable-runtime/pages/edge/[id].js
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/edge/foo">to /edge/foo</Link>
+    </div>
+  )
+}
+
+export const config = {
+  runtime: 'experimental-edge',
+}

--- a/test/e2e/switchable-runtime/pages/edge/foo.js
+++ b/test/e2e/switchable-runtime/pages/edge/foo.js
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/edge/123">to /edge/[id]</Link>
+    </div>
+  )
+}
+
+export const config = {
+  runtime: 'experimental-edge',
+}


### PR DESCRIPTION
Currently Edge SSR routes are added to both `routedPages` (catch-all page render routes) and `edgeRoutesSet` (catch-all edge function routes). This causes the request to be handled by both and results in an error (the Node server can't execute the Edge SSR route as a regular page). 

Another fix is to make sure Edge Function routes are sorted too, so `/foo` can be caught before dynamic ones like `/[id]`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
