### PR TITLE
Add test case for /404 client transition

### DIFF
--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -97,6 +97,36 @@ describe('basePath', () => {
   afterAll(() => next.destroy())
 
   const runTests = (isDev = false, isDeploy = false) => {
+    it('should navigate to /404 correctly client-side', async () => {
+      const browser = await webdriver(next.url, `${basePath}/slug-1`)
+      await check(
+        () => browser.eval('document.documentElement.innerHTML'),
+        /slug-1/
+      )
+
+      await browser.eval('next.router.push("/404", "/slug-2")')
+      await check(
+        () => browser.eval('document.documentElement.innerHTML'),
+        /page could not be found/
+      )
+      expect(await browser.eval('location.pathname')).toBe(`${basePath}/slug-2`)
+    })
+
+    it('should navigate to /_error correctly client-side', async () => {
+      const browser = await webdriver(next.url, `${basePath}/slug-1`)
+      await check(
+        () => browser.eval('document.documentElement.innerHTML'),
+        /slug-1/
+      )
+
+      await browser.eval('next.router.push("/_error", "/slug-2")')
+      await check(
+        () => browser.eval('document.documentElement.innerHTML'),
+        /page could not be found/
+      )
+      expect(await browser.eval('location.pathname')).toBe(`${basePath}/slug-2`)
+    })
+
     it('should navigate to external site and back', async () => {
       const browser = await webdriver(next.url, `${basePath}/external-and-back`)
       const initialText = await browser.elementByCss('p').text()

--- a/test/e2e/basepath/pages/404.js
+++ b/test/e2e/basepath/pages/404.js
@@ -1,0 +1,5 @@
+import NextError from 'next/error'
+
+export default function Page() {
+  return <NextError statusCode={404} />
+}


### PR DESCRIPTION
This adds a test case verifying client transitions to `/404` or `/_error` are working properly. 

Test deployment with patched reproduction can be seen here https://router-bug-repro-4bozmev4p-ijjk-testing.vercel.app/blocked

Closes: https://github.com/vercel/next.js/issues/40667