### PR TITLE
fix: remove assert of req.url

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -440,7 +440,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
     try {
-      const urlParts = (req.url || '').split('?')
+      const urlParts = req.url.split('?')
       const urlNoQuery = urlParts[0]
 
       // this normalizes repeated slashes in the path e.g. hello//world ->
@@ -448,7 +448,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       // handle trailing slash as that is handled the same as a next.config.js
       // redirect
       if (urlNoQuery?.match(/(\\|\/\/)/)) {
-        const cleanUrl = normalizeRepeatedSlashes(req.url!)
+        const cleanUrl = normalizeRepeatedSlashes(req.url)
         res.redirect(cleanUrl, 308).body(cleanUrl).send()
         return
       }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)


in `BaseNextRequest `, url is required