### PR TITLE
fix(ts): make `notFound` function return `null`

### DIFF
--- a/packages/next/client/components/not-found.ts
+++ b/packages/next/client/components/not-found.ts
@@ -5,4 +5,5 @@ export function notFound() {
   const error = new Error(NOT_FOUND_ERROR_CODE)
   ;(error as any).digest = NOT_FOUND_ERROR_CODE
   throw error
+  return null
 }


### PR DESCRIPTION
When using the `notFound` function to exit from component rendering logic [as it is described in the Next.js docs](https://beta.nextjs.org/docs/api-reference/notfound), you will get a TS error when building the application, since the return type of the current implementation is `void`.

```
Type error: Page "app/portfolio/[slug]/page.tsx" does not match the required types of a Next.js Page.
    Expected "ReactNode | Promise<ReactNode>", got "Promise<void | Element>".
      Expected "Promise<ReactNode>", got "Promise<void | Element>".
        Expected "ReactNode", got "void | Element".
          Expected "ReactNode", got "void".
```

This PR makes the `notFound` function return type conform to the expected return type of a React Component. Even though the `return` code is never reached, this helps TS compiler in figuring out what's happening.