### PR TITLE
[Docs] Remove babel from with-mobx example

### DIFF
--- a/examples/with-mobx/.babelrc
+++ b/examples/with-mobx/.babelrc
@@ -1,7 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    ["@babel/plugin-proposal-class-properties", { "loose": false }]
-  ]
-}

--- a/examples/with-mobx/jsconfig.json
+++ b/examples/with-mobx/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -6,15 +6,15 @@
     "start": "next start"
   },
   "dependencies": {
-    "mobx": "^6.0.1",
-    "mobx-react": "^7.0.0",
+    "mobx": "^6.6.1",
+    "mobx-react": "^7.5.2",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@babel/core": "7.14.5",
-    "@babel/plugin-proposal-class-properties": "^7.1.0",
-    "@babel/plugin-proposal-decorators": "^7.1.0"
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-decorators": "^7.19.0"
   }
 }

--- a/examples/with-mobx/package.json
+++ b/examples/with-mobx/package.json
@@ -11,10 +11,5 @@
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-  },
-  "devDependencies": {
-    "@babel/core": "7.14.5",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.19.0"
   }
 }


### PR DESCRIPTION
## Additional Info

Since this is a legacy example, I did not update react to version 18. 

## Related

https://github.com/vercel/next.js/pull/40302

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
