### PR TITLE
docs: Remove extraneous FallbackComponent prop from error boundary docs

### DIFF
--- a/docs/advanced-features/error-handling.md
+++ b/docs/advanced-features/error-handling.md
@@ -88,7 +88,7 @@ import ErrorBoundary from '../components/ErrorBoundary'
 function MyApp({ Component, pageProps }) {
   return (
     // Wrap the Component prop with ErrorBoundary component
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <ErrorBoundary>
       <Component {...pageProps} />
     </ErrorBoundary>
   )


### PR DESCRIPTION
It looks like the code snippet was copied over from https://github.com/bvaughn/react-error-boundary but the `ErrorBoundary` component on this docs page does not have a `FallbackComponent` prop but renders the error message content itself.


## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
