### PR TITLE
Fix static generation and crawler requests

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -145,6 +145,7 @@ export type RenderOptsPartial = {
   serverComponents?: boolean
   assetPrefix?: string
   fontLoaderManifest?: FontLoaderManifest
+  isBot?: boolean
 }
 
 export type RenderOpts = LoadComponentsReturnType & RenderOptsPartial
@@ -706,7 +707,8 @@ export async function renderToHTMLOrFlight(
    * These rules help ensure that other existing features like request caching,
    * coalescing, and ISR continue working as intended.
    */
-  const isStaticGeneration = renderOpts.supportsDynamicHTML !== true
+  const isStaticGeneration =
+    renderOpts.supportsDynamicHTML !== true && !renderOpts.isBot
   const isFlight = req.headers.__rsc__ !== undefined
 
   const capturedErrors: Error[] = []
@@ -737,9 +739,7 @@ export async function renderToHTMLOrFlight(
     supportsDynamicHTML,
   } = renderOpts
 
-  const generateStaticHTML = supportsDynamicHTML !== true || true
-
-  patchFetch(ComponentMod)
+  const generateStaticHTML = supportsDynamicHTML !== true
 
   const staticGenerationAsyncStorage = ComponentMod.staticGenerationAsyncStorage
   const requestAsyncStorage = ComponentMod.requestAsyncStorage

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1525,26 +1525,6 @@ export async function renderToHTMLOrFlight(
           ...validateRootLayout,
         })
 
-        if (generateStaticHTML) {
-          let html = await streamToString(result)
-
-          if (
-            allCapturedErrors.some(
-              (e: any) => e.digest === NOT_FOUND_ERROR_CODE
-            )
-          ) {
-            // If a not found error is thrown, we return 404 and make sure to
-            // inject the noindex tag.
-            res.statusCode = 404
-            html = html.replace(
-              '<head>',
-              '<head><meta name="robots" content="noindex"/>'
-            )
-          }
-
-          return html
-        }
-
         return result
       } catch (err: any) {
         const shouldNotIndex = err.digest === NOT_FOUND_ERROR_CODE

--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -739,6 +739,7 @@ export async function renderToHTMLOrFlight(
     supportsDynamicHTML,
   } = renderOpts
 
+  patchFetch(ComponentMod)
   const generateStaticHTML = supportsDynamicHTML !== true
 
   const staticGenerationAsyncStorage = ComponentMod.staticGenerationAsyncStorage

--- a/packages/next/server/base-server.ts
+++ b/packages/next/server/base-server.ts
@@ -205,6 +205,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     serverComponents?: boolean
     crossOrigin?: string
     supportsDynamicHTML?: boolean
+    isBot?: boolean
     serverComponentManifest?: any
     serverCSSManifest?: any
     fontLoaderManifest?: FontLoaderManifest
@@ -868,6 +869,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       renderOpts: {
         ...this.renderOpts,
         supportsDynamicHTML: !isBotRequest,
+        isBot: !!isBotRequest,
       },
     } as const
     const payload = await fn(ctx)
@@ -1160,6 +1162,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
       // cache if there are no dynamic data requirements
       opts.supportsDynamicHTML =
         !isSSG && !isBotRequest && !query.amp && isSupportedDocument
+      opts.isBot = isBotRequest
     }
 
     const defaultLocale = isSSG

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -253,6 +253,7 @@ export type RenderOptsPartial = {
   domainLocales?: DomainLocale[]
   disableOptimizedLoading?: boolean
   supportsDynamicHTML?: boolean
+  isBot?: boolean
   runtime?: ServerRuntime
   serverComponents?: boolean
   customServer?: boolean

--- a/test/e2e/app-dir/app/app/not-found/servercomponent/page.js
+++ b/test/e2e/app-dir/app/app/not-found/servercomponent/page.js
@@ -1,7 +1,31 @@
 // TODO-APP: enable when flight error serialization is implemented
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+import { Suspense } from 'react'
+
+let result
+let promise
+function Data() {
+  if (result) return result
+  if (!promise)
+    promise = new Promise((res) => {
+      setTimeout(() => {
+        result = <N />
+        res()
+      }, 500)
+    })
+  throw promise
+}
+
+function N() {
   notFound()
-  return <></>
+  return null
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="next_streaming_fallback">
+      <Data />
+    </Suspense>
+  )
 }

--- a/test/e2e/app-dir/app/app/not-found/servercomponent/page.js
+++ b/test/e2e/app-dir/app/app/not-found/servercomponent/page.js
@@ -1,31 +1,7 @@
 // TODO-APP: enable when flight error serialization is implemented
 import { notFound } from 'next/navigation'
 
-import { Suspense } from 'react'
-
-let result
-let promise
-function Data() {
-  if (result) return result
-  if (!promise)
-    promise = new Promise((res) => {
-      setTimeout(() => {
-        result = <N />
-        res()
-      }, 500)
-    })
-  throw promise
-}
-
-function N() {
-  notFound()
-  return null
-}
-
 export default function Page() {
-  return (
-    <Suspense fallback="next_streaming_fallback">
-      <Data />
-    </Suspense>
-  )
+  notFound()
+  return <></>
 }

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1899,6 +1899,18 @@ describe('app dir', () => {
       })
     })
 
+    describe('bots', () => {
+      it.skip('should block rendering for bots', async () => {
+        const res = await fetchViaHTTP(next.url, '/dashboard/index', '', {
+          headers: {
+            'User-Agent': 'Googlebot',
+          },
+        })
+
+        console.log(await res.text())
+      })
+    })
+
     describe('redirect', () => {
       describe('components', () => {
         it('should redirect in a server component', async () => {

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1900,14 +1900,20 @@ describe('app dir', () => {
     })
 
     describe('bots', () => {
-      it.skip('should block rendering for bots', async () => {
-        const res = await fetchViaHTTP(next.url, '/dashboard/index', '', {
-          headers: {
-            'User-Agent': 'Googlebot',
-          },
-        })
+      it('should block rendering for bots and return 404 status', async () => {
+        const res = await fetchViaHTTP(
+          next.url,
+          '/not-found/servercomponent',
+          '',
+          {
+            headers: {
+              'User-Agent': 'Googlebot',
+            },
+          }
+        )
 
-        console.log(await res.text())
+        expect(res.status).toBe(404)
+        expect(await res.text()).toInclude('"noindex"')
       })
     })
 


### PR DESCRIPTION
Right now the SSG condition is determined _only_ based on `supportsDynamicHTML`. However that `supportsDynamicHTML` flag can be affected by bots too.

Here we exclude the `isBot` condition from the SSG flag, and set proper status and meta tags for static HTML requests (and/or 404 cases).

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
