### PR TITLE
Change logic around NON_STANDARD_NODE_ENV

### DIFF
--- a/packages/next/bin/next.ts
+++ b/packages/next/bin/next.ts
@@ -87,7 +87,7 @@ if (process.env.NODE_ENV) {
       ? ['dev']
       : []
 
-  if (isNotStandard || shouldWarnCommands.includes(command)) {
+  if (isNotStandard && shouldWarnCommands.includes(command)) {
     log.warn(NON_STANDARD_NODE_ENV)
   }
 }


### PR DESCRIPTION
Currently, the NON_STANDARD_NODE_ENV warning is printed on every "next build" or "next start" when NODE_ENV is set to anything, even a valid string like "development" or "production". It is not printed when NODE_ENV is falsey, which I believe is why this issue is not more widely reported.

Changing `||` to `&&` here I believe corrects the intention - warn the user when an invalid NODE_ENV is set during start or build.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
