### PR TITLE
Fix broken link in `@next/font` docs

### DIFF
--- a/docs/api-reference/next/font.md
+++ b/docs/api-reference/next/font.md
@@ -294,7 +294,7 @@ import { greatVibes, sourceCodePro400 } from '@/fonts';
 ## Next Steps
 
 <div class="card">
-  <a href="/docs/optimizing/fonts.md">
+  <a href="/docs/basic-features/font-optimization.md">
     <b>Font Optmization</b>
     <small>Learn how to optimize fonts with the Font module.</small>
   </a>


### PR DESCRIPTION
As per https://twitter.com/pbshgthm/status/1585728924499480576

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
