### PR TITLE
[docs] Add precision about `pageExtensions`

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -50,8 +50,7 @@ export const config = {
 }
 ```
 
-> **Note** If you're changing `pageExtensions` in `next.config.js` you'll have to update your middleware file name.
-> ex: With `pageExtensions: ['page.tsx', 'page.ts']` it will be `middleware.page.ts`.
+> **Note** the `pageExtensions` config affects middleware as well, [see related documentation here](/docs/api-reference/next.config.js/custom-page-extensions.md).
 
 ## Matching Paths
 

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -31,7 +31,7 @@ To begin using Middleware, follow the steps below:
 npm install next@latest
 ```
 
-2. Create a `middleware.ts` (or `.js`) file at the same level as your `pages` directory 
+2. Create a `middleware.ts` (or `.js`) file at the same level as your `pages` directory
 3. Export a middleware function from the `middleware.ts` file:
 
 ```typescript

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -31,7 +31,7 @@ To begin using Middleware, follow the steps below:
 npm install next@latest
 ```
 
-2. Create a `middleware.ts` (or `.js`) file at the same level as your `pages` directory
+2. Create a `middleware.ts` (or `.js`) file at the same level as your `pages` directory 
 3. Export a middleware function from the `middleware.ts` file:
 
 ```typescript
@@ -49,6 +49,9 @@ export const config = {
   matcher: '/about/:path*',
 }
 ```
+
+> **Note** If you're changing `pageExtensions` in `next.config.js` you'll have to update your middleware file name.
+> ex: With `pageExtensions: ['page.tsx', 'page.ts']` it will be `middleware.page.ts`.
 
 ## Matching Paths
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Adding a precision because when you change the `pageExtensions` configuration in `next.config.js`, `middleware.ts` isn't recognized anymore.

Took me some time to debug this one, not sure if it should be considered a bug or just lack of documentation.
I'll let you be the judge of that.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
