### PR TITLE
Update docker image for stats action

### DIFF
--- a/.github/actions/next-stats-action/Dockerfile
+++ b/.github/actions/next-stats-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster
+FROM node:16-bullseye
 
 LABEL com.github.actions.name="Next.js PR Stats"
 LABEL com.github.actions.description="Compares stats of a PR with the main branch"

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -58,9 +58,15 @@ async function runConfigs(
       }
 
       const buildStart = Date.now()
-      await exec(`cd ${statsAppDir} && ${statsConfig.appBuildCommand}`, false, {
-        env: yarnEnvValues,
-      })
+      console.log(
+        await exec(
+          `cd ${statsAppDir} && ${statsConfig.appBuildCommand}`,
+          false,
+          {
+            env: yarnEnvValues,
+          }
+        )
+      )
       curStats.General.buildDuration = Date.now() - buildStart
 
       // apply renames to get deterministic output names
@@ -153,9 +159,15 @@ async function runConfigs(
       }
 
       const secondBuildStart = Date.now()
-      await exec(`cd ${statsAppDir} && ${statsConfig.appBuildCommand}`, false, {
-        env: yarnEnvValues,
-      })
+      console.log(
+        await exec(
+          `cd ${statsAppDir} && ${statsConfig.appBuildCommand}`,
+          false,
+          {
+            env: yarnEnvValues,
+          }
+        )
+      )
       curStats.General.buildDurationCached = Date.now() - secondBuildStart
 
       if (statsConfig.appDevCommand) {


### PR DESCRIPTION
Noticed the stats action was leveraging the wasm fallback incorrectly which seems to be due to the necessary glibc version not being available in the docker image we were leveraging so this updates the base docker image used so the wasm fallback isn't needed and the dev binary is correctly used again. 

Fixes: https://github.com/vercel/next.js/runs/8004433626?check_suite_focus=true
Fixes: https://github.com/vercel/next.js/runs/7988021570?check_suite_focus=true