### PR TITLE
fix(cli): tune filter for extracting example `.tar`

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -122,7 +122,7 @@ export async function downloadAndExtractExample(root: string, name: string) {
     file: tempFile,
     cwd: root,
     strip: 3,
-    filter: (p) => p.includes(`next.js-canary/examples/${name}`),
+    filter: (p) => p.includes(`next.js-canary/examples/${name}/`),
   })
 
   await fs.unlink(tempFile)


### PR DESCRIPTION
As pointed out in https://github.com/vercel/next.js/issues/40389#issuecomment-1243039792, the `filter` matched more files than necessary and merged different example directories together. This change makes the filter match the example directory name precisely.

Fixes #40389

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
