### PR TITLE
[eslint-plugin] Stop warning for head element in app/layout on Windows

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-head-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-head-element.ts
@@ -18,9 +18,10 @@ export = defineRule({
       JSXOpeningElement(node) {
         const paths = context.getFilename()
 
-        const isInAppDir = paths.includes('app/') && !paths.includes('pages/')
+        const isInAppDir = () =>
+          paths.includes('app/') && !paths.includes('pages/')
         // Only lint the <head> element in pages directory
-        if (node.name.name !== 'head' || isInAppDir) {
+        if (node.name.name !== 'head' || isInAppDir()) {
           return
         }
 

--- a/packages/eslint-plugin-next/src/rules/no-head-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-head-element.ts
@@ -1,3 +1,4 @@
+import path = require('path')
 import { defineRule } from '../utils/define-rule'
 
 const url = 'https://nextjs.org/docs/messages/no-head-element'
@@ -19,7 +20,10 @@ export = defineRule({
         const paths = context.getFilename()
 
         const isInAppDir = () =>
-          paths.includes('app/') && !paths.includes('pages/')
+          (paths.includes(`app${path.sep}`) ||
+            paths.includes(`app${path.posix.sep}`)) &&
+          !paths.includes(`pages${path.sep}`) &&
+          !paths.includes(`pages${path.posix.sep}`)
         // Only lint the <head> element in pages directory
         if (node.name.name !== 'head' || isInAppDir()) {
           return


### PR DESCRIPTION
## Bug

![image](https://user-images.githubusercontent.com/13413409/199451248-051751e5-0a5b-4ee0-bcae-05d2933f0090.png)

When trying to use app directory on Windows, the automatically created `Layout.tsx` get's a lint problem for having a `<head>` element.

## Solution

Update the rule to check paths using `path.sep` rather than hardcoded `/`

I also checked with `path.posix.sep` because some other rules was doing that (both `path.sep` and `path.posix.sep`), so I'm just following pattern