### PR TITLE
Revert "[docs] Add precision about `pageExtensions` (#40016)"

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -50,8 +50,6 @@ export const config = {
 }
 ```
 
-> **Note** the `pageExtensions` config affects middleware as well, [see related documentation here](/docs/api-reference/next.config.js/custom-page-extensions.md).
-
 ## Matching Paths
 
 Middleware will be invoked for **every route in your project**. The following is the execution order:


### PR DESCRIPTION
This reverts commit 1b61d1f5df3edffbf59bc35214ceb018ee981e37.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Errors have helpful link attached, see `contributing.md`

## Feature

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Documentation added
- [x] Telemetry added. In case of a feature if it's used or not.
- [x] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
