### PR TITLE
Add edge ssr to pr stats

### DIFF
--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -1,11 +1,10 @@
 {
   "name": "stats-app",
-  "version": "1.0.0",
-  "main": "index.js",
+  "private": true,
   "license": "MIT",
   "dependencies": {
     "next": "latest",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "18.0.2",
+    "react-dom": "18.0.2"
   }
 }

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "next": "latest",
-    "react": "18.0.2",
-    "react-dom": "18.0.2"
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   }
 }

--- a/test/.stats-app/pages/edge-ssr.js
+++ b/test/.stats-app/pages/edge-ssr.js
@@ -1,0 +1,13 @@
+export default function page() {
+  return 'edge-ssr'
+}
+
+export async function getServerSideProps() {
+  return {
+    props: {},
+  }
+}
+
+export const config = {
+  runtime: 'experimental-edge',
+}

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -32,6 +32,10 @@ const clientGlobs = [
     globs: ['fetched-pages/**/*.html'],
   },
   {
+    name: 'Edge SSR Page bundle Size',
+    globs: ['.next/server/pages/edge-ssr.js'],
+  },
+  {
     name: 'Middleware size',
     globs: [
       '.next/server/middleware*.js',


### PR DESCRIPTION
Monitoring edge-ssr bundle size in PR stats 

* change the react version in stats-app to 18
* checking size of edge ssr page