### PR TITLE
Use an ellipsis character instead

### DIFF
--- a/test/integration/preload-viewport/pages/invalid-prefetch.js
+++ b/test/integration/preload-viewport/pages/invalid-prefetch.js
@@ -3,7 +3,7 @@ import Link from 'next/link'
 export default () => (
   <>
     <Link href="/something-invalid-oops">
-      <a id="invalid-link">I'm broken...</a>
+      <a id="invalid-link">I'm broken…</a>
     </Link>
   </>
 )


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

For context, making a test change to allow testing CI changes in https://github.com/vercel/next.js/pull/40910 without approval each run. 

@ijjk How's this? The string's not being snapshotted so it shouldn't break any tests.