### PR TITLE
docs(testing): add JSDoc typing in `jest.config.js`

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -281,6 +281,7 @@ const createJestConfig = nextJest({
 })
 
 // Add any custom config to be passed to Jest
+/** @type {import('jest').Config} */
 const customJestConfig = {
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],


### PR DESCRIPTION
This PR improves the Testing documentation in [Setting up Jest (with the Rust Compiler)](https://nextjs.org/docs/testing#setting-up-jest-with-the-rust-compiler). It adds JSDoc typing in `jest.config.js`.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
