### PR TITLE
Fix app sc_client componet HMR server-side

### DIFF
--- a/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -68,15 +68,33 @@ export class NextJsRequireCacheHotReloader implements WebpackPluginInstance {
         )
         deleteCache(runtimeChunkPath)
       })
+      let hasAppPath = false
 
       // we need to make sure to clear all server entries from cache
       // since they can have a stale webpack-runtime cache
       // which needs to always be in-sync
-      const entries = [...compilation.entries.keys()].filter(
-        (entry) =>
-          entry.toString().startsWith('pages/') ||
-          entry.toString().startsWith('app/')
-      )
+      const entries = [...compilation.entries.keys()].filter((entry) => {
+        const isAppPath = entry.toString().startsWith('app/')
+        hasAppPath = hasAppPath || isAppPath
+        return entry.toString().startsWith('pages/') || isAppPath
+      })
+
+      if (hasAppPath) {
+        // ensure we reset the cache for sc_server components
+        // loaded via react-server-dom-webpack
+        const reactWebpackModId = require.resolve(
+          'next/dist/compiled/react-server-dom-webpack'
+        )
+        const reactWebpackMod = require.cache[reactWebpackModId]
+
+        if (reactWebpackMod) {
+          for (const child of reactWebpackMod.children) {
+            child.parent = null
+            delete require.cache[child.id]
+          }
+        }
+        delete require.cache[reactWebpackModId]
+      }
 
       entries.forEach((page) => {
         const outputPath = path.join(

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -8,7 +8,6 @@ import type { FontLoaderManifest } from '../build/webpack/plugins/font-loader-ma
 import React, { experimental_use as use } from 'react'
 
 import { ParsedUrlQuery } from 'querystring'
-import { createFromReadableStream } from 'next/dist/compiled/react-server-dom-webpack'
 import { NextParsedUrlQuery } from './request-meta'
 import RenderResult from './render-result'
 import {
@@ -261,6 +260,9 @@ function useFlightResponse(
   if (flightResponseRef.current !== null) {
     return flightResponseRef.current
   }
+  const {
+    createFromReadableStream,
+  } = require('next/dist/compiled/react-server-dom-webpack')
 
   const [renderStream, forwardStream] = readableStreamTee(req)
   const res = createFromReadableStream(renderStream, {


### PR DESCRIPTION
This ensures we properly clear the `sc_client` component cache from `react-server-dom-webpack` in development so that HMR works properly after a refresh. 

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

Fixes: [slack thread](https://vercel.slack.com/archives/C043ANYDB24/p1666051202574509)