### PR TITLE
Add function `setImageConfig` in `next/image/future`

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -190,9 +190,7 @@ export function getDefineEnv({
     'process.env.__NEXT_SCROLL_RESTORATION': JSON.stringify(
       config.experimental.scrollRestoration
     ),
-    'process.env.__NEXT_IMAGE_OPTS': JSON.stringify(
-      imageConfigOpts({ config, dev })
-    ),
+    'process.env.__NEXT_IMAGE_OPTS': imageConfigOpts({ config, dev }),
     'process.env.__NEXT_ROUTER_BASEPATH': JSON.stringify(config.basePath),
     'process.env.__NEXT_HAS_REWRITES': JSON.stringify(hasRewrites),
     'process.env.__NEXT_I18N_SUPPORT': JSON.stringify(!!config.i18n),

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -30,6 +30,7 @@ import {
   CompilerNameValues,
 } from '../shared/lib/constants'
 import { execOnce } from '../shared/lib/utils'
+import { imageConfigOpts } from '../shared/lib/image-config-opts'
 import { NextConfigComplete } from '../server/config-shared'
 import { finalizeEntrypoint } from './entries'
 import * as Log from './output/log'
@@ -93,7 +94,7 @@ export function getDefineEnv({
   middlewareRegex,
   hasServerComponents,
 }: {
-  dev?: boolean
+  dev: boolean
   distDir: string
   isClient?: boolean
   hasRewrites?: boolean
@@ -189,23 +190,9 @@ export function getDefineEnv({
     'process.env.__NEXT_SCROLL_RESTORATION': JSON.stringify(
       config.experimental.scrollRestoration
     ),
-    'process.env.__NEXT_IMAGE_OPTS': JSON.stringify({
-      deviceSizes: config.images.deviceSizes,
-      imageSizes: config.images.imageSizes,
-      path: config.images.path,
-      loader: config.images.loader,
-      dangerouslyAllowSVG: config.images.dangerouslyAllowSVG,
-      experimentalUnoptimized: config?.experimental?.images?.unoptimized,
-      experimentalFuture: config.experimental?.images?.allowFutureImage,
-      ...(dev
-        ? {
-            // pass domains in development to allow validating on the client
-            domains: config.images.domains,
-            experimentalRemotePatterns:
-              config.experimental?.images?.remotePatterns,
-          }
-        : {}),
-    }),
+    'process.env.__NEXT_IMAGE_OPTS': JSON.stringify(
+      imageConfigOpts({ config, dev })
+    ),
     'process.env.__NEXT_ROUTER_BASEPATH': JSON.stringify(config.basePath),
     'process.env.__NEXT_HAS_REWRITES': JSON.stringify(hasRewrites),
     'process.env.__NEXT_I18N_SUPPORT': JSON.stringify(!!config.i18n),

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -34,10 +34,10 @@ const VALID_LOADING_VALUES = ['lazy', 'eager', undefined] as const
 type LoadingValue = typeof VALID_LOADING_VALUES[number]
 type ImageConfig = ImageConfigComplete & { allSizes: number[] }
 export type ImageLoader = (p: ImageLoaderProps) => string
+type GlobalImageConfig = Omit<Partial<ImageConfigComplete>, 'path'>
+let globalImageConfig: GlobalImageConfig = {}
 
-let globalImageConfig: Partial<ImageConfigComplete> = {}
-
-export function setImageConfig(imageConfig: Partial<ImageConfigComplete>) {
+export function setImageConfig(imageConfig: GlobalImageConfig) {
   // We are not using React Context because we want the
   // `next/future/image` component to be a Shared component that will work
   // as both a Client component and a Server component. In particular,

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useEffect, useCallback, useState } from 'react'
 import Head from '../../shared/lib/head'
 import {
   ImageConfigComplete,
-  imageConfigDefault,
   RemotePattern,
 } from '../../shared/lib/image-future-config'
 import { warnOnce } from '../../shared/lib/utils'
@@ -27,14 +26,7 @@ type ImageConfig = ImageConfigComplete & {
 }
 export type ImageLoader = (p: ImageLoaderProps) => string
 type GlobalImageConfig = Omit<Partial<ImageConfigComplete>, 'path'>
-const opts = (process.env.__NEXT_IMAGE_OPTS as any) || {}
-let config = {
-  ...imageConfigDefault,
-  experimentalFuture: false,
-  experimentalRemotePatterns: [],
-  experimentalUnoptimized: false,
-  ...opts,
-} as any as ImageConfig
+let config = {} as ImageConfig
 
 export function setImageConfig(imageConfig: GlobalImageConfig) {
   // We are not using React Context because we want the
@@ -52,7 +44,7 @@ export function setImageConfig(imageConfig: GlobalImageConfig) {
   config.deviceSizes = deviceSizes
 }
 
-setImageConfig(config)
+setImageConfig((process.env.__NEXT_IMAGE_OPTS as any) || {})
 
 export type ImageLoaderProps = {
   src: string

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -44,7 +44,11 @@ export function setImageConfig(imageConfig: GlobalImageConfig) {
   config.deviceSizes = deviceSizes
 }
 
-setImageConfig((process.env.__NEXT_IMAGE_OPTS as any) || {})
+setImageConfig(
+  typeof process.env.__NEXT_IMAGE_OPTS === 'string'
+    ? JSON.parse(process.env.__NEXT_IMAGE_OPTS)
+    : process.env.__NEXT_IMAGE_OPTS
+)
 
 export type ImageLoaderProps = {
   src: string

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -41,6 +41,8 @@ export function setImageConfig(imageConfig: GlobalImageConfig) {
   config.deviceSizes = deviceSizes
 }
 
+setImageConfig(config)
+
 export type ImageLoaderProps = {
   src: string
   width: number

--- a/packages/next/client/image.tsx
+++ b/packages/next/client/image.tsx
@@ -22,9 +22,10 @@ function normalizeSrc(src: string): string {
   return src[0] === '/' ? src.slice(1) : src
 }
 
+const configEnv = (process.env.__NEXT_IMAGE_OPTS &&
+  JSON.parse(process.env.__NEXT_IMAGE_OPTS)) as ImageConfigComplete
 const { experimentalRemotePatterns = [], experimentalUnoptimized } =
-  (process.env.__NEXT_IMAGE_OPTS as any) || {}
-const configEnv = process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete
+  configEnv as any
 const loadedImageURLs = new Set<string>()
 const allImgs = new Map<
   string,

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -452,7 +452,9 @@ function AppContainer({
       <RouterContext.Provider value={makePublicRouterInstance(router)}>
         <HeadManagerContext.Provider value={headManager}>
           <ImageConfigContext.Provider
-            value={process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete}
+            value={
+              JSON.parse(process.env.__NEXT_IMAGE_OPTS!) as ImageConfigComplete
+            }
           >
             {children}
           </ImageConfigContext.Provider>

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -41,6 +41,7 @@ import { PrerenderManifest } from '../build'
 import { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
 import { getPagePath } from '../server/require'
 import { Span } from '../trace'
+import { RenderOpts } from './worker'
 
 const exists = promisify(existsOrig)
 
@@ -358,7 +359,7 @@ export default async function exportApp(
     }
 
     // Start the rendering process
-    const renderOpts = {
+    const renderOpts: any = {
       dir,
       buildId,
       nextExport: true,
@@ -385,12 +386,14 @@ export default async function exportApp(
       nextScriptWorkers: nextConfig.experimental.nextScriptWorkers,
       optimizeFonts: nextConfig.optimizeFonts,
       largePageDataBytes: nextConfig.experimental.largePageDataBytes,
+      configImages: nextConfig.images,
+      configImagesExperimental: nextConfig.experimental.images,
     }
 
     const { serverRuntimeConfig, publicRuntimeConfig } = nextConfig
 
     if (Object.keys(publicRuntimeConfig).length > 0) {
-      ;(renderOpts as any).runtimeConfig = publicRuntimeConfig
+      renderOpts.runtimeConfig = publicRuntimeConfig
     }
 
     // We need this for server rendering the Link component.

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -27,6 +27,7 @@ import { setHttpAgentOptions } from '../server/config'
 import RenderResult from '../server/render-result'
 import isError from '../lib/is-error'
 import { addRequestMeta } from '../server/request-meta'
+import { imageConfigOpts } from '../shared/lib/image-config-opts'
 
 loadRequireHook()
 const envConfig = require('../shared/lib/runtime-config')
@@ -76,7 +77,13 @@ interface ExportPageResults {
   duration: number
 }
 
-interface RenderOpts {
+export interface RenderOpts {
+  dir?: string
+  buildId?: string
+  nextExport?: boolean
+  assetPrefix?: string
+  distDir?: string
+  dev?: boolean
   runtimeConfig?: { [key: string]: any }
   params?: { [key: string]: string | string[] }
   ampPath?: string
@@ -92,6 +99,8 @@ interface RenderOpts {
   domainLocales?: DomainLocale[]
   trailingSlash?: boolean
   appDir?: boolean
+  configImages?: NextConfigComplete['images']
+  configImagesExperimental?: NextConfigComplete['experimental']['images']
 }
 
 type ComponentModule = ComponentType<{}> & {
@@ -119,6 +128,17 @@ export default async function exportPage({
   serverComponents,
 }: ExportPageInput): Promise<ExportPageResults> {
   setHttpAgentOptions(httpAgentOptions)
+  /*
+  process.env.__NEXT_IMAGE_OPTS = imageConfigOpts({
+    config: {
+      images: renderOpts.configImages || {}, 
+      experimental: { 
+        images: renderOpts.configImagesExperimental
+      } 
+    },
+    dev: renderOpts.dev === true,
+  }) as any
+  */
   const exportPageSpan = trace('export-page-worker', parentSpanId)
 
   return exportPageSpan.traceAsyncFn(async () => {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -334,7 +334,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     process.env.__NEXT_IMAGE_OPTS = imageConfigOpts({
       config: this.nextConfig,
       dev,
-    }) as any
+    })
     this.hostname = hostname
     this.port = port
     this.distDir =

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -68,6 +68,7 @@ import { getLocaleRedirect } from '../shared/lib/i18n/get-locale-redirect'
 import { getHostname } from '../shared/lib/get-hostname'
 import { parseUrl as parseUrlUtil } from '../shared/lib/router/utils/parse-url'
 import { getNextPathnameInfo } from '../shared/lib/router/utils/get-next-pathname-info'
+import { imageConfigOpts } from '../shared/lib/image-config-opts'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -330,6 +331,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     // TODO: should conf be normalized to prevent missing
     // values from causing issues as this can be user provided
     this.nextConfig = conf as NextConfigComplete
+    process.env.__NEXT_IMAGE_OPTS = imageConfigOpts({
+      config: this.nextConfig,
+      dev,
+    }) as any
     this.hostname = hostname
     this.port = port
     this.distDir =

--- a/packages/next/shared/lib/image-config-opts.ts
+++ b/packages/next/shared/lib/image-config-opts.ts
@@ -17,10 +17,10 @@ export function imageConfigOpts({
   config,
   dev,
 }: {
-  config: NextConfigComplete
+  config: Pick<NextConfigComplete, 'images' | 'experimental'>
   dev: boolean
-}): ImageConfigOpts {
-  return {
+}): string {
+  const opts: ImageConfigOpts = {
     deviceSizes: config.images.deviceSizes,
     imageSizes: config.images.imageSizes,
     path: config.images.path,
@@ -35,4 +35,5 @@ export function imageConfigOpts({
       ? config.experimental?.images?.remotePatterns || []
       : [],
   }
+  return JSON.stringify(opts)
 }

--- a/packages/next/shared/lib/image-config-opts.ts
+++ b/packages/next/shared/lib/image-config-opts.ts
@@ -1,0 +1,38 @@
+import { NextConfigComplete } from '../../server/config-shared'
+import { LoaderValue, RemotePattern } from './image-config'
+
+export interface ImageConfigOpts {
+  deviceSizes: number[]
+  imageSizes: number[]
+  path: string
+  loader: LoaderValue
+  dangerouslyAllowSVG: boolean
+  experimentalUnoptimized: boolean
+  experimentalFuture: boolean
+  domains?: string[]
+  experimentalRemotePatterns?: RemotePattern[]
+}
+
+export function imageConfigOpts({
+  config,
+  dev,
+}: {
+  config: NextConfigComplete
+  dev: boolean
+}): ImageConfigOpts {
+  return {
+    deviceSizes: config.images.deviceSizes,
+    imageSizes: config.images.imageSizes,
+    path: config.images.path,
+    loader: config.images.loader,
+    dangerouslyAllowSVG: config.images.dangerouslyAllowSVG,
+    experimentalUnoptimized: config.experimental?.images?.unoptimized || false,
+    experimentalFuture: config.experimental?.images?.allowFutureImage || false,
+    // The follow are only needed during development to allow validating on the client.
+    // We must not send this data during production to avoid leaking the list of valid domains.
+    domains: dev ? config.images.domains : [],
+    experimentalRemotePatterns: dev
+      ? config.experimental?.images?.remotePatterns || []
+      : [],
+  }
+}

--- a/packages/next/shared/lib/image-future-config.ts
+++ b/packages/next/shared/lib/image-future-config.ts
@@ -1,0 +1,82 @@
+export type RemotePattern = {
+  /**
+   * Must be `http` or `https`.
+   */
+  protocol?: 'http' | 'https'
+
+  /**
+   * Can be literal or wildcard.
+   * Single `*` matches a single subdomain.
+   * Double `**` matches any number of subdomains.
+   */
+  hostname: string
+
+  /**
+   * Can be literal port such as `8080` or empty string
+   * meaning no port.
+   */
+  port?: string
+
+  /**
+   * Can be literal or wildcard.
+   * Single `*` matches a single path segment.
+   * Double `**` matches any number of path segments.
+   */
+  pathname?: string
+}
+
+type ImageFormat = 'image/avif' | 'image/webp'
+
+/**
+ * Image configurations
+ *
+ * @see [Image configuration options](https://nextjs.org/docs/api-reference/next/image#configuration-options)
+ */
+export type ImageConfigComplete = {
+  /** @see [Device sizes documentation](https://nextjs.org/docs/api-reference/next/image#device-sizes) */
+  deviceSizes: number[]
+
+  /** @see [Image sizing documentation](https://nextjs.org/docs/basic-features/image-optimization#image-sizing) */
+  imageSizes: number[]
+
+  /** @see [Image loaders configuration](https://nextjs.org/docs/basic-features/image-optimization#loaders) */
+  loader: (() => string) | undefined
+
+  /** @see [Image loader configuration](https://nextjs.org/docs/api-reference/next/image#loader-configuration) */
+  path: string
+
+  /**
+   * @see [Image domains configuration](https://nextjs.org/docs/api-reference/next/image#domains)
+   */
+  domains: string[]
+
+  /** @see [Disable static image import configuration](https://nextjs.org/docs/api-reference/next/image#disable-static-imports) */
+  disableStaticImages: boolean
+
+  /** @see [Cache behavior](https://nextjs.org/docs/api-reference/next/image#caching-behavior) */
+  minimumCacheTTL: number
+
+  /** @see [Acceptable formats](https://nextjs.org/docs/api-reference/next/image#acceptable-formats) */
+  formats: ImageFormat[]
+
+  /** @see [Dangerously Allow SVG](https://nextjs.org/docs/api-reference/next/image#dangerously-allow-svg) */
+  dangerouslyAllowSVG: boolean
+
+  /** @see [Dangerously Allow SVG](https://nextjs.org/docs/api-reference/next/image#dangerously-allow-svg) */
+  contentSecurityPolicy: string
+}
+
+export type ImageConfig = Partial<ImageConfigComplete>
+
+export const imageConfigDefault: ImageConfigComplete = {
+  deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+  imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+  path: '/_next/image',
+  loader: undefined,
+  domains: [],
+  disableStaticImages: false,
+  minimumCacheTTL: 60,
+  formats: ['image/webp'],
+  dangerouslyAllowSVG: false,
+  contentSecurityPolicy: `script-src 'none'; frame-src 'none'; sandbox;`,
+}

--- a/packages/next/shared/lib/image-future-config.ts
+++ b/packages/next/shared/lib/image-future-config.ts
@@ -33,17 +33,17 @@ type ImageFormat = 'image/avif' | 'image/webp'
  * @see [Image configuration options](https://nextjs.org/docs/api-reference/next/image#configuration-options)
  */
 export type ImageConfigComplete = {
+  /** @private This is internal only */
+  path: string
+
   /** @see [Device sizes documentation](https://nextjs.org/docs/api-reference/next/image#device-sizes) */
   deviceSizes: number[]
 
   /** @see [Image sizing documentation](https://nextjs.org/docs/basic-features/image-optimization#image-sizing) */
   imageSizes: number[]
 
-  /** @see [Image loaders configuration](https://nextjs.org/docs/basic-features/image-optimization#loaders) */
+  /** @see [Image loaders prop](https://nextjs.org/docs/api-reference/next/future/image#loader) */
   loader: (() => string) | undefined
-
-  /** @see [Image loader configuration](https://nextjs.org/docs/api-reference/next/image#loader-configuration) */
-  path: string
 
   /**
    * @see [Image domains configuration](https://nextjs.org/docs/api-reference/next/image#domains)

--- a/test/integration/image-future/image-from-node-modules/test/index.test.ts
+++ b/test/integration/image-future/image-from-node-modules/test/index.test.ts
@@ -17,7 +17,7 @@ function runTests() {
   // This feature was added in PR #31065.
   // Skip this test until we promote `next/future/image` from
   // experimental to stable status.
-  it.skip('should apply image config for node_modules', async () => {
+  it('should apply image config for node_modules', async () => {
     const browser = await webdriver(appPort, '/')
     const src = await browser
       .elementById('image-from-node-modules')


### PR DESCRIPTION
This PR adds a new function that allows the user to set configuration options (as opposed to `next.config.js`)

- Closes #39680 