### PR TITLE
Prevent scripts from being injected into header

### DIFF
--- a/packages/next/server/node-web-streams-helper.ts
+++ b/packages/next/server/node-web-streams-helper.ts
@@ -157,7 +157,7 @@ export function createHeadInjectionTransformStream(
     async transform(chunk, controller) {
       const content = decodeText(chunk)
       let index
-      if (!injected && (index = content.indexOf('</head')) !== -1) {
+      if (!injected && (index = content.indexOf('</head>')) !== -1) {
         injected = true
         const injectedContent =
           content.slice(0, index) + (await inject()) + content.slice(index)


### PR DESCRIPTION
I noticed script tags were being injected into the header element when the head element was not included in the layout, causing a hydration error, this fixes #41953 

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
