### PR TITLE
Removing 'a' tag inside Link component.

### DIFF
--- a/examples/with-loading/pages/_app.tsx
+++ b/examples/with-loading/pages/_app.tsx
@@ -37,13 +37,13 @@ export default function App({ Component, pageProps }: AppProps) {
             margin: 0 10px 0 0;
           }
         `}</style>
-        <Link href="/">
+        <Link href="/" legacyBehavior>
           <a>Home</a>
         </Link>
-        <Link href="/about">
+        <Link href="/about" legacyBehavior>
           <a>About</a>
         </Link>
-        <Link href="/forever">
+        <Link href="/forever" legacyBehavior>
           <a>Forever</a>
         </Link>
         <a href="/non-existing">Non Existing Page</a>

--- a/examples/with-loading/pages/_app.tsx
+++ b/examples/with-loading/pages/_app.tsx
@@ -32,19 +32,19 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <nav>
-        <style jsx>{`
+        <style jsx global>{`
           a {
             margin: 0 10px 0 0;
           }
         `}</style>
-        <Link href="/" legacyBehavior>
-          <a>Home</a>
+        <Link href="/">
+          Home
         </Link>
-        <Link href="/about" legacyBehavior>
-          <a>About</a>
+        <Link href="/about">
+          About
         </Link>
-        <Link href="/forever" legacyBehavior>
-          <a>Forever</a>
+        <Link href="/forever">
+          Forever
         </Link>
         <a href="/non-existing">Non Existing Page</a>
       </nav>


### PR DESCRIPTION
@maxproske Removed `a` tag as per your below comment: 
https://github.com/vercel/next.js/pull/42127#issuecomment-1295874873

Also, made the styles global for the example for the spacing to work correctly.