### PR TITLE
Using Wasm in Edge API Routes

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -152,9 +152,9 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-## Web Assembly (WASM)
+## Web Assembly (Wasm)
 
-You can now use WASM within your Middleware by importing your `.wasm` binary with
+You can use Wasm within your Middleware by importing your `.wasm` binary with:
 
 ```ts
 import wasm from './my-file.wasm?module'

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -160,7 +160,7 @@ You can use Wasm within your Middleware by importing your `.wasm` binary with:
 import wasm from './my-file.wasm?module'
 ```
 
-Note the `?module` suffix. This will provide an array of the WASM data that can be instantiated using `WebAssembly.instantiate()`, which can be done as follows:
+Note the `?module` suffix. This will provide an array of the Wasm data that can be instantiated using `WebAssembly.instantiate()`, which can be done as follows:
 
 ```ts
 export default async function handler() {

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -160,10 +160,14 @@ You can now use WASM within your Middleware by importing your `.wasm` binary wit
 import wasm from './my-file.wasm?module'
 ```
 
-Note the `?module` suffix. This will provide an array of the WASM data that can be instantiated using `WebAssembly.instantiate()`.
+Note the `?module` suffix. This will provide an array of the WASM data that can be instantiated using `WebAssembly.instantiate()`, which can be done as follows:
 
 ```ts
-
+export default async function handler() {
+  const { exports } = (await WebAssembly.instantiate(wasmModule)) as any
+  const result = exports.xor(0xb4c9a91f, 0xf0c0ffee)
+  return new Response(result)
+}
 ```
 
 ## Related

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -152,6 +152,20 @@ export function middleware(request: NextRequest) {
 }
 ```
 
+## Web Assembly (WASM)
+
+You can now use WASM within your Middleware by importing your `.wasm` binary with
+
+```ts
+import wasm from './my-file.wasm?module'
+```
+
+Note the `?module` suffix. This will provide an array of the WASM data that can be instantiated using `WebAssembly.instantiate()`.
+
+```ts
+
+```
+
 ## Related
 
 <div class="card">

--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -132,4 +132,4 @@ export default async function handler() {
 }
 ```
 
-The example above is taken from the [WASM XOR API Route]() example.
+View more examples [here](https://github.com/vercel/examples/tree/main/edge-api-routes).

--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -114,9 +114,9 @@ Edge API Routes can [stream responses](/docs/api-reference/edge-runtime.md#web-s
 
 View the [supported APIs](/docs/api-reference/edge-runtime.md) and [unsupported APIs](/docs/api-reference/edge-runtime.md#unsupported-apis) for the Edge Runtime.
 
-## Web Assembly (WASM)
+## Web Assembly (Wasm)
 
-You can now use WASM within your Edge API Route by importing your `.wasm` binary with
+You can use Warm within your Edge API Route by importing your `.wasm` binary with:
 
 ```ts
 import wasm from './my-file.wasm?module'

--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -113,3 +113,17 @@ Edge API Routes use the [Edge Runtime](/docs/api-reference/edge-runtime.md), whe
 Edge API Routes can [stream responses](/docs/api-reference/edge-runtime.md#web-stream-apis) from the server and run _after_ cached files (e.g. HTML, CSS, JavaScript) have been accessed. Server-side streaming can help improve performance with faster [Time To First Byte (TTFB)](https://web.dev/ttfb/).
 
 View the [supported APIs](/docs/api-reference/edge-runtime.md) and [unsupported APIs](/docs/api-reference/edge-runtime.md#unsupported-apis) for the Edge Runtime.
+
+## Web Assembly (WASM)
+
+You can now use WASM within your Edge API Route by importing your `.wasm` binary with
+
+```ts
+import wasm from './my-file.wasm?module'
+```
+
+Note the `?module` suffix. This will provide an array of the WASM data that can be instantiated using `WebAssembly.instantiate()`.
+
+```ts
+
+```

--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -122,8 +122,14 @@ You can now use WASM within your Edge API Route by importing your `.wasm` binary
 import wasm from './my-file.wasm?module'
 ```
 
-Note the `?module` suffix. This will provide an array of the WASM data that can be instantiated using `WebAssembly.instantiate()`.
+Note the `?module` suffix. This will provide an array of the WASM data that can be instantiated using `WebAssembly.instantiate()`, which can be done as follows:
 
 ```ts
-
+export default async function handler() {
+  const { exports } = (await WebAssembly.instantiate(wasmModule)) as any
+  const result = exports.xor(0xb4c9a91f, 0xf0c0ffee)
+  return new Response(result)
+}
 ```
+
+The example above is taken from the [WASM XOR API Route]() example.


### PR DESCRIPTION
Added documentation about WASM support on API routes

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
