### PR TITLE
Update cms-makeswift example

### DIFF
--- a/examples/cms-makeswift/next.config.js
+++ b/examples/cms-makeswift/next.config.js
@@ -3,6 +3,7 @@ const withMakeswift = require('@makeswift/runtime/next/plugin')()
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  swcMinify: true,
 }
 
 module.exports = withMakeswift(nextConfig)

--- a/examples/cms-makeswift/package.json
+++ b/examples/cms-makeswift/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@makeswift/runtime": "0.1.10",
+    "@makeswift/runtime": "0.2.2",
     "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/examples/cms-makeswift/pages/[[...path]].ts
+++ b/examples/cms-makeswift/pages/[[...path]].ts
@@ -1,7 +1,0 @@
-import '../lib/makeswift/register-components'
-
-export {
-  getStaticPaths,
-  getStaticProps,
-  Page as default,
-} from '@makeswift/runtime/next'

--- a/examples/cms-makeswift/pages/[[...path]].tsx
+++ b/examples/cms-makeswift/pages/[[...path]].tsx
@@ -1,0 +1,51 @@
+import '../lib/makeswift/register-components'
+
+import { Makeswift } from '@makeswift/runtime/next'
+import {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next'
+
+import {
+  Page as MakeswiftPage,
+  PageProps as MakeswiftPageProps,
+} from '@makeswift/runtime/next'
+
+type ParsedUrlQuery = { path?: string[] }
+
+export async function getStaticPaths(): Promise<
+  GetStaticPathsResult<ParsedUrlQuery>
+> {
+  const makeswift = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY!)
+  const pages = await makeswift.getPages()
+
+  return {
+    paths: pages.map((page) => ({
+      params: {
+        path: page.path.split('/').filter((segment) => segment !== ''),
+      },
+    })),
+    fallback: 'blocking',
+  }
+}
+
+type Props = MakeswiftPageProps
+
+export async function getStaticProps(
+  ctx: GetStaticPropsContext<ParsedUrlQuery>
+): Promise<GetStaticPropsResult<Props>> {
+  const makeswift = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY!)
+  const path = '/' + (ctx.params?.path ?? []).join('/')
+  const snapshot = await makeswift.getPageSnapshot(path, {
+    preview: ctx.preview,
+  })
+
+  if (snapshot == null) return { notFound: true }
+
+  return { props: { snapshot } }
+}
+
+export default function Page({ snapshot }: Props) {
+  return <MakeswiftPage snapshot={snapshot} />
+}

--- a/examples/cms-makeswift/pages/api/makeswift/[...makeswift].ts
+++ b/examples/cms-makeswift/pages/api/makeswift/[...makeswift].ts
@@ -1,0 +1,3 @@
+import { MakeswiftApiHandler } from '@makeswift/runtime/next'
+
+export default MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY!)

--- a/examples/cms-makeswift/pages/makeswift.ts
+++ b/examples/cms-makeswift/pages/makeswift.ts
@@ -1,3 +1,0 @@
-import '../lib/makeswift/register-components'
-
-export { getServerSideProps, Page as default } from '@makeswift/runtime/next'


### PR DESCRIPTION
Makeswift now uses Next.js' Preview Mode so there's no need for a preview route. It also supports automatic on-demand revalidation with the introduction of the Makeswift API handler.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
