### PR TITLE
Add mongodb to default server externals

### DIFF
--- a/packages/next/lib/server-external-packages.ts
+++ b/packages/next/lib/server-external-packages.ts
@@ -18,4 +18,5 @@ export const EXTERNAL_PACKAGES = [
   'rimraf',
   'next-mdx-remote',
   'sqlite3',
+  'mongodb',
 ]


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/42294