### PR TITLE
Fix `Error: Invalid with <a> child.`.

### DIFF
--- a/examples/blog-starter/components/cover-image.tsx
+++ b/examples/blog-starter/components/cover-image.tsx
@@ -20,8 +20,8 @@ const CoverImage = ({ title, src, slug }: Props) => {
   return (
     <div className="sm:mx-0">
       {slug ? (
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
-          <a aria-label={title}>{image}</a>
+        <Link aria-label={title} as={`/posts/${slug}`} href="/posts/[slug]">
+          {image}
         </Link>
       ) : (
         image

--- a/examples/blog-starter/components/header.tsx
+++ b/examples/blog-starter/components/header.tsx
@@ -3,8 +3,8 @@ import Link from 'next/link'
 const Header = () => {
   return (
     <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
-      <Link href="/">
-        <a className="hover:underline">Blog</a>
+      <Link className="hover:underline" href="/">
+        Blog
       </Link>
       .
     </h2>

--- a/examples/blog-starter/components/hero-post.tsx
+++ b/examples/blog-starter/components/hero-post.tsx
@@ -29,8 +29,8 @@ const HeroPost = ({
       <div className="md:grid md:grid-cols-2 md:gap-x-16 lg:gap-x-8 mb-20 md:mb-28">
         <div>
           <h3 className="mb-4 text-4xl lg:text-5xl leading-tight">
-            <Link as={`/posts/${slug}`} href="/posts/[slug]">
-              <a className="hover:underline">{title}</a>
+            <Link as={`/posts/${slug}`} className="hover:underline" href="/posts/[slug]">
+              {title}
             </Link>
           </h3>
           <div className="mb-4 md:mb-0 text-lg">

--- a/examples/blog-starter/components/post-preview.tsx
+++ b/examples/blog-starter/components/post-preview.tsx
@@ -27,8 +27,8 @@ const PostPreview = ({
         <CoverImage slug={slug} title={title} src={coverImage} />
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
-        <Link as={`/posts/${slug}`} href="/posts/[slug]">
-          <a className="hover:underline">{title}</a>
+        <Link as={`/posts/${slug}`} className="hover:underline" href="/posts/[slug]">
+          {title}
         </Link>
       </h3>
       <div className="text-lg mb-4">


### PR DESCRIPTION
Thanks for the great example! I tried to build the example app and failed.
I'd appreciate if you check this PR.

Step to reproduce:
1. Run `yarn create next-app --example blog-starter blog`
2. Run `cd blog; yarn dev`
3. The error occurs and says `Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>.`

This error comes from a change of next/link in Next.js 13. ref: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor

I fix it as the document says, and I confirm the blog is up.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
