### PR TITLE
Update cms-makeswift example

### DIFF
--- a/examples/cms-makeswift/package.json
+++ b/examples/cms-makeswift/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@makeswift/runtime": "0.1.5",
+    "@makeswift/runtime": "0.1.10",
     "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
This upgrades @makeswift/runtime to the latest version, which adds support for the Slot control.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)
