### PR TITLE
Fix case where dispatch was missing

### DIFF
--- a/packages/next/client/components/react-dev-overlay/hot-reloader.tsx
+++ b/packages/next/client/components/react-dev-overlay/hot-reloader.tsx
@@ -128,7 +128,7 @@ function performFullReload(err: any, sendMessage: any) {
 
 // Attempt to update code on the fly, fall back to a hard reload.
 function tryApplyUpdates(
-  onHotUpdateSuccess: any,
+  onHotUpdateSuccess: (hasUpdates: boolean) => void,
   sendMessage: any,
   dispatch: DispatchFn
 ) {
@@ -174,7 +174,7 @@ function tryApplyUpdates(
     if (isUpdateAvailable()) {
       // While we were updating, there was a new update! Do it again.
       tryApplyUpdates(
-        hasUpdates ? onBuildOk : onHotUpdateSuccess,
+        hasUpdates ? () => onBuildOk(dispatch) : onHotUpdateSuccess,
         sendMessage,
         dispatch
       )


### PR DESCRIPTION
Ensure dispatch is always provided to onBuildOk
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
