### PR TITLE
Fix incorrect build log for moduleResolution

### DIFF
--- a/packages/next/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/lib/typescript/writeConfigurationDefaults.ts
@@ -90,9 +90,6 @@ export function getRequiredConfiguration(
   const desiredCompilerOptions = getDesiredCompilerOptions(ts)
   for (const optionKey of Object.keys(desiredCompilerOptions)) {
     const ev = desiredCompilerOptions[optionKey]
-    if (optionKey === 'moduleResolution') {
-      console.log({ optionKey, ev, current: res[optionKey] })
-    }
     if (!('value' in ev)) {
       continue
     }

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -22,9 +22,27 @@ describe('correct tsconfig.json defaults', () => {
   })
   afterAll(() => next.destroy())
 
-  it('should add `moduleResoution` when generating tsconfig.json in dev', async () => {
+  it('should add `moduleResolution` when generating tsconfig.json in dev', async () => {
     const tsconfigPath = path.join(next.testDir, 'tsconfig.json')
     expect(fs.existsSync(tsconfigPath)).toBeFalse()
+
+    await next.start()
+    await waitFor(1000)
+    await next.stop()
+
+    expect(fs.existsSync(tsconfigPath)).toBeTrue()
+
+    const tsconfig = JSON.parse(await next.readFile('tsconfig.json'))
+    expect(next.cliOutput).not.toContain('moduleResolution')
+
+    expect(tsconfig.compilerOptions).toEqual(
+      expect.objectContaining({ moduleResolution: 'node' })
+    )
+  })
+
+  it('should not warn for `moduleResolution` when already present and valid', async () => {
+    const tsconfigPath = path.join(next.testDir, 'tsconfig.json')
+    expect(fs.existsSync(tsconfigPath)).toBeTrue()
 
     await next.start()
     await waitFor(1000)
@@ -37,5 +55,6 @@ describe('correct tsconfig.json defaults', () => {
     expect(tsconfig.compilerOptions).toEqual(
       expect.objectContaining({ moduleResolution: 'node' })
     )
+    expect(next.cliOutput).not.toContain('moduleResolution')
   })
 })

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -65,7 +65,11 @@ describe('tsconfig.json verifier', () => {
     await new Promise((resolve) => setTimeout(resolve, 500))
     expect(await readFile(tsConfig, 'utf8')).toBe('')
 
-    const { code } = await nextBuild(appDir)
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('moduleResolution')
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
@@ -124,7 +128,11 @@ describe('tsconfig.json verifier', () => {
       `
     )
     await new Promise((resolve) => setTimeout(resolve, 500))
-    const { code } = await nextBuild(appDir)
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('moduleResolution')
     expect(code).toBe(0)
 
     // Weird comma placement until this issue is resolved:
@@ -180,7 +188,11 @@ describe('tsconfig.json verifier', () => {
       `{ "compilerOptions": { "esModuleInterop": false, "module": "commonjs" } }`
     )
     await new Promise((resolve) => setTimeout(resolve, 500))
-    const { code } = await nextBuild(appDir)
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('moduleResolution')
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
@@ -226,7 +238,11 @@ describe('tsconfig.json verifier', () => {
       `{ "compilerOptions": { "esModuleInterop": false, "module": "es2020" } }`
     )
     await new Promise((resolve) => setTimeout(resolve, 500))
-    const { code } = await nextBuild(appDir)
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('moduleResolution')
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
@@ -272,7 +288,11 @@ describe('tsconfig.json verifier', () => {
       `{ "compilerOptions": { "esModuleInterop": false, "moduleResolution": "node12" } }`
     )
     await new Promise((resolve) => setTimeout(resolve, 500))
-    const { code } = await nextBuild(appDir)
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('moduleResolution')
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
@@ -354,7 +374,11 @@ describe('tsconfig.json verifier', () => {
     await writeFile(tsConfig, `{ "extends": "./tsconfig.base.json" }`)
     await new Promise((resolve) => setTimeout(resolve, 500))
 
-    const { code } = await nextBuild(appDir)
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('moduleResolution')
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(
@@ -405,7 +429,11 @@ describe('tsconfig.json verifier', () => {
     await writeFile(tsConfig, `{ "extends": "./tsconfig.base.json" }`)
     await new Promise((resolve) => setTimeout(resolve, 500))
 
-    const { code } = await nextBuild(appDir)
+    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+      stderr: true,
+      stdout: true,
+    })
+    expect(stderr + stdout).not.toContain('moduleResolution')
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -128,11 +128,7 @@ describe('tsconfig.json verifier', () => {
       `
     )
     await new Promise((resolve) => setTimeout(resolve, 500))
-    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
-      stderr: true,
-      stdout: true,
-    })
-    expect(stderr + stdout).not.toContain('moduleResolution')
+    const { code } = await nextBuild(appDir)
     expect(code).toBe(0)
 
     // Weird comma placement until this issue is resolved:
@@ -188,11 +184,7 @@ describe('tsconfig.json verifier', () => {
       `{ "compilerOptions": { "esModuleInterop": false, "module": "commonjs" } }`
     )
     await new Promise((resolve) => setTimeout(resolve, 500))
-    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
-      stderr: true,
-      stdout: true,
-    })
-    expect(stderr + stdout).not.toContain('moduleResolution')
+    const { code } = await nextBuild(appDir)
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
@@ -238,11 +230,7 @@ describe('tsconfig.json verifier', () => {
       `{ "compilerOptions": { "esModuleInterop": false, "module": "es2020" } }`
     )
     await new Promise((resolve) => setTimeout(resolve, 500))
-    const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
-      stderr: true,
-      stdout: true,
-    })
-    expect(stderr + stdout).not.toContain('moduleResolution')
+    const { code } = await nextBuild(appDir)
     expect(code).toBe(0)
 
     expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`


### PR DESCRIPTION
Removes extra log shown when checking `moduleResolution` in `tsconfig.json` and adds regression test. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

