### PR TITLE
feat(codemod): add `NextCookies` upgrade codemod

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-cookies-spec/edge-api-route.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-cookies-spec/edge-api-route.input.js
@@ -1,0 +1,12 @@
+export default function handler(req) {
+  const cookie = req.cookies.get('token')
+  const { cookies, headers } = req
+  const c = cookies.get('token')
+
+  console.log(req.cookies.get('token'))
+  console.log(cookies.get('token'))
+  cookies.get('token')
+
+  const h = headers.get('bearer')
+  new URLSearchParams({}).set('bearer')
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-cookies-spec/edge-api-route.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-cookies-spec/edge-api-route.output.js
@@ -1,0 +1,12 @@
+export default function handler(req) {
+  const cookie = req.cookies.get('token')?.value
+  const { cookies, headers } = req
+  const c = cookies.get('token')?.value
+
+  console.log(req.cookies.get('token')?.value)
+  console.log(cookies.get('token')?.value)
+  cookies.get('token')?.value
+
+  const h = headers.get('bearer')
+  new URLSearchParams({}).set('bearer')
+}

--- a/packages/next-codemod/transforms/__testfixtures__/url-to-withrouter/using-inline-class.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/url-to-withrouter/using-inline-class.output.js
@@ -1,7 +1,7 @@
 import { withRouter } from "next/router";
 
-export default withRouter(class extends React.Component {
+export default withRouter((class extends React.Component {
   render() {
     const test = this.props.router
   }
-});
+}));

--- a/packages/next-codemod/transforms/__tests__/next-cookies-spec.test.js
+++ b/packages/next-codemod/transforms/__tests__/next-cookies-spec.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'next-cookies-spec'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter((file) => file.endsWith('.input.js'))
+  .map((file) => file.replace('.input.js', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`
+  defineTest(__dirname, fixtureDir, null, prefix)
+}

--- a/packages/next-codemod/transforms/next-cookies-spec.ts
+++ b/packages/next-codemod/transforms/next-cookies-spec.ts
@@ -1,0 +1,91 @@
+import type {
+  API,
+  Collection,
+  FileInfo,
+  JSCodeshift,
+  Options,
+} from 'jscodeshift'
+
+function defaultExportFuncAndFirstParam(root: Collection<any>, j: JSCodeshift) {
+  const defaultExport = root.find(j.ExportDefaultDeclaration)
+
+  /**
+   * export default function handler(req) {}
+   */
+  const funcDec = defaultExport.find(j.FunctionDeclaration)
+  if (funcDec.length) {
+    return { paramName: funcDec.get('params', 0).value.name, func: funcDec }
+  }
+
+  /**
+   * function handle(req) {}
+   * export default handle
+   */
+  const funcDec2 = root.find(j.FunctionDeclaration, {
+    id: { name: defaultExport.find(j.Identifier).get('name').value },
+  })
+  if (funcDec2.length) {
+    return { paramName: funcDec2.get('params', 0).value.name, func: funcDec2 }
+  }
+
+  /**
+   * const handle = (req) => {} OR const handle = function (req) {}
+   * export default handle
+   */
+  const varDec = root
+    .find(j.VariableDeclarator, {
+      id: { name: defaultExport.find(j.Identifier).get('name').value },
+    })
+    .find(j.Identifier)
+  if (varDec.length) {
+    return { paramName: varDec.get('name').value, func: varDec }
+  }
+
+  throw new Error('Could not find `NextRequest` parameter name')
+}
+
+export default function transformer(
+  file: FileInfo,
+  api: API,
+  options: Options
+) {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  const { func } = defaultExportFuncAndFirstParam(root, j)
+
+  // Replace `.get()` with `.get()?.value`
+  func
+    // TODO: Only look for `get` calls on `req.cookies`
+    .find(j.CallExpression, { callee: { property: { name: 'get' } } })
+    .forEach((exp) => {
+      const parentNode = exp.parentPath.value
+
+      const optionalValue = j.identifier('value')
+      if (Array.isArray(parentNode)) {
+        // console.log(parentNode[0])
+        // parentNode[0].callee = j.optionalMemberExpression(
+        //   parentNode[0].callee,
+        //   optionalValue
+        // )
+      } else if (parentNode.type === 'ExpressionStatement') {
+        parentNode.expression = j.optionalMemberExpression(
+          parentNode.expression,
+          optionalValue
+        )
+      } else if (parentNode.type === 'VariableDeclarator') {
+        parentNode.init = j.optionalMemberExpression(
+          parentNode.init,
+          optionalValue
+        )
+      }
+    })
+
+  // Rename `.getWithOptions()` to `.get()`
+  func
+    .find(j.BlockStatement)
+    .find(j.Identifier, { name: 'getWithOptions' })
+    .forEach((identifier) => (identifier.node.name = 'get'))
+
+  return root.toSource(options)
+}


### PR DESCRIPTION
Follow-up on #41526

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
