### PR TITLE
Rename flight parameters to rsc/next

### DIFF
--- a/packages/next/client/components/app-router.client.tsx
+++ b/packages/next/client/components/app-router.client.tsx
@@ -44,12 +44,12 @@ export async function fetchServerResponse(
   prefetch?: true
 ): Promise<[FlightData: FlightData, canonicalUrlOverride: URL | undefined]> {
   const headers: {
-    __flight__: '1'
+    __rsc__: '1'
     __flight_router_state_tree__: string
     __flight_prefetch__?: '1'
   } = {
     // Enable flight response
-    __flight__: '1',
+    __rsc__: '1',
     // Provide the current router state
     __flight_router_state_tree__: JSON.stringify(flightRouterState),
   }

--- a/packages/next/client/components/app-router.client.tsx
+++ b/packages/next/client/components/app-router.client.tsx
@@ -45,17 +45,17 @@ export async function fetchServerResponse(
 ): Promise<[FlightData: FlightData, canonicalUrlOverride: URL | undefined]> {
   const headers: {
     __rsc__: '1'
-    __flight_router_state_tree__: string
-    __flight_prefetch__?: '1'
+    __next_router_state_tree__: string
+    __next_router_prefetch__?: '1'
   } = {
     // Enable flight response
     __rsc__: '1',
     // Provide the current router state
-    __flight_router_state_tree__: JSON.stringify(flightRouterState),
+    __next_router_state_tree__: JSON.stringify(flightRouterState),
   }
   if (prefetch) {
     // Enable prefetch response
-    headers.__flight_prefetch__ = '1'
+    headers.__next_router_prefetch__ = '1'
   }
 
   const res = await fetch(url.toString(), {

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -579,7 +579,7 @@ function getScriptNonceFromHeader(cspHeaderValue: string): string | undefined {
 }
 
 const FLIGHT_PARAMETERS = [
-  '__flight__',
+  '__rsc__',
   '__flight_router_state_tree__',
   '__flight_prefetch__',
 ] as const
@@ -650,7 +650,7 @@ export async function renderToHTMLOrFlight(
     // don't modify original query object
     query = Object.assign({}, query)
 
-    const isFlight = req.headers.__flight__ !== undefined
+    const isFlight = req.headers.__rsc__ !== undefined
     const isPrefetch = req.headers.__flight_prefetch__ !== undefined
 
     // Handle client-side navigation to pages directory

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -580,8 +580,8 @@ function getScriptNonceFromHeader(cspHeaderValue: string): string | undefined {
 
 const FLIGHT_PARAMETERS = [
   '__rsc__',
-  '__flight_router_state_tree__',
-  '__flight_prefetch__',
+  '__next_router_state_tree__',
+  '__next_router_prefetch__',
 ] as const
 
 function headersWithoutFlight(headers: IncomingHttpHeaders) {
@@ -651,7 +651,7 @@ export async function renderToHTMLOrFlight(
     query = Object.assign({}, query)
 
     const isFlight = req.headers.__rsc__ !== undefined
-    const isPrefetch = req.headers.__flight_prefetch__ !== undefined
+    const isPrefetch = req.headers.__next_router_prefetch__ !== undefined
 
     // Handle client-side navigation to pages directory
     if (isFlight && isPagesDir) {
@@ -685,8 +685,8 @@ export async function renderToHTMLOrFlight(
      * Router state provided from the client-side router. Used to handle rendering from the common layout down.
      */
     const providedFlightRouterState: FlightRouterState = isFlight
-      ? req.headers.__flight_router_state_tree__
-        ? JSON.parse(req.headers.__flight_router_state_tree__ as string)
+      ? req.headers.__next_router_state_tree__
+        ? JSON.parse(req.headers.__next_router_state_tree__ as string)
         : {}
       : undefined
 

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1028,9 +1028,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       )
     }
 
-    // Don't delete query.__flight__ yet, it still needs to be used in renderToHTML later
+    // Don't delete query.__rsc__ yet, it still needs to be used in renderToHTML later
     const isFlightRequest = Boolean(
-      this.serverComponentManifest && req.headers.__flight__
+      this.serverComponentManifest && req.headers.__rsc__
     )
 
     // we need to ensure the status code if /404 is visited directly

--- a/packages/next/server/internal-utils.ts
+++ b/packages/next/server/internal-utils.ts
@@ -6,7 +6,7 @@ const INTERNAL_QUERY_NAMES = [
   '__nextDefaultLocale',
   '__nextIsNotFound',
   // RSC
-  '__flight__',
+  '__rsc__',
   // Routing
   '__flight_router_state_tree__',
   '__flight_prefetch__',

--- a/packages/next/server/internal-utils.ts
+++ b/packages/next/server/internal-utils.ts
@@ -8,8 +8,8 @@ const INTERNAL_QUERY_NAMES = [
   // RSC
   '__rsc__',
   // Routing
-  '__flight_router_state_tree__',
-  '__flight_prefetch__',
+  '__next_router_state_tree__',
+  '__next_router_prefetch__',
 ] as const
 
 const EXTENDED_INTERNAL_QUERY_NAMES = ['__nextDataReq'] as const

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -828,7 +828,7 @@ export default class NextNodeServer extends BaseServer {
 
     if (
       this.nextConfig.experimental.appDir &&
-      (renderOpts.isAppPath || req.headers.__flight__)
+      (renderOpts.isAppPath || req.headers.__rsc__)
     ) {
       const isPagesDir = !renderOpts.isAppPath
       return appRenderToHTMLOrFlight(

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -37,8 +37,8 @@ class NextRequestHint extends NextRequest {
 
 const FLIGHT_PARAMETERS = [
   '__rsc__',
-  '__flight_router_state_tree__',
-  '__flight_prefetch__',
+  '__next_router_state_tree__',
+  '__next_router_prefetch__',
 ] as const
 
 export async function adapter(params: {

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -36,7 +36,7 @@ class NextRequestHint extends NextRequest {
 }
 
 const FLIGHT_PARAMETERS = [
-  '__flight__',
+  '__rsc__',
   '__flight_router_state_tree__',
   '__flight_prefetch__',
 ] as const

--- a/test/e2e/app-dir/app/middleware.js
+++ b/test/e2e/app-dir/app/middleware.js
@@ -19,7 +19,7 @@ export function middleware(request) {
       ? 'rewrite'
       : 'redirect'
 
-    const internal = ['__flight__', '__flight_router_state_tree__']
+    const internal = ['__rsc__', '__flight_router_state_tree__']
     if (internal.some((name) => request.headers.has(name))) {
       return NextResponse[method](new URL('/internal/failure', request.url))
     }

--- a/test/e2e/app-dir/app/middleware.js
+++ b/test/e2e/app-dir/app/middleware.js
@@ -19,7 +19,7 @@ export function middleware(request) {
       ? 'rewrite'
       : 'redirect'
 
-    const internal = ['__rsc__', '__flight_router_state_tree__']
+    const internal = ['__rsc__', '__next_router_state_tree__']
     if (internal.some((name) => request.headers.has(name))) {
       return NextResponse[method](new URL('/internal/failure', request.url))
     }

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -42,7 +42,7 @@ describe('app dir', () => {
         {},
         {
           headers: {
-            __flight__: '1',
+            __rsc__: '1',
           },
         }
       )
@@ -56,7 +56,7 @@ describe('app dir', () => {
         {},
         {
           headers: {
-            __flight__: '1',
+            __rsc__: '1',
           },
         }
       )

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -91,7 +91,7 @@ describe('app dir - react server components', () => {
       '__nextLocale',
       '__nextDefaultLocale',
       '__nextIsNotFound',
-      '__flight__',
+      '__rsc__',
       '__flight_router_state_tree__',
       '__flight_prefetch__',
     ]
@@ -111,8 +111,8 @@ describe('app dir - react server components', () => {
           requestsCount++
           return request.allHeaders().then((headers) => {
             if (
-              headers.__flight__ === '1' &&
-              // Prefetches also include `__flight__`
+              headers.__rsc__ === '1' &&
+              // Prefetches also include `__rsc__`
               headers.__flight_prefetch__ !== '1'
             ) {
               hasFlightRequest = true
@@ -197,7 +197,7 @@ describe('app dir - react server components', () => {
         page.on('request', (request) => {
           return request.allHeaders().then((headers) => {
             if (
-              headers.__flight__ === '1' &&
+              headers.__rsc__ === '1' &&
               headers.__flight_prefetch__ !== '1'
             ) {
               hasFlightRequest = true
@@ -337,7 +337,7 @@ describe('app dir - react server components', () => {
       {},
       {
         headers: {
-          __flight__: '1',
+          __rsc__: '1',
         },
       }
     ).then(async (response) => {

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -92,8 +92,8 @@ describe('app dir - react server components', () => {
       '__nextDefaultLocale',
       '__nextIsNotFound',
       '__rsc__',
-      '__flight_router_state_tree__',
-      '__flight_prefetch__',
+      '__next_router_state_tree__',
+      '__next_router_prefetch__',
     ]
 
     const hasNextInternalQuery = inlineFlightContents.some((content) =>
@@ -113,7 +113,7 @@ describe('app dir - react server components', () => {
             if (
               headers.__rsc__ === '1' &&
               // Prefetches also include `__rsc__`
-              headers.__flight_prefetch__ !== '1'
+              headers.__next_router_prefetch__ !== '1'
             ) {
               hasFlightRequest = true
             }
@@ -198,7 +198,7 @@ describe('app dir - react server components', () => {
           return request.allHeaders().then((headers) => {
             if (
               headers.__rsc__ === '1' &&
-              headers.__flight_prefetch__ !== '1'
+              headers.__next_router_prefetch__ !== '1'
             ) {
               hasFlightRequest = true
             }

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -120,7 +120,7 @@ describe('Switchable runtime', () => {
           beforePageLoad(page) {
             page.on('request', (request) => {
               return request.allHeaders().then((headers) => {
-                if (headers.__flight__ === '1') {
+                if (headers.__rsc__ === '1') {
                   flightRequest = request.url()
                 }
               })
@@ -680,7 +680,7 @@ describe('Switchable runtime', () => {
           beforePageLoad(page) {
             page.on('request', (request) => {
               request.allHeaders().then((headers) => {
-                if (headers.__flight__ === '1') {
+                if (headers.__rsc__ === '1') {
                   flightRequest = request.url()
                 }
               })


### PR DESCRIPTION
- Rename `__flight__` to `__rsc__`
- Rename `__flight_router_state_tree__` to `__next_router_state_tree__`
- Rename `__flight_prefetch__` to `__next_router_prefetch__`
