### PR TITLE
Skip copying next-swc debug files during testing

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -51,7 +51,8 @@ async function createNextInstall(
           !item.includes('node_modules') &&
           !item.includes('.DS_Store') &&
           // Exclude Rust compilation files
-          !/next[\\/]build[\\/]swc[\\/]target/.test(item)
+          !/next[\\/]build[\\/]swc[\\/]target/.test(item) &&
+          !/next-swc[\\/]target[\\/]debug/.test(item)
         )
       },
     })

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -52,7 +52,7 @@ async function createNextInstall(
           !item.includes('.DS_Store') &&
           // Exclude Rust compilation files
           !/next[\\/]build[\\/]swc[\\/]target/.test(item) &&
-          !/next-swc[\\/]target[\\/]debug/.test(item)
+          !/next-swc[\\/]target/.test(item)
         )
       },
     })


### PR DESCRIPTION
I have next-swc compiled locally inside the folder so there're a lot of files there (totally unexpected). And then the `fs.copy` takes 28433 ms... by filtering it out it's only 1s.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
