### PR TITLE
Fix Windows resource path in manifests

### DIFF
--- a/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -33,8 +33,11 @@ const PLUGIN_NAME = 'ClientEntryPlugin'
 
 export const injectedClientEntries = new Map()
 
-export const serverModuleIds = new Map<string, string | number>()
-export const edgeServerModuleIds = new Map<string, string | number>()
+export const serverResourceToModuleIdMap = new Map<string, string | number>()
+export const edgeServerResourceToModuleIdMap = new Map<
+  string,
+  string | number
+>()
 
 // TODO-APP: move CSS manifest generation to the flight manifest plugin.
 const flightCSSManifest: FlightCSSManifest = {}
@@ -90,22 +93,14 @@ export class FlightClientEntryPlugin {
         }
 
         if (typeof modId !== 'undefined' && modResource) {
-          // Note that this isn't that reliable as webpack is still possible to assign
-          // additional queries to make sure there's no conflict even using the `named`
-          // module ID strategy.
-          let ssrNamedModuleId = path.relative(compiler.context, modResource)
-          if (!ssrNamedModuleId.startsWith('.')) {
-            // TODO use getModuleId instead
-            ssrNamedModuleId = `./${ssrNamedModuleId.replace(/\\/g, '/')}`
-          }
-
           if (this.isEdgeServer) {
-            edgeServerModuleIds.set(
-              ssrNamedModuleId.replace(/\/next\/dist\/esm\//, '/next/dist/'),
+            edgeServerResourceToModuleIdMap.set(
+              // Remove the "esm" path from the resource. Works for both Posix and Windows.
+              modResource.replace(/([/\\]next[/\\]dist[/\\])esm[/\\]/, '$1'),
               modId
             )
           } else {
-            serverModuleIds.set(ssrNamedModuleId, modId)
+            serverResourceToModuleIdMap.set(modResource, modId)
           }
         }
       }

--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -7,12 +7,11 @@
 
 import { webpack, sources } from 'next/dist/compiled/webpack/webpack'
 import { FLIGHT_MANIFEST } from '../../../shared/lib/constants'
-import { relative } from 'path'
 import { isClientComponentModule, regexCSS } from '../loaders/utils'
 
 import {
-  edgeServerModuleIds,
-  serverModuleIds,
+  edgeServerResourceToModuleIdMap,
+  serverResourceToModuleIdMap,
 } from './flight-client-entry-plugin'
 
 import { traverseModules } from '../utils'
@@ -179,16 +178,7 @@ export class FlightManifestPlugin {
         const moduleIdMapping = manifest.__ssr_module_mapping__
         const edgeModuleIdMapping = manifest.__edge_ssr_module_mapping__
 
-        // Note that this isn't that reliable as webpack is still possible to assign
-        // additional queries to make sure there's no conflict even using the `named`
-        // module ID strategy.
-        let ssrNamedModuleId = relative(
-          context,
-          mod.resourceResolveData?.path || resource
-        )
-
-        if (!ssrNamedModuleId.startsWith('.'))
-          ssrNamedModuleId = `./${ssrNamedModuleId.replace(/\\/g, '/')}`
+        const modResource = mod.resourceResolveData?.path || resource
 
         if (isCSSModule) {
           if (!manifest[resource]) {
@@ -281,19 +271,19 @@ export class FlightManifestPlugin {
             }
           }
 
-          if (serverModuleIds.has(ssrNamedModuleId)) {
+          if (serverResourceToModuleIdMap.has(modResource)) {
             moduleIdMapping[id] = moduleIdMapping[id] || {}
             moduleIdMapping[id][name] = {
               ...moduleExports[name],
-              id: serverModuleIds.get(ssrNamedModuleId)!,
+              id: serverResourceToModuleIdMap.get(modResource)!,
             }
           }
 
-          if (edgeServerModuleIds.has(ssrNamedModuleId)) {
+          if (edgeServerResourceToModuleIdMap.has(modResource)) {
             edgeModuleIdMapping[id] = edgeModuleIdMapping[id] || {}
             edgeModuleIdMapping[id][name] = {
               ...moduleExports[name],
-              id: edgeServerModuleIds.get(ssrNamedModuleId)!,
+              id: edgeServerResourceToModuleIdMap.get(modResource)!,
             }
           }
         })


### PR DESCRIPTION
With the current architecture, we no longer need to get the relative path and make that match the module ID generated via the "named" way. Instead, we directly use the absolute resource path so both sides match and the ID mapping can be created. Related to #42024, not sure if it fixes the problem entirely.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
