### PR TITLE
Merge app internal chunk into main chunk for layouts

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -981,7 +981,7 @@ export default async function build(
               if (key === APP_CLIENT_INTERNALS) {
                 clientEntry[CLIENT_STATIC_FILES_RUNTIME_MAIN_APP] = [
                   // TODO-APP: cast clientEntry[CLIENT_STATIC_FILES_RUNTIME_MAIN_APP] to type EntryDescription once it's available from webpack
-                  // @ts-ignore clientEntry['main-app'] is type EntryDescription { import: ... }
+                  // @ts-expect-error clientEntry['main-app'] is type EntryDescription { import: ... }
                   ...clientEntry[CLIENT_STATIC_FILES_RUNTIME_MAIN_APP].import,
                   value,
                 ]

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -123,7 +123,6 @@ import { RemotePattern } from '../shared/lib/image-config'
 import { eventSwcPlugins } from '../telemetry/events/swc-plugins'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { AppBuildManifest } from './webpack/plugins/app-build-manifest-plugin'
-import { EntryObject } from 'webpack'
 
 export type SsgRoute = {
   initialRevalidateSeconds: number | false

--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -60,7 +60,7 @@ import {
   RSC_MODULE_TYPES,
   FONT_LOADER_MANIFEST,
   CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
-  APP_INTERNALS,
+  APP_CLIENT_INTERNALS,
 } from '../shared/lib/constants'
 import { getSortedRoutes, isDynamicRoute } from '../shared/lib/router/utils'
 import { __ApiPreviewProps } from '../server/api-utils'
@@ -978,7 +978,7 @@ export default async function build(
           if (!serverResult.errors.length && !edgeServerResult?.errors.length) {
             injectedClientEntries.forEach((value, key) => {
               const clientEntry = clientConfig.entry as webpack.EntryObject
-              if (key === APP_INTERNALS) {
+              if (key === APP_CLIENT_INTERNALS) {
                 clientEntry[CLIENT_STATIC_FILES_RUNTIME_MAIN_APP] = [
                   // TODO-APP: cast clientEntry[CLIENT_STATIC_FILES_RUNTIME_MAIN_APP] to type EntryDescription once it's available from webpack
                   // @ts-ignore clientEntry['main-app'] is type EntryDescription { import: ... }

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -28,7 +28,6 @@ import {
   SERVER_DIRECTORY,
   COMPILER_NAMES,
   CompilerNameValues,
-  APP_CLIENT_INTERNALS,
 } from '../shared/lib/constants'
 import { execOnce } from '../shared/lib/utils'
 import { NextConfigComplete } from '../server/config-shared'

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -28,7 +28,7 @@ import {
   SERVER_DIRECTORY,
   COMPILER_NAMES,
   CompilerNameValues,
-  APP_INTERNALS,
+  APP_CLIENT_INTERNALS,
 } from '../shared/lib/constants'
 import { execOnce } from '../shared/lib/utils'
 import { NextConfigComplete } from '../server/config-shared'
@@ -78,11 +78,6 @@ const babelIncludeRegexes: RegExp[] = [
 ]
 
 const reactPackagesRegex = /^(react(?:$|\/)|react-dom(?:$|\/))/
-
-const builtinReactPackages = [
-  /next[\\/]dist[\\/]compiled[\\/](react|react-dom)[\\/]/,
-  /next[\\/]dist[\\/]compiled[\\/]react-server-dom-webpack[\\/]server.browser/,
-]
 
 const staticGenerationAsyncStorageRegex =
   /next[\\/]dist[\\/]client[\\/]components[\\/]static-generation-async-storage/

--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -28,6 +28,7 @@ import {
   SERVER_DIRECTORY,
   COMPILER_NAMES,
   CompilerNameValues,
+  APP_INTERNALS,
 } from '../shared/lib/constants'
 import { execOnce } from '../shared/lib/utils'
 import { NextConfigComplete } from '../server/config-shared'
@@ -77,6 +78,11 @@ const babelIncludeRegexes: RegExp[] = [
 ]
 
 const reactPackagesRegex = /^(react(?:$|\/)|react-dom(?:$|\/))/
+
+const builtinReactPackages = [
+  /next[\\/]dist[\\/]compiled[\\/](react|react-dom)[\\/]/,
+  /next[\\/]dist[\\/]compiled[\\/]react-server-dom-webpack[\\/]server.browser/,
+]
 
 const staticGenerationAsyncStorageRegex =
   /next[\\/]dist[\\/]client[\\/]components[\\/]static-generation-async-storage/
@@ -795,13 +801,18 @@ export default async function getBaseWebpackConfig(
                         )
                         .replace(/\\/g, '/'),
                   ]
-                : `./` +
-                  path
-                    .relative(
-                      dir,
-                      path.join(NEXT_PROJECT_ROOT_DIST_CLIENT, 'app-next.js')
-                    )
-                    .replace(/\\/g, '/'),
+                : [
+                    `./` +
+                      path
+                        .relative(
+                          dir,
+                          path.join(
+                            NEXT_PROJECT_ROOT_DIST_CLIENT,
+                            'app-next.js'
+                          )
+                        )
+                        .replace(/\\/g, '/'),
+                  ],
             }
           : {}),
       } as ClientEntries)

--- a/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -1,7 +1,6 @@
 import { stringify } from 'querystring'
 import path from 'path'
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
-import type { Dependency, EntryOptions } from 'webpack'
 import {
   getInvalidator,
   entries,
@@ -519,8 +518,8 @@ export class FlightClientEntryPlugin {
   addEntry(
     compilation: any,
     context: string,
-    dependency: Dependency,
-    options: EntryOptions
+    dependency: any /* Dependency */,
+    options: any /* EntryOptions */
   ): Promise<any> /* Promise<module> */ {
     return new Promise((resolve, reject) => {
       const entry = compilation.entries.get(options.name)

--- a/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -14,7 +14,7 @@ import type {
 } from '../loaders/next-flight-client-entry-loader'
 import { APP_DIR_ALIAS, WEBPACK_LAYERS } from '../../../lib/constants'
 import {
-  APP_INTERNALS,
+  APP_CLIENT_INTERNALS,
   COMPILER_NAMES,
   EDGE_RUNTIME_WEBPACK,
   FLIGHT_SERVER_CSS_MANIFEST,
@@ -221,7 +221,7 @@ export class FlightClientEntryPlugin {
           compilation,
           entryName: name,
           clientComponentImports: [...internalClientComponentEntryImports],
-          bundlePath: APP_INTERNALS,
+          bundlePath: APP_CLIENT_INTERNALS,
         })
       )
     })

--- a/packages/next/client/app-next.js
+++ b/packages/next/client/app-next.js
@@ -1,10 +1,12 @@
 import { appBootstrap } from './app-bootstrap'
 
-appBootstrap(() => {
-  // Include app-router and layout-router in the main chunk
-  import('next/dist/client/components/app-router.js')
-  import('next/dist/client/components/layout-router.js')
+// Include app-router and layout-router in the main chunk
+require('next/dist/client/components/app-router')
+require('next/dist/client/components/layout-router')
+require('react')
+require('next/dist/compiled/react-server-dom-webpack/client')
 
+appBootstrap(() => {
   const { hydrate } = require('./app-index')
   hydrate()
 })

--- a/packages/next/client/app-next.js
+++ b/packages/next/client/app-next.js
@@ -1,12 +1,9 @@
 import { appBootstrap } from './app-bootstrap'
 
-// Include app-router and layout-router in the main chunk
-require('next/dist/client/components/app-router')
-require('next/dist/client/components/layout-router')
-require('react')
-require('next/dist/compiled/react-server-dom-webpack/client')
-
 appBootstrap(() => {
+  // Include app-router and layout-router in the main chunk
+  require('next/dist/client/components/app-router')
+  require('next/dist/client/components/layout-router')
   const { hydrate } = require('./app-index')
   hydrate()
 })

--- a/packages/next/shared/lib/constants.ts
+++ b/packages/next/shared/lib/constants.ts
@@ -76,6 +76,8 @@ export const MIDDLEWARE_REACT_LOADABLE_MANIFEST =
 // static/runtime/main.js
 export const CLIENT_STATIC_FILES_RUNTIME_MAIN = `main`
 export const CLIENT_STATIC_FILES_RUNTIME_MAIN_APP = `${CLIENT_STATIC_FILES_RUNTIME_MAIN}-app`
+// next internal client components chunk for layouts
+export const APP_INTERNALS = 'app-internals'
 // static/runtime/react-refresh.js
 export const CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH = `react-refresh`
 // static/runtime/amp.js

--- a/packages/next/shared/lib/constants.ts
+++ b/packages/next/shared/lib/constants.ts
@@ -77,7 +77,7 @@ export const MIDDLEWARE_REACT_LOADABLE_MANIFEST =
 export const CLIENT_STATIC_FILES_RUNTIME_MAIN = `main`
 export const CLIENT_STATIC_FILES_RUNTIME_MAIN_APP = `${CLIENT_STATIC_FILES_RUNTIME_MAIN}-app`
 // next internal client components chunk for layouts
-export const APP_INTERNALS = 'app-internals'
+export const APP_CLIENT_INTERNALS = 'app-client-internals'
 // static/runtime/react-refresh.js
 export const CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH = `react-refresh`
 // static/runtime/amp.js

--- a/test/.stats-app/app/app-edge-ssr/page.js
+++ b/test/.stats-app/app/app-edge-ssr/page.js
@@ -1,5 +1,5 @@
 export default function page() {
-  return 'edge-ssr'
+  return 'app-edge-ssr'
 }
 
 export const runtime = 'experimental-edge'

--- a/test/.stats-app/app/app-ssr/page.js
+++ b/test/.stats-app/app/app-ssr/page.js
@@ -1,0 +1,5 @@
+export default function page() {
+  return 'app-ssr'
+}
+
+export const revalidate = 0


### PR DESCRIPTION
When emitting the client components entry from server compiler, merging app internal entry into main-app to avoid duplicated chunks like react are generated in both sides

chaing from `import()` to `require()` to ensure the chunks are included in the bundle

Related: https://github.com/vercel/next.js/issues/41870