### PR TITLE
Update stats config for release stats

### DIFF
--- a/test/.stats-app/next.config.js
+++ b/test/.stats-app/next.config.js
@@ -1,9 +1,0 @@
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: !!process.env.TEST_ANALYZE,
-})
-
-module.exports = withBundleAnalyzer({
-  experimental: {
-    appDir: true,
-  },
-})

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -94,6 +94,7 @@ module.exports = {
             module.exports = {
               experimental: {
                 appDir: true,
+                serverComponents: true,
               },
               generateBuildId: () => 'BUILD_ID',
               webpack(config) {
@@ -118,6 +119,7 @@ module.exports = {
           module.exports = {
               experimental: {
                 appDir: true,
+                serverComponents: true,
               },
               generateBuildId: () => 'BUILD_ID'
             }


### PR DESCRIPTION
This keeps the necessary config for release stats for app dir 

x-ref: https://github.com/vercel/next.js/pull/40776
Fixes: https://github.com/vercel/next.js/actions/runs/3102008544/jobs/5025346767