### PR TITLE
[Docs] Add config types to all examples

### DIFF
--- a/examples/active-class-name/next.config.js
+++ b/examples/active-class-name/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   async rewrites() {
     return [

--- a/examples/analyze-bundles/next.config.js
+++ b/examples/analyze-bundles/next.config.js
@@ -1,8 +1,8 @@
-/** @type {import('next').NextConfig} */
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 })
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   // any configs you need
 }

--- a/examples/blog-starter/tailwind.config.js
+++ b/examples/blog-starter/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./components/**/*.tsx', './pages/**/*.tsx'],
   theme: {

--- a/examples/blog-with-comment/tailwind.config.js
+++ b/examples/blog-with-comment/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   mode: 'jit',
   purge: ['./pages/**/*.js', './components/**/*.js'],

--- a/examples/blog/next.config.js
+++ b/examples/blog/next.config.js
@@ -1,10 +1,10 @@
-/** @type {import('next').NextConfig} */
 const withNextra = require('nextra')({
   theme: 'nextra-theme-blog',
   themeConfig: './theme.config.js',
   // optional: add `unstable_staticImage: true` to enable Nextra's auto image import
 })
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   // any configs you need
 }

--- a/examples/cms-agilitycms/tailwind.config.js
+++ b/examples/cms-agilitycms/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-builder-io/next.config.js
+++ b/examples/cms-builder-io/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['cdn.builder.io'],

--- a/examples/cms-builder-io/tailwind.config.js
+++ b/examples/cms-builder-io/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./components/**/*.js', './pages/**/*.js'],
   theme: {

--- a/examples/cms-buttercms/next.config.js
+++ b/examples/cms-buttercms/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
   async rewrites() {

--- a/examples/cms-contentful/next.config.js
+++ b/examples/cms-contentful/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     loader: 'custom',

--- a/examples/cms-contentful/tailwind.config.js
+++ b/examples/cms-contentful/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-cosmic/next.config.js
+++ b/examples/cms-cosmic/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['imgix.cosmicjs.com'],

--- a/examples/cms-cosmic/tailwind.config.js
+++ b/examples/cms-cosmic/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-datocms/next.config.js
+++ b/examples/cms-datocms/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['www.datocms-assets.com'],

--- a/examples/cms-datocms/tailwind.config.js
+++ b/examples/cms-datocms/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-drupal/next.config.js
+++ b/examples/cms-drupal/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: [process.env.NEXT_IMAGE_DOMAIN],

--- a/examples/cms-drupal/tailwind.config.js
+++ b/examples/cms-drupal/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-ghost/next.config.js
+++ b/examples/cms-ghost/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['static.ghost.org'],

--- a/examples/cms-ghost/tailwind.config.js
+++ b/examples/cms-ghost/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-graphcms/next.config.js
+++ b/examples/cms-graphcms/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['media.graphcms.com'],

--- a/examples/cms-graphcms/tailwind.config.js
+++ b/examples/cms-graphcms/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-kontent/tailwind.config.js
+++ b/examples/cms-kontent/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-prepr/next.config.js
+++ b/examples/cms-prepr/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['b-cdn.net'],

--- a/examples/cms-prepr/tailwind.config.js
+++ b/examples/cms-prepr/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-prismic/next.config.js
+++ b/examples/cms-prismic/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['images.prismic.io'],

--- a/examples/cms-prismic/tailwind.config.js
+++ b/examples/cms-prismic/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-sanity/next.config.js
+++ b/examples/cms-sanity/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   experimental: {
     images: {

--- a/examples/cms-sanity/tailwind.config.js
+++ b/examples/cms-sanity/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-storyblok/tailwind.config.js
+++ b/examples/cms-storyblok/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-strapi/next.config.js
+++ b/examples/cms-strapi/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['localhost'],

--- a/examples/cms-strapi/tailwind.config.js
+++ b/examples/cms-strapi/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-takeshape/tailwind.config.js
+++ b/examples/cms-takeshape/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-tina/tailwind.config.js
+++ b/examples/cms-tina/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./components/**/*.js', './pages/**/*.js'],
   theme: {

--- a/examples/cms-umbraco-heartcore/next.config.js
+++ b/examples/cms-umbraco-heartcore/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['media.umbraco.io'],

--- a/examples/cms-umbraco-heartcore/tailwind.config.js
+++ b/examples/cms-umbraco-heartcore/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/cms-wordpress/next.config.js
+++ b/examples/cms-wordpress/next.config.js
@@ -5,6 +5,7 @@ if (!process.env.WORDPRESS_API_URL) {
   `)
 }
 
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: [

--- a/examples/cms-wordpress/tailwind.config.js
+++ b/examples/cms-wordpress/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/github-pages/next.config.js
+++ b/examples/github-pages/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   basePath: '/gh-pages-test',
 }

--- a/examples/headers/next.config.js
+++ b/examples/headers/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   async headers() {
     return [

--- a/examples/i18n-routing/next.config.js
+++ b/examples/i18n-routing/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   i18n: {
     locales: ['en', 'fr', 'nl'],

--- a/examples/image-component/next.config.js
+++ b/examples/image-component/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   images: {
     domains: ['assets.vercel.com'],

--- a/examples/modularize-imports/next.config.js
+++ b/examples/modularize-imports/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   experimental: {
     modularizeImports: {

--- a/examples/react-remove-properties/next.config.js
+++ b/examples/react-remove-properties/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   experimental: {
     reactRemoveProperties: true,

--- a/examples/redirects/next.config.js
+++ b/examples/redirects/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   // Uncomment the line below to enable basePath, pages and
   // redirects will then have a path prefix (`/app` in this case)

--- a/examples/remove-console/next.config.js
+++ b/examples/remove-console/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   experimental: {
     removeConsole: {

--- a/examples/reproduction-template/next.config.js
+++ b/examples/reproduction-template/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import("next").NextConfig} */
-const config = {
+module.exports = {
   reactStrictMode: true,
 }
-
-module.exports = config

--- a/examples/rewrites/next.config.js
+++ b/examples/rewrites/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   async rewrites() {
     return [

--- a/examples/with-compiled-css/next.config.js
+++ b/examples/with-compiled-css/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack: (config) => {
     config.module.rules.push({

--- a/examples/with-docker-multi-env/next.config.js
+++ b/examples/with-docker-multi-env/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
 }

--- a/examples/with-docker/next.config.js
+++ b/examples/with-docker/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   output: 'standalone',
 }

--- a/examples/with-firebase-hosting/src/next.config.js
+++ b/examples/with-firebase-hosting/src/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   distDir: '../.next',
 }

--- a/examples/with-http2/next.config.js
+++ b/examples/with-http2/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   /*  this needs to be set to false until a bug in the compression npm module gets fixed. 
 reference: https://github.com/expressjs/compression/issues/122

--- a/examples/with-i18n-next-intl/next.config.js
+++ b/examples/with-i18n-next-intl/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   i18n: {
     locales: ['en', 'de'],

--- a/examples/with-ionic-typescript/next.config.js
+++ b/examples/with-ionic-typescript/next.config.js
@@ -1,5 +1,7 @@
 const path = require('path')
 const CopyPlugin = require('copy-webpack-plugin')
+
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack: (config) => {
     config.plugins.push(

--- a/examples/with-lingui/next.config.js
+++ b/examples/with-lingui/next.config.js
@@ -1,5 +1,6 @@
 const { locales, sourceLocale } = require('./lingui.config.js')
 
+/** @type {import('next').NextConfig} */
 module.exports = {
   i18n: {
     locales,

--- a/examples/with-mysql/next.config.js
+++ b/examples/with-mysql/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
 }

--- a/examples/with-mysql/tailwind.config.js
+++ b/examples/with-mysql/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',

--- a/examples/with-netlify-cms/next.config.js
+++ b/examples/with-netlify-cms/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack: (configuration) => {
     configuration.module.rules.push({

--- a/examples/with-react-native-web/next.config.js
+++ b/examples/with-react-native-web/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack: (config) => {
     config.resolve.alias = {

--- a/examples/with-redis/tailwind.config.js
+++ b/examples/with-redis/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   mode: 'jit',
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],

--- a/examples/with-sitemap/next.config.js
+++ b/examples/with-sitemap/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack: (config, { isServer }) => {
     if (isServer) {

--- a/examples/with-storybook/next.config.js
+++ b/examples/with-storybook/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
 }

--- a/examples/with-styletron/next.config.js
+++ b/examples/with-styletron/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack: function (config) {
     config.externals = config.externals || {}

--- a/examples/with-tailwindcss-emotion/tailwind.config.js
+++ b/examples/with-tailwindcss-emotion/tailwind.config.js
@@ -1,5 +1,6 @@
 const colors = require('tailwindcss/colors')
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',

--- a/examples/with-typescript-graphql/next.config.js
+++ b/examples/with-typescript-graphql/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack(config, options) {
     config.module.rules.push({

--- a/examples/with-userbase/tailwind.config.js
+++ b/examples/with-userbase/tailwind.config.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   mode: 'jit',
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],

--- a/examples/with-webassembly/next.config.js
+++ b/examples/with-webassembly/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack(config) {
     config.output.webassemblyModuleFilename = 'static/wasm/[modulehash].wasm'

--- a/examples/with-why-did-you-render/next.config.js
+++ b/examples/with-why-did-you-render/next.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 
+/** @type {import('next').NextConfig} */
 module.exports = {
   webpack(config, { dev, isServer }) {
     if (dev && !isServer) {

--- a/examples/with-zones/blog/next.config.js
+++ b/examples/with-zones/blog/next.config.js
@@ -1,3 +1,4 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   basePath: '/blog',
 }

--- a/examples/with-zones/home/next.config.js
+++ b/examples/with-zones/home/next.config.js
@@ -1,5 +1,6 @@
 const { BLOG_URL } = process.env
 
+/** @type {import('next').NextConfig} */
 module.exports = {
   async rewrites() {
     return [


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Summary

- Added jsdoc typing for all examples using `next.config.js`
- Added jsdoc typing for all examples using `tailwind.config.js`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
