### PR TITLE
Add support for assigning `loader` to the image provider from `next/future/image`

### DIFF
--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -400,7 +400,7 @@ function getInt(x: unknown): number | undefined {
 
 function defaultImageLoader(loaderProps: ImageLoaderPropsWithConfig) {
   const loaderKey = loaderProps.config?.loader || 'default'
-  const load = loaders.get(loaderKey)
+  const load = loaders.get(loaderKey as LoaderValue)
   if (load) {
     return load(loaderProps)
   }

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -18,6 +18,7 @@ import { loadWebpackHook } from './config-utils'
 import {
   ImageConfig,
   imageConfigDefault,
+  LoaderValue,
   VALID_LOADERS,
 } from '../shared/lib/image-config'
 import { loadEnvConfig } from '@next/env'
@@ -349,7 +350,7 @@ function assignDefaults(userConfig: { [key: string]: any }) {
       images.loader = 'default'
     }
 
-    if (!VALID_LOADERS.includes(images.loader)) {
+    if (!VALID_LOADERS.includes(images.loader as LoaderValue)) {
       throw new Error(
         `Specified images.loader should be one of (${VALID_LOADERS.join(
           ', '

--- a/packages/next/shared/lib/image-config-context.ts
+++ b/packages/next/shared/lib/image-config-context.ts
@@ -1,8 +1,9 @@
-import React from 'react'
-import { ImageConfigComplete, imageConfigDefault } from './image-config'
+import type { ImageConfigComplete } from './image-config'
+import { createContext } from 'react'
+import { imageConfigDefault } from './image-config'
 
 export const ImageConfigContext =
-  React.createContext<ImageConfigComplete>(imageConfigDefault)
+  createContext<ImageConfigComplete>(imageConfigDefault)
 
 if (process.env.NODE_ENV !== 'production') {
   ImageConfigContext.displayName = 'ImageConfigContext'

--- a/packages/next/shared/lib/image-config.ts
+++ b/packages/next/shared/lib/image-config.ts
@@ -1,3 +1,11 @@
+export type ImageLoader = (p: ImageLoaderProps) => string
+
+export type ImageLoaderProps = {
+  src: string
+  width: number
+  quality?: number
+}
+
 export const VALID_LOADERS = [
   'default',
   'imgix',
@@ -50,7 +58,7 @@ export type ImageConfigComplete = {
   imageSizes: number[]
 
   /** @see [Image loaders configuration](https://nextjs.org/docs/basic-features/image-optimization#loaders) */
-  loader: LoaderValue
+  loader: LoaderValue | ImageLoader
 
   /** @see [Image loader configuration](https://nextjs.org/docs/api-reference/next/image#loader-configuration) */
   path: string

--- a/packages/next/telemetry/events/version.ts
+++ b/packages/next/telemetry/events/version.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { NextConfigComplete } from '../../server/config-shared'
+import type { LoaderValue } from '../../shared/lib/image-config'
 
 const EVENT_VERSION = 'NEXT_CLI_SESSION_STARTED'
 
@@ -106,7 +107,7 @@ export function eventCliSession(
       ? experimental.images.remotePatterns.length
       : null,
     imageSizes: images?.imageSizes ? images.imageSizes.join(',') : null,
-    imageLoader: images?.loader,
+    imageLoader: images?.loader as LoaderValue,
     imageFormats: images?.formats ? images.formats.join(',') : null,
     trailingSlashEnabled: !!nextConfig?.trailingSlash,
     reactStrictMode: !!nextConfig?.reactStrictMode,

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -257,11 +257,13 @@ describe('app dir - react server components', () => {
     expect(manipulated).toBe(undefined)
   })
 
-  it('should suspense next/image in server components', async () => {
+  it('should support image components in server components', async () => {
     const imageHTML = await renderViaHTTP(next.url, '/next-api/image')
-    const imageTag = getNodeBySelector(imageHTML, '#myimg')
+    const imageTag = getNodeBySelector(imageHTML, '#legacy-img')
+    const futureImageTag = getNodeBySelector(imageHTML, '#without-loader')
 
     expect(imageTag.attr('src')).toContain('data:image')
+    expect(futureImageTag.attr('src')).toBe('/test.svg?width=256')
   })
 
   // TODO: support esm import for RSC

--- a/test/e2e/app-dir/rsc-basic/app/image-config.client.js
+++ b/test/e2e/app-dir/rsc-basic/app/image-config.client.js
@@ -1,0 +1,15 @@
+import { ImageConfigProvider } from 'next/future/image'
+
+export default function ImageConfig({ children }) {
+  return (
+    <ImageConfigProvider
+      value={{
+        loader: ({ src, width }) => {
+          return `${src}?width=${width}`
+        },
+      }}
+    >
+      {children}
+    </ImageConfigProvider>
+  )
+}

--- a/test/e2e/app-dir/rsc-basic/app/layout.server.js
+++ b/test/e2e/app-dir/rsc-basic/app/layout.server.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ImageConfig from './image-config.client'
 import RootStyleRegistry from './root-style-registry.client'
 
 export default function AppLayout({ children }) {
@@ -8,7 +9,9 @@ export default function AppLayout({ children }) {
         <title>RSC</title>
       </head>
       <body>
-        <RootStyleRegistry>{children}</RootStyleRegistry>
+        <ImageConfig>
+          <RootStyleRegistry>{children}</RootStyleRegistry>
+        </ImageConfig>
       </body>
     </html>
   )

--- a/test/e2e/app-dir/rsc-basic/app/next-api/image/page.server.js
+++ b/test/e2e/app-dir/rsc-basic/app/next-api/image/page.server.js
@@ -1,9 +1,20 @@
 import NextImage from 'next/image'
+import FutureImage from 'next/future/image'
 import src from '../../../public/test.jpg'
 
 // Keep arrow function to test rsc loaders
 const Page = () => {
-  return <NextImage id="myimg" src={src} />
+  return (
+    <div>
+      <NextImage id="legacy-img" src={src} />
+      <FutureImage
+        id="without-loader"
+        src="/test.svg"
+        width={100}
+        height={100}
+      />
+    </div>
+  )
 }
 
 export default Page

--- a/test/e2e/app-dir/rsc-basic/next.config.js
+++ b/test/e2e/app-dir/rsc-basic/next.config.js
@@ -6,5 +6,6 @@ module.exports = {
   experimental: {
     appDir: true,
     serverComponents: true,
+    images: { allowFutureImage: true },
   },
 }

--- a/test/e2e/app-dir/rsc-basic/public/test.svg
+++ b/test/e2e/app-dir/rsc-basic/public/test.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+ width="400" height="400" viewBox="0 0 400 400"
+ preserveAspectRatio="xMidYMid meet">
+<g transform="translate(0.000000,400.000000) scale(0.100000,-0.100000)"
+fill="#000000" stroke="none">
+<path d="M0 2000 l0 -2000 2000 0 2000 0 0 2000 0 2000 -2000 0 -2000 0 0
+-2000z m2401 118 l396 -693 -398 -3 c-220 -1 -578 -1 -798 0 l-398 3 396 693
+c217 380 398 692 401 692 3 0 184 -312 401 -692z"/>
+</g>
+</svg>


### PR DESCRIPTION
* Export image config provider in future image
* Test it for future image in layout with client components