### PR TITLE
ignore EEXIST errors when creating symlinks for output standalone

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1371,7 +1371,13 @@ export async function copyTracedFiles(
           const symlink = await fs.readlink(tracedFilePath).catch(() => null)
 
           if (symlink) {
-            await fs.symlink(symlink, fileOutputPath)
+            try {
+              await fs.symlink(symlink, fileOutputPath)
+            } catch (e) {
+              if (e.code !== 'EEXIST') {
+                throw e
+              }
+            }
           } else {
             await fs.copyFile(tracedFilePath, fileOutputPath)
           }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1373,7 +1373,7 @@ export async function copyTracedFiles(
           if (symlink) {
             try {
               await fs.symlink(symlink, fileOutputPath)
-            } catch (e) {
+            } catch (e: Error) {
               if (e.code !== 'EEXIST') {
                 throw e
               }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1373,8 +1373,8 @@ export async function copyTracedFiles(
           if (symlink) {
             try {
               await fs.symlink(symlink, fileOutputPath)
-            } catch (e: Error) {
-              if (e['code'] !== 'EEXIST') {
+            } catch (e: any) {
+              if (e.code !== 'EEXIST') {
                 throw e
               }
             }

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1374,7 +1374,7 @@ export async function copyTracedFiles(
             try {
               await fs.symlink(symlink, fileOutputPath)
             } catch (e: Error) {
-              if (e.code !== 'EEXIST') {
+              if (e['code'] !== 'EEXIST') {
                 throw e
               }
             }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

I think the `EEXIST` error may be because next already copies some files here
https://github.com/vercel/next.js/blob/e91cbcc03d7226cc6f2edb66c656ae08bdf5b903/packages/next/build/index.ts#L2442


partially fixes #36386 when using pnpm linker

## Bug

- [x] Related issues linked using 
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
