### PR TITLE
fix: honor `type: "module"` for `app` dir entries

### DIFF
--- a/packages/next/build/entries.ts
+++ b/packages/next/build/entries.ts
@@ -10,6 +10,7 @@ import type {
 import type { LoadedEnvFiles } from '@next/env'
 import chalk from 'next/dist/compiled/chalk'
 import { posix, join } from 'path'
+import { readFile } from 'fs/promises'
 import { stringify } from 'querystring'
 import {
   API_ROUTE,
@@ -220,6 +221,7 @@ export function getAppEntry(opts: {
   isDev?: boolean
   rootDir?: string
   tsconfigPath?: string
+  moduleType: boolean
 }) {
   return {
     import: `next-app-loader?${stringify(opts)}!`,
@@ -386,6 +388,9 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
         ]
       }
 
+      const moduleType =
+        JSON.parse(await readFile(await join(rootDir, 'package.json'), 'utf8'))
+          .type === 'module'
       await runDependingOnPageType({
         page,
         pageRuntime: staticInfo.runtime,
@@ -410,6 +415,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
               appDir,
               appPaths: matchedAppPaths,
               pageExtensions,
+              moduleType,
             })
           } else {
             server[serverBundlePath] = [mappings[page]]
@@ -426,6 +432,7 @@ export async function createEntrypoints(params: CreateEntrypointsParams) {
               appDir: appDir!,
               appPaths: matchedAppPaths,
               pageExtensions,
+              moduleType,
             }).import
           }
 

--- a/packages/next/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/build/webpack/loaders/next-app-loader.ts
@@ -42,6 +42,7 @@ async function createTreeCodeFromPath({
   const splittedPath = pagePath.split(/[\\/]/)
   const appDirPrefix = splittedPath[0]
   const pages: string[] = []
+
   let rootLayout: string | undefined
   async function createSubtreePropsFromSegmentPath(
     segments: string[]

--- a/packages/next/server/dev/hot-reloader.ts
+++ b/packages/next/server/dev/hot-reloader.ts
@@ -553,6 +553,11 @@ export default class HotReloader {
     }
     this.activeConfigs = await this.getWebpackConfig(startSpan)
 
+    const moduleType =
+      JSON.parse(
+        await fs.readFile(await join(this.dir, 'package.json'), 'utf8')
+      ).type === 'module'
+
     for (const config of this.activeConfigs) {
       const defaultEntry = config.entry
       config.entry = async (...args) => {
@@ -624,6 +629,7 @@ export default class HotReloader {
                       rootDir: this.dir,
                       isDev: true,
                       tsconfigPath: this.config.typescript.tsconfigPath,
+                      moduleType,
                     }).import
                   : undefined
 
@@ -705,6 +711,7 @@ export default class HotReloader {
                         rootDir: this.dir,
                         isDev: true,
                         tsconfigPath: this.config.typescript.tsconfigPath,
+                        moduleType,
                       })
                     : relativeRequest,
                   hasAppDir,

--- a/test/e2e/app-dir/module-type.test.ts
+++ b/test/e2e/app-dir/module-type.test.ts
@@ -1,0 +1,27 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { renderViaHTTP } from 'next-test-utils'
+import path from 'path'
+import cheerio from 'cheerio'
+
+describe('with babel', () => {
+  if ((global as any).isNextDeploy) {
+    it('should skip next deploy for now', () => {})
+    return
+  }
+
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: new FileRef(path.join(__dirname, 'module-type')),
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should support type:"module" in package.json in app dir', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    const $ = cheerio.load(html)
+    expect($('h1').text()).toBe('Hi')
+  })
+})

--- a/test/e2e/app-dir/module-type/app/layout.js
+++ b/test/e2e/app-dir/module-type/app/layout.js
@@ -1,0 +1,10 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <head>
+        <title>hello</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/module-type/app/package.json
+++ b/test/e2e/app-dir/module-type/app/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/e2e/app-dir/module-type/app/page.js
+++ b/test/e2e/app-dir/module-type/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hi</h1>
+}

--- a/test/e2e/app-dir/module-type/next.config.js
+++ b/test/e2e/app-dir/module-type/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+}


### PR DESCRIPTION
Fixes #41865

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
