### PR TITLE
Pass ref through dynamic

### DIFF
--- a/packages/next/shared/lib/loadable.js
+++ b/packages/next/shared/lib/loadable.js
@@ -136,12 +136,14 @@ function createLoadableComponent(loadFn, options) {
       subscription.getCurrentValue
     )
 
-    React.useImperativeHandle(
-      ref,
-      () => ({
+    // Ref to pass to the inner components
+    const innerRef = React.useRef()
+
+    // Modify the instance exposed to parents and expose the innerRef
+    React.useImperativeHandle(ref, () =>
+      Object.assign(innerRef, {
         retry: subscription.retry,
-      }),
-      []
+      })
     )
 
     return React.useMemo(() => {
@@ -154,7 +156,10 @@ function createLoadableComponent(loadFn, options) {
           retry: subscription.retry,
         })
       } else if (state.loaded) {
-        return React.createElement(resolve(state.loaded), props)
+        return React.createElement(resolve(state.loaded), {
+          ...props,
+          ref: innerRef,
+        })
       } else {
         return null
       }


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/40769. The issue I noticed was a `ref` passed to `dynamic` components won't be passed to the wrapped component in some cases.

