### PR TITLE
Fix  `onError` handling in `next/future/image`

### DIFF
--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -39,7 +39,6 @@ Compared to `next/image`, the new `next/future/image` component has the followin
 - Removes `layout`, `objectFit`, and `objectPosition` props in favor of `style` or `className`
 - Removes `IntersectionObserver` implementation in favor of [native lazy loading](https://caniuse.com/loading-lazy-attr)
 - Removes `loader` config in favor of [`loader`](#loader) prop
-- Note: the [`onError`](#onerror) prop might behave differently
 
 ## Known Browser Bugs
 
@@ -312,15 +311,13 @@ The callback function will be called with one argument, an object with the follo
 
 A callback function that is invoked when the image is loaded.
 
-Note that the load event might occur before client-side hydration completes, so this callback might not be invoked in that case.
+Note that the load event might occur before the placeholder is removed and the image is fully decoded.
 
 Instead, use [`onLoadingComplete`](#onloadingcomplete).
 
 ### onError
 
 A callback function that is invoked if the image fails to load.
-
-Note that the error might occur before client-side hydration completes, so this callback might not be invoked in that case.
 
 ### loading
 

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -359,6 +359,12 @@ const ImageElement = ({
         style={{ ...imgStyle, ...blurStyle }}
         ref={useCallback(
           (img: ImgElementWithDataProp) => {
+            if (onError) {
+              // If the image has an error before react hydrates, then the error is lost.
+              // The workaround is to wait until the image is mounted which is after hydration,
+              // then we set the src again to trigger the error handler (if there was an error).
+              img.src = img.src
+            }
             if (process.env.NODE_ENV !== 'production') {
               if (img && !srcString) {
                 console.error(`Image is missing required "src" property:`, img)

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -358,8 +358,8 @@ const ImageElement = ({
         loading={loading}
         style={{ ...imgStyle, ...blurStyle }}
         ref={useCallback(
-          (img: ImgElementWithDataProp) => {
-            if (onError) {
+          (img: ImgElementWithDataProp | null) => {
+            if (img && onError) {
               // If the image has an error before react hydrates, then the error is lost.
               // The workaround is to wait until the image is mounted which is after hydration,
               // then we set the src again to trigger the error handler (if there was an error).

--- a/packages/next/client/future/image.tsx
+++ b/packages/next/client/future/image.tsx
@@ -363,6 +363,7 @@ const ImageElement = ({
               // If the image has an error before react hydrates, then the error is lost.
               // The workaround is to wait until the image is mounted which is after hydration,
               // then we set the src again to trigger the error handler (if there was an error).
+              // eslint-disable-next-line no-self-assign
               img.src = img.src
             }
             if (process.env.NODE_ENV !== 'production') {
@@ -380,7 +381,13 @@ const ImageElement = ({
               )
             }
           },
-          [srcString, placeholder, onLoadingCompleteRef, setBlurComplete]
+          [
+            srcString,
+            placeholder,
+            onLoadingCompleteRef,
+            setBlurComplete,
+            onError,
+          ]
         )}
         onLoad={(event) => {
           const img = event.currentTarget as ImgElementWithDataProp

--- a/test/integration/image-future/default/pages/on-error-before-hydration.js
+++ b/test/integration/image-future/default/pages/on-error-before-hydration.js
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import Image from 'next/future/image'
+
+const Page = () => {
+  const [msg, setMsg] = useState(`default state`)
+  return (
+    <div>
+      <Image
+        id="img"
+        src="/404.jpg"
+        width="200"
+        height="200"
+        onError={() => {
+          setMsg(`error state`)
+        }}
+      />
+      <p id="msg">{msg}</p>
+    </div>
+  )
+}
+
+export default Page

--- a/test/integration/image-future/default/test/index.test.ts
+++ b/test/integration/image-future/default/test/index.test.ts
@@ -387,6 +387,14 @@ function runTests(mode) {
     )
   })
 
+  it('should callback native onError even when error before hydration', async () => {
+    let browser = await webdriver(appPort, '/on-error-before-hydration')
+    await check(
+      () => browser.eval(`document.getElementById("msg").textContent`),
+      'error state'
+    )
+  })
+
   it('should work with image with blob src', async () => {
     let browser
     try {


### PR DESCRIPTION
This PR fixes a race condition where the `onError` handler was never called because the error happened before react attached the error handler.