### PR TITLE
Revert "Include frameworks in main-app"

### DIFF
--- a/packages/next/build/webpack-config.ts
+++ b/packages/next/build/webpack-config.ts
@@ -1427,25 +1427,10 @@ export default async function getBaseWebpackConfig(
           // and all other chunk depend on them so there is no
           // duplication that need to be pulled out.
           chunks: (chunk: any) =>
-            !/^(polyfills|main|main-app|pages\/_app)$/.test(chunk.name),
+            !/^(polyfills|main|pages\/_app)$/.test(chunk.name),
           cacheGroups: {
             framework: {
-              chunks: (chunk) => {
-                const name = chunk.name
-
-                // Skip app directory and include shared modules in main-app.
-                if (
-                  name &&
-                  hasAppDir &&
-                  (name === 'main-app' ||
-                    name === 'app-internals' ||
-                    name.startsWith('app/'))
-                ) {
-                  return false
-                }
-
-                return true
-              },
+              chunks: 'all',
               name: 'framework',
               test(module: any) {
                 const resource = module.nameForCondition?.()


### PR DESCRIPTION
Reverts vercel/next.js#41465

This resolves #41870, will investigate and reopen a better solution to reduce number of loaded chunks in the future.