### PR TITLE
Add message for `appDir` feedback

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -42,6 +42,12 @@ const experimentalWarning = execOnce(
       `Experimental features are not covered by semver, and may cause unexpected or broken application behavior. ` +
         `Use at your own risk.`
     )
+    if (features.includes('appDir')) {
+      Log.warn(
+        `Thank you for testing \`appDir\` please leave your feedback at https://nextjs.link/app-feedback`
+      )
+    }
+
     console.warn()
   }
 )

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -43,7 +43,7 @@ const experimentalWarning = execOnce(
         `Use at your own risk.`
     )
     if (features.includes('appDir')) {
-      Log.warn(
+      Log.info(
         `Thank you for testing \`appDir\` please leave your feedback at https://nextjs.link/app-feedback`
       )
     }

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -348,4 +348,10 @@ describe('app-dir static/dynamic handling', () => {
 
     expect(secondDate).not.toBe(initialDate)
   })
+
+  it('should show a message to leave feedback for `appDir`', async () => {
+    expect(next.cliOutput).toContain(
+      `Thank you for testing \`appDir\` please leave your feedback at https://nextjs.link/app-feedback`
+    )
+  })
 })


### PR DESCRIPTION
This PR adds a message with a link to leave feedback for `appDir` when the user enables it.
