### PR TITLE
Update error message for invalid react-dom/server imports

### DIFF
--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseRSC.ts
@@ -24,10 +24,16 @@ export function formatRSCErrorMessage(
       formattedVerboseMessage =
         '\n\nMaybe one of these should be marked as a client entry with "use client":\n'
     } else if (NEXT_RSC_ERR_SERVER_IMPORT.test(message)) {
-      formattedMessage = message.replace(
-        NEXT_RSC_ERR_SERVER_IMPORT,
-        `\n\nYou're importing a component that imports $1. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\n\n`
-      )
+      const matches = message.match(NEXT_RSC_ERR_SERVER_IMPORT)
+      if (matches && matches[1] === 'react-dom/server') {
+        // If importing "react-dom/server", we should show a different error.
+        formattedMessage = `\n\nYou're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.`
+      } else {
+        formattedMessage = message.replace(
+          NEXT_RSC_ERR_SERVER_IMPORT,
+          `\n\nYou're importing a component that imports $1. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.\n\n`
+        )
+      }
       formattedVerboseMessage =
         '\n\nMaybe one of these should be marked as a client entry "use client":\n'
     } else if (NEXT_RSC_ERR_CLIENT_IMPORT.test(message)) {


### PR DESCRIPTION
Related discussion: https://vercel.slack.com/archives/C043ANYDB24/p1666208186363099?thread_ts=1664676119.265829&cid=C043ANYDB24.

Tl;dr: RSC already renders and serializes things dynamically, there is no need to manually do that in RSC and embed them via dangerouslySetInnerHTML.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
