### PR TITLE
[typescript] fix typo in edge runtime name

### DIFF
--- a/packages/next/server/next-typescript.ts
+++ b/packages/next/server/next-typescript.ts
@@ -114,7 +114,7 @@ const API_DOCS: Record<
       'The `runtime` option controls the preferred runtime to render this route.',
     options: {
       '"nodejs"': 'Prefer the Node.js runtime.',
-      '"experimenta-edge"': 'Prefer the experimental Edge runtime.',
+      '"experimental-edge"': 'Prefer the experimental Edge runtime.',
     },
   },
 }


### PR DESCRIPTION
There's a typo, the `l` is missing in "experimenta**l**-edge", so this PR fixes it <picture data-single-emoji=":sunglasses_+1:" title=":sunglasses_+1:"><img class="emoji" width="20" height="auto" src="https://single-emoji.vercel.app/api/emoji/eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..B00DybEi6bYmTabJ.fEYVYfpy5cyunNLcNqBuYTSBihe-6dI2rCrCj86n4w39k7716U8Hh6AuUxv8UlCqgZ0V7GwQwBm6cStGluT8zzTsTJiiGKj-GstoRCNSMVFOjdFIs2-vQbtURJW4TUEvTmY.V9nTVN3aYA0ahz1hfF7m5g" alt=":sunglasses_+1:" align="absmiddle"></picture> 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`
