### PR TITLE
Remove minify: false for webpack5 bundle

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1739,7 +1739,6 @@ export async function ncc_webpack_bundle5(task, opts) {
         if (path.endsWith('.runtime.js')) return `'./${basename(path)}'`
       },
       externals: bundleExternals,
-      minify: false,
       target: 'es5',
     })
     .target('compiled/webpack')


### PR DESCRIPTION
As noticed by @shuding we were disabling minifying for the webpack 5 bundle which was most likely left over from debugging which isn't necessary now as we can use the local version of webpack via the `NEXT_PRIVATE_LOCAL_WEBPACK5` env variable instead. 