### PR TITLE
Update docs with minimum node version 14.x

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ If you have questions about anything related to Next.js, you're always welcome t
 
 #### System Requirements
 
-- [Node.js 12.22.0](https://nodejs.org/) or later
+- [Node.js 14.0.0](https://nodejs.org/) or newer
 - MacOS, Windows (including WSL), and Linux are supported
 
 ## Automatic Setup

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -6,6 +6,8 @@ description: Learn how to upgrade Next.js.
 
 ## Upgrading from 12 to 13
 
+The minimum Node.js version has been bumped from 12.22.0 to 14.0.0, since 12.x has reached end-of-life.
+
 The `next/image` import was renamed to `next/legacy/image`. The `next/future/image` import was renamed to `next/image`.
 A [codemod is available](/docs/advanced-features/codemods.md#next-image-to-legacy-image) to safely and automatically rename your imports.
 


### PR DESCRIPTION
- Follow up to https://github.com/vercel/next.js/pull/41150