### PR TITLE
Add pretty error when image import is invalid format

### DIFF
--- a/packages/next/build/webpack/loaders/next-image-loader.js
+++ b/packages/next/build/webpack/loaders/next-image-loader.js
@@ -11,11 +11,6 @@ function nextImageLoader(content) {
     const { isServer, isDev, assetPrefix, basePath } = this.getOptions()
     const context = this.rootContext
     const opts = { context, content }
-    const importName = loaderUtils.interpolateName(
-      this,
-      '[path][name].[ext]',
-      opts
-    )
     const interpolatedName = loaderUtils.interpolateName(
       this,
       '/static/media/[name].[hash:8].[ext]',
@@ -33,9 +28,7 @@ function nextImageLoader(content) {
     )
 
     if (imageSize instanceof Error) {
-      const err = new Error(
-        `Image import "./${importName}" is not a valid image format`
-      )
+      const err = imageSize
       err.name = 'InvalidImageFormatError'
       throw err
     }

--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -118,3 +118,34 @@ export async function getNotFoundError(
     return input
   }
 }
+
+export async function getImageError(
+  compilation: any,
+  input: any,
+  fileName: string,
+  err: Error
+): Promise<SimpleWebpackError | false> {
+  if (err.name !== 'InvalidImageFormatError') {
+    return false
+  }
+
+  const moduleTrace = getModuleTrace(input, compilation)
+  const { origin, module } = moduleTrace[0] || {}
+  if (!origin || !module) {
+    return false
+  }
+  const page = origin.rawRequest.replace(/^private-next-pages/, './pages')
+  const importedFile = module.rawRequest
+  const source = origin.originalSource().buffer().toString('utf8') as string
+  let lineNumber = -1
+  source.split('\n').some((line) => {
+    lineNumber++
+    return line.includes(importedFile)
+  })
+  return new SimpleWebpackError(
+    `${chalk.cyan(page)}:${chalk.yellow(lineNumber.toString())}`,
+    chalk.red
+      .bold('Error')
+      .concat(`: Image import "${importedFile}" is not a valid image file`)
+  )
+}

--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -122,7 +122,6 @@ export async function getNotFoundError(
 export async function getImageError(
   compilation: any,
   input: any,
-  fileName: string,
   err: Error
 ): Promise<SimpleWebpackError | false> {
   if (err.name !== 'InvalidImageFormatError') {

--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -145,6 +145,8 @@ export async function getImageError(
     `${chalk.cyan(page)}:${chalk.yellow(lineNumber.toString())}`,
     chalk.red
       .bold('Error')
-      .concat(`: Image import "${importedFile}" is not a valid image file`)
+      .concat(
+        `: Image import "${importedFile}" is not a valid image file. The image may be corrupted or an unsupported format.`
+      )
   )
 }

--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/webpackModuleError.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/webpackModuleError.ts
@@ -5,7 +5,7 @@ import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { getBabelError } from './parseBabel'
 import { getCssError } from './parseCss'
 import { getScssError } from './parseScss'
-import { getNotFoundError } from './parseNotFoundError'
+import { getNotFoundError, getImageError } from './parseNotFoundError'
 import { SimpleWebpackError } from './simpleWebpackError'
 import isError from '../../../../lib/is-error'
 import { getRscError } from './parseRSC'
@@ -69,6 +69,16 @@ export async function getModuleBuildError(
   )
   if (notFoundError !== false) {
     return notFoundError
+  }
+
+  const imageError = await getImageError(
+    compilation,
+    input,
+    sourceFilename,
+    err
+  )
+  if (imageError !== false) {
+    return imageError
   }
 
   const babel = getBabelError(sourceFilename, err)

--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/webpackModuleError.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/webpackModuleError.ts
@@ -71,12 +71,7 @@ export async function getModuleBuildError(
     return notFoundError
   }
 
-  const imageError = await getImageError(
-    compilation,
-    input,
-    sourceFilename,
-    err
-  )
+  const imageError = await getImageError(compilation, input, err)
   if (imageError !== false) {
     return imageError
   }

--- a/test/integration/image-future/invalid-image-import/pages/index.js
+++ b/test/integration/image-future/invalid-image-import/pages/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import Image from 'next/future/image'
+import test from '../public/invalid.svg'
+
+const Page = () => {
+  return (
+    <div>
+      <h1>Try to import and invalid image file</h1>
+      <Image id="invalid-img" src={test} width={400} height={400} />
+    </div>
+  )
+}
+
+export default Page

--- a/test/integration/image-future/invalid-image-import/public/invalid.svg
+++ b/test/integration/image-future/invalid-image-import/public/invalid.svg
@@ -1,0 +1,3 @@
+{
+  "is-image": "nope"
+}

--- a/test/integration/image-future/invalid-image-import/test/index.test.ts
+++ b/test/integration/image-future/invalid-image-import/test/index.test.ts
@@ -1,0 +1,71 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import {
+  findPort,
+  getRedboxHeader,
+  getRedboxSource,
+  hasRedbox,
+  killApp,
+  launchApp,
+  nextBuild,
+  nextStart,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+
+const appDir = join(__dirname, '../')
+let appPort: number
+let app
+let stderr = ''
+const msg =
+  'Error: Image import "../public/invalid.svg" is not a valid image file'
+
+function runTests({ isDev }) {
+  it('should show error', async () => {
+    if (isDev) {
+      const browser = await webdriver(appPort, '/')
+      expect(await hasRedbox(browser)).toBe(true)
+      expect(await getRedboxHeader(browser)).toBe('Failed to compile')
+      expect(await getRedboxSource(browser)).toBe(`./pages/index.js:3\n${msg}`)
+      expect(stderr).toContain(msg)
+    } else {
+      expect(stderr).toContain(msg)
+    }
+  })
+}
+
+describe('Missing Import Image Tests', () => {
+  describe('dev mode', () => {
+    beforeAll(async () => {
+      stderr = ''
+      appPort = await findPort()
+      app = await launchApp(appDir, appPort, {
+        onStderr(msg) {
+          stderr += msg || ''
+        },
+      })
+    })
+    afterAll(async () => {
+      if (app) {
+        await killApp(app)
+      }
+    })
+
+    runTests({ isDev: true })
+  })
+
+  describe('server mode', () => {
+    beforeAll(async () => {
+      stderr = ''
+      const result = await nextBuild(appDir, [], { stderr: true })
+      stderr = result.stderr
+    })
+    afterAll(async () => {
+      if (app) {
+        await killApp(app)
+      }
+    })
+
+    runTests({ isDev: false })
+  })
+})

--- a/test/integration/image-future/invalid-image-import/test/index.test.ts
+++ b/test/integration/image-future/invalid-image-import/test/index.test.ts
@@ -9,7 +9,6 @@ import {
   killApp,
   launchApp,
   nextBuild,
-  nextStart,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 

--- a/test/integration/image-future/invalid-image-import/test/index.test.ts
+++ b/test/integration/image-future/invalid-image-import/test/index.test.ts
@@ -17,7 +17,7 @@ let appPort: number
 let app
 let stderr = ''
 const msg =
-  'Error: Image import "../public/invalid.svg" is not a valid image file'
+  'Error: Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format.'
 
 function runTests({ isDev }) {
   it('should show error', async () => {


### PR DESCRIPTION
This PR improves the error message when an invalid image is imported. It also ensures the page that imported the image is displayed.

### Before

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/229881/194674177-70f4ae73-64c9-497f-8e20-098f949a4219.png">


### After

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/229881/194716285-27dd3455-60a9-440f-a50e-eff8d49e764b.png">



