### PR TITLE
Pass a object with `setHeader` method for `context.res` when in edge runtime

### DIFF
--- a/packages/next/server/web-server.ts
+++ b/packages/next/server/web-server.ts
@@ -27,6 +27,8 @@ import {
   normalizeVercelUrl,
 } from '../build/webpack/loaders/next-serverless-loader/utils'
 import { getNamedRouteRegex } from '../shared/lib/router/utils/route-regex'
+import { ServerResponse } from 'http'
+import { GetServerSidePropsContext } from '../types'
 
 interface WebServerOptions extends Options {
   webServerConfig: {
@@ -366,13 +368,21 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     const curRenderToHTML = pagesRenderToHTML || appRenderToHTML
 
     if (curRenderToHTML) {
+      const patchedRes: Partial<ServerResponse> = {
+        setHeader: _res.setHeader.bind(_res),
+        getHeader: _res.getHeader.bind(_res),
+        statusMessage: _res.statusMessage!,
+        statusCode: _res.statusCode!,
+      }
+      const patchedReq: Partial<GetServerSidePropsContext['req']> = {
+        url: req.url,
+        cookies: req.cookies,
+        headers: req.headers,
+        method: req.method,
+      }
       return await curRenderToHTML(
-        {
-          url: req.url,
-          cookies: req.cookies,
-          headers: req.headers,
-        } as any,
-        {} as any,
+        patchedReq as any,
+        patchedRes as any,
         pathname,
         query,
         Object.assign(renderOpts, {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using 
fixes #41713
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

There are a lot of methods to add to respect the `ServerResponse` signature but `setHeader` is the most used one (required to add CDN caching to a SSR page)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
