### PR TITLE
docs: add tips for building first before running test for contribute Nextjs.

### DIFF
--- a/contributing/core/testing.md
+++ b/contributing/core/testing.md
@@ -2,6 +2,14 @@
 
 ## Running tests
 
+Before you start to run tests, you need to build project first:
+
+```bash
+pnpm build
+```
+
+And for more detail about building, you can check out [building.md](./building.md)
+
 We recommend running the tests in headless mode (with the browser windows hidden) and with a specific directory pattern and/or test name (`-t`) which ensures only a small part of the test suite is run locally:
 
 For example, running one test in the production test suite:


### PR DESCRIPTION
close https://github.com/vercel/next.js/issues/41378

add tips for building first before running tests for contribute Nextjs

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
