### PR TITLE
Add timeout to playwright setup job

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -281,6 +281,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: node run-tests.js --type development --timings -g ${{ matrix.group }}/2
@@ -340,6 +341,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: node run-tests.js --type development --timings -g ${{ matrix.group }}/2
@@ -400,6 +402,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: NEXT_TEST_MODE=dev node run-tests.js --type e2e --timings -g ${{ matrix.group }}/3
@@ -460,6 +463,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: NEXT_TEST_MODE=dev node run-tests.js --type e2e --timings -g ${{ matrix.group }}/3
@@ -519,6 +523,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: node run-tests.js --type production --timings -g ${{ matrix.group }}/2
@@ -568,6 +573,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: node run-tests.js --type production --timings -g ${{ matrix.group }}/2
@@ -618,6 +624,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: NEXT_TEST_MODE=start node run-tests.js --type e2e --timings -g ${{ matrix.group }}/3
@@ -668,6 +675,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: NEXT_TEST_MODE=start node run-tests.js --type e2e --timings -g ${{ matrix.group }}/3
@@ -739,6 +747,7 @@ jobs:
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/20
@@ -1043,6 +1052,7 @@ jobs:
         name: Install pnpm
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         name: Install playwright dependencies
 
       - run: RESET_VC_PROJECT=true node scripts/reset-vercel-project.mjs
@@ -1243,6 +1253,7 @@ jobs:
           check-latest: true
 
       - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 3
         if: ${{needs.build.outputs.docsChange == 'nope'}}
 
       - run: node ./scripts/setup-wasm.mjs


### PR DESCRIPTION
The `npm i` step sometimes stall due to the network in GitHub actions so this adds a timeout so we aren't wasting CI time on this. 

x-ref: https://github.com/vercel/next.js/actions/runs/3136162957/jobs/5092826951
x-ref: https://github.com/vercel/next.js/actions/runs/3137098456/jobs/5095018172
x-ref: https://github.com/vercel/next.js/actions/runs/3137355539/jobs/5095478355

