### PR TITLE
Fix disposing active entries in dev compilers

### DIFF
--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -3,7 +3,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { check, getRedboxHeader, hasRedbox } from 'next-test-utils'
+import { check, getRedboxHeader, hasRedbox, waitFor } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 
 const installCheckVisible = (browser) => {
@@ -318,6 +318,10 @@ describe('GS(S)P Server-Side Change Reloading', () => {
     const props = JSON.parse(await browser.elementByCss('#props').text())
     expect(props.count).toBe(1)
     expect(props.data).toEqual({ hello: 'world' })
+
+    // wait longer than the max inactive age for on-demand entries
+    // to ensure we aren't incorrectly disposing the active entry
+    await waitFor(20 * 1000)
 
     const page = 'lib/data.json'
     const originalContent = await next.readFile(page)


### PR DESCRIPTION
As noticed in https://github.com/markdoc/markdoc/issues/131 it seems we are incorrectly disposing active entries causing HMR to fail after the configured `maxInactiveAge`. To fix this instead of only updating lastActiveTime for one compiler type's entry we update all active compiler types for the active entry. 

This also updates an existing test to catch this by waiting the `maxInactiveAge` before attempting a change that should trigger HMR. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/markdoc/markdoc/issues/131