### PR TITLE
Default font config fix

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -90,8 +90,6 @@ export function setHttpClientAndAgentOptions(config: NextConfig) {
 }
 
 async function setFontLoaderDefaults(config: NextConfigComplete, dir: string) {
-  if (config.experimental?.fontLoaders) return
-
   // Add @next/font loaders by default if they're installed
   const hasNextFontDependency = (
     await getDependencies({
@@ -114,14 +112,14 @@ async function setFontLoaderDefaults(config: NextConfigComplete, dir: string) {
     }
     if (
       !config.experimental.fontLoaders.find(
-        ({ loader }: any) => loader === '@next/font/goggle'
+        ({ loader }: any) => loader === googleFontLoader.loader
       )
     ) {
       config.experimental.fontLoaders.push(googleFontLoader)
     }
     if (
       !config.experimental.fontLoaders.find(
-        ({ loader }: any) => loader === '@next/font/local'
+        ({ loader }: any) => loader === localFontLoader.loader
       )
     ) {
       config.experimental.fontLoaders.push(localFontLoader)

--- a/test/e2e/app-dir/next-font/next.config.js
+++ b/test/e2e/app-dir/next-font/next.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   experimental: {
     appDir: true,
+    fontLoaders: [],
   },
 }

--- a/test/e2e/next-font/basepath/next.config.js
+++ b/test/e2e/next-font/basepath/next.config.js
@@ -3,8 +3,7 @@ module.exports = {
   experimental: {
     fontLoaders: [
       {
-        loader: '@next/font/google',
-        options: { subsets: ['latin'] },
+        loader: '@next/font/local',
       },
     ],
   },

--- a/test/e2e/next-font/basepath/pages/index.js
+++ b/test/e2e/next-font/basepath/pages/index.js
@@ -1,5 +1,5 @@
 import { Open_Sans } from '@next/font/google'
-const openSans = Open_Sans()
+const openSans = Open_Sans({ subsets: ['latin'] })
 
 export default function Inter() {
   return <p className={openSans.className}>Hello world</p>

--- a/test/e2e/next-font/with-font-declarations-file/next.config.js
+++ b/test/e2e/next-font/with-font-declarations-file/next.config.js
@@ -5,9 +5,6 @@ module.exports = {
         loader: '@next/font/google',
         options: { subsets: ['latin'] },
       },
-      {
-        loader: '@next/font/local',
-      },
     ],
   },
 }


### PR DESCRIPTION
Fixes typo and makes sure both loaders always have a default value.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
