### PR TITLE
Allow rewrite to match regardless of trailing slash in rewrite source.

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -74,14 +74,12 @@ export function getUtils({
   basePath,
   rewrites,
   pageIsDynamic,
-  trailingSlash,
 }: {
   page: ServerlessHandlerCtx['page']
   i18n?: ServerlessHandlerCtx['i18n']
   basePath: ServerlessHandlerCtx['basePath']
   rewrites: ServerlessHandlerCtx['rewrites']
   pageIsDynamic: ServerlessHandlerCtx['pageIsDynamic']
-  trailingSlash?: boolean
 }) {
   let defaultRouteRegex: ReturnType<typeof getNamedRouteRegex> | undefined
   let dynamicRouteMatcher: RouteMatch | undefined
@@ -109,13 +107,9 @@ export function getUtils({
     }
 
     const checkRewrite = (rewrite: Rewrite): boolean => {
-      const matcher = getPathMatch(
-        rewrite.source + (trailingSlash ? '(/)?' : ''),
-        {
-          removeUnnamedParams: true,
-          strict: true,
-        }
-      )
+      const matcher = getPathMatch(removeTrailingSlash(rewrite.source), {
+        removeUnnamedParams: true,
+      })
       let params = matcher(parsedUrl.pathname)
 
       if (rewrite.has && params) {

--- a/packages/next/client/normalize-trailing-slash.ts
+++ b/packages/next/client/normalize-trailing-slash.ts
@@ -11,7 +11,7 @@ export const normalizePathTrailingSlash = (path: string) => {
   }
 
   const { pathname, query, hash } = parsePath(path)
-  if (process.env.__NEXT_TRAILING_SLASH) {
+  if (process.env.__NEXT_TRAILING_SLASH === 'true') {
     if (/\.[^/]+\/?$/.test(pathname)) {
       return `${removeTrailingSlash(pathname)}${query}${hash}`
     } else if (pathname.endsWith('/')) {

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -342,7 +342,7 @@ function getMiddlewareData<T extends FetchDataOutput>(
   const nextConfig = {
     basePath: options.router.basePath,
     i18n: { locales: options.router.locales },
-    trailingSlash: Boolean(process.env.__NEXT_TRAILING_SLASH),
+    trailingSlash: process.env.__NEXT_TRAILING_SLASH === 'true',
   }
   const rewriteHeader = response.headers.get('x-nextjs-rewrite')
 

--- a/packages/next/shared/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/shared/lib/router/utils/resolve-rewrites.ts
@@ -34,13 +34,9 @@ export default function resolveRewrites(
   let resolvedHref
 
   const handleRewrite = (rewrite: Rewrite) => {
-    const matcher = getPathMatch(
-      rewrite.source + (process.env.__NEXT_TRAILING_SLASH ? '(/)?' : ''),
-      {
-        removeUnnamedParams: true,
-        strict: true,
-      }
-    )
+    const matcher = getPathMatch(removeTrailingSlash(rewrite.source), {
+      removeUnnamedParams: true,
+    })
 
     let params = matcher(parsedAs.pathname)
 

--- a/test/unit/resolve-rewrites.test.ts
+++ b/test/unit/resolve-rewrites.test.ts
@@ -1,0 +1,129 @@
+/* eslint-env jest */
+import resolveRewrites from 'next/dist/shared/lib/router/utils/resolve-rewrites'
+import { removeTrailingSlash } from 'next/dist/shared/lib/router/utils/remove-trailing-slash'
+
+describe('resolveRewrites', () => {
+  it('does not match if there is no matching rewrite', () => {
+    const result = resolveRewrites(
+      '/default/test1/',
+      ['/part1/part2'],
+      {
+        beforeFiles: [],
+        afterFiles: [],
+        fallback: [
+          {
+            source: '/:nextInternalLocale(default)/test2',
+            destination: '/:nextInternalLocale/part1/part2',
+          },
+        ],
+      },
+      {},
+      (pathname: string) => {
+        return removeTrailingSlash(pathname)
+      },
+      ['default']
+    )
+
+    expect(result.matchedPage).toBe(false)
+  })
+
+  describe('trailingSlash true', () => {
+    it('should match rewrites that do not end in a trailing slash', () => {
+      const result = resolveRewrites(
+        '/default/test1/',
+        ['/part1/part2'],
+        {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [
+            {
+              source: '/:nextInternalLocale(default)/test1',
+              destination: '/:nextInternalLocale/part1/part2',
+            },
+          ],
+        },
+        {},
+        (pathname: string) => {
+          return removeTrailingSlash(pathname)
+        },
+        ['default']
+      )
+
+      expect(result.matchedPage).toBe(true)
+    })
+
+    it('should match rewrites that end in a trailing slash', () => {
+      const result = resolveRewrites(
+        '/default/test1/',
+        ['/part1/part2'],
+        {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [
+            {
+              source: '/:nextInternalLocale(default)/test1/',
+              destination: '/:nextInternalLocale/part1/part2/',
+            },
+          ],
+        },
+        {},
+        (pathname: string) => {
+          return removeTrailingSlash(pathname)
+        },
+        ['default']
+      )
+
+      expect(result.matchedPage).toBe(true)
+    })
+  })
+
+  describe('trailingSlash false', () => {
+    it('should match rewrites that do not end in a trailing slash', () => {
+      const result = resolveRewrites(
+        '/default/test1',
+        ['/part1/part2'],
+        {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [
+            {
+              source: '/:nextInternalLocale(default)/test1',
+              destination: '/:nextInternalLocale/part1/part2',
+            },
+          ],
+        },
+        {},
+        (pathname: string) => {
+          return removeTrailingSlash(pathname)
+        },
+        ['default']
+      )
+
+      expect(result.matchedPage).toBe(true)
+    })
+
+    it('should match rewrites that end in a trailing slash', () => {
+      const result = resolveRewrites(
+        '/default/test1',
+        ['/part1/part2'],
+        {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [
+            {
+              source: '/:nextInternalLocale(default)/test1/',
+              destination: '/:nextInternalLocale/part1/part2/',
+            },
+          ],
+        },
+        {},
+        (pathname: string) => {
+          return removeTrailingSlash(pathname)
+        },
+        ['default']
+      )
+
+      expect(result.matchedPage).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Remove strict rule from pathToRegex so that rewrites will match with and without a trailing slash.
Fixes #39638

Currently if nextConfig has `trailingSlash: true` and your rewrites source ends in a slash you will get some odd behavior on client side navigation. In dev the wrong js file will be fetched and nextjs will fall back to a server fetch. In production you will see a `Failed to lookup route` error just before the server fetch. 

This PR fixes the problem by removing the pattern match `(/)?` that was being added to the end of the rewrite source when `trailingSlash: true`. I think this was behaving incorrectly due to the strict rule from pathToRegex that requires the trailing slash to match exactly.

If there are other cases that require leaving the strict rule in place we can look at other solutions that maintain that. 

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
