### PR TITLE
Fix static info parsing when export data fetching method as variable

### DIFF
--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -53,6 +53,19 @@ export function checkExports(swcAST: any): { ssr: boolean; ssg: boolean } {
           }
         }
 
+        if (
+          node.type === 'ExportDeclaration' &&
+          node.declaration?.type === 'VariableDeclaration'
+        ) {
+          const id = node.declaration?.declarations[0]?.id.value
+          if (['getStaticProps', 'getServerSideProps'].includes(id)) {
+            return {
+              ssg: id === 'getStaticProps',
+              ssr: id === 'getServerSideProps',
+            }
+          }
+        }
+
         if (node.type === 'ExportNamedDeclaration') {
           const values = node.specifiers.map(
             (specifier: any) =>

--- a/test/unit/fixtures/page-runtime/ssr-variable-gssp.js
+++ b/test/unit/fixtures/page-runtime/ssr-variable-gssp.js
@@ -1,0 +1,12 @@
+export default function Nodejs() {
+  return 'nodejs'
+}
+
+// export an identifier instead of function
+export const getServerSideProps = async () => {
+  return { props: {} }
+}
+
+export const config = {
+  runtime: 'experimental-edge',
+}

--- a/test/unit/parse-page-static-info.test.ts
+++ b/test/unit/parse-page-static-info.test.ts
@@ -9,21 +9,25 @@ function createNextConfig(runtime?: 'experimental-edge' | 'nodejs') {
   }
 }
 
-describe('parse page runtime config', () => {
+describe('parse page static info', () => {
   it('should parse nodejs runtime correctly', async () => {
-    const { runtime } = await getPageStaticInfo({
+    const { runtime, ssr, ssg } = await getPageStaticInfo({
       pageFilePath: join(fixtureDir, 'page-runtime/nodejs-ssr.js'),
       nextConfig: createNextConfig(),
     })
     expect(runtime).toBe('nodejs')
+    expect(ssr).toBe(true)
+    expect(ssg).toBe(false)
   })
 
   it('should parse static runtime correctly', async () => {
-    const { runtime } = await getPageStaticInfo({
+    const { runtime, ssr, ssg } = await getPageStaticInfo({
       pageFilePath: join(fixtureDir, 'page-runtime/nodejs.js'),
       nextConfig: createNextConfig(),
     })
     expect(runtime).toBe(undefined)
+    expect(ssr).toBe(false)
+    expect(ssg).toBe(false)
   })
 
   it('should parse edge runtime correctly', async () => {
@@ -41,22 +45,35 @@ describe('parse page runtime config', () => {
     })
     expect(runtime).toBe(undefined)
   })
+
+  it('should parse ssr info with variable exported gSSP correctly', async () => {
+    const { ssr, ssg } = await getPageStaticInfo({
+      pageFilePath: join(fixtureDir, 'page-runtime/ssr-variable-gssp.js'),
+      nextConfig: createNextConfig(),
+    })
+    expect(ssr).toBe(true)
+    expect(ssg).toBe(false)
+  })
 })
 
 describe('fallback to the global runtime configuration', () => {
   it('should fallback when gSP is defined and exported', async () => {
-    const { runtime } = await getPageStaticInfo({
+    const { runtime, ssr, ssg } = await getPageStaticInfo({
       pageFilePath: join(fixtureDir, 'page-runtime/fallback-with-gsp.js'),
       nextConfig: createNextConfig('experimental-edge'),
     })
     expect(runtime).toBe('experimental-edge')
+    expect(ssr).toBe(false)
+    expect(ssg).toBe(true)
   })
 
   it('should fallback when gSP is re-exported from other module', async () => {
-    const { runtime } = await getPageStaticInfo({
+    const { runtime, ssr, ssg } = await getPageStaticInfo({
       pageFilePath: join(fixtureDir, 'page-runtime/fallback-re-export-gsp.js'),
       nextConfig: createNextConfig('experimental-edge'),
     })
     expect(runtime).toBe('experimental-edge')
+    expect(ssr).toBe(false)
+    expect(ssg).toBe(true)
   })
 })


### PR DESCRIPTION
Fix the ssr/ssg detection when you export a nextjs data fetching method as a variable instead of an async function.

- [x] Add case support in `checkExports`
- [x] Add unit tests for `getPageStaticInfo`

