### PR TITLE
Full page nav when missing layout

### DIFF
--- a/test/e2e/app-dir/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout.test.ts
@@ -75,6 +75,41 @@ describe.skip('app-dir root layout', () => {
           Missing required root layout tags: html, head, body"
         `)
       })
+
+      it('should error when missing layout', async () => {
+        const browser = await webdriver(next.url, '/missing-layout', {
+          waitHydration: false,
+        })
+        const rootLayoutContent = await next.readFile(
+          'app/(required-tags)/has-tags/layout.js'
+        )
+
+        expect(await hasRedbox(browser, true)).toBe(true)
+        expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+          "Please make sure to include the following tags in your root layout: <html>, <head>, <body>.
+
+          Missing required root layout tags: html, head, body"
+        `)
+
+        // Recover when adding layout
+        await next.patchFile(
+          'app/(required-tags)/missing-layout/layout.js',
+          rootLayoutContent
+        )
+        expect(
+          await browser.waitForElementByCss('#missing-layout-page').text()
+        ).toBe('Missing layout')
+        expect(await hasRedbox(browser, false)).toBe(false)
+
+        // Show error when removing layout
+        await next.deleteFile('app/(required-tags)/missing-layout/layout.js')
+        expect(await hasRedbox(browser, true)).toBe(true)
+        expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+          "Please make sure to include the following tags in your root layout: <html>, <head>, <body>.
+
+          Missing required root layout tags: html, head, body"
+        `)
+      })
     })
   }
 

--- a/test/e2e/app-dir/root-layout/app/(required-tags)/missing-layout/page.js
+++ b/test/e2e/app-dir/root-layout/app/(required-tags)/missing-layout/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="missing-layout-page">Missing layout</p>
+}


### PR DESCRIPTION
Force full page nav when navigating to a path without layout in DEV. Added test passes but is skipped until #41475

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
