### PR TITLE
Update failing e2e middleware response test

### DIFF
--- a/test/e2e/middleware-responses/test/index.test.ts
+++ b/test/e2e/middleware-responses/test/index.test.ts
@@ -33,9 +33,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/stream-a-response`)
       expect(res.status).toBe(500)
 
-      if ((global as any).isNextDeploy) {
-        expect(await res.text()).toContain('EDGE_FUNCTION_INVOCATION_FAILED')
-      } else {
+      if (!(global as any).isNextDeploy) {
         expect(await res.text()).toEqual('Internal Server Error')
         expect(next.cliOutput).toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`
@@ -47,9 +45,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/send-response`)
       expect(res.status).toBe(500)
 
-      if ((global as any).isNextDeploy) {
-        expect(await res.text()).toContain('EDGE_FUNCTION_INVOCATION_FAILED')
-      } else {
+      if (!(global as any).isNextDeploy) {
         expect(await res.text()).toEqual('Internal Server Error')
         expect(next.cliOutput).toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/actions/runs/3362784779/jobs/5576284398

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
