### PR TITLE
Update page config APIs

### DIFF
--- a/packages/next/build/utils.ts
+++ b/packages/next/build/utils.ts
@@ -1044,12 +1044,40 @@ export type AppConfig = {
   preferredRegion?: string
 }
 type GenerateParams = Array<{
-  config: AppConfig
+  config?: AppConfig
   segmentPath: string
   getStaticPaths?: GetStaticPaths
   generateStaticParams?: any
   isLayout?: boolean
 }>
+
+export const collectAppConfig = (mod: any): AppConfig | undefined => {
+  let hasConfig = false
+
+  const config: AppConfig = {}
+  if (typeof mod?.revalidate !== 'undefined') {
+    config.revalidate = mod.revalidate
+    hasConfig = true
+  }
+  if (typeof mod?.dynamicParams !== 'undefined') {
+    config.dynamicParams = mod.dynamicParams
+    hasConfig = true
+  }
+  if (typeof mod?.dynamic !== 'undefined') {
+    config.dynamic = mod.dynamic
+    hasConfig = true
+  }
+  if (typeof mod?.fetchCache !== 'undefined') {
+    config.fetchCache = mod.fetchCache
+    hasConfig = true
+  }
+  if (typeof mod?.preferredRegion !== 'undefined') {
+    config.preferredRegion = mod.preferredRegion
+    hasConfig = true
+  }
+
+  return hasConfig ? config : undefined
+}
 
 export const collectGenerateParams = (
   segment: any,
@@ -1059,13 +1087,14 @@ export const collectGenerateParams = (
   if (!Array.isArray(segment)) return generateParams
   const isLayout = !!segment[2]?.layout
   const mod = isLayout ? segment[2]?.layout?.() : segment[2]?.page?.()
+  const config = collectAppConfig(mod)
 
   const result = {
     isLayout,
     segmentPath: `/${parentSegments.join('/')}${
       segment[0] && parentSegments.length > 0 ? '/' : ''
     }${segment[0]}`,
-    config: mod?.config,
+    config,
     getStaticPaths: mod?.getStaticPaths,
     generateStaticParams: mod?.generateStaticParams,
   }

--- a/packages/next/build/webpack/plugins/flight-types-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-types-plugin.ts
@@ -32,16 +32,12 @@ interface IEntry {
       : `default: (props: { params?: any }) => React.ReactNode | null`
   }
   generateStaticParams?: (params?:any) => Promise<any[]>
-  config?: {
-    // TODO: remove revalidate here
-    revalidate?: number | boolean
-    ${options.type === 'page' ? 'runtime?: string' : ''}
-  }
   revalidate?: RevalidateRange<TEntry> | false
   dynamic?: 'auto' | 'force-dynamic' | 'error' | 'force-static'
   dynamicParams?: boolean
   fetchCache?: 'auto' | 'force-no-store' | 'only-no-store' | 'default-no-store' | 'default-cache' | 'only-cache' | 'force-cache'
   preferredRegion?: 'auto' | 'home' | 'edge'
+  ${options.type === 'page' ? "runtime?: 'nodejs' | 'experimental-edge'" : ''}
 }
 
 // =============

--- a/packages/next/build/webpack/plugins/flight-types-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-types-plugin.ts
@@ -31,6 +31,7 @@ interface IEntry {
       ? `default: (props: { children: React.ReactNode; params?: any }) => React.ReactNode | null`
       : `default: (props: { params?: any }) => React.ReactNode | null`
   }
+  config?: {}
   generateStaticParams?: (params?:any) => Promise<any[]>
   revalidate?: RevalidateRange<TEntry> | false
   dynamic?: 'auto' | 'force-dynamic' | 'error' | 'force-static'

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -947,8 +947,8 @@ export async function renderToHTMLOrFlight(
         ? await page()
         : undefined
 
-      if (layoutOrPageMod?.config) {
-        defaultRevalidate = layoutOrPageMod.config.revalidate
+      if (typeof layoutOrPageMod?.revalidate !== 'undefined') {
+        defaultRevalidate = layoutOrPageMod.revalidate
 
         if (isStaticGeneration && defaultRevalidate === 0) {
           const { DynamicServerError } =

--- a/test/e2e/app-dir/app-edge/app/app-edge/page.tsx
+++ b/test/e2e/app-dir/app-edge/app/app-edge/page.tsx
@@ -1,4 +1,4 @@
 export default function Page() {
   return <p>app-edge-ssr</p>
 }
-export const config = { runtime: 'experimental-edge' }
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/app-prefetch/app/dashboard/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/dashboard/page.js
@@ -1,8 +1,6 @@
 import { experimental_use as use } from 'react'
 
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 async function getData() {
   await new Promise((resolve) => setTimeout(resolve, 3000))

--- a/test/e2e/app-dir/app-rendering/app/isr-multiple/nested/page.js
+++ b/test/e2e/app-dir/app-rendering/app/isr-multiple/nested/page.js
@@ -1,8 +1,6 @@
 import { experimental_use as use } from 'react'
 
-export const config = {
-  revalidate: 1,
-}
+export const revalidate = 1
 
 async function getData() {
   return {

--- a/test/e2e/app-dir/app-rendering/app/ssr-only/layout.js
+++ b/test/e2e/app-dir/app-rendering/app/ssr-only/layout.js
@@ -1,8 +1,6 @@
 import { experimental_use as use } from 'react'
 
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 async function getData() {
   return {

--- a/test/e2e/app-dir/app-rendering/app/static-only/nested/page.js
+++ b/test/e2e/app-dir/app-rendering/app/static-only/nested/page.js
@@ -1,8 +1,6 @@
 import { experimental_use as use } from 'react'
 
-export const config = {
-  revalidate: false,
-}
+export const revalidate = false
 
 async function getData() {
   return {

--- a/test/e2e/app-dir/app-rendering/app/static-only/slow/page.js
+++ b/test/e2e/app-dir/app-rendering/app/static-only/slow/page.js
@@ -1,8 +1,6 @@
 import { experimental_use as use } from 'react'
 
-export const config = {
-  revalidate: false,
-}
+export const revalidate = false
 
 async function getData() {
   await new Promise((resolve) => setTimeout(resolve, 5000))

--- a/test/e2e/app-dir/app-static/app/(new)/custom/page.js
+++ b/test/e2e/app-dir/app-static/app/(new)/custom/page.js
@@ -1,6 +1,4 @@
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Page() {
   return <p>new root ssr</p>

--- a/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
@@ -1,4 +1,4 @@
-export const dynamicParams = false
+export const dynamicParams = true
 
 export default function Page({ params }) {
   return (

--- a/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
@@ -1,6 +1,4 @@
-export const config = {
-  dynamicParams: true,
-}
+export const dynamicParams = false
 
 export default function Page({ params }) {
   return (

--- a/test/e2e/app-dir/app-static/app/blog/[author]/page.js
+++ b/test/e2e/app-dir/app-static/app/blog/[author]/page.js
@@ -1,8 +1,6 @@
 import Link from 'next/link'
 
-export const config = {
-  dynamicParams: false,
-}
+export const dynamicParams = false
 
 export default function Page({ params }) {
   return (

--- a/test/e2e/app-dir/app-static/app/dynamic-no-gen-params-ssr/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/dynamic-no-gen-params-ssr/[slug]/page.js
@@ -1,6 +1,4 @@
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Page({ params }) {
   return (

--- a/test/e2e/app-dir/app-static/app/ssr-auto/fetch-revalidate-zero/page.js
+++ b/test/e2e/app-dir/app-static/app/ssr-auto/fetch-revalidate-zero/page.js
@@ -20,6 +20,4 @@ export default function Page() {
 }
 
 // TODO-APP: remove revalidate config once next.revalidate is supported
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0

--- a/test/e2e/app-dir/app-static/app/ssr-forced/page.js
+++ b/test/e2e/app-dir/app-static/app/ssr-forced/page.js
@@ -1,6 +1,4 @@
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/app-typescript/app/inner/page.tsx
+++ b/test/e2e/app-dir/app-typescript/app/inner/page.tsx
@@ -2,6 +2,4 @@ export default function Page() {
   return <div>hello</div>
 }
 
-export const config = {
-  runtime: 'nodejs',
-}
+export const runtime = 'nodejs'

--- a/test/e2e/app-dir/app-typescript/app/layout.js
+++ b/test/e2e/app-dir/app-typescript/app/layout.js
@@ -1,6 +1,4 @@
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 // export const revalidate = -1
 

--- a/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
+++ b/test/e2e/app-dir/app/app/(rootonly)/dashboard/hello/page.js
@@ -6,6 +6,4 @@ export default function HelloPage(props) {
   )
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-}
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/app/app/dashboard/page.js
+++ b/test/e2e/app-dir/app/app/dashboard/page.js
@@ -13,6 +13,4 @@ export default function DashboardPage(props) {
   )
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-}
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/app/app/error/server-component/custom-digest/page.js
+++ b/test/e2e/app-dir/app/app/error/server-component/custom-digest/page.js
@@ -1,6 +1,4 @@
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Page() {
   const err = new Error('this is a test')

--- a/test/e2e/app-dir/app/app/error/server-component/page.js
+++ b/test/e2e/app-dir/app/app/error/server-component/page.js
@@ -1,6 +1,4 @@
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Page() {
   throw new Error('this is a test')

--- a/test/e2e/app-dir/app/app/layout.js
+++ b/test/e2e/app-dir/app/app/layout.js
@@ -3,9 +3,7 @@ import { experimental_use as use } from 'react'
 import '../styles/global.css'
 import './style.css'
 
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 async function getData() {
   return {

--- a/test/e2e/app-dir/app/app/slow-page-no-loading/page.js
+++ b/test/e2e/app-dir/app/app/slow-page-no-loading/page.js
@@ -13,6 +13,4 @@ export default function SlowPage(props) {
   return <h1 id="slow-page-message">{data.message}</h1>
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-}
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/app/app/slow-page-with-loading/page.js
+++ b/test/e2e/app-dir/app/app/slow-page-with-loading/page.js
@@ -13,6 +13,4 @@ export default function SlowPage(props) {
   return <h1 id="slow-page-message">{data.message}</h1>
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-}
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/next-font/app/page.js
+++ b/test/e2e/app-dir/next-font/app/page.js
@@ -13,4 +13,4 @@ export default function HomePage() {
   )
 }
 
-export const config = { runtime: 'experimental-edge' }
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/root-layout/app/(mpa-navigation)/(route-group)/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(mpa-navigation)/(route-group)/layout.js
@@ -1,7 +1,5 @@
 // TODO-APP: remove after fixing filtering static flight data
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ children }) {
   return (

--- a/test/e2e/app-dir/root-layout/app/(mpa-navigation)/basic-route/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(mpa-navigation)/basic-route/layout.js
@@ -1,7 +1,5 @@
 // TODO-APP: remove after fixing filtering static flight data
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ children }) {
   return (

--- a/test/e2e/app-dir/root-layout/app/(mpa-navigation)/dynamic/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(mpa-navigation)/dynamic/layout.js
@@ -1,7 +1,5 @@
 // TODO-APP: remove after fixing filtering static flight data
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ children }) {
   return (

--- a/test/e2e/app-dir/root-layout/app/(mpa-navigation)/to-pages-dir/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(mpa-navigation)/to-pages-dir/layout.js
@@ -1,7 +1,5 @@
 // TODO-APP: remove after fixing filtering static flight data
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ children }) {
   return (

--- a/test/e2e/app-dir/root-layout/app/(mpa-navigation)/with-parallel-routes/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(mpa-navigation)/with-parallel-routes/layout.js
@@ -1,7 +1,5 @@
 // TODO-APP: remove after fixing filtering static flight data
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ one, two }) {
   return (

--- a/test/e2e/app-dir/root-layout/app/(required-tags)/has-tags/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(required-tags)/has-tags/layout.js
@@ -1,7 +1,5 @@
 // TODO-APP: remove after fixing filtering static flight data
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ children }) {
   return (

--- a/test/e2e/app-dir/root-layout/app/(required-tags)/missing-tags/layout.js
+++ b/test/e2e/app-dir/root-layout/app/(required-tags)/missing-tags/layout.js
@@ -1,7 +1,5 @@
 // TODO-APP: remove after fixing filtering static flight data
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function Root({ children }) {
   return children

--- a/test/e2e/app-dir/root-layout/app/(required-tags)/static-missing-tags/[slug]/page.js
+++ b/test/e2e/app-dir/root-layout/app/(required-tags)/static-missing-tags/[slug]/page.js
@@ -1,6 +1,4 @@
-export const config = {
-  dynamicParams: false,
-}
+export const dynamicParams = false
 
 export default function Page({ params }) {
   return <p>Static page</p>

--- a/test/e2e/app-dir/rsc-basic/app/edge/dynamic/[id]/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/edge/dynamic/[id]/page.js
@@ -2,6 +2,4 @@ export default function page() {
   return 'dynamic route [id] page'
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-}
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/rsc-basic/app/edge/dynamic/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/edge/dynamic/page.js
@@ -2,6 +2,4 @@ export default function page() {
   return 'dynamic route index page'
 }
 
-export const config = {
-  runtime: 'experimental-edge',
-}
+export const runtime = 'experimental-edge'

--- a/test/e2e/app-dir/rsc-basic/app/layout.js
+++ b/test/e2e/app-dir/rsc-basic/app/layout.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import RootStyleRegistry from './root-style-registry'
 
-export const config = {
-  revalidate: 0,
-}
+export const revalidate = 0
 
 export default function AppLayout({ children }) {
   return (

--- a/test/e2e/app-dir/rsc-basic/app/native-module/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/native-module/page.js
@@ -11,6 +11,4 @@ export default function Page() {
   )
 }
 
-export const config = {
-  runtime: 'nodejs',
-}
+export const runtime = 'nodejs'


### PR DESCRIPTION
This PR updates app configurations from `export const config = { ... }` to be directly exported.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
