### PR TITLE
Add missing release stats config for app

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -94,6 +94,7 @@ module.exports = {
             module.exports = {
               experimental: {
                 appDir: true,
+                // remove after next stable relase (current v12.3.1)
                 serverComponents: true,
               },
               generateBuildId: () => 'BUILD_ID',
@@ -119,6 +120,7 @@ module.exports = {
           module.exports = {
               experimental: {
                 appDir: true,
+                // remove after next stable relase (current v12.3.1)
                 serverComponents: true,
               },
               generateBuildId: () => 'BUILD_ID'
@@ -157,6 +159,8 @@ module.exports = {
             module.exports = {
               experimental: {
                 appDir: true,
+                // remove after next stable relase (current v12.3.1)
+                serverComponents: true
               },
               generateBuildId: () => 'BUILD_ID',
               swcMinify: true,
@@ -182,6 +186,8 @@ module.exports = {
             module.exports = {
               experimental: {
                 appDir: true,
+                // remove after next stable relase (current v12.3.1)
+                serverComponents: true
               },
               swcMinify: true,
               generateBuildId: () => 'BUILD_ID'


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/40780 adds the extra config that is still needed for release stats. 

x-ref: https://github.com/vercel/next.js/actions/runs/3103134847/jobs/5026594626