### PR TITLE
Add internal environment variable for production bundle

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -160,6 +160,7 @@ export function getDefineEnv({
     'process.env.__NEXT_TEST_MODE': JSON.stringify(
       process.env.__NEXT_TEST_MODE
     ),
+    'process.env.__NEXT_PROD_BUILD': JSON.stringify(!dev),
     // This is used in client/dev-error-overlay/hot-dev-client.js to replace the dist directory
     ...(dev && (isClient || isEdgeServer)
       ? {

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1397,7 +1397,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
           if (!isDataReq) {
             // Production already emitted the fallback as static HTML.
-            if (isProduction) {
+            if (isProduction || process.env.__NEXT_PROD_BUILD) {
               const html = await this.getFallback(
                 locale ? `/${locale}${pathname}` : pathname
               )

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -497,7 +497,7 @@ export async function renderToHTML(
 
   let asPath: string = renderOpts.resolvedAsPath || (req.url as string)
 
-  if (dev) {
+  if (dev && !process.env.__NEXT_PROD_BUILD) {
     const { isValidElementType } = require('next/dist/compiled/react-is')
     if (!isValidElementType(Component)) {
       throw new Error(


### PR DESCRIPTION
The Next.js server itself can be bundled by `next build` or `next dev`. In that case we can inject an internal environment variable to indicate if a condition can be DCE'd or not. cc @feedthejim 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
