### PR TITLE
Remove dev fields and use environment variable instead

### DIFF
--- a/packages/next/server/api-utils/node.ts
+++ b/packages/next/server/api-utils/node.ts
@@ -424,7 +424,6 @@ export async function apiResolver(
   resolverModule: any,
   apiContext: ApiContext,
   propagateError: boolean,
-  dev?: boolean,
   page?: string
 ): Promise<void> {
   const apiReq = req as NextApiRequest
@@ -535,7 +534,7 @@ export async function apiResolver(
     if (err instanceof ApiError) {
       sendError(apiRes, err.statusCode, err.message)
     } else {
-      if (dev) {
+      if (process.env.NODE_ENV === 'development') {
         if (isError(err)) {
           err.page = page
         }

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -36,7 +36,6 @@ const ReactDOMServer = shouldUseReactRoot
 
 export type RenderOptsPartial = {
   err?: Error | null
-  dev?: boolean
   serverComponentManifest?: FlightManifest
   serverCSSManifest?: FlightCSSManifest
   supportsDynamicHTML?: boolean

--- a/packages/next/server/next.ts
+++ b/packages/next/server/next.ts
@@ -192,6 +192,19 @@ function createServer(options: NextServerOptions): NextServer {
     )
   }
 
+  if (
+    (options.dev && process.env.NODE_ENV === 'production') ||
+    (!options.dev && process.env.NODE_ENV === 'development')
+  ) {
+    console.warn(
+      `Warning: the "dev" is ${
+        options.dev ? 'enabled' : 'disabled'
+      }, but the NODE_ENV environment variable is set to "${
+        process.env.NODE_ENV
+      }", which could introduce unexpected behavior. https://nextjs.org/docs/messages/invalid-server-options`
+    )
+  }
+
   if (shouldUseReactRoot) {
     ;(process.env as any).__NEXT_REACT_ROOT = 'true'
   }


### PR DESCRIPTION
Trying to cover #40693 better here.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
