### PR TITLE
[Docs] Remove babel from with-mobx-react-lite example

### DIFF
--- a/examples/with-mobx-react-lite/.babelrc
+++ b/examples/with-mobx-react-lite/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": [["@babel/plugin-proposal-class-properties", { "loose": false }]]
-}

--- a/examples/with-mobx-react-lite/package.json
+++ b/examples/with-mobx-react-lite/package.json
@@ -11,9 +11,5 @@
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
-  },
-  "devDependencies": {
-    "@babel/core": "7.19.0",
-    "@babel/plugin-proposal-class-properties": "^7.18.6"
   }
 }

--- a/examples/with-mobx-react-lite/package.json
+++ b/examples/with-mobx-react-lite/package.json
@@ -6,14 +6,14 @@
     "start": "next start"
   },
   "dependencies": {
-    "mobx": "^6.0.3",
-    "mobx-react-lite": "^3.1.5",
+    "mobx": "^6.6.1",
+    "mobx-react-lite": "^3.4.0",
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@babel/core": "7.14.5",
-    "@babel/plugin-proposal-class-properties": "^7.1.0"
+    "@babel/core": "7.19.0",
+    "@babel/plugin-proposal-class-properties": "^7.18.6"
   }
 }


### PR DESCRIPTION


## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
