### PR TITLE
Fix `image-component` example types

### DIFF
--- a/examples/image-component/pages/index.tsx
+++ b/examples/image-component/pages/index.tsx
@@ -5,7 +5,7 @@ import ViewSource from '../components/view-source'
 import vercel from '../public/vercel.png'
 import type { PropsWithChildren } from 'react'
 
-const Code = (props: PropsWithChildren) => (
+const Code = (props: PropsWithChildren<{}>) => (
   <code className={styles.inlineCode} {...props} />
 )
 


### PR DESCRIPTION
Fixes a bug from #40204 