### PR TITLE
Fix passing VERCEL_CLI_VERSION env for deploy tests

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -76,9 +76,7 @@ export class NextDeployInstance extends NextInstance {
 
     if (process.env.VERCEL_CLI_VERSION) {
       additionalEnv.push('--build-env')
-      additionalEnv.push(
-        `VERCEL_CLI_VERSION="${process.env.VERCEL_CLI_VERSION}"`
-      )
+      additionalEnv.push(`VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION}`)
     }
 
     const deployRes = await execa(


### PR DESCRIPTION
The quotes around the env were being passed literally breaking usage of the env variable so this removes them. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1661417510950809?thread_ts=1659529028.137779&cid=C02K2HCH5V4)