### PR TITLE
Remove un-necessary internal jest-worker error during ts/lint error

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -368,47 +368,57 @@ export default async function build(
 
       const typeCheckStart = process.hrtime()
 
-      const [[verifyResult, typeCheckEnd]] = await Promise.all([
-        nextBuildSpan.traceChild('verify-typescript-setup').traceAsyncFn(() =>
-          verifyTypeScriptSetup(
-            dir,
-            [pagesDir, appDir].filter(Boolean) as string[],
-            !ignoreTypeScriptErrors,
-            config.typescript.tsconfigPath,
-            config.images.disableStaticImages,
-            cacheDir,
-            config.experimental.cpus,
-            config.experimental.workerThreads
-          ).then((resolved) => {
-            const checkEnd = process.hrtime(typeCheckStart)
-            return [resolved, checkEnd] as const
-          })
-        ),
-        shouldLint &&
-          nextBuildSpan.traceChild('verify-and-lint').traceAsyncFn(async () => {
-            await verifyAndLint(
+      try {
+        const [[verifyResult, typeCheckEnd]] = await Promise.all([
+          nextBuildSpan.traceChild('verify-typescript-setup').traceAsyncFn(() =>
+            verifyTypeScriptSetup(
               dir,
-              eslintCacheDir,
-              config.eslint?.dirs,
+              [pagesDir, appDir].filter(Boolean) as string[],
+              !ignoreTypeScriptErrors,
+              config.typescript.tsconfigPath,
+              config.images.disableStaticImages,
+              cacheDir,
               config.experimental.cpus,
-              config.experimental.workerThreads,
-              telemetry
-            )
-          }),
-      ])
+              config.experimental.workerThreads
+            ).then((resolved) => {
+              const checkEnd = process.hrtime(typeCheckStart)
+              return [resolved, checkEnd] as const
+            })
+          ),
+          shouldLint &&
+            nextBuildSpan
+              .traceChild('verify-and-lint')
+              .traceAsyncFn(async () => {
+                await verifyAndLint(
+                  dir,
+                  eslintCacheDir,
+                  config.eslint?.dirs,
+                  config.experimental.cpus,
+                  config.experimental.workerThreads,
+                  telemetry
+                )
+              }),
+        ])
+        typeCheckingAndLintingSpinner?.stopAndPersist()
 
-      typeCheckingAndLintingSpinner?.stopAndPersist()
-
-      if (!ignoreTypeScriptErrors && verifyResult) {
-        telemetry.record(
-          eventTypeCheckCompleted({
-            durationInSeconds: typeCheckEnd[0],
-            typescriptVersion: verifyResult.version,
-            inputFilesCount: verifyResult.result?.inputFilesCount,
-            totalFilesCount: verifyResult.result?.totalFilesCount,
-            incremental: verifyResult.result?.incremental,
-          })
-        )
+        if (!ignoreTypeScriptErrors && verifyResult) {
+          telemetry.record(
+            eventTypeCheckCompleted({
+              durationInSeconds: typeCheckEnd[0],
+              typescriptVersion: verifyResult.version,
+              inputFilesCount: verifyResult.result?.inputFilesCount,
+              totalFilesCount: verifyResult.result?.totalFilesCount,
+              incremental: verifyResult.result?.incremental,
+            })
+          )
+        }
+      } catch (err) {
+        // prevent showing jest-worker internal error as it
+        // isn't helpful for users and clutters output
+        if (isError(err) && err.message === 'Call retries were exceeded') {
+          process.exit(1)
+        }
+        throw err
       }
 
       const buildLintEvent: EventBuildFeatureUsage = {

--- a/test/production/ci-missing-typescript-deps/index.test.ts
+++ b/test/production/ci-missing-typescript-deps/index.test.ts
@@ -26,6 +26,8 @@ describe('ci-missing-typescript-deps', () => {
         `It looks like you're trying to use TypeScript but do not have the required package(s) installed.`
       )
       expect(next.cliOutput).toContain(`Please install`)
+      expect(next.cliOutput).not.toContain('Call retries were exceeded')
+      expect(next.cliOutput).not.toContain('WorkerError')
     } finally {
       await next.destroy()
     }


### PR DESCRIPTION
This ensures we strip the un-necessary `jest-worker` error shown from an error with verifying TypeScript during build as this error just clutters the output and doesn't provide any additional helpful context. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1661300070830909)

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
