### PR TITLE
Rename allowDynamic to unstable_allowDynamic

### DIFF
--- a/docs/api-reference/edge-runtime.md
+++ b/docs/api-reference/edge-runtime.md
@@ -145,14 +145,14 @@ You can relax the check to allow specific files with your Middleware or Edge API
 ```javascript
 export const config = {
   runtime: 'experimental-edge', // for Edge API Routes only
-  allowDynamic: [
+  unstable_allowDynamic: [
     '/lib/utilities.js', // allows a single file
     '/node_modules/function-bind/**', // use a glob to allow anything in the function-bind 3rd party module
   ],
 }
 ```
 
-`allowDynamic` is a [glob](https://github.com/micromatch/micromatch#matching-features), or an array of globs, ignoring dynamic code evaluation for specific files. The globs are relative to your application root folder.
+`unstable_allowDynamic` is a [glob](https://github.com/micromatch/micromatch#matching-features), or an array of globs, ignoring dynamic code evaluation for specific files. The globs are relative to your application root folder.
 
 Be warned that if these statements are executed on the Edge, _they will throw and cause a runtime error_.
 

--- a/packages/next/build/analysis/get-page-static-info.ts
+++ b/packages/next/build/analysis/get-page-static-info.ts
@@ -16,7 +16,7 @@ import { matcher } from 'next/dist/compiled/micromatch'
 
 export interface MiddlewareConfig {
   matchers: MiddlewareMatcher[]
-  allowDynamicGlobs: string[]
+  unstable_allowDynamicGlobs: string[]
 }
 
 export interface MiddlewareMatcher {
@@ -174,16 +174,18 @@ function getMiddlewareConfig(
     result.matchers = getMiddlewareMatchers(config.matcher, nextConfig)
   }
 
-  if (config.allowDynamic) {
-    result.allowDynamicGlobs = Array.isArray(config.allowDynamic)
-      ? config.allowDynamic
-      : [config.allowDynamic]
-    for (const glob of result.allowDynamicGlobs ?? []) {
+  if (config.unstable_allowDynamic) {
+    result.unstable_allowDynamicGlobs = Array.isArray(
+      config.unstable_allowDynamic
+    )
+      ? config.unstable_allowDynamic
+      : [config.unstable_allowDynamic]
+    for (const glob of result.unstable_allowDynamicGlobs ?? []) {
       try {
         matcher(glob)
       } catch (err) {
         throw new Error(
-          `${pageFilePath} exported 'config.allowDynamic' contains invalid pattern '${glob}': ${
+          `${pageFilePath} exported 'config.unstable_allowDynamic' contains invalid pattern '${glob}': ${
             (err as Error).message
           }`
         )
@@ -244,7 +246,7 @@ export async function getPageStaticInfo(params: {
 
   const fileContent = (await tryToReadFile(pageFilePath, !isDev)) || ''
   if (
-    /runtime|getStaticProps|getServerSideProps|matcher|allowDynamic/.test(
+    /runtime|getStaticProps|getServerSideProps|matcher|unstable_allowDynamic/.test(
       fileContent
     )
   ) {

--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -255,7 +255,7 @@ function isDynamicCodeEvaluationAllowed(
   rootDir?: string
 ) {
   const name = fileName.replace(rootDir ?? '', '')
-  return isMatch(name, edgeFunctionConfig?.allowDynamicGlobs ?? [])
+  return isMatch(name, edgeFunctionConfig?.unstable_allowDynamicGlobs ?? [])
 }
 
 function buildUnsupportedApiError({
@@ -694,7 +694,7 @@ function getExtractMetadata(params: {
             continue
           }
 
-          if (edgeFunctionConfig?.config?.allowDynamicGlobs) {
+          if (edgeFunctionConfig?.config?.unstable_allowDynamicGlobs) {
             telemetry.record({
               eventName: 'NEXT_EDGE_ALLOW_DYNAMIC_USED',
               payload: {

--- a/test/integration/edge-runtime-configurable-guards/test/index.test.js
+++ b/test/integration/edge-runtime-configurable-guards/test/index.test.js
@@ -63,7 +63,7 @@ describe('Edge runtime configurable guards', () => {
           return NextResponse.next()
         }
         export const config = {
-          allowDynamic: '/middleware.js'
+          unstable_allowDynamic: '/middleware.js'
         }
       `)
       context.api.write(`
@@ -73,7 +73,7 @@ describe('Edge runtime configurable guards', () => {
         }
         export const config = {
           runtime: 'experimental-edge',
-          allowDynamic: '/lib/**'
+          unstable_allowDynamic: '/lib/**'
         }
       `)
     })
@@ -126,7 +126,7 @@ describe('Edge runtime configurable guards', () => {
           }
           export const config = {
             runtime: 'experimental-edge',
-            allowDynamic: '**'
+            unstable_allowDynamic: '**'
           }
         `)
       },
@@ -143,7 +143,7 @@ describe('Edge runtime configurable guards', () => {
             return NextResponse.next()
           }
           export const config = {
-            allowDynamic: '**'
+            unstable_allowDynamic: '**'
           }
         `)
       },
@@ -160,7 +160,7 @@ describe('Edge runtime configurable guards', () => {
           }
           export const config = {
             runtime: 'experimental-edge',
-            allowDynamic: '/lib/**'
+            unstable_allowDynamic: '/lib/**'
           }
         `)
         context.lib.write(`
@@ -184,7 +184,7 @@ describe('Edge runtime configurable guards', () => {
             return NextResponse.next()
           }
           export const config = {
-            allowDynamic: '/lib/**'
+            unstable_allowDynamic: '/lib/**'
           }
         `)
         context.lib.write(`
@@ -222,7 +222,7 @@ describe('Edge runtime configurable guards', () => {
           }
           export const config = {
             runtime: 'experimental-edge',
-            allowDynamic: '**'
+            unstable_allowDynamic: '**'
           }
         `)
       },
@@ -241,7 +241,7 @@ describe('Edge runtime configurable guards', () => {
             return NextResponse.next()
           }
           export const config = {
-            allowDynamic: '**'
+            unstable_allowDynamic: '**'
           }
         `)
       },
@@ -258,7 +258,7 @@ describe('Edge runtime configurable guards', () => {
           }
           export const config = {
             runtime: 'experimental-edge',
-            allowDynamic: '/lib/**'
+            unstable_allowDynamic: '/lib/**'
           }
         `)
         context.lib.write(`
@@ -283,7 +283,7 @@ describe('Edge runtime configurable guards', () => {
             return NextResponse.next()
           }
           export const config = {
-            allowDynamic: '/lib/**'
+            unstable_allowDynamic: '/lib/**'
           }
         `)
         context.lib.write(`
@@ -329,7 +329,7 @@ describe('Edge runtime configurable guards', () => {
           }
           export const config = {
             runtime: 'experimental-edge',
-            allowDynamic: '/pages/**'
+            unstable_allowDynamic: '/pages/**'
           }
         `)
         context.lib.write(`
@@ -351,7 +351,7 @@ describe('Edge runtime configurable guards', () => {
             return NextResponse.next()
           }
           export const config = {
-            allowDynamic: '/pages/**'
+            unstable_allowDynamic: '/pages/**'
           }
         `)
         context.lib.write(`

--- a/test/production/edge-config-validations/index.test.ts
+++ b/test/production/edge-config-validations/index.test.ts
@@ -6,7 +6,7 @@ describe('Edge config validations', () => {
 
   afterAll(() => next.destroy())
 
-  it('fails to build when allowDynamic is not a string', async () => {
+  it('fails to build when unstable_allowDynamic is not a string', async () => {
     next = await createNext({
       skipStart: true,
       files: {
@@ -23,13 +23,13 @@ describe('Edge config validations', () => {
 
           eval('toto')
 
-          export const config = { allowDynamic: true }
+          export const config = { unstable_allowDynamic: true }
         `,
       },
     })
     await expect(next.start()).rejects.toThrow('next build failed')
     expect(next.cliOutput).toMatch(
-      `/middleware exported 'config.allowDynamic' contains invalid pattern 'true': Expected pattern to be a non-empty string`
+      `/middleware exported 'config.unstable_allowDynamic' contains invalid pattern 'true': Expected pattern to be a non-empty string`
     )
   })
 })


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/39539 as discussed this renames to `unstable_` prefix initially while we test this out further. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
