### PR TITLE
Fix entry creation on Windows

### DIFF
--- a/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -189,7 +189,7 @@ export class FlightClientEntryPlugin {
             dependency: layoutOrPageDependency,
           })
 
-        const isAbsoluteRequest = layoutOrPageRequest[0] === '/'
+        const isAbsoluteRequest = path.isAbsolute(layoutOrPageRequest)
 
         // Next.js internals are put into a separate entry.
         if (!isAbsoluteRequest) {

--- a/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/build/webpack/plugins/flight-manifest-plugin.ts
@@ -201,7 +201,7 @@ export class FlightManifestPlugin {
               },
             }
           } else {
-            // It is possible that there are mtuliepl modules with the same resouce,
+            // It is possible that there are multiple modules with the same resource,
             // e.g. extracted by mini-css-extract-plugin. In that case we need to
             // merge the chunks.
             manifest[resource].default.chunks = [


### PR DESCRIPTION
In Windows absolute paths start with things like `C:\` instead of `/`. This PR closes #42024 as I confirmed the reproduction app is working properly with this fix. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
