### PR TITLE
docs(README): next.js logo with dark mode

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://nextjs.org">
-    <img src="https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_light_background.png" height="128">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_dark_background.png">
+      <img src="https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_light_background.png" height="128">
+    </picture>
     <h1 align="center">Next.js</h1>
   </a>
 </p>


### PR DESCRIPTION
This PR follows #40181, adding the dark mode support for the brand new Next.js logo (BTW, the new logo is awesome!). The dark version of the logo is also served from `assets.vercel.com` (I just change the original logo URL, replace the `light` with `dark`, and surprisingly find out that doesn't result in 404).

cc @Nutlope @steven-tey 

Ref: [Specify theme context for images in Markdown (Beta) - GitHub Blog](https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/)

Currently, the Next.js README in dark mode:

<img width="917" alt="image" src="https://user-images.githubusercontent.com/40715044/188449078-864f6b71-7741-44f4-aee6-02a281b0a263.png">

After the PR:

<img width="914" alt="image" src="https://user-images.githubusercontent.com/40715044/188449265-a3556565-d866-4e0e-9b97-be62fba6c6fe.png">

Preview link: https://github.com/SukkaW/next.js/tree/readme-logo-darkmode
