### PR TITLE
Handle hmr for edge ssr in app dir

### DIFF
--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -612,22 +612,21 @@ export default class HotReloader {
               onEdgeServer: () => {
                 // TODO-APP: verify if child entry should support.
                 if (!isEdgeServerCompilation || !isEntry) return
-                const appDirLoader =
-                  isAppPath && this.appDir
-                    ? getAppEntry({
-                        name: bundlePath,
-                        appPaths: entryData.appPaths,
-                        pagePath: posix.join(
-                          APP_DIR_ALIAS,
-                          relative(
-                            this.appDir!,
-                            entryData.absolutePagePath
-                          ).replace(/\\/g, '/')
-                        ),
-                        appDir: this.appDir!,
-                        pageExtensions: this.config.pageExtensions,
-                      }).import
-                    : undefined
+                const appDirLoader = isAppPath
+                  ? getAppEntry({
+                      name: bundlePath,
+                      appPaths: entryData.appPaths,
+                      pagePath: posix.join(
+                        APP_DIR_ALIAS,
+                        relative(
+                          this.appDir!,
+                          entryData.absolutePagePath
+                        ).replace(/\\/g, '/')
+                      ),
+                      appDir: this.appDir!,
+                      pageExtensions: this.config.pageExtensions,
+                    }).import
+                  : undefined
 
                 entries[entryKey].status = BUILDING
                 entrypoints[bundlePath] = finalizeEntrypoint({
@@ -688,25 +687,24 @@ export default class HotReloader {
                 }
 
                 entrypoints[bundlePath] = finalizeEntrypoint({
-                  compilerType: 'server',
+                  compilerType: COMPILER_NAMES.server,
                   name: bundlePath,
                   isServerComponent,
-                  value:
-                    this.appDir && bundlePath.startsWith('app/')
-                      ? getAppEntry({
-                          name: bundlePath,
-                          appPaths: entryData.appPaths,
-                          pagePath: posix.join(
-                            APP_DIR_ALIAS,
-                            relative(
-                              this.appDir!,
-                              entryData.absolutePagePath
-                            ).replace(/\\/g, '/')
-                          ),
-                          appDir: this.appDir!,
-                          pageExtensions: this.config.pageExtensions,
-                        })
-                      : relativeRequest,
+                  value: isAppPath
+                    ? getAppEntry({
+                        name: bundlePath,
+                        appPaths: entryData.appPaths,
+                        pagePath: posix.join(
+                          APP_DIR_ALIAS,
+                          relative(
+                            this.appDir!,
+                            entryData.absolutePagePath
+                          ).replace(/\\/g, '/')
+                        ),
+                        appDir: this.appDir!,
+                        pageExtensions: this.config.pageExtensions,
+                      })
+                    : relativeRequest,
                   appDir: this.config.experimental.appDir,
                 })
               },
@@ -895,7 +893,12 @@ export default class HotReloader {
         changedServerPages,
         changedClientPages
       )
+      const edgeServerOnlyChanges = difference<string>(
+        changedEdgeServerPages,
+        changedClientPages
+      )
       const serverComponentChanges = serverOnlyChanges
+        .concat(edgeServerOnlyChanges)
         .filter((key) => key.startsWith('app/'))
         .concat(Array.from(changedCSSImportPages))
       const pageChanges = serverOnlyChanges.filter((key) =>

--- a/test/e2e/app-dir/app-edge/app/app-edge/layout.tsx
+++ b/test/e2e/app-dir/app-edge/app/app-edge/layout.tsx
@@ -1,5 +1,7 @@
 'client'
 
+// TODO-APP: support typing for useSelectedLayoutSegment
+// @ts-ignore
 import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client'
 
 export default function Layout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Include the edge server changes that starting in app dir into server components changes. Most changes are merging condition `isAppPath && this.appDir` into `isAppPath`.

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`
