### PR TITLE
proper error if middleware or api/route not return a Response

### DIFF
--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -103,6 +103,20 @@ export async function adapter(params: {
   const event = new NextFetchEvent({ request, page: params.page })
   let response = await params.handler(request, event)
 
+  // check if response is a Response object
+  if (
+    response &&
+    !(
+      typeof response === 'object' &&
+      (!response.headers || typeof response.headers.get === 'function') &&
+      (!response.body || typeof response.body.getReader === 'function') &&
+      typeof response.status === 'number' &&
+      typeof response.statusText === 'string'
+    )
+  ) {
+    throw new Error('Response must be an instance of Response type')
+  }
+
   /**
    * For rewrites we must always include the locale in the final pathname
    * so we re-create the NextURL forcing it to include it when the it is

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -114,7 +114,7 @@ export async function adapter(params: {
       typeof response.statusText === 'string'
     )
   ) {
-    throw new Error('Response must be an instance of Response type')
+    throw new TypeError('Response must be an instance of Response type')
   }
 
   /**

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -114,7 +114,7 @@ export async function adapter(params: {
       typeof response.statusText === 'string'
     )
   ) {
-    throw new TypeError('Response must be an instance of Response type')
+    throw new TypeError('Expected an instance of Response to be returned')
   }
 
   /**

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -106,13 +106,7 @@ export async function adapter(params: {
   // check if response is a Response object
   if (
     response &&
-    !(
-      typeof response === 'object' &&
-      (!response.headers || typeof response.headers.get === 'function') &&
-      (!response.body || typeof response.body.getReader === 'function') &&
-      typeof response.status === 'number' &&
-      typeof response.statusText === 'string'
-    )
+    !(response instanceof Response)
   ) {
     throw new TypeError('Expected an instance of Response to be returned')
   }

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -107,10 +107,7 @@ export async function adapter(params: {
   let response = await params.handler(request, event)
 
   // check if response is a Response object
-  if (
-    response &&
-    !(response instanceof Response)
-  ) {
+  if (response && !(response instanceof Response)) {
     throw new TypeError('Expected an instance of Response to be returned')
   }
 

--- a/test/integration/edge-runtime-response-error/lib.js
+++ b/test/integration/edge-runtime-response-error/lib.js
@@ -1,0 +1,1 @@
+// populated with tests

--- a/test/integration/edge-runtime-response-error/middleware.js
+++ b/test/integration/edge-runtime-response-error/middleware.js
@@ -1,0 +1,6 @@
+// populated with tests
+export default () => {
+  return 'Boom'
+}
+
+export const config = { matcher: '/' }

--- a/test/integration/edge-runtime-response-error/pages/api/route.js
+++ b/test/integration/edge-runtime-response-error/pages/api/route.js
@@ -1,0 +1,5 @@
+export default async function handler(request) {
+  return 'Boom'
+}
+
+export const config = { runtime: 'experimental-edge' }

--- a/test/integration/edge-runtime-response-error/pages/index.js
+++ b/test/integration/edge-runtime-response-error/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>ok</div>
+}

--- a/test/integration/edge-runtime-response-error/test/index.test.js
+++ b/test/integration/edge-runtime-response-error/test/index.test.js
@@ -80,7 +80,7 @@ describe('Edge runtime code with imports', () => {
       context.app = await nextStart(context.appDir, context.appPort, appOption)
       const res = await fetchViaHTTP(context.appPort, url)
       expect(context.logs.stderr).toContain(
-        'Response must be an instance of Response type'
+        'Expected an instance of Response to be returned'
       )
       expect(res.status).toBe(500)
     })

--- a/test/integration/edge-runtime-response-error/test/index.test.js
+++ b/test/integration/edge-runtime-response-error/test/index.test.js
@@ -1,0 +1,88 @@
+/* eslint-disable jest/no-identical-title */
+/* eslint-env jest */
+
+import { remove } from 'fs-extra'
+import { join } from 'path'
+import {
+  fetchViaHTTP,
+  File,
+  findPort,
+  killApp,
+  launchApp,
+  nextBuild,
+  nextStart,
+} from 'next-test-utils'
+
+jest.setTimeout(1000 * 60 * 2)
+
+const context = {
+  appDir: join(__dirname, '../'),
+  logs: { output: '', stdout: '', stderr: '' },
+  api: new File(join(__dirname, '../pages/api/route.js')),
+  lib: new File(join(__dirname, '../lib.js')),
+  middleware: new File(join(__dirname, '../middleware.js')),
+  page: new File(join(__dirname, '../pages/index.js')),
+}
+const appOption = {
+  env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
+  onStdout(msg) {
+    context.logs.output += msg
+    context.logs.stdout += msg
+  },
+  onStderr(msg) {
+    context.logs.output += msg
+    context.logs.stderr += msg
+  },
+}
+const routeUrl = '/api/route'
+const middlewareUrl = '/'
+
+describe('Edge runtime code with imports', () => {
+  beforeEach(async () => {
+    context.appPort = await findPort()
+    context.logs = { output: '', stdout: '', stderr: '' }
+    await remove(join(__dirname, '../.next'))
+  })
+
+  afterEach(() => {
+    if (context.app) {
+      killApp(context.app)
+    }
+    context.api.restore()
+    context.middleware.restore()
+    context.lib.restore()
+    context.page.restore()
+  })
+
+  describe.each([
+    {
+      title: 'Edge API',
+      url: routeUrl,
+    },
+    {
+      title: 'Middleware',
+      url: middlewareUrl,
+    },
+  ])('test error if response is not Response type', ({ title, url }) => {
+    it(`${title} dev test Response`, async () => {
+      context.app = await launchApp(context.appDir, context.appPort, appOption)
+      const res = await fetchViaHTTP(context.appPort, url)
+      expect(context.logs.stderr).toContain(
+        'Response must be an instance of Response type'
+      )
+      expect(res.status).toBe(500)
+    })
+
+    it(`${title} build test Response`, async () => {
+      await nextBuild(context.appDir, undefined, {
+        stderr: true,
+      })
+      context.app = await nextStart(context.appDir, context.appPort, appOption)
+      const res = await fetchViaHTTP(context.appPort, url)
+      expect(context.logs.stderr).toContain(
+        'Response must be an instance of Response type'
+      )
+      expect(res.status).toBe(500)
+    })
+  })
+})

--- a/test/integration/edge-runtime-response-error/test/index.test.js
+++ b/test/integration/edge-runtime-response-error/test/index.test.js
@@ -68,7 +68,7 @@ describe('Edge runtime code with imports', () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
       const res = await fetchViaHTTP(context.appPort, url)
       expect(context.logs.stderr).toContain(
-        'Response must be an instance of Response type'
+        'Expected an instance of Response to be returned'
       )
       expect(res.status).toBe(500)
     })


### PR DESCRIPTION
## Bug

The error which is thrown if the fetch method returns not a falsy or Response value 
is misleading.


