### PR TITLE
Adds note about custom server requirements

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -21,6 +21,8 @@ Middleware runs _before_ cached content, so you can personalize static files and
 
 > **Note:** If you were using Middleware prior to `12.2`, please see the [upgrade guide](https://nextjs.org/docs/messages/middleware-upgrade-guide).
 
+> **Note:** If you are using a [custom server](https://nextjs.org/docs/advanced-features/custom-server) you must provide `hostname` and `port` when calling `next` i.e `next({ hostname: 'localhost', port: 3000 })`.
+
 ## Using Middleware
 
 To begin using Middleware, follow the steps below:


### PR DESCRIPTION
This wasn't obvious to me when trying out middleware in our project, and the error message was `Invalid URL` - took me embarrassingly long to remember that we run a custom server. Would it be possibly to detect that middleware is used and then throw a descriptive error message when trying to call `next` without `hostname` and `port` in a custom server? If someone can point me to where that could be done, I would be happy to make a pull request.

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`

I made the change in Github ui, so couldn't run `pnpm lint`. Is this automated or should I clone and run it locally?
