### PR TITLE
Fix edge wasm handling during deploy

### DIFF
--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -433,16 +433,18 @@ function getCodeAnalyzer(params: {
         return
       }
 
-      const { ConstDependency } = wp.dependencies
-      const dep1 = new ConstDependency(
-        '__next_webassembly_instantiate__(function() { return ',
-        expr.range[0]
-      )
-      dep1.loc = expr.loc
-      parser.state.module.addPresentationalDependency(dep1)
-      const dep2 = new ConstDependency('})', expr.range[1])
-      dep2.loc = expr.loc
-      parser.state.module.addPresentationalDependency(dep2)
+      if (dev) {
+        const { ConstDependency } = wp.dependencies
+        const dep1 = new ConstDependency(
+          '__next_webassembly_instantiate__(function() { return ',
+          expr.range[0]
+        )
+        dep1.loc = expr.loc
+        parser.state.module.addPresentationalDependency(dep1)
+        const dep2 = new ConstDependency('})', expr.range[1])
+        dep2.loc = expr.loc
+        parser.state.module.addPresentationalDependency(dep2)
+      }
     }
 
     /**


### PR DESCRIPTION
This fixes the WASM handling for edge during deploy as the sandbox context won't be present so we should keep this restricted to dev. No additional tests were added as our existing tests caught this. 

x-ref: https://github.com/vercel/next.js/pull/39539
Fixes: https://github.com/vercel/next.js/actions/runs/3049403049/jobs/4915784368

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

