### PR TITLE
Fix negative lookahead example in middleware.md

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -98,7 +98,7 @@ export const config = {
      * - static (static files)
      * - favicon.ico (favicon file)
      */
-    '/((?!api|static|favicon.ico).*)',
+    '/((?!api|_next/static|favicon.ico).*)',
   ],
 }
 ```

--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -95,7 +95,7 @@ export const config = {
     /*
      * Match all request paths except for the ones starting with:
      * - api (API routes)
-     * - static (static files)
+     * - _next/static (static files)
      * - favicon.ico (favicon file)
      */
     '/((?!api|_next/static|favicon.ico).*)',


### PR DESCRIPTION
If you don't prefix `static` with `_next`, none of the JS will be able to load.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
