### PR TITLE
Change image sizes docs to use em instead of px

### DIFF
--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -248,8 +248,8 @@ const Example = () => (
     <Image
       src="/example.png"
       layout="fill"
-      sizes="(min-width: 75em) 33vw,
-              (min-width: 48em) 50vw,
+      sizes="(min-width: 1200px) 33vw,
+              (min-width: 768px) 50vw,
               100vw"
     />
   </div>

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -147,8 +147,8 @@ const Example = () => (
     <Image
       src="/example.png"
       layout="fill"
-      sizes="(min-width: 75em) 33vw,
-              (min-width: 48em) 50vw,
+      sizes="(min-width: 1200px) 33vw,
+              (min-width: 768px) 50vw,
               100vw"
     />
   </div>


### PR DESCRIPTION
This PR is a minor change to the image docs (`next/image` and `next/future/image`). The example sizes media queries are switched from `em` to `px` for readability.