### PR TITLE
fix: eslint no-script-component-in-head error url

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-script-component-in-head.js
+++ b/packages/eslint-plugin-next/lib/rules/no-script-component-in-head.js
@@ -1,5 +1,5 @@
 const url =
-  'https://nextjs.org/docs/messages/no-script-tags-in-head-component'
+  'https://nextjs.org/docs/messages/no-script-component-in-head'
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin-next/lib/rules/no-script-component-in-head.js
+++ b/packages/eslint-plugin-next/lib/rules/no-script-component-in-head.js
@@ -1,5 +1,4 @@
-const url =
-  'https://nextjs.org/docs/messages/no-script-component-in-head'
+const url = 'https://nextjs.org/docs/messages/no-script-component-in-head'
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin-next/lib/rules/no-script-component-in-head.js
+++ b/packages/eslint-plugin-next/lib/rules/no-script-component-in-head.js
@@ -1,5 +1,5 @@
 const url =
-  'https://nextjs.org/docs/messages/no-script-component-in-head-component'
+  'https://nextjs.org/docs/messages/no-script-tags-in-head-component'
 
 module.exports = {
   meta: {

--- a/test/unit/eslint-plugin-next/no-script-component-in-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-script-component-in-head.test.ts
@@ -44,7 +44,7 @@ ruleTester.run('no-script-in-head', rule, {
       errors: [
         {
           message:
-            '`next/script` should not be used in `next/head` component. Move `<Script />` outside of `<Head>` instead. See: https://nextjs.org/docs/messages/no-script-component-in-head-component',
+            '`next/script` should not be used in `next/head` component. Move `<Script />` outside of `<Head>` instead. See: https://nextjs.org/docs/messages/no-script-component-in-head',
         },
       ],
     },


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
