### PR TITLE
Bugfix: do not use synthetic import (fixes #40835)

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode, useContext } from 'react'
+import * as React from 'react'
+import { ReactElement, ReactNode, useContext } from 'react'
 import {
   OPTIMIZED_FONT_PROVIDERS,
   NEXT_BUILTIN_DOCUMENT,


### PR DESCRIPTION
The Next.js codebase is using TypeScript's `allowSyntheticDefaultImports` hack to do things like `import React from 'react'`. However, this leaks into built files like `node_modules/next/dist/pages/_document.d.ts`. From the perspective of a Next.js project with `allowSyntheticDefaultImports: false`, those built type declaration files are broken: `import React from 'react'` makes no sense, because that module has no default export.

An example bug caused by this is https://github.com/vercel/next.js/issues/40835. There are probably others, due to other uses `import React from 'react'`, and maybe other "synthetic defaults".

Ideally, Next.js should set `allowSyntheticDefaultImports: false`, and fix all these instances in the Next.js codebase. However, this PR just does the minimum to fix https://github.com/vercel/next.js/issues/40835.

## Bug

- [x] Related issues linked using `fixes #number`