### PR TITLE
Fix handling with custom _error and pages/500

### DIFF
--- a/packages/next/server/request-meta.ts
+++ b/packages/next/server/request-meta.ts
@@ -63,6 +63,7 @@ type NextQueryMetadata = {
   __nextSsgPath?: string
   _nextBubbleNoFallback?: '1'
   __nextDataReq?: '1'
+  __nextCustomErrorRender?: '1'
 }
 
 export type NextParsedUrlQuery = ParsedUrlQuery &

--- a/test/production/custom-error-500/index.test.ts
+++ b/test/production/custom-error-500/index.test.ts
@@ -1,0 +1,77 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { check, renderViaHTTP } from 'next-test-utils'
+
+describe('custom-error-500', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.js': `
+          export function getServerSideProps() {
+            throw new Error('custom error')
+          }
+          
+          export default function Page() {
+            return <p>index page</p>
+          }
+        `,
+        'pages/500.js': `
+          export default function Custom500() {
+            return (
+              <>
+                <p>pages/500</p>
+              </>
+            )
+          }
+        `,
+        'pages/_error.js': `
+          function Error({ hasError }) {
+            return (
+              <>
+                <p>/_error</p>
+              </>
+            )
+          }
+          
+          Error.getInitialProps = ({ err }) => {
+            console.log(\`called Error.getInitialProps \${!!err}\`)
+            return {
+              hasError: !!err
+            }
+          }
+          
+          export default Error
+        `,
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should correctly use pages/500 and call Error.getInitialProps', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('pages/500')
+
+    await check(() => next.cliOutput, /called Error\.getInitialProps true/)
+  })
+
+  it('should work correctly with pages/404 present', async () => {
+    await next.stop()
+    await next.patchFile(
+      'pages/404.js',
+      `
+      export default function Page() {
+        return <p>custom 404 page</p>
+      }
+    `
+    )
+    await next.start()
+
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('pages/500')
+
+    await check(() => next.cliOutput, /called Error\.getInitialProps true/)
+  })
+})


### PR DESCRIPTION
This ensures we are properly calling `getInitialProps` in `_error` before serving `pages/500` as this has been the expected behavior since we introduced the process exiting behavior when deployed. This also ensures we don't attempt serving the `pages/500` before logging the error and exiting as this file isn't always expected to be present when statically optimized. 

Test deployments from provided reproduction can be seen here: 
- https://next-500-issue-ijdlh0e9y-ijjk-testing.vercel.app/
- https://next-500-issue-acn2vi68j-ijjk-testing.vercel.app/

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/40065
Fixes: https://github.com/vercel/next.js/issues/39952