### PR TITLE
Ensure we detect config correctly with turbo flag

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -340,6 +340,7 @@ export default async function build(
             (!!appDir && path.relative(dir, appDir).startsWith('src')),
           hasNowJson: !!(await findUp('now.json', { cwd: dir })),
           isCustomServer: null,
+          turboFlag: false,
         })
       )
 

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -160,7 +160,7 @@ const nextDev: cliCommand = (argv) => {
           configKey === 'transpilePackages' ||
           configKey === 'reactStrictMode' ||
           configKey === 'swcMinify' ||
-          configKey == 'configFileName'
+          configKey === 'configFileName'
         ) {
           return false
         }

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -12,6 +12,8 @@ import { CONFIG_FILES } from '../shared/lib/constants'
 import path from 'path'
 import type { NextConfig } from '../types'
 import { interopDefault } from '../lib/interop-default'
+import { Telemetry } from '../telemetry/storage'
+import { NextConfigComplete } from '../server/config-shared'
 
 const nextDev: cliCommand = (argv) => {
   const validArgs: arg.Spec = {
@@ -121,6 +123,10 @@ const nextDev: cliCommand = (argv) => {
         require('../shared/lib/constants') as typeof import('../shared/lib/constants')
       const chalk =
         require('next/dist/compiled/chalk') as typeof import('next/dist/compiled/chalk')
+      const { eventCliSession } =
+        require('../telemetry/events/version') as typeof import('../telemetry/events/version')
+      const { findPagesDir } =
+        require('../lib/find-pages-dir') as typeof import('../lib/find-pages-dir')
 
       // To regenerate the TURBOPACK gradient require('gradient-string')('blue', 'red')('>>> TURBOPACK')
       const isTTY = process.stdout.isTTY
@@ -153,7 +159,8 @@ const nextDev: cliCommand = (argv) => {
           configKey === 'appDir' ||
           configKey === 'transpilePackages' ||
           configKey === 'reactStrictMode' ||
-          configKey === 'swcMinify'
+          configKey === 'swcMinify' ||
+          configKey == 'configFileName'
         ) {
           return false
         }
@@ -163,7 +170,7 @@ const nextDev: cliCommand = (argv) => {
         if (typeof defaultValue !== 'object') {
           return defaultValue !== userValue
         }
-        return Object.keys(userValue).some((key: string) => {
+        return Object.keys(userValue || {}).some((key: string) => {
           return checkUnsupportedCustomConfig(key, userValue, defaultValue)
         })
       }
@@ -277,10 +284,29 @@ If you cannot make the changes above, but still want to try out\nNext.js v13 wit
       console.log(feedbackMessage)
 
       return loadBindings()
-        .then((bindings: any) => {
-          // eslint-disable-next-line no-shadow
-          const findUp =
-            require('next/dist/compiled/find-up') as typeof import('next/dist/compiled/find-up')
+        .then(async (bindings: any) => {
+          const distDir = path.join(dir, rawNextConfig.distDir || '.next')
+          const { pagesDir, appDir } = findPagesDir(
+            dir,
+            !!rawNextConfig.experimental?.appDir
+          )
+          const telemetry = new Telemetry({
+            distDir,
+          })
+
+          telemetry.record(
+            eventCliSession(distDir, rawNextConfig as NextConfigComplete, {
+              webpackVersion: 5,
+              cliCommand: 'dev',
+              isSrcDir:
+                (!!pagesDir &&
+                  path.relative(dir, pagesDir).startsWith('src')) ||
+                (!!appDir && path.relative(dir, appDir).startsWith('src')),
+              hasNowJson: !!(await findUp('now.json', { cwd: dir })),
+              isCustomServer: false,
+              turboFlag: true,
+            })
+          )
           const turboJson = findUp.sync('turbo.json', { cwd: dir })
           // eslint-disable-next-line no-shadow
           const packagePath = findUp.sync('package.json', { cwd: dir })
@@ -300,6 +326,8 @@ If you cannot make the changes above, but still want to try out\nNext.js v13 wit
           })
           // Start preflight after server is listening and ignore errors:
           preflight().catch(() => {})
+
+          await telemetry.flush()
           return server
         })
         .then(

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -182,6 +182,7 @@ export default async function exportApp(
           isSrcDir: null,
           hasNowJson: !!(await findUp('now.json', { cwd: dir })),
           isCustomServer: null,
+          turboFlag: false,
         })
       )
     }

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -728,6 +728,7 @@ export default class DevServer extends Server {
           (!!this.appDir && relative(this.dir, this.appDir).startsWith('src')),
         hasNowJson: !!(await findUp('now.json', { cwd: this.dir })),
         isCustomServer: this.isCustomServer,
+        turboFlag: false,
       })
     )
     // This is required by the tracing subsystem.

--- a/packages/next/telemetry/events/version.ts
+++ b/packages/next/telemetry/events/version.ts
@@ -29,6 +29,7 @@ type EventCliSessionStarted = {
   trailingSlashEnabled: boolean
   reactStrictMode: boolean
   webpackVersion: number | null
+  turboFlag: boolean
 }
 
 function hasBabelConfig(dir: string): boolean {
@@ -111,6 +112,7 @@ export function eventCliSession(
     trailingSlashEnabled: !!nextConfig?.trailingSlash,
     reactStrictMode: !!nextConfig?.reactStrictMode,
     webpackVersion: event.webpackVersion || null,
+    turboFlag: event.turboFlag || false,
   }
   return [{ eventName: EVENT_VERSION, payload }]
 }

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -368,6 +368,32 @@ describe('Telemetry CLI', () => {
     expect(stderr).toMatch(/isSrcDir.*?true/)
   })
 
+  it('detects --turbo correctly for `next dev`', async () => {
+    let port = await findPort()
+    let stderr = ''
+
+    const handleStderr = (msg) => {
+      stderr += msg
+    }
+    let app = await launchApp(appDir, port, {
+      onStderr: handleStderr,
+      env: {
+        NEXT_TELEMETRY_DEBUG: 1,
+      },
+      turbo: true,
+    })
+    await waitFor(1000)
+
+    if (app) {
+      await killApp(app)
+    }
+    const event1 = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+      .exec(stderr)
+      .pop()
+
+    expect(event1).toMatch(/"turboFlag": true/)
+  })
+
   it('detect reportWebVitals correctly for `next build`', async () => {
     // Case 1: When _app.js does not exist.
     let build = await nextBuild(appDir, [], {
@@ -484,6 +510,7 @@ describe('Telemetry CLI', () => {
     expect(event1).toMatch(/"imageFormats": "image\/avif,image\/webp"/)
     expect(event1).toMatch(/"trailingSlashEnabled": false/)
     expect(event1).toMatch(/"reactStrictMode": false/)
+    expect(event1).toMatch(/"turboFlag": false/)
 
     await fs.rename(
       path.join(appDir, 'next.config.i18n-images'),


### PR DESCRIPTION
Ensures we handle the `configFileName` field properly from `next.config.js`.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
