### PR TITLE
Keep react-dom/server.node in precompiled

### DIFF
--- a/packages/next/compiled/react-dom/server.node.js
+++ b/packages/next/compiled/react-dom/server.node.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var l, s;
+if (process.env.NODE_ENV === 'production') {
+  l = require('./cjs/react-dom-server-legacy.node.production.min.js');
+  s = require('./cjs/react-dom-server.node.production.min.js');
+} else {
+  l = require('./cjs/react-dom-server-legacy.node.development.js');
+  s = require('./cjs/react-dom-server.node.development.js');
+}
+
+exports.version = l.version;
+exports.renderToString = l.renderToString;
+exports.renderToStaticMarkup = l.renderToStaticMarkup;
+exports.renderToNodeStream = l.renderToNodeStream;
+exports.renderToStaticNodeStream = l.renderToStaticNodeStream;
+exports.renderToPipeableStream = s.renderToPipeableStream;

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1537,7 +1537,6 @@ export async function ncc_react(task, opts) {
   await fs.remove(join(reactDomCompiledDir, 'static.browser.js'))
   await fs.remove(join(reactDomCompiledDir, 'unstable_testing.js'))
   await fs.remove(join(reactDomCompiledDir, 'test-utils.js'))
-  await fs.remove(join(reactDomCompiledDir, 'server.node.js'))
   await fs.remove(join(reactDomCompiledDir, 'profiling.js'))
   await fs.remove(
     join(reactDomCompiledDir, 'unstable_server-external-runtime.js')


### PR DESCRIPTION
In `server/render.tsx` we're switching between `react-dom/server.browser` and `react-dom/server` based on the react version users're using, unlike directly resolving them with nodejs on server side, turbopack needs to resolve both while bundling.