### PR TITLE
[Docs] Update with-mobx example

### DIFF
--- a/examples/with-mobx/.babelrc
+++ b/examples/with-mobx/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/examples/with-mobx/.babelrc
+++ b/examples/with-mobx/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["next/babel"],
-  "plugins": [["@babel/plugin-proposal-class-properties", { "loose": false }]]
+  "presets": ["next/babel"]
 }

--- a/examples/with-mobx/.babelrc
+++ b/examples/with-mobx/.babelrc
@@ -1,7 +1,4 @@
 {
   "presets": ["next/babel"],
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    ["@babel/plugin-proposal-class-properties", { "loose": false }]
-  ]
+  "plugins": [["@babel/plugin-proposal-class-properties", { "loose": false }]]
 }

--- a/examples/with-mobx/README.md
+++ b/examples/with-mobx/README.md
@@ -8,7 +8,7 @@ To illustrate SSG and SSR, go to `/ssg` and `/ssr`, those pages are using Next.j
 
 The trick here for supporting universal mobx is to separate the cases for the client and the server. When we are on the server we want to create a new store every time, otherwise different users data will be mixed up. If we are in the client we want to use always the same store. That's what we accomplish on `store.js`.
 
-The clock, under `components/Clock.js`, has access to the state using the `inject` and `observer` functions from `mobx-react`. In this case Clock is a direct child from the page but it could be deep down the render tree.
+The clock, under `components/Clock.js`, has access to the state using the `observer` functions from `mobx-react-lite`. In this case Clock is a direct child from the page but it could be deep down the render tree.
 
 ## Deploy your own
 

--- a/examples/with-mobx/components/Clock.js
+++ b/examples/with-mobx/components/Clock.js
@@ -1,8 +1,16 @@
-import { observer } from 'mobx-react'
-const Clock = observer((props) => {
+import { observer } from 'mobx-react-lite'
+import { useEffect } from 'react'
+import { useStore } from '../store'
+
+export default observer(function Clock() {
+  const { start, stop, light, timeString } = useStore()
+  useEffect(() => {
+    start()
+    return () => stop()
+  }, [start, stop])
   return (
-    <div className={props.light ? 'light' : ''}>
-      {props.timeString}
+    <div className={light ? 'light' : ''}>
+      {timeString}
       <style jsx>{`
         div {
           padding: 15px;
@@ -19,4 +27,3 @@ const Clock = observer((props) => {
     </div>
   )
 })
-export default Clock

--- a/examples/with-mobx/components/Page.js
+++ b/examples/with-mobx/components/Page.js
@@ -3,7 +3,7 @@ import Clock from './Clock'
 
 export default function Page({ title, linkTo }) {
   return (
-    <div>
+    <>
       <h1>{title}</h1>
       <Clock />
       <nav>
@@ -11,6 +11,6 @@ export default function Page({ title, linkTo }) {
           <a>Navigate</a>
         </Link>
       </nav>
-    </div>
+    </>
   )
 }

--- a/examples/with-mobx/components/Page.js
+++ b/examples/with-mobx/components/Page.js
@@ -3,8 +3,6 @@ import Link from 'next/link'
 import { inject, observer } from 'mobx-react'
 import Clock from './Clock'
 
-@inject('store')
-@observer
 class Page extends React.Component {
   componentDidMount() {
     this.props.store.start()
@@ -32,4 +30,4 @@ class Page extends React.Component {
   }
 }
 
-export default Page
+export default inject('store')(observer(Page))

--- a/examples/with-mobx/components/Page.js
+++ b/examples/with-mobx/components/Page.js
@@ -1,33 +1,16 @@
-import React from 'react'
 import Link from 'next/link'
-import { inject, observer } from 'mobx-react'
 import Clock from './Clock'
 
-class Page extends React.Component {
-  componentDidMount() {
-    this.props.store.start()
-  }
-
-  componentWillUnmount() {
-    this.props.store.stop()
-  }
-
-  render() {
-    return (
-      <div>
-        <h1>{this.props.title}</h1>
-        <Clock
-          timeString={this.props.store.timeString}
-          light={this.props.store.light}
-        />
-        <nav>
-          <Link href={this.props.linkTo}>
-            <a>Navigate</a>
-          </Link>
-        </nav>
-      </div>
-    )
-  }
+export default function Page({ title, linkTo }) {
+  return (
+    <div>
+      <h1>{title}</h1>
+      <Clock />
+      <nav>
+        <Link href={linkTo}>
+          <a>Navigate</a>
+        </Link>
+      </nav>
+    </div>
+  )
 }
-
-export default inject('store')(observer(Page))

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "mobx": "^6.6.1",
-    "mobx-react": "^7.5.2",
+    "mobx-react-lite": "3.4.0",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -13,7 +13,6 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@babel/core": "7.14.5",
-    "@babel/plugin-proposal-class-properties": "^7.1.0"
+    "@babel/core": "7.14.5"
   }
 }

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.14.5",
-    "@babel/plugin-proposal-class-properties": "^7.1.0",
-    "@babel/plugin-proposal-decorators": "^7.1.0"
+    "@babel/plugin-proposal-class-properties": "^7.1.0"
   }
 }

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -11,8 +11,5 @@
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-  },
-  "devDependencies": {
-    "@babel/core": "7.14.5"
   }
 }

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -6,10 +6,10 @@
     "start": "next start"
   },
   "dependencies": {
-    "mobx": "^6.0.1",
-    "mobx-react": "^7.0.0",
+    "mobx": "^6.6.1",
+    "mobx-react": "^7.5.2",
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/examples/with-mobx/pages/_app.js
+++ b/examples/with-mobx/pages/_app.js
@@ -1,12 +1,12 @@
-import { Provider } from 'mobx-react'
-import { useStore } from '../store'
+import { StoreProvider } from '../store'
 
-export default function App({ Component, pageProps }) {
-  const store = useStore(pageProps.initialState)
-
+export default function App({
+  Component,
+  pageProps: { initialState, ...pageProps },
+}) {
   return (
-    <Provider store={store}>
+    <StoreProvider initialState={initialState}>
       <Component {...pageProps} />
-    </Provider>
+    </StoreProvider>
   )
 }

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -8,13 +8,19 @@ let store
 
 class Store {
   constructor() {
-    makeObservable(this)
+    makeObservable(this, {
+      lastUpdate: observable,
+      light: observable,
+      start: action,
+      timeString: computed,
+      hydrate: action,
+    })
   }
 
-  @observable lastUpdate = 0
-  @observable light = false
+  lastUpdate = 0
+  light = false
 
-  @action start = () => {
+  start = () => {
     this.timer = setInterval(() => {
       runInAction(() => {
         this.lastUpdate = Date.now()
@@ -23,7 +29,7 @@ class Store {
     }, 1000)
   }
 
-  @computed get timeString() {
+  get timeString() {
     const pad = (n) => (n < 10 ? `0${n}` : n)
     const format = (t) =>
       `${pad(t.getUTCHours())}:${pad(t.getUTCMinutes())}:${pad(
@@ -34,7 +40,7 @@ class Store {
 
   stop = () => clearInterval(this.timer)
 
-  @action hydrate = (data) => {
+  hydrate = (data) => {
     if (!data) return
 
     this.lastUpdate = data.lastUpdate !== null ? data.lastUpdate : Date.now()

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -7,7 +7,7 @@ enableStaticRendering(typeof window === 'undefined')
 
 const StoreContext = createContext(null)
 
-class Store {
+class GlobalStore {
   constructor() {
     makeObservable(this, {
       lastUpdate: observable,
@@ -50,8 +50,8 @@ class Store {
 }
 
 let store
-function initializeStore(initialData = null) {
-  const _store = store ?? new Store()
+function initializeGlobalStore(initialData = null) {
+  const _store = store ?? new GlobalStore()
 
   // If your page has Next.js data fetching methods that use a Mobx store, it will
   // get hydrated here, check `pages/ssg.js` and `pages/ssr.js` for more details
@@ -67,7 +67,7 @@ function initializeStore(initialData = null) {
 }
 
 export function StoreProvider({ children, initialState }) {
-  const store = useLocalObservable(() => initializeStore(initialState))
+  const store = useLocalObservable(() => initializeGlobalStore(initialState))
   return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
 }
 

--- a/examples/with-mobx/store.js
+++ b/examples/with-mobx/store.js
@@ -1,10 +1,11 @@
 import { action, observable, computed, runInAction, makeObservable } from 'mobx'
-import { enableStaticRendering } from 'mobx-react'
-import { useMemo } from 'react'
+import { enableStaticRendering, useLocalObservable } from 'mobx-react-lite'
+import { createContext, useContext } from 'react'
+
 // eslint-disable-next-line react-hooks/rules-of-hooks
 enableStaticRendering(typeof window === 'undefined')
 
-let store
+const StoreContext = createContext(null)
 
 class Store {
   constructor() {
@@ -48,6 +49,7 @@ class Store {
   }
 }
 
+let store
 function initializeStore(initialData = null) {
   const _store = store ?? new Store()
 
@@ -64,7 +66,11 @@ function initializeStore(initialData = null) {
   return _store
 }
 
-export function useStore(initialState) {
-  const store = useMemo(() => initializeStore(initialState), [initialState])
-  return store
+export function StoreProvider({ children, initialState }) {
+  const store = useLocalObservable(() => initializeStore(initialState))
+  return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
+}
+
+export function useStore() {
+  return useContext(StoreContext)
 }


### PR DESCRIPTION
## Info

In order to keep the review smaller I will migrate this example to typescript in another pr.

## Notable

- Removed legacy code
- Moved to `mobx-react-lite` this will reduce bundle size and is recommended for greenfield projects
- Refactored Code

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
