### PR TITLE
Ensure entry tracing applies for app correctly

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1817,8 +1817,8 @@ export default async function getBaseWebpackConfig(
           {
             appDir: dir,
             esmExternals: config.experimental.esmExternals,
-            staticImageImports: !config.images.disableStaticImages,
             outputFileTracingRoot: config.experimental.outputFileTracingRoot,
+            appDirEnabled: !!config.experimental.appDir,
           }
         ),
       // Moment.js is an extremely popular library that bundles large locale files

--- a/test/e2e/app-dir/app/app/dashboard/deployments/[id]/data.json
+++ b/test/e2e/app-dir/app/app/dashboard/deployments/[id]/data.json
@@ -1,0 +1,3 @@
+{
+  "hello": "world"
+}

--- a/test/e2e/app-dir/app/app/dashboard/deployments/[id]/page.js
+++ b/test/e2e/app-dir/app/app/dashboard/deployments/[id]/page.js
@@ -1,6 +1,15 @@
 import { experimental_use as use } from 'react'
+import fs from 'fs'
+import path from 'path'
 
 async function getData({ params }) {
+  const data = JSON.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), 'app/dashboard/deployments/[id]/data.json')
+    )
+  )
+  console.log('data.json', data)
+
   return {
     id: params.id,
   }

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -35,6 +35,19 @@ describe('app dir', () => {
     })
     afterAll(() => next.destroy())
 
+    if ((global as any).isNextStart) {
+      it('should generate build traces correctly', async () => {
+        const trace = JSON.parse(
+          await next.readFile(
+            '.next/server/app/dashboard/deployments/[id]/page.js.nft.json'
+          )
+        ) as { files: string[] }
+        expect(trace.files.some((file) => file.endsWith('data.json'))).toBe(
+          true
+        )
+      })
+    }
+
     it('should use application/octet-stream for flight', async () => {
       const res = await fetchViaHTTP(
         next.url,


### PR DESCRIPTION
This ensures we properly detect and trace `app` dir entries and adds a regression test to ensure this is working as expected. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`


