### PR TITLE
Mention `largePageDataBytes` in warning docs

### DIFF
--- a/errors/large-page-data.md
+++ b/errors/large-page-data.md
@@ -6,7 +6,7 @@ One of your pages includes a large amount of page data (>= 128kB). This can nega
 
 #### Possible Ways to Fix It
 
-Reduce the amount of data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` to only the essential data to render the page. The default threshold of 128kB can be configured in `largePageDataBytes`.
+Reduce the amount of data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` to only the essential data to render the page. The default threshold of 128kB can be configured in `largePageDataBytes` if absolutely necessary and the performance implications are understood.
 
 ### Useful Links
 

--- a/errors/large-page-data.md
+++ b/errors/large-page-data.md
@@ -2,11 +2,11 @@
 
 #### Why This Error Occurred
 
-One of your pages includes a large amount of page data (>= 128KB). This can negatively impact performance since page data must be parsed by the client before the page is hydrated.
+One of your pages includes a large amount of page data (>= 128kB). This can negatively impact performance since page data must be parsed by the client before the page is hydrated.
 
 #### Possible Ways to Fix It
 
-Reduce the amount of data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` to only the essential data to render the page.
+Reduce the amount of data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` to only the essential data to render the page. The default threshold of 128kB can be configured in `largePageDataBytes`.
 
 ### Useful Links
 


### PR DESCRIPTION
Also fix the KB unit to `kB` (https://en.wikipedia.org/wiki/Kilobyte)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
