### PR TITLE
Aggregate updates using `addStatusHandler` and `Promise.resolve` instead of `setTimeout`

### DIFF
--- a/packages/next/client/components/react-dev-overlay/internal/helpers/use-error-handler.ts
+++ b/packages/next/client/components/react-dev-overlay/internal/helpers/use-error-handler.ts
@@ -1,34 +1,105 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
+
+export type ErrorHandler = (error: Error) => void
+
+export const RuntimeErrorHandler = {
+  hadRuntimeError: false,
+}
+
+function isNextRouterError(error: any): boolean {
+  return (
+    error &&
+    error.digest &&
+    (error.digest.startsWith('NEXT_REDIRECT') ||
+      error.digest === 'NEXT_NOT_FOUND')
+  )
+}
+
+function isHydrationError(error: Error): boolean {
+  return (
+    error.message.match(/(hydration|content does not match|did not match)/i) !=
+    null
+  )
+}
+
+try {
+  Error.stackTraceLimit = 50
+} catch {}
+
+const errorQueue: Array<Error> = []
+const rejectionQueue: Array<Error> = []
+const errorHandlers: Array<ErrorHandler> = []
+const rejectionHandlers: Array<ErrorHandler> = []
+
+// These event handlers must be added outside of the hook because there is no
+// guarantee that the hook will be alive in a mounted component in time to
+// when the errors occur.
+window.addEventListener('error', (ev: WindowEventMap['error']): void => {
+  if (isNextRouterError(ev.error)) {
+    ev.preventDefault()
+    return
+  }
+
+  RuntimeErrorHandler.hadRuntimeError = true
+
+  const error = ev?.error
+  if (!error || !(error instanceof Error) || typeof error.stack !== 'string') {
+    // A non-error was thrown, we don't have anything to show. :-(
+    return
+  }
+
+  if (isHydrationError(error)) {
+    error.message += `\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error`
+  }
+
+  const e = error
+  errorQueue.push(e)
+  for (const handler of errorHandlers) {
+    handler(e)
+  }
+})
+window.addEventListener(
+  'unhandledrejection',
+  (ev: WindowEventMap['unhandledrejection']): void => {
+    RuntimeErrorHandler.hadRuntimeError = true
+
+    const reason = ev?.reason
+    if (
+      !reason ||
+      !(reason instanceof Error) ||
+      typeof reason.stack !== 'string'
+    ) {
+      // A non-error was thrown, we don't have anything to show. :-(
+      return
+    }
+
+    const e = reason
+    rejectionQueue.push(e)
+    for (const handler of rejectionHandlers) {
+      handler(e)
+    }
+  }
+)
 
 export function useErrorHandler(
-  handleOnUnhandledError: (event: WindowEventMap['error']) => void,
-  handleOnUnhandledRejection: (
-    event: WindowEventMap['unhandledrejection']
-  ) => void
+  handleOnUnhandledError: ErrorHandler,
+  handleOnUnhandledRejection: ErrorHandler
 ) {
-  const stacktraceLimitRef = useRef<undefined | number>()
-
   useEffect(() => {
-    try {
-      const limit = Error.stackTraceLimit
-      Error.stackTraceLimit = 50
-      stacktraceLimitRef.current = limit
-    } catch {}
+    // Handle queued errors.
+    errorQueue.forEach(handleOnUnhandledError)
+    rejectionQueue.forEach(handleOnUnhandledRejection)
 
-    window.addEventListener('error', handleOnUnhandledError)
-    window.addEventListener('unhandledrejection', handleOnUnhandledRejection)
+    // Listen to new errors.
+    errorHandlers.push(handleOnUnhandledError)
+    rejectionHandlers.push(handleOnUnhandledRejection)
+
     return () => {
-      if (stacktraceLimitRef.current !== undefined) {
-        try {
-          Error.stackTraceLimit = stacktraceLimitRef.current
-        } catch {}
-        stacktraceLimitRef.current = undefined
-      }
-
-      window.removeEventListener('error', handleOnUnhandledError)
-      window.removeEventListener(
-        'unhandledrejection',
-        handleOnUnhandledRejection
+      // Remove listeners.
+      errorHandlers.splice(errorHandlers.indexOf(handleOnUnhandledError), 1)
+      rejectionHandlers.splice(
+        rejectionHandlers.indexOf(handleOnUnhandledRejection),
+        1
       )
     }
   }, [handleOnUnhandledError, handleOnUnhandledRejection])

--- a/packages/next/client/components/react-dev-overlay/internal/helpers/use-error-handler.ts
+++ b/packages/next/client/components/react-dev-overlay/internal/helpers/use-error-handler.ts
@@ -31,55 +31,61 @@ const rejectionQueue: Array<Error> = []
 const errorHandlers: Array<ErrorHandler> = []
 const rejectionHandlers: Array<ErrorHandler> = []
 
-// These event handlers must be added outside of the hook because there is no
-// guarantee that the hook will be alive in a mounted component in time to
-// when the errors occur.
-window.addEventListener('error', (ev: WindowEventMap['error']): void => {
-  if (isNextRouterError(ev.error)) {
-    ev.preventDefault()
-    return
-  }
+if (typeof window !== 'undefined') {
+  // These event handlers must be added outside of the hook because there is no
+  // guarantee that the hook will be alive in a mounted component in time to
+  // when the errors occur.
+  window.addEventListener('error', (ev: WindowEventMap['error']): void => {
+    if (isNextRouterError(ev.error)) {
+      ev.preventDefault()
+      return
+    }
 
-  RuntimeErrorHandler.hadRuntimeError = true
-
-  const error = ev?.error
-  if (!error || !(error instanceof Error) || typeof error.stack !== 'string') {
-    // A non-error was thrown, we don't have anything to show. :-(
-    return
-  }
-
-  if (isHydrationError(error)) {
-    error.message += `\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error`
-  }
-
-  const e = error
-  errorQueue.push(e)
-  for (const handler of errorHandlers) {
-    handler(e)
-  }
-})
-window.addEventListener(
-  'unhandledrejection',
-  (ev: WindowEventMap['unhandledrejection']): void => {
     RuntimeErrorHandler.hadRuntimeError = true
 
-    const reason = ev?.reason
+    const error = ev?.error
     if (
-      !reason ||
-      !(reason instanceof Error) ||
-      typeof reason.stack !== 'string'
+      !error ||
+      !(error instanceof Error) ||
+      typeof error.stack !== 'string'
     ) {
       // A non-error was thrown, we don't have anything to show. :-(
       return
     }
 
-    const e = reason
-    rejectionQueue.push(e)
-    for (const handler of rejectionHandlers) {
+    if (isHydrationError(error)) {
+      error.message += `\n\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error`
+    }
+
+    const e = error
+    errorQueue.push(e)
+    for (const handler of errorHandlers) {
       handler(e)
     }
-  }
-)
+  })
+  window.addEventListener(
+    'unhandledrejection',
+    (ev: WindowEventMap['unhandledrejection']): void => {
+      RuntimeErrorHandler.hadRuntimeError = true
+
+      const reason = ev?.reason
+      if (
+        !reason ||
+        !(reason instanceof Error) ||
+        typeof reason.stack !== 'string'
+      ) {
+        // A non-error was thrown, we don't have anything to show. :-(
+        return
+      }
+
+      const e = reason
+      rejectionQueue.push(e)
+      for (const handler of rejectionHandlers) {
+        handler(e)
+      }
+    }
+  )
+}
 
 export function useErrorHandler(
   handleOnUnhandledError: ErrorHandler,

--- a/packages/next/client/dev/error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev/error-overlay/hot-dev-client.js
@@ -30,6 +30,7 @@ import {
   register,
   onBuildError,
   onBuildOk,
+  onBeforeRefresh,
   onRefresh,
 } from 'next/dist/compiled/@next/react-dev-overlay/dist/client'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
@@ -98,11 +99,7 @@ function handleSuccess() {
 
   // Attempt to apply hot updates or reload.
   if (isHotUpdate) {
-    tryApplyUpdates(function onSuccessfulHotUpdate(hasUpdates) {
-      // Only dismiss it when we're sure it's a hot update.
-      // Otherwise it would flicker right before the reload.
-      onFastRefresh(hasUpdates)
-    })
+    tryApplyUpdates(onBeforeFastRefresh, onFastRefresh)
   }
 }
 
@@ -139,11 +136,7 @@ function handleWarnings(warnings) {
 
   // Attempt to apply hot updates or reload.
   if (isHotUpdate) {
-    tryApplyUpdates(function onSuccessfulHotUpdate(hasUpdates) {
-      // Only dismiss it when we're sure it's a hot update.
-      // Otherwise it would flicker right before the reload.
-      onFastRefresh(hasUpdates)
-    })
+    tryApplyUpdates(onBeforeFastRefresh, onFastRefresh)
   }
 }
 
@@ -182,9 +175,19 @@ function handleErrors(errors) {
 
 let startLatency = undefined
 
+function onBeforeFastRefresh(hasUpdates) {
+  if (hasUpdates) {
+    // Only trigger a pending state if we have updates to apply
+    // (cf. onFastRefresh)
+    onBeforeRefresh()
+  }
+}
+
 function onFastRefresh(hasUpdates) {
   onBuildOk()
   if (hasUpdates) {
+    // Only complete a pending state if we applied updates
+    // (cf. onBeforeFastRefresh)
     onRefresh()
   }
 
@@ -301,7 +304,7 @@ function afterApplyUpdates(fn) {
 }
 
 // Attempt to update code on the fly, fall back to a hard reload.
-function tryApplyUpdates(onHotUpdateSuccess) {
+function tryApplyUpdates(onBeforeHotUpdate, onHotUpdateSuccess) {
   if (!module.hot) {
     // HotModuleReplacementPlugin is not in Webpack configuration.
     console.error('HotModuleReplacementPlugin is not in Webpack configuration.')
@@ -342,7 +345,10 @@ function tryApplyUpdates(onHotUpdateSuccess) {
 
     if (isUpdateAvailable()) {
       // While we were updating, there was a new update! Do it again.
-      tryApplyUpdates(hasUpdates ? onBuildOk : onHotUpdateSuccess)
+      tryApplyUpdates(
+        onBeforeHotUpdate,
+        hasUpdates ? onBuildOk : onHotUpdateSuccess
+      )
     } else {
       onBuildOk()
       if (process.env.__NEXT_TEST_MODE) {
@@ -357,14 +363,21 @@ function tryApplyUpdates(onHotUpdateSuccess) {
   }
 
   // https://webpack.js.org/api/hot-module-replacement/#check
-  module.hot.check(/* autoApply */ true).then(
-    (updatedModules) => {
-      handleApplyUpdates(null, updatedModules)
-    },
-    (err) => {
-      handleApplyUpdates(err, null)
-    }
-  )
+  module.hot
+    .check(/* autoApply */ false)
+    .then((updatedModules) => {
+      const hasUpdates = Boolean(updatedModules.length)
+      onBeforeHotUpdate(hasUpdates)
+      return module.hot.apply()
+    })
+    .then(
+      (updatedModules) => {
+        handleApplyUpdates(null, updatedModules)
+      },
+      (err) => {
+        handleApplyUpdates(err, null)
+      }
+    )
 }
 
 function performFullReload(err) {

--- a/packages/next/client/dev/error-overlay/hot-dev-client.js
+++ b/packages/next/client/dev/error-overlay/hot-dev-client.js
@@ -345,8 +345,9 @@ function tryApplyUpdates(onBeforeHotUpdate, onHotUpdateSuccess) {
 
     if (isUpdateAvailable()) {
       // While we were updating, there was a new update! Do it again.
+      // However, this time, don't trigger a pending refresh state.
       tryApplyUpdates(
-        onBeforeHotUpdate,
+        hasUpdates ? undefined : onBeforeHotUpdate,
         hasUpdates ? onBuildOk : onHotUpdateSuccess
       )
     } else {
@@ -366,8 +367,10 @@ function tryApplyUpdates(onBeforeHotUpdate, onHotUpdateSuccess) {
   module.hot
     .check(/* autoApply */ false)
     .then((updatedModules) => {
-      const hasUpdates = Boolean(updatedModules.length)
-      onBeforeHotUpdate(hasUpdates)
+      if (typeof onBeforeHotUpdate === 'function') {
+        const hasUpdates = Boolean(updatedModules.length)
+        onBeforeHotUpdate(hasUpdates)
+      }
       return module.hot.apply()
     })
     .then(

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -301,16 +301,15 @@ function renderApp(App: AppComponent, appProps: AppProps) {
 function AppContainer({
   children,
 }: React.PropsWithChildren<{}>): React.ReactElement {
-  console.log('hello world 1')
   return (
     <Container
-      fn={(error) => {
+      fn={(error) =>
         // TODO: Fix disabled eslint rule
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         renderError({ App: CachedApp, err: error }).catch((err) =>
           console.error('Error rendering page: ', err)
         )
-      }}
+      }
     >
       <AppRouterContext.Provider value={adaptForAppRouterInstance(router)}>
         <SearchParamsContext.Provider value={adaptForSearchParams(router)}>

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -301,15 +301,16 @@ function renderApp(App: AppComponent, appProps: AppProps) {
 function AppContainer({
   children,
 }: React.PropsWithChildren<{}>): React.ReactElement {
+  console.log('hello world 1')
   return (
     <Container
-      fn={(error) =>
+      fn={(error) => {
         // TODO: Fix disabled eslint rule
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         renderError({ App: CachedApp, err: error }).catch((err) =>
           console.error('Error rendering page: ', err)
         )
-      }
+      }}
     >
       <AppRouterContext.Provider value={adaptForAppRouterInstance(router)}>
         <SearchParamsContext.Provider value={adaptForSearchParams(router)}>

--- a/packages/react-dev-overlay/src/client.ts
+++ b/packages/react-dev-overlay/src/client.ts
@@ -89,7 +89,18 @@ function onRefresh() {
   Bus.emit({ type: Bus.TYPE_REFRESH })
 }
 
+function onBeforeRefresh() {
+  Bus.emit({ type: Bus.TYPE_BEFORE_REFRESH })
+}
+
 export { getErrorByType } from './internal/helpers/getErrorByType'
 export { getServerError } from './internal/helpers/nodeStackFrames'
 export { default as ReactDevOverlay } from './internal/ReactDevOverlay'
-export { onBuildOk, onBuildError, register, unregister, onRefresh }
+export {
+  onBuildOk,
+  onBuildError,
+  register,
+  unregister,
+  onBeforeRefresh,
+  onRefresh,
+}

--- a/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
+++ b/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
@@ -28,6 +28,19 @@ type OverlayState = {
   refreshState: RefreshState
 }
 
+function pushErrorFilterDuplicates(
+  errors: SupportedErrorEvent[],
+  err: SupportedErrorEvent
+): SupportedErrorEvent[] {
+  return [
+    ...errors.filter((e) => {
+      // Filter out duplicate errors
+      return e.event.reason !== err.event.reason
+    }),
+    err,
+  ]
+}
+
 function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
   switch (ev.type) {
     case Bus.TYPE_BUILD_OK: {
@@ -82,6 +95,10 @@ function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
             },
           }
         }
+        default:
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const _: never = state.refreshState
+          return state
       }
     }
     default: {
@@ -90,19 +107,6 @@ function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
       return state
     }
   }
-}
-
-function pushErrorFilterDuplicates(
-  errors: SupportedErrorEvent[],
-  err: SupportedErrorEvent
-): SupportedErrorEvent[] {
-  return [
-    ...errors.filter((e) => {
-      // Filter out duplicate errors
-      return e.event.reason !== err.event.reason
-    }),
-    err,
-  ]
 }
 
 type ErrorType = 'runtime' | 'build'

--- a/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
+++ b/packages/react-dev-overlay/src/internal/ReactDevOverlay.tsx
@@ -9,10 +9,23 @@ import { Base } from './styles/Base'
 import { ComponentStyles } from './styles/ComponentStyles'
 import { CssReset } from './styles/CssReset'
 
+type RefreshState =
+  | {
+      // No refresh in progress.
+      type: 'idle'
+    }
+  | {
+      // The refresh process has been triggered, but the new code has not been
+      // executed yet.
+      type: 'pending'
+      errors: SupportedErrorEvent[]
+    }
+
 type OverlayState = {
   nextId: number
   buildError: string | null
   errors: SupportedErrorEvent[]
+  refreshState: RefreshState
 }
 
 function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
@@ -23,21 +36,52 @@ function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
     case Bus.TYPE_BUILD_ERROR: {
       return { ...state, buildError: ev.message }
     }
+    case Bus.TYPE_BEFORE_REFRESH: {
+      return { ...state, refreshState: { type: 'pending', errors: [] } }
+    }
     case Bus.TYPE_REFRESH: {
-      return { ...state, buildError: null, errors: [] }
+      return {
+        ...state,
+        buildError: null,
+        errors:
+          // Errors can come in during updates. In this case, UNHANDLED_ERROR
+          // and UNHANDLED_REJECTION events might be dispatched between the
+          // BEFORE_REFRESH and the REFRESH event. We want to keep those errors
+          // around until the next refresh. Otherwise we run into a race
+          // condition where those errors would be cleared on refresh completion
+          // before they can be displayed.
+          state.refreshState.type === 'pending'
+            ? state.refreshState.errors
+            : [],
+        refreshState: { type: 'idle' },
+      }
     }
     case Bus.TYPE_UNHANDLED_ERROR:
     case Bus.TYPE_UNHANDLED_REJECTION: {
-      return {
-        ...state,
-        nextId: state.nextId + 1,
-        errors: [
-          ...state.errors.filter((err) => {
-            // Filter out duplicate errors
-            return err.event.reason !== ev.reason
-          }),
-          { id: state.nextId, event: ev },
-        ],
+      switch (state.refreshState.type) {
+        case 'idle': {
+          return {
+            ...state,
+            nextId: state.nextId + 1,
+            errors: pushErrorFilterDuplicates(state.errors, {
+              id: state.nextId,
+              event: ev,
+            }),
+          }
+        }
+        case 'pending': {
+          return {
+            ...state,
+            nextId: state.nextId + 1,
+            refreshState: {
+              ...state.refreshState,
+              errors: pushErrorFilterDuplicates(state.refreshState.errors, {
+                id: state.nextId,
+                event: ev,
+              }),
+            },
+          }
+        }
       }
     }
     default: {
@@ -46,6 +90,19 @@ function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
       return state
     }
   }
+}
+
+function pushErrorFilterDuplicates(
+  errors: SupportedErrorEvent[],
+  err: SupportedErrorEvent
+): SupportedErrorEvent[] {
+  return [
+    ...errors.filter((e) => {
+      // Filter out duplicate errors
+      return e.event.reason !== err.event.reason
+    }),
+    err,
+  ]
 }
 
 type ErrorType = 'runtime' | 'build'
@@ -74,6 +131,9 @@ const ReactDevOverlay: React.FunctionComponent<ReactDevOverlayProps> =
       nextId: 1,
       buildError: null,
       errors: [],
+      refreshState: {
+        type: 'idle',
+      },
     })
 
     React.useEffect(() => {

--- a/packages/react-dev-overlay/src/internal/bus.ts
+++ b/packages/react-dev-overlay/src/internal/bus.ts
@@ -3,6 +3,7 @@ import { StackFrame } from 'stacktrace-parser'
 export const TYPE_BUILD_OK = 'build-ok'
 export const TYPE_BUILD_ERROR = 'build-error'
 export const TYPE_REFRESH = 'fast-refresh'
+export const TYPE_BEFORE_REFRESH = 'before-fast-refresh'
 export const TYPE_UNHANDLED_ERROR = 'unhandled-error'
 export const TYPE_UNHANDLED_REJECTION = 'unhandled-rejection'
 
@@ -11,6 +12,7 @@ export type BuildError = {
   type: typeof TYPE_BUILD_ERROR
   message: string
 }
+export type BeforeFastRefresh = { type: typeof TYPE_BEFORE_REFRESH }
 export type FastRefresh = { type: typeof TYPE_REFRESH }
 export type UnhandledError = {
   type: typeof TYPE_UNHANDLED_ERROR
@@ -26,6 +28,7 @@ export type BusEvent =
   | BuildOk
   | BuildError
   | FastRefresh
+  | BeforeFastRefresh
   | UnhandledError
   | UnhandledRejection
 


### PR DESCRIPTION
The current `setTimeout` logic adds a constant overhead of 30ms when applying updates, which slows down HMR. As @sokra suggested, we can use the `addStatusHandler` API to have the HMR runtime let us know when its status changes. This also switches to `Promise.resolve` for update aggregation.