### PR TITLE
Fix edge entry layer resolution bug

### DIFF
--- a/test/e2e/app-dir/app/app/edge-apis/cookies/page.js
+++ b/test/e2e/app-dir/app/app/edge-apis/cookies/page.js
@@ -1,0 +1,8 @@
+import { cookies } from 'next/headers'
+
+export const runtime = 'experimental-edge'
+
+export default function Page() {
+  cookies()
+  return <h1>Hello!</h1>
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -955,6 +955,11 @@ describe('app dir', () => {
             }
           })
 
+          it('should retrieve cookies in a server component in the edge runtime', async () => {
+            const res = await fetchViaHTTP(next.url, '/edge-apis/cookies')
+            expect(await res.text()).toInclude('Hello')
+          })
+
           it('should access cookies on <Link /> navigation', async () => {
             const browser = await webdriver(next.url, '/navigation')
 


### PR DESCRIPTION
By default the edge page entry is in the client layer because it bundles Next.js. It's a virtual loader (edge-ssr-loader) but that makes the SWC loader think the page's source is a client component.

We use the resource query `__edge_ssr_entry__` to convert it to the server layer but we need to add that condition to the SWC loader too.

## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
