### PR TITLE
Fix middleware dynamic route param on query hydration

### DIFF
--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -1602,7 +1602,9 @@ export default class Router implements BaseRouter {
             rewriteAs = localeResult.pathname
           }
           const routeRegex = getRouteRegex(pathname)
-          const curRouteMatch = getRouteMatcher(routeRegex)(rewriteAs)
+          const curRouteMatch = getRouteMatcher(routeRegex)(
+            new URL(rewriteAs, location.href).pathname
+          )
 
           if (curRouteMatch) {
             Object.assign(query, curRouteMatch)

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -381,6 +381,30 @@ describe('Middleware Rewrite', () => {
       )
     })
 
+    it('should have correct query info for dynamic route after query hydration', async () => {
+      const browser = await webdriver(
+        next.url,
+        '/fallback-true-blog/first?hello=world'
+      )
+
+      await check(
+        () =>
+          browser.eval(
+            'next.router.query.hello === "world" ? "success" : JSON.stringify(next.router.query)'
+          ),
+        'success'
+      )
+
+      expect(await browser.eval('next.router.query')).toEqual({
+        slug: 'first',
+        hello: 'world',
+      })
+      expect(await browser.eval('location.pathname')).toBe(
+        '/fallback-true-blog/first'
+      )
+      expect(await browser.eval('location.search')).toBe('?hello=world')
+    })
+
     it('should handle shallow navigation correctly (non-dynamic page)', async () => {
       const browser = await webdriver(next.url, '/about')
       const requests = []


### PR DESCRIPTION
Ensures query params aren't included when parsing dynamic route params during query hydration for a middleware matched path. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

Fixes: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1665692236623799)