### PR TITLE
misc: remove NEXT_RUNTIME=edge from middleware tests

### DIFF
--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -56,7 +56,6 @@ describe('Middleware Runtime', () => {
           ANOTHER_MIDDLEWARE_TEST: 'asdf2',
           STRING_ENV_VAR: 'asdf3',
           MIDDLEWARE_TEST: 'asdf',
-          NEXT_RUNTIME: 'edge',
         },
       })
     })

--- a/test/integration/middleware-prefetch/tests/index.test.js
+++ b/test/integration/middleware-prefetch/tests/index.test.js
@@ -38,7 +38,6 @@ describe('Middleware Production Prefetch', () => {
     context.app = await nextStart(context.appDir, context.appPort, {
       env: {
         MIDDLEWARE_TEST: 'asdf',
-        NEXT_RUNTIME: 'edge',
       },
       onStdout(msg) {
         context.logs.output += msg


### PR DESCRIPTION
This seems to be the cause for the failure of  https://github.com/vercel/next.js/actions/runs/3133433920/jobs/5087331787 that caused[ the revert](https://github.com/vercel/next.js/pull/40967) of my [commit ](https://github.com/vercel/next.js/commit/11deaaa82bda301254167967903a384ef6c4c51f) that changed the edge bundle to SSR.

After investigating, I realised this was the culprit: this forces the test app code to run with this on, somehow, when built on Vercel.

Removing it should fix it. Let's merge if all tests still pass?

Open questions:
- I'm not sure why this is/was needed, since this variable should always be inlined by webpack
- furthermore, this was causing client code to run as-if on the edge?
- but also, this still shouldn't happen because webpack should get rid of it


<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
