### PR TITLE
Fix rsc basic e2e test on deploy

### DIFF
--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -29,6 +29,11 @@ describe('app dir - react server components', () => {
   let next: NextInstance
   let distDir: string
 
+  if ((global as any).isNextDeploy) {
+    it('should skip for deploy mode for now', () => {})
+    return
+  }
+
   beforeAll(async () => {
     const appDir = path.join(__dirname, './rsc-basic')
     next = await createNext({


### PR DESCRIPTION
This test is currently not expected to run against deploy mode similar to the other app tests so this skips it for now. 

Fixes: https://github.com/vercel/next.js/runs/7988021472?check_suite_focus=true