### PR TITLE
Fix Docs API Reference font.md broken link

### DIFF
--- a/docs/api-reference/next/font.md
+++ b/docs/api-reference/next/font.md
@@ -91,7 +91,7 @@ A string value to define the CSS variable name to be used if the style is applie
 
 ### Font function arguments
 
-For usage, review [Local Fonts](/docs/optimizing/fonts#local-fonts).
+For usage, review [Local Fonts](/docs/basic-features/font-optimization.md#google-fonts).
 
 | Key                                         | Example                                                     | Data type                              | Required |
 | ------------------------------------------- | ----------------------------------------------------------- | -------------------------------------- | -------- |

--- a/docs/api-reference/next/font.md
+++ b/docs/api-reference/next/font.md
@@ -91,7 +91,7 @@ A string value to define the CSS variable name to be used if the style is applie
 
 ### Font function arguments
 
-For usage, review [Local Fonts](/docs/basic-features/font-optimization.md#google-fonts).
+For usage, review [Local Fonts](/docs/basic-features/font-optimization.md#local-fonts).
 
 | Key                                         | Example                                                     | Data type                              | Required |
 | ------------------------------------------- | ----------------------------------------------------------- | -------------------------------------- | -------- |


### PR DESCRIPTION
## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
