### PR TITLE
chore: Update swc

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -2929,7 +2929,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.40.0"
+version = "0.42.0"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "easy-error",
  "swc_core",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.13.0",
  "byteorder",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -2929,7 +2929,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "easy-error",
  "swc_core",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "base64 0.13.0",
  "byteorder",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.12.0"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148582743dcb4f3a872f6275a412e8e0c1b64023790fa33c8590e98e7b81d40e"
+checksum = "7755bde4fab3fe4e4c386e0bc6091b2151e5acd2d809663e2a862a34e24cdb7b"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2987,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.224.0"
+version = "0.224.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cc8d2e59e8d7a2650ea97193aaf50e4b1aa940e0476522a97e4913f63620ef"
+checksum = "c12dc9e84b4effc20aae2da2c26f10d169d5ff571ccc316180718735ff9ace4b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3050,9 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.185.0"
+version = "0.185.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a67427e87cddb6a9502530c966d22f7099cb42783a50712a2ec3cc05ded7f9"
+checksum = "e868bb01c4716209191ce829bd1dde41af84710302e17e3aba1272ae7cc464ee"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.20.4"
+version = "0.20.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e3327c208ae240cb71b1da1a660e2cdffb4b3316f402c75c9ebc979dc563b2"
+checksum = "3472cfcd876df6b413207a6db22c685c588d8c35904c6128497414d36999ddc2"
 dependencies = [
  "binding_macros",
  "swc",
@@ -3298,12 +3298,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.90.15"
+version = "0.90.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571989e199094be58d107e032c0b868f7b04a59a238e0a31bc9df8faf537dcd3"
+checksum = "41e78ceea39b1dacef1e7cda29488131677224bf6111ed5e853791d81c8a36da"
 dependencies = [
  "bitflags",
- "bytecheck",
  "is-macro",
  "num-bigint",
  "rkyv",
@@ -3317,9 +3316,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.123.0"
+version = "0.123.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616548c924bb4834b0570078c8edb85c07f5033d438316c482693d8968686dbb"
+checksum = "a787c39a5b30c077744c564c533bd294db36d70edfb43d1073e249ca14316b87"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -3349,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc13886dcab94205e82358abd59b49a6ca06f15ee66f28c082d0277c4f0a1f"
+checksum = "44f20b4b6225f8fcdfbc3fb901ea8fa08e6647b6d218b5bd141aa3d0241d754c"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -3363,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3240efa29a4a5968134622766cd122ae2cbb81c3bb3f3fdd9e81814f15d28b47"
+checksum = "2016bcb561426bd8ef511c118525c58ab11439ed34f76c1e45b610cc47198e07"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -3406,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.152.3"
+version = "0.152.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62550be2e2773991286ea412d5277b39c81f8a47b1fbcfe68af6bf8788c58722"
+checksum = "3ddb5a2ac5b3b720c9f0670181ff7832f9d329f4a4546728d91ca1e1287ba0f5"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -3440,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.118.5"
+version = "0.118.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da59bf24d3284fd5a93d0aee8f16d618ab43f032f7bdf9985553f4ba26584377"
+checksum = "b993963c284a2cadf46213ba0f4faa8a5153cfb02437f07ef21ebd90e598cae7"
 dependencies = [
  "either",
  "enum_kind",
@@ -3459,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.167.0"
+version = "0.167.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d37f5aecc5e4e809946ea76021c00c80ca797471c1b1d36e9225643c999b36"
+checksum = "bd1c7fb836ec38eb8a958749216b83db6be382765fd0f4d0f538870f5a793f4e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3484,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a333f88b7a6e373fe94911f145064044ab1ffb6f2dfd4bcd36ac7ea90026fa6"
+checksum = "b972b7b14ba0759e88c5991a93c9057728cbb7e7567294919057de51876e7d30"
 dependencies = [
  "anyhow",
  "hex",
@@ -3500,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.191.0"
+version = "0.191.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca874b86485f26b882110bc711e718707a28aeb8528b1880e46923f619706bc"
+checksum = "c7a391e557fd0e3af437104e816f6dc86daef23a21797fc8611b660c9afb2c11"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3520,13 +3519,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.106.1"
+version = "0.106.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a5bd2f4633734c712b3539b60d5ee7151a93fa827f2b9b19ffb05accece2b0"
+checksum = "ecfcecd7aad760171c0c392a856bec5291365a33bc03da5a1f24e26eccdffb7e"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
- "num_cpus",
  "once_cell",
  "phf",
  "rayon",
@@ -3544,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.95.0"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd6ef2fe490311bb13898a464f2a582374c50f81996fbcce7358674522f992a"
+checksum = "b748eddc9fe274648f7f6344f405a520a30f8574af76f8fb22c6a59508418382"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3558,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.129.0"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce692c9efbfebbc068253eb4d1f97f18809878e4a3d6a85a6900cc507bf08c"
+checksum = "f23ca33defee9a755e1aff44964e378e3bc0424df090c435cc250c83add82a0a"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -3599,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.146.0"
+version = "0.146.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39d8eca155d211e191d8b3a3ba44908d6aaa82e82152fca73524382e68d9fb3"
+checksum = "f3468686561b5317c86a78a46d66555c398ab574d5bf8538f69db449708307e4"
 dependencies = [
  "Inflector",
  "ahash",
@@ -3627,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.160.3"
+version = "0.160.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60929573686464dd117839acef42287205407865385eed448e5625dd4ff5214b"
+checksum = "d6deba435837e698ed8c26a0bf9ba24e08000874bb3ae92ddc59848800dfdc9e"
 dependencies = [
  "ahash",
  "dashmap",
@@ -3653,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.137.0"
+version = "0.137.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2b44281820a732b88b26da3448846ac82e6338af133928b7a879b14ea40e59"
+checksum = "b2bfcb3be3cdf374b53f61a2efdddfccaf6c1261171d02b0eb5838fd44c51223"
 dependencies = [
  "either",
  "serde",
@@ -3672,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.148.0"
+version = "0.148.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b148e31430d71af020a9eaed963f55126a150036a8de708fcfd03e6a1b852159"
+checksum = "cb912b97e944a4bcf7088823efb068e037f5c64db9e75c94a3138bd8c202578f"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -3699,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.108.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780945cfbf7755795b5c5d2755c28c17a9cb87ce2549e3597eae66967d63053b"
+checksum = "b4d09453be14e1481d633a68bea5e737b56b44943e8a7b56dd19038b094e4a9a"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3723,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.152.0"
+version = "0.152.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acba735ad42b7658045c7bb43b8989dfe2681c97b627f264b760d4ca300e670"
+checksum = "c919518f8b5f03df0e2c6a55ad44a0a3835125fbf569e5983bd2380b76e2e7c6"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3739,11 +3737,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.101.0"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bf09a91b69dc0ffa57a7bde2a8131be8dbe09997e95b9a51b08ba76e7384fb"
+checksum = "57a8a5b246246809b4cf526e838fd1284828ccaca56521d9af19b082862bc845"
 dependencies = [
  "indexmap",
+ "num_cpus",
  "once_cell",
  "rayon",
  "swc_atoms",
@@ -3756,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.76.6"
+version = "0.76.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cb4c2c4213d603543e7232db69e763a9292953db511b0ed5d1bf8c1b227b90"
+checksum = "c658568ed63dd13357bae4129999bacb9260d709f260fb49e14a56587ed5dab9"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -3813,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b5c705601d607480e67add408af73144712b445db5872ee2483d76acffb55"
+checksum = "3f2eb48057452a960071c60e00e345b6fdd21b1ba62551b66ac7413cbae31501"
 dependencies = [
  "ahash",
  "indexmap",
@@ -3872,12 +3871,11 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.18.13"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4cbccf3bf3b808d10371c4e0890b7a5871926519077c0a343ada9b6012aa1e"
+checksum = "67dd600c4892e58009f509fa9b19c82704d3a3e09a68d2849c30663848040d18"
 dependencies = [
  "better_scoped_tls",
- "bytecheck",
  "rkyv",
  "swc_common",
  "swc_ecma_ast",
@@ -3887,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.73.1"
+version = "0.73.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabaa68c69344c1fdf7e802e7d059d7f5f08ee9afdbacb3470a4f6e115b7887e"
+checksum = "980fcc4da1d4d2df39efd44bc98668d77b94565a2d2bcdfe46e228989d166754"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.12.9"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c226ef07c49e6f28180762df7f9e5ec33ca0cbb7b9e5d2a0f93341a2e3d743"
+checksum = "41b1ea69afade9429e482477df2bfd0f1feb6e3429c40d3e38f3265235c5b8ce"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2987,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.224.11"
+version = "0.226.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d902b15bd8618ebcbf3bbe27443db095ffc1933b7f59e6f698f6571592bfa88"
+checksum = "8d8214d84f03d1d54ae304ec2d704ca658511c92c68b5025ea5128096cb9aed7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3036,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb43a79c8affc20f5d52b7db093399585ce87674427adc60843dbc8ec242608"
+checksum = "60343f7e7a830f2724908e3e9ba38e5aa4a93e7b4bfe3bc92e50188a4f8300ec"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -3050,9 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.185.9"
+version = "0.187.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a0819b0fb9a865608429e009c97f905a4c664c06d331410853bedb481e2a9d"
+checksum = "2fd38e0c2c447186c1fd4ebcac4d4b45a43237d8dc1bcce82e8b613c43eda77d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3084,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "swc_cached"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96395ee002185e0b4bc9fa88e21b7065e77e9795d7e35dfcb02fc8085b5cd1ce"
+checksum = "7b7369f6f89364d8e96140cf0e0975e74aa1d3cb968139728b154b256b91550d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3099,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.27.14"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392b1be452ae176fe74613d8bc99c1511801dbf2deab63e18a82f0ec48886cdb"
+checksum = "edff0b912141ad8ea2e88547ca9f5c0b3e98236570776c96ea133f8f3b1a1108"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3158,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.20.16"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca0ce70088d9a79a033e0dc534cb064587a3b2bff8d0802e242e352d84aa123"
+checksum = "e465646ecd731d09ea6c385334b6e6c5f8dc6c4c4b60ef2a77f21a682a57f906"
 dependencies = [
  "binding_macros",
  "swc",
@@ -3196,9 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.110.1"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2d4091cb4f5cf607d83658a1ef291c94cf7ed82930005f6760bc0080316f4d"
+checksum = "df3bec08939dcca7299037110f4e374ecb7473ae293109d4906d9501f653f533"
 dependencies = [
  "is-macro",
  "serde",
@@ -3209,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.120.1"
+version = "0.121.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a4cbd3f0aedda63dd2bb7b367eb4c2066bd70166ca129e0c4dda11324d66d9"
+checksum = "6554847c8efc4e1affa6fd372cb8c1381638105606a3175c66a82c394e10ec7f"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -3238,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.119.1"
+version = "0.120.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fe4a6550ecd70a59ae00ffeeb23fc0139747484c85c0b56e79e792589d0821"
+checksum = "f1e544ae9e22af55b74f385e32a016ffc576a240ceedf8d94f51c9c1f84058c6"
 dependencies = [
  "bitflags",
  "lexical",
@@ -3252,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.121.1"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7e1d6ba692ac97d0c9f690661a3a649fba4484f2fc1c635b970eaf426c8c03"
+checksum = "cbf069adc6b1ba68e3ac39731c2777ac2cbf13dcac99d023ce56571ec8075da6"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -3269,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.107.1"
+version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8b1cf73baf0f8f6367fb295d2696c67fb7f211f5aa35c53c84d33178fecff2"
+checksum = "7e8c81463614236e311599ae864c6bd7c5db3ab255854c3d69aeaf5776cbb971"
 dependencies = [
  "once_cell",
  "serde",
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.109.1"
+version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54dd904b034b404c973ff7fa031b76b1fb9adedca1adf1d05dbf33683d3ed613"
+checksum = "36a5cdfa29ebfbae02c8fac6a28b385094cc39eec50a08a3dfea9355af39b327"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3297,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.90.18"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfcf3e12a571c1b964a9b8a655d93b8334f0be6df3d502949667cb903cba3e8"
+checksum = "3b4685a1a3da866f37616067c097276af9d53fc46269b83656f3736983510a3a"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -3315,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.123.3"
+version = "0.124.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3d83cc3982a7499be11e9df18efa6669e9b7137d2ee87fe5927af66eb6f4a4"
+checksum = "c8d340fd209ece39d791f18670521254e9721afc3b54d6133da2ed71492e795c"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -3347,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.87.2"
+version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f867c64e382d9f8d4dd2bad98362d8a9634b1aa67c83da8e23046969da63076f"
+checksum = "ac83c6901143ef4b6e27ec11663c1ba720e540af975f1e914f75781ac3afac71"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -3361,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.61.3"
+version = "0.63.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a319c8e709b1b42418c99a311474a12e2a19c32ac793c9d49b4b61153e758764"
+checksum = "35d077a94d07955222f5775dddfc4a021e570631dc6e7e6bef1777099eefc93c"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -3382,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.39.5"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92573e4e37c9488b55f99371e7d4c9c488c6a2c47fefbdda7c004be5fb680cae"
+checksum = "203d02530097a78677f684af316a703fc18270b120df6f7c22a6c32ff977a7e1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3404,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.152.16"
+version = "0.154.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a3bee1a349a54dd54480191d4cd694ff66b7ef2a53b55c925c7d63bc5f375a"
+checksum = "61bd03038ced37f965ada147cb2a7ac928162afa0e22aeaedb9495224222476a"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.118.8"
+version = "0.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca289a927ba0d724f9ae0e5ddfed25312be14ab184a9d1e43ea9a4d4a27a213"
+checksum = "00e4dfd30206132cb1e66a4a98182b2ae2480ac6407418fba98d2f80e60c53bd"
 dependencies = [
  "either",
  "enum_kind",
@@ -3457,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.167.3"
+version = "0.169.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3c660cc1049ee6b66550c25c5efc0566e8deaf711406039ac527f37f82bf16"
+checksum = "9f394fa11182401ed27a3ee8bcb9997f29e86aaa0a128c98b54dbc8150db9db4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3482,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103edbc04f05d562704f21c9376e47207a3aa0caeddc8d36bb8cb87e8660bb0c"
+checksum = "6b812a560c37b954e4d6b0dde1eca35281ec397a9281560ba8275e3c23369a93"
 dependencies = [
  "anyhow",
  "hex",
@@ -3498,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.191.4"
+version = "0.193.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d440147a28e6fbaf00e9d96f965a0d413b292162ad67336b910a95eb7d5c26"
+checksum = "8f31a9ce0fede50283e66825dd436b54a186631f0f8fc7f55793f7fc8b7413e8"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3518,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.106.6"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b754fcd4c9737ff317bd0d29c4cd9a3e43735efd2ba8e83f044050b6c4b02f1"
+checksum = "f549d34f9ba9f33989bc0680183609434cc4729b2bc6a31b516958493947d45a"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -3541,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.95.3"
+version = "0.97.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2edfb41ddca0be4769633236aeb67fc0c9bddc2f90010022d0eecb19734f79c"
+checksum = "d2bb41eaa3febb1edfa7ba740ac6c99e3270ffd9339320fe5ba7a2fe44fcb309"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3555,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.129.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "792f9769ecb00a44de95d37191c58e3ddbdb942c95843a92d371a7b49e53f6c1"
+checksum = "699e56d6e28dd26ab1fcc823be0de0bdcf486f9b5a3c5c700757b42d49ee87eb"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -3596,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.146.3"
+version = "0.148.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4113b829190a2cf68a834888d5726e0bcd1a251a108f90c34e34e52ac885dbe4"
+checksum = "ecbc7b777d4a7ebf396fba2ed5f146cb6f76d55a8ebdb31fd0919819a8df3708"
 dependencies = [
  "Inflector",
  "ahash",
@@ -3624,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.160.11"
+version = "0.162.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faecaf857919ccb48e6eab0bb686e01c801a5bcb92897de630612ba9547eb7d9"
+checksum = "ed2ee11129360ab9f13eaa932844f88df02970300d2684545265890cec46e11b"
 dependencies = [
  "ahash",
  "dashmap",
@@ -3650,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.137.3"
+version = "0.139.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a981a236f7e2b81a9dd2663761ed65c9ca2b436f86a689e98a332df9f0c87d3"
+checksum = "231f536b837d0a4fe5c1b36466909bdcfdda6cd57ed31809bda4a4976cd0adac"
 dependencies = [
  "either",
  "serde",
@@ -3669,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.148.3"
+version = "0.150.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e26d37aad3fa16ec2f8ab16bdfbd8c91eecc0f5d764f9cd179d6eaf1215bece"
+checksum = "2abe0bc888b67344d4e890c9bfd3716176849f35f881263b51d2405ec1efaee3"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -3696,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.108.3"
+version = "0.110.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac8873dfa7d5fff9827652ed4120efaf17e90a8eed39fb6fac2fea3508dd407"
+checksum = "d5280e6d5e250085f25a84f03ab044b9bb1aa751013eb85540e254d1c17be2a4"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3720,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.152.3"
+version = "0.154.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f111b67c2ad9ce08a518543cc77c33c439f9b82ea86ef81a0aa5ce281c68934"
+checksum = "f34ac7c3ebcae7a383d277a73554311122065db17aa46474c15488be1ce99a40"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3736,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.101.4"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b94d4ffec7041eb37201d459699a3cfc2f11aa0860d340814f4a263c002fcec"
+checksum = "0bddd1a279d48e3cca2ee3977040cab764941241669329239a3243d44db10656"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -3754,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.76.8"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26dde86dea801f356edd67b8b9aa6347ec117ba71abc8756754f833ed4bdc0c9"
+checksum = "62095bb4acbee86b182c26b2d2e45b629eaa5687649adf09391f5d13fac96079"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -3798,9 +3798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffbb765efef43313236e6b38948e4740fcd92a0e01b5d2d3f7ba6d1d3dd9b5a"
+checksum = "05b79de61e6d5a424a3b098d77a26084b38c32be114622bafa7260dc0f030ab4"
 dependencies = [
  "anyhow",
  "miette",
@@ -3811,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.15.7"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82eff023bc80ba7f1187c3773e70abe88147c869e18b619ed3d8e103c1c4278"
+checksum = "63a86b91f3d2135f202e399d3fd641ddb491db22f71b228e8498327f1255e64b"
 dependencies = [
  "ahash",
  "indexmap",
@@ -3823,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.16.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd5e47b38b27f520e59f0b2d04af3a006d0e99a5c5bfac2d00f286fe02e68e2"
+checksum = "d41a0e2ceb3834422c0dd0d6ecd9cbdc3d79f6b1d72f5c6c69cf01f2819aed99"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -3858,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077e8160363362e1e50a794476eb8e87bdbcf0d6605ed7abb042ff60befbb401"
+checksum = "fb3e725f1331dbaf5a611d6c2f438dfab8bbacc533c68702a0ff80c54474bc01"
 dependencies = [
  "ahash",
  "dashmap",
@@ -3870,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.18.15"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26688bff5429b332dc18fae7ca0e3fd912dc60970f0095340c2363b1abd896af"
+checksum = "fc3ef97400d703ee77d385b32e575f345270e1d22492fc654a570fa81d13e943"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -3884,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.73.3"
+version = "0.74.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cf2271ac4fd1cbc71b72215c377fb0c5e3ffa65013ffd8ac94c04e32a9d6fe"
+checksum = "d1b116d97058176c148615a06aea31dc86cfdb4cdb6c544eecb1f8fc18b78942"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3904,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee25e3a1bcb5cf1e4c7e60f94f6daf8fdcaeb91d749b77107506f2d0384fdbd"
+checksum = "7608e49fb80b82bf85086a9abe5c3458ad6ec63da274b6eced3e41976cae1b3b"
 dependencies = [
  "tracing",
 ]
@@ -3998,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51653a32089289ca73ed789661dc8a3b9b9311aa44e4a10311fa9ed7bcceb8e"
+checksum = "a0405c4a90862fd9e264da30ed20cd04ea94ba25d6d4f7a228b2c902dcd05aea"
 dependencies = [
  "ansi_term",
  "difference",

--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ast_node"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87549fcb780f81054407f313a1693d102396c223f5c49ccc5d90b46a6cbef34a"
+checksum = "0a614981a880a40522cf6fbe8b1a8365eb253655939f812a9db03e8ba4e2cb1f"
 dependencies = [
  "darling",
  "pmutil",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.12.5"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7755bde4fab3fe4e4c386e0bc6091b2151e5acd2d809663e2a862a34e24cdb7b"
+checksum = "88c226ef07c49e6f28180762df7f9e5ec33ca0cbb7b9e5d2a0f93341a2e3d743"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2987,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.224.7"
+version = "0.224.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12dc9e84b4effc20aae2da2c26f10d169d5ff571ccc316180718735ff9ace4b"
+checksum = "2d902b15bd8618ebcbf3bbe27443db095ffc1933b7f59e6f698f6571592bfa88"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3050,9 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.185.5"
+version = "0.185.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e868bb01c4716209191ce829bd1dde41af84710302e17e3aba1272ae7cc464ee"
+checksum = "76a0819b0fb9a865608429e009c97f905a4c664c06d331410853bedb481e2a9d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3099,16 +3099,15 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.27.13"
+version = "0.27.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba38a2f1291fcf3f78f357802b8cec72ecf5e95808e9d937783e60cd3570b93"
+checksum = "392b1be452ae176fe74613d8bc99c1511801dbf2deab63e18a82f0ec48886cdb"
 dependencies = [
  "ahash",
  "anyhow",
  "ast_node",
  "atty",
  "better_scoped_tls",
- "bytecheck",
  "cfg-if 1.0.0",
  "debug_unreachable",
  "either",
@@ -3159,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.20.12"
+version = "0.20.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3472cfcd876df6b413207a6db22c685c588d8c35904c6128497414d36999ddc2"
+checksum = "2ca0ce70088d9a79a033e0dc534cb064587a3b2bff8d0802e242e352d84aa123"
 dependencies = [
  "binding_macros",
  "swc",
@@ -3197,9 +3196,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.110.0"
+version = "0.110.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a509e0985a7f9fad59ffe2fca9c32e50f18d443a100b45e0caf3dcfdad3ffbcf"
+checksum = "4f2d4091cb4f5cf607d83658a1ef291c94cf7ed82930005f6760bc0080316f4d"
 dependencies = [
  "is-macro",
  "serde",
@@ -3210,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.120.0"
+version = "0.120.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7285b5dcc1c196f8798f4391f94b7f97fc097c371d99337775ef07f2779682a6"
+checksum = "24a4cbd3f0aedda63dd2bb7b367eb4c2066bd70166ca129e0c4dda11324d66d9"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -3239,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.119.0"
+version = "0.119.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680fc749baaf53a0ebb5ba09482c43701b3d523ab823005376e39cfb3e4ca213"
+checksum = "f5fe4a6550ecd70a59ae00ffeeb23fc0139747484c85c0b56e79e792589d0821"
 dependencies = [
  "bitflags",
  "lexical",
@@ -3253,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.121.0"
+version = "0.121.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774759d18cf8a0e2f5cab1d7fff457bb383f4b8e8c2fbe25a0a52e2a74c9a7be"
+checksum = "8d7e1d6ba692ac97d0c9f690661a3a649fba4484f2fc1c635b970eaf426c8c03"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -3270,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.107.0"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b611f636a937f50361b8d18cfae08ae20fa1e3b659ab7d2e5ec7e774a6fbef4"
+checksum = "9a8b1cf73baf0f8f6367fb295d2696c67fb7f211f5aa35c53c84d33178fecff2"
 dependencies = [
  "once_cell",
  "serde",
@@ -3285,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.109.0"
+version = "0.109.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706be455229bd4c5c5761295fb02ef13f82c26daa0ef8f6efd1d769805462fe6"
+checksum = "54dd904b034b404c973ff7fa031b76b1fb9adedca1adf1d05dbf33683d3ed613"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3298,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.90.17"
+version = "0.90.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e78ceea39b1dacef1e7cda29488131677224bf6111ed5e853791d81c8a36da"
+checksum = "1bfcf3e12a571c1b964a9b8a655d93b8334f0be6df3d502949667cb903cba3e8"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -3316,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.123.2"
+version = "0.123.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a787c39a5b30c077744c564c533bd294db36d70edfb43d1073e249ca14316b87"
+checksum = "dd3d83cc3982a7499be11e9df18efa6669e9b7137d2ee87fe5927af66eb6f4a4"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -3348,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.87.1"
+version = "0.87.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f20b4b6225f8fcdfbc3fb901ea8fa08e6647b6d218b5bd141aa3d0241d754c"
+checksum = "f867c64e382d9f8d4dd2bad98362d8a9634b1aa67c83da8e23046969da63076f"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -3362,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.61.1"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2016bcb561426bd8ef511c118525c58ab11439ed34f76c1e45b610cc47198e07"
+checksum = "a319c8e709b1b42418c99a311474a12e2a19c32ac793c9d49b4b61153e758764"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -3383,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.39.4"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece6023a43222e3bd36e3d191fa5289c848245b97fbf0127d9c0923165648d18"
+checksum = "92573e4e37c9488b55f99371e7d4c9c488c6a2c47fefbdda7c004be5fb680cae"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3405,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.152.12"
+version = "0.152.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddb5a2ac5b3b720c9f0670181ff7832f9d329f4a4546728d91ca1e1287ba0f5"
+checksum = "27a3bee1a349a54dd54480191d4cd694ff66b7ef2a53b55c925c7d63bc5f375a"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -3439,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.118.7"
+version = "0.118.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b993963c284a2cadf46213ba0f4faa8a5153cfb02437f07ef21ebd90e598cae7"
+checksum = "cca289a927ba0d724f9ae0e5ddfed25312be14ab184a9d1e43ea9a4d4a27a213"
 dependencies = [
  "either",
  "enum_kind",
@@ -3458,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.167.1"
+version = "0.167.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1c7fb836ec38eb8a958749216b83db6be382765fd0f4d0f538870f5a793f4e"
+checksum = "4a3c660cc1049ee6b66550c25c5efc0566e8deaf711406039ac527f37f82bf16"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3483,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b972b7b14ba0759e88c5991a93c9057728cbb7e7567294919057de51876e7d30"
+checksum = "103edbc04f05d562704f21c9376e47207a3aa0caeddc8d36bb8cb87e8660bb0c"
 dependencies = [
  "anyhow",
  "hex",
@@ -3499,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.191.2"
+version = "0.191.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a391e557fd0e3af437104e816f6dc86daef23a21797fc8611b660c9afb2c11"
+checksum = "32d440147a28e6fbaf00e9d96f965a0d413b292162ad67336b910a95eb7d5c26"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3519,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.106.4"
+version = "0.106.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecfcecd7aad760171c0c392a856bec5291365a33bc03da5a1f24e26eccdffb7e"
+checksum = "7b754fcd4c9737ff317bd0d29c4cd9a3e43735efd2ba8e83f044050b6c4b02f1"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -3542,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.95.1"
+version = "0.95.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b748eddc9fe274648f7f6344f405a520a30f8574af76f8fb22c6a59508418382"
+checksum = "c2edfb41ddca0be4769633236aeb67fc0c9bddc2f90010022d0eecb19734f79c"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3556,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.129.1"
+version = "0.129.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ca33defee9a755e1aff44964e378e3bc0424df090c435cc250c83add82a0a"
+checksum = "792f9769ecb00a44de95d37191c58e3ddbdb942c95843a92d371a7b49e53f6c1"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -3597,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.146.1"
+version = "0.146.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3468686561b5317c86a78a46d66555c398ab574d5bf8538f69db449708307e4"
+checksum = "4113b829190a2cf68a834888d5726e0bcd1a251a108f90c34e34e52ac885dbe4"
 dependencies = [
  "Inflector",
  "ahash",
@@ -3625,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.160.9"
+version = "0.160.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6deba435837e698ed8c26a0bf9ba24e08000874bb3ae92ddc59848800dfdc9e"
+checksum = "faecaf857919ccb48e6eab0bb686e01c801a5bcb92897de630612ba9547eb7d9"
 dependencies = [
  "ahash",
  "dashmap",
@@ -3651,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.137.1"
+version = "0.137.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bfcb3be3cdf374b53f61a2efdddfccaf6c1261171d02b0eb5838fd44c51223"
+checksum = "4a981a236f7e2b81a9dd2663761ed65c9ca2b436f86a689e98a332df9f0c87d3"
 dependencies = [
  "either",
  "serde",
@@ -3670,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.148.1"
+version = "0.148.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb912b97e944a4bcf7088823efb068e037f5c64db9e75c94a3138bd8c202578f"
+checksum = "6e26d37aad3fa16ec2f8ab16bdfbd8c91eecc0f5d764f9cd179d6eaf1215bece"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -3697,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.108.1"
+version = "0.108.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d09453be14e1481d633a68bea5e737b56b44943e8a7b56dd19038b094e4a9a"
+checksum = "6ac8873dfa7d5fff9827652ed4120efaf17e90a8eed39fb6fac2fea3508dd407"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3721,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.152.1"
+version = "0.152.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c919518f8b5f03df0e2c6a55ad44a0a3835125fbf569e5983bd2380b76e2e7c6"
+checksum = "9f111b67c2ad9ce08a518543cc77c33c439f9b82ea86ef81a0aa5ce281c68934"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3737,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.101.3"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8a5b246246809b4cf526e838fd1284828ccaca56521d9af19b082862bc845"
+checksum = "9b94d4ffec7041eb37201d459699a3cfc2f11aa0860d340814f4a263c002fcec"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -3755,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.76.7"
+version = "0.76.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c658568ed63dd13357bae4129999bacb9260d709f260fb49e14a56587ed5dab9"
+checksum = "26dde86dea801f356edd67b8b9aa6347ec117ba71abc8756754f833ed4bdc0c9"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -3799,9 +3798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0171a43e5d90cdea0efbf5844e3780f8650a22e4152b0c49549387d5f6b3da"
+checksum = "6ffbb765efef43313236e6b38948e4740fcd92a0e01b5d2d3f7ba6d1d3dd9b5a"
 dependencies = [
  "anyhow",
  "miette",
@@ -3812,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2eb48057452a960071c60e00e345b6fdd21b1ba62551b66ac7413cbae31501"
+checksum = "b82eff023bc80ba7f1187c3773e70abe88147c869e18b619ed3d8e103c1c4278"
 dependencies = [
  "ahash",
  "indexmap",
@@ -3824,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba02e0726abddde48fecef483fb0b067c88a6c0da736b91d3ef424be3cfcaa39"
+checksum = "7fd5e47b38b27f520e59f0b2d04af3a006d0e99a5c5bfac2d00f286fe02e68e2"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -3859,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809a8d29020a11b0171f033110c9d0bd260b8797429f9e26672afd8353a14cce"
+checksum = "077e8160363362e1e50a794476eb8e87bdbcf0d6605ed7abb042ff60befbb401"
 dependencies = [
  "ahash",
  "dashmap",
@@ -3871,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.18.14"
+version = "0.18.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dd600c4892e58009f509fa9b19c82704d3a3e09a68d2849c30663848040d18"
+checksum = "26688bff5429b332dc18fae7ca0e3fd912dc60970f0095340c2363b1abd896af"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -3885,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.73.2"
+version = "0.73.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980fcc4da1d4d2df39efd44bc98668d77b94565a2d2bcdfe46e228989d166754"
+checksum = "a4cf2271ac4fd1cbc71b72215c377fb0c5e3ffa65013ffd8ac94c04e32a9d6fe"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3905,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94c875f92763879d638174414a94762cd8f865d237ad75b34094c18395bc796"
+checksum = "fee25e3a1bcb5cf1e4c7e60f94f6daf8fdcaeb91d749b77107506f2d0384fdbd"
 dependencies = [
  "tracing",
 ]
@@ -3999,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5d89dc2a392aab3a29a2d4e430e4ec3692fd3bd91d0a54bc092f4b8ea26d96"
+checksum = "b51653a32089289ca73ed789661dc8a3b9b9311aa44e4a10311fa9ed7bcceb8e"
 dependencies = [
  "ansi_term",
  "difference",

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -28,7 +28,7 @@ styled_jsx = {path="../styled_jsx"}
 modularize_imports = {path="../modularize_imports"}
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 
-swc_core = { version = "0.20.4", features = [
+swc_core = { version = "0.20.12", features = [
   "common_concurrent",
   "ecma_ast",
   "ecma_visit",
@@ -47,6 +47,6 @@ swc_core = { version = "0.20.4", features = [
 ] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.4", features = ["testing_transform"] }
+swc_core = { version = "0.20.12", features = ["testing_transform"] }
 testing = "0.29.4"
 walkdir = "2.3.2"

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -28,7 +28,7 @@ styled_jsx = {path="../styled_jsx"}
 modularize_imports = {path="../modularize_imports"}
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 
-swc_core = { version = "0.20.16", features = [
+swc_core = { version = "0.22.4", features = [
   "common_concurrent",
   "ecma_ast",
   "ecma_visit",
@@ -47,6 +47,6 @@ swc_core = { version = "0.20.16", features = [
 ] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.16", features = ["testing_transform"] }
-testing = "0.29.5"
+swc_core = { version = "0.22.4", features = ["testing_transform"] }
+testing = "0.30.0"
 walkdir = "2.3.2"

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -28,7 +28,7 @@ styled_jsx = {path="../styled_jsx"}
 modularize_imports = {path="../modularize_imports"}
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 
-swc_core = { version = "0.20.12", features = [
+swc_core = { version = "0.20.16", features = [
   "common_concurrent",
   "ecma_ast",
   "ecma_visit",
@@ -47,6 +47,6 @@ swc_core = { version = "0.20.12", features = [
 ] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.12", features = ["testing_transform"] }
-testing = "0.29.4"
+swc_core = { version = "0.20.16", features = ["testing_transform"] }
+testing = "0.29.5"
 walkdir = "2.3.2"

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -19,7 +19,7 @@ regex = "1.5"
 serde = "1"
 sourcemap = "6.0.1"
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
-swc_core = { version = "0.20.4", features = ["common_concurrent", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
+swc_core = { version = "0.20.4", features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
 
 [dev-dependencies]
 swc_core = { version = "0.20.4", features = ["testing_transform", "ecma_transforms_react"] }

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -19,9 +19,9 @@ regex = "1.5"
 serde = "1"
 sourcemap = "6.0.1"
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
-swc_core = { version = "0.20.12", features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
+swc_core = { version = "0.20.16", features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.12", features = ["testing_transform", "ecma_transforms_react"] }
-testing = "0.29.4"
+swc_core = { version = "0.20.16", features = ["testing_transform", "ecma_transforms_react"] }
+testing = "0.29.5"
 serde_json = "1"

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -5,7 +5,7 @@ description = "AST Transforms for emotion"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.19.0"
+version = "0.19.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -19,9 +19,9 @@ regex = "1.5"
 serde = "1"
 sourcemap = "6.0.1"
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
-swc_core = { version = "0.20.4", features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
+swc_core = { version = "0.20.12", features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.4", features = ["testing_transform", "ecma_transforms_react"] }
+swc_core = { version = "0.20.12", features = ["testing_transform", "ecma_transforms_react"] }
 testing = "0.29.4"
 serde_json = "1"

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -19,9 +19,9 @@ regex = "1.5"
 serde = "1"
 sourcemap = "6.0.1"
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
-swc_core = { version = "0.20.16", features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
+swc_core = { version = "0.22.4", features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.16", features = ["testing_transform", "ecma_transforms_react"] }
-testing = "0.29.5"
+swc_core = { version = "0.22.4", features = ["testing_transform", "ecma_transforms_react"] }
+testing = "0.30.0"
 serde_json = "1"

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -5,7 +5,7 @@ description = "AST Transforms for emotion"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.17.0"
+version = "0.19.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/modularize_imports/Cargo.toml
+++ b/packages/next-swc/crates/modularize_imports/Cargo.toml
@@ -15,8 +15,8 @@ handlebars = "4.2.1"
 once_cell = "1.13.0"
 regex = "1.5"
 serde = "1"
-swc_core = { version = "0.20.16", features = ["cached", "ecma_ast", "ecma_visit"] }
+swc_core = { version = "0.22.4", features = ["cached", "ecma_ast", "ecma_visit"] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.16", features = ["testing_transform"] }
-testing = "0.29.5"
+swc_core = { version = "0.22.4", features = ["testing_transform"] }
+testing = "0.30.0"

--- a/packages/next-swc/crates/modularize_imports/Cargo.toml
+++ b/packages/next-swc/crates/modularize_imports/Cargo.toml
@@ -15,8 +15,8 @@ handlebars = "4.2.1"
 once_cell = "1.13.0"
 regex = "1.5"
 serde = "1"
-swc_core = { version = "0.20.12", features = ["cached", "ecma_ast", "ecma_visit"] }
+swc_core = { version = "0.20.16", features = ["cached", "ecma_ast", "ecma_visit"] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.12", features = ["testing_transform"] }
-testing = "0.29.4"
+swc_core = { version = "0.20.16", features = ["testing_transform"] }
+testing = "0.29.5"

--- a/packages/next-swc/crates/modularize_imports/Cargo.toml
+++ b/packages/next-swc/crates/modularize_imports/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.15.0"
+version = "0.17.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/modularize_imports/Cargo.toml
+++ b/packages/next-swc/crates/modularize_imports/Cargo.toml
@@ -15,8 +15,8 @@ handlebars = "4.2.1"
 once_cell = "1.13.0"
 regex = "1.5"
 serde = "1"
-swc_core = { version = "0.20.4", features = ["cached", "ecma_ast", "ecma_visit"] }
+swc_core = { version = "0.20.12", features = ["cached", "ecma_ast", "ecma_visit"] }
 
 [dev-dependencies]
-swc_core = { version = "0.20.4", features = ["testing_transform"] }
+swc_core = { version = "0.20.12", features = ["testing_transform"] }
 testing = "0.29.4"

--- a/packages/next-swc/crates/modularize_imports/Cargo.toml
+++ b/packages/next-swc/crates/modularize_imports/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.17.0"
+version = "0.17.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -30,7 +30,7 @@ next-swc = {version = "0.0.0", path = "../core"}
 once_cell = "1.13.0"
 serde = "1"
 serde_json = "1"
-swc_core = { version = "0.20.16", features = [
+swc_core = { version = "0.22.4", features = [
   "allocator_node",
   "base_concurrent", # concurrent?
   "common_concurrent",

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -30,7 +30,7 @@ next-swc = {version = "0.0.0", path = "../core"}
 once_cell = "1.13.0"
 serde = "1"
 serde_json = "1"
-swc_core = { version = "0.20.12", features = [
+swc_core = { version = "0.20.16", features = [
   "allocator_node",
   "base_concurrent", # concurrent?
   "common_concurrent",

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -30,7 +30,7 @@ next-swc = {version = "0.0.0", path = "../core"}
 once_cell = "1.13.0"
 serde = "1"
 serde_json = "1"
-swc_core = { version = "0.20.4", features = [
+swc_core = { version = "0.20.12", features = [
   "allocator_node",
   "base_concurrent", # concurrent?
   "common_concurrent",

--- a/packages/next-swc/crates/styled_components/Cargo.toml
+++ b/packages/next-swc/crates/styled_components/Cargo.toml
@@ -16,7 +16,7 @@ once_cell = "1.13.0"
 regex = {version = "1.5.4", features = ["std", "perf"], default-features = false}
 serde = {version = "1.0.130", features = ["derive"]}
 tracing = "0.1.32"
-swc_core = { version = "0.20.16", features = [
+swc_core = { version = "0.22.4", features = [
   "common",
   "ecma_ast",
   "ecma_utils",
@@ -25,8 +25,8 @@ swc_core = { version = "0.20.16", features = [
 
 [dev-dependencies]
 serde_json = "1"
-testing = "0.29.5"
-swc_core = { version = "0.20.16", features = [
+testing = "0.30.0"
+swc_core = { version = "0.22.4", features = [
   "ecma_parser",
   "ecma_transforms",
   "testing_transform"

--- a/packages/next-swc/crates/styled_components/Cargo.toml
+++ b/packages/next-swc/crates/styled_components/Cargo.toml
@@ -16,7 +16,7 @@ once_cell = "1.13.0"
 regex = {version = "1.5.4", features = ["std", "perf"], default-features = false}
 serde = {version = "1.0.130", features = ["derive"]}
 tracing = "0.1.32"
-swc_core = { version = "0.20.12", features = [
+swc_core = { version = "0.20.16", features = [
   "common",
   "ecma_ast",
   "ecma_utils",
@@ -25,8 +25,8 @@ swc_core = { version = "0.20.12", features = [
 
 [dev-dependencies]
 serde_json = "1"
-testing = "0.29.4"
-swc_core = { version = "0.20.12", features = [
+testing = "0.29.5"
+swc_core = { version = "0.20.16", features = [
   "ecma_parser",
   "ecma_transforms",
   "testing_transform"

--- a/packages/next-swc/crates/styled_components/Cargo.toml
+++ b/packages/next-swc/crates/styled_components/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.42.0"
+version = "0.42.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/styled_components/Cargo.toml
+++ b/packages/next-swc/crates/styled_components/Cargo.toml
@@ -17,7 +17,7 @@ regex = {version = "1.5.4", features = ["std", "perf"], default-features = false
 serde = {version = "1.0.130", features = ["derive"]}
 tracing = "0.1.32"
 swc_core = { version = "0.20.4", features = [
-  "common_concurrent",
+  "common",
   "ecma_ast",
   "ecma_utils",
   "ecma_visit"

--- a/packages/next-swc/crates/styled_components/Cargo.toml
+++ b/packages/next-swc/crates/styled_components/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.40.0"
+version = "0.42.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/styled_components/Cargo.toml
+++ b/packages/next-swc/crates/styled_components/Cargo.toml
@@ -16,7 +16,7 @@ once_cell = "1.13.0"
 regex = {version = "1.5.4", features = ["std", "perf"], default-features = false}
 serde = {version = "1.0.130", features = ["derive"]}
 tracing = "0.1.32"
-swc_core = { version = "0.20.4", features = [
+swc_core = { version = "0.20.12", features = [
   "common",
   "ecma_ast",
   "ecma_utils",
@@ -26,7 +26,7 @@ swc_core = { version = "0.20.4", features = [
 [dev-dependencies]
 serde_json = "1"
 testing = "0.29.4"
-swc_core = { version = "0.20.4", features = [
+swc_core = { version = "0.20.12", features = [
   "ecma_parser",
   "ecma_transforms",
   "testing_transform"

--- a/packages/next-swc/crates/styled_jsx/Cargo.toml
+++ b/packages/next-swc/crates/styled_jsx/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.17.1"
 easy-error = "1.0.0"
 tracing = "0.1.32"
 
-swc_core = { version = "0.20.12", features = [
+swc_core = { version = "0.20.16", features = [
   "common",
   "css_ast",
   "css_codegen",
@@ -27,7 +27,7 @@ swc_core = { version = "0.20.12", features = [
 ] }
 
 [dev-dependencies]
-testing = "0.29.4"
-swc_core = { version = "0.20.12", features = [
+testing = "0.29.5"
+swc_core = { version = "0.20.16", features = [
   "testing_transform"
 ] }

--- a/packages/next-swc/crates/styled_jsx/Cargo.toml
+++ b/packages/next-swc/crates/styled_jsx/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "Apache-2.0"
 name = "styled_jsx"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.17.0"
+version = "0.17.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/styled_jsx/Cargo.toml
+++ b/packages/next-swc/crates/styled_jsx/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "Apache-2.0"
 name = "styled_jsx"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.15.0"
+version = "0.17.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/next-swc/crates/styled_jsx/Cargo.toml
+++ b/packages/next-swc/crates/styled_jsx/Cargo.toml
@@ -14,7 +14,7 @@ easy-error = "1.0.0"
 tracing = "0.1.32"
 
 swc_core = { version = "0.20.4", features = [
-  "common_concurrent",
+  "common",
   "css_ast",
   "css_codegen",
   "css_parser",

--- a/packages/next-swc/crates/styled_jsx/Cargo.toml
+++ b/packages/next-swc/crates/styled_jsx/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.17.1"
 easy-error = "1.0.0"
 tracing = "0.1.32"
 
-swc_core = { version = "0.20.4", features = [
+swc_core = { version = "0.20.12", features = [
   "common",
   "css_ast",
   "css_codegen",
@@ -28,6 +28,6 @@ swc_core = { version = "0.20.4", features = [
 
 [dev-dependencies]
 testing = "0.29.4"
-swc_core = { version = "0.20.4", features = [
+swc_core = { version = "0.20.12", features = [
   "testing_transform"
 ] }

--- a/packages/next-swc/crates/styled_jsx/Cargo.toml
+++ b/packages/next-swc/crates/styled_jsx/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.17.1"
 easy-error = "1.0.0"
 tracing = "0.1.32"
 
-swc_core = { version = "0.20.16", features = [
+swc_core = { version = "0.22.4", features = [
   "common",
   "css_ast",
   "css_codegen",
@@ -27,7 +27,7 @@ swc_core = { version = "0.20.16", features = [
 ] }
 
 [dev-dependencies]
-testing = "0.29.5"
-swc_core = { version = "0.20.16", features = [
+testing = "0.30.0"
+swc_core = { version = "0.22.4", features = [
   "testing_transform"
 ] }

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 
-swc_core = { version = "0.20.12", features = [
+swc_core = { version = "0.20.16", features = [
   "common_concurrent",
   "binding_macro_wasm",
   "ecma_codegen",

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 
-swc_core = { version = "0.20.16", features = [
+swc_core = { version = "0.22.4", features = [
   "common_concurrent",
   "binding_macro_wasm",
   "ecma_codegen",

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -31,7 +31,7 @@ wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
 
-swc_core = { version = "0.20.4", features = [
+swc_core = { version = "0.20.12", features = [
   "common_concurrent",
   "binding_macro_wasm",
   "ecma_codegen",


### PR DESCRIPTION
This PR update swc crates to https://github.com/swc-project/swc/commit/4c078b0ac3c26254ae94648e00fac90a4e31d34c

This PR applies
 - patches for the performance of minifier
 - https://github.com/swc-project/swc/pull/5796
   - Closes https://github.com/vercel/next.js/issues/40399