### PR TITLE
Increase proxy limit from 30s to 60s

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -621,7 +621,7 @@ export default class NextNodeServer extends BaseServer {
       ws: true,
       // we limit proxy requests to 30s by default, in development
       // we don't time out WebSocket requests to allow proxying
-      proxyTimeout: upgradeHead && this.renderOpts.dev ? undefined : 30_000,
+      proxyTimeout: upgradeHead && this.renderOpts.dev ? undefined : 60_000,
     })
 
     await new Promise((proxyResolve, proxyReject) => {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes #36251

Increasing the limit since original issue wasn't addressed in 4 months. `60_000` value was picked based on default nginx values. See [proxy_connect_timeout](http://nginx.org/ru/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout), [proxy_read_timeout](http://nginx.org/ru/docs/http/ngx_http_proxy_module.html#proxy_read_timeout) and [proxy_send_timeout](http://nginx.org/ru/docs/http/ngx_http_proxy_module.html#proxy_send_timeout).
