### PR TITLE
Docs: Fix misleading `console.log` output example

### DIFF
--- a/docs/api-reference/edge-runtime.md
+++ b/docs/api-reference/edge-runtime.md
@@ -121,7 +121,7 @@ Running `console.log` on `process.env` **will not** show all your Environment Va
 console.log(process.env)
 // { NEXT_RUNTIME: 'edge' }
 console.log(process.env.TEST_VARIABLE)
-// { NEXT_RUNTIME: 'edge', TEST_VARIABLE: 'value' }
+// value
 ```
 
 ## Unsupported APIs


### PR DESCRIPTION
The docs have a misleading `console.log` output for the input `process.env` that doesn't display all the variables on edge runtime. The example shows an output of a supposed object with all the environment variables, but it does this when logging a specific variable. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
