### PR TITLE
fix: prefer `query` over `params`

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -78,6 +78,15 @@ export type FindComponentsResult = {
   query: NextParsedUrlQuery
 }
 
+export type FindComponentsParams = {
+  pathname: string
+  query: NextParsedUrlQuery
+  params: Params
+  isAppPath: boolean
+  appPaths?: string[] | null
+  sriEnabled?: boolean
+}
+
 export interface RoutingItem {
   page: string
   match: RouteMatch
@@ -243,14 +252,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   protected abstract getBuildId(): string
 
   protected abstract getFilesystemPaths(): Set<string>
-  protected abstract findPageComponents(params: {
-    pathname: string
-    query: NextParsedUrlQuery
-    params: Params
-    isAppPath: boolean
-    appPaths?: string[] | null
-    sriEnabled?: boolean
-  }): Promise<FindComponentsResult | null>
+  protected abstract findPageComponents(
+    params: FindComponentsParams
+  ): Promise<FindComponentsResult | null>
   protected abstract getFontManifest(): FontManifest | undefined
   protected abstract getPrerenderManifest(): PrerenderManifest
   protected abstract getServerComponentManifest(): any

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -978,6 +978,8 @@ export default class NextNodeServer extends BaseServer {
         return {
           components,
           query: {
+            // For appDir params is excluded.
+            ...((isAppPath ? {} : params) || {}),
             ...(components.getStaticProps
               ? ({
                   amp: query.amp,
@@ -986,8 +988,6 @@ export default class NextNodeServer extends BaseServer {
                   __nextDefaultLocale: query.__nextDefaultLocale,
                 } as NextParsedUrlQuery)
               : query),
-            // For appDir params is excluded.
-            ...((isAppPath ? {} : params) || {}),
           },
         }
       } catch (err) {

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -71,7 +71,7 @@ import loadRequireHook from '../build/webpack/require-hook'
 
 import BaseServer, {
   Options,
-  FindComponentsResult,
+  FindComponentsParams,
   prepareServerlessUrl,
   MiddlewareRoutingItem,
   RoutingItem,
@@ -932,12 +932,7 @@ export default class NextNodeServer extends BaseServer {
     query,
     params,
     isAppPath,
-  }: {
-    pathname: string
-    query: NextParsedUrlQuery
-    params: Params | null
-    isAppPath: boolean
-  }): Promise<FindComponentsResult | null> {
+  }: FindComponentsParams) {
     const paths: string[] = [pathname]
     if (query.amp) {
       // try serving a static AMP version first
@@ -979,7 +974,7 @@ export default class NextNodeServer extends BaseServer {
           components,
           query: {
             // For appDir params is excluded.
-            ...((isAppPath ? {} : params) || {}),
+            ...(isAppPath ? {} : params),
             ...(components.getStaticProps
               ? ({
                   amp: query.amp,

--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -2,10 +2,9 @@ import type { WebNextRequest, WebNextResponse } from './base-http/web'
 import type { RenderOpts } from './render'
 import type RenderResult from './render-result'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
-import type { Params } from '../shared/lib/router/utils/route-matcher'
 import type { PayloadOptions } from './send-payload'
 import type { LoadComponentsReturnType } from './load-components'
-import { NoFallbackError, Options } from './base-server'
+import { FindComponentsParams, NoFallbackError, Options } from './base-server'
 import type { DynamicRoutes, PageChecker, Route } from './router'
 import type { NextConfig } from './config-shared'
 
@@ -418,23 +417,15 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     pathname,
     query,
     params,
-  }: {
-    pathname: string
-    query: NextParsedUrlQuery
-    params: Params | null
-    isAppPath: boolean
-  }) {
-    const result = await this.serverOptions.webServerConfig.loadComponent(
+  }: FindComponentsParams) {
+    const components = await this.serverOptions.webServerConfig.loadComponent(
       pathname
     )
-    if (!result) return null
+    if (!components) return null
 
     return {
-      query: {
-        ...(query || {}),
-        ...(params || {}),
-      },
-      components: result,
+      components,
+      query: { ...params, ...query },
     }
   }
 }

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -599,7 +599,7 @@ const runTests = (isDev = false, isDeploy = false) => {
     )
     const $ = cheerio.load(html)
     const query = JSON.parse($('#query').text())
-    expect(query.post).toBe('post-1')
+    expect(query.post).toBe('something-else')
   })
 
   it('should parse query values on mount correctly', async () => {


### PR DESCRIPTION
Fixes #40936

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
