### PR TITLE
[web-runtime] Add a test case for the user agent parser

### DIFF
--- a/test/unit/web-runtime/user-agent.test.ts
+++ b/test/unit/web-runtime/user-agent.test.ts
@@ -6,12 +6,12 @@ import { userAgentFromString, userAgent, NextRequest } from 'next/server'
 
 const UA_STRING =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36'
+const MOBULE_UA_STRING =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1'
 
 it('parse an user agent', () => {
   const parser = userAgentFromString(UA_STRING)
-  expect(parser.ua).toBe(
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36'
-  )
+  expect(parser.ua).toBe(UA_STRING)
   expect(parser.browser).toStrictEqual({
     name: 'Chrome',
     version: '89.0.4389.90',
@@ -23,6 +23,28 @@ it('parse an user agent', () => {
   })
   expect(parser.os).toStrictEqual({ name: 'Mac OS', version: '11.2.3' })
   expect(parser.cpu).toStrictEqual({ architecture: undefined })
+  expect(parser.isBot).toBe(false)
+})
+
+it('parse an user agent (mobile)', () => {
+  const parser = userAgentFromString(MOBULE_UA_STRING)
+  expect(parser.ua).toBe(MOBULE_UA_STRING)
+  expect(parser.browser).toStrictEqual({
+    major: '14',
+    name: 'Mobile Safari',
+    version: '14.0',
+  })
+  expect(parser.engine).toStrictEqual({
+    name: 'WebKit',
+    version: '605.1.15',
+  })
+  expect(parser.os).toStrictEqual({ name: 'iOS', version: '14.0' })
+  expect(parser.cpu).toStrictEqual({ architecture: undefined })
+  expect(parser.device).toStrictEqual({
+    model: 'iPhone',
+    type: 'mobile',
+    vendor: 'Apple',
+  })
   expect(parser.isBot).toBe(false)
 })
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR improve the test coverage of the user agent parser used in middlewares. Especially it makes sure that the `device` field is filled for iOS user agent strings.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
