### PR TITLE
Update dev process exit handling

### DIFF
--- a/packages/next/build/index.ts
+++ b/packages/next/build/index.ts
@@ -341,6 +341,8 @@ export default async function build(
           hasNowJson: !!(await findUp('now.json', { cwd: dir })),
           isCustomServer: null,
           turboFlag: false,
+          pagesDir: !!pagesDir,
+          appDir: !!appDir,
         })
       )
 

--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -36,6 +36,8 @@ const handleSessionStop = async () => {
       cliCommand: 'dev',
       turboFlag: isTurboSession,
       durationMilliseconds: Date.now() - sessionStarted,
+      pagesDir: !!traceGlobals.get('pagesDir'),
+      appDir: !!traceGlobals.get('appDir'),
     })
   )
   await telemetry.flush()
@@ -329,6 +331,8 @@ If you cannot make the changes above, but still want to try out\nNext.js v13 wit
           const telemetry = new Telemetry({
             distDir,
           })
+          setGlobal('appDir', appDir)
+          setGlobal('pagesDir', pagesDir)
           setGlobal('telemetry', telemetry)
 
           telemetry.record(
@@ -342,6 +346,8 @@ If you cannot make the changes above, but still want to try out\nNext.js v13 wit
               hasNowJson: !!(await findUp('now.json', { cwd: dir })),
               isCustomServer: false,
               turboFlag: true,
+              pagesDir: !!pagesDir,
+              appDir: !!appDir,
             })
           )
           const turboJson = findUp.sync('turbo.json', { cwd: dir })

--- a/packages/next/export/index.ts
+++ b/packages/next/export/index.ts
@@ -183,6 +183,8 @@ export default async function exportApp(
           hasNowJson: !!(await findUp('now.json', { cwd: dir })),
           isCustomServer: null,
           turboFlag: false,
+          pagesDir: null,
+          appDir: null,
         })
       )
     }

--- a/packages/next/server/dev/next-dev-server.ts
+++ b/packages/next/server/dev/next-dev-server.ts
@@ -729,9 +729,13 @@ export default class DevServer extends Server {
         hasNowJson: !!(await findUp('now.json', { cwd: this.dir })),
         isCustomServer: this.isCustomServer,
         turboFlag: false,
+        pagesDir: !!this.pagesDir,
+        appDir: !!this.appDir,
       })
     )
     // This is required by the tracing subsystem.
+    setGlobal('appDir', this.appDir)
+    setGlobal('pagesDir', this.pagesDir)
     setGlobal('telemetry', telemetry)
 
     process.on('unhandledRejection', (reason) => {

--- a/packages/next/telemetry/events/session-stopped.ts
+++ b/packages/next/telemetry/events/session-stopped.ts
@@ -6,6 +6,8 @@ export type EventCliSessionStopped = {
   nodeVersion: string
   turboFlag?: boolean | null
   durationMilliseconds?: number | null
+  pagesDir?: boolean
+  appDir?: boolean
 }
 
 export function eventCliSession(
@@ -26,6 +28,8 @@ export function eventCliSession(
           turboFlag: !!event.turboFlag,
         }
       : {}),
+    pagesDir: event.pagesDir,
+    appDir: event.appDir,
   }
   return [{ eventName: EVENT_VERSION, payload }]
 }

--- a/packages/next/telemetry/events/version.ts
+++ b/packages/next/telemetry/events/version.ts
@@ -30,6 +30,8 @@ type EventCliSessionStarted = {
   reactStrictMode: boolean
   webpackVersion: number | null
   turboFlag: boolean
+  appDir: boolean | null
+  pagesDir: boolean | null
 }
 
 function hasBabelConfig(dir: string): boolean {
@@ -113,6 +115,8 @@ export function eventCliSession(
     reactStrictMode: !!nextConfig?.reactStrictMode,
     webpackVersion: event.webpackVersion || null,
     turboFlag: event.turboFlag || false,
+    appDir: event.appDir,
+    pagesDir: event.pagesDir,
   }
   return [{ eventName: EVENT_VERSION, payload }]
 }


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/42255

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
