### PR TITLE
Update RSC detection in minimal mode and fix config collection

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1051,14 +1051,14 @@ type GenerateParams = Array<{
   isLayout?: boolean
 }>
 
-export const collectGenerateParams = (
+export const collectGenerateParams = async (
   segment: any,
   parentSegments: string[] = [],
   generateParams: GenerateParams = []
-): GenerateParams => {
+): Promise<GenerateParams> => {
   if (!Array.isArray(segment)) return generateParams
   const isLayout = !!segment[2]?.layout
-  const mod = isLayout ? segment[2]?.layout?.() : segment[2]?.page?.()
+  const mod = await (isLayout ? segment[2]?.layout?.() : segment[2]?.page?.())
 
   const result = {
     isLayout,
@@ -1264,7 +1264,7 @@ export async function isPageStatic({
 
       if (pageType === 'app') {
         const tree = componentsResult.ComponentMod.tree
-        const generateParams = collectGenerateParams(tree)
+        const generateParams = await collectGenerateParams(tree)
 
         appConfig = generateParams.reduce(
           (builtConfig: AppConfig, curGenParams): AppConfig => {

--- a/packages/next/server/dev/static-paths-worker.ts
+++ b/packages/next/server/dev/static-paths-worker.ts
@@ -80,7 +80,9 @@ export async function loadStaticPaths({
   workerWasUsed = true
 
   if (isAppPath) {
-    const generateParams = collectGenerateParams(components.ComponentMod.tree)
+    const generateParams = await collectGenerateParams(
+      components.ComponentMod.tree
+    )
     return buildAppStaticPaths({
       page: pathname,
       generateParams,

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -41,6 +41,7 @@ describe('app-dir static/dynamic handling', () => {
       ).filter((file) => file.match(/.*\.(js|html|rsc)$/))
 
       expect(files).toEqual([
+        '(new)/custom/page.js',
         'blog/[author]/[slug]/page.js',
         'blog/[author]/page.js',
         'blog/seb.html',

--- a/test/e2e/app-dir/app-static/app/(new)/custom/page.js
+++ b/test/e2e/app-dir/app-static/app/(new)/custom/page.js
@@ -1,0 +1,7 @@
+export const config = {
+  revalidate: 0,
+}
+
+export default function Page() {
+  return <p>new root ssr</p>
+}

--- a/test/e2e/app-dir/app-static/app/(new)/layout.js
+++ b/test/e2e/app-dir/app-static/app/(new)/layout.js
@@ -1,0 +1,10 @@
+export default function Layout({ children }) {
+  return (
+    <html lang="en">
+      <head>
+        <title>my static blog</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}


### PR DESCRIPTION
Updates our RSC detection for revalidation in minimal mode and also ensures we await import promises when collecting app dir config. 

x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1666202250144319)
x-ref: [slack thread](https://vercel.slack.com/archives/C035J346QQL/p1666125853222599?thread_ts=1666122861.189349&cid=C035J346QQL)