### PR TITLE
Add missing hyphens

### DIFF
--- a/docs/api-reference/create-next-app.md
+++ b/docs/api-reference/create-next-app.md
@@ -19,9 +19,9 @@ You can create a [TypeScript project](https://github.com/vercel/next.js/blob/can
 ```bash
 npx create-next-app@latest --ts
 # or
-yarn create next-app --typescript
+yarn create-next-app --typescript
 # or
-pnpm create next-app --ts
+pnpm create-next-app --ts
 ```
 
 ### Options


### PR DESCRIPTION
`create next-app` should be `create-next-app`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
