### PR TITLE
Fix revalidate check in client component

### DIFF
--- a/packages/next/server/app-render.tsx
+++ b/packages/next/server/app-render.tsx
@@ -1007,7 +1007,7 @@ export async function renderToHTMLOrFlight(
         ? DefaultNotFound
         : undefined
 
-      if (typeof layoutOrPageMod?.revalidate !== 'undefined') {
+      if (typeof layoutOrPageMod?.revalidate === 'number') {
         defaultRevalidate = layoutOrPageMod.revalidate
 
         if (isStaticGeneration && defaultRevalidate === 0) {

--- a/test/e2e/app-dir/app-static.test.ts
+++ b/test/e2e/app-dir/app-static.test.ts
@@ -12,11 +12,6 @@ const glob = promisify(globOrig)
 describe('app-dir static/dynamic handling', () => {
   const isDev = (global as any).isNextDev
 
-  if ((global as any).isNextDeploy) {
-    it('should skip next deploy for now', () => {})
-    return
-  }
-
   let next: NextInstance
 
   beforeAll(async () => {
@@ -392,19 +387,22 @@ describe('app-dir static/dynamic handling', () => {
         )
       })
 
-      it('should have values from canonical url on rewrite', async () => {
-        const browser = await webdriver(
-          next.url,
-          '/rewritten-use-search-params?first=a&second=b&third=c'
-        )
+      // TODO-APP: re-enable after investigating rewrite params
+      if (!(global as any).isNextDeploy) {
+        it('should have values from canonical url on rewrite', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/rewritten-use-search-params?first=a&second=b&third=c'
+          )
 
-        expect(await browser.elementByCss('#params-first').text()).toBe('a')
-        expect(await browser.elementByCss('#params-second').text()).toBe('b')
-        expect(await browser.elementByCss('#params-third').text()).toBe('c')
-        expect(await browser.elementByCss('#params-not-real').text()).toBe(
-          'N/A'
-        )
-      })
+          expect(await browser.elementByCss('#params-first').text()).toBe('a')
+          expect(await browser.elementByCss('#params-second').text()).toBe('b')
+          expect(await browser.elementByCss('#params-third').text()).toBe('c')
+          expect(await browser.elementByCss('#params-not-real').text()).toBe(
+            'N/A'
+          )
+        })
+      }
     })
 
     describe('usePathname', () => {
@@ -432,10 +430,13 @@ describe('app-dir static/dynamic handling', () => {
         )
       })
     })
-    it('should show a message to leave feedback for `appDir`', async () => {
-      expect(next.cliOutput).toContain(
-        `Thank you for testing \`appDir\` please leave your feedback at https://nextjs.link/app-feedback`
-      )
-    })
+
+    if (!(global as any).isNextDeploy) {
+      it('should show a message to leave feedback for `appDir`', async () => {
+        expect(next.cliOutput).toContain(
+          `Thank you for testing \`appDir\` please leave your feedback at https://nextjs.link/app-feedback`
+        )
+      })
+    }
   })
 })

--- a/test/e2e/app-dir/app-static/app/dynamic-no-gen-params/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/dynamic-no-gen-params/[slug]/page.js
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 
 export default function Page({ params }) {


### PR DESCRIPTION
Ensures we check for the explicit type on revalidate as client components can return an object when accessing module export. 

Patched deployment can be seen here https://next-13-client-page-iuqrog6hj-ijjk-testing.vercel.app/broken

## Bug

- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

Fixes: https://github.com/vercel/next.js/issues/41890