### PR TITLE
Add test for server CSS imports

### DIFF
--- a/test/e2e/app-dir/app/app/css/css-page/page.server.js
+++ b/test/e2e/app-dir/app/app/css/css-page/page.server.js
@@ -1,5 +1,13 @@
 import './style.css'
+import styles from './style.module.css'
 
 export default function Page() {
-  return <h1>Page</h1>
+  return (
+    <>
+      <h1>Page</h1>
+      <div id="cssm" className={styles.mod}>
+        CSSM
+      </div>
+    </>
+  )
 }

--- a/test/e2e/app-dir/app/app/css/css-page/style.module.css
+++ b/test/e2e/app-dir/app/app/css/css-page/style.module.css
@@ -1,0 +1,3 @@
+.mod {
+  color: blue;
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1080,8 +1080,16 @@ describe('app dir', () => {
         })
       })
 
-      describe.skip('server pages', () => {
-        it('should support global css inside server pages', async () => {})
+      describe('server pages', () => {
+        it('should support global css inside server pages', async () => {
+          const browser = await webdriver(next.url, '/css/css-page')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('h1')).color`
+            )
+          ).toBe('rgb(255, 0, 0)')
+        })
+
         it('should support css modules inside server pages', async () => {})
       })
 

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1090,7 +1090,14 @@ describe('app dir', () => {
           ).toBe('rgb(255, 0, 0)')
         })
 
-        it('should support css modules inside server pages', async () => {})
+        it('should support css modules inside server pages', async () => {
+          const browser = await webdriver(next.url, '/css/css-page')
+          expect(
+            await browser.eval(
+              `window.getComputedStyle(document.querySelector('#cssm')).color`
+            )
+          ).toBe('rgb(0, 0, 255)')
+        })
       })
 
       describe('client layouts', () => {


### PR DESCRIPTION
Now we are covering all 8 scenarios in our tests: server-client × global-CSS Modules × page-layout. Next step is to cover HMR and page navigation cases.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
