### PR TITLE
Update flakey relay analytics test

### DIFF
--- a/test/integration/relay-analytics/test/index.test.js
+++ b/test/integration/relay-analytics/test/index.test.js
@@ -117,9 +117,15 @@ function runTest() {
     )
     // INP metric is only reported on pagehide or visibilitychange event, so refresh the page
     await browser.refresh()
-    const INP = parseInt(await browser.eval('localStorage.getItem("INP")'), 10)
-    // We introduced a delay of 100ms, so INP duration should be >= 100
-    expect(INP).toBeGreaterThanOrEqual(100)
+    await check(async () => {
+      const INP = parseInt(
+        await browser.eval('localStorage.getItem("INP")'),
+        10
+      )
+      // We introduced a delay of 100ms, so INP duration should be >= 100
+      expect(INP).toBeGreaterThanOrEqual(100)
+      return 'success'
+    }, 'success')
     await browser.close()
   })
 }


### PR DESCRIPTION
Implements `check` on relay analytics test as the timing can be indeterminate. 

Fixes: https://github.com/vercel/next.js/runs/7979410199?check_suite_focus=true#step:9:230