### PR TITLE
Update font-optimization.md

### DIFF
--- a/docs/basic-features/font-optimization.md
+++ b/docs/basic-features/font-optimization.md
@@ -15,7 +15,7 @@ Next.js helps you optimize loading web fonts by inlining font CSS during `next b
 
 // After
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<style data-href="https://fonts.googleapis.com/css2?family=Inter&display=optional">
+<style data-href="https://fonts.googleapis.com/css2?family=Inter&display=swap">
   @font-face{font-family:'Inter';font-style:normal...
 </style>
 ```


### PR DESCRIPTION
`display=optional` doesn't seem to work on localhost anyway. `display=swap` seems to work fine. I'm not sure if I'm overlooking something.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
