### PR TITLE
Add test for rewrite from pages to app with existing pages path

### DIFF
--- a/test/e2e/app-dir/app/middleware.js
+++ b/test/e2e/app-dir/app/middleware.js
@@ -6,6 +6,10 @@ import { NextResponse } from 'next/server'
  * @returns {NextResponse | undefined}
  */
 export function middleware(request) {
+  if (request.nextUrl.pathname === '/exists-but-not-routed') {
+    return NextResponse.rewrite(new URL('/dashboard', request.url))
+  }
+
   if (request.nextUrl.pathname === '/middleware-to-dashboard') {
     return NextResponse.rewrite(new URL('/dashboard', request.url))
   }

--- a/test/e2e/app-dir/app/pages/exists-but-not-routed.js
+++ b/test/e2e/app-dir/app/pages/exists-but-not-routed.js
@@ -1,0 +1,15 @@
+export async function getServerSideProps() {
+  return {
+    props: {
+      message: 'Hello World!',
+    },
+  }
+}
+
+export default function Page({ message }) {
+  return (
+    <>
+      <p>hello from exists but not routed {message}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/pages/link-to-rewritten-path.js
+++ b/test/e2e/app-dir/app/pages/link-to-rewritten-path.js
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+
+export default function Page(props) {
+  return (
+    <>
+      <Link href="/exists-but-not-routed">
+        <a id="link-to-rewritten-path">Exists but not routed</a>
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -238,11 +238,32 @@ describe('app dir', () => {
     })
 
     describe('rewrites', () => {
-      // TODO-APP:
+      // TODO-APP: rewrite url is broken
       it.skip('should support rewrites on initial load', async () => {
         const browser = await webdriver(next.url, '/rewritten-to-dashboard')
         expect(await browser.elementByCss('h1').text()).toBe('Dashboard')
         expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
+      })
+
+      it('should support rewrites on client-side navigation from pages to app with existing pages path', async () => {
+        const browser = await webdriver(next.url, '/link-to-rewritten-path')
+
+        try {
+          // Click the link.
+          await browser.elementById('link-to-rewritten-path').click()
+          await browser.waitForElementByCss('#from-dashboard')
+
+          // Check to see that we were rewritten and not redirected.
+          // TODO-APP: rewrite url is broken
+          // expect(await browser.url()).toBe(`${next.url}/rewritten-to-dashboard`)
+
+          // Check to see that the page we navigated to is in fact the dashboard.
+          expect(await browser.elementByCss('#from-dashboard').text()).toBe(
+            'hello from app/dashboard'
+          )
+        } finally {
+          await browser.close()
+        }
       })
 
       it('should support rewrites on client-side navigation', async () => {


### PR DESCRIPTION
Rather specific test for when you incrementally migrate using middleware and only route to the `app` route based on some condition.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
