### PR TITLE
Update publish to skip private package

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -16,8 +16,5 @@
     "prepublishOnly": "cd ../../ && turbo run build",
     "dev": "tsc -d -w -p tsconfig.json",
     "typescript": "tsec --noEmit -p tsconfig.json"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/40815 ensures we skip attempting to publish private packages like `next-swc`

x-ref: https://github.com/vercel/next.js/actions/runs/3109438515/jobs/5039954716