### PR TITLE
chore: use `link:` instead of `file:` in CONTRIBUTING.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -147,7 +147,7 @@ There are two options to develop with your local version of the codebase:
    with:
 
    ```json
-   "next": "file:/path/to/next.js/packages/next",
+   "next": "link:/path/to/next.js/packages/next",
    ```
 
 2. In your app's root directory, make sure to remove `next` from `node_modules` with:


### PR DESCRIPTION
Closes #40497

Ref: https://pnpm.io/cli/link, https://stackoverflow.com/a/70266777

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
