### PR TITLE
Update to use HEAD request for middleware query hydration

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1551,6 +1551,7 @@ export default class Router implements BaseRouter {
         isPreview: nextState.isPreview,
         hasMiddleware: isMiddlewareMatch,
         unstable_skipClientCache: options.unstable_skipClientCache,
+        isQueryUpdating: isQueryUpdating && !this.isFallback,
       })
 
       if ('route' in routeInfo && isMiddlewareMatch) {
@@ -1896,6 +1897,7 @@ export default class Router implements BaseRouter {
     hasMiddleware,
     isPreview,
     unstable_skipClientCache,
+    isQueryUpdating,
   }: {
     route: string
     pathname: string
@@ -1907,6 +1909,7 @@ export default class Router implements BaseRouter {
     locale: string | undefined
     isPreview: boolean
     unstable_skipClientCache?: boolean
+    isQueryUpdating?: boolean
   }) {
     /**
      * This `route` binding can change if there's a rewrite
@@ -1949,6 +1952,7 @@ export default class Router implements BaseRouter {
         persistCache: !isPreview,
         isPrefetch: false,
         unstable_skipClientCache,
+        isBackground: isQueryUpdating,
       }
 
       const data = await withMiddlewareEffects({
@@ -1957,6 +1961,10 @@ export default class Router implements BaseRouter {
         locale: locale,
         router: this,
       })
+
+      if (isQueryUpdating && data) {
+        data.json = self.__NEXT_DATA__.props
+      }
       handleCancelled()
 
       if (


### PR DESCRIPTION
When fetching the middleware rewrite information via `_next/data` for a static page that is not a `fallback` we can use a `HEAD` request instead of a `GET` request which provides the necessary header information and saves some bandwidth by avoiding sending back the data that is already present in the page. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1664229966495469)

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

