### PR TITLE
fix(image): don't show placeholder warning in Jest

### DIFF
--- a/packages/next/build/jest/__mocks__/fileMock.js
+++ b/packages/next/build/jest/__mocks__/fileMock.js
@@ -1,6 +1,6 @@
 module.exports = {
   src: '/img.jpg',
-  height: 24,
-  width: 24,
+  height: 40,
+  width: 40,
   blurDataURL: 'data:image/png;base64,imagedata',
 }


### PR DESCRIPTION
In Jest, we were mocking the `next/image` imports with a width and height of `24`. If the developer set `placeholder="blur"` on their images though, this triggered the warning:

> Image with src "/img.jpg" is smaller than 40x40. Consider removing the "placeholder='blur'" property to improve performance.

Since we cannot reliably hide this warning without knowing the actual image dimensions, and we also provide a `blurDataURL` by default, we should increase the mock image size to suppress the warning.

Note that using `moduleNameMapper` in `jest.config.js`, the developer can already tweak the mock behavior:

https://github.com/vercel/next.js/blob/a78163dc613f168f991b29018adbc3472004d38b/packages/next/build/jest/jest.ts#L111-L121

Fixes #41248