### PR TITLE
Send web vitals to Vercel analytics in app

### DIFF
--- a/packages/next/client/app-index.tsx
+++ b/packages/next/client/app-index.tsx
@@ -5,6 +5,8 @@ import ReactDOMClient from 'react-dom/client'
 import React from 'react'
 import { createFromReadableStream } from 'next/dist/compiled/react-server-dom-webpack'
 
+import measureWebVitals from './performance-relayer'
+
 /// <reference types="react-dom/experimental" />
 
 // Override chunk URL mapping in the webpack runtime
@@ -151,6 +153,10 @@ function ServerRoot({ cacheKey }: { cacheKey: string }) {
 }
 
 function Root({ children }: React.PropsWithChildren<{}>): React.ReactElement {
+  React.useEffect(() => {
+    measureWebVitals()
+  }, [])
+
   if (process.env.__NEXT_TEST_MODE) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {

--- a/packages/next/client/performance-relayer.ts
+++ b/packages/next/client/performance-relayer.ts
@@ -32,7 +32,7 @@ function onReport(metric: Metric): void {
     const body: Record<string, string> = {
       dsn: process.env.__NEXT_ANALYTICS_ID,
       id: metric.id,
-      page: window.__NEXT_DATA__.page,
+      page: window.__NEXT_DATA__?.page,
       href: initialHref,
       event_name: metric.name,
       value: metric.value.toString(),

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -29,6 +29,9 @@ describe('app dir', () => {
           'react-dom': 'experimental',
         },
         skipStart: true,
+        env: {
+          VERCEL_ANALYTICS_ID: 'fake-analytics-id',
+        },
       })
 
       if (assetPrefix) {
@@ -1451,6 +1454,40 @@ describe('app dir', () => {
           .map((x) => x.message)
           .join('\n')
         expect(errors).toInclude('Error during SSR')
+      })
+    })
+
+    // Analytics events are only sent in production
+    ;(isDev ? describe.skip : describe)('Vercel analytics', () => {
+      it('should send web vitals to Vercel analytics', async () => {
+        let eventsCount = 0
+        let countEvents = false
+        const browser = await webdriver(next.url, '/client-nested', {
+          beforePageLoad(page) {
+            page.route(
+              'https://vitals.vercel-insights.com/v1/vitals',
+              (route) => {
+                if (countEvents) {
+                  eventsCount += 1
+                }
+
+                route.fulfill()
+              }
+            )
+          },
+        })
+
+        // Start counting analytics events
+        countEvents = true
+
+        // Refresh will trigger CLS and LCP. When page loads FCP and TTFB will trigger:
+        await browser.refresh()
+
+        // After interaction LCP and FID will trigger
+        await browser.elementByCss('button').click()
+
+        // Make sure all registered events in performance-relayer has fired
+        await check(() => eventsCount, /6/)
       })
     })
 


### PR DESCRIPTION
Sends web vitals to Vercel analytics.

My plan for the test was to assert the data sent by the client but there's a bug where it's always null when sending a blob https://github.com/microsoft/playwright/issues/6479.

When adding support for a custom web vitals reporter it will be easier to assert the values sent by the reporter.