### PR TITLE
Stop writing window specific paths in vscode configuration

### DIFF
--- a/packages/next/lib/typescript/writeVscodeConfigurations.ts
+++ b/packages/next/lib/typescript/writeVscodeConfigurations.ts
@@ -24,8 +24,7 @@ export async function writeVscodeConfigurations(
       }
     }
 
-    const libPath =
-      '.' + path.sep + path.join('node_modules', 'typescript', 'lib')
+    const libPath = './node_modules/typescript/lib'
     if (
       settings['typescript.tsdk'] === libPath &&
       settings['typescript.enablePromptUseWorkspaceTsdk']


### PR DESCRIPTION
Vscode `tsdk` configuration handles POSIX path even on Windows, so there's no reason to write window-specific path to the configuration. 

I've always had forward slash path in `tsdk` and work on windows and in WSL, and that works.

https://github.com/oBusk/npm-diff.app/blob/f71e4671430373c2af6a88c3c13f7c437334ab8d/.vscode/settings.json#L3

Current solution will give a diff for people who have ran previous versions on windows. We could update the check to allow windows if you want to.