### PR TITLE
chore: turn off debug mode on issue validator

### DIFF
--- a/.github/workflows/validate_issue.yml
+++ b/.github/workflows/validate_issue.yml
@@ -15,4 +15,3 @@ jobs:
         run: node ./.github/actions/issue-validator/index.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEBUG: 1


### PR DESCRIPTION
The issue validator GitHub action has been running in the background for a while, and the output looks good: https://github.com/vercel/next.js/actions/workflows/validate_issue.yml

This PR switches off debug mode and will start commenting on improper bug reports to make triaging more effective.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
