### PR TITLE
Fix wrong code condition used when bundling the server

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -988,6 +988,7 @@ export default async function getBaseWebpackConfig(
     if (layer === WEBPACK_LAYERS.server) {
       if (
         request === 'react' ||
+        request === 'react/jsx-runtime' ||
         request ===
           'next/dist/compiled/react-server-dom-webpack/writer.browser.server'
       ) {
@@ -1492,7 +1493,7 @@ export default async function getBaseWebpackConfig(
                 issuerLayer: WEBPACK_LAYERS.server,
                 test: (req: string) => {
                   if (
-                    !/\.m?js/.test(req) ||
+                    !/\.(mjs|js|jsx|ts|tsx)/.test(req) ||
                     config.experimental.optoutServerComponentsBundle?.some(
                       (mod) => {
                         return req.includes('/node_modules/' + mod + '/')

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1493,7 +1493,7 @@ export default async function getBaseWebpackConfig(
                 issuerLayer: WEBPACK_LAYERS.server,
                 test: (req: string) => {
                   if (
-                    !/\.(mjs|js|jsx|ts|tsx)/.test(req) ||
+                    !codeCondition.test.test(req) ||
                     config.experimental.optoutServerComponentsBundle?.some(
                       (mod) => {
                         return req.includes('/node_modules/' + mod + '/')

--- a/test/e2e/app-dir/app-alias/app/button/page.tsx
+++ b/test/e2e/app-dir/app-alias/app/button/page.tsx
@@ -1,5 +1,10 @@
 import Button from '@/ui/button'
+import React from 'react'
 
 export default function page() {
+  if ('useState' in React) {
+    throw new Error('React is not resolved correctly.')
+  }
+
   return <Button>click</Button>
 }


### PR DESCRIPTION
We observed this bug when using `.tsx` as the extension (currently the condition only matches `.m?js`). Besides that, `react/jsx-runtime` shouldn't be external too because it has React imported.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
