### PR TITLE
Add vscode task config

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,11 +4,20 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Compile Next.js Core",
+      "label": "Compile Next.js Core (watch)",
       "type": "npm",
       "script": "dev",
       "options": {
         "cwd": "${workspaceFolder}/packages/next"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Build All Packages",
+      "type": "npm",
+      "script": "build",
+      "options": {
+        "cwd": "${workspaceFolder}"
       },
       "problemMatcher": []
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Compile Next.js Core",
+      "type": "npm",
+      "script": "dev",
+      "options": {
+        "cwd": "${workspaceFolder}/packages/next"
+      },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
Small change to add a specific task for Next.js compilation in vscode.

This can be triggered through `cmd + p` type in `task ` (including the spacebar) to open the task launcher. 
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
