### PR TITLE
Add `remotePatterns` link to next-image-unconfigured-host

### DIFF
--- a/errors/next-image-unconfigured-host.md
+++ b/errors/next-image-unconfigured-host.md
@@ -38,3 +38,4 @@ module.exports = {
 ### Useful Links
 
 - [Image Optimization Documentation](https://nextjs.org/docs/basic-features/image-optimization)
+- [Remote Patterns Documentation](https://nextjs.org/docs/api-reference/next/image#remote-patterns)


### PR DESCRIPTION
Didn't realize the `remotePatterns` usage was already in here (not live yet, but merged into `canary`) - so just also added on this link for the end 👍 