### PR TITLE
feat: Option to disable inlining of public env vars for node server

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -151,13 +151,15 @@ export function getDefineEnv({
   middlewareMatchers?: MiddlewareMatcher[]
   config: NextConfigComplete
 }) {
+  const disablePublicEnvInlining =
+    isNodeServer && config.experimental.disableServerPublicEnvInlining
   return {
     // internal field to identify the plugin config
     __NEXT_DEFINE_ENV: 'true',
 
     ...Object.keys(process.env).reduce(
       (prev: { [key: string]: string }, key: string) => {
-        if (key.startsWith('NEXT_PUBLIC_')) {
+        if (key.startsWith('NEXT_PUBLIC_') && !disablePublicEnvInlining) {
           prev[`process.env.${key}`] = JSON.stringify(process.env[key]!)
         }
         return prev

--- a/packages/next/server/config-shared.ts
+++ b/packages/next/server/config-shared.ts
@@ -99,6 +99,7 @@ export interface ExperimentalConfig {
   isrFlushToDisk?: boolean
   workerThreads?: boolean
   pageEnv?: boolean
+  disableServerPublicEnvInlining: boolean
   // optimizeCss can be boolean or critters' option object
   // Use Record<string, unknown> as critters doesn't export its Option type
   // https://github.com/GoogleChromeLabs/critters/blob/a590c05f9197b656d2aeaae9369df2483c26b072/packages/critters/src/index.d.ts


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
## What

Add an experimental option to disable the inlining of `NEXT_PUBLIC_` env vars for the node server.

## Why

I am maintaining on a [CDK construct](https://github.com/jetbridge/cdk-nextjs) to deploy NextJS to AWS using the standalone output mode. The issue that I have is that I want to allow env vars to be provided by AWS infrastructure, things like API URLs that aren't resolved until after your deployment completes. This means that certain env vars are not available at Next build time.

I can work around this by setting environment variables for the server and rewriting the static values after deployment (this is much trickier with the server code for esoteric reasons), but I need the standalone server JS bundles to read the actual environment variables and not rewrite them at build-time.


Fixes #40897, discussion here: https://github.com/vercel/next.js/discussions/40482

## Bug

- [X] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [X] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
