### PR TITLE
Tolerate already published error for retrying

### DIFF
--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -46,7 +46,17 @@ const cwd = process.cwd()
       } catch (err) {
         // don't block publishing other versions on single platform error
         console.error(`Failed to publish`, platform)
-        throw err
+
+        if (
+          err.message &&
+          err.message.includes(
+            'You cannot publish over the previously published versions'
+          )
+        ) {
+          console.error('Ignoring already published error', platform)
+        } else {
+          throw err
+        }
       }
       // lerna publish in next step will fail if git status is not clean
       execSync(


### PR DESCRIPTION
This updates our `publish-native` script to tolerate the already published npm error so that we can retry publishing on an `npm` [service error like noticed here](https://github.com/vercel/next.js/actions/runs/3108335849/jobs/5037966318#step:10:2076). We probably want to migrate away from using `lerna` for publishing the non-swc packages as well so that we can retry there as well but will investigate that in a follow-up. 

x-ref: https://github.com/vercel/next.js/actions/runs/3108335849/jobs/5038069555 