### PR TITLE
feat: add type safety to NextApiRequest

### DIFF
--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -8,6 +8,14 @@ import type { ParsedUrlQuery } from 'querystring'
 import type { PreviewData } from 'next/types'
 import { COMPILER_NAMES } from './constants'
 
+type ShapeOf<T> = {
+  [K in keyof T]: any
+}
+
+type Extended<Base, Extension> = {
+  [K in keyof Omit<Base, keyof Extension>]: Base[K]
+} & Extension
+
 export type NextComponentType<
   C extends BaseContext = NextPageContext,
   IP = {},
@@ -194,24 +202,32 @@ export type DocumentInitialProps = RenderPageResult & {
 
 export type DocumentProps = DocumentInitialProps & HtmlProps
 
-/**
- * Next `API` route request
- */
-export interface NextApiRequest extends IncomingMessage {
-  /**
-   * Object of `query` values from url
-   */
+export type NextApiRequestConfig = {
   query: Partial<{
     [key: string]: string | string[]
   }>
+  cookies: {
+    [key: string]: string
+  }
+  body: any
+}
+
+/**
+ * Next `API` route request
+ */
+export interface NextApiRequest<
+  Extension extends Partial<ShapeOf<NextApiRequestConfig>> = {}
+> extends IncomingMessage {
+  /**
+   * Object of `query` values from url
+   */
+  query: Extended<NextApiRequestConfig, Extension>['query']
   /**
    * Object of `cookies` from header
    */
-  cookies: Partial<{
-    [key: string]: string
-  }>
+  cookies: Extended<NextApiRequestConfig, Extension>['cookies']
 
-  body: any
+  body: Extended<NextApiRequestConfig, Extension>['body']
 
   env: Env
 

--- a/packages/next/shared/lib/utils.ts
+++ b/packages/next/shared/lib/utils.ts
@@ -9,7 +9,7 @@ import type { PreviewData } from 'next/types'
 import { COMPILER_NAMES } from './constants'
 
 type ShapeOf<T> = {
-  [K in keyof T]: any
+  [K in keyof T]: unknown
 }
 
 type Extended<Base, Extension> = {


### PR DESCRIPTION
The current PR proposes a simple addition to overload the types of `req.query`, `req.cookies` and `req.body` independently and without the hassle of passing all the types at once.

The DX is focused in not repeating [the inconvenience of Express types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1e0a6f3923a9d9502b50f8c327e2b9e2c07bda8b/types/express/index.d.ts#L112-L118), where you need to pass 4 generics defaults in a row in order to overload the query type.

Here, we allow simply for an engineer to pass only the types they need, and we provide a default fallback type for each property.

---

EDIT: i've just found https://github.com/vercel/next.js/issues/32677 - i understand the standpoint of data validation - that said the changes here dont alter the default behavior, and simply provide further help in a convenient way, if ever needed. 