### PR TITLE
Change flight querystring to header

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'http'
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'http'
 import type { LoadComponentsReturnType } from './load-components'
 import type { ServerRuntime } from '../types'
 
@@ -499,7 +499,7 @@ const FLIGHT_PARAMETERS = [
   '__flight_prefetch__',
 ] as const
 
-function headersWithoutFlight(headers: { [key: string]: string }) {
+function headersWithoutFlight(headers: IncomingHttpHeaders) {
   const newHeaders = { ...headers }
   for (const param of FLIGHT_PARAMETERS) {
     delete newHeaders[param]

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -493,6 +493,20 @@ function getScriptNonceFromHeader(cspHeaderValue: string): string | undefined {
   return nonce
 }
 
+const FLIGHT_PARAMETERS = [
+  '__flight__',
+  '__flight_router_state_tree__',
+  '__flight_prefetch__',
+] as const
+
+function headersWithoutFlight(headers: { [key: string]: string }) {
+  const newHeaders = { ...headers }
+  for (const param of FLIGHT_PARAMETERS) {
+    delete newHeaders[param]
+  }
+  return newHeaders
+}
+
 export async function renderToHTMLOrFlight(
   req: IncomingMessage,
   res: ServerResponse,
@@ -545,8 +559,8 @@ export async function renderToHTMLOrFlight(
       ComponentMod,
     } = renderOpts
 
-    const isFlight = query.__flight__ !== undefined
-    const isPrefetch = query.__flight_prefetch__ !== undefined
+    const isFlight = req.headers.__flight__ !== undefined
+    const isPrefetch = req.headers.__flight_prefetch__ !== undefined
 
     // Handle client-side navigation to pages directory
     if (isFlight && isPagesDir) {
@@ -569,8 +583,8 @@ export async function renderToHTMLOrFlight(
      * Router state provided from the client-side router. Used to handle rendering from the common layout down.
      */
     const providedFlightRouterState: FlightRouterState = isFlight
-      ? query.__flight_router_state_tree__
-        ? JSON.parse(query.__flight_router_state_tree__ as string)
+      ? req.headers.__flight_router_state_tree__
+        ? JSON.parse(req.headers.__flight_router_state_tree__ as string)
         : {}
       : undefined
 
@@ -584,7 +598,7 @@ export async function renderToHTMLOrFlight(
       | typeof import('../client/components/hot-reloader.client').default
       | null
 
-    const headers = req.headers
+    const headers = headersWithoutFlight(req.headers)
     // TODO-APP: fix type of req
     // @ts-expect-error
     const cookies = req.cookies

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1032,7 +1032,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
     // Don't delete query.__flight__ yet, it still needs to be used in renderToHTML later
     const isFlightRequest = Boolean(
-      this.serverComponentManifest && query.__flight__
+      this.serverComponentManifest && req.headers.__flight__
     )
 
     // we need to ensure the status code if /404 is visited directly

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -825,7 +825,7 @@ export default class NextNodeServer extends BaseServer {
 
     if (
       this.nextConfig.experimental.appDir &&
-      (renderOpts.isAppPath || query.__flight__)
+      (renderOpts.isAppPath || req.headers.__flight__)
     ) {
       const isPagesDir = !renderOpts.isAppPath
       return appRenderToHTMLOrFlight(
@@ -981,7 +981,6 @@ export default class NextNodeServer extends BaseServer {
                   __nextDataReq: query.__nextDataReq,
                   __nextLocale: query.__nextLocale,
                   __nextDefaultLocale: query.__nextDefaultLocale,
-                  __flight__: query.__flight__,
                 } as NextParsedUrlQuery)
               : query),
             // For appDir params is excluded.

--- a/test/e2e/app-dir/app/middleware.js
+++ b/test/e2e/app-dir/app/middleware.js
@@ -20,7 +20,7 @@ export function middleware(request) {
       : 'redirect'
 
     const internal = ['__flight__', '__flight_router_state_tree__']
-    if (internal.some((name) => request.nextUrl.searchParams.has(name))) {
+    if (internal.some((name) => request.headers.has(name))) {
       return NextResponse[method](new URL('/internal/failure', request.url))
     }
 

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -38,13 +38,28 @@ describe('app dir', () => {
     it('should use application/octet-stream for flight', async () => {
       const res = await fetchViaHTTP(
         next.url,
-        '/dashboard/deployments/123?__flight__'
+        '/dashboard/deployments/123',
+        {},
+        {
+          headers: {
+            __flight__: '1',
+          },
+        }
       )
       expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
     })
 
     it('should use application/octet-stream for flight with edge runtime', async () => {
-      const res = await fetchViaHTTP(next.url, '/dashboard?__flight__')
+      const res = await fetchViaHTTP(
+        next.url,
+        '/dashboard',
+        {},
+        {
+          headers: {
+            __flight__: '1',
+          },
+        }
+      )
       expect(res.headers.get('Content-Type')).toBe('application/octet-stream')
     })
 

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -94,7 +94,8 @@ describe('app dir - react server components', () => {
       '__nextDefaultLocale',
       '__nextIsNotFound',
       '__flight__',
-      '__flight_router_path__',
+      '__flight_router_state_tree__',
+      '__flight_prefetch__',
     ]
 
     const hasNextInternalQuery = inlineFlightContents.some((content) =>
@@ -110,11 +111,11 @@ describe('app dir - react server components', () => {
       beforePageLoad(page) {
         page.on('request', (request) => {
           requestsCount++
-          const url = request.url()
+          const headers = request.allHeaders()
           if (
-            url.includes('__flight__=1') &&
+            headers.__flight__ === '1' &&
             // Prefetches also include `__flight__`
-            !url.includes('__flight_prefetch__=1')
+            headers.__flight_prefetch__ !== '1'
           ) {
             hasFlightRequest = true
           }
@@ -215,11 +216,10 @@ describe('app dir - react server components', () => {
     const browser = await webdriver(next.url, '/root', {
       beforePageLoad(page) {
         page.on('request', (request) => {
-          const url = request.url()
+          const headers = request.allHeaders()
           if (
-            url.includes('__flight__=1') &&
-            // Prefetches also include `__flight__`
-            !url.includes('__flight_prefetch__=1')
+            headers.__flight__ === '1' &&
+            headers.__flight_prefetch__ !== '1'
           ) {
             hasFlightRequest = true
           }
@@ -336,7 +336,16 @@ describe('app dir - react server components', () => {
   })
 
   it('should support streaming for flight response', async () => {
-    await fetchViaHTTP(next.url, '/?__flight__=1').then(async (response) => {
+    await fetchViaHTTP(
+      next.url,
+      '/',
+      {},
+      {
+        headers: {
+          __flight__: '1',
+        },
+      }
+    ).then(async (response) => {
       const result = await resolveStreamResponse(response)
       expect(result).toContain('component:index.server')
     })

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -111,14 +111,15 @@ describe('app dir - react server components', () => {
       beforePageLoad(page) {
         page.on('request', (request) => {
           requestsCount++
-          const headers = request.allHeaders()
-          if (
-            headers.__flight__ === '1' &&
-            // Prefetches also include `__flight__`
-            headers.__flight_prefetch__ !== '1'
-          ) {
-            hasFlightRequest = true
-          }
+          return request.allHeaders().then((headers) => {
+            if (
+              headers.__flight__ === '1' &&
+              // Prefetches also include `__flight__`
+              headers.__flight_prefetch__ !== '1'
+            ) {
+              hasFlightRequest = true
+            }
+          })
         })
       },
     })
@@ -216,13 +217,14 @@ describe('app dir - react server components', () => {
     const browser = await webdriver(next.url, '/root', {
       beforePageLoad(page) {
         page.on('request', (request) => {
-          const headers = request.allHeaders()
-          if (
-            headers.__flight__ === '1' &&
-            headers.__flight_prefetch__ !== '1'
-          ) {
-            hasFlightRequest = true
-          }
+          return request.allHeaders().then((headers) => {
+            if (
+              headers.__flight__ === '1' &&
+              headers.__flight_prefetch__ !== '1'
+            ) {
+              hasFlightRequest = true
+            }
+          })
         })
       },
     })

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -119,9 +119,9 @@ describe('Switchable runtime', () => {
         const browser = await webdriver(context.appPort, '/node', {
           beforePageLoad(page) {
             page.on('request', (request) => {
-              const url = request.url()
-              if (/\?__flight__=1/.test(url)) {
-                flightRequest = url
+              const headers = request.allHeaders()
+              if (headers.__flight__ === '1') {
+                flightRequest = request.url()
               }
             })
           },
@@ -136,7 +136,7 @@ describe('Switchable runtime', () => {
           () => browser.eval('document.documentElement.innerHTML'),
           /This is a SSR RSC page/
         )
-        expect(flightRequest).toContain('/node-rsc-ssr?__flight__=1')
+        expect(flightRequest).toContain('/node-rsc-ssr')
       })
 
       it.skip('should support client side navigation to ssg rsc pages', async () => {
@@ -678,9 +678,9 @@ describe('Switchable runtime', () => {
         const browser = await webdriver(context.appPort, '/node', {
           beforePageLoad(page) {
             page.on('request', (request) => {
-              const url = request.url()
-              if (/\?__flight__=1/.test(url)) {
-                flightRequest = url
+              const headers = request.allHeaders()
+              if (headers.__flight__ === '1') {
+                flightRequest = request.url()
               }
             })
           },
@@ -691,7 +691,7 @@ describe('Switchable runtime', () => {
         expect(await browser.elementByCss('body').text()).toContain(
           'This is a SSR RSC page.'
         )
-        expect(flightRequest).toContain('/node-rsc-ssr?__flight__=1')
+        expect(flightRequest).toContain('/node-rsc-ssr')
       })
 
       it.skip('should support client side navigation to ssg rsc pages', async () => {

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -119,10 +119,11 @@ describe('Switchable runtime', () => {
         const browser = await webdriver(context.appPort, '/node', {
           beforePageLoad(page) {
             page.on('request', (request) => {
-              const headers = request.allHeaders()
-              if (headers.__flight__ === '1') {
-                flightRequest = request.url()
-              }
+              return request.allHeaders().then((headers) => {
+                if (headers.__flight__ === '1') {
+                  flightRequest = request.url()
+                }
+              })
             })
           },
         })
@@ -678,10 +679,11 @@ describe('Switchable runtime', () => {
         const browser = await webdriver(context.appPort, '/node', {
           beforePageLoad(page) {
             page.on('request', (request) => {
-              const headers = request.allHeaders()
-              if (headers.__flight__ === '1') {
-                flightRequest = request.url()
-              }
+              request.allHeaders().then((headers) => {
+                if (headers.__flight__ === '1') {
+                  flightRequest = request.url()
+                }
+              })
             })
           },
         })


### PR DESCRIPTION
Changes `__flight__=1` to be a header instead of a querystring parameter.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
