### PR TITLE
Fix docs typo in `next/image` sizes using fill prop

### DIFF
--- a/docs/api-reference/next/image.md
+++ b/docs/api-reference/next/image.md
@@ -147,7 +147,7 @@ const Example = () => (
   <div className="grid-element">
     <Image
       src="/example.png"
-      layout="fill"
+      fill
       sizes="(max-width: 768px) 100vw,
               (max-width: 1200px) 50vw,
               33vw"


### PR DESCRIPTION
Fix typo mentioned in https://github.com/vercel/next.js/pull/41434#issuecomment-1283855509