### PR TITLE
Remove unnecessary experimental flag

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -270,11 +270,7 @@ export default async function build(
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
       setGlobal('distDir', distDir)
 
-      // We enable concurrent features (Fizz-related rendering architecture) when
-      // using React 18 or experimental.
       const hasReactRoot = !!process.env.__NEXT_REACT_ROOT
-      const hasServerComponents =
-        hasReactRoot && !!config.experimental.serverComponents
 
       const { target } = config
       const buildId: string = await nextBuildSpan
@@ -814,7 +810,7 @@ export default async function build(
             BUILD_MANIFEST,
             PRERENDER_MANIFEST,
             path.join(SERVER_DIRECTORY, MIDDLEWARE_MANIFEST),
-            ...(hasServerComponents
+            ...(appDir
               ? [
                   path.join(SERVER_DIRECTORY, FLIGHT_MANIFEST + '.js'),
                   path.join(SERVER_DIRECTORY, FLIGHT_MANIFEST + '.json'),
@@ -912,10 +908,8 @@ export default async function build(
           let edgeServerResult: SingleCompilerResult | null = null
 
           if (isLikeServerless) {
-            if (config.experimental.serverComponents) {
-              throw new Error(
-                'Server Components are not supported in serverless mode.'
-              )
+            if (appDir) {
+              throw new Error('`appDir` is not supported in serverless mode.')
             }
 
             // Build client first
@@ -1357,7 +1351,7 @@ export default async function build(
                           pageRuntime,
                           edgeInfo,
                           pageType,
-                          hasServerComponents,
+                          hasServerComponents: !!appDir,
                         })
                       }
                     )

--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -118,7 +118,7 @@ function getBaseSWCOptions({
     modularizeImports: nextConfig?.experimental?.modularizeImports,
     relay: nextConfig?.compiler?.relay,
     emotion: getEmotionOptions(nextConfig, development),
-    serverComponents: nextConfig?.experimental?.serverComponents
+    serverComponents: nextConfig?.experimental?.appDir
       ? {
           isServer: !!isServerLayer,
         }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -544,22 +544,16 @@ export default async function getBaseWebpackConfig(
           '`experimental.runtime` requires React 18 to be installed.'
         )
       }
-      if (config.experimental.serverComponents) {
+      if (config.experimental.appDir) {
         throw new Error(
-          '`experimental.serverComponents` requires React 18 to be installed.'
+          '`experimental.appDir` requires React 18 to be installed.'
         )
       }
-    }
-    if (!config.experimental.appDir && config.experimental.serverComponents) {
-      throw new Error(
-        '`experimental.serverComponents` requires experimental.appDir to be enabled.'
-      )
     }
   }
 
   const hasConcurrentFeatures = hasReactRoot
-  const hasServerComponents =
-    hasConcurrentFeatures && !!config.experimental.serverComponents
+  const hasServerComponents = !!config.experimental.appDir
   const disableOptimizedLoading = hasConcurrentFeatures
     ? true
     : config.experimental.disableOptimizedLoading
@@ -1747,7 +1741,7 @@ export default async function getBaseWebpackConfig(
             } = require('./webpack/plugins/nextjs-require-cache-hot-reloader')
             const devPlugins = [
               new NextJsRequireCacheHotReloader({
-                hasServerComponents: config.experimental.serverComponents,
+                hasServerComponents,
               }),
             ]
 
@@ -1816,11 +1810,9 @@ export default async function getBaseWebpackConfig(
           },
         }),
       !!config.experimental.appDir &&
-        hasServerComponents &&
         isClient &&
         new AppBuildManifestPlugin({ dev }),
       hasServerComponents &&
-        !!config.experimental.appDir &&
         (isClient
           ? new FlightManifestPlugin({
               dev,

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -388,7 +388,7 @@ export default async function exportApp(
       nextScriptWorkers: nextConfig.experimental.nextScriptWorkers,
       optimizeFonts: nextConfig.optimizeFonts as FontConfig,
       largePageDataBytes: nextConfig.experimental.largePageDataBytes,
-      serverComponents: nextConfig.experimental.serverComponents,
+      serverComponents: !!nextConfig.experimental.appDir,
     }
 
     const { serverRuntimeConfig, publicRuntimeConfig } = nextConfig
@@ -613,7 +613,7 @@ export default async function exportApp(
               nextConfig.experimental.disableOptimizedLoading,
             parentSpanId: pageExportSpan.id,
             httpAgentOptions: nextConfig.httpAgentOptions,
-            serverComponents: nextConfig.experimental.serverComponents,
+            serverComponents: !!nextConfig.experimental.appDir,
             appPaths: options.appPaths || [],
           })
 

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -363,7 +363,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     this.buildId = this.getBuildId()
     this.minimalMode = minimalMode || !!process.env.NEXT_PRIVATE_MINIMAL_MODE
 
-    const serverComponents = this.nextConfig.experimental.serverComponents
+    const serverComponents = !!this.nextConfig.experimental.appDir
     this.serverComponentManifest = serverComponents
       ? this.getServerComponentManifest()
       : undefined

--- a/packages/next/server/config-schema.ts
+++ b/packages/next/server/config-schema.ts
@@ -342,9 +342,6 @@ const configSchema = {
         scrollRestoration: {
           type: 'boolean',
         },
-        serverComponents: {
-          type: 'boolean',
-        },
         sharedPool: {
           type: 'boolean',
         },

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -114,7 +114,6 @@ export interface ExperimentalConfig {
   esmExternals?: boolean | 'loose'
   isrMemoryCacheSize?: number
   runtime?: Exclude<ServerRuntime, undefined>
-  serverComponents?: boolean
   fullySpecified?: boolean
   urlImports?: NonNullable<webpack.Configuration['experiments']>['buildHttp']
   outputFileTracingRoot?: string

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -569,7 +569,6 @@ export const defaultConfig: NextConfig = {
     // default to 50MB limit
     isrMemoryCacheSize: 50 * 1024 * 1024,
     incrementalCacheHandlerPath: undefined,
-    serverComponents: false,
     fullySpecified: false,
     outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
     swcTraceProfiling: false,

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -217,8 +217,7 @@ export default class HotReloader {
 
     this.config = config
     this.hasReactRoot = !!process.env.__NEXT_REACT_ROOT
-    this.hasServerComponents =
-      this.hasReactRoot && !!config.experimental.serverComponents
+    this.hasServerComponents = this.hasReactRoot && !!config.experimental.appDir
     this.previewProps = previewProps
     this.rewrites = rewrites
     this.hotReloaderSpan = trace('hot-reloader', undefined, {

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -1347,11 +1347,9 @@ export default class DevServer extends Server {
         clientOnly: false,
       })
 
-      const serverComponents = this.nextConfig.experimental.serverComponents
-
       // When the new page is compiled, we need to reload the server component
       // manifest.
-      if (serverComponents) {
+      if (this.nextConfig.experimental.appDir) {
         this.serverComponentManifest = super.getServerComponentManifest()
         this.serverCSSManifest = super.getServerCSSManifest()
       }

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1003,12 +1003,12 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected getServerComponentManifest() {
-    if (!this.nextConfig.experimental.serverComponents) return undefined
+    if (!this.nextConfig.experimental.appDir) return undefined
     return require(join(this.distDir, 'server', FLIGHT_MANIFEST + '.json'))
   }
 
   protected getServerCSSManifest() {
-    if (!this.nextConfig.experimental.serverComponents) return undefined
+    if (!this.nextConfig.experimental.appDir) return undefined
     return require(join(
       this.distDir,
       'server',

--- a/test/e2e/app-dir/app-alias/next.config.js
+++ b/test/e2e/app-dir/app-alias/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    serverComponents: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
   },

--- a/test/e2e/app-dir/app-prefetch/next.config.js
+++ b/test/e2e/app-dir/app-prefetch/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    serverComponents: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
   },

--- a/test/e2e/app-dir/app-rendering/next.config.js
+++ b/test/e2e/app-dir/app-rendering/next.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   experimental: {
     appDir: true,
-    serverComponents: true,
   },
 }

--- a/test/e2e/app-dir/app-static/next.config.js
+++ b/test/e2e/app-dir/app-static/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    serverComponents: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
   },

--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    serverComponents: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
     sri: {

--- a/test/e2e/app-dir/asset-prefix/next.config.js
+++ b/test/e2e/app-dir/asset-prefix/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    serverComponents: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
   },

--- a/test/e2e/app-dir/rsc-basic/next.config.js
+++ b/test/e2e/app-dir/rsc-basic/next.config.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   experimental: {
     appDir: true,
-    serverComponents: true,
   },
   rewrites: async () => {
     return {

--- a/test/e2e/app-dir/trailingslash/next.config.js
+++ b/test/e2e/app-dir/trailingslash/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
-    serverComponents: true,
     legacyBrowsers: false,
     browsersListForSwc: true,
   },

--- a/test/e2e/switchable-runtime/next.config.js
+++ b/test/e2e/switchable-runtime/next.config.js
@@ -3,7 +3,6 @@ module.exports = {
   reactStrictMode: true,
   experimental: {
     appDir: true,
-    serverComponents: true,
   },
   async rewrites() {
     return {

--- a/test/integration/react-streaming/app/next.config.js
+++ b/test/integration/react-streaming/app/next.config.js
@@ -5,7 +5,6 @@ module.exports = {
   // },
   // pageExtensions: ['js', 'ts', 'jsx'], // .tsx won't be treat as page,
   experimental: {
-    // serverComponents: true,
     runtime: 'nodejs',
   },
 }

--- a/test/integration/react-streaming/unsupported-native-module/next.config.js
+++ b/test/integration/react-streaming/unsupported-native-module/next.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  experimental: {
-    serverComponents: true,
-  },
+  experimental: {},
 }


### PR DESCRIPTION
`config.experimental.serverComponents` is currently required to be enabled or disabled together with `config.experimental.appDir` (which means `serverComponents === appDir` otherwise it will throw) so there is no reason to keep both of them. This PR removes `serverComponents` from Next.js and only rely on `appDir` instead.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
