### PR TITLE
Create hash digest for errors in app in production

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -190,12 +190,8 @@ function createErrorHandler(
     // console.error(_source, err)
     console.error(err)
     capturedErrors.push(err)
-    if (err.digest) {
-      return err.digest
-    }
-
     // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
-    return stringHash(err.message).toString()
+    return stringHash(err.message + err.stack + (err.digest || '')).toString()
   }
 }
 

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -195,7 +195,7 @@ function createErrorHandler(
     }
 
     // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
-    return stringHash(err.message)
+    return stringHash(err.message).toString()
   }
 }
 

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -177,7 +177,7 @@ function createErrorHandler(
   _source: string,
   capturedErrors: Error[]
 ) {
-  return (err: any) => {
+  return (err: any): string => {
     if (
       err.digest === DYNAMIC_ERROR_CODE ||
       err.digest === NOT_FOUND_ERROR_CODE ||

--- a/test/e2e/app-dir/app/app/error/server-component/custom-digest/page.js
+++ b/test/e2e/app-dir/app/app/error/server-component/custom-digest/page.js
@@ -1,0 +1,9 @@
+export const config = {
+  revalidate: 0,
+}
+
+export default function Page() {
+  const err = new Error('this is a test')
+  err.digest = 'custom'
+  throw err
+}

--- a/test/e2e/app-dir/app/app/error/server-component/error.js
+++ b/test/e2e/app-dir/app/app/error/server-component/error.js
@@ -1,0 +1,13 @@
+'use client'
+
+export default function ErrorBoundary({ error, reset }) {
+  return (
+    <>
+      <p id="error-boundary-message">{error.message}</p>
+      <p id="error-boundary-digest">{error.digest}</p>
+      <button id="reset" onClick={() => reset()}>
+        Try again
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/error/server-component/page.js
+++ b/test/e2e/app-dir/app/app/error/server-component/page.js
@@ -1,0 +1,7 @@
+export const config = {
+  revalidate: 0,
+}
+
+export default function Page() {
+  throw new Error('this is a test')
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1598,6 +1598,40 @@ describe('app dir', () => {
         }
       })
 
+      it('should trigger error component when an error with custom digest happens during server components rendering', async () => {
+        const browser = await webdriver(
+          next.url,
+          '/error/server-component/custom-digest'
+        )
+
+        if (isDev) {
+          expect(
+            await browser
+              .waitForElementByCss('#error-boundary-message')
+              .elementByCss('#error-boundary-message')
+              .text()
+          ).toBe('this is a test')
+          expect(
+            await browser.waitForElementByCss('#error-boundary-digest').text()
+            // Digest of the error message should be stable.
+          ).toBe('custom')
+          // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
+          // expect(await hasRedbox(browser)).toBe(true)
+          // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+        } else {
+          await browser
+          expect(
+            await browser.waitForElementByCss('#error-boundary-message').text()
+          ).toBe(
+            'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+          )
+          expect(
+            await browser.waitForElementByCss('#error-boundary-digest').text()
+            // Digest of the error message should be stable.
+          ).toBe('custom')
+        }
+      })
+
       it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {
         const browser = await webdriver(
           next.url,

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1553,8 +1553,9 @@ describe('app dir', () => {
 
         if (isDev) {
           expect(await hasRedbox(browser)).toBe(true)
-          console.log('getRedboxHeader', await getRedboxHeader(browser))
-          // expect(await getRedboxHeader(browser)).toMatch(/An error occurred: this is a test/)
+          expect(await getRedboxHeader(browser)).toMatch(
+            /An error occurred: this is a test/
+          )
         } else {
           await browser
           expect(
@@ -1563,6 +1564,37 @@ describe('app dir', () => {
               .elementByCss('#error-boundary-message')
               .text()
           ).toBe('An error occurred: this is a test')
+        }
+      })
+
+      it('should trigger error component when an error happens during server components rendering', async () => {
+        const browser = await webdriver(next.url, '/error/server-component')
+
+        if (isDev) {
+          expect(
+            await browser
+              .waitForElementByCss('#error-boundary-message')
+              .elementByCss('#error-boundary-message')
+              .text()
+          ).toBe('this is a test')
+          expect(
+            await browser.waitForElementByCss('#error-boundary-digest').text()
+            // Digest of the error message should be stable.
+          ).toBe('2397877870')
+          // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
+          // expect(await hasRedbox(browser)).toBe(true)
+          // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
+        } else {
+          await browser
+          expect(
+            await browser.waitForElementByCss('#error-boundary-message').text()
+          ).toBe(
+            'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+          )
+          expect(
+            await browser.waitForElementByCss('#error-boundary-digest').text()
+            // Digest of the error message should be stable.
+          ).toBe('2397877870')
         }
       })
 

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1553,9 +1553,7 @@ describe('app dir', () => {
 
         if (isDev) {
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatch(
-            /An error occurred: this is a test/
-          )
+          expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
         } else {
           await browser
           expect(

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1578,7 +1578,7 @@ describe('app dir', () => {
           expect(
             await browser.waitForElementByCss('#error-boundary-digest').text()
             // Digest of the error message should be stable.
-          ).toBe('2397877870')
+          ).not.toBe('')
           // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
           // expect(await hasRedbox(browser)).toBe(true)
           // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
@@ -1592,41 +1592,7 @@ describe('app dir', () => {
           expect(
             await browser.waitForElementByCss('#error-boundary-digest').text()
             // Digest of the error message should be stable.
-          ).toBe('2397877870')
-        }
-      })
-
-      it('should trigger error component when an error with custom digest happens during server components rendering', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/error/server-component/custom-digest'
-        )
-
-        if (isDev) {
-          expect(
-            await browser
-              .waitForElementByCss('#error-boundary-message')
-              .elementByCss('#error-boundary-message')
-              .text()
-          ).toBe('this is a test')
-          expect(
-            await browser.waitForElementByCss('#error-boundary-digest').text()
-            // Digest of the error message should be stable.
-          ).toBe('custom')
-          // TODO-APP: ensure error overlay is shown for errors that happened before/during hydration
-          // expect(await hasRedbox(browser)).toBe(true)
-          // expect(await getRedboxHeader(browser)).toMatch(/this is a test/)
-        } else {
-          await browser
-          expect(
-            await browser.waitForElementByCss('#error-boundary-message').text()
-          ).toBe(
-            'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
-          )
-          expect(
-            await browser.waitForElementByCss('#error-boundary-digest').text()
-            // Digest of the error message should be stable.
-          ).toBe('custom')
+          ).not.toBe('')
         }
       })
 


### PR DESCRIPTION
Ensures errors in production always have a digest.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
