### PR TITLE
Move pagesDir handling out of wrappedRender

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -604,6 +604,8 @@ export async function renderToHTMLOrFlight(
   isPagesDir: boolean,
   isStaticGeneration: boolean = false
 ): Promise<RenderResult | null> {
+  const isFlight = req.headers.__rsc__ !== undefined
+
   const capturedErrors: Error[] = []
 
   const serverComponentsErrorHandler = createErrorHandler(
@@ -627,6 +629,32 @@ export async function renderToHTMLOrFlight(
     supportsDynamicHTML,
     ComponentMod,
   } = renderOpts
+
+  // Handle client-side navigation to pages directory
+  // This is handled before
+  if (isFlight && isPagesDir) {
+    stripInternalQueries(query)
+    const search = stringifyQuery(query)
+
+    // For pages dir, there is only the SSR pass and we don't have the bundled
+    // React subset. Here we directly import the flight renderer with the
+    // unbundled React.
+    // TODO-APP: Is it possible to hard code the flight response here instead of
+    // rendering it?
+    const ReactServerDOMWebpack = require('next/dist/compiled/react-server-dom-webpack/writer.browser.server')
+
+    // Empty so that the client-side router will do a full page navigation.
+    const flightData: FlightData = pathname + (search ? `?${search}` : '')
+    return new FlightRenderResult(
+      ReactServerDOMWebpack.renderToReadableStream(
+        flightData,
+        serverComponentManifest,
+        {
+          onError: flightDataRendererErrorHandler,
+        }
+      ).pipeThrough(createBufferedTransformStream())
+    )
+  }
 
   patchFetch(ComponentMod)
 
@@ -653,33 +681,7 @@ export async function renderToHTMLOrFlight(
     // don't modify original query object
     query = Object.assign({}, query)
 
-    const isFlight = req.headers.__rsc__ !== undefined
     const isPrefetch = req.headers.__next_router_prefetch__ !== undefined
-
-    // Handle client-side navigation to pages directory
-    if (isFlight && isPagesDir) {
-      stripInternalQueries(query)
-      const search = stringifyQuery(query)
-
-      // For pages dir, there is only the SSR pass and we don't have the bundled
-      // React subset. Here we directly import the flight renderer with the
-      // unbundled React.
-      // TODO-APP: Is it possible to hard code the flight response here instead of
-      // rendering it?
-      const ReactServerDOMWebpack = require('next/dist/compiled/react-server-dom-webpack/writer.browser.server')
-
-      // Empty so that the client-side router will do a full page navigation.
-      const flightData: FlightData = pathname + (search ? `?${search}` : '')
-      return new FlightRenderResult(
-        ReactServerDOMWebpack.renderToReadableStream(
-          flightData,
-          serverComponentManifest,
-          {
-            onError: flightDataRendererErrorHandler,
-          }
-        ).pipeThrough(createBufferedTransformStream())
-      )
-    }
 
     // TODO-APP: verify the tree is valid
     // TODO-APP: verify query param is single value (not an array)


### PR DESCRIPTION
Fixes a problem where getStore is undefined as it doesn't exist on the componentMod of pages

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
