### PR TITLE
Update cms-makeswift example

### DIFF
--- a/examples/cms-makeswift/.env.local.example
+++ b/examples/cms-makeswift/.env.local.example
@@ -1,2 +1,1 @@
-MAKESWIFT_API_HOST=https://api.makeswift.com
 MAKESWIFT_SITE_API_KEY=

--- a/examples/cms-makeswift/package.json
+++ b/examples/cms-makeswift/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@makeswift/runtime": "0.1.2",
+    "@makeswift/runtime": "0.1.5",
     "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
Upgrade @makeswift/runtime to the latest version. This removes the need
for the MAKESWIFT_API_HOST environment variable and improves error
messages when integrating Next.js with Makeswift.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
