### PR TITLE
Enable ReactRefreshLogBox-builtins.test.ts, remove loader from import trace

### DIFF
--- a/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -85,7 +85,7 @@ export async function getNotFoundError(
         .filter(
           (name) =>
             name &&
-            !/next-(middleware|client-pages|flight-(client|server))-loader\.js/.test(
+            !/next-(middleware|client-pages|flight-(client|server|client-entry))-loader\.js/.test(
               name
             )
         )

--- a/test/development/acceptance-app/ReactRefresh.test.ts
+++ b/test/development/acceptance-app/ReactRefresh.test.ts
@@ -15,6 +15,10 @@ describe('ReactRefresh app', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+      dependencies: {
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
+      },
       skipStart: true,
     })
   })

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -4,7 +4,7 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import path from 'path'
 
 // TODO-APP: Investigate snapshot mismatch
-describe.skip('ReactRefreshLogBox app', () => {
+describe('ReactRefreshLogBox app', () => {
   if (process.env.NEXT_TEST_REACT_VERSION === '^17') {
     it('should skip for react v17', () => {})
     return
@@ -15,6 +15,10 @@ describe.skip('ReactRefreshLogBox app', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+      dependencies: {
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
+      },
       skipStart: true,
     })
   })
@@ -109,7 +113,7 @@ describe.skip('ReactRefreshLogBox app', () => {
     await cleanup()
   })
 
-  test('Module not found (missing global CSS)', async () => {
+  test('Module not found missing global CSS', async () => {
     const { session, cleanup } = await sandbox(
       next,
       new Map([

--- a/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
@@ -20,6 +20,8 @@ describe.skip('ReactRefreshLogBox app', () => {
       skipStart: true,
       dependencies: {
         sass: 'latest',
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
       },
     })
   })

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -16,6 +16,10 @@ describe('ReactRefreshLogBox app', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+      dependencies: {
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
+      },
       skipStart: true,
     })
   })

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -16,6 +16,10 @@ describe.skip('ReactRefreshLogBox app', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+      dependencies: {
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
+      },
       skipStart: true,
     })
   })

--- a/test/development/acceptance-app/ReactRefreshModule.test.ts
+++ b/test/development/acceptance-app/ReactRefreshModule.test.ts
@@ -14,6 +14,10 @@ describe('ReactRefreshModule app', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+      dependencies: {
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
+      },
       skipStart: true,
     })
   })

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -20,6 +20,8 @@ describe('ReactRefreshRegression app', () => {
         'styled-components': '5.1.0',
         '@next/mdx': 'canary',
         '@mdx-js/loader': '0.18.0',
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
       },
     })
   })

--- a/test/development/acceptance-app/ReactRefreshRequire.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRequire.test.ts
@@ -10,6 +10,10 @@ describe('ReactRefreshRequire app', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+      dependencies: {
+        react: '0.0.0-experimental-9cdf8a99e-20221018',
+        'react-dom': '0.0.0-experimental-9cdf8a99e-20221018',
+      },
       skipStart: true,
     })
   })

--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox-builtins.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox-builtins.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactRefreshLogBox app Module not found 1`] = `
+"./index.js:1:0
+Module not found: Can't resolve 'b'
+> 1 | import Comp from 'b'
+  2 |       export default function Oops() {
+  3 |         return (
+  4 |           <div>
+
+Import trace for requested module:
+./app/page.js
+
+https://nextjs.org/docs/messages/module-not-found"
+`;
+
+exports[`ReactRefreshLogBox app Module not found empty import trace 1`] = `
+"./app/page.js:2:6
+Module not found: Can't resolve 'b'
+  1 | 'use client'
+> 2 |       import Comp from 'b'
+    |      ^
+  3 |       export default function Oops() {
+  4 |         return (
+  5 |           <div>
+
+https://nextjs.org/docs/messages/module-not-found"
+`;
+
+exports[`ReactRefreshLogBox app Module not found missing global CSS 1`] = `
+"./app/page.js:2:10
+Module not found: Can't resolve './non-existent.css'
+  1 | 'use client'
+> 2 |           import './non-existent.css'
+    |          ^
+  3 |         export default function Page(props) {
+  4 |           return <p>index page</p>
+  5 |         }
+
+https://nextjs.org/docs/messages/module-not-found"
+`;
+
+exports[`ReactRefreshLogBox app Node.js builtins 1`] = `
+"./node_modules/my-package/index.js:2:0
+Module not found: Can't resolve 'dns'
+
+Import trace for requested module:
+./index.js
+./app/page.js
+
+https://nextjs.org/docs/messages/module-not-found"
+`;


### PR DESCRIPTION
Follow-up to #41598. Going to land this as the tests are failing currently because of the experimental React revert.
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
