### PR TITLE
fix: fix dev mode css files being processed by asset/resource

### DIFF
--- a/packages/next/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/build/webpack/config/blocks/css/index.ts
@@ -610,6 +610,7 @@ export const css = curry(async function css(
             issuer: regexLikeCss,
             // Exclude extensions that webpack handles by default
             exclude: [
+              /\.(css|sass|scss)$/,
               /\.(js|mjs|jsx|ts|tsx)$/,
               /\.html$/,
               /\.json$/,


### PR DESCRIPTION
## Bug
I found a bug in the development environment，As shown in the picture below, the content in the style tag is a url string，not css content.
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/23253540/199200650-85f5596d-66d8-45dd-8d4b-3c65071aaed6.png">

because styles/globals.css will be processed by stlye-loader first，At this point, the style-loader will require again
```js
// https://github.com/vercel/next.js/blob/canary/packages/next/build/webpack/loaders/next-style-loader/index.js#L259

var content = require(${stringifyRequest(this, `!!${request}`)});

//  var content = require('!!xxx/css-loader/src/index.js??xxx/postcss-loader/src/index.js??ruleSet[1].rules[3].oneOf[6].use[2]!./globals.css')
```
The issuer of require in style-loader is styles/globals.css， So it will be processed by asset/resource
```js
// https://github.com/vercel/next.js/blob/canary/packages/next/build/webpack/config/blocks/css/index.ts#L607

oneOf: [
          markRemovable({
            // This should only be applied to CSS files
            issuer: regexLikeCss,
            // Exclude extensions that webpack handles by default
            exclude: [
              /\.(js|mjs|jsx|ts|tsx)$/,
              /\.html$/,
              /\.json$/,
              /\.webpack\[[^\]]+\]$/,
            ],
            // `asset/resource` always emits a URL reference, where `asset`
            // might inline the asset as a data URI
            type: 'asset/resource',
          }),
        ],
```
I know more about [Webpack Rule.oneOf](https://webpack.js.org/configuration/module/#ruleoneof)  now.
!!xxx/css-loader/src/index.js??xxx/postcss-loader/src/index.js??ruleSet[1].rules[3].oneOf[6].use[2]!./globals.css will not pick any loader, but asset/resource can be merged in, not sure if it's intentional or not
![image](https://user-images.githubusercontent.com/23253540/199205113-5391d538-ec4d-47c4-abe1-b15658e86284.png)
