### PR TITLE
Leverage VERCEL_CLI_VERSION env for deploy tests

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -74,14 +74,19 @@ export class NextDeployInstance extends NextInstance {
       additionalEnv.push(`${key}=${this.env[key]}`)
     }
 
+    if (process.env.VERCEL_CLI_VERSION) {
+      additionalEnv.push('--build-env')
+      additionalEnv.push(
+        `VERCEL_CLI_VERSION="${process.env.VERCEL_CLI_VERSION}"`
+      )
+    }
+
     const deployRes = await execa(
       'vercel',
       [
         'deploy',
         '--build-env',
         'NEXT_PRIVATE_TEST_MODE=1',
-        '--build-env',
-        'FORCE_RUNTIME_TAG=canary',
         '--build-env',
         'NEXT_TELEMETRY_DISABLED=1',
         ...additionalEnv,


### PR DESCRIPTION
This updates our `next-e2e` test deploy mode to auto pass along the `VERCEL_CLI_VERSION` env variable to allow testing builder changes easier. cc @nkzawa who encountered this. 