### PR TITLE
Revert "Adds note about custom server requirements"

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -21,8 +21,6 @@ Middleware runs _before_ cached content, so you can personalize static files and
 
 > **Note:** If you were using Middleware prior to `12.2`, please see the [upgrade guide](https://nextjs.org/docs/messages/middleware-upgrade-guide).
 
-> **Note:** If you are using a [custom server](https://nextjs.org/docs/advanced-features/custom-server) you must provide `hostname` and `port` when calling `next` i.e `next({ hostname: 'localhost', port: 3000 })`.
-
 ## Using Middleware
 
 To begin using Middleware, follow the steps below:


### PR DESCRIPTION
Reverts vercel/next.js#39931

Let's instead add this to the custom server documentation, in a section on "Using Middleware". Since such a low percentage of folks eject out of the default server, this shouldn't be so high up on the Middleware docs page. 