### PR TITLE
Update swc_core to 0.32.2

### DIFF
--- a/packages/next-swc/Cargo.lock
+++ b/packages/next-swc/Cargo.lock
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.19.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee99add2bcb359734864c99dc0c6088b17aa0b9d3f49bba75d1fb816766a2857"
+checksum = "337ded92ae536d67cb0be06608e632e100a8adf0bb8c6fd5a7b16391bb72b001"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -313,6 +313,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -532,6 +542,50 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "cxx"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f39818dcfc97d45b03953c1292efc4e80954e1583c4aa770bac1383e2310a4"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e580d70777c116df50c390d1211993f62d40302881e54d4b79727acb83d0199"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a46460b88d1cec95112c8c363f0e2c39afdb237f60583b0b36343bf627ea9c"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747b608fecf06b0d72d440f27acc99288207324b793be2c17991839f3d4995ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "darling"
@@ -1107,15 +1161,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde6edd6cef363e9359ed3c98ba64590ba9eecba2293eb5a723ab32aee8926aa"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1197,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -1309,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libloading"
@@ -1321,6 +1386,15 @@ checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1647,6 +1721,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,15 +1853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1860,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2436,6 +2517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",
@@ -2866,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f584cc881e9e5f1fd6bf827b0444aa94c30d8fe6378cf241071b5f5700b2871f"
+checksum = "994453cd270ad0265796eb24abf5540091ed03e681c5f3c12bc33e4db33253e1"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2943,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.231.4"
+version = "0.232.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b4fa8bd71c6b15a06d2c4b17fe3f73887ee3b90eb42a27c421905195512183"
+checksum = "f10f028d03dde4bbea7743baf99252a3b9c1a072a1bbc388cc256df7a6ad5e45"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3007,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.191.4"
+version = "0.192.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1921c44d8d05200da2e82e22670d8eb1d674d45749530260c75c3e61b390d7b"
+checksum = "2dabae7e9d84527f8d29319790bc459e5384a38712e620fbae36e3df7bb67875"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3041,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "swc_cached"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb9e461aba8d2d5b94c94499af5c7a4a8aa4a93a1e3672b7b205248cd98a87f"
+checksum = "9745d42d167cb60aeb1e85d2ee813ca455c3185bf7417f11fd102d745ae2b9e1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3051,14 +3138,13 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "swc_atoms",
 ]
 
 [[package]]
 name = "swc_common"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b79bef6a4a4a7f273c51f64a61ad601c3b9b101f41f9d43a202832620c2f8cd"
+checksum = "34875a019a869ae0e9af55100df92df710e4cba7708cb80e210e24d94b214e72"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3089,11 +3175,10 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc17721410f3f12aeb42dcb99528350adf122681ab4796e48c2cfc0bda0c752c"
+checksum = "b4de36224eb9498fccd4e68971f0b83326ccf8592c2d424f257f3a1c76b2b211"
 dependencies = [
- "anyhow",
  "indexmap",
  "serde",
  "serde_json",
@@ -3115,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.29.5"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b86736f8670ced8ad8fc72b78a0aea2b812b944254c9e9d0aa7347d2c92b7b"
+checksum = "ef09497ffdad619d9151c45c0b466a091357d584e75e4e8a80817e4b0b43d451"
 dependencies = [
  "binding_macros",
  "swc",
@@ -3153,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.114.6"
+version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35da1b34ed1a4013bf1b047e7c495b68227a2c0fccbb892d1cb62655252aa147"
+checksum = "62956b962258a226a89ca9ab946949573ffa15e1c616351b93f8747bbc187818"
 dependencies = [
  "is-macro",
  "serde",
@@ -3166,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.124.6"
+version = "0.126.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815260af29653310c9ecb0677df26d35bae47aca1c9638513e2872d591ab5acf"
+checksum = "a99a3bca41c579f6f12fc039bc0793b349a975c0d45bdc30015ab4205ce60326"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -3196,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.123.6"
+version = "0.125.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac51eca7321466b299cb4385648a64ad5c847a4d1d554eff3019828b450a1f3"
+checksum = "a245259501b5f8dc21d746bc1e1280b5727701c2ef6defeaf02ef99999412d2b"
 dependencies = [
  "bitflags",
  "lexical",
@@ -3210,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.125.6"
+version = "0.127.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43efaf76c1fb4cb1243f6616045b4786e706e3e5b4a7f42861fc39a136d2069"
+checksum = "58fba187856209952c72f2bc70a5a931f1b081687d5e2a7009ab5a7bd34fec9f"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -3227,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.111.6"
+version = "0.113.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ea175bc397cb77f3811eab3a5649c1842cb12614e3c6dc8f6e0bee76ad5aec"
+checksum = "a80276b47f1a8618882a2e4763f3b588bd0ed2dda20e797c2c6aaa9e6189b4e5"
 dependencies = [
  "once_cell",
  "serde",
@@ -3242,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.113.6"
+version = "0.115.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968d3e48b28e760362c8b00670b52ec60e9e7381db0b45371418e93d7ba01062"
+checksum = "3ca311204de3378c939b2446ab1c821df7e3fa48d04fe0831bdc9cda9439431f"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3255,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.94.4"
+version = "0.94.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f35e76f46d51a118ac4a5e08eb4df855a33f8ec764dbdffe7cbe5066e08d82a"
+checksum = "c2f16811040448cc7adf4984b26cc3b8601d6b56ce678eb4464648d46c274a88"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -3273,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.127.7"
+version = "0.127.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc8e054b412f4def211ecfe1f365b3f77e3284706f877b6c7870f50831d0168"
+checksum = "907147c29cd795b81820e49ba7e2b7332c4009f4316e365033cf8971d7865367"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -3305,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.91.6"
+version = "0.91.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c028ca81905c093608f5ad84b9e78376ad2b0c1886edff4a99915711932bf155"
+checksum = "98dc5f0b817ac14445b2e99bd8e4b054d1f32bbec7ccc195613356bbdaedc4e5"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -3319,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.66.11"
+version = "0.66.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9404193770f98c09d0a785117ae7aa2bd33f79ce4aa87c53625f4d4cbabdf717"
+checksum = "29844d6424ee5a3b81132243bce6b343cd47e24e28b5365375b211b35d235262"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -3340,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.41.4"
+version = "0.41.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e4ef6069a6a03fcb31a139c429211f843225c2c4c256d1f972e86e02f53b4"
+checksum = "91a04efda8595acbc47f9391252ad5ea52ac2a488371f9293c22f33b50cbe489"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3362,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.158.4"
+version = "0.159.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f011dcf9af87cc74ca0854062ba191cb2c556ea2f2ff3dcb9b3968a8fe89a31"
+checksum = "3b021a586264e6300af41d56cb349d560b2ebad60de7352a83ecc783e9262a46"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -3396,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.122.5"
+version = "0.122.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d040a13b3c39514255d161345b2730c9fbf52f02ad579a0a68a05af039247b5"
+checksum = "2bbb20ddfdf47a4079a3354e022502bf434075ec2aea77bc8102f0a2095d5a60"
 dependencies = [
  "either",
  "enum_kind",
@@ -3415,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.173.2"
+version = "0.174.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0f6d56561bfe1b58e54bcf282aa117aa64dc432f72a59fcea7bb3f3af901c3"
+checksum = "869af128171f218ab06dbb94cf66e2e56839f2d35e451e8ad55739a3ffe4cb18"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3440,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a09d0c939e8e691b27f91f430067ad0acca688a3e805b459956fd338966e87"
+checksum = "21ecc467eff7ef4ec0a64919402b94da637003015d019de4d649e8efeceafd3f"
 dependencies = [
  "anyhow",
  "hex",
@@ -3456,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.197.2"
+version = "0.198.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7873d4a6ce07f34f256645c731ec4c64bff0430b0c2be200932b3ff0cf39df5"
+checksum = "ce8fcf355a3a5d7d911fcc5e1e2ad9850925a410b3e470166b9be409b1c87d17"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3476,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.111.12"
+version = "0.111.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8771e64d9c19b9ac78c38b6fccc1ec1f2e964e4e928e291cb95540636b8cb1"
+checksum = "ec38bd9ce2fa5e59e50909231cd60d8a737f486923d1eac3f750ce229a265be0"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -3499,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.100.11"
+version = "0.100.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a19903a8e999083e5199300ae89650e3e0ba9dce988c09db4876b14199e30ce"
+checksum = "042b1c88115257becce3d9044aecfd4ab1b6c588f505c23a5c92d3b518f7d189"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3513,16 +3598,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.135.2"
+version = "0.136.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f475ba65bdeda2dd3bae29d2285c7a8c98fb22f35dc8ef8ed29a0cc07423441"
+checksum = "842284adaad289b202b5460e6104f9e1496f43ecdf2d52f270e040f915b44871"
 dependencies = [
  "ahash",
  "arrayvec",
  "indexmap",
  "is-macro",
  "num-bigint",
- "ordered-float",
  "rayon",
  "serde",
  "smallvec",
@@ -3554,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.152.2"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f03ae8b6d654cb2fd02c731988ec7db918b55e6fe0c59a17ee583e3e05227fb"
+checksum = "90502a51df216757541f2eb280235adbd0e0b310d0069208c0858fda1085f189"
 dependencies = [
  "Inflector",
  "ahash",
@@ -3582,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.166.2"
+version = "0.167.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b972d650531005a50dd4a2b90b924c998203308042f73fb3ae746be5f3e00584"
+checksum = "e852f4da63146b61009c77d08859eee9301e4ea8a51f4878f1118da699aa5cfa"
 dependencies = [
  "ahash",
  "dashmap",
@@ -3608,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.143.2"
+version = "0.144.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa530c88885bf8d7553b3e2aacd7d4806b802ceb9759b610582f21c540b4051b"
+checksum = "806ef12ce9829105b38eb83fd901233959f2360668800d06f9d1582ad1737b01"
 dependencies = [
  "either",
  "serde",
@@ -3627,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.154.2"
+version = "0.155.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ecaf9321c93fca23f1112a80716f25cdd82232f89862ac799ea4c50deb01b3"
+checksum = "21c92037fc226cfca561b8e33949199bc7283a52fffa79c2bfa500a502613cb4"
 dependencies = [
  "ahash",
  "base64",
@@ -3654,16 +3738,18 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.113.11"
+version = "0.114.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb46ef1f434c80d66ba971e3f6908fa625a11d0658ccff378256a2814f416e2"
+checksum = "384feb8ae74c3e124ac0735c72d695306f663f894d15c355a934a67d7bb30a18"
 dependencies = [
  "ansi_term",
  "anyhow",
+ "base64",
  "hex",
  "serde",
  "serde_json",
  "sha-1",
+ "sourcemap",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -3678,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.158.2"
+version = "0.159.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51db159e63caae3bf41b754f34a8930e2f2e0852394d270ba7f42bb44f2b10f8"
+checksum = "4ddd1a3459cb84b7b5e22cdba6ca5cfdc9240afb0f1f760d21b9538ed51a1c01"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3694,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.105.6"
+version = "0.105.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1064b08af03fe7ea2887cf80d4b3200544158520e324abe48d3b57eab31317"
+checksum = "031c8660b5daae4ed07537d68d2bac771b7f27c60c1db490ddf88f457cdfe13a"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -3712,9 +3798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.80.4"
+version = "0.80.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e5e96387513533be7c2094aefd1cb7ab05b17477def007fd709ea00d730e2"
+checksum = "df1e7d6f84fdfa191c796fad64d17fec018bfe8de3e14120fc66b19bd43a6f80"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -3756,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7e3246738064b3b5c151638eeb8b71701711e5aec2002fbe083793dacdf412"
+checksum = "87c296e1d533b27fb738b6ec1d2b8d44845e61f6ad373e042fb2cf8b5416b561"
 dependencies = [
  "anyhow",
  "miette",
@@ -3769,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.4"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c896c7b96b1af515498979546dd8a00bf892fde1f727d32ad6ae9461e38bc2"
+checksum = "1206921ee3d7c5b4f9211a3c1cc56a9f0839437c8133511cf57e8d9c13b2c4bc"
 dependencies = [
  "ahash",
  "indexmap",
@@ -3781,9 +3867,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e691625cb09e967935f499a13eb1fb6db0b03c9714de1fa83d872ee81c261c"
+checksum = "a0e5b87736c72988c9437525a9de16d94179de20ea31fb9fcd2b1ced79ec3f93"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -3816,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d17400e0f0175824465905e006cd02d7c5df765fe8d0508e5d1b91da19e6b61"
+checksum = "a1f0ac98ee6c95c69b78a20f7f6abbc70ceaab00902033861c0437cc5baec8af"
 dependencies = [
  "ahash",
  "dashmap",
@@ -3828,9 +3914,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.22.4"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2270658050fd6b570339138103b0a22a62336d62e3af7b44dc8cd60b29f681c"
+checksum = "8dd3cb9ba685f9059cf3e3048a238da77bfc59f8a53854674b1290c3c5ee5f76"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -3842,9 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.77.5"
+version = "0.77.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5ef3d009b91af32a3d5195ddda48c32cbe7fb1169f93cba7d43cbb53a24ce0"
+checksum = "af44618ba21d02d7064574ce1bd26c867403595d8b3d898d3951256689b6cba7"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3862,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90d1d5acb5f25421d1c528c58b413553080329307b972a0fc004385ee8e8be9"
+checksum = "44209841ce5f00bef5dd32b1de5840143488b3c7f690b817b79e23c6a75dd4ad"
 dependencies = [
  "tracing",
 ]
@@ -3906,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3956,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.4"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542cacf565846829c5ab5bcf64f601a1f412b1de5fcc9d4b1f5297926c16fddf"
+checksum = "1e7d110e76eb708ab08846d2c52cf54c56e3c97e704809fced27b78db2ef444e"
 dependencies = [
  "ansi_term",
  "difference",
@@ -4186,9 +4272,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4199,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4221,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4252,12 +4338,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -4325,9 +4411,9 @@ checksum = "d70b6494226b36008c8366c288d77190b3fad2eb4c10533139c1c1f461127f1a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4383,9 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
  "serde",

--- a/packages/next-swc/Cargo.toml
+++ b/packages/next-swc/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
 
-members = [
-  "crates/core",
-  "crates/napi",
-  "crates/wasm"
-]
+members = ["crates/core", "crates/napi", "crates/wasm"]
 
 [profile.dev.package.swc_css_prefixer]
 opt-level = 2
@@ -15,3 +11,6 @@ debug-assertions = false
 
 [profile.release]
 lto = true
+
+[workspace.dependencies]
+swc_core = "0.32.2"

--- a/packages/next-swc/crates/core/Cargo.toml
+++ b/packages/next-swc/crates/core/Cargo.toml
@@ -8,9 +8,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-plugin = [
-  "swc_core/plugin_transform_host_native"
-]
+plugin = ["swc_core/plugin_transform_host_native"]
 
 [dependencies]
 chrono = "0.4"
@@ -22,10 +20,10 @@ pathdiff = "0.2.0"
 regex = "1.5"
 serde = "1"
 serde_json = "1"
-swc_emotion = {path="../emotion"}
-styled_components = {path="../styled_components"}
-styled_jsx = {path="../styled_jsx"}
-modularize_imports = {path="../modularize_imports"}
+swc_emotion = { path = "../emotion" }
+styled_components = { path = "../styled_components" }
+styled_jsx = { path = "../styled_jsx" }
+modularize_imports = { path = "../modularize_imports" }
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 
 swc_core = { features = [
@@ -44,10 +42,10 @@ swc_core = { features = [
   "ecma_parser",
   "ecma_parser_typescript",
   "cached",
-  "base"
-], version = "0.29.5" }
+  "base",
+], workspace = true }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.29.5" }
+swc_core = { features = ["testing_transform"], workspace = true }
 testing = "0.31.4"
 walkdir = "2.3.2"

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -8,8 +8,11 @@ use next_swc::{
 use std::path::PathBuf;
 use swc_core::{
     common::FileName,
-    ecma::parser::{EsConfig, Syntax},
-    ecma::transforms::testing::test_fixture_allowing_error,
+    ecma::transforms::testing::test_fixture,
+    ecma::{
+        parser::{EsConfig, Syntax},
+        transforms::testing::FixtureTestConfig,
+    },
 };
 use testing::fixture;
 
@@ -20,21 +23,29 @@ fn syntax() -> Syntax {
     })
 }
 
+fn allow_error() -> FixtureTestConfig {
+    FixtureTestConfig {
+        sourcemap: false,
+        allow_error: true,
+    }
+}
+
 #[fixture("tests/errors/re-export-all-in-page/**/input.js")]
 fn re_export_all_in_page(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture_allowing_error(
+    test_fixture(
         syntax(),
         &|_tr| disallow_re_export_all_in_page(true),
         &input,
         &output,
+        allow_error(),
     );
 }
 
 #[fixture("tests/errors/next-dynamic/**/input.js")]
 fn next_dynamic_errors(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture_allowing_error(
+    test_fixture(
         syntax(),
         &|_tr| {
             next_dynamic(
@@ -46,24 +57,26 @@ fn next_dynamic_errors(input: PathBuf) {
         },
         &input,
         &output,
+        allow_error(),
     );
 }
 
 #[fixture("tests/errors/next-ssg/**/input.js")]
 fn next_ssg_errors(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture_allowing_error(
+    test_fixture(
         syntax(),
         &|_tr| next_ssg(Default::default()),
         &input,
         &output,
+        allow_error(),
     );
 }
 
 #[fixture("tests/errors/react-server-components/server-graph/**/input.js")]
 fn react_server_components_server_graph_errors(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture_allowing_error(
+    test_fixture(
         syntax(),
         &|tr| {
             server_components(
@@ -76,13 +89,14 @@ fn react_server_components_server_graph_errors(input: PathBuf) {
         },
         &input,
         &output,
+        allow_error(),
     );
 }
 
 #[fixture("tests/errors/react-server-components/client-graph/**/input.js")]
 fn react_server_components_client_graph_errors(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture_allowing_error(
+    test_fixture(
         syntax(),
         &|tr| {
             server_components(
@@ -95,13 +109,14 @@ fn react_server_components_client_graph_errors(input: PathBuf) {
         },
         &input,
         &output,
+        allow_error(),
     );
 }
 
 #[fixture("tests/errors/next-font-loaders/**/input.js")]
 fn next_font_loaders_errors(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture_allowing_error(
+    test_fixture(
         syntax(),
         &|_tr| {
             next_font_loaders(FontLoaderConfig {
@@ -111,5 +126,6 @@ fn next_font_loaders_errors(input: PathBuf) {
         },
         &input,
         &output,
+        allow_error(),
     );
 }

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -29,7 +29,13 @@ fn syntax() -> Syntax {
 #[fixture("tests/fixture/amp/**/input.js")]
 fn amp_attributes_fixture(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture(syntax(), &|_tr| amp_attributes(), &input, &output);
+    test_fixture(
+        syntax(),
+        &|_tr| amp_attributes(),
+        &input,
+        &output,
+        Default::default(),
+    );
 }
 
 #[fixture("tests/fixture/next-dynamic/**/input.js")]
@@ -49,6 +55,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         },
         &input,
         &output_dev,
+        Default::default(),
     );
     test_fixture(
         syntax(),
@@ -62,6 +69,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         },
         &input,
         &output_prod,
+        Default::default(),
     );
     test_fixture(
         syntax(),
@@ -75,6 +83,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         },
         &input,
         &output_server,
+        Default::default(),
     );
 }
 
@@ -106,13 +115,20 @@ fn next_ssg_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
 #[fixture("tests/fixture/page-config/**/input.js")]
 fn page_config_fixture(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
-    test_fixture(syntax(), &|_tr| page_config_test(), &input, &output);
+    test_fixture(
+        syntax(),
+        &|_tr| page_config_test(),
+        &input,
+        &output,
+        Default::default(),
+    );
 }
 
 #[fixture("tests/fixture/relay/**/input.ts*")]
@@ -134,6 +150,7 @@ fn relay_no_artifact_dir_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -145,6 +162,7 @@ fn remove_console_fixture(input: PathBuf) {
         &|_tr| remove_console(next_swc::remove_console::Config::All(true)),
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -156,6 +174,7 @@ fn react_remove_properties_default_fixture(input: PathBuf) {
         &|_tr| remove_properties(next_swc::react_remove_properties::Config::All(true)),
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -173,6 +192,7 @@ fn react_remove_properties_custom_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -194,6 +214,7 @@ fn shake_exports_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -209,6 +230,7 @@ fn shake_exports_fixture_default(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -228,6 +250,7 @@ fn react_server_components_server_graph_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -247,6 +270,7 @@ fn react_server_components_client_graph_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -263,5 +287,6 @@ fn next_font_loaders_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }

--- a/packages/next-swc/crates/emotion/Cargo.toml
+++ b/packages/next-swc/crates/emotion/Cargo.toml
@@ -19,9 +19,19 @@ regex = "1.5"
 serde = "1"
 sourcemap = "6.0.1"
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
-swc_core = { features = ["common", "ecma_ast","ecma_codegen", "ecma_utils", "ecma_visit", "trace_macro"], version = "0.29.5" }
+swc_core = { features = [
+	"common",
+	"ecma_ast",
+	"ecma_codegen",
+	"ecma_utils",
+	"ecma_visit",
+	"trace_macro",
+], workspace = true }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform", "ecma_transforms_react"], version = "0.29.5" }
+swc_core = { features = [
+	"testing_transform",
+	"ecma_transforms_react",
+], workspace = true }
 testing = "0.31.4"
 serde_json = "1"

--- a/packages/next-swc/crates/emotion/tests/fixture.rs
+++ b/packages/next-swc/crates/emotion/tests/fixture.rs
@@ -59,5 +59,6 @@ fn next_emotion_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }

--- a/packages/next-swc/crates/modularize_imports/Cargo.toml
+++ b/packages/next-swc/crates/modularize_imports/Cargo.toml
@@ -15,8 +15,8 @@ handlebars = "4.2.1"
 once_cell = "1.13.0"
 regex = "1.5"
 serde = "1"
-swc_core = { features = ["cached", "ecma_ast", "ecma_visit"], version = "0.29.5" }
+swc_core = { features = ["cached", "ecma_ast", "ecma_visit"], workspace = true }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.29.5" }
+swc_core = { features = ["testing_transform"], workspace = true }
 testing = "0.31.4"

--- a/packages/next-swc/crates/modularize_imports/tests/fixture.rs
+++ b/packages/next-swc/crates/modularize_imports/tests/fixture.rs
@@ -61,5 +61,6 @@ fn modularize_imports_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -13,10 +13,7 @@ default = []
 # when build (i.e napi --build --features plugin), same for the wasm as well.
 # this is due to some of transitive dependencies have features cannot be enabled at the same time
 # (i.e wasmer/default vs wasmer/js-default) while cargo merges all the features at once.
-plugin = [
-  "swc_core/plugin_transform_host_native",
-  "next-swc/plugin"
-]
+plugin = ["swc_core/plugin_transform_host_native", "next-swc/plugin"]
 sentry_native_tls = ["_sentry_native_tls"]
 sentry_rustls = ["_sentry_rustls"]
 
@@ -24,15 +21,15 @@ sentry_rustls = ["_sentry_rustls"]
 anyhow = "1.0"
 backtrace = "0.3"
 fxhash = "0.2.1"
-napi = {version = "1", features = ["serde-json"]}
+napi = { version = "1", features = ["serde-json"] }
 napi-derive = "1"
-next-swc = {version = "0.0.0", path = "../core"}
+next-swc = { version = "0.0.0", path = "../core" }
 once_cell = "1.13.0"
 serde = "1"
 serde_json = "1"
 swc_core = { features = [
   "allocator_node",
-  "base_concurrent", # concurrent?
+  "base_concurrent",              # concurrent?
   "common_concurrent",
   "ecma_ast",
   "ecma_loader_node",
@@ -48,8 +45,8 @@ swc_core = { features = [
   "ecma_transforms_react",
   "ecma_transforms_typescript",
   "ecma_utils",
-  "ecma_visit"
-], version = "0.29.5" }
+  "ecma_visit",
+], workspace = true }
 tracing = { version = "0.1.32", features = ["release_max_level_info"] }
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.9"
@@ -64,7 +61,7 @@ _sentry_rustls = { package = "sentry", version = "0.27.0", default-features = fa
   "contexts",
   "panic",
   "rustls",
-  "reqwest"
+  "reqwest",
 ], optional = true }
 
 [build-dependencies]

--- a/packages/next-swc/crates/styled_components/Cargo.toml
+++ b/packages/next-swc/crates/styled_components/Cargo.toml
@@ -13,15 +13,18 @@ version = "0.45.0"
 [dependencies]
 Inflector = "0.11.4"
 once_cell = "1.13.0"
-regex = {version = "1.5.4", features = ["std", "perf"], default-features = false}
-serde = {version = "1.0.130", features = ["derive"]}
+regex = { version = "1.5.4", features = [
+  "std",
+  "perf",
+], default-features = false }
+serde = { version = "1.0.130", features = ["derive"] }
 tracing = "0.1.32"
 swc_core = { features = [
   "common",
   "ecma_ast",
   "ecma_utils",
-  "ecma_visit"
-], version = "0.29.5" }
+  "ecma_visit",
+], workspace = true }
 
 [dev-dependencies]
 serde_json = "1"
@@ -29,5 +32,5 @@ testing = "0.31.4"
 swc_core = { features = [
   "ecma_parser",
   "ecma_transforms",
-  "testing_transform"
-], version = "0.29.5" }
+  "testing_transform",
+], workspace = true }

--- a/packages/next-swc/crates/styled_components/tests/fixture.rs
+++ b/packages/next-swc/crates/styled_components/tests/fixture.rs
@@ -32,5 +32,6 @@ fn fixture(input: PathBuf) {
         },
         &input,
         &dir.join("output.js"),
+        Default::default(),
     )
 }

--- a/packages/next-swc/crates/styled_jsx/Cargo.toml
+++ b/packages/next-swc/crates/styled_jsx/Cargo.toml
@@ -23,11 +23,9 @@ swc_core = { features = [
   "ecma_parser",
   "ecma_minifier",
   "ecma_utils",
-  "ecma_visit"
-], version = "0.29.5" }
+  "ecma_visit",
+], workspace = true }
 
 [dev-dependencies]
 testing = "0.31.4"
-swc_core = { features = [
-  "testing_transform"
-], version = "0.29.5" }
+swc_core = { features = ["testing_transform"], workspace = true }

--- a/packages/next-swc/crates/styled_jsx/tests/fixture.rs
+++ b/packages/next-swc/crates/styled_jsx/tests/fixture.rs
@@ -4,8 +4,8 @@ use styled_jsx::styled_jsx;
 use swc_core::{
     common::{chain, FileName, Mark, Span, DUMMY_SP},
     ecma::parser::{EsConfig, Syntax},
-    ecma::transforms::base::resolver,
-    ecma::transforms::testing::{test_fixture, test_fixture_allowing_error},
+    ecma::transforms::testing::test_fixture,
+    ecma::transforms::{base::resolver, testing::FixtureTestConfig},
 };
 use testing::fixture;
 
@@ -32,6 +32,7 @@ fn styled_jsx_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 
     test_fixture(
@@ -56,6 +57,7 @@ fn styled_jsx_fixture(input: PathBuf) {
         },
         &input,
         &output,
+        Default::default(),
     );
 }
 
@@ -74,10 +76,14 @@ fn styled_jsx_errors(input: PathBuf) {
         false => FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
     };
 
-    test_fixture_allowing_error(
+    test_fixture(
         syntax(),
         &|t| styled_jsx(t.cm.clone(), file_name.clone()),
         &input,
         &output,
+        FixtureTestConfig {
+            sourcemap: false,
+            allow_error: true,
+        },
     );
 }

--- a/packages/next-swc/crates/styled_jsx/tests/fixture/css-selector-after-pseudo/output.js
+++ b/packages/next-swc/crates/styled_jsx/tests/fixture/css-selector-after-pseudo/output.js
@@ -1,5 +1,5 @@
 import _JSXStyle from "styled-jsx/style";
-function NavigationItem({ active , className ,  }) {
+function NavigationItem({ active , className  }) {
     return <span className={"jsx-2342aae4628612c6" + " " + (cn({
         active
     }, className, 'navigation-item') || "")}>

--- a/packages/next-swc/crates/styled_jsx/tests/fixture/too-many/output.js
+++ b/packages/next-swc/crates/styled_jsx/tests/fixture/too-many/output.js
@@ -1,5 +1,5 @@
 import _JSXStyle from "styled-jsx/style";
-export const Red = ({ Component ='button' ,  })=>{
+export const Red = ({ Component ='button'  })=>{
     return <Component className={_JSXStyle.dynamic([
         [
             "1a9f9e2fa701f7ec",

--- a/packages/next-swc/crates/wasm/Cargo.toml
+++ b/packages/next-swc/crates/wasm/Cargo.toml
@@ -9,24 +9,24 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["swc_v1"]
-swc_v1  = []
+swc_v1 = []
 
-plugin = [
-  "getrandom/js",
-  "swc_core/plugin_transform_host_js"
-]
+plugin = ["getrandom/js", "swc_core/plugin_transform_host_js"]
 
 [dependencies]
 anyhow = "1.0.42"
 console_error_panic_hook = "0.1.6"
-next-swc = {version = "0.0.0", path = "../core"}
+next-swc = { version = "0.0.0", path = "../core" }
 once_cell = "1.13.0"
 parking_lot_core = "=0.8.0"
 path-clean = "0.1"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tracing = { version = "0.1.32", features = ["release_max_level_off","max_level_off"] }
-wasm-bindgen = {version = "0.2", features = ["enable-interning"]}
+tracing = { version = "0.1.32", features = [
+  "release_max_level_off",
+  "max_level_off",
+] }
+wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
 wasm-bindgen-futures = "0.4.8"
 getrandom = { version = "0.2.5", optional = true, default-features = false }
 js-sys = "0.3.59"
@@ -44,8 +44,8 @@ swc_core = { features = [
   "ecma_parser",
   "ecma_parser_typescript",
   "ecma_utils",
-  "ecma_visit"
-], version = "0.29.5" }
+  "ecma_visit",
+], workspace = true }
 
 
 # Workaround a bug


### PR DESCRIPTION
This updates swc_core to 0.32.2, similar to #40520.

This also centralizes the version of swc_core in the main Cargo.toml as a workspace dependency for ease of maintenance and consistency across packages [0]

Test Plan: Updated test fixtures accordingly. `cd packages/next-swc && cargo test`

[0] https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
