### PR TITLE
Do not strip loader arg in dynamic for server components

### DIFF
--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -185,10 +185,7 @@ where
         next_dynamic::next_dynamic(
             opts.is_development,
             opts.is_server,
-            match &opts.server_components {
-                Some(_) => true,
-                None => false,
-            },
+            opts.server_components.is_some(),
             file.name.clone(),
             opts.pages_dir.clone()
         ),

--- a/packages/next-swc/crates/core/src/lib.rs
+++ b/packages/next-swc/crates/core/src/lib.rs
@@ -185,6 +185,10 @@ where
         next_dynamic::next_dynamic(
             opts.is_development,
             opts.is_server,
+            match &opts.server_components {
+                Some(_) => true,
+                None => false,
+            },
             file.name.clone(),
             opts.pages_dir.clone()
         ),

--- a/packages/next-swc/crates/core/src/next_dynamic.rs
+++ b/packages/next-swc/crates/core/src/next_dynamic.rs
@@ -17,12 +17,14 @@ use swc_core::{
 pub fn next_dynamic(
     is_development: bool,
     is_server: bool,
+    is_server_components: bool,
     filename: FileName,
     pages_dir: Option<PathBuf>,
 ) -> impl Fold {
     NextDynamicPatcher {
         is_development,
         is_server,
+        is_server_components,
         pages_dir,
         filename,
         dynamic_bindings: vec![],
@@ -35,6 +37,7 @@ pub fn next_dynamic(
 struct NextDynamicPatcher {
     is_development: bool,
     is_server: bool,
+    is_server_components: bool,
     pages_dir: Option<PathBuf>,
     filename: FileName,
     dynamic_bindings: Vec<Id>,
@@ -279,9 +282,13 @@ impl Fold for NextDynamicPatcher {
                             props.extend(options_props.iter().cloned());
                         }
                     }
-                    // Don't need to strip the `loader` argument if suspense is true
-                    // See https://github.com/vercel/next.js/issues/36636 for background
-                    if has_ssr_false && !has_suspense && self.is_server {
+
+                    // Don't strip the `loader` argument if suspense is true
+                    // See https://github.com/vercel/next.js/issues/36636 for background.
+
+                    // Also don't strip the `loader` argument for server components (both server/client layers),
+                    // since they're aliased to a React.lazy implementation.
+                    if has_ssr_false && !has_suspense && self.is_server && !self.is_server_components {
                         expr.args[0] = Lit::Null(Null { span: DUMMY_SP }).as_arg();
                     }
 

--- a/packages/next-swc/crates/core/src/next_dynamic.rs
+++ b/packages/next-swc/crates/core/src/next_dynamic.rs
@@ -286,9 +286,14 @@ impl Fold for NextDynamicPatcher {
                     // Don't strip the `loader` argument if suspense is true
                     // See https://github.com/vercel/next.js/issues/36636 for background.
 
-                    // Also don't strip the `loader` argument for server components (both server/client layers),
-                    // since they're aliased to a React.lazy implementation.
-                    if has_ssr_false && !has_suspense && self.is_server && !self.is_server_components {
+                    // Also don't strip the `loader` argument for server components (both
+                    // server/client layers), since they're aliased to a
+                    // React.lazy implementation.
+                    if has_ssr_false
+                        && !has_suspense
+                        && self.is_server
+                        && !self.is_server_components
+                    {
                         expr.args[0] = Lit::Null(Null { span: DUMMY_SP }).as_arg();
                     }
 

--- a/packages/next-swc/crates/core/tests/errors.rs
+++ b/packages/next-swc/crates/core/tests/errors.rs
@@ -46,6 +46,7 @@ fn next_dynamic_errors(input: PathBuf) {
             next_dynamic(
                 true,
                 false,
+                false,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),
             )

--- a/packages/next-swc/crates/core/tests/fixture.rs
+++ b/packages/next-swc/crates/core/tests/fixture.rs
@@ -49,6 +49,7 @@ fn next_dynamic_fixture(input: PathBuf) {
             next_dynamic(
                 true,
                 false,
+                false,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),
             )
@@ -61,6 +62,7 @@ fn next_dynamic_fixture(input: PathBuf) {
         syntax(),
         &|_tr| {
             next_dynamic(
+                false,
                 false,
                 false,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
@@ -77,6 +79,7 @@ fn next_dynamic_fixture(input: PathBuf) {
             next_dynamic(
                 false,
                 true,
+                false,
                 FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
                 Some("/some-project/src".into()),
             )

--- a/test/e2e/app-dir/app/app/dashboard/index/dynamic-imports/dynamic-server.js
+++ b/test/e2e/app-dir/app/app/dashboard/index/dynamic-imports/dynamic-server.js
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic'
 
-const Dynamic = dynamic(() => import('../text-dynamic-server'))
+const Dynamic = dynamic(() => import('../text-dynamic-server'), {
+  ssr: false,
+})
 
 export function NextDynamicServerComponent() {
   return <Dynamic />


### PR DESCRIPTION
When `ssr: false` option is presented, we stripped the loader option for `next/dynamic` call. But for react server components (both server and client ones) we're using a `React.lazy` based implementation so we shouldn't do it for them.


## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

