### PR TITLE
Ensure RSC paths are normalized in minimal mode

### DIFF
--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -29,6 +29,7 @@ import cookie from 'next/dist/compiled/cookie'
 import { TEMPORARY_REDIRECT_STATUS } from '../../../../shared/lib/constants'
 import { addRequestMeta } from '../../../../server/request-meta'
 import { removeTrailingSlash } from '../../../../shared/lib/router/utils/remove-trailing-slash'
+import { normalizeRscPath } from '../../../../shared/lib/router/utils/app-paths'
 
 export const vercelHeader = 'x-vercel-id'
 
@@ -365,6 +366,18 @@ export function getUtils({
 
     params = Object.keys(defaultRouteRegex.groups).reduce((prev, key) => {
       let value: string | string[] | undefined = params[key]
+
+      if (typeof value === 'string') {
+        value = normalizeRscPath(value, true)
+      }
+      if (Array.isArray(value)) {
+        value = value.map((value) => {
+          if (typeof value === 'string') {
+            value = normalizeRscPath(value, true)
+          }
+          return value
+        })
+      }
 
       // if the value matches the default value we can't rely
       // on the parsed params, this is used to signal if we need

--- a/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
+++ b/packages/next/build/webpack/loaders/next-serverless-loader/utils.ts
@@ -371,11 +371,11 @@ export function getUtils({
         value = normalizeRscPath(value, true)
       }
       if (Array.isArray(value)) {
-        value = value.map((value) => {
-          if (typeof value === 'string') {
-            value = normalizeRscPath(value, true)
+        value = value.map((val) => {
+          if (typeof val === 'string') {
+            val = normalizeRscPath(val, true)
           }
-          return value
+          return val
         })
       }
 

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -64,7 +64,10 @@ import { addRequestMeta, getRequestMeta } from './request-meta'
 
 import { ImageConfigComplete } from '../shared/lib/image-config'
 import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
-import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
+import {
+  normalizeAppPath,
+  normalizeRscPath,
+} from '../shared/lib/router/utils/app-paths'
 import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { getHostname } from '../shared/lib/get-hostname'
@@ -495,6 +498,11 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       if (typeof parsedUrl.query === 'string') {
         parsedUrl.query = parseQs(parsedUrl.query)
       }
+      req.url = normalizeRscPath(req.url, this.hasAppDir)
+      parsedUrl.pathname = normalizeRscPath(
+        parsedUrl.pathname || '',
+        this.hasAppDir
+      )
 
       this.attachRequestMeta(req, parsedUrl)
 
@@ -525,10 +533,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         try {
           // x-matched-path is the source of truth, it tells what page
           // should be rendered because we don't process rewrites in minimalMode
-          let matchedPath = new URL(
-            req.headers['x-matched-path'],
-            'http://localhost'
-          ).pathname
+          let matchedPath = normalizeRscPath(
+            new URL(req.headers['x-matched-path'], 'http://localhost').pathname,
+            this.hasAppDir
+          )
 
           let urlPathname = new URL(req.url, 'http://localhost').pathname
 

--- a/packages/next/server/web/adapter.ts
+++ b/packages/next/server/web/adapter.ts
@@ -9,6 +9,7 @@ import { relativizeURL } from '../../shared/lib/router/utils/relativize-url'
 import { waitUntilSymbol } from './spec-extension/fetch-event'
 import { NextURL } from './next-url'
 import { stripInternalSearchParams } from '../internal-utils'
+import { normalizeRscPath } from '../../shared/lib/router/utils/app-paths'
 
 class NextRequestHint extends NextRequest {
   sourcePage: string
@@ -48,6 +49,8 @@ export async function adapter(params: {
 }): Promise<FetchEventResult> {
   // TODO-APP: use explicit marker for this
   const isEdgeRendering = typeof self.__BUILD_MANIFEST !== 'undefined'
+
+  params.request.url = normalizeRscPath(params.request.url, true)
 
   const requestUrl = new NextURL(params.request.url, {
     headers: params.request.headers,

--- a/packages/next/shared/lib/router/utils/app-paths.ts
+++ b/packages/next/shared/lib/router/utils/app-paths.ts
@@ -21,3 +21,7 @@ export function normalizeAppPath(pathname: string) {
     return acc + `/${segment}`
   }, '')
 }
+
+export function normalizeRscPath(pathname: string, enabled?: boolean) {
+  return enabled ? pathname.replace(/\.rsc($|\?)/, '') : pathname
+}


### PR DESCRIPTION
This ensures we probably remove RSC from the path/URL when in minimal mode. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

Fixes: [slack thread](https://vercel.slack.com/archives/C043ANYDB24/p1665517894397169?thread_ts=1664913868.516049&cid=C043ANYDB24)