### PR TITLE
fix: detect ESLint config in package.json

### DIFF
--- a/packages/next/lib/eslint/hasEslintConfiguration.ts
+++ b/packages/next/lib/eslint/hasEslintConfiguration.ts
@@ -33,12 +33,10 @@ export async function hasEslintConfiguration(
     }
     return { ...configObject, exists: true }
   } else if (packageJsonConfig?.eslintConfig) {
-    if (Object.entries(packageJsonConfig?.eslintConfig).length === 0) {
-      return {
-        ...configObject,
-        emptyPkgJsonConfig: true,
-      }
+    if (Object.keys(packageJsonConfig?.eslintConfig).length) {
+      return { ...configObject, emptyPkgJsonConfig: true }
     }
+    return { ...configObject, exists: true }
   }
   return configObject
 }

--- a/packages/next/lib/eslint/hasEslintConfiguration.ts
+++ b/packages/next/lib/eslint/hasEslintConfiguration.ts
@@ -34,9 +34,9 @@ export async function hasEslintConfiguration(
     return { ...configObject, exists: true }
   } else if (packageJsonConfig?.eslintConfig) {
     if (Object.keys(packageJsonConfig?.eslintConfig).length) {
-      return { ...configObject, emptyPkgJsonConfig: true }
+      return { ...configObject, exists: true }
     }
-    return { ...configObject, exists: true }
+    return { ...configObject, emptyPkgJsonConfig: true }
   }
   return configObject
 }

--- a/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
+++ b/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
@@ -65,5 +65,25 @@ describe('no-eslint-warn-with-no-eslint-config', () => {
         await next.patchFile('package.json', origPkgJson)
       }
     })
+
+    it('should not warn with eslint config in package.json', async () => {
+      await next.stop()
+      const origPkgJson = await next.readFile('package.json')
+      const pkgJson = JSON.parse(origPkgJson)
+      pkgJson.eslintConfig = { rules: { semi: 'off' } }
+
+      try {
+        await next.patchFile('package.json', JSON.stringify(pkgJson))
+        await next.start()
+
+        console.log(next.cliOutput)
+
+        expect(next.cliOutput).not.toContain(
+          'No ESLint configuration detected. Run next lint to begin setup'
+        )
+      } finally {
+        await next.patchFile('package.json', origPkgJson)
+      }
+    })
   }
 })

--- a/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
+++ b/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
@@ -76,8 +76,6 @@ describe('no-eslint-warn-with-no-eslint-config', () => {
         await next.patchFile('package.json', JSON.stringify(pkgJson))
         await next.start()
 
-        console.log(next.cliOutput)
-
         expect(next.cliOutput).not.toContain(
           'No ESLint configuration detected. Run next lint to begin setup'
         )


### PR DESCRIPTION
Fixes #40133

Fixes a small regression introduced in #39872. We should be able to detect if a non-empty `package.json#eslintConfig` property is present.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
