### PR TITLE
Update link.md

### DIFF
--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -145,6 +145,37 @@ function Home() {
 export default Home
 ```
 
+## If the child is a functional component (solution without reactforwardref)
+
+If the child of `Link` is a functional component and the component is not a child of <a></a>, in addition to using `passHref` you must wrap it inside anchor tags in-place.
+
+```jsx
+import Link from 'next/link'
+
+// `onClick`, `href`, and `ref` need to be passed to the DOM element
+// for proper handling
+const MyComponent = ({title, description}) => {
+  return (
+    <div id="blogpost" style={{background:'black', color:'white'}}>
+      <h1>{title}</h1>
+      <p>{description}</p>
+    </div>
+  )
+}
+
+function Home() {
+  return (
+     <Link href="/blogpost" passHref>
+       <a>
+         <MyComponent title="Hello World" description="Lorem ipsum"/>
+       </a>
+     </Link>
+  )
+}
+
+export default Home
+```
+
 ## With URL Object
 
 `Link` can also receive a URL object and it will automatically format it to create the URL string. Here's how to do it:


### PR DESCRIPTION
Easier solution for wrapping components inside Link tags. passHref is directly passed to anchor tag.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
