### PR TITLE
issue-41925 fix: skip duplicate props when transferring props from anchor to link

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/new-link/handle-duplicate-props.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/new-link/handle-duplicate-props.input.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <Link href="/about">
+      <a href="/about" className="some-class">Link</a>
+    </Link>
+  );
+}

--- a/packages/next-codemod/transforms/__testfixtures__/new-link/handle-duplicate-props.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/new-link/handle-duplicate-props.output.js
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <Link href="/about" className="some-class">
+      Link
+    </Link>
+  );
+}

--- a/packages/next-codemod/transforms/__tests__/new-link.test.js
+++ b/packages/next-codemod/transforms/__tests__/new-link.test.js
@@ -11,6 +11,7 @@ const fixtures = [
   'spread-props',
   'link-string',
   'styled-jsx',
+  'handle-duplicate-props'
 ]
 
 for (const fixture of fixtures) {

--- a/packages/next-codemod/transforms/new-link.ts
+++ b/packages/next-codemod/transforms/new-link.ts
@@ -86,13 +86,24 @@ export default function transformer(file: FileInfo, api: API) {
         const hasProps = props.length > 0
 
         if (hasProps) {
-          // Add props to <Link>
-          $link.get('attributes').value.push(...props)
+          // Add only unique props to <Link> (skip duplicate props)
+          const linkPropNames = $link
+            .get('attributes')
+            .value.map((linkProp) => linkProp?.name?.name)
+          const uniqueProps = []
+
+          props.forEach((anchorProp) => {
+            if (!linkPropNames.includes(anchorProp?.name?.name)) {
+              uniqueProps.push(anchorProp)
+            }
+          })
+
+          $link.get('attributes').value.push(...uniqueProps)
+
           // Remove props from <a>
           props.length = 0
         }
 
-        //
         const childrenProps = $childrenWithA.get('children')
         $childrenWithA.replaceWith(childrenProps.value)
       })


### PR DESCRIPTION
Fixes issue #41925 by skipping duplicate props. I've tested the changes locally - the duplicate prop is being skipped successfully. The new-link.test.js suite is also passing.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
