### PR TITLE
Fix prefetching for static app paths

### DIFF
--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -1064,6 +1064,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         ) {
           delete req.headers['__rsc__']
           delete req.headers['__next_router_state_tree__']
+          delete req.headers['__next_router_prefetch__']
         }
       }
     }

--- a/test/e2e/app-dir/app-prefetch/app/dashboard/[id]/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/dashboard/[id]/page.js
@@ -8,6 +8,10 @@ async function getData() {
   }
 }
 
+export function generateStaticParams() {
+  return [{ id: 'static' }]
+}
+
 export default function IdPage({ params }) {
   const data = use(getData())
   console.log(data)

--- a/test/e2e/app-dir/app-prefetch/app/dashboard/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/dashboard/page.js
@@ -1,5 +1,9 @@
 import { experimental_use as use } from 'react'
 
+export const config = {
+  revalidate: 0,
+}
+
 async function getData() {
   await new Promise((resolve) => setTimeout(resolve, 3000))
   return {

--- a/test/e2e/app-dir/app-prefetch/app/layout.js
+++ b/test/e2e/app-dir/app-prefetch/app/layout.js
@@ -1,7 +1,3 @@
-export const config = {
-  revalidate: 0,
-}
-
 export default function Root({ children }) {
   return (
     <html>

--- a/test/e2e/app-dir/prefetching.test.ts
+++ b/test/e2e/app-dir/prefetching.test.ts
@@ -55,4 +55,13 @@ describe('app dir prefetching', () => {
       'Welcome to the dashboard'
     )
   })
+
+  it('should not have prefetch error for static path', async () => {
+    const browser = await webdriver(next.url, '/')
+    await browser.eval('window.nd.router.prefetch("/dashboard/123")')
+    await browser.eval('window.nd.router.push("/dashboard/123")')
+    await waitFor(1000)
+    expect(next.cliOutput).not.toContain('ReferenceError')
+    expect(next.cliOutput).not.toContain('is not defined')
+  })
 })

--- a/test/e2e/app-dir/prefetching.test.ts
+++ b/test/e2e/app-dir/prefetching.test.ts
@@ -59,8 +59,8 @@ describe('app dir prefetching', () => {
   it('should not have prefetch error for static path', async () => {
     const browser = await webdriver(next.url, '/')
     await browser.eval('window.nd.router.prefetch("/dashboard/123")')
+    await waitFor(3000)
     await browser.eval('window.nd.router.push("/dashboard/123")')
-    await waitFor(1000)
     expect(next.cliOutput).not.toContain('ReferenceError')
     expect(next.cliOutput).not.toContain('is not defined')
   })


### PR DESCRIPTION
Ensures we delete the prefetch header when the path is static as it can't be honored and the full tree must be sent instead. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1665610012952039?thread_ts=1665582783.184029&cid=C035J346QQL)