### PR TITLE
Fix next-app-loader bug in windows

### DIFF
--- a/packages/next/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/build/webpack/loaders/next-app-loader.ts
@@ -2,7 +2,7 @@ import type webpack from 'webpack'
 import type { ValueOf } from '../../../shared/lib/constants'
 import { NODE_RESOLVE_OPTIONS } from '../../webpack-config'
 import { getModuleBuildInfo } from './get-module-build-info'
-import path from 'path'
+import { sep } from 'path'
 
 export const FILE_TYPES = {
   layout: 'layout',
@@ -118,7 +118,7 @@ function createAbsolutePath(appDir: string, pathToTurnAbsolute: string) {
   return (
     pathToTurnAbsolute
       // Replace all POSIX path separators with the current OS path separator
-      .replace(/\//g, path.sep)
+      .replace(/\//g, sep)
       .replace(/^private-next-app-dir/, appDir)
   )
 }

--- a/packages/next/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/build/webpack/loaders/next-app-loader.ts
@@ -2,6 +2,7 @@ import type webpack from 'webpack'
 import type { ValueOf } from '../../../shared/lib/constants'
 import { NODE_RESOLVE_OPTIONS } from '../../webpack-config'
 import { getModuleBuildInfo } from './get-module-build-info'
+import path from 'path'
 
 export const FILE_TYPES = {
   layout: 'layout',
@@ -114,7 +115,12 @@ async function createTreeCodeFromPath({
 }
 
 function createAbsolutePath(appDir: string, pathToTurnAbsolute: string) {
-  return pathToTurnAbsolute.replace(/^private-next-app-dir/, appDir)
+  return (
+    pathToTurnAbsolute
+      // Replace all POSIX path separators with the current OS path separator
+      .replace(/\//g, path.sep)
+      .replace(/^private-next-app-dir/, appDir)
+  )
 }
 
 const nextAppLoader: webpack.LoaderDefinitionFunction<{


### PR DESCRIPTION
There is this `createAbsolutePath` function that concatenates a virtual route and a dir path. The virtual route uses the posix separator `/` but the dir path uses `\` in Windows.

Here's an example of the error:

```
error - ./node_modules/.pnpm/next@12.3.2-canary.29_ikefsjgelhtr3cq7h24gohqzbe/node_modules/next/dist/build/webpack/loaders/next-app-loader.js?name=app%2Fpage&appPaths=%2Fpage&pagePath=private-next-app-dir%
2Fpage.tsx&appDir=E%3A%5CWorkSpace%5C2022%5Csongbook.studio%5Capp&pageExtensions=tsx&pageExtensions=ts&pageExtensions=jsx&pageExtensions=js!
Module parse failed: Octal literal in strict mode (9:41)
```

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
