### PR TITLE
feat: `router.go`

### DIFF
--- a/docs/api-reference/next/router.md
+++ b/docs/api-reference/next/router.md
@@ -361,6 +361,31 @@ export default function Page() {
 }
 ```
 
+### router.go
+
+Navigate in history. It executes `window.history.go(delta)`.
+
+#### Usage
+
+```jsx
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const router = useRouter()
+
+  return (
+    <div>
+      <button type="button" onClick={() => router.go(-2)}>
+        Click here to go -2(back twice)
+      </button>
+      <button type="button" onClick={() => router.go(1)}>
+        Click here to go 1(forward)
+      </button>
+    </div>
+  )
+}
+```
+
 ### router.reload
 
 Reload the current URL. Equivalent to clicking the browser’s refresh button. It executes `window.location.reload()`.

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -177,6 +177,9 @@ class ServerRouter implements NextRouter {
   back() {
     noRouter()
   }
+  go() {
+    noRouter()
+  }
   prefetch(): any {
     noRouter()
   }

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -542,6 +542,7 @@ export type NextRouter = BaseRouter &
     | 'replace'
     | 'reload'
     | 'back'
+    | 'go'
     | 'prefetch'
     | 'beforePopState'
     | 'events'
@@ -1135,6 +1136,13 @@ export default class Router implements BaseRouter {
    */
   back() {
     window.history.back()
+  }
+
+  /**
+   * Go delta in history
+   */
+  go(delta?: number | undefined) {
+    window.history.go(delta)
   }
 
   /**

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -209,6 +209,14 @@ describe('basePath', () => {
       await browser.eval('window.history.forward()')
       await check(() => browser.elementByCss('p').text(), /second/)
       expect(await browser.eval('window.beforeNav')).toBe(1)
+
+      await browser.eval('window.next.router.go(-1)')
+      await check(() => browser.elementByCss('p').text(), /first/)
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+
+      await browser.eval('window.next.router.go(1)')
+      await check(() => browser.elementByCss('p').text(), /second/)
+      expect(await browser.eval('window.beforeNav')).toBe(1)
     })
 
     it('should respect basePath in amphtml link rel', async () => {

--- a/test/integration/typescript/components/router.tsx
+++ b/test/integration/typescript/components/router.tsx
@@ -10,6 +10,7 @@ export default withRouter(({ router }) => {
     Router.prefetch('/page')
     Router.push
     Router.back
+    Router.go
     Router.reload
 
     router.events.on('routeChangeComplete', () => {})
@@ -18,6 +19,7 @@ export default withRouter(({ router }) => {
     router.prefetch('/page')
     router.push
     router.back
+    router.go
     router.reload
   })
   return <>{router.pathname}</>


### PR DESCRIPTION
## Feature
Add `router.go` to implement specific behavior like go back twice.
It can be achieved with `window.history.go`, but `next/router` has `router.back`. Therefore I think it is natural to have `go` in `next/router`
fixes: #18333

- [x] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`
