### PR TITLE
Add test case for `react-server` import condition

### DIFF
--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -405,9 +405,11 @@ describe('app dir - react server components', () => {
         const result = await resolveStreamResponse(response)
 
         // Package should be resolved based on the react-server condition,
-        // as well as package's dependencies.
-        expect(result).toContain('Server: index.react-server:react.subset')
-        expect(result).toContain('Client: index.default:react.full')
+        // as well as package's internal & external dependencies.
+        expect(result).toContain(
+          'Server: index.react-server:react.subset:dep.server'
+        )
+        expect(result).toContain('Client: index.default:react.full:dep.default')
 
         // Subpath exports should be resolved based on the condition too.
         expect(result).toContain('Server subpath: subpath.react-server')

--- a/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/dep.js
+++ b/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/dep.js
@@ -1,0 +1,1 @@
+module.exports = 'dep.default'

--- a/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/dep.server.js
+++ b/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/dep.server.js
@@ -1,0 +1,1 @@
+module.exports = 'dep.server'

--- a/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/index.js
+++ b/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/index.js
@@ -1,4 +1,8 @@
 const react = require('react')
+const dep = require('#dep')
 
 module.exports =
-  'index.default:' + ('useState' in react ? 'react.full' : 'react.subset')
+  'index.default:' +
+  ('useState' in react ? 'react.full' : 'react.subset') +
+  ':' +
+  dep

--- a/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/index.server.js
+++ b/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/index.server.js
@@ -1,4 +1,8 @@
 const react = require('react')
+const dep = require('#dep')
 
 module.exports =
-  'index.react-server:' + ('useState' in react ? 'react.full' : 'react.subset')
+  'index.react-server:' +
+  ('useState' in react ? 'react.full' : 'react.subset') +
+  ':' +
+  dep

--- a/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/package.json
+++ b/test/e2e/app-dir/rsc-basic/node_modules_bak/conditional-exports/package.json
@@ -1,6 +1,12 @@
 {
   "name": "conditional-exports",
   "main": "index.js",
+  "imports": {
+    "#dep": {
+      "react-server": "./dep.server.js",
+      "default": "./dep.js"
+    }
+  },
   "exports": {
     ".": {
       "react-server": "./index.server.js",


### PR DESCRIPTION
The `react-server` condition for `exports` is already covered. This PR adds a new test case to cover the `imports` condition for internal dependencies.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
