### PR TITLE
Fix `new-link` codemod with multiple children

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/new-link/multiple-children.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/new-link/multiple-children.input.js
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Page() {
+    return (
+        <Link href="/about">
+            <a id="about">
+                <h3>About Us</h3>
+                <p>Learn more</p>
+            </a>
+        </Link>
+    );
+}

--- a/packages/next-codemod/transforms/__testfixtures__/new-link/multiple-children.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/new-link/multiple-children.output.js
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Page() {
+    return (
+        <Link href="/about" id="about">
+            <>
+                <h3>About Us</h3>
+                <p>Learn more</p>
+            </>
+        </Link>
+    );
+}

--- a/packages/next-codemod/transforms/__tests__/new-link.test.js
+++ b/packages/next-codemod/transforms/__tests__/new-link.test.js
@@ -1,23 +1,16 @@
 /* global jest */
 jest.autoMockOff()
 const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
 
-const fixtures = [
-  'link-a',
-  'move-props',
-  'add-legacy-behavior',
-  'excludes-links-with-legacybehavior-prop',
-  'children-interpolation',
-  'spread-props',
-  'link-string',
-  'styled-jsx',
-]
+const fixtureDir = 'new-link'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.js'))
+  .map(file => file.replace('.input.js', ''))
 
 for (const fixture of fixtures) {
-  defineTest(
-    __dirname,
-    'new-link',
-    null,
-    `new-link/${fixture}`
-  )
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, fixtureDir,  null, prefix)
 }

--- a/packages/next-codemod/transforms/new-link.ts
+++ b/packages/next-codemod/transforms/new-link.ts
@@ -45,7 +45,7 @@ export default function transformer(file: FileInfo, api: API) {
         }
 
         // If file has <style jsx> enable legacyBehavior
-        // and keep <a> to  stay on the safe side
+        // and keep <a> to stay on the safe side
         if (hasStylesJSX) {
           $link
             .get('attributes')
@@ -92,7 +92,22 @@ export default function transformer(file: FileInfo, api: API) {
           props.length = 0
         }
 
-        //
+        // If <a> has more than one child, then we can't remove it.
+        // So change <a> to <> an return early.
+        if ($childrenWithA.childElements().length > 1) {
+          $childrenWithA.forEach((childPath) => {
+            const opener = childPath.value.openingElement.name
+            if (opener.type === 'JSXIdentifier') {
+              opener.name = ''
+            }
+            const closer = childPath.value.closingElement.name
+            if (closer.type === 'JSXIdentifier') {
+              closer.name = ''
+            }
+          })
+          return
+        }
+
         const childrenProps = $childrenWithA.get('children')
         $childrenWithA.replaceWith(childrenProps.value)
       })


### PR DESCRIPTION
This PR fixes a bug where the `new-link` codemod was incorrectly removing `<a>` and instead it should use `<>`