### PR TITLE
Skip flakey AMP test for now

### DIFF
--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -489,7 +489,8 @@ describe('AMP Usage', () => {
       }
     })
 
-    it('should detect changes and refresh an AMP page at root pages/', async () => {
+    // TODO: investigate flakey failures on this test (Sept 13, 2022)
+    it.skip('should detect changes and refresh an AMP page at root pages/', async () => {
       let browser
       try {
         browser = await webdriver(dynamicAppPort, '/root-hmr')


### PR DESCRIPTION
Temporarily disables the flakey AMP test that has failed intermittently for a very long time now

x-ref: https://github.com/vercel/next.js/pull/40517#issuecomment-1245467668

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
