### PR TITLE
Check Error.getInitialProps is set before running it

### DIFF
--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -397,8 +397,11 @@ function renderError(renderErrorProps: RenderErrorProps): Promise<any> {
           AppTree,
         },
       }
+      const isInitialRenderError = !!renderErrorProps.props?.err;
+      const hasGetInitialProps = Boolean((appCtx.Component as any).getInitialProps)
+
       return Promise.resolve(
-        renderErrorProps.props?.err
+        (isInitialRenderError || !hasGetInitialProps)
           ? renderErrorProps.props
           : loadGetInitialProps(App, appCtx)
       ).then((initProps) =>

--- a/test/integration/render-error-on-render-error/with-get-initial-props/pages/_error.js
+++ b/test/integration/render-error-on-render-error/with-get-initial-props/pages/_error.js
@@ -1,0 +1,11 @@
+const Error = ({ message }) => {
+  return <p id="error-p">Error Rendered with: {message}</p>
+}
+
+Error.getInitialProps = ({ err }) => {
+  return {
+    message: err && err.message,
+  }
+}
+
+export default Error

--- a/test/integration/render-error-on-render-error/with-get-initial-props/pages/index.js
+++ b/test/integration/render-error-on-render-error/with-get-initial-props/pages/index.js
@@ -1,0 +1,8 @@
+const Index = () => {
+  throw new Error('fail render')
+  return null
+}
+
+Index.getInitialProps = () => ({})
+
+export default Index

--- a/test/integration/render-error-on-render-error/with-get-initial-props/test/index.test.js
+++ b/test/integration/render-error-on-render-error/with-get-initial-props/test/index.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+import {
+  nextBuild,
+  nextServer,
+  startApp,
+  stopApp,
+  waitFor,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { join } from 'path'
+
+const appDir = join(__dirname, '..')
+
+let appPort
+let app
+let server
+
+describe('Render Error', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    app = nextServer({
+      dir: join(__dirname, '../'),
+      dev: false,
+      quiet: true,
+    })
+
+    server = await startApp(app)
+    appPort = server.address().port
+  })
+  afterAll(() => stopApp(server))
+
+  it('should render error page', async () => {
+    const browser = await webdriver(appPort, '/')
+    try {
+      await waitFor(2000)
+      const text = await browser.elementByCss('#error-p').text()
+      expect(text).toBe('Error Rendered with: 500 - Internal Server Error.')
+    } finally {
+      await browser.close()
+    }
+  })
+})

--- a/test/integration/render-error-on-render-error/with-get-serverside-props/pages/_error.js
+++ b/test/integration/render-error-on-render-error/with-get-serverside-props/pages/_error.js
@@ -1,0 +1,13 @@
+const Error = ({ message }) => {
+  return <p id="error-p">Error Rendered with: {message}</p>
+}
+
+export function getServerSideProps () {
+  return {
+    props: {
+      message: '_error server side props data',
+    }
+  }
+}
+
+export default Error

--- a/test/integration/render-error-on-render-error/with-get-serverside-props/pages/index.js
+++ b/test/integration/render-error-on-render-error/with-get-serverside-props/pages/index.js
@@ -1,0 +1,10 @@
+const Index = () => {
+  throw new Error('fail render')
+  return null
+}
+
+export const getServerSideProps = () => ({
+  props: {}
+})
+
+export default Index

--- a/test/integration/render-error-on-render-error/with-get-serverside-props/test/index.test.js
+++ b/test/integration/render-error-on-render-error/with-get-serverside-props/test/index.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+import {
+  nextBuild,
+  nextServer,
+  startApp,
+  stopApp,
+  waitFor,
+} from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { join } from 'path'
+
+const appDir = join(__dirname, '..')
+
+let appPort
+let app
+let server
+
+describe('Render Error', () => {
+  beforeAll(async () => {
+    await nextBuild(appDir)
+    app = nextServer({
+      dir: join(__dirname, '../'),
+      dev: false,
+      quiet: true,
+    })
+
+    server = await startApp(app)
+    appPort = server.address().port
+  })
+  afterAll(() => stopApp(server))
+
+  it('should render error page', async () => {
+    const browser = await webdriver(appPort, '/')
+    try {
+      await waitFor(2000)
+      const text = await browser.elementByCss('#error-p').text()
+      expect(text).toBe('Error Rendered with: _error server side props data')
+    } finally {
+      await browser.close()
+    }
+  })
+})


### PR DESCRIPTION
Closes #41715 

Mentioned in the issue are more option to solving this, I'm open to feedback if there's a better way to bring back this functionality.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

Makes the existing documented example work correctly again https://nextjs.org/docs/advanced-features/custom-error-page#more-advanced-error-page-customizing.
