### PR TITLE
fix(lint): disable `react/no-unknown-property`

### DIFF
--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -60,7 +60,7 @@ module.exports = {
   plugins: ['import', 'react', 'jsx-a11y'],
   rules: {
     'import/no-anonymous-default-export': 'warn',
-    'react/no-unknown-property': [1, { allow: ['style', 'jsx'] }],
+    'react/no-unknown-property': [2, { ignore: ['jsx'] }],
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     'jsx-a11y/alt-text': [

--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -60,6 +60,7 @@ module.exports = {
   plugins: ['import', 'react', 'jsx-a11y'],
   rules: {
     'import/no-anonymous-default-export': 'warn',
+    'react/no-unknown-property': [1, { allow: ['style', 'jsx'] }],
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     'jsx-a11y/alt-text': [

--- a/packages/eslint-config-next/index.js
+++ b/packages/eslint-config-next/index.js
@@ -60,7 +60,7 @@ module.exports = {
   plugins: ['import', 'react', 'jsx-a11y'],
   rules: {
     'import/no-anonymous-default-export': 'warn',
-    'react/no-unknown-property': [2, { ignore: ['jsx'] }],
+    'react/no-unknown-property': 'off',
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     'jsx-a11y/alt-text': [


### PR DESCRIPTION
~(PR https://github.com/jsx-eslint/eslint-plugin-react/pull/3377) introduced a change in `eslint-plugin-react@7.31.2` that will now show an error when unknown properties appear on elements. We can opt out of this by overriding the default.~

As discussed internally, we are turning `react/no-unknown-property` off, as it might be confusing even if different props are being used, (eg.: `css` for `emotion`). 

It's easy to fix https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md#rule-options, but it might not be clear at first glance that Next.js is using `eslint-plugin-react` internally.

If the user wants to enforce this rule, they can still add it to their own `rules` config.

Fixes #40321, ref: https://github.com/vercel/next.js/discussions/40269, https://github.com/vercel/next.js/issues/38333

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
