### PR TITLE
Update publish to scope as public for initializing

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -15,5 +15,8 @@
     "prepublishOnly": "cd ../../ && turbo run build",
     "dev": "tsc -d -w -p tsconfig.json",
     "typescript": "tsec --noEmit -p tsconfig.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
New scoped packages need to be initialized as public so this adds the `publishConfig` for this. 

Fixes: https://github.com/vercel/next.js/actions/runs/3101494786/jobs/5023375720