### PR TITLE
fix(link): disable `IntersectionObserver` when `prefetch={false}`

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -474,6 +474,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
 
     const [setIntersectionRef, isVisible, resetVisible] = useIntersection({
       rootMargin: '200px',
+      disabled: !p,
     })
 
     const setRef = React.useCallback(


### PR DESCRIPTION
Co-authored-by: Jett Love <jett@jett.software>

Fixes #40239