### PR TITLE
Bump TypeScript version in with-typescript

### DIFF
--- a/examples/with-typescript/package.json
+++ b/examples/with-typescript/package.json
@@ -15,6 +15,6 @@
     "@types/node": "^12.12.21",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.1",
-    "typescript": "4.0"
+    "typescript": "^4.8.3"
   }
 }


### PR DESCRIPTION
Bumps the version for the legacy `with-typescript` example as it's behind our recommended TypeScript version. We can investigate aliasing this example to the default template in a follow-up. 

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

x-ref: https://github.com/vercel/next.js/pull/40863#issuecomment-1258771279