### PR TITLE
test(dev): support to run test with --turbo

### DIFF
--- a/test/development/basic/styled-components-disabled.test.ts
+++ b/test/development/basic/styled-components-disabled.test.ts
@@ -4,11 +4,15 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP } from 'next-test-utils'
 
-describe('styled-components SWC transform', () => {
+describe.each([
+  ['dev', false],
+  ['turbo', true],
+])('styled-components SWC transform', (_name, turbo) => {
   let next: NextInstance
 
   beforeAll(async () => {
     next = await createNext({
+      turbo: !!turbo,
       files: {
         'next.config.js': new FileRef(
           join(__dirname, 'styled-components-disabled/next.config.js')

--- a/test/integration/css-modules/test/index.test.js
+++ b/test/integration/css-modules/test/index.test.js
@@ -130,7 +130,10 @@ describe('3rd Party CSS Module Support', () => {
   })
 })
 
-describe('Has CSS Module in computed styles in Development', () => {
+describe.each([
+  ['dev', false],
+  ['turbo', true],
+])('Has CSS Module in computed styles in Development %s', (turbo) => {
   const appDir = join(fixturesDir, 'dev-module')
 
   let appPort
@@ -138,7 +141,7 @@ describe('Has CSS Module in computed styles in Development', () => {
   beforeAll(async () => {
     await remove(join(appDir, '.next'))
     appPort = await findPort()
-    app = await launchApp(appDir, appPort)
+    app = await launchApp(appDir, appPort, { turbo })
   })
   afterAll(async () => {
     await killApp(app)

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -27,6 +27,7 @@ export interface NextInstanceOpts {
   startCommand?: string
   env?: Record<string, string>
   dirSuffix?: string
+  turbo?: boolean
 }
 
 export class NextInstance {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

This PR updates test fixture setup to pass `--turbo` when devserver is initiated. Due to lot of existing tests are not working with turbopack yet, changes are focused to setup necessary logics for the fixtures only. With this change we can create some sort of burndown list to fix forward.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
