### PR TITLE
Fix flaky full reload hmr tests

### DIFF
--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -793,13 +793,14 @@ describe('basic HMR', () => {
       )
       const newFileContent = currentFileContent.replace(
         '<p>hello world</p>',
-        '<p>hello world!!!</p>'
+        '<p id="updated">hello world!!!</p>'
       )
       await next.patchFile(
         './pages/hmr/anonymous-page-function.js',
         newFileContent
       )
-      await check(() => browser.elementByCss('p').text(), 'hello world!!!')
+
+      await browser.waitForElementByCss('#updated')
 
       // CLI warning and stacktrace
       expect(next.cliOutput.slice(start)).toContain(
@@ -834,9 +835,13 @@ describe('basic HMR', () => {
       const currentFileContent = await next.readFile(
         './pages/hmr/runtime-error.js'
       )
-      const newFileContent = currentFileContent.replace('whoops', '"whoops"')
+      const newFileContent = currentFileContent.replace(
+        'whoops',
+        '<p id="updated">whoops</p>'
+      )
       await next.patchFile('./pages/hmr/runtime-error.js', newFileContent)
-      await check(() => browser.elementByCss('body').text(), 'whoops')
+
+      await browser.waitForElementByCss('#updated')
 
       // CLI warning and stacktrace
       expect(next.cliOutput.slice(start)).toContain(

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -800,7 +800,9 @@ describe('basic HMR', () => {
         newFileContent
       )
 
-      await browser.waitForElementByCss('#updated')
+      expect(await browser.waitForElementByCss('#updated').text()).toBe(
+        'hello world!!!'
+      )
 
       // CLI warning and stacktrace
       expect(next.cliOutput.slice(start)).toContain(
@@ -841,7 +843,9 @@ describe('basic HMR', () => {
       )
       await next.patchFile('./pages/hmr/runtime-error.js', newFileContent)
 
-      await browser.waitForElementByCss('#updated')
+      expect(await browser.waitForElementByCss('#updated').text()).toBe(
+        'whoops'
+      )
 
       // CLI warning and stacktrace
       expect(next.cliOutput.slice(start)).toContain(


### PR DESCRIPTION
The issue seems to be that ` await check(() => browser.elementByCss('p').text(), 'hello world!!!')` sometimes tries to get `.text()` from the DOM before the full reload and it times out.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
