### PR TITLE
Update to use specific swc version for PR stats

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -72,11 +72,15 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
     }
     /* eslint-disable-next-line */
     actionInfo.commitId = await getCommitId(diffRepoDir)
+    let mainNextSwcVersion
 
     if (!actionInfo.skipClone) {
       if (actionInfo.isRelease) {
         logger('Release detected, resetting mainRepo to last stable tag')
         const lastStableTag = await getLastStable(mainRepoDir, actionInfo.prRef)
+        mainNextSwcVersion = {
+          '@next/swc-linux-x64-gnu': lastStableTag,
+        }
         if (!lastStableTag) throw new Error('failed to get last stable tag')
         console.log('using latestStable', lastStableTag)
         await checkoutRef(lastStableTag, mainRepoDir)
@@ -130,9 +134,13 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
         .catch(console.error)
 
       logger(`Linking packages in ${dir}`)
-      const pkgPaths = await linkPackages(dir)
+      const isMainRepo = dir === mainRepoDir
+      const pkgPaths = await linkPackages(
+        dir,
+        isMainRepo ? mainNextSwcVersion : undefined
+      )
 
-      if (dir === mainRepoDir) mainRepoPkgPaths = pkgPaths
+      if (isMainRepo) mainRepoPkgPaths = pkgPaths
       else diffRepoPkgPaths = pkgPaths
     }
 

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -53,7 +53,7 @@ module.exports = (actionInfo) => {
         }
       }
     },
-    async linkPackages(repoDir = '') {
+    async linkPackages(repoDir = '', nextSwcPkg) {
       const pkgPaths = new Map()
       const pkgDatas = new Map()
       let pkgs
@@ -109,11 +109,15 @@ module.exports = (actionInfo) => {
           )
         }
         if (pkg === 'next') {
-          if (pkgDatas.get('@next/swc')) {
-            pkgData.dependencies['@next/swc'] =
-              pkgDatas.get('@next/swc').packedPkgPath
+          if (nextSwcPkg) {
+            Object.assign(pkgData.dependencies, nextSwcPkg)
           } else {
-            pkgData.files.push('native')
+            if (pkgDatas.get('@next/swc')) {
+              pkgData.dependencies['@next/swc'] =
+                pkgDatas.get('@next/swc').packedPkgPath
+            } else {
+              pkgData.files.push('native')
+            }
           }
         }
         await fs.writeFile(

--- a/.github/actions/next-stats-action/src/run/get-dir-size.js
+++ b/.github/actions/next-stats-action/src/run/get-dir-size.js
@@ -8,6 +8,10 @@ async function getDirSize(dir, ctx = { size: 0 }) {
 
   await Promise.all(
     subDirs.map(async (curDir) => {
+      // we use dev builds so the size isn't helpful to track
+      // here as it's not reflective of full releases
+      if (curDir.includes('@next/swc')) return
+
       const fileStat = await fs.stat(curDir)
       if (fileStat.isDirectory()) {
         return getDirSize(curDir, ctx)


### PR DESCRIPTION
Currently we use one dev swc build for running release/PR stats although the latest swc build could be incompatible with previous tags/commits being compared against so this updates to use the specific version related to that tag. This also updates to omit the swc size from `node_modules` size since it's a dev build and not helpful to track. 

Fixes: https://github.com/vercel/next.js/runs/8189857273?check_suite_focus=true