### PR TITLE
Fix test hydration check in Safari 10.1

### DIFF
--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -118,7 +118,8 @@ export default async function webdriver(
         if (
           document.documentElement.innerHTML.indexOf('__NEXT_DATA__') === -1 &&
           // @ts-ignore next exists on window if it's a Next.js page.
-          typeof (window as any).next?.version === 'undefined'
+          typeof ((window as any).next && (window as any).next.version) ===
+            'undefined'
         ) {
           console.log('Not a next.js page, resolving hydrate check')
           callback()


### PR DESCRIPTION
This removes the optional chaining inside of the `executeAsync` as that is treated literally when passed to the browser and Safari 10.1 doesn't support optional chaining. 

fixes: https://github.com/vercel/next.js/runs/8213273664?check_suite_focus=true
fixes: https://github.com/vercel/next.js/runs/8213237056?check_suite_focus=true