### PR TITLE
Support TS exactOptionalPropertyTypes on Link.tsx

### DIFF
--- a/packages/next/client/link.tsx
+++ b/packages/next/client/link.tsx
@@ -36,13 +36,13 @@ type InternalLinkProps = {
   /**
    * Optional decorator for the path that will be shown in the browser URL bar. Before Next.js 9.5.3 this was used for dynamic routes, check our [previous docs](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes) to see how it worked. Note: when this path differs from the one provided in `href` the previous `href`/`as` behavior is used as shown in the [previous docs](https://nextjs.org/docs/tag/v9.5.2/api-reference/next/link#dynamic-routes).
    */
-  as?: Url
+  as?: Url | undefined
   /**
    * Replace the current `history` state instead of adding a new url into the stack.
    *
    * @defaultValue `false`
    */
-  replace?: boolean
+  replace?: boolean | undefined
   /**
    * Whether to override the default scroll behavior
    *
@@ -50,19 +50,19 @@ type InternalLinkProps = {
    *
    * @defaultValue `true`
    */
-  scroll?: boolean
+  scroll?: boolean | undefined
   /**
    * Update the path of the current page without rerunning [`getStaticProps`](/docs/basic-features/data-fetching/get-static-props.md), [`getServerSideProps`](/docs/basic-features/data-fetching/get-server-side-props.md) or [`getInitialProps`](/docs/api-reference/data-fetching/get-initial-props.md).
    *
    * @defaultValue `false`
    */
-  shallow?: boolean
+  shallow?: boolean | undefined
   /**
    * Forces `Link` to send the `href` property to its child.
    *
    * @defaultValue `false`
    */
-  passHref?: boolean
+  passHref?: boolean | undefined
   /**
    * Prefetch the page in the background.
    * Any `<Link />` that is in the viewport (initially or through scroll) will be preloaded.
@@ -70,33 +70,33 @@ type InternalLinkProps = {
    *
    * @defaultValue `true`
    */
-  prefetch?: boolean
+  prefetch?: boolean | undefined
   /**
    * The active locale is automatically prepended. `locale` allows for providing a different locale.
    * When `false` `href` has to include the locale as the default behavior is disabled.
    */
-  locale?: string | false
+  locale?: string | false | undefined
   /**
    * Enable legacy link behaviour.
    * @defaultValue `true`
    * @see https://github.com/vercel/next.js/commit/489e65ed98544e69b0afd7e0cfc3f9f6c2b803b7
    */
-  legacyBehavior?: boolean
+  legacyBehavior?: boolean | undefined
   // e: any because as it would otherwise overlap with existing types
   /**
    * requires experimental.newNextLinkBehavior
    */
-  onMouseEnter?: (e: any) => void
+  onMouseEnter?: (e: any) => void | undefined
   // e: any because as it would otherwise overlap with existing types
   /**
    * requires experimental.newNextLinkBehavior
    */
-  onTouchStart?: (e: any) => void
+  onTouchStart?: (e: any) => void | undefined
   // e: any because as it would otherwise overlap with existing types
   /**
    * requires experimental.newNextLinkBehavior
    */
-  onClick?: (e: any) => void
+  onClick?: (e: any) => void | undefined
 }
 
 // TODO-APP: Include the full set of Anchor props


### PR DESCRIPTION
This adds support for stricter tsconfig with exactOptionalPropertyTypes enabled, same as #35281
