### PR TITLE
Flight client navigation error

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -572,6 +572,8 @@ export async function renderToHTMLOrFlight(
       // For pages dir, there is only the SSR pass and we don't have the bundled
       // React subset. Here we directly import the flight renderer with the
       // unbundled React.
+      // TODO-APP: Is it possible to hard code the flight response here instead of
+      // rendering it?
       const ReactServerDOMWebpack = require('next/dist/compiled/react-server-dom-webpack/writer.browser.server')
 
       // Empty so that the client-side router will do a full page navigation.


### PR DESCRIPTION
When navigating from app to pages, we do a flight render on the server to generate the redirected path. However due to our new bundling strategy we can't use the bundled `ComponentMod.renderToReadableStream` because the component is now a regular component, not a RSC. In that case we have to import the unbundled flight server.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
