### PR TITLE
Avoid breaking useRouter() type change

### DIFF
--- a/packages/next/client/router.ts
+++ b/packages/next/client/router.ts
@@ -130,7 +130,7 @@ export default singletonRouter as SingletonRouter
 export { default as withRouter } from './with-router'
 
 export function useRouter(throwOnMissing: true): NextRouter
-export function useRouter(): NextRouter | null
+export function useRouter(): NextRouter
 export function useRouter(throwOnMissing?: boolean) {
   const router = React.useContext(RouterContext)
   if (!router && throwOnMissing) {


### PR DESCRIPTION
Since `useRouter()` can still be used in `pages` alone and should always be a valid instance we shouldn't change the default return type to avoid a breaking type change. 

Fixes: https://github.com/vercel/next.js/issues/42409

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
