### PR TITLE
Make the code frame caret absolutely positioned

### DIFF
--- a/packages/next/client/components/react-dev-overlay/internal/components/CodeFrame/CodeFrame.tsx
+++ b/packages/next/client/components/react-dev-overlay/internal/components/CodeFrame/CodeFrame.tsx
@@ -64,7 +64,6 @@ export const CodeFrame: React.FC<CodeFrameProps> = function CodeFrame({
       )
   }, [stackFrame])
 
-  // TODO: make the caret absolute
   return (
     <div data-nextjs-codeframe>
       <div>

--- a/packages/next/client/components/react-dev-overlay/internal/components/CodeFrame/styles.tsx
+++ b/packages/next/client/components/react-dev-overlay/internal/components/CodeFrame/styles.tsx
@@ -29,19 +29,21 @@ const styles = css`
     border-bottom: 1px solid var(--color-ansi-bright-black);
   }
   [data-nextjs-codeframe] > div > p {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    position: relative;
     cursor: pointer;
     margin: 0;
+    padding-right: calc(1em + 8px);
   }
   [data-nextjs-codeframe] > div > p:hover {
     text-decoration: underline dotted;
   }
   [data-nextjs-codeframe] div > p > svg {
-    width: auto;
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: 1em;
     height: 1em;
-    margin-left: 8px;
+    transform: translate(0, -50%);
   }
   [data-nextjs-codeframe] div > pre {
     overflow: hidden;


### PR DESCRIPTION
Makes the code frame caret, from the dev overlay component, absolutely positioned as [described](https://github.com/vercel/next.js/blob/canary/packages/next/client/components/react-dev-overlay/internal/components/CodeFrame/CodeFrame.tsx#L67).

This change prevents the caret to reduce it's width for long file paths.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
