### PR TITLE
Disable head element lint rule for appDir

### DIFF
--- a/packages/eslint-plugin-next/lib/rules/no-head-element.js
+++ b/packages/eslint-plugin-next/lib/rules/no-head-element.js
@@ -16,8 +16,9 @@ module.exports = {
       JSXOpeningElement(node) {
         const paths = context.getFilename()
 
+        const isInAppDir = paths.includes('app/') && !paths.includes('pages/')
         // Only lint the <head> element in pages directory
-        if (node.name.name !== 'head' || !paths.startsWith('pages')) {
+        if (node.name.name !== 'head' || isInAppDir) {
           return
         }
 

--- a/packages/eslint-plugin-next/lib/rules/no-head-element.js
+++ b/packages/eslint-plugin-next/lib/rules/no-head-element.js
@@ -14,7 +14,10 @@ module.exports = {
   create: function (context) {
     return {
       JSXOpeningElement(node) {
-        if (node.name.name !== 'head') {
+        const paths = context.getFilename()
+
+        // Only lint the <head> element in pages directory
+        if (node.name.name !== 'head' || !paths.startsWith('pages')) {
           return
         }
 

--- a/test/unit/eslint-plugin-next/no-head-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-head-element.test.ts
@@ -48,6 +48,21 @@ ruleTester.run('no-head-element', rule, {
     `,
       filename: 'pages/index.tsx',
     },
+    {
+      code: `
+      export default function Layout({ children }) {
+        return (
+          <html>
+            <head>
+              <title>layout</title>
+            </head>
+            <body>{children}</body>
+          </html>
+        );
+      }
+    `,
+      filename: 'app/layout.js',
+    },
   ],
   invalid: [
     {

--- a/test/unit/eslint-plugin-next/no-head-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-head-element.test.ts
@@ -61,7 +61,7 @@ ruleTester.run('no-head-element', rule, {
         );
       }
     `,
-      filename: 'app/layout.js',
+      filename: './app/layout.js',
     },
   ],
   invalid: [
@@ -78,7 +78,7 @@ ruleTester.run('no-head-element', rule, {
           );
         }
       }`,
-      filename: 'pages/index.js',
+      filename: './pages/index.js',
       errors: [
         {
           message:


### PR DESCRIPTION
Only lint `<head>` elements usage in `pages/`, `<head>` should be able to use in appDir