### PR TITLE
Attach module trace for RSC related errors

### DIFF
--- a/packages/next/client/dev/error-overlay/format-webpack-messages.js
+++ b/packages/next/client/dev/error-overlay/format-webpack-messages.js
@@ -44,7 +44,7 @@ function formatMessage(message, verbose) {
       message.moduleTrace &&
       message.moduleTrace.filter(
         (trace) =>
-          !/next-(middleware|client-pages|edge-function|flight-(client|server))-loader\.js/.test(
+          !/next-(middleware|client-pages|edge-function)-loader\.js/.test(
             trace.originName
           )
       )
@@ -62,7 +62,7 @@ function formatMessage(message, verbose) {
       (message.details && verbose ? '\n' + message.details : '') +
       (filteredModuleTrace && filteredModuleTrace.length && verbose
         ? '\n\nImport trace for requested module:' +
-          filteredModuleTrace.map((trace) => `\n${trace.originName}`).join('')
+          filteredModuleTrace.map((trace) => `\n${trace.moduleName}`).join('')
         : '') +
       (message.stack && verbose ? '\n' + message.stack : '')
   }
@@ -171,6 +171,17 @@ function formatMessage(message, verbose) {
 
 function formatWebpackMessages(json, verbose) {
   const formattedErrors = json.errors.map(function (message) {
+    // TODO: Shall we use invisible characters in the original error
+    // message as meta information?
+    if (
+      message &&
+      message.message &&
+      / (Client|Server) Components compilation\./.test(message.message)
+    ) {
+      // Comes from the "React Server Components" transform in SWC, always
+      // attach the module trace.
+      verbose = true
+    }
     return formatMessage(message, verbose)
   })
   const formattedWarnings = json.warnings.map(function (message) {


### PR DESCRIPTION
When the error comes from the RSC transform in SWC, we want to enforce the verbose mode because the module trace can be critical here. An example:

<img width="635" alt="CleanShot 2022-09-18 at 12 37 02@2x" src="https://user-images.githubusercontent.com/3676859/190898135-7b258ae1-64e4-4c7b-b4d3-b2e9d2ee0245.png">

Also in this PR I changed `trace.originName` to `trace.moduleName` in the output as the former can contain loader information and options:

```
Import trace for requested module:
./app/dashboard/index/page.js
../../../../packages/next/dist/build/webpack/loaders/next-app-loader.js?name=app%2Fdashboard%2Findex%2Fpage&appPaths=%2Fdashboard%2Findex%2Fpage&pagePath=private-next-app-dir%2Fdashboard%2Findex%2Fpage.js&appDir=%2FUsers%2Fshu%2FDocuments%2Fgit%2Fnext.js%2Ftest%2Fe2e%2Fapp-dir%2Fapp%2Fapp&pageExtensions=tsx&pageExtensions=server.tsx&pageExtensions=client.tsx&pageExtensions=ts&pageExtensions=server.ts&pageExtensions=client.ts&pageExtensions=jsx&pageExtensions=server.jsx&pageExtensions=client.jsx&pageExtensions=js&pageExtensions=server.js&pageExtensions=client.js!
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
