### PR TITLE
fix: allow `next.config.js` overwrite `cache-control` header

### DIFF
--- a/packages/next/server/send-payload/revalidate-headers.ts
+++ b/packages/next/server/send-payload/revalidate-headers.ts
@@ -7,7 +7,7 @@ export function setRevalidateHeaders(
   options: PayloadOptions
 ) {
   if (options.private || options.stateful) {
-    if (options.private || !res.hasHeader('Cache-Control')) {
+    if (options.private || !res.getHeader('Cache-Control')) {
       res.setHeader(
         'Cache-Control',
         `private, no-cache, no-store, max-age=0, must-revalidate`
@@ -20,11 +20,18 @@ export function setRevalidateHeaders(
       )
     }
 
-    res.setHeader(
-      'Cache-Control',
-      `s-maxage=${options.revalidate}, stale-while-revalidate`
-    )
+    if (!res.getHeader('Cache-Control')) {
+      res.setHeader(
+        'Cache-Control',
+        `s-maxage=${options.revalidate}, stale-while-revalidate`
+      )
+    }
   } else if (options.revalidate === false) {
-    res.setHeader('Cache-Control', `s-maxage=31536000, stale-while-revalidate`)
+    if (!res.getHeader('Cache-Control')) {
+      res.setHeader(
+        'Cache-Control',
+        `s-maxage=31536000, stale-while-revalidate`
+      )
+    }
   }
 }


### PR DESCRIPTION
## Update (2022-12-31): My Solution

> Before the PR merge, if anyone else is bothered by it, my solution is to modify [`node_modules/next/dist/server/send-payload/revalidate-headers.js`](https://github.com/vercel/next.js/pull/39707/files) and then use [patch-package](https://github.com/ds300/patch-package) to generate the patch. If you use `pnpm` then you can just use [`pnpm patch next`](https://pnpm.io/cli/patch) to generate the patch using [`pnpm patch-commit`](https://pnpm.io/cli/patch-commit) after making changes in the temporary directory.

Fixes #21827, fixes #22319 #28557

https://nextjs.org/docs/api-reference/next.config.js/headers#cache-control

>You cannot set `Cache-Control` headers in `next.config.js` file as these will be overwritten in production to ensure that API Routes and static assets are cached effectively.

In the documentation it is described that `Cache-Control` cannot be overridden and will affect static resources, but in fact static resources will set their own `Cache-Control`, so it does not seem to affect them.

https://github.com/vercel/next.js/blob/9c416341048a4467d8bcd147c1d5c399fa1ab17a/packages/next/server/next-server.ts#L428-L451

I use `getHeader('Cache-Control')` to check if the user has set their cache, which by default is the same behavior as before.
By the way `hasHeader` is `undefined` in some cases, I don't know why. (#34929 #37338)