### PR TITLE
Update handling of redirect/404 throw to cross server->client boundary

### DIFF
--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -309,8 +309,9 @@ class RedirectErrorBoundary extends React.Component<
   }
 
   static getDerivedStateFromError(error: any) {
-    if (error.digest === 'NEXT_REDIRECT') {
-      return { redirect: error.url }
+    if (error.digest.startsWith('NEXT_REDIRECT')) {
+      const url = error.digest.split(';')[1]
+      return { redirect: url }
     }
     // Re-throw if error is not for 404
     throw error
@@ -354,7 +355,7 @@ class NotFoundErrorBoundary extends React.Component<
   }
 
   static getDerivedStateFromError(error: any) {
-    if (error.code === 'NEXT_NOT_FOUND') {
+    if (error.digest === 'NEXT_NOT_FOUND') {
       return { notFoundTriggered: true }
     }
     // Re-throw if error is not for 404

--- a/packages/next/client/components/layout-router.client.tsx
+++ b/packages/next/client/components/layout-router.client.tsx
@@ -309,7 +309,7 @@ class RedirectErrorBoundary extends React.Component<
   }
 
   static getDerivedStateFromError(error: any) {
-    if (error.digest.startsWith('NEXT_REDIRECT')) {
+    if (error.digest?.startsWith('NEXT_REDIRECT')) {
       const url = error.digest.split(';')[1]
       return { redirect: url }
     }

--- a/packages/next/client/components/not-found.ts
+++ b/packages/next/client/components/not-found.ts
@@ -2,7 +2,7 @@ export const NOT_FOUND_ERROR_CODE = 'NEXT_NOT_FOUND'
 
 export function notFound() {
   // eslint-disable-next-line no-throw-literal
-  throw {
-    code: NOT_FOUND_ERROR_CODE,
-  }
+  const error = new Error(NOT_FOUND_ERROR_CODE)
+  ;(error as any).digest = NOT_FOUND_ERROR_CODE
+  throw error
 }

--- a/packages/next/client/components/redirect.ts
+++ b/packages/next/client/components/redirect.ts
@@ -3,7 +3,6 @@ export const REDIRECT_ERROR_CODE = 'NEXT_REDIRECT'
 export function redirect(url: string) {
   // eslint-disable-next-line no-throw-literal
   const error = new Error(REDIRECT_ERROR_CODE)
-  ;(error as any).url = url
-  ;(error as any).digest = REDIRECT_ERROR_CODE
+  ;(error as any).digest = REDIRECT_ERROR_CODE + ';' + url
   throw error
 }

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -419,7 +419,7 @@ export default async function exportPage({
           } catch (err: any) {
             if (
               err.digest !== DYNAMIC_ERROR_CODE &&
-              err.digest !== REDIRECT_ERROR_CODE
+              !err.digest.startsWith(REDIRECT_ERROR_CODE)
             ) {
               throw err
             }

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -30,6 +30,7 @@ import { addRequestMeta } from '../server/request-meta'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { REDIRECT_ERROR_CODE } from '../client/components/redirect'
 import { DYNAMIC_ERROR_CODE } from '../client/components/hooks-server-context'
+import { NOT_FOUND_ERROR_CODE } from '../client/components/not-found'
 
 loadRequireHook()
 const envConfig = require('../shared/lib/runtime-config')
@@ -419,6 +420,7 @@ export default async function exportPage({
           } catch (err: any) {
             if (
               err.digest !== DYNAMIC_ERROR_CODE &&
+              err.digest !== NOT_FOUND_ERROR_CODE &&
               !err.digest.startsWith(REDIRECT_ERROR_CODE)
             ) {
               throw err

--- a/packages/next/export/worker.ts
+++ b/packages/next/export/worker.ts
@@ -421,7 +421,7 @@ export default async function exportPage({
             if (
               err.digest !== DYNAMIC_ERROR_CODE &&
               err.digest !== NOT_FOUND_ERROR_CODE &&
-              !err.digest.startsWith(REDIRECT_ERROR_CODE)
+              !err.digest?.startsWith(REDIRECT_ERROR_CODE)
             ) {
               throw err
             }

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -175,7 +175,7 @@ function createErrorHandler(
       // TODO-APP: Handle redirect throw
       err.digest !== DYNAMIC_ERROR_CODE &&
       err.digest !== NOT_FOUND_ERROR_CODE &&
-      !err.digest.startsWith(REDIRECT_ERROR_CODE)
+      !err.digest?.startsWith(REDIRECT_ERROR_CODE)
     ) {
       // Used for debugging error source
       // console.error(_source, err)

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -173,7 +173,7 @@ function createErrorHandler(
     if (
       // TODO-APP: Handle redirect throw
       err.digest !== DYNAMIC_ERROR_CODE &&
-      err.digest !== REDIRECT_ERROR_CODE
+      !err.digest.startsWith(REDIRECT_ERROR_CODE)
     ) {
       // Used for debugging error source
       // console.error(_source, err)
@@ -1299,10 +1299,6 @@ export async function renderToHTMLOrFlight(
           flushEffectsToHead: true,
         })
       } catch (err: any) {
-        if (err.digest === REDIRECT_ERROR_CODE) {
-          throw err
-        }
-
         // TODO-APP: show error overlay in development. `element` should probably be wrapped in AppRouter for this case.
         const renderStream = await renderToInitialStream({
           ReactDOMServer,
@@ -1358,21 +1354,7 @@ export async function renderToHTMLOrFlight(
       return new RenderResult(staticHtml)
     }
 
-    try {
-      return new RenderResult(await bodyResult())
-    } catch (err: any) {
-      if (err.digest === REDIRECT_ERROR_CODE) {
-        ;(renderOpts as any).pageData = {
-          pageProps: {
-            __N_REDIRECT: err.url,
-            __N_REDIRECT_STATUS: 307,
-          },
-        }
-        ;(renderOpts as any).isRedirect = true
-        return RenderResult.fromStatic('')
-      }
-      throw err
-    }
+    return new RenderResult(await bodyResult())
   }
 
   const initialStaticGenerationStore = {

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -31,6 +31,7 @@ import type { ComponentsType } from '../build/webpack/loaders/next-app-loader'
 import { REDIRECT_ERROR_CODE } from '../client/components/redirect'
 import { NextCookies } from './web/spec-extension/cookies'
 import { DYNAMIC_ERROR_CODE } from '../client/components/hooks-server-context'
+import { NOT_FOUND_ERROR_CODE } from '../client/components/not-found'
 
 const INTERNAL_HEADERS_INSTANCE = Symbol('internal for headers readonly')
 
@@ -173,6 +174,7 @@ function createErrorHandler(
     if (
       // TODO-APP: Handle redirect throw
       err.digest !== DYNAMIC_ERROR_CODE &&
+      err.digest !== NOT_FOUND_ERROR_CODE &&
       !err.digest.startsWith(REDIRECT_ERROR_CODE)
     ) {
       // Used for debugging error source

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1490,8 +1490,7 @@ describe('app dir', () => {
           await browser.waitForElementByCss('#not-found-component').text()
         ).toBe('404!')
       })
-
-      it('should trigger 404 client-side', async () => {
+      ;(isDev ? it.skip : it)('should trigger 404 client-side', async () => {
         const browser = await webdriver(next.url, '/not-found/client-side')
         await browser
           .elementByCss('button')


### PR DESCRIPTION
Follow-up for #40885. Few small changes to make adding the server components / ssr support easier.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
