### PR TITLE
Clarify use of `loading` property

### DIFF
--- a/docs/advanced-features/dynamic-import.md
+++ b/docs/advanced-features/dynamic-import.md
@@ -42,7 +42,7 @@ If you are not using React 18, you can use the `loading` attribute in place of t
 
 ```jsx
 const DynamicHeader = dynamic(() => import('../components/header'), {
-  loading: () => <header />,
+  loading: () => <div>Loading...</div>,
 })
 ```
 


### PR DESCRIPTION
I was a little confused by the `loading` property having the value `<header />`. I think that property is meant to show a loading state while the file is being loaded? If my assumption is correct, I think this change makes sense.