### PR TITLE
Correcting documentation

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -167,9 +167,9 @@ export function middleware(request: NextRequest) {
   const allCookies = request.cookies.getAll()
   console.log(allCookies) // => [{ name: 'vercel', value: 'fast' }]
 
-  response.cookies.has('nextjs') // => true
-  response.cookies.delete('nextjs')
-  response.cookies.has('nextjs') // => false
+  request.cookies.has('nextjs') // => true
+  request.cookies.delete('nextjs')
+  request.cookies.has('nextjs') // => false
 
   // Setting cookies on the response using the `ResponseCookies` API
   const response = NextResponse.next()


### PR DESCRIPTION
`response` hasn't been defined in the documentation at the point that a cookie check is being made. The update makes the check against the `request` object instead.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [] Make sure the linting passes by running `pnpm build && pnpm lint`
- [] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
