### PR TITLE
Skip experimental undici test for deploy mode

### DIFF
--- a/test/e2e/undici-fetch/index.test.ts
+++ b/test/e2e/undici-fetch/index.test.ts
@@ -5,7 +5,8 @@ import semver from 'semver'
 
 if (
   semver.lt(process.version, '16.8.0') ||
-  semver.gte(process.version, '18.0.0')
+  semver.gte(process.version, '18.0.0') ||
+  (global as any).isNextDeploy
 ) {
   it('skipping for Node.js versions <16.8.0 and >18.0.0', () => {
     expect(true).toBe(true)


### PR DESCRIPTION
Skipping for now as the test doesn't work correctly in deploy mode. 

x-ref: https://github.com/vercel/next.js/actions/runs/3145043013/jobs/5112533360