### PR TITLE
misc: add MANGLING_DEBUG option

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -902,7 +902,7 @@ export default async function getBaseWebpackConfig(
     },
     mangle: {
       safari10: true,
-      ...(process.env.MANGLING_DEBUG
+      ...(process.env.__NEXT_MANGLING_DEBUG
         ? {
             toplevel: true,
             module: true,
@@ -917,7 +917,7 @@ export default async function getBaseWebpackConfig(
       comments: false,
       // Fixes usage of Emoji and certain Regex
       ascii_only: true,
-      ...(process.env.MANGLING_DEBUG
+      ...(process.env.__NEXT_MANGLING_DEBUG
         ? {
             beautify: true,
           }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -900,13 +900,28 @@ export default async function getBaseWebpackConfig(
       comparisons: false,
       inline: 2, // https://github.com/vercel/next.js/issues/7178#issuecomment-493048965
     },
-    mangle: { safari10: true },
+    mangle: {
+      safari10: true,
+      ...(process.env.MANGLING_DEBUG
+        ? {
+            toplevel: true,
+            module: true,
+            keep_classnames: true,
+            keep_fnames: true,
+          }
+        : {}),
+    },
     output: {
       ecma: 5,
       safari10: true,
       comments: false,
       // Fixes usage of Emoji and certain Regex
       ascii_only: true,
+      ...(process.env.MANGLING_DEBUG
+        ? {
+            beautify: true,
+          }
+        : {}),
     },
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
Context:

I am doing some work re: bundle size so I'm spending a lot of time looking at the bundles we generate. This debug options basically deactives mangling and beautifies the output whilst keeping the dead code elimination from Terser which is helpful for me to check what I'm removing.

this is what the output is like with it.

<img width="566" alt="image" src="https://user-images.githubusercontent.com/11064311/192574974-4ff50fb8-43b2-44fe-9df3-c9e3a1b593f8.png">


## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature






- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
