### PR TITLE
test: pin typescript version to 4.7

### DIFF
--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -14,7 +14,7 @@ describe('correct tsconfig.json defaults', () => {
       },
       skipStart: true,
       dependencies: {
-        typescript: 'latest',
+        typescript: '4.7.4',
         '@types/react': 'latest',
         '@types/node': 'latest',
       },

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -35,7 +35,7 @@ describe('jsconfig-path-reloading', () => {
               }),
         },
         dependencies: {
-          typescript: 'latest',
+          typescript: '4.7.4',
           '@types/react': 'latest',
           '@types/node': 'latest',
         },

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -35,7 +35,7 @@ describe('tsconfig-path-reloading', () => {
               }),
         },
         dependencies: {
-          typescript: 'latest',
+          typescript: '4.7.4',
           '@types/react': 'latest',
           '@types/node': 'latest',
         },

--- a/test/production/middleware-typescript/test/index.test.ts
+++ b/test/production/middleware-typescript/test/index.test.ts
@@ -19,7 +19,7 @@ describe('should set-up next', () => {
         'next.config.js': new FileRef(join(appDir, 'next.config.js')),
       },
       dependencies: {
-        typescript: 'latest',
+        typescript: '4.7.4',
         '@types/node': 'latest',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -11,7 +11,7 @@ describe('TypeScript basic', () => {
       files: new FileRef(path.join(__dirname, 'app')),
       dependencies: {
         '@next/bundle-analyzer': 'canary',
-        typescript: 'latest',
+        typescript: '4.7.4',
         '@types/node': 'latest',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',


### PR DESCRIPTION
Typescript published 4.8 and the ts tests are filling. Fix it by pining it to 4.7 temproraily 

x-ref: https://github.com/vercel/next.js/runs/8037717851?check_suite_focus=true#step:9:211