### PR TITLE
Remove warning for swcMinify being enabled

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -511,10 +511,6 @@ function assignDefaults(userConfig: { [key: string]: any }) {
     result.compiler.removeConsole = (result.experimental as any).removeConsole
   }
 
-  if (result.swcMinify) {
-    Log.info('SWC minify release candidate enabled. https://nextjs.link/swcmin')
-  }
-
   if (result.experimental?.swcMinifyDebugOptions) {
     Log.warn(
       'SWC minify debug option specified. This option is for debugging minifier issues and will be removed once SWC minifier is stable.'


### PR DESCRIPTION
This removes the warning for `swcMinify` as a release candidate as it is now being marked as stable. 

x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1662647498560729)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
