### PR TITLE
Remove semi in Convex example

### DIFF
--- a/examples/convex/pages/_app.tsx
+++ b/examples/convex/pages/_app.tsx
@@ -8,7 +8,7 @@ const convex = new ConvexReactClient(convexConfig.origin)
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ConvexProvider client={convex}>
-      <Component {...pageProps} />;
+      <Component {...pageProps} />
     </ConvexProvider>
   )
 }


### PR DESCRIPTION
Remove semicolon from Convex example.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
