### PR TITLE
Memoize `<AmpStyles />` 🚗 

### DIFF
--- a/packages/next/pages/_document.tsx
+++ b/packages/next/pages/_document.tsx
@@ -90,11 +90,11 @@ function hasComponentProps(child: any): child is React.ReactElement {
   return !!child && !!child.props
 }
 
-function AmpStyles({
+const AmpStyles = React.memo(({
   styles,
 }: {
   styles?: React.ReactElement[] | React.ReactFragment
-}) {
+}) => {
   if (!styles) return null
 
   // try to parse styles from fragment for backwards compat
@@ -132,7 +132,7 @@ function AmpStyles({
       }}
     />
   )
-}
+})
 
 function getDynamicChunks(
   context: HtmlProps,


### PR DESCRIPTION
Memoize the AmpStyles internal component using shallow comparison to prevent unnecessary re renders.

_Sorry if I am wrong :(_