### PR TITLE
fix: expose HttpProxy options to next config

### DIFF
--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -399,6 +399,9 @@ const configSchema = {
         fontLoaders: {
           type: 'object',
         },
+        upstreamHttpProxyConfig: {
+          type: 'object',
+        },
       },
       type: 'object',
     },

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -1,5 +1,6 @@
 import os from 'os'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
+import type { ServerOptions as HttpProxyOptions } from 'next/dist/compiled/http-proxy'
 import type { Header, Redirect, Rewrite } from '../lib/load-custom-routes'
 import {
   ImageConfig,
@@ -147,6 +148,7 @@ export interface ExperimentalConfig {
    */
   fallbackNodePolyfills?: false
   enableUndici?: boolean
+  upstreamHttpProxyConfig?: HttpProxyOptions
   sri?: {
     algorithm?: SubresourceIntegrityAlgorithm
   }

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -706,6 +706,7 @@ export default class NextNodeServer extends BaseServer {
         upgradeHead && this.renderOpts.dev
           ? undefined
           : this.nextConfig.experimental.proxyTimeout || 30_000,
+      ...this.nextConfig.experimental.upstreamHttpProxyConfig,
     })
 
     await new Promise((proxyResolve, proxyReject) => {

--- a/test/e2e/upstream-proxy-custom-configuration/constants.ts
+++ b/test/e2e/upstream-proxy-custom-configuration/constants.ts
@@ -1,0 +1,2 @@
+export const PROXIED_HEADER_NAME = 'x-testing-header'
+export const PROXIED_HEADER_VALUE = 'testing-header-value'

--- a/test/e2e/upstream-proxy-custom-configuration/index.test.ts
+++ b/test/e2e/upstream-proxy-custom-configuration/index.test.ts
@@ -1,0 +1,64 @@
+import { createNext } from 'e2e-utils'
+import { findPort, renderViaHTTP } from 'next-test-utils'
+import { PROXIED_HEADER_NAME, PROXIED_HEADER_VALUE } from './constants'
+import http from 'http'
+import { NextInstance } from 'test/lib/next-modes/base'
+
+const buildRewriteFunction = (port: number) => async () => {
+  return {
+    fallback: [
+      {
+        source: '/:path*',
+        destination: `http://localhost:${port}'/:path*`,
+      },
+    ],
+    afterFiles: [],
+    beforeFiles: [],
+  }
+}
+
+describe('upstream proxy custom configuration', () => {
+  it('uses proxy settings from next config to connect to upstream', async () => {
+    const upstream = new http.Server((req, res) => {
+      res.writeHead(200)
+      res.end(req.headers[PROXIED_HEADER_NAME])
+    })
+    const port = await findPort()
+    upstream.listen(port)
+
+    const next = await createNext({
+      files: {
+        'pages/index.js': `
+          export default function Page() { 
+            return <p>hello world</p>
+          } 
+        `,
+      },
+      nextConfig: {
+        experimental: {
+          upstreamHttpProxyConfig: {
+            headers: { [PROXIED_HEADER_NAME]: PROXIED_HEADER_VALUE },
+          },
+        },
+        async rewrites() {
+          return {
+            fallback: [
+              {
+                source: '/:path*',
+                destination: `http://localhost:${process.env.UPSTREAM_PORT}/:path*`,
+              },
+            ],
+            afterFiles: [],
+            beforeFiles: [],
+          }
+        },
+      },
+      env: { UPSTREAM_PORT: String(port) },
+    })
+    const html = await renderViaHTTP(next.url, '/foo')
+    expect(html).toEqual(PROXIED_HEADER_VALUE)
+
+    next.destroy()
+    upstream.close()
+  })
+})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [X] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
