### PR TITLE
Add missing types for ScriptProps

### DIFF
--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -14,6 +14,8 @@ export interface ScriptProps extends ScriptHTMLAttributes<HTMLScriptElement> {
   onReady?: () => void | null
   onError?: (e: any) => void
   children?: React.ReactNode
+  dangerouslySetInnerHTML?: { __html: string }
+  src?: string
 }
 
 /**


### PR DESCRIPTION
I added types for ScriptProps that were missing. It can be seen typescript warnings in **_document.tsx** line 247 ( route packages -> next -> pages) and in **script.tsx** line 35 ( route packages -> next -> client )
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
