### PR TITLE
Fix failing e2e getServerSideProps test

### DIFF
--- a/test/e2e/getserversideprops/app/pages/500.js
+++ b/test/e2e/getserversideprops/app/pages/500.js
@@ -1,0 +1,3 @@
+export default function Error() {
+  return <p>custom pages/500</p>
+}

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -372,9 +372,7 @@ const runTests = (isDev = false, isDeploy = false) => {
       expect(html).toContain('oof')
     } else {
       expect(res.status).toBe(500)
-      expect(html).toContain(
-        isDeploy ? 'FUNCTION_INVOCATION_FAILED' : 'Internal Server Error'
-      )
+      expect(html).toContain('custom pages/500')
       expect(html).not.toContain('This page could not be found')
     }
   })


### PR DESCRIPTION
After the fix was landed for `_error` being used even when it's a serverless function this test no longer shows the default Vercel error page.  

Fixes: https://github.com/vercel/next.js/runs/7985910009?check_suite_focus=true