### PR TITLE
Break assetPrefix app tests into separate suite

### DIFF
--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -8,10 +8,8 @@ module.exports = {
       algorithm: 'sha256',
     },
   },
-  // assetPrefix: '/assets',
   rewrites: async () => {
     return {
-      // beforeFiles: [ { source: '/assets/:path*', destination: '/:path*' } ],
       afterFiles: [
         {
           source: '/rewritten-to-dashboard',

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -1,0 +1,66 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
+import path from 'path'
+import cheerio from 'cheerio'
+import webdriver from 'next-webdriver'
+
+describe('app-dir assetPrefix handling', () => {
+  if ((global as any).isNextDeploy) {
+    it('should skip next deploy for now', () => {})
+    return
+  }
+
+  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
+    it('should skip for react v17', () => {})
+    return
+  }
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(path.join(__dirname, 'asset-prefix')),
+      dependencies: {
+        react: 'experimental',
+        'react-dom': 'experimental',
+      },
+      skipStart: true,
+    })
+
+    await next.start()
+  })
+  afterAll(() => next.destroy())
+
+  it('should redirect route when requesting it directly', async () => {
+    const res = await fetchViaHTTP(
+      next.url,
+      '/a/',
+      {},
+      {
+        redirect: 'manual',
+      }
+    )
+    expect(res.status).toBe(308)
+    expect(res.headers.get('location')).toBe(next.url + '/a')
+  })
+
+  it('should render link', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    const $ = cheerio.load(html)
+    expect($('#to-a-trailing-slash').attr('href')).toBe('/a')
+  })
+
+  it('should redirect route when requesting it directly by browser', async () => {
+    const browser = await webdriver(next.url, '/a')
+    expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
+  })
+
+  it('should redirect route when clicking link', async () => {
+    const browser = await webdriver(next.url, '/')
+    await browser
+      .elementByCss('#to-a-trailing-slash')
+      .click()
+      .waitForElementByCss('#a-page')
+    expect(await browser.waitForElementByCss('#a-page').text()).toBe('A page')
+  })
+})

--- a/test/e2e/app-dir/asset-prefix/app/a/page.js
+++ b/test/e2e/app-dir/asset-prefix/app/a/page.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+export default function HomePage() {
+  return (
+    <>
+      <h1 id="a-page">A page</h1>
+      <Link href="/">To home</Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/asset-prefix/app/layout.js
+++ b/test/e2e/app-dir/asset-prefix/app/layout.js
@@ -1,0 +1,10 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <head>
+        <title>Hello</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/asset-prefix/app/page.js
+++ b/test/e2e/app-dir/asset-prefix/app/page.js
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+export default function HomePage() {
+  return (
+    <>
+      <p>
+        <Link href="/a/">
+          <a id="to-a-trailing-slash">To a with trailing slash</a>
+        </Link>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/asset-prefix/next.config.js
+++ b/test/e2e/app-dir/asset-prefix/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+    serverComponents: true,
+    legacyBrowsers: false,
+    browsersListForSwc: true,
+  },
+  assetPrefix: '/assets',
+  rewrites() {
+    return {
+      beforeFiles: [{ source: '/assets/:path*', destination: '/:path*' }],
+    }
+  },
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -20,7 +20,7 @@ describe('app dir', () => {
   }
   let next: NextInstance
 
-  function runTests({ assetPrefix }: { assetPrefix?: boolean }) {
+  function runTests() {
     beforeAll(async () => {
       next = await createNext({
         files: new FileRef(path.join(__dirname, 'app')),
@@ -34,15 +34,6 @@ describe('app dir', () => {
         },
       })
 
-      if (assetPrefix) {
-        const content = await next.readFile('next.config.js')
-        await next.patchFile(
-          'next.config.js',
-          content
-            .replace('// assetPrefix', 'assetPrefix')
-            .replace('// beforeFiles', 'beforeFiles')
-        )
-      }
       await next.start()
     })
     afterAll(() => next.destroy())
@@ -1507,11 +1498,5 @@ describe('app dir', () => {
     })
   }
 
-  describe('without assetPrefix', () => {
-    runTests({})
-  })
-
-  describe('with assetPrefix', () => {
-    runTests({ assetPrefix: true })
-  })
+  runTests()
 })


### PR DESCRIPTION
As discussed in slack this breaks out the `assetPrefix` tests to a separate suite to speed up the main `app` suite. 

x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1663623560467579)