### PR TITLE
Remove eslint warning when no eslint config is present

### DIFF
--- a/packages/next/lib/eslint/hasEslintConfiguration.ts
+++ b/packages/next/lib/eslint/hasEslintConfiguration.ts
@@ -38,9 +38,6 @@ export async function hasEslintConfiguration(
         emptyPkgJsonConfig: true,
       }
     }
-  } else {
-    return configObject
   }
-
-  return { ...configObject, exists: true }
+  return configObject
 }

--- a/packages/next/lib/eslint/hasEslintConfiguration.ts
+++ b/packages/next/lib/eslint/hasEslintConfiguration.ts
@@ -31,6 +31,7 @@ export async function hasEslintConfiguration(
     ) {
       return { ...configObject, emptyEslintrc: true }
     }
+    return { ...configObject, exists: true }
   } else if (packageJsonConfig?.eslintConfig) {
     if (Object.entries(packageJsonConfig?.eslintConfig).length === 0) {
       return {

--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -321,13 +321,17 @@ export async function runLintCheck(
         outputFile
       )
     } else {
-      // Display warning if no ESLint configuration is present during "next build"
+      // Display warning if no ESLint configuration is present inside
+      // config file during "next build", no warning is shown when
+      // no eslintrc file is present
       if (lintDuringBuild) {
-        Log.warn(
-          `No ESLint configuration detected. Run ${chalk.bold.cyan(
-            'next lint'
-          )} to begin setup`
-        )
+        if (eslintrcFile) {
+          Log.warn(
+            `No ESLint configuration detected. Run ${chalk.bold.cyan(
+              'next lint'
+            )} to begin setup`
+          )
+        }
         return null
       } else {
         // Ask user what config they would like to start with for first time "next lint" setup

--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -324,14 +324,15 @@ export async function runLintCheck(
       // Display warning if no ESLint configuration is present inside
       // config file during "next build", no warning is shown when
       // no eslintrc file is present
-      if (lintDuringBuild) {
-        if (eslintrcFile) {
-          Log.warn(
-            `No ESLint configuration detected. Run ${chalk.bold.cyan(
-              'next lint'
-            )} to begin setup`
-          )
-        }
+      if (
+        lintDuringBuild &&
+        (config.emptyPkgJsonConfig || config.emptyEslintrc)
+      ) {
+        Log.warn(
+          `No ESLint configuration detected. Run ${chalk.bold.cyan(
+            'next lint'
+          )} to begin setup`
+        )
         return null
       } else {
         // Ask user what config they would like to start with for first time "next lint" setup

--- a/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
+++ b/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
@@ -1,0 +1,33 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { renderViaHTTP } from 'next-test-utils'
+
+describe('no-eslint-warn-with-no-eslint-config', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.js': `
+          export default function Page() { 
+            return <p>hello world</p>
+          } 
+        `,
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should render', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('hello world')
+  })
+
+  it('should not have eslint warnings when no eslint config', async () => {
+    expect(next.cliOutput).not.toContain(
+      'No ESLint configuration detected. Run next lint to begin setup'
+    )
+    expect(next.cliOutput).not.toBe('warn')
+  })
+})


### PR DESCRIPTION
We shouldn't be warning when no eslint config file is present as it's valid not to use eslint. The warning is still shown if an empty eslint config file is added as this gives intent to using eslint. 

x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1661268593890619?thread_ts=1661266342.496699&cid=CGU8HUTUH)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

