### PR TITLE
Add test for link to catchall route in new router

### DIFF
--- a/test/e2e/app-dir/app/app/catch-all-link/page.js
+++ b/test/e2e/app-dir/app/app/catch-all-link/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <div>
+        <Link href="/catch-all/this/is/a/test">
+          <a id="to-catch-all">To catch-all</a>
+        </Link>
+      </div>
+      <div>
+        <Link href="/catch-all-optional/this/is/a/test">
+          <a id="to-catch-all-optional">To optional catch-all</a>
+        </Link>
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/catch-all-optional/[[...slug]]/page.js
+++ b/test/e2e/app-dir/app/app/catch-all-optional/[[...slug]]/page.js
@@ -1,7 +1,7 @@
 export default function Page({ params }) {
   return (
     <h1 id="text" data-params={params.slug?.join('/') ?? ''}>
-      hello from /optional-catch-all/{params.slug?.join('/')}
+      hello from /catch-all-optional/{params.slug?.join('/')}
     </h1>
   )
 }

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -639,16 +639,27 @@ describe('app dir', () => {
           const route = params.join('/')
           const html = await renderViaHTTP(
             next.url,
-            `/optional-catch-all/${route}`
+            `/catch-all-optional/${route}`
           )
           const $ = cheerio.load(html)
           expect($('#text').attr('data-params')).toBe(route)
         })
 
         it('should handle optional segments root', async () => {
-          const html = await renderViaHTTP(next.url, `/optional-catch-all`)
+          const html = await renderViaHTTP(next.url, `/catch-all-optional`)
           const $ = cheerio.load(html)
           expect($('#text').attr('data-params')).toBe('')
+        })
+
+        it('should handle optional catch-all segments link', async () => {
+          const browser = await webdriver(next.url, '/catch-all-link')
+          expect(
+            await browser
+              .elementByCss('#to-catch-all-optional')
+              .click()
+              .waitForElementByCss('#text')
+              .text()
+          ).toBe(`hello from /catch-all-optional/this/is/a/test`)
         })
 
         it('should handle required segments', async () => {
@@ -667,6 +678,17 @@ describe('app dir', () => {
           const res = await fetchViaHTTP(next.url, `/catch-all`)
           expect(res.status).toBe(404)
           expect(await res.text()).toContain('This page could not be found')
+        })
+
+        it('should handle catch-all segments link', async () => {
+          const browser = await webdriver(next.url, '/catch-all-link')
+          expect(
+            await browser
+              .elementByCss('#to-catch-all')
+              .click()
+              .waitForElementByCss('#text')
+              .text()
+          ).toBe(`hello from /catch-all/this/is/a/test`)
         })
       })
 


### PR DESCRIPTION
Adds tests for navigating to a catch-all and optional catch-all route using `next/link` in the new router.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
