### PR TITLE
Ensure app revalidate has correct default

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -2208,6 +2208,15 @@ export default async function build(
                     ? appConfig.revalidate
                     : false
               }
+
+              // ensure revalidate is normalized correctly
+              if (
+                typeof revalidate !== 'number' &&
+                typeof revalidate !== 'boolean'
+              ) {
+                revalidate = false
+              }
+
               if (revalidate !== 0) {
                 const normalizedRoute = normalizePagePath(route)
                 const dataRoute = path.posix.join(`${normalizedRoute}.rsc`)

--- a/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/blog/[author]/[slug]/page.js
@@ -1,5 +1,7 @@
 import { notFound } from 'next/navigation'
 
+export const revalidate = null
+
 export const dynamicParams = true
 
 export default function Page({ params }) {


### PR DESCRIPTION
Ensures if an invalidate revalidate value is used we correctly override with our default. 

x-ref: [slack thread](https://vercel.slack.com/archives/C048Q9QSNDA)

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
