### PR TITLE
Skip pagesDirRules when pagesDir is not present

### DIFF
--- a/packages/next/lib/eslint/runLintCheck.ts
+++ b/packages/next/lib/eslint/runLintCheck.ts
@@ -154,7 +154,6 @@ async function lint(
 
     let nextEslintPluginIsEnabled = false
     const nextRulesEnabled = new Map<string, Severity>()
-    const pagesDirRules = ['@next/next/no-html-link-for-pages']
 
     for (const configFile of [eslintrcFile, pkgJsonPath]) {
       if (!configFile) continue
@@ -187,6 +186,7 @@ async function lint(
     }
 
     const pagesDir = findPagesDir(baseDir, hasAppDir).pages
+    const pagesDirRules = pagesDir ? ['@next/next/no-html-link-for-pages'] : []
 
     if (nextEslintPluginIsEnabled) {
       let updatedPagesDir = false


### PR DESCRIPTION
Follow up for #40132

Do not apply pages lint rule `@next/next/no-html-link-for-pages` for appDir