### PR TITLE
Add local font loader

### DIFF
--- a/packages/font/local/index.d.ts
+++ b/packages/font/local/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from '../dist/local/index'

--- a/packages/font/local/index.js
+++ b/packages/font/local/index.js
@@ -1,0 +1,1 @@
+throw new Error('@next/font/local is not correctly setup')

--- a/packages/font/local/loader.d.ts
+++ b/packages/font/local/loader.d.ts
@@ -1,0 +1,1 @@
+export { default } from '../dist/local/loader'

--- a/packages/font/local/loader.js
+++ b/packages/font/local/loader.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/local/loader')

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -7,7 +7,8 @@
   },
   "files": [
     "dist",
-    "google"
+    "google",
+    "local"
   ],
   "license": "MIT",
   "scripts": {

--- a/packages/font/src/google/index.ts
+++ b/packages/font/src/google/index.ts
@@ -1,4 +1,4 @@
-import type { FontModule } from 'next'
+import type { FontModule } from 'next/font'
 type Display = 'auto' | 'block' | 'swap' | 'fallback' | 'optional'
 export declare function ABeeZee(options: {
   variant: '400' | '400-italic'

--- a/packages/font/src/google/index.ts
+++ b/packages/font/src/google/index.ts
@@ -1,9 +1,5 @@
+import type { FontModule } from 'next'
 type Display = 'auto' | 'block' | 'swap' | 'fallback' | 'optional'
-type FontModule = {
-  className: string
-  variable: string
-  style: { fontFamily: string; fontWeight?: number; fontStyle?: string }
-}
 export declare function ABeeZee(options: {
   variant: '400' | '400-italic'
   display?: Display

--- a/packages/font/src/google/loader.ts
+++ b/packages/font/src/google/loader.ts
@@ -1,4 +1,4 @@
-import type { FontLoader } from 'next'
+import type { FontLoader } from 'next/font'
 // @ts-ignore
 import fetch from 'next/dist/compiled/node-fetch'
 // @ts-ignore

--- a/packages/font/src/google/loader.ts
+++ b/packages/font/src/google/loader.ts
@@ -1,3 +1,4 @@
+import type { FontLoader } from 'next'
 // @ts-ignore
 import fetch from 'next/dist/compiled/node-fetch'
 // @ts-ignore
@@ -9,19 +10,12 @@ import {
   validateData,
 } from './utils'
 
-type FontLoaderOptions = {
-  functionName: string
-  data: any[]
-  config: any
-  emitFontFile: (content: Buffer, ext: string, preload: boolean) => string
-}
-
-export default async function downloadGoogleFonts({
+const downloadGoogleFonts: FontLoader = async ({
   functionName,
   data,
   config,
   emitFontFile,
-}: FontLoaderOptions) {
+}) => {
   if (!config?.subsets) {
     throw new Error(
       'Please specify subsets for `@next/font/google` in your `next.config.js`'
@@ -119,3 +113,5 @@ export default async function downloadGoogleFonts({
     fallbackFonts: fallback,
   }
 }
+
+export default downloadGoogleFonts

--- a/packages/font/src/local/index.ts
+++ b/packages/font/src/local/index.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { FontModule } from 'next'
+type Display = 'auto' | 'block' | 'swap' | 'fallback' | 'optional'
+type LocalFont = {
+  src: string | Array<{ file: string; unicodeRange: string }>
+  display?: Display
+  weight?: string
+  style?: string
+  fallback?: string[]
+  preload?: boolean
+
+  ascentOverride?: string
+  descentOverride?: string
+  fontStretch?: string
+  fontVariant?: string
+  fontFeatureSettings?: string
+  fontVariationSettings?: string
+  lineGapOverride?: string
+  sizeAdjust?: string
+}
+
+export default function localFont(options: LocalFont): FontModule {
+  throw new Error()
+}

--- a/packages/font/src/local/index.ts
+++ b/packages/font/src/local/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { FontModule } from 'next'
+import type { FontModule } from 'next/font'
 type Display = 'auto' | 'block' | 'swap' | 'fallback' | 'optional'
 type LocalFont = {
   src: string | Array<{ file: string; unicodeRange: string }>

--- a/packages/font/src/local/loader.ts
+++ b/packages/font/src/local/loader.ts
@@ -1,4 +1,4 @@
-import type { FontLoader } from 'next'
+import type { FontLoader } from 'next/font'
 
 import { promisify } from 'util'
 import { validateData } from './utils'

--- a/packages/font/src/local/loader.ts
+++ b/packages/font/src/local/loader.ts
@@ -1,0 +1,67 @@
+import type { FontLoader } from 'next'
+
+import { promisify } from 'util'
+import { validateData } from './utils'
+
+const fetchFonts: FontLoader = async ({
+  functionName,
+  data,
+  emitFontFile,
+  resolve,
+  fs,
+}) => {
+  const {
+    family,
+    files,
+    display,
+    weight,
+    style,
+    fallback,
+    preload,
+    ascentOverride,
+    descentOverride,
+    lineGapOverride,
+    fontStretch,
+    fontFeatureSettings,
+    sizeAdjust,
+  } = validateData(functionName, data)
+
+  const fontFaces = await Promise.all(
+    files.map(async ({ file, ext, format, unicodeRange }) => {
+      const resolved = await resolve(file)
+      const fileBuffer = await promisify(fs.readFile)(resolved)
+
+      const fontUrl = emitFontFile(fileBuffer, ext, preload)
+
+      const fontFaceProperties = [
+        ['font-family', `'${family}'`],
+        ['src', `url(${fontUrl}) format('${format}')`],
+        ['font-display', display],
+        ...(weight ? [['font-weight', weight]] : []),
+        ...(style ? [['font-style', style]] : []),
+        ...(ascentOverride ? [['ascent-override', ascentOverride]] : []),
+        ...(descentOverride ? [['descent-override', descentOverride]] : []),
+        ...(lineGapOverride ? [['line-gap-override', lineGapOverride]] : []),
+        ...(fontStretch ? [['font-stretch', fontStretch]] : []),
+        ...(fontFeatureSettings
+          ? [['font-feature-settings', fontFeatureSettings]]
+          : []),
+        ...(sizeAdjust ? [['size-adjust', sizeAdjust]] : []),
+        ...(unicodeRange ? [['unicode-range', unicodeRange]] : ''),
+      ]
+
+      return `@font-face {
+${fontFaceProperties
+  .map(([property, value]) => `${property}: ${value};`)
+  .join('\n')}
+}`
+    })
+  )
+
+  return {
+    css: fontFaces.join('\n'),
+    fallbackFonts: fallback,
+  }
+}
+
+export default fetchFonts

--- a/packages/font/src/local/utils.ts
+++ b/packages/font/src/local/utils.ts
@@ -17,21 +17,21 @@ type FontOptions = {
     file: string
     ext: string
     format: string
-    unicodeRange: string
+    unicodeRange?: string
   }>
   display: string
-  weight: string
-  style: string
+  weight?: string
+  style?: string
   fallback?: string[]
   preload: boolean
-  ascentOverride: string
-  descentOverride: string
-  fontStretch: string
-  fontVariant: string
-  fontFeatureSettings: string
-  fontVariationSettings: string
-  lineGapOverride: string
-  sizeAdjust: string
+  ascentOverride?: string
+  descentOverride?: string
+  fontStretch?: string
+  fontVariant?: string
+  fontFeatureSettings?: string
+  fontVariationSettings?: string
+  lineGapOverride?: string
+  sizeAdjust?: string
 }
 export function validateData(functionName: string, data: any): FontOptions {
   if (functionName) {

--- a/packages/font/src/local/utils.ts
+++ b/packages/font/src/local/utils.ts
@@ -1,0 +1,112 @@
+const allowedDisplayValues = ['auto', 'block', 'swap', 'fallback', 'optional']
+
+const formatValues = (values: string[]) =>
+  values.map((val) => `\`${val}\``).join(', ')
+
+const extToFormat = {
+  woff: 'woff',
+  woff2: 'woff2',
+  ttf: 'truetype',
+  otf: 'opentype',
+  eot: 'embedded-opentype',
+}
+
+type FontOptions = {
+  family: string
+  files: Array<{
+    file: string
+    ext: string
+    format: string
+    unicodeRange: string
+  }>
+  display: string
+  weight: string
+  style: string
+  fallback?: string[]
+  preload: boolean
+  ascentOverride: string
+  descentOverride: string
+  fontStretch: string
+  fontVariant: string
+  fontFeatureSettings: string
+  fontVariationSettings: string
+  lineGapOverride: string
+  sizeAdjust: string
+}
+export function validateData(functionName: string, data: any): FontOptions {
+  if (functionName) {
+    throw new Error(`@next/font/local has no named exports`)
+  }
+  let {
+    src,
+    display = 'optional',
+    weight,
+    style,
+    fallback,
+    preload = true,
+    ascentOverride,
+    descentOverride,
+    fontStretch,
+    fontVariant,
+    fontFeatureSettings,
+    fontVariationSettings,
+    lineGapOverride,
+    sizeAdjust,
+  } = data[0] || ({} as any)
+
+  if (!allowedDisplayValues.includes(display)) {
+    throw new Error(
+      `Invalid display value \`${display}\`.\nAvailable display values: ${formatValues(
+        allowedDisplayValues
+      )}`
+    )
+  }
+
+  const srcArray = Array.isArray(src) ? src : [{ file: src }]
+
+  if (srcArray.length === 0) {
+    throw new Error('Src must contain one or more files')
+  }
+
+  const files = srcArray.map(({ file, unicodeRange }) => {
+    if (!file) {
+      throw new Error('Src array objects must have a `file` property')
+    }
+    if (srcArray.length > 1 && !unicodeRange) {
+      throw new Error(
+        "Files must have a unicode-range if there's more than one"
+      )
+    }
+
+    const ext = /\.(woff|woff2|eot|ttf|otf)$/.exec(file)?.[1]
+    if (!ext) {
+      throw new Error(`Unexpected file \`${file}\``)
+    }
+    return {
+      file,
+      unicodeRange,
+      ext,
+      format: extToFormat[ext as 'woff' | 'woff2' | 'eot' | 'ttf' | 'otf'],
+    }
+  })
+
+  const family = /.+\/(.+?)\./.exec(files[0].file)![1]
+
+  return {
+    family,
+    files,
+    display,
+    weight,
+    style,
+    fallback,
+    preload,
+    ascentOverride,
+    descentOverride,
+    fontStretch,
+    fontVariant,
+    fontFeatureSettings,
+    fontVariationSettings,
+    lineGapOverride,
+    sizeAdjust,
+  }
+}

--- a/packages/font/tsconfig.json
+++ b/packages/font/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "resolveJsonModule": true,
     "module": "commonjs",
     "esModuleInterop": true,

--- a/packages/font/tsconfig.json
+++ b/packages/font/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "resolveJsonModule": true,
     "module": "commonjs",
     "esModuleInterop": true,

--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -36,7 +36,6 @@ use serde::Deserialize;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::{path::PathBuf, sync::Arc};
-use swc_core::ecma::atoms::JsWord;
 
 use swc_core::{
     base::config::ModuleConfig,
@@ -113,7 +112,7 @@ pub struct TransformOptions {
     pub modularize_imports: Option<modularize_imports::Config>,
 
     #[serde(default)]
-    pub font_loaders: Option<Vec<JsWord>>,
+    pub font_loaders: Option<next_font_loaders::Config>,
 }
 
 pub fn custom_before_pass<'a, C: Comments + 'a>(
@@ -218,10 +217,9 @@ where
             None => Either::Right(noop()),
         },
         match &opts.font_loaders {
-            Some(font_loaders) =>
-                Either::Left(next_font_loaders::next_font_loaders(font_loaders.clone())),
+            Some(config) => Either::Left(next_font_loaders::next_font_loaders(config.clone())),
             None => Either::Right(noop()),
-        }
+        },
     )
 }
 

--- a/packages/next-swc/crates/core/src/next_font_loaders/font_imports_generator.rs
+++ b/packages/next-swc/crates/core/src/next_font_loaders/font_imports_generator.rs
@@ -7,6 +7,7 @@ use swc_core::ecma::visit::{noop_visit_type, Visit};
 
 pub struct FontImportsGenerator<'a> {
     pub state: &'a mut super::State,
+    pub relative_path: &'a str,
 }
 
 impl<'a> FontImportsGenerator<'a> {
@@ -41,7 +42,7 @@ impl<'a> FontImportsGenerator<'a> {
                             Some(function) => String::from(&**function),
                             None => String::new(),
                         };
-                        let mut values = vec![function_name];
+                        let mut values = vec![self.relative_path.to_string(), function_name];
                         values.append(&mut json_values);
 
                         return Some(ImportDecl {

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -1,6 +1,8 @@
 use next_swc::{
-    disallow_re_export_all_in_page::disallow_re_export_all_in_page, next_dynamic::next_dynamic,
-    next_font_loaders::next_font_loaders, next_ssg::next_ssg,
+    disallow_re_export_all_in_page::disallow_re_export_all_in_page,
+    next_dynamic::next_dynamic,
+    next_font_loaders::{next_font_loaders, Config as FontLoaderConfig},
+    next_ssg::next_ssg,
     react_server_components::server_components,
 };
 use std::path::PathBuf;
@@ -101,7 +103,12 @@ fn next_font_loaders_errors(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
     test_fixture_allowing_error(
         syntax(),
-        &|_tr| next_font_loaders(vec!["@next/font/google".into(), "cool-fonts".into()]),
+        &|_tr| {
+            next_font_loaders(FontLoaderConfig {
+                relative_file_path_from_root: "pages/test.tsx".into(),
+                font_loaders: vec!["@next/font/google".into(), "cool-fonts".into()],
+            })
+        },
         &input,
         &output,
     );

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/not-const/output.js
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/not-const/output.js
@@ -1,4 +1,4 @@
-import inter1 from '@next/font/google?Inter;{"variant":"400"}';
-import inter2 from '@next/font/google?Inter;{"variant":"400"}';
+import inter1 from '@next/font/google?pages/test.tsx;Inter;{"variant":"400"}';
+import inter2 from '@next/font/google?pages/test.tsx;Inter;{"variant":"400"}';
 var i = 10;
 var i2 = 20;

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/options-object/output.js
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/options-object/output.js
@@ -1,7 +1,7 @@
-import a from "@next/font/google?ABeeZee;{}";
-import a from "@next/font/google?ABeeZee;{}";
-import a from "@next/font/google?ABeeZee;{}";
-import a from "@next/font/google?ABeeZee;{}";
+import a from "@next/font/google?pages/test.tsx;ABeeZee;{}";
+import a from "@next/font/google?pages/test.tsx;ABeeZee;{}";
+import a from "@next/font/google?pages/test.tsx;ABeeZee;{}";
+import a from "@next/font/google?pages/test.tsx;ABeeZee;{}";
 const a = fn({
     10: 'hello'
 });

--- a/packages/next-swc/crates/core/tests/errors/next-font-loaders/spread-arg/output.js
+++ b/packages/next-swc/crates/core/tests/errors/next-font-loaders/spread-arg/output.js
@@ -1,2 +1,2 @@
-import inter from "@next/font/google?Inter;{};[]";
+import inter from "@next/font/google?pages/test.tsx;Inter;{};[]";
 const a = fn(...{}, ...[]);

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -1,7 +1,7 @@
 use next_swc::{
     amp_attributes::amp_attributes,
     next_dynamic::next_dynamic,
-    next_font_loaders::next_font_loaders,
+    next_font_loaders::{next_font_loaders, Config as FontLoaderConfig},
     next_ssg::next_ssg,
     page_config::page_config_test,
     react_remove_properties::remove_properties,
@@ -255,7 +255,12 @@ fn next_font_loaders_fixture(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
     test_fixture(
         syntax(),
-        &|_tr| next_font_loaders(vec!["@next/font/google".into(), "cool-fonts".into()]),
+        &|_tr| {
+            next_font_loaders(FontLoaderConfig {
+                relative_file_path_from_root: "pages/test.tsx".into(),
+                font_loaders: vec!["@next/font/google".into(), "cool-fonts".into()],
+            })
+        },
         &input,
         &output,
     );

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/default-import/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/default-import/output.js
@@ -1,1 +1,1 @@
-import font from 'cool-fonts?;{"prop":true}';
+import font from 'cool-fonts?pages/test.tsx;;{"prop":true}';

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/exports/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/exports/output.js
@@ -1,5 +1,5 @@
-import firaCode from "@next/font/google?Abel";
-import inter from "@next/font/google?Inter";
+import firaCode from "@next/font/google?pages/test.tsx;Abel";
+import inter from "@next/font/google?pages/test.tsx;Inter";
 import React from 'react';
 export { firaCode };
 export default inter;

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/font-options/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/font-options/output.js
@@ -1,3 +1,3 @@
-import firaCode from '@next/font/google?Fira_Code;{"fallback":["system-ui",{"key":false},[]],"key":{"key2":{}},"preload":true,"variant":"400"}';
+import firaCode from '@next/font/google?pages/test.tsx;Fira_Code;{"fallback":["system-ui",{"key":false},[]],"key":{"key2":{}},"preload":true,"variant":"400"}';
 import React from 'react';
 console.log(firaCode);

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/import-as/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/import-as/output.js
@@ -1,2 +1,2 @@
-import acme1 from 'cool-fonts?Acme;{"variant":"400"}';
+import acme1 from 'cool-fonts?pages/test.tsx;Acme;{"variant":"400"}';
 import React from 'react';

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/many-args/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/many-args/output.js
@@ -1,1 +1,1 @@
-import geo from '@next/font/google?Geo;"test";[1.0];{"a":2.0};3.0';
+import geo from '@next/font/google?pages/test.tsx;Geo;"test";[1.0];{"a":2.0};3.0';

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-calls/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-calls/output.js
@@ -1,3 +1,3 @@
-import inter from '@next/font/google?Inter;{"display":"swap","variant":"900"}';
-import inter from '@next/font/google?Inter;{"display":"swap","variant":"900"}';
+import inter from '@next/font/google?pages/test.tsx;Inter;{"display":"swap","variant":"900"}';
+import inter from '@next/font/google?pages/test.tsx;Inter;{"display":"swap","variant":"900"}';
 import React from 'react';

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-font-downloaders/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-font-downloaders/output.js
@@ -1,3 +1,3 @@
-import inter from '@next/font/google?Inter;{"variant":"900"}';
-import fira from 'cool-fonts?Fira_Code;{"display":"swap","variant":"400"}';
+import inter from '@next/font/google?pages/test.tsx;Inter;{"variant":"900"}';
+import fira from 'cool-fonts?pages/test.tsx;Fira_Code;{"display":"swap","variant":"400"}';
 import React from 'react';

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-fonts/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-fonts/output.js
@@ -1,3 +1,3 @@
-import firaCode from '@next/font/google?Fira_Code;{"fallback":["system-ui"],"variant":"400"}';
-import inter from '@next/font/google?Inter;{"display":"swap","variant":"900"}';
+import firaCode from '@next/font/google?pages/test.tsx;Fira_Code;{"fallback":["system-ui"],"variant":"400"}';
+import inter from '@next/font/google?pages/test.tsx;Inter;{"display":"swap","variant":"900"}';
 import React from 'react';

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-imports/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/multiple-imports/output.js
@@ -1,3 +1,3 @@
-import inter from '@next/font/google?Inter;{"variant":"900"}';
-import fira from '@next/font/google?Fira_Code;{"display":"swap","variant":"400"}';
+import inter from '@next/font/google?pages/test.tsx;Inter;{"variant":"900"}';
+import fira from '@next/font/google?pages/test.tsx;Fira_Code;{"display":"swap","variant":"400"}';
 import React from 'react';

--- a/packages/next-swc/crates/core/tests/fixture/next-font-loaders/no-args/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/next-font-loaders/no-args/output.js
@@ -1,1 +1,1 @@
-import fira from "@next/font/google?Fira_Code";
+import fira from "@next/font/google?pages/test.tsx;Fira_Code";

--- a/packages/next/build/swc/options.js
+++ b/packages/next/build/swc/options.js
@@ -33,6 +33,7 @@ function getBaseSWCOptions({
   jsConfig,
   swcCacheDir,
   isServerLayer,
+  relativeFilePathFromRoot,
 }) {
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
@@ -124,8 +125,12 @@ function getBaseSWCOptions({
         }
       : false,
     fontLoaders:
-      nextConfig?.experimental?.fontLoaders &&
-      Object.keys(nextConfig.experimental.fontLoaders),
+      nextConfig?.experimental?.fontLoaders && relativeFilePathFromRoot
+        ? {
+            fontLoaders: Object.keys(nextConfig.experimental.fontLoaders),
+            relativeFilePathFromRoot,
+          }
+        : null,
   }
 }
 
@@ -220,6 +225,7 @@ export function getLoaderSWCOptions({
   jsConfig,
   supportedBrowsers,
   swcCacheDir,
+  relativeFilePathFromRoot,
   // This is not passed yet as "paths" resolving is handled by webpack currently.
   // resolvedBaseUrl,
 }) {
@@ -233,6 +239,7 @@ export function getLoaderSWCOptions({
     // resolvedBaseUrl,
     swcCacheDir,
     isServerLayer,
+    relativeFilePathFromRoot,
   })
 
   const isNextDist = nextDistPath.test(filename)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -646,6 +646,7 @@ export default async function getBaseWebpackConfig(
           loader: 'next-swc-loader',
           options: {
             isServer: isNodeServer || isEdgeServer,
+            rootDir: dir,
             pagesDir,
             hasReactRefresh: dev && isClient,
             fileReading: config.experimental.swcFileReading,

--- a/packages/next/build/webpack/loaders/next-font-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-font-loader/index.ts
@@ -1,13 +1,10 @@
+import type { FontLoader } from '../../../../types'
+
 import path from 'path'
 import loaderUtils from 'next/dist/compiled/loader-utils3'
 import postcssFontLoaderPlugn from './postcss-font-loader'
-
-type FontLoader = (options: {
-  functionName: string
-  data: any[]
-  config: any
-  emitFontFile: (content: Buffer, ext: string, preload: boolean) => string
-}) => Promise<{ css: string; fallbackFonts: string[] }>
+import { promisify } from 'util'
+import chalk from 'next/dist/compiled/chalk'
 
 export default async function nextFontLoader(this: any) {
   const fontLoaderSpan = this.currentTraceSpan.traceChild('next-font-loader')
@@ -36,7 +33,9 @@ export default async function nextFontLoader(this: any) {
     }
 
     // next-swc next_font_loaders turns each function call argument into JSON seperated by semicolons
-    let [functionName, ...data] = this.resourceQuery.slice(1).split(';')
+    let [relativeFilePathFromRoot, functionName, ...data] = this.resourceQuery
+      .slice(1)
+      .split(';')
     data = data.map((value: string) => JSON.parse(value))
 
     try {
@@ -49,6 +48,12 @@ export default async function nextFontLoader(this: any) {
         data,
         config: fontLoaderOptions,
         emitFontFile,
+        resolve: (src: string) =>
+          promisify(this.resolve)(
+            path.dirname(path.join(this.rootContext, relativeFilePathFromRoot)),
+            src
+          ),
+        fs: this.fs,
       })
 
       const { postcss } = await getPostcss()
@@ -77,6 +82,9 @@ export default async function nextFontLoader(this: any) {
       callback(null, result.css, null, { exports, ast, fontFamilyHash })
     } catch (err: any) {
       err.stack = false
+      err.message += `
+
+${chalk.cyan(`Location: ${relativeFilePathFromRoot}`)}`
       callback(err)
     }
   })

--- a/packages/next/build/webpack/loaders/next-font-loader/index.ts
+++ b/packages/next/build/webpack/loaders/next-font-loader/index.ts
@@ -1,4 +1,4 @@
-import type { FontLoader } from '../../../../types'
+import type { FontLoader } from '../../../../font'
 
 import path from 'path'
 import loaderUtils from 'next/dist/compiled/loader-utils3'

--- a/packages/next/build/webpack/loaders/next-swc-loader.js
+++ b/packages/next/build/webpack/loaders/next-swc-loader.js
@@ -28,7 +28,7 @@ DEALINGS IN THE SOFTWARE.
 
 import { isWasm, transform } from '../../swc'
 import { getLoaderSWCOptions } from '../../swc/options'
-import { isAbsolute } from 'path'
+import path, { isAbsolute } from 'path'
 
 async function loaderTransform(parentTrace, source, inputSourceMap) {
   // Make the loader async
@@ -39,6 +39,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
   const {
     isServer,
     isServerLayer,
+    rootDir,
     pagesDir,
     hasReactRefresh,
     nextConfig,
@@ -47,6 +48,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
     swcCacheDir,
   } = loaderOptions
   const isPageFile = filename.startsWith(pagesDir)
+  const relativeFilePathFromRoot = path.relative(rootDir, filename)
 
   const swcOptions = getLoaderSWCOptions({
     pagesDir,
@@ -60,6 +62,7 @@ async function loaderTransform(parentTrace, source, inputSourceMap) {
     jsConfig,
     supportedBrowsers,
     swcCacheDir,
+    relativeFilePathFromRoot,
   })
 
   const programmaticOptions = {

--- a/packages/next/font/index.d.ts
+++ b/packages/next/font/index.d.ts
@@ -1,0 +1,14 @@
+export type FontModule = {
+  className: string
+  variable: string
+  style: { fontFamily: string; fontWeight?: number; fontStyle?: string }
+}
+
+export type FontLoader = (options: {
+  functionName: string
+  data: any[]
+  config: any
+  emitFontFile: (content: Buffer, ext: string, preload: boolean) => string
+  resolve: (src: string) => string
+  fs: any
+}) => Promise<{ css: string; fallbackFonts?: string[] }>

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -182,6 +182,21 @@ export type InferGetServerSidePropsType<T extends (args: any) => any> = Awaited<
   Extract<Awaited<ReturnType<T>>, { props: any }>['props']
 >
 
+export type FontModule = {
+  className: string
+  variable: string
+  style: { fontFamily: string; fontWeight?: number; fontStyle?: string }
+}
+
+export type FontLoader = (options: {
+  functionName: string
+  data: any[]
+  config: any
+  emitFontFile: (content: Buffer, ext: string, preload: boolean) => string
+  resolve: (src: string) => string
+  fs: any
+}) => Promise<{ css: string; fallbackFonts?: string[] }>
+
 declare global {
   interface Crypto {
     readonly subtle: SubtleCrypto

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -182,21 +182,6 @@ export type InferGetServerSidePropsType<T extends (args: any) => any> = Awaited<
   Extract<Awaited<ReturnType<T>>, { props: any }>['props']
 >
 
-export type FontModule = {
-  className: string
-  variable: string
-  style: { fontFamily: string; fontWeight?: number; fontStyle?: string }
-}
-
-export type FontLoader = (options: {
-  functionName: string
-  data: any[]
-  config: any
-  emitFontFile: (content: Buffer, ext: string, preload: boolean) => string
-  resolve: (src: string) => string
-  fs: any
-}) => Promise<{ css: string; fallbackFonts?: string[] }>
-
 declare global {
   interface Crypto {
     readonly subtle: SubtleCrypto

--- a/scripts/update-google-fonts.js
+++ b/scripts/update-google-fonts.js
@@ -7,7 +7,7 @@ const fetch = require('node-fetch')
     'https://fonts.google.com/metadata/fonts'
   ).then((r) => r.json())
 
-  let fontFunctions = `import type { FontModule } from 'next'
+  let fontFunctions = `import type { FontModule } from 'next/font'
   type Display = 'auto'|'block'|'swap'|'fallback'|'optional'
   `
   const fontData = {}

--- a/scripts/update-google-fonts.js
+++ b/scripts/update-google-fonts.js
@@ -7,8 +7,8 @@ const fetch = require('node-fetch')
     'https://fonts.google.com/metadata/fonts'
   ).then((r) => r.json())
 
-  let fontFunctions = `type Display = 'auto'|'block'|'swap'|'fallback'|'optional'
-type FontModule = { className: string, variable: string, style: { fontFamily: string, fontWeight?: number, fontStyle?: string } }
+  let fontFunctions = `import type { FontModule } from 'next'
+  type Display = 'auto'|'block'|'swap'|'fallback'|'optional'
   `
   const fontData = {}
   for (let { family, fonts, axes } of familyMetadataList) {

--- a/test/e2e/next-font/app/fonts/my-font.woff2
+++ b/test/e2e/next-font/app/fonts/my-font.woff2
@@ -1,0 +1,1 @@
+fake font

--- a/test/e2e/next-font/app/fonts/my-other-font.woff
+++ b/test/e2e/next-font/app/fonts/my-other-font.woff
@@ -1,0 +1,1 @@
+my other fake font

--- a/test/e2e/next-font/app/next.config.js
+++ b/test/e2e/next-font/app/next.config.js
@@ -4,6 +4,7 @@ module.exports = {
       '@next/font/google': {
         subsets: ['latin'],
       },
+      '@next/font/local': {},
     },
   },
 }

--- a/test/e2e/next-font/app/pages/with-local-fonts.js
+++ b/test/e2e/next-font/app/pages/with-local-fonts.js
@@ -1,0 +1,24 @@
+import localFont from '@next/font/local'
+
+const myFont1 = localFont({
+  src: '../fonts/my-font.woff2',
+  style: 'italic',
+  weight: '100',
+})
+const myFont2 = localFont({
+  src: '../fonts/my-other-font.woff',
+  preload: false,
+})
+
+export default function WithFonts() {
+  return (
+    <>
+      <div id="first-local-font" className={myFont1.className}>
+        {JSON.stringify(myFont1)}
+      </div>
+      <div id="second-local-font" className={myFont2.className}>
+        {JSON.stringify(myFont2)}
+      </div>
+    </>
+  )
+}

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -22,6 +22,7 @@ describe('@next/font/google', () => {
       files: {
         pages: new FileRef(join(__dirname, 'app/pages')),
         components: new FileRef(join(__dirname, 'app/components')),
+        fonts: new FileRef(join(__dirname, 'app/fonts')),
         'next.config.js': new FileRef(join(__dirname, 'app/next.config.js')),
       },
       dependencies: {
@@ -76,6 +77,39 @@ describe('@next/font/google', () => {
           fontFamily: "'__Roboto_72084b', '__roboto-fallback_72084b'",
           fontStyle: 'italic',
           fontWeight: 100,
+        },
+      })
+    })
+
+    test('page with local fonts', async () => {
+      const html = await renderViaHTTP(next.url, '/with-local-fonts')
+      const $ = cheerio.load(html)
+
+      // _app.js
+      expect(JSON.parse($('#app-open-sans').text())).toEqual({
+        className: expect.any(String),
+        variable: expect.any(String),
+        style: {
+          fontFamily: "'__Open_Sans_bbc724', '__open-sans-fallback_bbc724'",
+          fontStyle: 'normal',
+        },
+      })
+
+      // with-local-fonts.js
+      expect(JSON.parse($('#first-local-font').text())).toEqual({
+        className: expect.any(String),
+        variable: expect.any(String),
+        style: {
+          fontFamily: "'__my-font_2cddd5'",
+          fontStyle: 'italic',
+          fontWeight: 100,
+        },
+      })
+      expect(JSON.parse($('#second-local-font').text())).toEqual({
+        className: expect.any(String),
+        variable: expect.any(String),
+        style: {
+          fontFamily: "'__my-other-font_0a2813'",
         },
       })
     })
@@ -286,6 +320,33 @@ describe('@next/font/google', () => {
         as: 'font',
         crossorigin: 'anonymous',
         href: '/_next/static/fonts/0812efcfaefec5ea.p.woff2',
+        rel: 'preload',
+        type: 'font/woff2',
+      })
+    })
+
+    test('page with local fonts', async () => {
+      const html = await renderViaHTTP(next.url, '/with-local-fonts')
+      const $ = cheerio.load(html)
+
+      // Preconnect
+      expect($('link[rel="preconnect"]').length).toBe(0)
+
+      // Preload
+      expect($('link[as="font"]').length).toBe(2)
+      // _app
+      expect($('link[as="font"]').get(0).attribs).toEqual({
+        as: 'font',
+        crossorigin: 'anonymous',
+        href: '/_next/static/fonts/0812efcfaefec5ea.p.woff2',
+        rel: 'preload',
+        type: 'font/woff2',
+      })
+      // with-local-fonts
+      expect($('link[as="font"]').get(1).attribs).toEqual({
+        as: 'font',
+        crossorigin: 'anonymous',
+        href: '/_next/static/fonts/7be88d77534e80fd.p.woff2',
         rel: 'preload',
         type: 'font/woff2',
       })

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -30,6 +30,9 @@ describe('@next/font/google with-font-declarations-file', () => {
         'fonts.js': new FileRef(
           join(__dirname, 'with-font-declarations-file/fonts.js')
         ),
+        'my-font.woff2': new FileRef(
+          join(__dirname, 'with-font-declarations-file/my-font.woff2')
+        ),
         'next.config.js': new FileRef(
           join(__dirname, 'with-font-declarations-file/next.config.js')
         ),
@@ -53,7 +56,7 @@ describe('@next/font/google with-font-declarations-file', () => {
 
     if (isDev) {
       // In dev all fonts will be preloaded since it's before DCE
-      expect($('link[as="font"]').length).toBe(3)
+      expect($('link[as="font"]').length).toBe(4)
     } else {
       // Preload
       expect($('link[as="font"]').length).toBe(2)
@@ -85,7 +88,7 @@ describe('@next/font/google with-font-declarations-file', () => {
 
     if (isDev) {
       // In dev all fonts will be preloaded since it's before DCE
-      expect($('link[as="font"]').length).toBe(3)
+      expect($('link[as="font"]').length).toBe(4)
     } else {
       // Preload
       expect($('link[as="font"]').length).toBe(2)
@@ -102,6 +105,38 @@ describe('@next/font/google with-font-declarations-file', () => {
         as: 'font',
         crossorigin: 'anonymous',
         href: '/_next/static/fonts/9a7e84b4dd095b33.p.woff2',
+        rel: 'preload',
+        type: 'font/woff2',
+      })
+    }
+  })
+
+  test('preload correct files at /local-font', async () => {
+    const html = await renderViaHTTP(next.url, '/local-font')
+    const $ = cheerio.load(html)
+
+    // Preconnect
+    expect($('link[rel="preconnect"]').length).toBe(0)
+
+    if (isDev) {
+      // In dev all fonts will be preloaded since it's before DCE
+      expect($('link[as="font"]').length).toBe(4)
+    } else {
+      // Preload
+      expect($('link[as="font"]').length).toBe(2)
+      // From /_app
+      expect($('link[as="font"]').get(0).attribs).toEqual({
+        as: 'font',
+        crossorigin: 'anonymous',
+        href: '/_next/static/fonts/0812efcfaefec5ea.p.woff2',
+        rel: 'preload',
+        type: 'font/woff2',
+      })
+      // From /local-font
+      expect($('link[as="font"]').get(1).attribs).toEqual({
+        as: 'font',
+        crossorigin: 'anonymous',
+        href: '/_next/static/fonts/2a931eed088772c9.p.woff2',
         rel: 'preload',
         type: 'font/woff2',
       })

--- a/test/e2e/next-font/with-font-declarations-file/fonts.js
+++ b/test/e2e/next-font/with-font-declarations-file/fonts.js
@@ -1,3 +1,4 @@
+import localFont from '@next/font/local'
 import {
   Open_Sans,
   Source_Code_Pro,
@@ -13,4 +14,8 @@ const abel = Abel({ variant: '400', display: 'optional', preload: false })
 const inter = Inter({ display: 'block', preload: true })
 const roboto = Roboto({ variant: '400' })
 
-export { openSans, sourceCodePro, abel, inter, roboto }
+const myLocalFont = localFont({
+  src: './my-font.woff2',
+})
+
+export { openSans, sourceCodePro, abel, inter, roboto, myLocalFont }

--- a/test/e2e/next-font/with-font-declarations-file/my-font.woff2
+++ b/test/e2e/next-font/with-font-declarations-file/my-font.woff2
@@ -1,0 +1,1 @@
+fake font data

--- a/test/e2e/next-font/with-font-declarations-file/next.config.js
+++ b/test/e2e/next-font/with-font-declarations-file/next.config.js
@@ -4,6 +4,7 @@ module.exports = {
       '@next/font/google': {
         subsets: ['latin'],
       },
+      '@next/font/local': {},
     },
   },
 }

--- a/test/e2e/next-font/with-font-declarations-file/pages/local-font.js
+++ b/test/e2e/next-font/with-font-declarations-file/pages/local-font.js
@@ -1,0 +1,5 @@
+import { myLocalFont } from '../fonts'
+
+export default function LocalFont() {
+  return <p className={myLocalFont.className}>Hello world!</p>
+}

--- a/test/unit/google-font-loader.test.ts
+++ b/test/unit/google-font-loader.test.ts
@@ -78,6 +78,8 @@ describe('@next/font/google loader', () => {
         data: [{ adjustFontFallback: false, ...data }],
         config: { subsets: [] },
         emitFontFile: jest.fn(),
+        resolve: jest.fn(),
+        fs: {} as any,
       })
       expect(css).toBe('OK')
       expect(fetch).toHaveBeenCalledTimes(1)
@@ -96,6 +98,8 @@ describe('@next/font/google loader', () => {
         data: [],
         config: { subsets: [] },
         emitFontFile: jest.fn(),
+        resolve: jest.fn(),
+        fs: {} as any,
       })
       expect(css).toMatchInlineSnapshot(`
 "
@@ -121,6 +125,8 @@ describe('@next/font/google loader', () => {
         data: [],
         config: { subsets: [] },
         emitFontFile: jest.fn(),
+        resolve: jest.fn(),
+        fs: {} as any,
       })
       expect(css).toMatchInlineSnapshot(`
 "
@@ -146,6 +152,8 @@ describe('@next/font/google loader', () => {
         data: [{ fallback: ['Abc', 'Def'] }],
         config: { subsets: [] },
         emitFontFile: jest.fn(),
+        resolve: jest.fn(),
+        fs: {} as any,
       })
       expect(css).toMatchInlineSnapshot(`
 "
@@ -171,6 +179,8 @@ describe('@next/font/google loader', () => {
         data: [{ adjustFontFallback: false, fallback: ['system-ui', 'Arial'] }],
         config: { subsets: [] },
         emitFontFile: jest.fn(),
+        resolve: jest.fn(),
+        fs: {} as any,
       })
       expect(css).toBe('')
       expect(fallbackFonts).toEqual(['system-ui', 'Arial'])
@@ -189,6 +199,8 @@ describe('@next/font/google loader', () => {
           data: [],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
                         "Failed to fetch font  \`Inter\`.
@@ -203,6 +215,8 @@ describe('@next/font/google loader', () => {
           data: [],
           config: undefined,
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Please specify subsets for \`@next/font/google\` in your \`next.config.js\`"`
@@ -216,6 +230,8 @@ describe('@next/font/google loader', () => {
           data: [],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"@next/font/google has no default export"`
@@ -229,6 +245,8 @@ describe('@next/font/google loader', () => {
           data: [],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Unknown font \`Unknown Font\`"`
@@ -242,6 +260,8 @@ describe('@next/font/google loader', () => {
           data: [{ variant: '123' }],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
                       "Unknown variant \`123\` for font \`Inter\`.
@@ -256,6 +276,8 @@ describe('@next/font/google loader', () => {
           data: [],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
               "Missing variant for font \`Abel\`.
@@ -270,6 +292,8 @@ describe('@next/font/google loader', () => {
           data: [{ display: 'invalid' }],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
                       "Invalid display value \`invalid\` for font \`Inter\`.
@@ -284,6 +308,8 @@ describe('@next/font/google loader', () => {
           data: [{ variant: '400', axes: [] }],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Axes can only be defined for variable fonts"`
@@ -297,6 +323,8 @@ describe('@next/font/google loader', () => {
           data: [{ axes: [] }],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Font \`Lora\` has no definable \`axes\`"`
@@ -310,6 +338,8 @@ describe('@next/font/google loader', () => {
           data: [{ axes: true }],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
               "Invalid axes value for font \`Inter\`, expected an array of axes.
@@ -324,6 +354,8 @@ describe('@next/font/google loader', () => {
           data: [{ axes: ['INVALID'] }],
           config: { subsets: [] },
           emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {} as any,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
               "Invalid axes value \`INVALID\` for font \`Roboto Flex\`.

--- a/test/unit/local-font-loader.test.ts
+++ b/test/unit/local-font-loader.test.ts
@@ -1,0 +1,315 @@
+import loader from '@next/font/local/loader'
+
+describe('@next/font/local', () => {
+  describe('generated CSS', () => {
+    test('Default CSS', async () => {
+      const { css } = await loader({
+        functionName: '',
+        data: [{ src: './my-font.woff2' }],
+        config: {},
+        emitFontFile: () => '/_next/static/fonts/my-font.woff2',
+        resolve: jest.fn(),
+        fs: {
+          readFile: (_, cb) => cb(null, 'fontdata'),
+        },
+      })
+
+      expect(css).toMatchInlineSnapshot(`
+"@font-face {
+font-family: 'my-font';
+src: url(/_next/static/fonts/my-font.woff2) format('woff2');
+font-display: optional;
+}"
+`)
+    })
+
+    test('Default CSS - src array with unicodeRange', async () => {
+      const { css } = await loader({
+        functionName: '',
+        data: [
+          { src: [{ file: './my-font.woff2', unicodeRange: 'unicode-range' }] },
+        ],
+        config: {},
+        emitFontFile: () => '/_next/static/fonts/my-font.woff2',
+        resolve: jest.fn(),
+        fs: {
+          readFile: (_, cb) => cb(null, 'fontdata'),
+        },
+      })
+
+      expect(css).toMatchInlineSnapshot(`
+"@font-face {
+font-family: 'my-font';
+src: url(/_next/static/fonts/my-font.woff2) format('woff2');
+font-display: optional;
+unicode-range: unicode-range;
+}"
+`)
+    })
+
+    test('Default CSS - src array without unicodeRange', async () => {
+      const { css } = await loader({
+        functionName: '',
+        data: [{ src: [{ file: './my-font.woff2' }] }],
+        config: {},
+        emitFontFile: () => '/_next/static/fonts/my-font.woff2',
+        resolve: jest.fn(),
+        fs: {
+          readFile: (_, cb) => cb(null, 'fontdata'),
+        },
+      })
+
+      expect(css).toMatchInlineSnapshot(`
+"@font-face {
+font-family: 'my-font';
+src: url(/_next/static/fonts/my-font.woff2) format('woff2');
+font-display: optional;
+}"
+`)
+    })
+
+    test('Weight and style', async () => {
+      const { css } = await loader({
+        functionName: '',
+        data: [{ src: './my-font.woff2', weight: '100 900', style: 'italic' }],
+        config: {},
+        emitFontFile: () => '/_next/static/fonts/my-font.woff2',
+        resolve: jest.fn(),
+        fs: {
+          readFile: (_, cb) => cb(null, 'fontdata'),
+        },
+      })
+
+      expect(css).toMatchInlineSnapshot(`
+"@font-face {
+font-family: 'my-font';
+src: url(/_next/static/fonts/my-font.woff2) format('woff2');
+font-display: optional;
+font-weight: 100 900;
+font-style: italic;
+}"
+`)
+    })
+
+    test('Other properties', async () => {
+      const { css } = await loader({
+        functionName: '',
+        data: [
+          {
+            src: './my-font.woff2',
+            weight: '100 900',
+            style: 'italic',
+            ascentOverride: 'ascentOverride',
+            descentOverride: 'descentOverride',
+            lineGapOverride: 'lineGapOverride',
+            fontStretch: 'fontStretch',
+            fontFeatureSettings: 'fontFeatureSettings',
+            sizeAdjust: 'sizeAdjust',
+          },
+        ],
+        config: {},
+        emitFontFile: () => '/_next/static/fonts/my-font.woff2',
+        resolve: jest.fn(),
+        fs: {
+          readFile: (_, cb) => cb(null, 'fontdata'),
+        },
+      })
+
+      expect(css).toMatchInlineSnapshot(`
+"@font-face {
+font-family: 'my-font';
+src: url(/_next/static/fonts/my-font.woff2) format('woff2');
+font-display: optional;
+font-weight: 100 900;
+font-style: italic;
+ascent-override: ascentOverride;
+descent-override: descentOverride;
+line-gap-override: lineGapOverride;
+font-stretch: fontStretch;
+font-feature-settings: fontFeatureSettings;
+size-adjust: sizeAdjust;
+}"
+`)
+    })
+
+    test('Multiple files', async () => {
+      const { css } = await loader({
+        functionName: '',
+        data: [
+          {
+            src: [
+              { file: './my-font1.woff', unicodeRange: '1' },
+              { file: './my-font2.woff2', unicodeRange: '2' },
+              { file: './my-font3.eot', unicodeRange: '3' },
+              { file: './my-font4.ttf', unicodeRange: '4' },
+              { file: './my-font5.otf', unicodeRange: '5' },
+            ],
+          },
+        ],
+        config: {},
+        emitFontFile: () => `/_next/static/fonts/font-file`,
+        resolve: jest.fn(),
+        fs: {
+          readFile: (_, cb) => cb(null, 'fontdata'),
+        },
+      })
+
+      expect(css).toMatchInlineSnapshot(`
+"@font-face {
+font-family: 'my-font1';
+src: url(/_next/static/fonts/font-file) format('woff');
+font-display: optional;
+unicode-range: 1;
+}
+@font-face {
+font-family: 'my-font1';
+src: url(/_next/static/fonts/font-file) format('woff2');
+font-display: optional;
+unicode-range: 2;
+}
+@font-face {
+font-family: 'my-font1';
+src: url(/_next/static/fonts/font-file) format('embedded-opentype');
+font-display: optional;
+unicode-range: 3;
+}
+@font-face {
+font-family: 'my-font1';
+src: url(/_next/static/fonts/font-file) format('truetype');
+font-display: optional;
+unicode-range: 4;
+}
+@font-face {
+font-family: 'my-font1';
+src: url(/_next/static/fonts/font-file) format('opentype');
+font-display: optional;
+unicode-range: 5;
+}"
+`)
+    })
+  })
+
+  describe('Errors', () => {
+    test('Not using default export', async () => {
+      await expect(
+        loader({
+          functionName: 'Named',
+          data: [],
+          config: {},
+          emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {},
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"@next/font/local has no named exports"`
+      )
+    })
+
+    test('Invalid file extension', async () => {
+      await expect(
+        loader({
+          functionName: '',
+          data: [{ src: './font/font-file.abc' }],
+          config: {},
+          emitFontFile: jest.fn(),
+          resolve: jest.fn().mockResolvedValue(''),
+          fs: {},
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Unexpected file \`./font/font-file.abc\`"`
+      )
+    })
+
+    test('Invalid display value', async () => {
+      await expect(
+        loader({
+          functionName: '',
+          data: [{ src: './font-file.woff2', display: 'invalid' }],
+          config: {},
+          emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {},
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`
+              "Invalid display value \`invalid\`.
+              Available display values: \`auto\`, \`block\`, \`swap\`, \`fallback\`, \`optional\`"
+            `)
+    })
+
+    test('Empty src array', async () => {
+      await expect(
+        loader({
+          functionName: '',
+          data: [{ src: [] }],
+          config: {},
+          emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {},
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Src must contain one or more files"`
+      )
+    })
+
+    test('Src array must have one or more elements', async () => {
+      await expect(
+        loader({
+          functionName: '',
+          data: [{ src: [] }],
+          config: {},
+          emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {},
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Src must contain one or more files"`
+      )
+    })
+
+    test('Src array elements must have file property', async () => {
+      await expect(
+        loader({
+          functionName: '',
+          data: [
+            {
+              src: [
+                { file: './my-font1.woff2', unicodeRange: '1' },
+                { unicodeRange: '2' },
+              ],
+            },
+          ],
+
+          config: {},
+          emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {},
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Src array objects must have a \`file\` property"`
+      )
+    })
+
+    test("Src array files must have unicodeRange if there's many files", async () => {
+      await expect(
+        loader({
+          functionName: '',
+          data: [
+            {
+              src: [
+                { file: './my-font1.woff2', unicodeRange: '1' },
+                { file: './my-font2.woff2' },
+              ],
+            },
+          ],
+
+          config: {},
+          emitFontFile: jest.fn(),
+          resolve: jest.fn(),
+          fs: {},
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Files must have a unicode-range if there's more than one"`
+      )
+    })
+  })
+})


### PR DESCRIPTION
Moves font related types to `next/font` so they can be reused in font loaders.

Adds an argument to font loaders, the relative path from the app root to the module consuming the loader. Needed for resolving local files relative to the module calling it. Also used to improve error message.

Adds `@next/font/local` font loader. Similar to `@next/font/google` but used to host locally downloaded font files.