### PR TITLE
Avoid using the CSS href as the link tag key

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1115,7 +1115,7 @@ export async function renderToHTMLOrFlight(
                 )
               })}
               {stylesheets
-                ? stylesheets.map((href) => (
+                ? stylesheets.map((href, index) => (
                     <link
                       rel="stylesheet"
                       href={`${assetPrefix}/_next/${href}${cacheBustingUrlSuffix}`}
@@ -1124,7 +1124,7 @@ export async function renderToHTMLOrFlight(
                       // https://github.com/facebook/react/pull/25060
                       // @ts-ignore
                       precedence="high"
-                      key={href}
+                      key={index}
                     />
                   ))
                 : null}


### PR DESCRIPTION
There is no need to use the href as key in our case because it's pure during SSR and it won't re-order on the client. By using `index` we can avoid some duplicate bytes here:

![CleanShot 2022-10-18 at 00 21 20@2x](https://user-images.githubusercontent.com/3676859/196295175-c5b437f7-0ae9-4d89-9d96-9594686168ae.png)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
