### PR TITLE
Remove reload on serverComponentChanges in pages

### DIFF
--- a/packages/next/client/dev/error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev/error-overlay/hot-dev-client.js
@@ -260,16 +260,6 @@ function processMessage(e) {
       )
       return handleSuccess()
     }
-
-    case 'serverComponentChanges': {
-      sendMessage(
-        JSON.stringify({
-          event: 'server-component-reload-page',
-          clientId: window.__nextDevClientId,
-        })
-      )
-      return window.location.reload()
-    }
     default: {
       if (customHmrEventHandler) {
         customHmrEventHandler(obj)


### PR DESCRIPTION
This caused unexpected full page reloads when viewing pages in `pages`. E.g. when navigating to `app`. Since `app` is the only place you can have server components now this is no longer needed.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
