### PR TITLE
Switch ESLint TS to ESM exports

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-img-element.ts
+++ b/packages/eslint-plugin-next/lib/rules/no-img-element.ts
@@ -2,39 +2,36 @@ import type { Rule } from 'eslint'
 
 const url = 'https://nextjs.org/docs/messages/no-img-element'
 
-const rule: Rule.RuleModule = {
-  meta: {
-    docs: {
-      description: 'Prevent usage of `<img>` element to prevent layout shift.',
-      category: 'HTML',
-      recommended: true,
-      url,
-    },
-    type: 'problem',
-    schema: [],
+export const meta: Rule.RuleModule['meta'] = {
+  docs: {
+    description: 'Prevent usage of `<img>` element to prevent layout shift.',
+    category: 'HTML',
+    recommended: true,
+    url,
   },
-  create(context) {
-    return {
-      JSXOpeningElement(node) {
-        if (node.name.name !== 'img') {
-          return
-        }
-
-        if (node.attributes.length === 0) {
-          return
-        }
-
-        if (node.parent?.parent?.openingElement?.name?.name === 'picture') {
-          return
-        }
-
-        context.report({
-          node,
-          message: `Do not use \`<img>\` element. Use \`<Image />\` from \`next/image\` instead. See: ${url}`,
-        })
-      },
-    }
-  },
+  type: 'problem',
+  schema: [],
 }
 
-module.exports = rule
+export const create: Rule.RuleModule['create'] = (context) => {
+  return {
+    JSXOpeningElement(node) {
+      if (node.name.name !== 'img') {
+        return
+      }
+
+      if (node.attributes.length === 0) {
+        return
+      }
+
+      if (node.parent?.parent?.openingElement?.name?.name === 'picture') {
+        return
+      }
+
+      context.report({
+        node,
+        message: `Do not use \`<img>\` element. Use \`<Image />\` from \`next/image\` instead. See: ${url}`,
+      })
+    },
+  }
+}

--- a/test/unit/eslint-plugin-next/no-img-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-img-element.test.ts
@@ -1,4 +1,4 @@
-import rule from '@next/eslint-plugin-next/dist/rules/no-img-element'
+import * as rule from '@next/eslint-plugin-next/dist/rules/no-img-element'
 import { RuleTester } from 'eslint'
 ;(RuleTester as any).setDefaultConfig({
   parserOptions: {


### PR DESCRIPTION
This is just to show that ESLint rules can be written in ESM using `export` keyword. I suggest reviewing with [whitespace changes hidden](https://github.com/vercel/next.js/pull/40283/files?w=1).

/cc @balazsorban44