### PR TITLE
Ensure smooth scroll is disabled for navigation in new and existing router

### DIFF
--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -164,7 +164,10 @@ export function InnerLayoutRouter({
       focusAndScrollElementRef.current.focus()
       // Only scroll into viewport when the layout is not visible currently.
       if (!topOfElementInViewport(focusAndScrollElementRef.current)) {
+        const htmlElement = document.querySelector('html')
+        if (htmlElement) htmlElement.style.scrollBehavior = 'auto'
         focusAndScrollElementRef.current.scrollIntoView()
+        if (htmlElement) htmlElement.style.scrollBehavior = ''
       }
     }
   }, [focusAndScrollRef])

--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -165,9 +165,10 @@ export function InnerLayoutRouter({
       // Only scroll into viewport when the layout is not visible currently.
       if (!topOfElementInViewport(focusAndScrollElementRef.current)) {
         const htmlElement = document.documentElement
+        const existing = htmlElement.style.scrollBehavior
         htmlElement.style.scrollBehavior = 'auto'
         focusAndScrollElementRef.current.scrollIntoView()
-        htmlElement.style.scrollBehavior = ''
+        htmlElement.style.scrollBehavior = existing
       }
     }
   }, [focusAndScrollRef])

--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -164,10 +164,10 @@ export function InnerLayoutRouter({
       focusAndScrollElementRef.current.focus()
       // Only scroll into viewport when the layout is not visible currently.
       if (!topOfElementInViewport(focusAndScrollElementRef.current)) {
-        const htmlElement = document.querySelector('html')
-        if (htmlElement) htmlElement.style.scrollBehavior = 'auto'
+        const htmlElement = document.documentElement
+        htmlElement.style.scrollBehavior = 'auto'
         focusAndScrollElementRef.current.scrollIntoView()
-        if (htmlElement) htmlElement.style.scrollBehavior = ''
+        htmlElement.style.scrollBehavior = ''
       }
     }
   }, [focusAndScrollRef])

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -688,7 +688,11 @@ function doRender(input: RenderRouteInfo): Promise<any> {
     }
 
     if (input.scroll) {
+      const htmlElement = document.documentElement
+      const existing = htmlElement.style.scrollBehavior
+      htmlElement.style.scrollBehavior = 'auto'
       window.scrollTo(input.scroll.x, input.scroll.y)
+      htmlElement.style.scrollBehavior = existing
     }
   }
 

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -655,6 +655,14 @@ interface FetchNextDataParams {
   unstable_skipClientCache?: boolean
 }
 
+function handleSmoothScroll(fn: () => void) {
+  const htmlElement = document.documentElement
+  const existing = htmlElement.style.scrollBehavior
+  htmlElement.style.scrollBehavior = 'auto'
+  fn()
+  htmlElement.style.scrollBehavior = existing
+}
+
 function tryToParseAsJSON(text: string) {
   try {
     return JSON.parse(text)
@@ -2141,7 +2149,7 @@ export default class Router implements BaseRouter {
     // Scroll to top if the hash is just `#` with no value or `#top`
     // To mirror browsers
     if (hash === '' || hash === 'top') {
-      window.scrollTo(0, 0)
+      handleSmoothScroll(() => window.scrollTo(0, 0))
       return
     }
 
@@ -2150,14 +2158,14 @@ export default class Router implements BaseRouter {
     // First we check if the element by id is found
     const idEl = document.getElementById(rawHash)
     if (idEl) {
-      idEl.scrollIntoView()
+      handleSmoothScroll(() => idEl.scrollIntoView())
       return
     }
     // If there's no element with the id, we check the `name` property
     // To mirror browsers
     const nameEl = document.getElementsByName(rawHash)[0]
     if (nameEl) {
-      nameEl.scrollIntoView()
+      handleSmoothScroll(() => nameEl.scrollIntoView())
     }
   }
 


### PR DESCRIPTION
Fixes a problem where navigation ends up smooth scrolling if the application sets scroll-behavior on `html`.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
