### PR TITLE
Fix undici warning showing unexpectedly

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -61,8 +61,8 @@ export function setHttpClientAndAgentOptions(config: NextConfig) {
   if (isAboveNodejs16) {
     if (
       config.experimental?.enableUndici &&
-      isAboveNodejs18 &&
-      !config.experimental.appDir
+      !config.experimental?.appDir &&
+      isAboveNodejs18
     ) {
       Log.warn(
         `\`enableUndici\` option is unnecessary in Node.js v${NODE_18_VERSION} or greater.`

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -59,7 +59,11 @@ const experimentalWarning = execOnce(
 
 export function setHttpClientAndAgentOptions(config: NextConfig) {
   if (isAboveNodejs16) {
-    if (config.experimental?.enableUndici && isAboveNodejs18) {
+    if (
+      config.experimental?.enableUndici &&
+      isAboveNodejs18 &&
+      !config.experimental.appDir
+    ) {
       Log.warn(
         `\`enableUndici\` option is unnecessary in Node.js v${NODE_18_VERSION} or greater.`
       )


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/42441

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
