### PR TITLE
Skip creating virtual app client entry for pages

### DIFF
--- a/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -96,6 +96,9 @@ export class FlightClientEntryPlugin {
       }) => void
     ) {
       for (const [name, entry] of compilation.entries.entries()) {
+        // Skip for entries under pages/
+        if (name.startsWith('pages/')) continue
+
         // Check if the page entry is a server component or not.
         const entryDependency: webpack.NormalModule | undefined =
           entry.dependencies?.[0]

--- a/test/e2e/app-dir/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge.test.ts
@@ -1,0 +1,40 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { renderViaHTTP } from 'next-test-utils'
+import path from 'path'
+
+describe('app-dir edge SSR', () => {
+  if ((global as any).isNextDeploy) {
+    it('should skip next deploy for now', () => {})
+    return
+  }
+
+  if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
+    it('should skip for react v17', () => {})
+    return
+  }
+
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(path.join(__dirname, 'app-edge')),
+      dependencies: {
+        react: 'experimental',
+        'react-dom': 'experimental',
+        typescript: 'latest',
+        '@types/react': 'latest',
+        '@types/node': 'latest',
+      },
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should handle edge only routes', async () => {
+    const appHtml = await renderViaHTTP(next.url, '/app-edge')
+    expect(appHtml).toContain('<p>app-edge-ssr</p>')
+
+    const pageHtml = await renderViaHTTP(next.url, '/pages-edge')
+    expect(pageHtml).toContain('<p>pages-edge-ssr</p>')
+  })
+})

--- a/test/e2e/app-dir/app-edge/app/app-edge/page.tsx
+++ b/test/e2e/app-dir/app-edge/app/app-edge/page.tsx
@@ -1,0 +1,4 @@
+export default function Page() {
+  return <p>app-edge-ssr</p>
+}
+export const config = { runtime: 'experimental-edge' }

--- a/test/e2e/app-dir/app-edge/app/layout.tsx
+++ b/test/e2e/app-dir/app-edge/app/layout.tsx
@@ -1,0 +1,8 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <head></head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-edge/next.config.js
+++ b/test/e2e/app-dir/app-edge/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+    legacyBrowsers: false,
+    browsersListForSwc: true,
+  },
+}

--- a/test/e2e/app-dir/app-edge/pages/pages-edge.tsx
+++ b/test/e2e/app-dir/app-edge/pages/pages-edge.tsx
@@ -1,0 +1,5 @@
+export default function Page() {
+  return <p>pages-edge-ssr</p>
+}
+
+export const config = { runtime: 'experimental-edge' }

--- a/test/e2e/app-dir/app-edge/tsconfig.json
+++ b/test/e2e/app-dir/app-edge/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/ui/*": ["ui/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
When there're only one edge route in `pages/` and one in `app/`, the virtual client entry is split into pages chunks which is not expected.
We should only create client virtual entries for `app/`, not `pages/`, now we skip the `pages/` entries for client entry now

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`
