### PR TITLE
Fix latest experimental react and experimental-edge and unpin test versions

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1217,7 +1217,6 @@ export default async function getBaseWebpackConfig(
                       '{}',
                     './cjs/react-dom-server-legacy.browser.development.js':
                       '{}',
-                    'react-dom': '{}',
                   },
                   handleWebpackExternalForEdgeRuntime,
                 ]

--- a/test/e2e/app-dir/app-alias.test.ts
+++ b/test/e2e/app-dir/app-alias.test.ts
@@ -20,8 +20,8 @@ describe('app-dir alias handling', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'app-alias')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
         typescript: 'latest',
         '@types/react': 'latest',
         '@types/node': 'latest',

--- a/test/e2e/app-dir/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge.test.ts
@@ -20,8 +20,8 @@ describe('app-dir edge SSR', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'app-edge')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
         typescript: 'latest',
         '@types/react': 'latest',
         '@types/node': 'latest',

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -24,8 +24,8 @@ describe('app-dir static/dynamic handling', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'app-static')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
     })
   })

--- a/test/e2e/app-dir/asset-prefix.test.ts
+++ b/test/e2e/app-dir/asset-prefix.test.ts
@@ -21,8 +21,8 @@ describe('app-dir assetPrefix handling', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'asset-prefix')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
       skipStart: true,
     })

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -25,8 +25,8 @@ describe('app dir', () => {
       next = await createNext({
         files: new FileRef(path.join(__dirname, 'app')),
         dependencies: {
-          react: '0.0.0-experimental-cb5084d1c-20220924',
-          'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+          react: 'experimental',
+          'react-dom': 'experimental',
         },
         skipStart: true,
       })

--- a/test/e2e/app-dir/next-font.test.ts
+++ b/test/e2e/app-dir/next-font.test.ts
@@ -22,8 +22,8 @@ describe('app dir next-font', () => {
       files: new FileRef(path.join(__dirname, 'next-font')),
       dependencies: {
         '@next/font': 'canary',
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
       skipStart: true,
     })

--- a/test/e2e/app-dir/prefetching.test.ts
+++ b/test/e2e/app-dir/prefetching.test.ts
@@ -21,8 +21,8 @@ describe('app dir prefetching', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'app-prefetch')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
       skipStart: true,
     })

--- a/test/e2e/app-dir/rendering.test.ts
+++ b/test/e2e/app-dir/rendering.test.ts
@@ -22,8 +22,8 @@ describe('app dir rendering', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'app-rendering')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
     })
   })

--- a/test/e2e/app-dir/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout.test.ts
@@ -27,8 +27,8 @@ describe('app-dir root layout', () => {
         ),
       },
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
     })
   })

--- a/test/e2e/app-dir/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic.test.ts
@@ -39,8 +39,8 @@ describe('app dir - react server components', () => {
       files: new FileRef(path.join(__dirname, './rsc-basic')),
       dependencies: {
         'styled-components': '6.0.0-beta.2',
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
       packageJson: {
         scripts: {

--- a/test/e2e/app-dir/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash.test.ts
@@ -21,8 +21,8 @@ describe('app-dir trailingSlash handling', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'trailingslash')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
       skipStart: true,
     })

--- a/test/e2e/app-dir/vercel-analytics.test.ts
+++ b/test/e2e/app-dir/vercel-analytics.test.ts
@@ -23,8 +23,8 @@ describe('vercel analytics', () => {
       next = await createNext({
         files: new FileRef(path.join(__dirname, 'app')),
         dependencies: {
-          react: '0.0.0-experimental-cb5084d1c-20220924',
-          'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+          react: 'experimental',
+          'react-dom': 'experimental',
         },
         skipStart: true,
         env: {

--- a/test/e2e/app-dir/with-babel.test.ts
+++ b/test/e2e/app-dir/with-babel.test.ts
@@ -20,8 +20,8 @@ describe('with babel', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'with-babel')),
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
     })
   })

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -52,8 +52,8 @@ describe('Switchable runtime', () => {
         'next.config.js': new FileRef(join(__dirname, './next.config.js')),
       },
       dependencies: {
-        react: '0.0.0-experimental-cb5084d1c-20220924',
-        'react-dom': '0.0.0-experimental-cb5084d1c-20220924',
+        react: 'experimental',
+        'react-dom': 'experimental',
       },
     })
     context = {


### PR DESCRIPTION
This ensures we don't stub `react-dom` with the `experimental-edge` runtime and also unpins our tests to use the latest experimental release. 