### PR TITLE
chore(examples): use `next@latest` in all examples

### DIFF
--- a/examples/image-component/package.json
+++ b/examples/image-component/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/image-legacy-component/package.json
+++ b/examples/image-legacy-component/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "canary",
+    "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/next-offline/package.json
+++ b/examples/next-offline/package.json
@@ -8,15 +8,9 @@
   },
   "dependencies": {
     "next": "latest",
-<<<<<<< Updated upstream:examples/next-offline/package.json
     "next-offline": "^5.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
-=======
-    "next-offline": "4.0.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
->>>>>>> Stashed changes:examples/with-next-offline/package.json
   },
   "devDependencies": {
     "@types/node": "^18.11.5",

--- a/examples/next-offline/package.json
+++ b/examples/next-offline/package.json
@@ -8,9 +8,15 @@
   },
   "dependencies": {
     "next": "latest",
+<<<<<<< Updated upstream:examples/next-offline/package.json
     "next-offline": "^5.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+=======
+    "next-offline": "4.0.6",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+>>>>>>> Stashed changes:examples/with-next-offline/package.json
   },
   "devDependencies": {
     "@types/node": "^18.11.5",


### PR DESCRIPTION
Ref: #41787

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
