### PR TITLE
Export page config type for appDir

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1,4 +1,5 @@
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
+import type { AppConfig } from 'next/types'
 import { loadEnvConfig } from '@next/env'
 import chalk from 'next/dist/compiled/chalk'
 import crypto from 'crypto'
@@ -23,11 +24,11 @@ import {
 import { fileExists } from '../lib/file-exists'
 import { findPagesDir } from '../lib/find-pages-dir'
 import loadCustomRoutes, {
-  CustomRoutes,
   normalizeRouteRegex,
-  Redirect,
-  Rewrite,
-  RouteType,
+  type CustomRoutes,
+  type Redirect,
+  type Rewrite,
+  type RouteType,
 } from '../lib/load-custom-routes'
 import { getRedirectStatus, modifyRouteRegex } from '../lib/redirect-status'
 import { nonNullable } from '../lib/non-nullable'
@@ -98,7 +99,6 @@ import {
   printTreeView,
   copyTracedFiles,
   isReservedPage,
-  AppConfig,
 } from './utils'
 import getBaseWebpackConfig from './webpack-config'
 import { PagesManifest } from './webpack/plugins/pages-manifest-plugin'

--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1,4 +1,5 @@
 import type { NextConfigComplete } from '../server/config-shared'
+import type { AppConfig } from 'next/types'
 
 import '../server/node-polyfill-fetch'
 import loadRequireHook from '../build/webpack/require-hook'
@@ -1029,13 +1030,6 @@ export async function buildStaticPaths({
   }
 }
 
-export type AppConfig = {
-  revalidate?: number | false
-  dynamicParams?: true | false
-  dynamic?: 'auto' | 'error' | 'force-static'
-  fetchCache?: 'force-cache' | 'only-cache'
-  preferredRegion?: string
-}
 type GenerateParams = Array<{
   config: AppConfig
   segmentPath: string

--- a/packages/next/types/index.d.ts
+++ b/packages/next/types/index.d.ts
@@ -62,7 +62,7 @@ export type Redirect =
 export type NextPage<P = {}, IP = P> = NextComponentType<NextPageContext, IP, P>
 
 /**
- * `Config` type, use it for export const config
+ * `Config` type, use it for export const config in pages/
  */
 export type PageConfig = {
   amp?: boolean | 'hybrid'
@@ -91,6 +91,18 @@ export type PageConfig = {
   unstable_JsPreload?: false
   unstable_includeFiles?: string[]
   unstable_excludeFiles?: string[]
+}
+
+/**
+ * `Config` type, use it for export const config in app/
+ */
+export type AppConfig = {
+  runtime?: ServerRuntime
+  revalidate?: number | false
+  dynamicParams?: true | false
+  dynamic?: 'auto' | 'error' | 'force-static'
+  fetchCache?: 'force-cache' | 'only-cache'
+  preferredRegion?: string
 }
 
 export {


### PR DESCRIPTION
Since most props are not shared with the page config in pages, export another type `AppConfig` for the page config in appDir

