### PR TITLE
Add a default not found component

### DIFF
--- a/packages/next/client/components/layout-router.tsx
+++ b/packages/next/client/components/layout-router.tsx
@@ -353,12 +353,11 @@ class NotFoundErrorBoundary extends React.Component<
 }
 
 function NotFoundBoundary({ notFound, children }: NotFoundBoundaryProps) {
-  return notFound ? (
-    <NotFoundErrorBoundary notFound={notFound}>
+  return (
+    // TODO-APP: Add a default not found component.
+    <NotFoundErrorBoundary notFound={notFound || (() => null)}>
       {children}
     </NotFoundErrorBoundary>
-  ) : (
-    <>{children}</>
   )
 }
 

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -262,6 +262,19 @@ describe('app-dir static/dynamic handling', () => {
     expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
+  it('should render the not found page correctly', async () => {
+    const res = await fetchViaHTTP(next.url, `/blog/shu/hi`, undefined, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    const $ = cheerio.load(html)
+
+    expect(JSON.parse($('#author-layout-params').text())).toEqual({
+      author: 'shu',
+    })
+  })
+
   it('should ssr dynamically when detected automatically with fetch cache option', async () => {
     const pathname = '/ssr-auto/cache-no-store'
     const initialRes = await fetchViaHTTP(next.url, pathname, undefined, {

--- a/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
@@ -1,6 +1,12 @@
 export const dynamicParams = true
 
+import { notFound } from 'next/navigation'
+
 export default function Page({ params }) {
+  if (params.author === 'shu') {
+    notFound()
+  }
+
   return (
     <>
       <p id="page">/blog/[author]/[slug]</p>


### PR DESCRIPTION
When there is no user specified notFound component, we should not render a runtime error.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
