### PR TITLE
Change sizes docs to use max-width in media query

### DIFF
--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -248,9 +248,9 @@ const Example = () => (
     <Image
       src="/example.png"
       layout="fill"
-      sizes="(min-width: 1200px) 33vw,
-              (min-width: 768px) 50vw,
-              100vw"
+      sizes="(max-width: 768px) 100vw,
+              (max-width: 1200px) 50vw,
+              33vw"
     />
   </div>
 )

--- a/docs/api-reference/next/future/image.md
+++ b/docs/api-reference/next/future/image.md
@@ -248,8 +248,8 @@ const Example = () => (
     <Image
       src="/example.png"
       layout="fill"
-      sizes="(min-width: 75em) 33vw,
-              (min-width: 48em) 50vw,
+      sizes="(min-width: 1200px) 33vw,
+              (min-width: 768px) 50vw,
               100vw"
     />
   </div>

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -147,9 +147,9 @@ const Example = () => (
     <Image
       src="/example.png"
       layout="fill"
-      sizes="(min-width: 1200px) 33vw,
-              (min-width: 768px) 50vw,
-              100vw"
+      sizes="(max-width: 768px) 100vw,
+              (max-width: 1200px) 50vw,
+              33vw"
     />
   </div>
 )

--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -147,8 +147,8 @@ const Example = () => (
     <Image
       src="/example.png"
       layout="fill"
-      sizes="(min-width: 75em) 33vw,
-              (min-width: 48em) 50vw,
+      sizes="(min-width: 1200px) 33vw,
+              (min-width: 768px) 50vw,
               100vw"
     />
   </div>


### PR DESCRIPTION
This PR updates the next/image and `next/future/image` sizes docs to use `max-width` in the `sizes` media query, for code style and consistency reasons.
