### PR TITLE
useSelectedLayoutSegment -> useSelectedLayoutSegments, add useSelectedLayoutSegment with previous behavior

### DIFF
--- a/packages/next/client/components/navigation.ts
+++ b/packages/next/client/components/navigation.ts
@@ -140,11 +140,26 @@ function getSelectedLayoutSegmentPath(
 
 // TODO-APP: Expand description when the docs are written for it.
 /**
- * Get the canonical segment path from this level to the leaf node.
+ * Get the canonical segment path from the current level to the leaf node.
  */
-export function useSelectedLayoutSegment(
+export function useSelectedLayoutSegments(
   parallelRouteKey: string = 'children'
 ): string[] {
   const { tree } = useContext(LayoutRouterContext)
   return getSelectedLayoutSegmentPath(tree, parallelRouteKey)
+}
+
+// TODO-APP: Expand description when the docs are written for it.
+/**
+ * Get the segment below the current level
+ */
+export function useSelectedLayoutSegment(
+  parallelRouteKey: string = 'children'
+): string {
+  const selectedLayoutSegments = useSelectedLayoutSegments(parallelRouteKey)
+  if (selectedLayoutSegments.length === 0) {
+    throw new Error('No selected layout segment below the current level')
+  }
+
+  return selectedLayoutSegments[0]
 }

--- a/test/e2e/app-dir/app-edge/app/app-edge/layout.tsx
+++ b/test/e2e/app-dir/app-edge/app/app-edge/layout.tsx
@@ -2,10 +2,10 @@
 
 // TODO-APP: support typing for useSelectedLayoutSegment
 // @ts-ignore
-import { useSelectedLayoutSegment } from 'next/navigation'
+import { useSelectedLayoutSegments } from 'next/navigation'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   // useSelectedLayoutSegment should not be thrown
-  useSelectedLayoutSegment()
+  useSelectedLayoutSegments()
   return children
 }

--- a/test/e2e/app-dir/app/app/hooks/use-selected-layout-segment/first/[dynamic]/(group)/second/[...catchall]/page.js
+++ b/test/e2e/app-dir/app/app/hooks/use-selected-layout-segment/first/[dynamic]/(group)/second/[...catchall]/page.js
@@ -1,9 +1,9 @@
 'use client'
 
-import { useSelectedLayoutSegment } from 'next/navigation'
+import { useSelectedLayoutSegments } from 'next/navigation'
 
 export default function Page() {
-  const selectedLayoutSegment = useSelectedLayoutSegment()
+  const selectedLayoutSegment = useSelectedLayoutSegments()
 
   return (
     <p id="page-layout-segments">{JSON.stringify(selectedLayoutSegment)}</p>

--- a/test/e2e/app-dir/app/app/hooks/use-selected-layout-segment/first/layout.js
+++ b/test/e2e/app-dir/app/app/hooks/use-selected-layout-segment/first/layout.js
@@ -1,9 +1,9 @@
 'use client'
 
-import { useSelectedLayoutSegment } from 'next/navigation'
+import { useSelectedLayoutSegments } from 'next/navigation'
 
 export default function Layout({ children }) {
-  const selectedLayoutSegment = useSelectedLayoutSegment()
+  const selectedLayoutSegment = useSelectedLayoutSegments()
 
   return (
     <>

--- a/test/e2e/app-dir/app/app/hooks/use-selected-layout-segment/layout.js
+++ b/test/e2e/app-dir/app/app/hooks/use-selected-layout-segment/layout.js
@@ -1,9 +1,9 @@
 'use client'
 
-import { useSelectedLayoutSegment } from 'next/navigation'
+import { useSelectedLayoutSegments } from 'next/navigation'
 
 export default function Layout({ children }) {
-  const selectedLayoutSegment = useSelectedLayoutSegment()
+  const selectedLayoutSegment = useSelectedLayoutSegments()
 
   return (
     <>

--- a/test/e2e/app-dir/app/app/nested-navigation/CategoryNav.js
+++ b/test/e2e/app-dir/app/app/nested-navigation/CategoryNav.js
@@ -1,10 +1,10 @@
 'use client'
 
 import { TabNavItem } from './TabNavItem'
-import { useSelectedLayoutSegment } from 'next/navigation'
+import { useSelectedLayoutSegments } from 'next/navigation'
 
 const CategoryNav = ({ categories }) => {
-  const selectedLayoutSegment = useSelectedLayoutSegment()
+  const selectedLayoutSegment = useSelectedLayoutSegments()
 
   return (
     <div style={{ display: 'flex' }}>

--- a/test/e2e/app-dir/app/app/nested-navigation/[categorySlug]/SubCategoryNav.js
+++ b/test/e2e/app-dir/app/app/nested-navigation/[categorySlug]/SubCategoryNav.js
@@ -1,10 +1,10 @@
 'use client'
 
 import { TabNavItem } from '../TabNavItem'
-import { useSelectedLayoutSegment } from 'next/navigation'
+import { useSelectedLayoutSegments } from 'next/navigation'
 
 const SubCategoryNav = ({ category }) => {
-  const selectedLayoutSegment = useSelectedLayoutSegment()
+  const selectedLayoutSegment = useSelectedLayoutSegments()
 
   return (
     <div style={{ display: 'flex' }}>


### PR DESCRIPTION
Renames `useSelectedLayoutSegment` to `useSelectedLayoutSegments` and adds a single-value version of it under `useSelectedLayoutSegment`.


<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
