### PR TITLE
Fix runLintCheck during build

### DIFF
--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -324,15 +324,14 @@ export async function runLintCheck(
       // Display warning if no ESLint configuration is present inside
       // config file during "next build", no warning is shown when
       // no eslintrc file is present
-      if (
-        lintDuringBuild &&
-        (config.emptyPkgJsonConfig || config.emptyEslintrc)
-      ) {
-        Log.warn(
-          `No ESLint configuration detected. Run ${chalk.bold.cyan(
-            'next lint'
-          )} to begin setup`
-        )
+      if (lintDuringBuild) {
+        if (config.emptyPkgJsonConfig || config.emptyEslintrc) {
+          Log.warn(
+            `No ESLint configuration detected. Run ${chalk.bold.cyan(
+              'next lint'
+            )} to begin setup`
+          )
+        }
         return null
       } else {
         // Ask user what config they would like to start with for first time "next lint" setup

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -20,6 +20,12 @@ describe('TypeScript basic', () => {
   })
   afterAll(() => next.destroy())
 
+  it('should not have eslint setup started', async () => {
+    expect(next.cliOutput).not.toContain(
+      'How would you like to configure ESLint'
+    )
+  })
+
   it('have built and started correctly', async () => {
     const html = await renderViaHTTP(next.url, '/')
     expect(html).toContain('hello world')


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/39872 this fixes a check in `runLintCheck` causing setup to start during build and adds a regression test. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
