### PR TITLE
misc: make useReducerWithDevtools noop on server

### DIFF
--- a/packages/next/client/components/use-reducer-with-devtools.ts
+++ b/packages/next/client/components/use-reducer-with-devtools.ts
@@ -104,7 +104,20 @@ function devToolReducer(
   }
 }
 
-export function useReducerWithReduxDevtools(
+function useReducerWithReduxDevtoolsNoop(
+  fn: typeof reducer,
+  initialState: ReturnType<typeof reducer>
+): [
+  ReturnType<typeof reducer>,
+  Dispatch<ReducerAction<typeof reducer>>,
+  () => void
+] {
+  const [state, dispatch] = useReducer(fn, initialState)
+
+  return [state, dispatch, () => {}]
+}
+
+function useReducerWithReduxDevtoolsImpl(
   fn: typeof reducer,
   initialState: ReturnType<typeof reducer>
 ): [
@@ -158,3 +171,8 @@ export function useReducerWithReduxDevtools(
   }, [state])
   return [state, dispatch, sync]
 }
+
+export const useReducerWithReduxDevtools =
+  typeof window !== 'undefined'
+    ? useReducerWithReduxDevtoolsImpl
+    : useReducerWithReduxDevtoolsNoop


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Making this function a noop on server for bundle size gains with DCE since most of the code is in an useEffect and is not gonna run

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
