### PR TITLE
Temporarily skip switchable runtime test on deploy

### DIFF
--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -37,6 +37,12 @@ describe('Switchable runtime', () => {
   let next: NextInstance
   let context
 
+  if ((global as any).isNextDeploy) {
+    // TODO-APP: re-enable after Prerenders are handled on deploy
+    it('should skip for deploy temporarily', () => {})
+    return
+  }
+
   beforeAll(async () => {
     next = await createNext({
       files: {


### PR DESCRIPTION
We can re-enable this after the necessary support has been landed in the builder. 

x-ref: https://github.com/vercel/next.js/actions/runs/3086118218/jobs/4990617168