### PR TITLE
Fix next/link codemod errors in with-turbopack

### DIFF
--- a/examples/with-turbopack/app/GlobalNav.tsx
+++ b/examples/with-turbopack/app/GlobalNav.tsx
@@ -36,7 +36,6 @@ export default function GlobalNav() {
                         'block rounded-md px-3 py-2 text-sm font-medium hover:bg-zinc-800 hover:text-zinc-100',
                         { 'text-zinc-400': !isActive, 'text-white': isActive },
                       )}
-                      legacyBehavior
                     >
                       {item.name}
                     </Link>

--- a/examples/with-turbopack/app/page.tsx
+++ b/examples/with-turbopack/app/page.tsx
@@ -25,7 +25,6 @@ export default function Page() {
                           href={`/${item.slug}`}
                           key={item.name}
                           className="block space-y-1.5 rounded-lg border border-white/10 px-4 py-3 hover:border-white/20"
-                          legacyBehavior
                         >
                           <div>{item.name}</div>
 

--- a/examples/with-turbopack/ui/SectionLink.tsx
+++ b/examples/with-turbopack/ui/SectionLink.tsx
@@ -9,7 +9,7 @@ export const SectionLink = ({
   href: string;
   text: string;
 }) => (
-  <Link href={href} className="group block space-y-2" legacyBehavior>
+  <Link href={href} className="group block space-y-2">
     <div className="-m-[5px] rounded-[20px] border border-zinc-900 p-1 transition group-hover:border-blue-600">
       {children}
     </div>

--- a/examples/with-turbopack/ui/TabNavItem.tsx
+++ b/examples/with-turbopack/ui/TabNavItem.tsx
@@ -18,7 +18,6 @@ export const TabNavItem = ({
           !isActive,
         'bg-vercel-blue text-white': isActive,
       })}
-      legacyBehavior
     >
       {children}
     </Link>


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/pull/41913

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
