### PR TITLE
Add noindex for not found in ssr

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1518,7 +1518,11 @@ export async function renderToHTMLOrFlight(
           ReactDOMServer,
           element: (
             <html id="__next_error__">
-              <head></head>
+              <head>
+                {err?.digest === NOT_FOUND_ERROR_CODE && (
+                  <meta name="robots" content="noindex" />
+                )}
+              </head>
               <body></body>
             </html>
           ),

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1859,7 +1859,7 @@ describe('app dir', () => {
 
     describe('not-found', () => {
       it('should trigger not-found in a server component', async () => {
-        const html = renderViaHTTP(next.url, '/not-found/servercomponent')
+        const html = await renderViaHTTP(next.url, '/not-found/servercomponent')
         expect(html).toContain('<meta name="robots" content="noindex"/>')
 
         const browser = await webdriver(next.url, '/not-found/servercomponent')
@@ -1875,7 +1875,7 @@ describe('app dir', () => {
       })
 
       it('should trigger not-found in a client component', async () => {
-        const html = renderViaHTTP(next.url, '/not-found/clientcomponent')
+        const html = await renderViaHTTP(next.url, '/not-found/clientcomponent')
         expect(html).toContain('<meta name="robots" content="noindex"/>')
 
         const browser = await webdriver(next.url, '/not-found/clientcomponent')

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1859,6 +1859,9 @@ describe('app dir', () => {
 
     describe('not-found', () => {
       it('should trigger not-found in a server component', async () => {
+        const html = renderViaHTTP(next.url, '/not-found/servercomponent')
+        expect(html).toContain('<meta name="robots" content="noindex"/>')
+
         const browser = await webdriver(next.url, '/not-found/servercomponent')
 
         expect(
@@ -1872,6 +1875,9 @@ describe('app dir', () => {
       })
 
       it('should trigger not-found in a client component', async () => {
+        const html = renderViaHTTP(next.url, '/not-found/clientcomponent')
+        expect(html).toContain('<meta name="robots" content="noindex"/>')
+
         const browser = await webdriver(next.url, '/not-found/clientcomponent')
         expect(
           await browser.waitForElementByCss('#not-found-component').text()


### PR DESCRIPTION
We should render noindex meta tag for `notFound`,  will do it only for blocking rendering later once it's enabled. cc @shuding 