### PR TITLE
Change `usePathname` to return `string | null`

### DIFF
--- a/packages/next/client/components/navigation.ts
+++ b/packages/next/client/components/navigation.ts
@@ -76,7 +76,6 @@ export function useSearchParams() {
     throw new Error('invariant expected search params to be mounted')
   }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const readonlySearchParams = useMemo(() => {
     return new ReadonlyURLSearchParams(searchParams)
   }, [searchParams])
@@ -87,14 +86,9 @@ export function useSearchParams() {
 /**
  * Get the current pathname. For example usePathname() on /dashboard?foo=bar would return "/dashboard"
  */
-export function usePathname(): string {
+export function usePathname(): string | null {
   staticGenerationBailout('usePathname')
-  const pathname = useContext(PathnameContext)
-  if (pathname === null) {
-    throw new Error('invariant expected pathname to be mounted')
-  }
-
-  return pathname
+  return useContext(PathnameContext)
 }
 
 // TODO-APP: getting all params when client-side navigating is non-trivial as it does not have route matchers so this might have to be a server context instead.

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -316,7 +316,6 @@ function AppContainer({
           <PathnameContextProviderAdapter
             router={router}
             isAutoExport={self.__NEXT_DATA__.autoExport ?? false}
-            isFallback={initialData.isFallback ?? false}
           >
             <RouterContext.Provider value={makePublicRouterInstance(router)}>
               <HeadManagerContext.Provider value={headManager}>

--- a/packages/next/client/index.tsx
+++ b/packages/next/client/index.tsx
@@ -39,13 +39,10 @@ import { hasBasePath } from './has-base-path'
 import { AppRouterContext } from '../shared/lib/app-router-context'
 import {
   adaptForAppRouterInstance,
-  adaptForPathname,
   adaptForSearchParams,
+  PathnameContextProviderAdapter,
 } from '../shared/lib/router/adapters'
-import {
-  PathnameContext,
-  SearchParamsContext,
-} from '../shared/lib/hooks-client-context'
+import { SearchParamsContext } from '../shared/lib/hooks-client-context'
 
 /// <reference types="react-dom/experimental" />
 
@@ -316,7 +313,11 @@ function AppContainer({
     >
       <AppRouterContext.Provider value={adaptForAppRouterInstance(router)}>
         <SearchParamsContext.Provider value={adaptForSearchParams(router)}>
-          <PathnameContext.Provider value={adaptForPathname(asPath)}>
+          <PathnameContextProviderAdapter
+            router={router}
+            isAutoExport={self.__NEXT_DATA__.autoExport ?? false}
+            isFallback={initialData.isFallback ?? false}
+          >
             <RouterContext.Provider value={makePublicRouterInstance(router)}>
               <HeadManagerContext.Provider value={headManager}>
                 <ImageConfigContext.Provider
@@ -328,7 +329,7 @@ function AppContainer({
                 </ImageConfigContext.Provider>
               </HeadManagerContext.Provider>
             </RouterContext.Provider>
-          </PathnameContext.Provider>
+          </PathnameContextProviderAdapter>
         </SearchParamsContext.Provider>
       </AppRouterContext.Provider>
     </Container>

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -84,14 +84,11 @@ import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { stripInternalQueries } from './internal-utils'
 import {
   adaptForAppRouterInstance,
-  adaptForPathname,
   adaptForSearchParams,
+  PathnameContextProviderAdapter,
 } from '../shared/lib/router/adapters'
 import { AppRouterContext } from '../shared/lib/app-router-context'
-import {
-  PathnameContext,
-  SearchParamsContext,
-} from '../shared/lib/hooks-client-context'
+import { SearchParamsContext } from '../shared/lib/hooks-client-context'
 
 let tryGetPreviewData: typeof import('./api-utils/node').tryGetPreviewData
 let warn: typeof import('../build/output/log').warn
@@ -621,7 +618,11 @@ export async function renderToHTML(
   const AppContainer = ({ children }: { children: JSX.Element }) => (
     <AppRouterContext.Provider value={appRouter}>
       <SearchParamsContext.Provider value={adaptForSearchParams(router)}>
-        <PathnameContext.Provider value={adaptForPathname(asPath)}>
+        <PathnameContextProviderAdapter
+          router={router}
+          isAutoExport={isAutoExport}
+          isFallback={isFallback}
+        >
           <RouterContext.Provider value={router}>
             <AmpStateContext.Provider value={ampState}>
               <HeadManagerContext.Provider
@@ -648,7 +649,7 @@ export async function renderToHTML(
               </HeadManagerContext.Provider>
             </AmpStateContext.Provider>
           </RouterContext.Provider>
-        </PathnameContext.Provider>
+        </PathnameContextProviderAdapter>
       </SearchParamsContext.Provider>
     </AppRouterContext.Provider>
   )

--- a/packages/next/server/render.tsx
+++ b/packages/next/server/render.tsx
@@ -621,7 +621,6 @@ export async function renderToHTML(
         <PathnameContextProviderAdapter
           router={router}
           isAutoExport={isAutoExport}
-          isFallback={isFallback}
         >
           <RouterContext.Provider value={router}>
             <AmpStateContext.Provider value={ampState}>


### PR DESCRIPTION
This changes the API of `usePathname` to return `string | null` to support hybrid use-cases where the pathname is unknown at build time (during automatic static optimization and when fallback is set true with dynamic parameters in the pathname).

This supports a cleaner DX experience for those moving from `pages/` to `app/` so they can begin to use `usePathname` in components that are shared across them.