### PR TITLE
Update utils.ts

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1410,7 +1410,7 @@ server.listen(currentPort, (err) => {
     customServer: false,
     conf: ${JSON.stringify({
       ...serverConfig,
-      distDir: `./${path.relative(dir, distDir)}`,
+      distDir: `./${path.relative(dir, distDir)}`.split("\\").join("/"),
     })},
   })
   handler = nextServer.getRequestHandler()


### PR DESCRIPTION
Fix: distDir path bug on windows

This pr fixes the error arises when building the standalone version from windows, and then deploy to linux machine.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
