### PR TITLE
Small change to note `<Link />` executes server methods

### DIFF
--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -68,7 +68,7 @@ The example above uses multiple links. Each one maps a path (`href`) to a known 
 - `/about` → `pages/about.js`
 - `/blog/hello-world` → `pages/blog/[slug].js`
 
-Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default (including the corresponding data) for pages using [Static Generation](/docs/basic-features/data-fetching/get-static-props.md). The corresponding data for [server-rendered](/docs/basic-features/data-fetching/get-server-side-props.md) routes is prefetched _only when_ the <Link /> is clicked.
+Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default (including the corresponding data) for pages using [Static Generation](/docs/basic-features/data-fetching/get-static-props.md). The corresponding data for [server-rendered](/docs/basic-features/data-fetching/get-server-side-props.md) routes is fetched _only when_ the <Link /> is clicked.
 
 ### Linking to dynamic paths
 

--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -70,6 +70,8 @@ The example above uses multiple links. Each one maps a path (`href`) to a known 
 
 Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default (including the corresponding data) for pages using [Static Generation](/docs/basic-features/data-fetching/get-static-props.md). The corresponding data for [server-rendered](/docs/basic-features/data-fetching/get-server-side-props.md) routes is _not_ prefetched.
 
+Also note that when navigating to another page using `<Link />` even tough routing happens client side, the data for that page (via `GetServerSideProps`) _is_ fetched before navigating to the new route.
+
 ### Linking to dynamic paths
 
 You can also use interpolation to create the path, which comes in handy for [dynamic route segments](#dynamic-route-segments). For example, to show a list of posts which have been passed to the component as a prop:

--- a/docs/routing/introduction.md
+++ b/docs/routing/introduction.md
@@ -68,9 +68,7 @@ The example above uses multiple links. Each one maps a path (`href`) to a known 
 - `/about` → `pages/about.js`
 - `/blog/hello-world` → `pages/blog/[slug].js`
 
-Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default (including the corresponding data) for pages using [Static Generation](/docs/basic-features/data-fetching/get-static-props.md). The corresponding data for [server-rendered](/docs/basic-features/data-fetching/get-server-side-props.md) routes is _not_ prefetched.
-
-Also note that when navigating to another page using `<Link />` even tough routing happens client side, the data for that page (via `GetServerSideProps`) _is_ fetched before navigating to the new route.
+Any `<Link />` in the viewport (initially or through scroll) will be prefetched by default (including the corresponding data) for pages using [Static Generation](/docs/basic-features/data-fetching/get-static-props.md). The corresponding data for [server-rendered](/docs/basic-features/data-fetching/get-server-side-props.md) routes is prefetched _only when_ the <Link /> is clicked.
 
 ### Linking to dynamic paths
 


### PR DESCRIPTION
I stumbled upon a lack of clarity when using `<Link />` where I believed it didn't execute the server methods before navigation. This change makes it a bit more clear

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
