### PR TITLE
Revert "edge-ssr: bundle next/dist as ESM for better tree-shaking (#40251)

### DIFF
--- a/packages/next/amp.js
+++ b/packages/next/amp.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/shared/lib/amp')
-    : require('./dist/shared/lib/amp')
+module.exports = require('./dist/shared/lib/amp')

--- a/packages/next/app.js
+++ b/packages/next/app.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/pages/_app')
-    : require('./dist/pages/_app')
+module.exports = require('./dist/pages/_app')

--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -219,7 +219,6 @@ export function getAppEntry(opts: {
   appDir: string
   appPaths: string[] | null
   pageExtensions: string[]
-  nextRuntime: string
 }) {
   return {
     import: `next-app-loader?${stringify(opts)}!`,
@@ -456,7 +455,6 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
               appDir,
               appPaths: matchedAppPaths,
               pageExtensions,
-              nextRuntime: 'nodejs',
             })
           } else if (isTargetLikeServerless(target)) {
             if (page !== '/_app' && page !== '/_document') {
@@ -481,7 +479,6 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
               appDir: appDir!,
               appPaths: matchedAppPaths,
               pageExtensions,
-              nextRuntime: 'edge',
             }).import
           }
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -180,9 +180,11 @@ export function getDefineEnv({
         }),
     // TODO: enforce `NODE_ENV` on `process.env`, and add a test:
     'process.env.NODE_ENV': JSON.stringify(dev ? 'development' : 'production'),
-    'process.env.NEXT_RUNTIME': JSON.stringify(
-      isEdgeServer ? 'edge' : isNodeServer ? 'nodejs' : undefined
-    ),
+    ...((isNodeServer || isEdgeServer) && {
+      'process.env.NEXT_RUNTIME': JSON.stringify(
+        isEdgeServer ? 'edge' : 'nodejs'
+      ),
+    }),
     'process.env.__NEXT_MIDDLEWARE_MATCHERS': JSON.stringify(
       middlewareMatchers || []
     ),
@@ -793,7 +795,7 @@ export default async function getBaseWebpackConfig(
             return prev
           }, [] as string[])
         : []),
-      isEdgeServer ? 'next/dist/esm/pages/_app.js' : 'next/dist/pages/_app.js',
+      'next/dist/pages/_app.js',
     ]
     customAppAliases[`${PAGES_DIR_ALIAS}/_error`] = [
       ...(pagesDir
@@ -802,9 +804,7 @@ export default async function getBaseWebpackConfig(
             return prev
           }, [] as string[])
         : []),
-      isEdgeServer
-        ? 'next/dist/esm/pages/_error.js'
-        : 'next/dist/pages/_error.js',
+      'next/dist/pages/_error.js',
     ]
     customDocumentAliases[`${PAGES_DIR_ALIAS}/_document`] = [
       ...(pagesDir
@@ -813,9 +813,7 @@ export default async function getBaseWebpackConfig(
             return prev
           }, [] as string[])
         : []),
-      isEdgeServer
-        ? `next/dist/esm/pages/_document.js`
-        : `next/dist/pages/_document.js`,
+      `next/dist/pages/_document.js`,
     ]
   }
 

--- a/packages/next/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/build/webpack/loaders/next-app-loader.ts
@@ -120,9 +120,8 @@ const nextAppLoader: webpack.LoaderDefinitionFunction<{
   appDir: string
   appPaths: string[] | null
   pageExtensions: string[]
-  nextRuntime: string
 }> = async function nextAppLoader() {
-  const { name, appDir, appPaths, pagePath, pageExtensions, nextRuntime } =
+  const { name, appDir, appPaths, pagePath, pageExtensions } =
     this.getOptions() || {}
 
   const buildInfo = getModuleBuildInfo((this as any)._module)
@@ -180,24 +179,23 @@ const nextAppLoader: webpack.LoaderDefinitionFunction<{
     resolveParallelSegments,
   })
 
-  const rootDistFolder = nextRuntime === 'edge' ? 'next/dist/esm' : 'next/dist'
   const result = `
     export ${treeCode}
 
-    export const AppRouter = require('${rootDistFolder}/client/components/app-router.client.js').default
-    export const LayoutRouter = require('${rootDistFolder}/client/components/layout-router.client.js').default
-    export const RenderFromTemplateContext = require('${rootDistFolder}/client/components/render-from-template-context.client.js').default
+    export const AppRouter = require('next/dist/client/components/app-router.client.js').default
+    export const LayoutRouter = require('next/dist/client/components/layout-router.client.js').default
+    export const RenderFromTemplateContext = require('next/dist/client/components/render-from-template-context.client.js').default
     export const HotReloader = ${
       // Disable HotReloader component in production
       this.mode === 'development'
-        ? `require('${rootDistFolder}/client/components/hot-reloader.client.js').default`
+        ? `require('next/dist/client/components/hot-reloader.client.js').default`
         : 'null'
     }
 
-    export const staticGenerationAsyncStorage = require('${rootDistFolder}/client/components/static-generation-async-storage.js').staticGenerationAsyncStorage
-    export const requestAsyncStorage = require('${rootDistFolder}/client/components/request-async-storage.js').requestAsyncStorage
+    export const staticGenerationAsyncStorage = require('next/dist/client/components/static-generation-async-storage.js').staticGenerationAsyncStorage
+    export const requestAsyncStorage = require('next/dist/client/components/request-async-storage.js').requestAsyncStorage
 
-    export const serverHooks = require('${rootDistFolder}/client/components/hooks-server-context.js')
+    export const serverHooks = require('next/dist/client/components/hooks-server-context.js')
 
     export const renderToReadableStream = require('next/dist/compiled/react-server-dom-webpack/writer.browser.server').renderToReadableStream
     export const __next_app_webpack_require__ = __webpack_require__

--- a/packages/next/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -1,5 +1,4 @@
 import type { NextConfig } from '../../../../server/config-shared'
-
 import type { DocumentType, AppType } from '../../../../shared/lib/utils'
 import type { BuildManifest } from '../../../../server/get-page-files'
 import type { ReactLoadableManifest } from '../../../../server/load-components'

--- a/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -307,19 +307,9 @@ export class FlightClientEntryPlugin {
       modules: clientComponentImports,
       server: false,
     }
-
-    // For the client entry, we always use the CJS build of Next.js. If the
-    // server is using the ESM build (when using the Edge runtime), we need to
-    // replace them.
-    const clientLoader = `next-flight-client-entry-loader?${stringify({
-      modules: this.isEdgeServer
-        ? clientComponentImports.map((importPath) =>
-            importPath.replace('next/dist/esm/', 'next/dist/')
-          )
-        : clientComponentImports,
-      server: false,
-    })}!`
-
+    const clientLoader = `next-flight-client-entry-loader?${stringify(
+      loaderOptions
+    )}!`
     const clientSSRLoader = `next-flight-client-entry-loader?${stringify({
       ...loaderOptions,
       server: true,

--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -56,9 +56,6 @@ export type FlightManifest = {
   __ssr_module_mapping__: {
     [moduleId: string]: ManifestNode
   }
-  __edge_ssr_module_mapping__: {
-    [moduleId: string]: ManifestNode
-  }
 } & {
   [modulePath: string]: ManifestNode
 }
@@ -144,7 +141,6 @@ export class FlightManifestPlugin {
   ) {
     const manifest: FlightManifest = {
       __ssr_module_mapping__: {},
-      __edge_ssr_module_mapping__: {},
     }
     const dev = this.dev
     const fontLoaderTargets = this.fontLoaderTargets
@@ -200,7 +196,6 @@ export class FlightManifestPlugin {
 
         const moduleExports = manifest[resource] || {}
         const moduleIdMapping = manifest.__ssr_module_mapping__
-        const edgeModuleIdMapping = manifest.__edge_ssr_module_mapping__
 
         // Note that this isn't that reliable as webpack is still possible to assign
         // additional queries to make sure there's no conflict even using the `named`
@@ -309,25 +304,10 @@ export class FlightManifestPlugin {
             ...moduleExports[name],
             id: ssrNamedModuleId,
           }
-
-          edgeModuleIdMapping[id] = edgeModuleIdMapping[id] || {}
-          edgeModuleIdMapping[id][name] = {
-            ...moduleExports[name],
-            id: ssrNamedModuleId.replace(/\/next\/dist\//, '/next/dist/esm/'),
-          }
         })
 
         manifest[resource] = moduleExports
-
-        // The client compiler will always use the CJS Next.js build, so here we
-        // also add the mapping for the ESM build (Edge runtime) to consume.
-        if (/\/next\/dist\//.test(resource)) {
-          manifest[resource.replace(/\/next\/dist\//, '/next/dist/esm/')] =
-            moduleExports
-        }
-
         manifest.__ssr_module_mapping__ = moduleIdMapping
-        manifest.__edge_ssr_module_mapping__ = edgeModuleIdMapping
       }
 
       chunkGroup.chunks.forEach((chunk: webpack.Chunk) => {

--- a/packages/next/build/webpack/plugins/telemetry-plugin.ts
+++ b/packages/next/build/webpack/plugins/telemetry-plugin.ts
@@ -110,15 +110,11 @@ function findFeatureInModule(module: Module): Feature | undefined {
  * dependency.
  */
 function findUniqueOriginModulesInConnections(
-  connections: Connection[],
-  originModule: Module
+  connections: Connection[]
 ): Set<unknown> {
   const originModules = new Set()
   for (const connection of connections) {
-    if (
-      !originModules.has(connection.originModule) &&
-      connection.originModule !== originModule
-    ) {
+    if (!originModules.has(connection.originModule)) {
       originModules.add(connection.originModule)
     }
   }
@@ -165,10 +161,8 @@ export class TelemetryPlugin implements webpack.WebpackPluginInstance {
               const connections = (
                 compilation as any
               ).moduleGraph.getIncomingConnections(module)
-              const originModules = findUniqueOriginModulesInConnections(
-                connections,
-                module
-              )
+              const originModules =
+                findUniqueOriginModulesInConnections(connections)
               this.usageTracker.get(feature)!.invocationCount =
                 originModules.size
             }

--- a/packages/next/client.js
+++ b/packages/next/client.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/client/index')
-    : require('./dist/client/index')
+module.exports = require('./dist/client/index')

--- a/packages/next/config.js
+++ b/packages/next/config.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/shared/lib/runtime-config')
-    : require('./dist/shared/lib/runtime-config')
+module.exports = require('./dist/shared/lib/runtime-config')

--- a/packages/next/constants.js
+++ b/packages/next/constants.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/shared/lib/constants')
-    : require('./dist/shared/lib/constants')
+module.exports = require('./dist/shared/lib/constants')

--- a/packages/next/document.js
+++ b/packages/next/document.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/pages/_document')
-    : require('./dist/pages/_document')
+module.exports = require('./dist/pages/_document')

--- a/packages/next/dynamic.js
+++ b/packages/next/dynamic.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/shared/lib/dynamic')
-    : require('./dist/shared/lib/dynamic')
+module.exports = require('./dist/shared/lib/dynamic')

--- a/packages/next/error.js
+++ b/packages/next/error.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/pages/_error')
-    : require('./dist/pages/_error')
+module.exports = require('./dist/pages/_error')

--- a/packages/next/head.js
+++ b/packages/next/head.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/shared/lib/head')
-    : require('./dist/shared/lib/head')
+module.exports = require('./dist/shared/lib/head')

--- a/packages/next/image.js
+++ b/packages/next/image.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/client/image')
-    : require('./dist/client/image')
+module.exports = require('./dist/client/image')

--- a/packages/next/link.js
+++ b/packages/next/link.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/client/link')
-    : require('./dist/client/link')
+module.exports = require('./dist/client/link')

--- a/packages/next/pages/_app.tsx
+++ b/packages/next/pages/_app.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-
-import type {
+import {
+  loadGetInitialProps,
   AppContextType,
   AppInitialProps,
   AppPropsType,
@@ -8,8 +8,6 @@ import type {
   AppType,
 } from '../shared/lib/utils'
 import type { Router } from '../client/router'
-
-import { loadGetInitialProps } from '../shared/lib/utils'
 
 export { AppInitialProps, AppType }
 

--- a/packages/next/router.js
+++ b/packages/next/router.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/client/router')
-    : require('./dist/client/router')
+module.exports = require('./dist/client/router')

--- a/packages/next/script.js
+++ b/packages/next/script.js
@@ -1,4 +1,1 @@
-module.exports =
-  process.env.NEXT_RUNTIME === 'edge'
-    ? require('./dist/esm/client/script')
-    : require('./dist/client/script')
+module.exports = require('./dist/client/script')

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -258,10 +258,7 @@ function useFlightResponse(
 
   const [renderStream, forwardStream] = readableStreamTee(req)
   const res = createFromReadableStream(renderStream, {
-    moduleMap:
-      process.env.NEXT_RUNTIME === 'edge'
-        ? serverComponentManifest.__edge_ssr_module_mapping__
-        : serverComponentManifest.__ssr_module_mapping__,
+    moduleMap: serverComponentManifest.__ssr_module_mapping__,
   })
   flightResponseRef.current = res
 
@@ -273,7 +270,7 @@ function useFlightResponse(
     ? `<script nonce=${JSON.stringify(nonce)}>`
     : '<script>'
 
-  function read() {
+  function process() {
     forwardReader.read().then(({ done, value }) => {
       if (value) {
         rscChunks.push(value)
@@ -299,11 +296,11 @@ function useFlightResponse(
         )})</script>`
 
         writer.write(encodeText(scripts))
-        read()
+        process()
       }
     })
   }
-  read()
+  process()
 
   return res
 }

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -626,7 +626,6 @@ export default class HotReloader {
                         ),
                         appDir: this.appDir!,
                         pageExtensions: this.config.pageExtensions,
-                        nextRuntime: 'edge',
                       }).import
                     : undefined
 
@@ -706,7 +705,6 @@ export default class HotReloader {
                           ),
                           appDir: this.appDir!,
                           pageExtensions: this.config.pageExtensions,
-                          nextRuntime: 'nodejs',
                         })
                       : relativeRequest,
                   appDir: this.config.experimental.appDir,

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -18,7 +18,6 @@ module.exports = function (task) {
         stripExtension,
         keepImportAssertions = false,
         interopClientDefaultExport = false,
-        esm = false,
       } = {}
     ) {
       // Don't compile .d.ts
@@ -29,7 +28,7 @@ module.exports = function (task) {
       /** @type {import('@swc/core').Options} */
       const swcClientOptions = {
         module: {
-          type: esm ? 'es6' : 'commonjs',
+          type: 'commonjs',
           ignoreDynamic: true,
         },
         jsc: {
@@ -60,7 +59,7 @@ module.exports = function (task) {
       /** @type {import('@swc/core').Options} */
       const swcServerOptions = {
         module: {
-          type: esm ? 'es6' : 'commonjs',
+          type: 'commonjs',
           ignoreDynamic: true,
         },
         env: {
@@ -127,7 +126,7 @@ module.exports = function (task) {
       }
 
       if (output.map) {
-        if (interopClientDefaultExport && !esm) {
+        if (interopClientDefaultExport) {
           output.code += `
 if ((typeof exports.default === 'function' || (typeof exports.default === 'object' && exports.default !== null)) && typeof exports.default.__esModule === 'undefined') {
   Object.defineProperty(exports.default, '__esModule', { value: true });

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1946,23 +1946,16 @@ export async function compile(task, opts) {
       'cli',
       'bin',
       'server',
-      'server_esm',
       'nextbuild',
       'nextbuildjest',
       'nextbuildstatic',
-      'nextbuild_esm',
       'pages',
-      'pages_esm',
       'lib',
-      'lib_esm',
       'client',
-      'client_esm',
       'telemetry',
       'trace',
       'shared',
-      'shared_esm',
       'shared_re_exported',
-      'shared_re_exported_esm',
       'server_wasm',
       // we compile this each time so that fresh runtime data is pulled
       // before each publish
@@ -1997,14 +1990,6 @@ export async function lib(task, opts) {
   notify('Compiled lib files')
 }
 
-export async function lib_esm(task, opts) {
-  await task
-    .source(opts.src || 'lib/**/*.+(js|ts|tsx)')
-    .swc('server', { dev: opts.dev, esm: true })
-    .target('dist/esm/lib')
-  notify('Compiled lib files')
-}
-
 export async function server(task, opts) {
   await task
     .source(opts.src || 'server/**/*.+(js|ts|tsx)')
@@ -2019,14 +2004,6 @@ export async function server(task, opts) {
   notify('Compiled server files')
 }
 
-export async function server_esm(task, opts) {
-  await task
-    .source(opts.src || 'server/**/*.+(js|ts|tsx)')
-    .swc('server', { dev: opts.dev, esm: true })
-    .target('dist/esm/server')
-  notify('Compiled server files to ESM')
-}
-
 export async function nextbuild(task, opts) {
   await task
     .source(opts.src || 'build/**/*.+(js|ts|tsx)', {
@@ -2035,16 +2012,6 @@ export async function nextbuild(task, opts) {
     .swc('server', { dev: opts.dev })
     .target('dist/build')
   notify('Compiled build files')
-}
-
-export async function nextbuild_esm(task, opts) {
-  await task
-    .source(opts.src || 'build/**/*.+(js|ts|tsx)', {
-      ignore: ['**/fixture/**', '**/tests/**', '**/jest/**'],
-    })
-    .swc('server', { dev: opts.dev, esm: true })
-    .target('dist/esm/build')
-  notify('Compiled build files to ESM')
 }
 
 export async function nextbuildjest(task, opts) {
@@ -2063,14 +2030,6 @@ export async function client(task, opts) {
     .swc('client', { dev: opts.dev, interopClientDefaultExport: true })
     .target('dist/client')
   notify('Compiled client files')
-}
-
-export async function client_esm(task, opts) {
-  await task
-    .source(opts.src || 'client/**/*.+(js|ts|tsx)')
-    .swc('client', { dev: opts.dev, esm: true })
-    .target('dist/esm/client')
-  notify('Compiled client files to ESM')
 }
 
 // export is a reserved keyword for functions
@@ -2103,36 +2062,8 @@ export async function pages_document(task, opts) {
     .target('dist/pages')
 }
 
-export async function pages_app_esm(task, opts) {
-  await task
-    .source('pages/_app.tsx')
-    .swc('client', { dev: opts.dev, keepImportAssertions: true, esm: true })
-    .target('dist/esm/pages')
-}
-
-export async function pages_error_esm(task, opts) {
-  await task
-    .source('pages/_error.tsx')
-    .swc('client', { dev: opts.dev, keepImportAssertions: true, esm: true })
-    .target('dist/esm/pages')
-}
-
-export async function pages_document_esm(task, opts) {
-  await task
-    .source('pages/_document.tsx')
-    .swc('server', { dev: opts.dev, keepImportAssertions: true, esm: true })
-    .target('dist/esm/pages')
-}
-
 export async function pages(task, opts) {
   await task.parallel(['pages_app', 'pages_error', 'pages_document'], opts)
-}
-
-export async function pages_esm(task, opts) {
-  await task.parallel(
-    ['pages_app_esm', 'pages_error_esm', 'pages_document_esm'],
-    opts
-  )
 }
 
 export async function telemetry(task, opts) {
@@ -2162,15 +2093,11 @@ export default async function (task) {
   await task.watch('bin/*', 'bin', opts)
   await task.watch('pages/**/*.+(js|ts|tsx)', 'pages', opts)
   await task.watch('server/**/*.+(js|ts|tsx)', 'server', opts)
-  await task.watch('server/**/*.+(js|ts|tsx)', 'server_esm', opts)
   await task.watch('build/**/*.+(js|ts|tsx)', 'nextbuild', opts)
-  await task.watch('build/**/*.+(js|ts|tsx)', 'nextbuild_esm', opts)
   await task.watch('build/jest/**/*.+(js|ts|tsx)', 'nextbuildjest', opts)
   await task.watch('export/**/*.+(js|ts|tsx)', 'nextbuildstatic', opts)
   await task.watch('client/**/*.+(js|ts|tsx)', 'client', opts)
-  await task.watch('client/**/*.+(js|ts|tsx)', 'client_esm', opts)
   await task.watch('lib/**/*.+(js|ts|tsx)', 'lib', opts)
-  await task.watch('lib/**/*.+(js|ts|tsx)', 'lib_esm', opts)
   await task.watch('cli/**/*.+(js|ts|tsx)', 'cli', opts)
   await task.watch('telemetry/**/*.+(js|ts|tsx)', 'telemetry', opts)
   await task.watch('trace/**/*.+(js|ts|tsx)', 'trace', opts)
@@ -2182,16 +2109,6 @@ export default async function (task) {
   await task.watch(
     'shared/**/!(amp|config|constants|dynamic|head|runtime-config).+(js|ts|tsx)',
     'shared',
-    opts
-  )
-  await task.watch(
-    'shared/**/!(amp|config|constants|dynamic|head).+(js|ts|tsx)',
-    'shared_esm',
-    opts
-  )
-  await task.watch(
-    'shared/lib/{amp,config,constants,dynamic,head}.+(js|ts|tsx)',
-    'shared_re_exported_esm',
     opts
   )
   await task.watch('server/**/*.+(wasm)', 'server_wasm', opts)
@@ -2213,16 +2130,6 @@ export async function shared(task, opts) {
   notify('Compiled shared files')
 }
 
-export async function shared_esm(task, opts) {
-  await task
-    .source(
-      opts.src || 'shared/**/!(amp|config|constants|dynamic|head).+(js|ts|tsx)'
-    )
-    .swc('client', { dev: opts.dev, esm: true })
-    .target('dist/esm/shared')
-  notify('Compiled shared files to ESM')
-}
-
 export async function shared_re_exported(task, opts) {
   await task
     .source(
@@ -2232,19 +2139,6 @@ export async function shared_re_exported(task, opts) {
     .swc('client', { dev: opts.dev, interopClientDefaultExport: true })
     .target('dist/shared')
   notify('Compiled shared re-exported files')
-}
-
-export async function shared_re_exported_esm(task, opts) {
-  await task
-    .source(
-      opts.src || 'shared/**/{amp,config,constants,dynamic,head}.+(js|ts|tsx)'
-    )
-    .swc('client', {
-      dev: opts.dev,
-      esm: true,
-    })
-    .target('dist/esm/shared')
-  notify('Compiled shared re-exported files as ESM')
 }
 
 export async function server_wasm(task, opts) {


### PR DESCRIPTION
This reverts commit 11deaaa82bda301254167967903a384ef6c4c51f.

Temporarily reverts the above commit due to breaking middleware/edge functions once deployed. 

Fixes: https://github.com/vercel/next.js/actions/runs/3133433920/jobs/5087331787

cc @shuding @feedthejim 

```sh
[GET] /blog/first
13:56:56:61
2022-09-27T20:56:56.671Z	61d43a6a-34a1-40c0-b71f-4ae5d1918431	ERROR	/var/task/node_modules/next/dist/esm/client/router.js:1
/* global window */ import React from 'react';
                    ^^^^^^
SyntaxError: Cannot use import statement outside a module
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1033:15)
    at Module._compile (node:internal/modules/cjs/loader:1069:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/var/task/node_modules/next/router.js:3:7)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
```
