### PR TITLE
Update eslint.md

### DIFF
--- a/docs/basic-features/eslint.md
+++ b/docs/basic-features/eslint.md
@@ -126,7 +126,7 @@ If you're using `eslint-plugin-next` in a project where Next.js isn't installed 
 
 ## Linting Custom Directories and Files
 
-By default, Next.js will run ESLint for all files in the `pages/`, `components/`, `lib/`, and `src/` directories. However, you can specify which directories using the `dirs` option in the `eslint` config in `next.config.js` for production builds:
+By default, Next.js will run ESLint for all files in the `pages/`, `components/` and`lib/` directories. However, you can specify which directories using the `dirs` option in the `eslint` config in `next.config.js` for production builds:
 
 ```js
 module.exports = {


### PR DESCRIPTION
I noticed today that I get more errors when manually adding this to my `next.config.js` and running `next lint`.
```
eslint: {
    dirs: ['src'],
},
```
Then I found this, which suggests the code and the docs differ:
https://github.com/vercel/next.js/blob/0ca24563be9658732eac158c31046ff58bfe78ca/packages/next/cli/next-lint.ts#L94

Perhaps you prefer to ignore this PR and instead add `src` to the lint path as this would make more sense I guess.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
