### PR TITLE
Fix reading edge info for app paths

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -1358,7 +1358,7 @@ export default async function build(
                         MIDDLEWARE_MANIFEST
                       ))
                       const manifestKey =
-                        pageType === 'pages' ? page : join(page, 'page')
+                        pageType === 'pages' ? page : originalAppPath || ''
 
                       edgeInfo = manifest.functions[manifestKey]
                     }

--- a/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
+++ b/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
@@ -5,3 +5,7 @@ export default function HelloPage(props) {
     </>
   )
 }
+
+export const config = {
+  runtime: 'experimental-edge',
+}


### PR DESCRIPTION
This fixes the build failing due to attempting to read `edgeInfo` that wasn't present from using the wrong key to look up the manifest entry. Regression test added by enabling `experimental-edge` on a page that was failing to be looked up. 

Fixes: 
```sh
TypeError: Cannot read properties of undefined (reading 'files')
    at /Users/jj/dev/vercel/layouts-playground/node_modules/next/dist/build/utils.js:786:33
    at Span.traceAsyncFn (/Users/jj/dev/vercel/layouts-playground/node_modules/next/dist/trace/trace.js:79:26)
    at Object.isPageStatic (/Users/jj/dev/vercel/layouts-playground/node_modules/next/dist/build/utils.js:771:29)
```

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

