### PR TITLE
fix: handle multiple `Set-Cookie` in `headers`

### DIFF
--- a/packages/next/server/server-route-utils.ts
+++ b/packages/next/server/server-route-utils.ts
@@ -91,7 +91,13 @@ export const createHeaderRoute = ({
           key = compileNonPath(key, params)
           value = compileNonPath(value, params)
         }
-        res.setHeader(key, value)
+        if (key === 'Set-Cookie') {
+          const previous = res.getHeader('Set-Cookie')
+          const cookies = [previous, value].filter(Boolean) as string[]
+          res.setHeader(`Set-Cookie`, cookies)
+        } else {
+          res.setHeader(key, value)
+        }
       }
       return { finished: false }
     },

--- a/packages/next/server/server-route-utils.ts
+++ b/packages/next/server/server-route-utils.ts
@@ -92,9 +92,7 @@ export const createHeaderRoute = ({
           value = compileNonPath(value, params)
         }
         if (key === 'Set-Cookie') {
-          const previous = res.getHeader('Set-Cookie')
-          const cookies = [previous, value].filter(Boolean) as string[]
-          res.setHeader(`Set-Cookie`, cookies)
+          res.appendHeader(`Set-Cookie`, value)
         } else {
           res.setHeader(key, value)
         }

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -14,7 +14,8 @@ module.exports = {
           : []),
         {
           source: '/to-websocket',
-          destination: 'http://localhost:45689/_next/webpack-hmr?page=/about',
+          destination:
+            'http://localhost:__EXTERNAL_PORT__/_next/webpack-hmr?page=/about',
         },
         {
           source: '/to-nowhere',

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  // target: 'serverless',
+  target: 'serverless',
   async rewrites() {
     // no-rewrites comment
     return {
@@ -14,8 +14,7 @@ module.exports = {
           : []),
         {
           source: '/to-websocket',
-          destination:
-            'http://localhost:__EXTERNAL_PORT__/_next/webpack-hmr?page=/about',
+          destination: 'http://localhost:45689/_next/webpack-hmr?page=/about',
         },
         {
           source: '/to-nowhere',
@@ -87,7 +86,7 @@ module.exports = {
         },
         {
           source: '/proxy-me/:path*',
-          destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
+          destination: 'http://localhost:45689/:path*',
         },
         {
           source: '/api-hello',
@@ -631,6 +630,19 @@ module.exports = {
           {
             key: 'x-is-host',
             value: 'yuuuup',
+          },
+        ],
+      },
+      {
+        source: '/multi-set-cookie',
+        headers: [
+          {
+            key: 'Set-Cookie',
+            value: 'firstCookie=cookie1; Path=/',
+          },
+          {
+            key: 'Set-Cookie',
+            value: 'secondCookie=cookie2; Path=/',
           },
         ],
       },

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  target: 'serverless',
+  // target: 'serverless',
   async rewrites() {
     // no-rewrites comment
     return {
@@ -86,7 +86,7 @@ module.exports = {
         },
         {
           source: '/proxy-me/:path*',
-          destination: 'http://localhost:45689/:path*',
+          destination: 'http://localhost:__EXTERNAL_PORT__/:path*',
         },
         {
           source: '/api-hello',

--- a/test/integration/custom-routes/pages/multi-set-cookie.js
+++ b/test/integration/custom-routes/pages/multi-set-cookie.js
@@ -1,0 +1,1 @@
+export default function Page() {}

--- a/test/integration/custom-routes/pages/multi-set-cookie.js
+++ b/test/integration/custom-routes/pages/multi-set-cookie.js
@@ -1,1 +1,3 @@
-export default function Page() {}
+export default function Page() {
+  return 'multi-set-cookie'
+}

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -1805,6 +1805,20 @@ const runTests = (isDev = false) => {
             regex: normalizeRegEx('^\\/has-header-4(?:\\/)?$'),
             source: '/has-header-4',
           },
+          {
+            headers: [
+              {
+                key: 'Set-Cookie',
+                value: 'firstCookie=cookie1; Path=/',
+              },
+              {
+                key: 'Set-Cookie',
+                value: 'secondCookie=cookie2; Path=/',
+              },
+            ],
+            regex: '^\\/multi-set-cookie(?:\\/)?$',
+            source: '/multi-set-cookie',
+          },
         ],
         rewrites: {
           beforeFiles: [
@@ -2196,6 +2210,12 @@ const runTests = (isDev = false) => {
             namedRegex: '^/multi\\-rewrites(?:/)?$',
             page: '/multi-rewrites',
             regex: '^/multi\\-rewrites(?:/)?$',
+            routeKeys: {},
+          },
+          {
+            namedRegex: '^/multi\\-set\\-cookie(?:/)?$',
+            page: '/multi-set-cookie',
+            regex: '^/multi\\-set\\-cookie(?:/)?$',
             routeKeys: {},
           },
           {

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -320,6 +320,13 @@ const runTests = (isDev = false) => {
     )
   })
 
+  it('should handle multiple Set-Cookie', async () => {
+    const res = await fetchViaHTTP(appPort, '/multi-set-cookie')
+    expect(res.headers.get('Set-Cookie')).toBe(
+      'firstCookie=cookie1; Path=/, secondCookie=cookie2; Path=/'
+    )
+  })
+
   it('should not match dynamic route immediately after applying header', async () => {
     const res = await fetchViaHTTP(appPort, '/blog/post-321')
     expect(res.headers.get('x-something')).toBe('applied-everywhere')


### PR DESCRIPTION
`res.setHeader`:
> Sets a value for the header overwriting existing values

This means that any previously set `Set-Cookie` header was overridden. Using `appendHeader` for `Set-Cookie` we can ensure that we concatenate with the already set value instead of overriding.

Fixes #40518

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The examples guidelines are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing.md#adding-examples)

fix NEXT-582 ([link](https://linear.app/vercel/issue/NEXT-582))