### PR TITLE
Disable esm resolving for appDir and alias react

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -3,7 +3,7 @@ import { loadEnvConfig } from '@next/env'
 import chalk from 'next/dist/compiled/chalk'
 import crypto from 'crypto'
 import { isMatch, makeRe } from 'next/dist/compiled/micromatch'
-import { fstat, promises, writeFileSync } from 'fs'
+import { promises, writeFileSync } from 'fs'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
 import { Worker } from '../lib/worker'
 import devalue from 'next/dist/compiled/devalue'
@@ -302,17 +302,20 @@ export default async function build(
 
       const publicDir = path.join(dir, 'public')
       const isAppDirEnabled = !!config.experimental.appDir
-      const filePath = require.resolve(
+      const initialRequireHookFilePath = require.resolve(
         'next/dist/server/initialize-require-hook'
       )
-      const content = await promises.readFile(filePath, 'utf8')
+      const content = await promises.readFile(
+        initialRequireHookFilePath,
+        'utf8'
+      )
 
       if (isAppDirEnabled) {
         process.env.NEXT_PREBUNDLED_REACT = '1'
       }
       await promises
         .writeFile(
-          filePath,
+          initialRequireHookFilePath,
           content.replace(
             /isPrebundled = (true|false)/,
             `isPrebundled = ${isAppDirEnabled}`

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -342,7 +342,7 @@ export default async function build(
           Log.info('Skipping validation of types')
         }
         if (runLint && ignoreESLint) {
-          // only print log when build requre lint while ignoreESLint is enabled
+          // only print log when build require lint while ignoreESLint is enabled
           Log.info('Skipping linting')
         }
 

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -3,7 +3,7 @@ import { loadEnvConfig } from '@next/env'
 import chalk from 'next/dist/compiled/chalk'
 import crypto from 'crypto'
 import { isMatch, makeRe } from 'next/dist/compiled/micromatch'
-import { promises, writeFileSync } from 'fs'
+import { fstat, promises, writeFileSync } from 'fs'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
 import { Worker } from '../lib/worker'
 import devalue from 'next/dist/compiled/devalue'
@@ -304,6 +304,15 @@ export default async function build(
       const isAppDirEnabled = !!config.experimental.appDir
       if (isAppDirEnabled) {
         process.env.NEXT_PREBUNDLED_REACT = '1'
+
+        const filePath = require.resolve(
+          'next/dist/server/initialize-require-hook'
+        )
+        const content = await promises.readFile(filePath, 'utf8')
+        await promises.writeFile(
+          filePath,
+          content.replace(/process\.env\.NEXT_PREBUNDLED_REACT/, 'true')
+        )
       }
       const { pagesDir, appDir } = findPagesDir(dir, isAppDirEnabled)
       const hasPublicDir = await fileExists(publicDir)

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -129,7 +129,6 @@ const bundledReactImports = [
   'react',
   'react/jsx-runtime',
   'react/jsx-dev-runtime',
-  // 'react-dom',
   'next/dist/compiled/react-server-dom-webpack/server.browser',
 ]
 
@@ -437,11 +436,12 @@ export const nextImageLoaderRegex =
   /\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$/i
 
 export async function resolveExternal(
-  appDir: string,
+  dir: string,
   esmExternalsConfig: NextConfigComplete['experimental']['esmExternals'],
   context: string,
   request: string,
   isEsmRequested: boolean,
+  hasAppDir: boolean,
   getResolve: (
     options: any
   ) => (
@@ -463,6 +463,11 @@ export async function resolveExternal(
 
   let preferEsmOptions =
     esmExternals && isEsmRequested ? [true, false] : [false]
+  // Disable esm resolving for app/ and pages/ so for esm package using under pages/
+  // won't load react through esm loader
+  if (hasAppDir) {
+    preferEsmOptions = [false]
+  }
   for (const preferEsm of preferEsmOptions) {
     const resolve = getResolve(
       preferEsm ? esmResolveOptions : nodeResolveOptions
@@ -502,7 +507,7 @@ export async function resolveExternal(
         const baseResolve = getResolve(
           isEsm ? baseEsmResolveOptions : baseResolveOptions
         )
-        ;[baseRes, baseIsEsm] = await baseResolve(appDir, request)
+        ;[baseRes, baseIsEsm] = await baseResolve(dir, request)
       } catch (err) {
         baseRes = null
         baseIsEsm = false
@@ -1060,8 +1065,11 @@ export default async function getBaseWebpackConfig(
     // Absolute requires (require('/foo')) are extremely uncommon, but
     // also have no need for customization as they're already resolved.
     if (!isLocal) {
-      if (/^(?:next$|react(?:$|\/)|react-dom(?:$|\/))/.test(request)) {
+      if (/^(?:next$)/.test(request)) {
         return `commonjs ${request}`
+      }
+      if (/^(react(?:$|\/)|react-dom(?:$|\/))/.test(request)) {
+        return `commonjs ${hasAppDir ? 'next/dist/compiled/' : ''}${request}`
       }
 
       const notExternalModules =
@@ -1118,6 +1126,7 @@ export default async function getBaseWebpackConfig(
       context,
       request,
       isEsmRequested,
+      hasAppDir,
       getResolve,
       isLocal ? isLocalCallback : undefined
     )

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1158,7 +1158,7 @@ export default async function getBaseWebpackConfig(
       )
     }
 
-    const externalType = isEsm ? 'module' : 'commonjs'
+    const externalType = !hasAppDir && isEsm ? 'module' : 'commonjs'
 
     if (
       /next[/\\]dist[/\\]shared[/\\](?!lib[/\\]router[/\\]router)/.test(res) ||

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1088,7 +1088,7 @@ export default async function getBaseWebpackConfig(
     // When in esm externals mode, and using import, we resolve with
     // ESM resolving options.
     // Also disable esm request when appDir is enabled
-    const isEsmRequested = !hasAppDir && dependencyType === 'esm'
+    const isEsmRequested = dependencyType === 'esm'
 
     const isLocalCallback = (localRes: string) => {
       // Makes sure dist/shared and dist/server are not bundled
@@ -1158,7 +1158,7 @@ export default async function getBaseWebpackConfig(
       )
     }
 
-    const externalType = !hasAppDir && isEsm ? 'module' : 'commonjs'
+    const externalType = isEsm ? 'module' : 'commonjs'
 
     if (
       /next[/\\]dist[/\\]shared[/\\](?!lib[/\\]router[/\\]router)/.test(res) ||

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -127,6 +127,7 @@ function isResourceInPackages(resource: string, packageNames?: string[]) {
 
 const bundledReactImports = [
   'react',
+  'react-dom',
   'react/jsx-runtime',
   'react/jsx-dev-runtime',
   'next/dist/compiled/react-server-dom-webpack/server.browser',
@@ -1069,6 +1070,10 @@ export default async function getBaseWebpackConfig(
         return `commonjs ${request}`
       }
       if (/^(react(?:$|\/)|react-dom(?:$|\/))/.test(request)) {
+        // override react-dom to server-rendering-stub for server
+        if (request === 'react-dom' && hasAppDir) {
+          request = 'react-dom/server-rendering-stub'
+        }
         return `commonjs ${hasAppDir ? 'next/dist/compiled/' : ''}${request}`
       }
 

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1087,7 +1087,8 @@ export default async function getBaseWebpackConfig(
 
     // When in esm externals mode, and using import, we resolve with
     // ESM resolving options.
-    const isEsmRequested = dependencyType === 'esm'
+    // Also disable esm request when appDir is enabled
+    const isEsmRequested = !hasAppDir && dependencyType === 'esm'
 
     const isLocalCallback = (localRes: string) => {
       // Makes sure dist/shared and dist/server are not bundled

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1071,7 +1071,7 @@ export default async function getBaseWebpackConfig(
       }
       if (/^(react(?:$|\/)|react-dom(?:$|\/))/.test(request)) {
         // override react-dom to server-rendering-stub for server
-        if (request === 'react-dom' && hasAppDir) {
+        if (request === 'react-dom' && hasAppDir && !isClient) {
           request = 'react-dom/server-rendering-stub'
         }
         return `commonjs ${hasAppDir ? 'next/dist/compiled/' : ''}${request}`

--- a/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -643,6 +643,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
             context,
             request,
             isEsmRequested,
+            !!this.appDirEnabled,
             (options) => (_: string, resRequest: string) => {
               return getResolve(options)(parent, resRequest, job)
             },

--- a/packages/next/server/initialize-require-hook.ts
+++ b/packages/next/server/initialize-require-hook.ts
@@ -5,6 +5,8 @@ import {
 
 loadRequireHook()
 
-if (process.env.NEXT_PREBUNDLED_REACT) {
+const isPrebundled = false
+
+if (isPrebundled) {
   overrideBuiltInReactPackages()
 }

--- a/packages/next/server/initialize-require-hook.ts
+++ b/packages/next/server/initialize-require-hook.ts
@@ -1,0 +1,10 @@
+import {
+  loadRequireHook,
+  overrideBuiltInReactPackages,
+} from '../build/webpack/require-hook'
+
+loadRequireHook()
+
+if (process.env.NEXT_PREBUNDLED_REACT) {
+  overrideBuiltInReactPackages()
+}

--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -1,3 +1,4 @@
+import './initialize-require-hook'
 import './node-polyfill-fetch'
 import './node-polyfill-web-streams'
 
@@ -97,16 +98,12 @@ import { shouldUseReactRoot } from './utils'
 import ResponseCache from './response-cache'
 import { IncrementalCache } from './lib/incremental-cache'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
-import { loadRequireHook } from '../build/webpack/require-hook'
 
 if (shouldUseReactRoot) {
   ;(process.env as any).__NEXT_REACT_ROOT = 'true'
 }
 
 import { renderToHTMLOrFlight as appRenderToHTMLOrFlight } from './app-render'
-
-// require hook for custom server
-loadRequireHook()
 
 export * from './base-server'
 

--- a/test/e2e/app-dir/app/pages/index.js
+++ b/test/e2e/app-dir/app/pages/index.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import Link from 'next/link'
+import useSWR from 'swr'
 import styles from '../styles/shared.module.css'
 
 export default function Page(props) {
+  const { data } = useSWR('swr-index', (v) => v, { fallbackData: 'swr-index' })
   return (
     <>
       <b>rc:{React.Component ? 'c' : 'no'}</b>
       <p className={styles.content}>hello from pages/index</p>
       <Link href="/dashboard">Dashboard</Link>
+      <div>{data}</div>
     </>
   )
 }

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -117,6 +117,9 @@ describe('app dir', () => {
     it('should serve from pages', async () => {
       const html = await renderViaHTTP(next.url, '/')
       expect(html).toContain('hello from pages/index')
+
+      // esm imports should work fine in pages/
+      expect(html).toContain('swr-index')
     })
 
     it('should serve dynamic route from pages', async () => {

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -29,8 +29,8 @@ describe('app dir', () => {
         files: new FileRef(path.join(__dirname, 'app')),
         dependencies: {
           swr: '2.0.0-rc.0',
-          react: 'experimental',
-          'react-dom': 'experimental',
+          react: 'latest',
+          'react-dom': 'latest',
         },
         skipStart: true,
       })

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -28,6 +28,7 @@ describe('app dir', () => {
       next = await createNext({
         files: new FileRef(path.join(__dirname, 'app')),
         dependencies: {
+          swr: '2.0.0-rc.0',
           react: 'experimental',
           'react-dom': 'experimental',
         },

--- a/test/e2e/app-dir/rsc-external/node_modules_bak/non-isomorphic-text/index.js
+++ b/test/e2e/app-dir/rsc-external/node_modules_bak/non-isomorphic-text/index.js
@@ -1,0 +1,6 @@
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.default = () => 'esm-export'
+exports.named = 'named'
+exports.value = 123
+exports.array = [4, 5, 6]
+exports.obj = { x: 1 }

--- a/test/e2e/app-dir/rsc-external/node_modules_bak/non-isomorphic-text/package.json
+++ b/test/e2e/app-dir/rsc-external/node_modules_bak/non-isomorphic-text/package.json
@@ -1,6 +1,8 @@
 {
   "name": "non-isomorphic-text",
-  "type": "module",
-  "exports": "./index.mjs",
+  "exports": {
+    "import": "./index.mjs",
+    "require": "./index.js"
+  },
   "browser": "./browser.js"
 }

--- a/test/e2e/app-dir/vercel-analytics.test.ts
+++ b/test/e2e/app-dir/vercel-analytics.test.ts
@@ -19,6 +19,7 @@ describe('vercel analytics', () => {
       next = await createNext({
         files: new FileRef(path.join(__dirname, 'app')),
         dependencies: {
+          swr: '2.0.0-rc.0',
           react: 'experimental',
           'react-dom': 'experimental',
           sass: 'latest',


### PR DESCRIPTION
When esm package that depending on react is used between `pages/` and `app/`, it's loading the user installed react through esm loader which doesn't go through require hook, so we cannot intercept it with require-hook.

Disable esm resolving when `appDir` is enabled for now, prefering to pick the cjs bundle so that react import is intercepted by require hook and pointing to the built-in react