### PR TITLE
fix: improved hybrid hook support

### DIFF
--- a/packages/next/client/components/app-navigation.ts
+++ b/packages/next/client/components/app-navigation.ts
@@ -1,0 +1,21 @@
+import { useContext } from 'react'
+import {
+  AppRouterContext,
+  AppRouterInstance,
+} from '../../shared/lib/app-router-context'
+
+/**
+ * useAppRouter will get the AppRouterInstance on the context if it's mounted.
+ * If it is not mounted, it will throw an error. This method should only be used
+ * when you expect only to have the app router mounted (not pages router).
+ *
+ * @returns the app router instance
+ */
+export function useAppRouter(): AppRouterInstance {
+  const router = useContext(AppRouterContext)
+  if (!router) {
+    throw new Error('invariant expected app router to be mounted')
+  }
+
+  return router
+}

--- a/packages/next/client/components/hooks-client-context.ts
+++ b/packages/next/client/components/hooks-client-context.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react'
 
-export const SearchParamsContext = createContext<URLSearchParams>(null as any)
+export const SearchParamsContext = createContext<URLSearchParams | null>(null)
 export const PathnameContext = createContext<string>(null as any)
 export const ParamsContext = createContext(null as any)
 export const LayoutSegmentsContext = createContext(null as any)

--- a/packages/next/client/components/hooks-client-context.ts
+++ b/packages/next/client/components/hooks-client-context.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react'
 
 export const SearchParamsContext = createContext<URLSearchParams | null>(null)
-export const PathnameContext = createContext<string>(null as any)
+export const PathnameContext = createContext<string | null>(null)
 export const ParamsContext = createContext(null as any)
 export const LayoutSegmentsContext = createContext(null as any)
 

--- a/packages/next/client/components/hybrid-router.ts
+++ b/packages/next/client/components/hybrid-router.ts
@@ -1,0 +1,16 @@
+import { AppRouterInstance } from '../../shared/lib/app-router-context'
+import { NextRouter } from '../router'
+
+export const HYBRID_ROUTER_TYPE = Symbol('HYBRID_ROUTER_TYPE')
+
+type MaskedHybridRouter<T extends string, Router, OtherRouter> = {
+  // Store the router type on the router via this private symbol.
+  [HYBRID_ROUTER_TYPE]: T
+} & Router &
+  // Add partial fields of the other router so it's type-compatible with it, but
+  // it will show those extra fields as undefined.
+  Partial<Omit<OtherRouter, keyof Router>>
+
+export type HybridRouter =
+  | MaskedHybridRouter<'app', AppRouterInstance, NextRouter>
+  | MaskedHybridRouter<'pages', NextRouter, AppRouterInstance>

--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -25,12 +25,12 @@ import {
   LayoutRouterContext,
   GlobalLayoutRouterContext,
   TemplateContext,
-  AppRouterContext,
 } from '../../shared/lib/app-router-context'
 import { fetchServerResponse } from './app-router'
 import { createInfinitePromise } from './infinite-promise'
 import { ErrorBoundary } from './error-boundary'
 import { matchSegment } from './match-segments'
+import { useAppRouter } from './app-navigation'
 
 /**
  * Add refetch marker to router state at the point of the current layout segment.
@@ -279,7 +279,7 @@ interface RedirectBoundaryProps {
 }
 
 function HandleRedirect({ redirect }: { redirect: string }) {
-  const router = useContext(AppRouterContext)
+  const router = useAppRouter()
 
   useEffect(() => {
     router.replace(redirect, {})
@@ -316,7 +316,7 @@ class RedirectErrorBoundary extends React.Component<
 }
 
 function RedirectBoundary({ children }: { children: React.ReactNode }) {
-  const router = useContext(AppRouterContext)
+  const router = useAppRouter()
   return (
     <RedirectErrorBoundary router={router}>{children}</RedirectErrorBoundary>
   )

--- a/packages/next/client/components/navigation.ts
+++ b/packages/next/client/components/navigation.ts
@@ -108,6 +108,10 @@ export function useSearchParams() {
     // To support migration from pages to app, this adds a workaround that'll
     // support the pages router here too.
     if (router) {
+      if (!router.isReady) {
+        return new ReadonlyURLSearchParams(new URLSearchParams())
+      }
+
       return new ReadonlyURLSearchParams(
         parsedURLQueryToURLSearchParams(router.query)
       )

--- a/packages/next/client/components/navigation.ts
+++ b/packages/next/client/components/navigation.ts
@@ -76,6 +76,11 @@ class ReadonlyURLSearchParams {
 export function useSearchParams() {
   const searchParams = useContext(SearchParamsContext)
   const readonlySearchParams = useMemo(() => {
+    if (!searchParams) {
+      // TODO-APP: consider throwing an error or adapting this to support pages router
+      return null
+    }
+
     return new ReadonlyURLSearchParams(searchParams)
   }, [searchParams])
   return readonlySearchParams

--- a/packages/next/client/components/navigation.ts
+++ b/packages/next/client/components/navigation.ts
@@ -90,7 +90,10 @@ export function useSearchParams() {
 /**
  * Get the router methods. For example router.push('/dashboard')
  */
-export function useRouter(): import('../../shared/lib/app-router-context').AppRouterInstance {
+export function useRouter():
+  | import('../../shared/lib/app-router-context').AppRouterInstance
+  | null {
+  // TODO-APP: consider throwing an error or adapting this to support pages router
   return useContext(AppRouterContext)
 }
 
@@ -102,7 +105,8 @@ export function useRouter(): import('../../shared/lib/app-router-context').AppRo
 /**
  * Get the current pathname. For example usePathname() on /dashboard?foo=bar would return "/dashboard"
  */
-export function usePathname(): string {
+export function usePathname(): string | null {
+  // TODO-APP: consider throwing an error or adapting this to support pages router
   return useContext(PathnameContext)
 }
 

--- a/packages/next/client/components/react-dev-overlay/hot-reloader-client.tsx
+++ b/packages/next/client/components/react-dev-overlay/hot-reloader-client.tsx
@@ -9,7 +9,6 @@ import React, {
 } from 'react'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import formatWebpackMessages from '../../dev/error-overlay/format-webpack-messages'
-import { useRouter } from '../navigation'
 import { errorOverlayReducer } from './internal/error-overlay-reducer'
 import {
   ACTION_BUILD_OK,
@@ -26,6 +25,7 @@ import {
   useWebsocket,
   useWebsocketPing,
 } from './internal/helpers/use-websocket'
+import { useAppRouter } from '../app-navigation'
 
 interface Dispatcher {
   onBuildOk(): void
@@ -174,7 +174,7 @@ function tryApplyUpdates(
 function processMessage(
   e: any,
   sendMessage: any,
-  router: ReturnType<typeof useRouter>,
+  router: ReturnType<typeof useAppRouter>,
   dispatcher: Dispatcher
 ) {
   const obj = JSON.parse(e.data)
@@ -442,7 +442,7 @@ export default function HotReload({
   useWebsocketPing(webSocketRef)
   const sendMessage = useSendMessage(webSocketRef)
 
-  const router = useRouter()
+  const router = useAppRouter()
   useEffect(() => {
     const handler = (event: MessageEvent<PongEvent>) => {
       if (

--- a/packages/next/client/route-announcer.tsx
+++ b/packages/next/client/route-announcer.tsx
@@ -17,7 +17,12 @@ const nextjsRouteAnnouncerStyles: React.CSSProperties = {
 }
 
 export const RouteAnnouncer = () => {
-  const { asPath } = useRouter()
+  const router = useRouter()
+  if (!router) {
+    throw new Error('invariant expected pages router to be mounted')
+  }
+
+  const { asPath } = router
   const [routeAnnouncement, setRouteAnnouncement] = React.useState('')
 
   // Only announce the path change, but not for the first load because screen

--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -129,7 +129,7 @@ export default singletonRouter as SingletonRouter
 // Reexport the withRoute HOC
 export { default as withRouter } from './with-router'
 
-export function useRouter(): NextRouter {
+export function useRouter(): NextRouter | null {
   return React.useContext(RouterContext)
 }
 

--- a/packages/next/shared/lib/app-router-context.ts
+++ b/packages/next/shared/lib/app-router-context.ts
@@ -57,8 +57,8 @@ export interface AppRouterInstance {
   prefetch(href: string): void
 }
 
-export const AppRouterContext = React.createContext<AppRouterInstance>(
-  null as any
+export const AppRouterContext = React.createContext<AppRouterInstance | null>(
+  null
 )
 export const LayoutRouterContext = React.createContext<{
   childNodes: CacheNode['parallelRoutes']

--- a/packages/next/shared/lib/router-context.ts
+++ b/packages/next/shared/lib/router-context.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { NextRouter } from './router/router'
 
-export const RouterContext = React.createContext<NextRouter>(null as any)
+export const RouterContext = React.createContext<NextRouter | null>(null)
 
 if (process.env.NODE_ENV !== 'production') {
   RouterContext.displayName = 'RouterContext'

--- a/packages/next/shared/lib/router/router.ts
+++ b/packages/next/shared/lib/router/router.ts
@@ -48,6 +48,7 @@ import { getNextPathnameInfo } from './utils/get-next-pathname-info'
 import { formatNextPathnameInfo } from './utils/format-next-pathname-info'
 import { compareRouterStates } from './utils/compare-states'
 import { isBot } from './utils/is-bot'
+import { AppRouterInstance } from '../app-router-context'
 
 declare global {
   interface Window {
@@ -220,7 +221,7 @@ export function interpolateAs(
  * Preserves absolute urls.
  */
 export function resolveHref(
-  router: NextRouter,
+  router: NextRouter | AppRouterInstance,
   href: Url,
   resolveAs?: boolean
 ): string {
@@ -252,7 +253,13 @@ export function resolveHref(
 
   try {
     base = new URL(
-      urlAsString.startsWith('#') ? router.asPath : router.pathname,
+      // TODO-APP: investigate if this is the intended beheviour
+      'asPath' in router
+        ? urlAsString.startsWith('#')
+          ? router.asPath
+          : router.pathname
+        : // Emulate the fallback in the catch below
+          '/',
       'http://n'
     )
   } catch (_) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

These hooks when accessed from different router context's in fact, return `null`. These new router hooks have been adapted to be backwards compatible with the pages router to ease the migration process.
 
## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
