### PR TITLE
Fix docker Example Readme

### DIFF
--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -30,7 +30,9 @@ To add support for Docker to an existing project, just copy the `Dockerfile` int
 // next.config.js
 module.exports = {
   // ... rest of the configuration.
-  output: 'standalone',
+  experimental: {
+        outputStandalone: true,
+  },
 }
 ```
 


### PR DESCRIPTION
I was migrating a Non-docker next app to Docker and found that the docs were wrong.

just a small change but that will save some devs time.
