### PR TITLE
Enabel appDir when flag and dir existed at the same time

### DIFF
--- a/packages/next-plugin-storybook/preset.js
+++ b/packages/next-plugin-storybook/preset.js
@@ -7,7 +7,7 @@ const CWD = process.cwd()
 
 async function webpackFinal(config) {
   const nextConfig = await loadConfig(PHASE_PRODUCTION_BUILD, CWD)
-  const pagesDir = findPagesDir(CWD, !!nextConfig.experimental.appDir)
+  const { pagesDir } = findPagesDir(CWD, !!nextConfig.experimental.appDir)
   const nextWebpackConfig = await getWebpackConfig(CWD, {
     pagesDir,
     entrypoints: {},

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -301,8 +301,8 @@ export default async function build(
       setGlobal('telemetry', telemetry)
 
       const publicDir = path.join(dir, 'public')
-      const hasAppDir = !!config.experimental.appDir
-      const { pagesDir, appDir } = findPagesDir(dir, hasAppDir)
+      const isAppDirEnabled = !!config.experimental.appDir
+      const { pagesDir, appDir } = findPagesDir(dir, isAppDirEnabled)
 
       const hasPublicDir = await fileExists(publicDir)
 
@@ -394,7 +394,7 @@ export default async function build(
                   config.experimental.cpus,
                   config.experimental.workerThreads,
                   telemetry,
-                  hasAppDir
+                  isAppDirEnabled && !!appDir
                 )
               }),
         ])
@@ -1988,7 +1988,7 @@ export default async function build(
         combinedPages.length > 0 ||
         useStatic404 ||
         useDefaultStatic500 ||
-        hasAppDir
+        isAppDirEnabled
       ) {
         const staticGenerationSpan =
           nextBuildSpan.traceChild('static-generation')

--- a/packages/next/build/jest/jest.ts
+++ b/packages/next/build/jest/jest.ts
@@ -72,8 +72,8 @@ export default function nextJest(options: { dir?: string } = {}) {
         isEsmProject = packageConfig.type === 'module'
 
         nextConfig = await getConfig(resolvedDir)
-        const hasAppDir = !!nextConfig.experimental.appDir
-        const findPagesDirResult = findPagesDir(resolvedDir, hasAppDir)
+        const isAppDirEnabled = !!nextConfig.experimental.appDir
+        const findPagesDirResult = findPagesDir(resolvedDir, isAppDirEnabled)
         hasServerComponents = !!findPagesDirResult.appDir
         pagesDir = findPagesDirResult.pagesDir
         setUpEnv(resolvedDir, nextConfig)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -563,7 +563,7 @@ export default async function getBaseWebpackConfig(
     rewrites.afterFiles.length > 0 ||
     rewrites.fallback.length > 0
 
-  const hasAppDir = !!config.experimental.appDir
+  const hasAppDir = !!config.experimental.appDir && !!appDir
   const hasConcurrentFeatures = hasReactRoot
   const hasServerComponents = hasAppDir
 
@@ -1587,7 +1587,7 @@ export default async function getBaseWebpackConfig(
             ]
           : []),
         // Alias `next/dynamic` to React.lazy implementation for RSC
-        ...(hasServerComponents && appDir
+        ...(hasServerComponents
           ? [
               {
                 test: codeCondition.test,

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -368,7 +368,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     this.buildId = this.getBuildId()
     this.minimalMode = minimalMode || !!process.env.NEXT_PRIVATE_MINIMAL_MODE
 
-    this.hasAppDir = this.getHasAppDir(dev)
+    this.hasAppDir =
+      !!this.nextConfig.experimental.appDir && this.getHasAppDir(dev)
     const serverComponents = this.hasAppDir
     this.serverComponentManifest = serverComponents
       ? this.getServerComponentManifest()

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -191,7 +191,10 @@ export default class DevServer extends Server {
 
     this.isCustomServer = !options.isNextDevCommand
 
-    const { pagesDir, appDir } = findPagesDir(this.dir, this.hasAppDir)
+    const { pagesDir, appDir } = findPagesDir(
+      this.dir,
+      !!this.nextConfig.experimental.appDir
+    )
     this.pagesDir = pagesDir
     this.appDir = appDir
   }

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -22,6 +22,11 @@ describe('react 18 streaming SSR with custom next configs', () => {
   beforeAll(async () => {
     next = await createNext({
       files: {
+        'app/page.js': `
+        export default function Page() {
+          return 'fake-app' /* this should not enable appDir */
+        }
+      `,
         pages: new FileRef(join(__dirname, 'streaming-ssr/pages')),
       },
       nextConfig: require(join(__dirname, 'streaming-ssr/next.config.js')),


### PR DESCRIPTION
If there's an existing folder named `app/` but `appDir` flag is not enabled, do not enabled server components

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

