### PR TITLE
Avoid bundling `next/script` in the server build by default

### DIFF
--- a/packages/next/client/script.tsx
+++ b/packages/next/client/script.tsx
@@ -207,4 +207,6 @@ function Script(props: ScriptProps): JSX.Element | null {
   return null
 }
 
+Object.defineProperty(Script, '__nextScript', { value: true })
+
 export default Script

--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -10,10 +10,10 @@ import type {
   DocumentType,
   NEXT_DATA,
 } from '../shared/lib/utils'
+import type { ScriptProps } from '../client/script'
+
 import { BuildManifest, getPageFiles } from '../server/get-page-files'
-import { cleanAmpPath } from '../server/utils'
 import { htmlEscapeJsonString } from '../server/htmlescape'
-import Script, { ScriptProps } from '../client/script'
 import isError from '../lib/is-error'
 
 import { HtmlContext } from '../shared/lib/html-context'
@@ -765,7 +765,10 @@ export class Head extends Component<HeadProps> {
             {!hasCanonicalRel && (
               <link
                 rel="canonical"
-                href={canonicalBase + cleanAmpPath(dangerousAsPath)}
+                href={
+                  canonicalBase +
+                  require('../server/utils').cleanAmpPath(dangerousAsPath)
+                }
               />
             )}
             {/* https://www.ampproject.org/docs/fundamentals/optimize_amp#optimize-the-amp-runtime-loading */}
@@ -871,7 +874,8 @@ function handleDocumentScriptLoaderItems(
   React.Children.forEach(combinedChildren, (child: any) => {
     if (!child) return
 
-    if (child.type === Script) {
+    // When using the `next/script` component, register it in script loader.
+    if (child.type?.__nextScript) {
       if (child.props.strategy === 'beforeInteractive') {
         scriptLoader.beforeInteractive = (
           scriptLoader.beforeInteractive || []


### PR DESCRIPTION
We only use `if (child.type === Script)` on the server side to check the element type, that's unnecessary because we can add a special flag for that (`__nextScript` in this PR). 

This reduces the server bundle by ~13kb if `next/script` is not imported by the user.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
