### PR TITLE
[Docs] Update react-remove-properties example

### DIFF
--- a/examples/react-remove-properties/next.config.js
+++ b/examples/react-remove-properties/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  experimental: {
+  compiler: {
     reactRemoveProperties: true,
     // Or, specify a custom list of regular expressions to match properties to remove.
     // The regexes defined here are processed in Rust so the syntax is different from


### PR DESCRIPTION
Hi 👋 

Based on https://nextjs.org/docs/advanced-features/compiler#remove-react-properties, this is not experimental but lives under `compiler` now.

## Documentation / Examples
- [x] Make sure the linting passes by running pnpm lint
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
