### PR TITLE
Fix build type error of page params

### DIFF
--- a/packages/next/build/webpack/plugins/flight-types-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-types-plugin.ts
@@ -28,7 +28,7 @@ check<IEntry, TEntry>(entry)
 type PageParams = Record<string, string>
 interface PageProps {
   params: any
-  searchParams: any
+  searchParams?: any
 }
 interface LayoutProps {
   children: React.ReactNode

--- a/packages/next/build/webpack/plugins/flight-types-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-types-plugin.ts
@@ -27,12 +27,12 @@ check<IEntry, TEntry>(entry)
 
 type PageParams = Record<string, string>
 interface PageProps {
-  params?: PageParams
-  searchParams?: Record<string, string | string[]>
+  params: any
+  searchParams: any
 }
 interface LayoutProps {
   children: React.ReactNode
-  params?: PageParams
+  params: any
 }
 
 type PageComponent = (props: PageProps) => React.ReactNode | Promise<React.ReactNode>


### PR DESCRIPTION
This PR temporarily fixes #41884 by loosing the type check rules. I will work on a follow up PR to type params better with tests.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
