### PR TITLE
Add Fastly Compute@Edge as deployment option

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -121,6 +121,7 @@ You can also manually deploy the [`next export`](/docs/advanced-features/static-
 - [AWS Serverless](https://github.com/serverless-nextjs/serverless-next.js)
 - [Terraform](https://github.com/milliHQ/terraform-aws-next-js)
 - [Netlify](https://docs.netlify.com/integrations/frameworks/next-js)
+- [Fastly Compute@Edge](https://github.com/fastly/next-compute-js)
 
 > **Note:** Not all serverless providers implement the [Next.js Build API](/docs/deployment.md#nextjs-build-api) from `next start`. Please check with the provider to see what features are supported.
 


### PR DESCRIPTION
List fastly/next-compute-js as a serverless deployment option to deploy to Fastly's Compute@Edge platform.

Fastly has created [`@fastly/next-compute-js`](https://github.com/fastly/next-compute-js), a tool that enables developers to deploy their Next.js project to Fastly's high-speed edge platform. This PR adds a link to this tool to the list of serverless deployment options.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
