### PR TITLE
Fix next/dynamic loading type

### DIFF
--- a/packages/next/shared/lib/dynamic.tsx
+++ b/packages/next/shared/lib/dynamic.tsx
@@ -25,7 +25,7 @@ export type DynamicOptionsLoadingProps = {
 }
 
 export type DynamicOptions<P = {}> = LoadableGeneratedOptions & {
-  loading?: (loadingProps: DynamicOptionsLoadingProps) => JSX.Element | null
+  loading?: (loadingProps: DynamicOptionsLoadingProps) => React.ReactNode
   loader?: Loader<P> | LoaderMap
   loadableGenerated?: LoadableGeneratedOptions
   ssr?: boolean


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR fixes the types for `next/dynamic`. Before `JSX.Element` was used as a loading component return type. This type prevents certain element like `string`s. Even though react-loadable allows such types:

https://github.com/vercel/next.js/blob/611e13f5159457fedf96d850845650616a1f75dd/packages/next/shared/lib/loadable.js#L149-L155

Since `Suspense` also allows strings as loading component this PR improves possible migration steps by streamlining the apis between both approaches.

```js
const DynamicComponent = dynamic(
  () => import('../components/component'),
  { loading: () => 'Loading ...' }
)
```

## Feature


- [x] Documentation added



