### PR TITLE
rename with-react-query example to with-tanstack-query

### DIFF
--- a/examples/with-tanstack-query/README.md
+++ b/examples/with-tanstack-query/README.md
@@ -1,4 +1,4 @@
-# React Query
+# TanStack Query
 
 **Note:** This example is maintained outside of the Next.js repository:
 


### PR DESCRIPTION
Rename `with-react-query` example to `with-tanstack-query`.