### PR TITLE
Add test for link back to original page

### DIFF
--- a/packages/next/client/components/reducer.ts
+++ b/packages/next/client/components/reducer.ts
@@ -471,11 +471,16 @@ function shouldHardNavigate(
     string
   ]
 
-  // If dynamic parameter in tree doesn't match up with segment path a hard navigation is triggered.
-  if (Array.isArray(currentSegment) && !matchSegment(currentSegment, segment)) {
-    return true
-  }
+  // Check if current segment matches the existing segment
+  if (!matchSegment(currentSegment, segment)) {
+    // If dynamic parameter in tree doesn't match up with segment path a hard navigation is triggered.
+    if (Array.isArray(currentSegment)) {
+      return true
+    }
 
+    // If the existing segment did not match we'll soft navigate
+    return false
+  }
   const lastSegment = flightSegmentPath.length <= 2
 
   if (lastSegment) {

--- a/packages/next/client/components/reducer.ts
+++ b/packages/next/client/components/reducer.ts
@@ -471,14 +471,14 @@ function shouldHardNavigate(
     string
   ]
 
-  // Check if current segment matches the existing segment
+  // Check if current segment matches the existing segment.
   if (!matchSegment(currentSegment, segment)) {
     // If dynamic parameter in tree doesn't match up with segment path a hard navigation is triggered.
     if (Array.isArray(currentSegment)) {
       return true
     }
 
-    // If the existing segment did not match we'll soft navigate
+    // If the existing segment did not match soft navigation is triggered.
     return false
   }
   const lastSegment = flightSegmentPath.length <= 2

--- a/test/e2e/app-dir/app/app/linking/about/page.js
+++ b/test/e2e/app-dir/app/app/linking/about/page.js
@@ -1,0 +1,3 @@
+export default function AboutPage() {
+  return <p id="about-page">About page</p>
+}

--- a/test/e2e/app-dir/app/app/linking/layout.js
+++ b/test/e2e/app-dir/app/app/linking/layout.js
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <header>
+        <nav>
+          <Link href="/linking">Home</Link>
+          <Link href="/linking/about">About</Link>
+        </nav>
+      </header>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/linking/page.js
+++ b/test/e2e/app-dir/app/app/linking/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home-page">Home page</p>
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1572,6 +1572,24 @@ describe('app dir', () => {
             .text()
         ).toBe(`hello from app/dashboard/deployments/info/[id]. ID is: 123`)
       })
+      it('should handle next/link back to initially loaded page', async () => {
+        const browser = await webdriver(next.url, '/linking/about')
+        expect(
+          await browser
+            .elementByCss('a[href="/linking"]')
+            .click()
+            .waitForElementByCss('#home-page')
+            .text()
+        ).toBe(`Home page`)
+
+        expect(
+          await browser
+            .elementByCss('a[href="/linking/about"]')
+            .click()
+            .waitForElementByCss('#about-page')
+            .text()
+        ).toBe(`About page`)
+      })
     })
 
     describe('not-found', () => {


### PR DESCRIPTION
- Implements failing test
- Implemented handling for the case where the router tree does not match up with the segment path being navigated to. This is what caused the underlying error. 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
