### PR TITLE
Remove references to `withSentry` function in `with-sentry` example

### DIFF
--- a/examples/with-sentry/README.md
+++ b/examples/with-sentry/README.md
@@ -7,7 +7,6 @@ This is an example showing how to use [Sentry](https://sentry.io) to catch and r
 - `sentry.server.config.js` and `sentry.client.config.js` are used to configure and initialize Sentry
 - `next.config.js` automatically injects Sentry into your app using `withSentryConfig`
 - `_error.js` (which is rendered by Next.js when handling certain types of exceptions) is overridden so those exceptions can be passed along to Sentry
-- Each API route is handled with `withSentry`
 
 ## Preview
 

--- a/examples/with-sentry/pages/api/test1.js
+++ b/examples/with-sentry/pages/api/test1.js
@@ -1,10 +1,6 @@
-import { withSentry } from '@sentry/nextjs'
-
 const doAsyncWork = () => Promise.reject(new Error('API Test 1'))
 doAsyncWork()
 
-async function handler(req, res) {
+export default function handler(req, res) {
   res.status(200).json({ name: 'John Doe' })
 }
-
-export default withSentry(handler)

--- a/examples/with-sentry/pages/api/test2.js
+++ b/examples/with-sentry/pages/api/test2.js
@@ -1,13 +1,9 @@
-import { withSentry } from '@sentry/nextjs'
-
 function work() {
   throw new Error('API Test 2')
 }
 
 work()
 
-async function handler(req, res) {
+export default function handler(req, res) {
   res.status(200).json({ name: 'John Doe' })
 }
-
-export default withSentry(handler)

--- a/examples/with-sentry/pages/api/test3.js
+++ b/examples/with-sentry/pages/api/test3.js
@@ -1,13 +1,9 @@
-import { withSentry } from '@sentry/nextjs'
-
 function work() {
   throw new Error('API Test 3')
 }
 
-async function handler(req, res) {
+export default function handler(req, res) {
   work()
 
   res.status(200).json({ name: 'John Doe' })
 }
-
-export default withSentry(handler)

--- a/examples/with-sentry/pages/api/test4.js
+++ b/examples/with-sentry/pages/api/test4.js
@@ -1,16 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
 
-async function handler(req, res) {
+export default function handler(req, res) {
   try {
     throw new Error('API Test 4')
   } catch (error) {
     Sentry.captureException(error)
   }
 
-  // Flushing before returning is necessary if deploying to Vercel, see
-  // https://vercel.com/docs/platform/limits#streaming-responses
-  await Sentry.flush(2000)
   res.status(200).json({ name: 'John Doe' })
 }
-
-export default Sentry.withSentry(handler)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

## Content

In version [`7.15.0`](https://github.com/getsentry/sentry-javascript/releases/tag/7.15.0) of the `@sentry/nextjs` SDK we introduced a new build-time feature that removes the need for manually wrapping API routes.

This PR removes all manual `withSentry` calls from the `with-sentry` example.
