### PR TITLE
docs(security-headers): interest-cohort has been replaced by browsing-topics

### DIFF
--- a/docs/advanced-features/security-headers.md
+++ b/docs/advanced-features/security-headers.md
@@ -81,7 +81,7 @@ This header allows you to control which features and APIs can be used in the bro
 ```jsx
 {
   key: 'Permissions-Policy',
-  value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()'
+  value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()'
 }
 ```
 


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/9814

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
