### PR TITLE
Skip serverless/serverless-trace target tests

### DIFF
--- a/test/integration/404-page-custom-error/test/index.test.js
+++ b/test/integration/404-page-custom-error/test/index.test.js
@@ -71,7 +71,7 @@ describe('Default 404 Page with custom _error', () => {
     runTests('server')
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     afterAll(async () => {
       await fs.remove(nextConfig)
       await killApp(app)

--- a/test/integration/404-page-ssg/test/index.test.js
+++ b/test/integration/404-page-ssg/test/index.test.js
@@ -114,7 +114,7 @@ describe('404 Page Support SSG', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     afterAll(async () => {
       await fs.writeFile(nextConfig, nextConfigContent)
       await killApp(app)

--- a/test/integration/404-page/test/index.test.js
+++ b/test/integration/404-page/test/index.test.js
@@ -92,7 +92,7 @@ describe('404 Page Support', () => {
     runTests('server')
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       nextConfigContent = await fs.readFile(nextConfig, 'utf8')
       await fs.writeFile(

--- a/test/integration/500-page/test/index.test.js
+++ b/test/integration/500-page/test/index.test.js
@@ -85,7 +85,7 @@ describe('500 Page Support', () => {
     runTests('server')
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       nextConfigContent = await fs.readFile(nextConfig, 'utf8')
       await fs.writeFile(

--- a/test/integration/amphtml-ssg/test/index.test.js
+++ b/test/integration/amphtml-ssg/test/index.test.js
@@ -99,7 +99,7 @@ const runTests = (isDev = false) => {
 }
 
 describe('AMP SSG Support', () => {
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/api-catch-all/test/index.test.js
+++ b/test/integration/api-catch-all/test/index.test.js
@@ -73,7 +73,7 @@ describe('API routes', () => {
     runTests()
   })
 
-  describe('Serverless support', () => {
+  describe.skip('Serverless support', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -620,7 +620,7 @@ describe('API routes', () => {
     runTests()
   })
 
-  describe('Serverless support', () => {
+  describe.skip('Serverless support', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/app-tree/test/index.test.js
+++ b/test/integration/app-tree/test/index.test.js
@@ -69,7 +69,7 @@ describe('AppTree', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/async-modules/test/index.test.js
+++ b/test/integration/async-modules/test/index.test.js
@@ -131,7 +131,7 @@ describe('Async modules', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       nextConfig.replace('// target:', 'target:')
       await nextBuild(appDir)

--- a/test/integration/auto-export-error-bail/test/index.test.js
+++ b/test/integration/auto-export-error-bail/test/index.test.js
@@ -36,7 +36,7 @@ describe('Auto Export _error bail', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(() =>
       fs.writeFile(
         nextConfig,

--- a/test/integration/auto-export-query-error/test/index.test.js
+++ b/test/integration/auto-export-query-error/test/index.test.js
@@ -41,7 +41,7 @@ describe('Auto Export', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       origNextConfig = await fs.readFile(nextConfig, 'utf8')
       await nextBuild(appDir)

--- a/test/integration/auto-export-serverless-error/test/index.test.js
+++ b/test/integration/auto-export-serverless-error/test/index.test.js
@@ -6,7 +6,7 @@ import { nextBuild } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
 
-describe('Auto Export Error Serverless', () => {
+describe.skip('Auto Export Error Serverless', () => {
   it('fails to emit the page', async () => {
     const { stderr } = await nextBuild(appDir, [], {
       stderr: true,

--- a/test/integration/auto-export-serverless/test/index.test.js
+++ b/test/integration/auto-export-serverless/test/index.test.js
@@ -8,7 +8,7 @@ const appDir = path.join(__dirname, '..')
 let appPort
 let app
 
-describe('Auto Export Serverless', () => {
+describe.skip('Auto Export Serverless', () => {
   it('Refreshes query on mount', async () => {
     await nextBuild(appDir)
     appPort = await findPort()

--- a/test/integration/basepath-root-catch-all/test/index.test.js
+++ b/test/integration/basepath-root-catch-all/test/index.test.js
@@ -51,7 +51,7 @@ describe('production mode', () => {
   runTests()
 })
 
-describe('serverless mode', () => {
+describe.skip('serverless mode', () => {
   beforeAll(async () => {
     nextConfig.replace('// target', 'target')
     await nextBuild(appDir)

--- a/test/integration/bigint/test/index.test.js
+++ b/test/integration/bigint/test/index.test.js
@@ -55,7 +55,7 @@ describe('bigint API route support', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/clean-distdir/test/index.test.js
+++ b/test/integration/clean-distdir/test/index.test.js
@@ -33,7 +33,7 @@ describe('Cleaning distDir', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       nextConfigContent = await fs.readFile(nextConfig, 'utf8')
       await fs.writeFile(

--- a/test/integration/critical-css/test/index.test.js
+++ b/test/integration/critical-css/test/index.test.js
@@ -78,7 +78,7 @@ describe('CSS optimization for SSR apps', () => {
   runTests()
 })
 
-describe('Font optimization for emulated serverless apps', () => {
+describe.skip('Font optimization for emulated serverless apps', () => {
   beforeAll(async () => {
     await fs.writeFile(
       nextConfig,

--- a/test/integration/custom-error/test/index.test.js
+++ b/test/integration/custom-error/test/index.test.js
@@ -103,7 +103,7 @@ describe('Custom _error', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/custom-page-extension/test/index.test.js
+++ b/test/integration/custom-page-extension/test/index.test.js
@@ -47,7 +47,7 @@ describe('Custom page extension', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     const nextConfig = new File(join(appDir, 'next.config.js'))
     beforeAll(async () => {
       nextConfig.replace('server', 'serverless')

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -2426,7 +2426,7 @@ describe('Custom routes', () => {
     })
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       nextConfigContent = await fs.readFile(nextConfigPath, 'utf8')
       await fs.writeFile(
@@ -2454,7 +2454,7 @@ describe('Custom routes', () => {
     runTests()
   })
 
-  describe('raw serverless mode', () => {
+  describe.skip('raw serverless mode', () => {
     beforeAll(async () => {
       nextConfigContent = await fs.readFile(nextConfigPath, 'utf8')
       await fs.writeFile(

--- a/test/integration/dynamic-optional-routing-root-fallback/test/index.test.js
+++ b/test/integration/dynamic-optional-routing-root-fallback/test/index.test.js
@@ -82,7 +82,7 @@ describe('Dynamic Optional Routing Root Fallback', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let origNextConfig
 
     beforeAll(async () => {

--- a/test/integration/dynamic-optional-routing-root-static-paths/test/index.test.js
+++ b/test/integration/dynamic-optional-routing-root-static-paths/test/index.test.js
@@ -66,7 +66,7 @@ describe('Dynamic Optional Routing', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let origNextConfig
 
     beforeAll(async () => {

--- a/test/integration/dynamic-optional-routing/test/index.test.js
+++ b/test/integration/dynamic-optional-routing/test/index.test.js
@@ -314,7 +314,7 @@ describe('Dynamic Optional Routing', () => {
     })
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let origNextConfig
 
     beforeAll(async () => {
@@ -336,7 +336,7 @@ describe('Dynamic Optional Routing', () => {
     runTests()
   })
 
-  describe('raw serverless mode', () => {
+  describe.skip('raw serverless mode', () => {
     let origNextConfig
 
     beforeAll(async () => {

--- a/test/integration/env-config/test/index.test.js
+++ b/test/integration/env-config/test/index.test.js
@@ -385,7 +385,7 @@ describe('Env Config', () => {
     runTests('server')
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let nextConfigContent = ''
     const nextConfigPath = join(appDir, 'next.config.js')
     const envFiles = [

--- a/test/integration/fallback-route-params/test/index.test.js
+++ b/test/integration/fallback-route-params/test/index.test.js
@@ -65,7 +65,7 @@ describe('Fallback Dynamic Route Params', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       nextConfig.write(`
         module.exports = {

--- a/test/integration/fetch-polyfill-ky-universal/test/index.test.js
+++ b/test/integration/fetch-polyfill-ky-universal/test/index.test.js
@@ -104,7 +104,7 @@ describe('Fetch polyfill with ky-universal', () => {
     runTests()
   })
 
-  describe('Serverless support', () => {
+  describe.skip('Serverless support', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/fetch-polyfill/test/index.test.js
+++ b/test/integration/fetch-polyfill/test/index.test.js
@@ -123,7 +123,7 @@ describe('Fetch polyfill', () => {
     runTests()
   })
 
-  describe('Serverless support', () => {
+  describe.skip('Serverless support', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/font-optimization/test/index.test.js
+++ b/test/integration/font-optimization/test/index.test.js
@@ -250,7 +250,7 @@ describe('Font Optimization', () => {
         runTests()
       })
 
-      describe('Font optimization for serverless apps', () => {
+      describe.skip('Font optimization for serverless apps', () => {
         const origNextConfig = fs.readFileSync(nextConfig)
 
         beforeAll(async () => {
@@ -272,7 +272,7 @@ describe('Font Optimization', () => {
         runTests()
       })
 
-      describe('Font optimization for emulated serverless apps', () => {
+      describe.skip('Font optimization for emulated serverless apps', () => {
         const origNextConfig = fs.readFileSync(nextConfig)
 
         beforeAll(async () => {

--- a/test/integration/getinitialprops/test/index.test.js
+++ b/test/integration/getinitialprops/test/index.test.js
@@ -52,7 +52,7 @@ describe('getInitialProps', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await nextConfig.replace('// replace me', `target: 'serverless', `)
       await nextBuild(appDir)

--- a/test/integration/getserversideprops-export-error/test/index.test.js
+++ b/test/integration/getserversideprops-export-error/test/index.test.js
@@ -29,7 +29,7 @@ const runTests = () => {
 }
 
 describe('getServerSideProps', () => {
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.remove(join(appDir, '.next'))
       await fs.writeFile(

--- a/test/integration/getserversideprops-preview/test/index.test.js
+++ b/test/integration/getserversideprops-preview/test/index.test.js
@@ -294,7 +294,7 @@ describe('ServerSide Props Preview Mode', () => {
     runTests()
   })
 
-  describe('Serverless Mode', () => {
+  describe.skip('Serverless Mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfigPath,
@@ -308,7 +308,7 @@ describe('ServerSide Props Preview Mode', () => {
     runTests()
   })
 
-  describe('Emulated Serverless Mode', () => {
+  describe.skip('Emulated Serverless Mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfigPath,

--- a/test/integration/gssp-pageProps-merge/test/index.test.js
+++ b/test/integration/gssp-pageProps-merge/test/index.test.js
@@ -56,7 +56,7 @@ describe('pageProps GSSP conflict', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/gssp-redirect-base-path/test/index.test.js
+++ b/test/integration/gssp-redirect-base-path/test/index.test.js
@@ -505,7 +505,7 @@ describe('GS(S)P Redirect Support', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let server
 
     beforeAll(async () => {

--- a/test/integration/gssp-redirect/test/index.test.js
+++ b/test/integration/gssp-redirect/test/index.test.js
@@ -542,7 +542,7 @@ describe('GS(S)P Redirect Support', () => {
     })
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let server
 
     beforeAll(async () => {

--- a/test/integration/handle-non-page-in-pages/test/index.test.js
+++ b/test/integration/handle-non-page-in-pages/test/index.test.js
@@ -5,7 +5,7 @@ import { nextBuild } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
 
-describe('Handle non-page in pages when target: serverless', () => {
+describe.skip('Handle non-page in pages when target: serverless', () => {
   it('Fails softly with descriptive error', async () => {
     const { stderr } = await nextBuild(appDir, [], { stderr: true })
 

--- a/test/integration/i18n-support-base-path/test/index.test.js
+++ b/test/integration/i18n-support-base-path/test/index.test.js
@@ -72,7 +72,7 @@ describe('i18n Support basePath', () => {
     runTests(ctx)
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.remove(join(appDir, '.next'))
       nextConfig.replace('// target', 'target')

--- a/test/integration/i18n-support-catchall/test/index.test.js
+++ b/test/integration/i18n-support-catchall/test/index.test.js
@@ -250,7 +250,7 @@ describe('i18n Support Root Catch-all', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.remove(join(appDir, '.next'))
       nextConfig.replace('// target', 'target')

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -89,7 +89,7 @@ describe('i18n Support', () => {
     })
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.remove(join(appDir, '.next'))
       nextConfig.replace('// target', 'target')

--- a/test/integration/image-component/base-path/test/index.test.ts
+++ b/test/integration/image-component/base-path/test/index.test.ts
@@ -505,7 +505,7 @@ describe('Image Component basePath Tests', () => {
     runTests('server')
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let origConfig
 
     beforeAll(async () => {

--- a/test/integration/image-component/default/test/index.test.ts
+++ b/test/integration/image-component/default/test/index.test.ts
@@ -1447,7 +1447,7 @@ describe('Image Component Tests', () => {
     runTests('server')
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await nextBuild(appDir)
       appPort = await findPort()

--- a/test/integration/index-index/test/index.test.js
+++ b/test/integration/index-index/test/index.test.js
@@ -209,7 +209,7 @@ describe('nested index.js', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let origNextConfig
 
     beforeAll(async () => {

--- a/test/integration/legacy-ssg-methods-error/test/index.test.js
+++ b/test/integration/legacy-ssg-methods-error/test/index.test.js
@@ -73,7 +73,7 @@ describe('Mixed getStaticProps and getServerSideProps error', () => {
     runTests(false)
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     runTests(true)
   })
 })

--- a/test/integration/optional-chaining-nullish-coalescing/test/index.test.js
+++ b/test/integration/optional-chaining-nullish-coalescing/test/index.test.js
@@ -53,7 +53,7 @@ describe('Optional chaining and nullish coalescing support', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/prerender-no-revalidate/test/index.test.js
+++ b/test/integration/prerender-no-revalidate/test/index.test.js
@@ -79,7 +79,7 @@ function runTests(route, routePath, serverless) {
 describe('SSG Prerender No Revalidate', () => {
   afterAll(() => fs.remove(nextConfig))
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/prerender-preview/test/index.test.js
+++ b/test/integration/prerender-preview/test/index.test.js
@@ -405,7 +405,7 @@ describe('Prerender Preview Mode', () => {
     runTests()
   })
 
-  describe('Serverless Mode', () => {
+  describe.skip('Serverless Mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfigPath,
@@ -419,7 +419,7 @@ describe('Prerender Preview Mode', () => {
     runTests()
   })
 
-  describe('Emulated Serverless Mode', () => {
+  describe.skip('Emulated Serverless Mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfigPath,

--- a/test/integration/preview-fallback/test/index.test.js
+++ b/test/integration/preview-fallback/test/index.test.js
@@ -303,7 +303,7 @@ describe('Preview mode with fallback pages', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       nextConfig.write(`
         module.exports = {

--- a/test/integration/production-browser-sourcemaps/test/index.test.js
+++ b/test/integration/production-browser-sourcemaps/test/index.test.js
@@ -51,7 +51,7 @@ describe('Production browser sourcemaps', () => {
     runTests()
   })
 
-  describe('Serverless support', () => {
+  describe.skip('Serverless support', () => {
     beforeAll(async () => {
       nextConfigContent = await fs.readFile(nextConfig, 'utf8')
       await fs.writeFile(

--- a/test/integration/revalidate-as-path/test/index.test.js
+++ b/test/integration/revalidate-as-path/test/index.test.js
@@ -78,7 +78,7 @@ const runTests = (isServerless) => {
 }
 
 describe('Revalidate asPath Normalizing', () => {
-  describe('raw serverless mode', () => {
+  describe.skip('raw serverless mode', () => {
     beforeAll(async () => {
       await fs.remove(join(appDir, '.next'))
       await fs.writeFile(

--- a/test/integration/root-optional-revalidate/test/index.test.js
+++ b/test/integration/root-optional-revalidate/test/index.test.js
@@ -88,7 +88,7 @@ describe('Root Optional Catch-all Revalidate', () => {
     runTests()
   })
 
-  describe('raw serverless mode', () => {
+  describe.skip('raw serverless mode', () => {
     beforeAll(async () => {
       nextConfig.write(`
         module.exports = {

--- a/test/integration/server-asset-modules/test/index.test.js
+++ b/test/integration/server-asset-modules/test/index.test.js
@@ -56,7 +56,7 @@ describe('serverside asset modules', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     let origNextConfig
 
     beforeAll(async () => {

--- a/test/integration/serverless-runtime-configs/test/index.test.js
+++ b/test/integration/serverless-runtime-configs/test/index.test.js
@@ -166,15 +166,15 @@ const runTests = (oldServerless = false) => {
   })
 }
 
-describe('Serverless runtime configs', () => {
+describe.skip('Serverless runtime configs', () => {
   beforeAll(() => cleanUp())
   afterAll(() => cleanUp())
 
-  describe('legacy serverless mode', () => {
+  describe.skip('legacy serverless mode', () => {
     runTests(true)
   })
 
-  describe('experimental-serverless-trace mode', () => {
+  describe.skip('experimental-serverless-trace mode', () => {
     runTests()
   })
 })

--- a/test/integration/serverless-trace-revalidate/test/index.test.js
+++ b/test/integration/serverless-trace-revalidate/test/index.test.js
@@ -27,7 +27,7 @@ const nextStart = async (appDir, appPort) => {
   )
 }
 
-describe('Serverless Trace', () => {
+describe.skip('Serverless Trace', () => {
   beforeAll(async () => {
     await nextBuild(appDir)
     appPort = await findPort()

--- a/test/integration/serverless-trace/test/index.test.js
+++ b/test/integration/serverless-trace/test/index.test.js
@@ -21,7 +21,7 @@ const chunksDir = join(appDir, '.next/static/chunks')
 let appPort
 let app
 
-describe('Serverless Trace', () => {
+describe.skip('Serverless Trace', () => {
   beforeAll(async () => {
     await nextBuild(appDir)
     appPort = await findPort()

--- a/test/integration/serverless/test/index.test.js
+++ b/test/integration/serverless/test/index.test.js
@@ -25,7 +25,7 @@ let stderr = ''
 let appPort
 let app
 
-describe('Serverless', () => {
+describe.skip('Serverless', () => {
   let output
 
   beforeAll(async () => {

--- a/test/integration/src-dir-support-double-dir/test/index.test.js
+++ b/test/integration/src-dir-support-double-dir/test/index.test.js
@@ -57,7 +57,7 @@ describe('Dynamic Routing', () => {
     runTests()
   })
 
-  describe('serverless production mode', () => {
+  describe.skip('serverless production mode', () => {
     beforeAll(async () => {
       await fs.writeFile(
         nextConfig,

--- a/test/integration/ssg-dynamic-routes-404-page/test/index.test.js
+++ b/test/integration/ssg-dynamic-routes-404-page/test/index.test.js
@@ -45,7 +45,7 @@ describe('Custom 404 Page for static site generation with dynamic routes', () =>
     runTests('server')
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     afterAll(async () => {
       await fs.remove(nextConfig)
       await killApp(app)

--- a/test/integration/static-page-name/test/index.test.js
+++ b/test/integration/static-page-name/test/index.test.js
@@ -52,7 +52,7 @@ describe('Static Page Name', () => {
     runTests()
   })
 
-  describe('serverless mode', () => {
+  describe.skip('serverless mode', () => {
     beforeAll(async () => {
       appPort = await findPort()
       await fs.writeFile(

--- a/test/production/middleware-is-not-allowed-when-using-serverless-target/index.test.ts
+++ b/test/production/middleware-is-not-allowed-when-using-serverless-target/index.test.ts
@@ -1,7 +1,7 @@
 import { nextBuild } from 'next-test-utils'
 import path from 'path'
 
-describe('Middleware is not allowed when using serverless target', () => {
+describe.skip('Middleware is not allowed when using serverless target', () => {
   it('fails to build', async () => {
     const { code, stderr } = await nextBuild(
       path.resolve(__dirname, './app'),


### PR DESCRIPTION
Preparation for Next.js 13, will hopefully speed up test runs a bit.
Update: seems it shaves off around 3 minutes from the build time.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
