### PR TITLE
Fix unused CSS module imports are tracked on the server

### DIFF
--- a/test/e2e/app-dir/app/app/css/css-page/unused/page.js
+++ b/test/e2e/app-dir/app/app/css/css-page/unused/page.js
@@ -1,6 +1,4 @@
-import './style.css'
-
-import styles from './style.module.css'
+import { styles } from './styles'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/app/app/css/css-page/unused/styles.js
+++ b/test/e2e/app-dir/app/app/css/css-page/unused/styles.js
@@ -1,0 +1,4 @@
+import unused from './unused.module.css'
+import styles from '../style.module.css'
+
+export { unused, styles }

--- a/test/e2e/app-dir/app/app/css/css-page/unused/unused.module.css
+++ b/test/e2e/app-dir/app/app/css/css-page/unused/unused.module.css
@@ -1,0 +1,3 @@
+.this_should_not_be_included {
+  color: red;
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1186,6 +1186,17 @@ describe('app dir', () => {
             )
           ).toBe('rgb(0, 0, 255)')
         })
+
+        if (!isDev) {
+          it('should not include unused css modules in the page in prod', async () => {
+            const browser = await webdriver(next.url, '/css/css-page')
+            expect(
+              await browser.eval(
+                `[...document.styleSheets].some(({ rules }) => [...rules].some(rule => rule.selectorText.includes('this_should_not_be_included')))`
+              )
+            ).toBe(false)
+          })
+        }
       })
 
       describe('client layouts', () => {


### PR DESCRIPTION
Reported by @hanneslund, when a CSS modules file gets imported in server components, during `collectClientComponentsAndCSSForDependency` in our client entry plugin it will always be collected no matter it is used or not. Due to the restriction that we have to collect these imports to create the client entry, it has to run in the `finishMake` compiler phase and at that time, module optimization hasn't started yet.

To fix that issue, we run another pass in `afterOptimizeModules` just to collect CSS imports for the server style manifest and we can filter out unused modules there.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
