### PR TITLE
[Docs] Remove babel from custom-server-typescript example

### DIFF
--- a/examples/custom-server-typescript/.babelrc
+++ b/examples/custom-server-typescript/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/examples/custom-server-typescript/package.json
+++ b/examples/custom-server-typescript/package.json
@@ -6,17 +6,17 @@
     "start": "cross-env NODE_ENV=production node dist/index.js"
   },
   "dependencies": {
-    "cross-env": "^7.0.2",
+    "cross-env": "^7.0.3",
     "next": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "^12.0.12",
-    "@types/react": "^16.9.44",
-    "@types/react-dom": "^16.9.8",
-    "nodemon": "^2.0.4",
-    "ts-node": "^8.10.2",
-    "typescript": "4.0"
+    "@types/node": "^18.7.15",
+    "@types/react": "^18.0.18",
+    "@types/react-dom": "^18.0.6",
+    "nodemon": "^2.0.19",
+    "ts-node": "^10.9.1",
+    "typescript": "~4.8.2"
   }
 }

--- a/examples/custom-server-typescript/tsconfig.json
+++ b/examples/custom-server-typescript/tsconfig.json
@@ -19,7 +19,8 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "incremental": true
   },
   "exclude": ["dist", ".next", "out", "next.config.js"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
