### PR TITLE
Improved the Readability of Readme.md

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -25,31 +25,31 @@
 
 ## Getting Started
 
-Visit <a aria-label="next.js learn" href="https://nextjs.org/learn">https://nextjs.org/learn</a> to get started with Next.js.
+> Visit <a aria-label="next.js learn" href="https://nextjs.org/learn">https://nextjs.org/learn</a> to get started with Next.js.
 
 ## Documentation
 
-Visit [https://nextjs.org/docs](https://nextjs.org/docs) to view the full documentation.
+> Visit [https://nextjs.org/docs](https://nextjs.org/docs) to view the full documentation.
 
 ## Who is using Next.js?
 
-Next.js is used by the world's leading companies. Check out the [Next.js Showcase](https://nextjs.org/showcase) to learn more.
+> Next.js is used by the world's leading companies. Check out the [Next.js Showcase](https://nextjs.org/showcase) to learn more.
 
 ## Community
 
-The Next.js community can be found on [GitHub Discussions](https://github.com/vercel/next.js/discussions), where you can ask questions, voice ideas, and share your projects.
+> The Next.js community can be found on [GitHub Discussions](https://github.com/vercel/next.js/discussions), where you can ask questions, voice ideas, and share your projects.
 
-To chat with other community members you can join the [Next.js Discord](https://nextjs.org/discord).
+> To chat with other community members you can join the [Next.js Discord](https://nextjs.org/discord).
 
-Our [Code of Conduct](https://github.com/vercel/next.js/blob/canary/CODE_OF_CONDUCT.md) applies to all Next.js community channels.
+> Our [Code of Conduct](https://github.com/vercel/next.js/blob/canary/CODE_OF_CONDUCT.md) applies to all Next.js community channels.
 
 ## Contributing
 
-Please see our [contributing.md](/contributing.md).
+> Please see our [contributing.md](/contributing.md).
 
 ### Good First Issues
 
-We have a list of [good first issues](https://github.com/vercel/next.js/labels/good%20first%20issue) that contain bugs that have a relatively limited scope. This is a great place to get started, gain experience, and get familiar with our contribution process.
+> We have a list of [good first issues](https://github.com/vercel/next.js/labels/good%20first%20issue) that contain bugs that have a relatively limited scope. This is a great place to get started, gain experience, and get familiar with our contribution process.
 
 ## Authors
 
@@ -62,6 +62,6 @@ We have a list of [good first issues](https://github.com/vercel/next.js/labels/g
 
 ## Security
 
-If you believe you have found a security vulnerability in Next.js, we encourage you to responsibly disclose this and not open a public issue. We will investigate all legitimate reports. Email `security@vercel.com` to disclose any security vulnerabilities.
+> If you believe you have found a security vulnerability in Next.js, we encourage you to responsibly disclose this and not open a public issue. We will investigate all legitimate reports. Email `security@vercel.com` to disclose any security vulnerabilities.
 
 https://vercel.com/security


### PR DESCRIPTION
# Improved the Readability of readme.md 

## Before 

<img width="892" alt="Next BEFORE" src="https://user-images.githubusercontent.com/64742906/196097540-94bcb2aa-dc00-487a-9da4-927a45a40be9.png">

## After 
<img width="1192" alt="Next AFTER" src="https://user-images.githubusercontent.com/64742906/196097544-b28dc175-ed9e-425e-b4e2-f8f06ae39ad0.png">

## Documentation / Examples

- [X] Make sure the linting passes by running `pnpm lint`
- [X] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
