### PR TITLE
Fix mdx docs

### DIFF
--- a/docs/advanced-features/using-mdx.md
+++ b/docs/advanced-features/using-mdx.md
@@ -33,7 +33,7 @@ The following steps outline how to setup `@next/mdx` in your Next.js project:
 1. Install the required packages:
 
    ```bash
-     npm install @next/mdx @mdx-js/loader
+     npm install @next/mdx @mdx-js/loader @mdx-js/react
    ```
 
 2. Require the package and configure to support top level `.mdx` pages. The following adds the `options` object key allowing you to pass in any plugins:

--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -5,13 +5,13 @@ Use [MDX](https://github.com/mdx-js/mdx) with [Next.js](https://github.com/verce
 ## Installation
 
 ```
-npm install @next/mdx @mdx-js/loader
+npm install @next/mdx @mdx-js/loader @mdx-js/react
 ```
 
 or
 
 ```
-yarn add @next/mdx @mdx-js/loader
+yarn add @next/mdx @mdx-js/loader @mdx-js/react
 ```
 
 ## Usage


### PR DESCRIPTION
## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)

The MDX guide is missing `@mdx-js/react` as a required dependency in the setup section.