### PR TITLE
Update test failure logging 

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -287,7 +287,7 @@ async function main() {
       child.on('exit', async (code, signal) => {
         children.delete(child)
         if (code !== 0 || signal !== null) {
-          if (isFinalRun && hideOutput) {
+          if (hideOutput) {
             // limit out to last 64kb so that we don't
             // run out of log room in CI
             outputChunks.forEach(({ type, chunk }) => {

--- a/run-tests.js
+++ b/run-tests.js
@@ -273,7 +273,7 @@ async function main() {
         }
       )
       const handleOutput = (type) => (chunk) => {
-        if (hideOutput) {
+        if (hideOutput && !isFinalRun) {
           outputChunks.push({ type, chunk })
         } else {
           process.stderr.write(chunk)


### PR DESCRIPTION
This attempts to address the missing log outputs noticed in the below test run. 

x-ref: https://github.com/vercel/next.js/runs/7839842437?check_suite_focus=true

