### PR TITLE
Tweak Convex example

### DIFF
--- a/.prettierignore_staged
+++ b/.prettierignore_staged
@@ -8,3 +8,4 @@ lerna.json
 packages/next-codemod/transforms/__testfixtures__/**/*
 packages/next-codemod/transforms/__tests__/**/*
 pnpm-lock.yaml
+**/convex/_generated/**

--- a/examples/convex/convex.json
+++ b/examples/convex/convex.json
@@ -1,6 +1,0 @@
-{
-  "authInfo": [],
-  "functions": "convex/",
-  "instanceName": "handsome-turtle-915",
-  "origin": "https://handsome-turtle-915.convex.cloud"
-}

--- a/examples/convex/convex/_generated/dataModel.ts
+++ b/examples/convex/convex/_generated/dataModel.ts
@@ -9,8 +9,8 @@
  * @module
  */
 
-import { AnyDataModel } from 'convex/server'
-import { GenericId } from 'convex/values'
+import { AnyDataModel } from "convex/server";
+import { GenericId } from "convex/values";
 
 /**
  * No `schema.ts` file found!
@@ -26,12 +26,12 @@ import { GenericId } from 'convex/values'
 /**
  * The names of all of your Convex tables.
  */
-export type TableNames = string
+export type TableNames = string;
 
 /**
  * The type of a document stored in Convex.
  */
-export type Document = any
+export type Document = any;
 
 /**
  * An identifier for a document in Convex.
@@ -45,8 +45,8 @@ export type Document = any
  * Using `===` will not work because two different instances of `Id` can refer
  * to the same document.
  */
-export type Id = GenericId<string>
-export const Id = GenericId
+export type Id = GenericId<string>;
+export const Id = GenericId;
 
 /**
  * A type describing your Convex data model.
@@ -57,4 +57,4 @@ export const Id = GenericId
  * This type is used to parameterize methods like `queryGeneric` and
  * `mutationGeneric` to make them type-safe.
  */
-export type DataModel = AnyDataModel
+export type DataModel = AnyDataModel;

--- a/examples/convex/convex/_generated/react.ts
+++ b/examples/convex/convex/_generated/react.ts
@@ -9,10 +9,10 @@
  * @module
  */
 
-import type getCounter from '../getCounter'
-import type incrementCounter from '../incrementCounter'
-import type { OptimisticLocalStore as GenericOptimisticLocalStore } from 'convex/browser'
-import type { ClientMutation, ClientQuery } from 'convex/server'
+import type getCounter from "../getCounter";
+import type incrementCounter from "../incrementCounter";
+import type { OptimisticLocalStore as GenericOptimisticLocalStore } from "convex/browser";
+import type { ClientMutation, ClientQuery } from "convex/server";
 
 /**
  * A type describing your app's public Convex API.
@@ -25,14 +25,14 @@ import type { ClientMutation, ClientQuery } from 'convex/server'
  */
 export type ConvexAPI = {
   queries: {
-    getCounter: ClientQuery<typeof getCounter>
-  }
+    getCounter: ClientQuery<typeof getCounter>;
+  };
   mutations: {
-    incrementCounter: ClientMutation<typeof incrementCounter>
-  }
-}
+    incrementCounter: ClientMutation<typeof incrementCounter>;
+  };
+};
 
-import { makeUseQuery, makeUseMutation, makeUseConvex } from 'convex/react'
+import { makeUseQuery, makeUseMutation, makeUseConvex } from "convex/react";
 
 /**
  * Load a reactive query within a React component.
@@ -46,7 +46,7 @@ import { makeUseQuery, makeUseMutation, makeUseConvex } from 'convex/react'
  * @param args - The arguments to the query function.
  * @returns `undefined` if loading and the query's return value otherwise.
  */
-export const useQuery = makeUseQuery<ConvexAPI>()
+export const useQuery = makeUseQuery<ConvexAPI>();
 
 /**
  * Construct a new {@link ReactMutation}.
@@ -64,7 +64,7 @@ export const useQuery = makeUseQuery<ConvexAPI>()
  * @param name - The name of the mutation.
  * @returns The {@link ReactMutation} object with that name.
  */
-export const useMutation = makeUseMutation<ConvexAPI>()
+export const useMutation = makeUseMutation<ConvexAPI>();
 
 /**
  * Get the {@link ConvexReactClient} within a React component.
@@ -73,10 +73,10 @@ export const useMutation = makeUseMutation<ConvexAPI>()
  *
  * @returns The active {@link ConvexReactClient} object, or `undefined`.
  */
-export const useConvex = makeUseConvex<ConvexAPI>()
+export const useConvex = makeUseConvex<ConvexAPI>();
 
 /**
  * A view of the query results currently in the Convex client for use within
  * optimistic updates.
  */
-export type OptimisticLocalStore = GenericOptimisticLocalStore<ConvexAPI>
+export type OptimisticLocalStore = GenericOptimisticLocalStore<ConvexAPI>;

--- a/examples/convex/convex/_generated/server.ts
+++ b/examples/convex/convex/_generated/server.ts
@@ -16,8 +16,8 @@ import {
   MutationCtx as GenericMutationCtx,
   DatabaseReader as GenericDatabaseReader,
   DatabaseWriter as GenericDatabaseWriter,
-} from 'convex/server'
-import { DataModel } from './dataModel.js'
+} from "convex/server";
+import { DataModel } from "./dataModel.js";
 
 /**
  * Define a query in this Convex app's public API.
@@ -27,7 +27,7 @@ import { DataModel } from './dataModel.js'
  * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
  * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
  */
-export const query = makeQuery<DataModel>()
+export const query = makeQuery<DataModel>();
 
 /**
  * Define a mutation in this Convex app's public API.
@@ -37,7 +37,7 @@ export const query = makeQuery<DataModel>()
  * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
  * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
  */
-export const mutation = makeMutation<DataModel>()
+export const mutation = makeMutation<DataModel>();
 
 /**
  * A set of services for use within Convex query functions.
@@ -48,7 +48,7 @@ export const mutation = makeMutation<DataModel>()
  * This differs from the {@link MutationCtx} because all of the services are
  * read-only.
  */
-export type QueryCtx = GenericQueryCtx<DataModel>
+export type QueryCtx = GenericQueryCtx<DataModel>;
 
 /**
  * A set of services for use within Convex mutation functions.
@@ -56,7 +56,7 @@ export type QueryCtx = GenericQueryCtx<DataModel>
  * The mutation context is passed as the first argument to any Convex mutation
  * function run on the server.
  */
-export type MutationCtx = GenericMutationCtx<DataModel>
+export type MutationCtx = GenericMutationCtx<DataModel>;
 
 /**
  * An interface to read from the database within Convex query functions.
@@ -65,7 +65,7 @@ export type MutationCtx = GenericMutationCtx<DataModel>
  * document by its {@link Id}, or {@link DatabaseReader.table}, which starts
  * building a query.
  */
-export type DatabaseReader = GenericDatabaseReader<DataModel>
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
 
 /**
  * An interface to read from and write to the database within Convex mutation
@@ -76,4 +76,4 @@ export type DatabaseReader = GenericDatabaseReader<DataModel>
  * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
  * for the guarantees Convex provides your functions.
  */
-export type DatabaseWriter = GenericDatabaseWriter<DataModel>
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/convex/convex/incrementCounter.ts
+++ b/examples/convex/convex/incrementCounter.ts
@@ -2,7 +2,7 @@ import { mutation } from './_generated/server'
 
 export default mutation(
   async ({ db }, counterName: string, increment: number) => {
-    let counterDoc = await db
+    const counterDoc = await db
       .table('counter_table')
       .filter((q) => q.eq(q.field('name'), counterName))
       .first()

--- a/examples/convex/package.json
+++ b/examples/convex/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "convex": "latest",
     "next": "latest",
-    "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -16,6 +15,7 @@
     "@types/node": "~16.11.12",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
+    "prettier": "^2.7.1",
     "typescript": "^4.7.3"
   }
 }


### PR DESCRIPTION
This is a followup to https://github.com/vercel/next.js/pull/39562 because I realized I made a few mistakes.

- Remove `convex.json` file. Developers using the example should generate this on their own by running `npx convex init`.
- Switch prettier to a dev dependency.
- Ignore formatting in Convex generated code while running lint-staged and revert them back to the default generated form (I previously was only ignoring generated code in the main `.prettierignore`)
- Change a `let` to a `const`

cc @thomasballinger 

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
