### PR TITLE
chore(docs): link-multiple-children: correct fix suggestion

### DIFF
--- a/errors/link-multiple-children.md
+++ b/errors/link-multiple-children.md
@@ -28,9 +28,7 @@ import Link from 'next/link'
 
 export default function Home() {
   return (
-    <Link href="/about">
-      <a>To About</a>
-    </Link>
+    <Link href="/about">To About</Link>
   )
 }
 ```

--- a/errors/link-multiple-children.md
+++ b/errors/link-multiple-children.md
@@ -21,7 +21,7 @@ export default function Home() {
 
 #### Possible Ways to Fix It
 
-Make sure only one child is used when using `<Link>`:
+Make sure that only one child is used with `<Link>` component:
 
 ```js
 import Link from 'next/link'


### PR DESCRIPTION
# Why

After Next 13 release this doc suggest the fix which is no longer valid.

# How

Correct the suggested solution.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)

