### PR TITLE
Skip building /500 in dev mode

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1705,14 +1705,18 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       let using404Page = false
 
       // use static 404 page if available and is 404 response
-      if (is404) {
+      if (is404 && (await this.hasPage('/404'))) {
         result = await this.findPageComponents('/404', query)
         using404Page = result !== null
       }
       let statusPage = `/${res.statusCode}`
 
       if (!result && STATIC_STATUS_PAGES.includes(statusPage)) {
-        result = await this.findPageComponents(statusPage, query)
+        // skip ensuring /500 in dev mode as it isn't used and the
+        // dev overlay is used instead
+        if (statusPage !== '/500' || !this.renderOpts.dev) {
+          result = await this.findPageComponents(statusPage, query)
+        }
       }
 
       if (!result) {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/39826 this skips ensuring the `/500` page when in development as it's not used since we use the error overlay instead. This also fixes the case where we don't clear the stalled timeout debug log when an error is thrown during ensuring. 

