### PR TITLE
[docs] Update Cypress config file name

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,7 +107,7 @@ describe('Navigation', () => {
 })
 ```
 
-You can use `cy.visit("/")` instead of `cy.visit("http://localhost:3000/")` if you add `"baseUrl": "http://localhost:3000"` to the `cypress.json` configuration file.
+You can use `cy.visit("/")` instead of `cy.visit("http://localhost:3000/")` if you add `baseUrl: 'http://localhost:3000'` to the `cypress.config.js` configuration file.
 
 ### Running your Cypress tests
 


### PR DESCRIPTION
The latest version of Cypress no longer supports `cypress.json`, use `cypress.config.js` instead. See details in the Cypress [docs](https://docs.cypress.io/guides/references/configuration).