### PR TITLE
Rename more references to "use client"

### DIFF
--- a/packages/next-swc/crates/core/src/react_server_components.rs
+++ b/packages/next-swc/crates/core/src/react_server_components.rs
@@ -94,7 +94,7 @@ impl<C: Comments> ReactServerComponents<C> {
                             Some(expr_stmt) => {
                                 match &*expr_stmt.expr {
                                     Expr::Lit(Lit::Str(Str { value, .. })) => {
-                                        if &**value == "client" {
+                                        if &**value == "use client" {
                                             is_client_entry = true;
 
                                             // Remove the directive.

--- a/packages/next-swc/crates/core/tests/fixture/react-server-components/client-graph/client-entry/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/react-server-components/client-graph/client-entry/input.js
@@ -6,17 +6,17 @@
  * This is a comment.
  */
 
-"client";
+"use client";
 
 // This is a comment.
 
 "foo";
 
-"client";
+"use client";
 
 import "fs"
 
-"client";
+"use client";
 
 "bar";
 

--- a/packages/next-swc/crates/core/tests/fixture/react-server-components/client-graph/client-entry/output.js
+++ b/packages/next-swc/crates/core/tests/fixture/react-server-components/client-graph/client-entry/output.js
@@ -3,7 +3,7 @@
 // This is a comment.
 "foo";
 import "fs";
-"client";
+"use client";
 "bar";
 // This is a comment.
 1 + 1;

--- a/packages/next-swc/crates/core/tests/fixture/react-server-components/server-graph/client-entry/input.js
+++ b/packages/next-swc/crates/core/tests/fixture/react-server-components/server-graph/client-entry/input.js
@@ -6,7 +6,7 @@
  * This is a comment.
  */
 
-"client";
+"use client";
 
 // This is a comment.
 

--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
@@ -19,24 +19,24 @@ export function formatRSCErrorMessage(
     if (NEXT_RSC_ERR_REACT_API.test(message)) {
       formattedMessage = message.replace(
         NEXT_RSC_ERR_REACT_API,
-        `\n\nYou're importing a component that needs $1. It only works in a Client Component but none of its parents are marked with "client", so they're Server Components by default.\n\n`
+        `\n\nYou're importing a component that needs $1. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\n\n`
       )
       formattedVerboseMessage =
-        '\n\nMaybe one of these should be marked as a "client" entry:\n'
+        '\n\nMaybe one of these should be marked as a "use client" entry:\n'
     } else if (NEXT_RSC_ERR_SERVER_IMPORT.test(message)) {
       formattedMessage = message.replace(
         NEXT_RSC_ERR_SERVER_IMPORT,
-        `\n\nYou're importing a component that imports $1. It only works in a Client Component but none of its parents are marked with "client", so they're Server Components by default.\n\n`
+        `\n\nYou're importing a component that imports $1. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\n\n`
       )
       formattedVerboseMessage =
-        '\n\nMaybe one of these should be marked as a "client" entry:\n'
+        '\n\nMaybe one of these should be marked as a "use client" entry:\n'
     } else if (NEXT_RSC_ERR_CLIENT_IMPORT.test(message)) {
       formattedMessage = message.replace(
         NEXT_RSC_ERR_CLIENT_IMPORT,
-        `\n\nYou're importing a component that needs $1. That only works in a Server Component but one of its parents is marked with "client", so it's a Client Component.\n\n`
+        `\n\nYou're importing a component that needs $1. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.\n\n`
       )
       formattedVerboseMessage =
-        '\n\nOne of these is marked as a "client" entry:\n'
+        '\n\nOne of these is marked as a "use client" entry:\n'
     }
 
     return [formattedMessage, formattedVerboseMessage]

--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -113,10 +113,10 @@ module.exports = function (task) {
       const output = yield transform(source, options)
       const ext = path.extname(file.base)
 
-      // Make sure the output content keeps the `"client"` directive.
+      // Make sure the output content keeps the `use "client"` directive.
       // TODO: Remove this once SWC fixes the issue.
-      if (/^['"]client['"]/.test(source)) {
-        output.code = '"client";\n' + output.code
+      if (/^['"]use client['"]/.test(source)) {
+        output.code = '"use client";\n' + output.code
       }
 
       // Replace `.ts|.tsx` with `.js` in files with an extension


### PR DESCRIPTION
I found a number of references to the old `"client"` directive name. Should these be updated?