### PR TITLE
Use startTransition for hydrateRoot to opt-in to non-blocking hydration

### DIFF
--- a/packages/next/client/app-index.tsx
+++ b/packages/next/client/app-index.tsx
@@ -186,7 +186,9 @@ export function hydrate() {
   const isError = document.documentElement.id === '__next_error__'
   const reactRoot = isError
     ? (ReactDOMClient as any).createRoot(appElement)
-    : (ReactDOMClient as any).hydrateRoot(appElement, reactEl)
+    : (React as any).startTransition(() =>
+        (ReactDOMClient as any).hydrateRoot(appElement, reactEl)
+      )
   if (isError) {
     reactRoot.render(reactEl)
   }


### PR DESCRIPTION
As per @sebmarkbage's recommendation.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
