### PR TITLE
fix: re-render on browser navigation when search params have changed

### DIFF
--- a/test/e2e/app-dir/app/app/search-params-navigation/page.js
+++ b/test/e2e/app-dir/app/app/search-params-navigation/page.js
@@ -1,0 +1,15 @@
+'use client'
+import Link from 'next/link'
+
+export default function Page({ searchParams }) {
+  return (
+    <nav data-param-page={searchParams.page}>
+      <Link id="link-1" href="/search-params-navigation?page=1">
+        Page 1
+      </Link>
+      <Link id="link-2" href="/search-params-navigation?page=2">
+        Page 2
+      </Link>
+    </nav>
+  )
+}

--- a/test/e2e/app-dir/app/app/search-params-navigation/server/page.js
+++ b/test/e2e/app-dir/app/app/search-params-navigation/server/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Page({ searchParams }) {
+  return (
+    <nav data-param-page={searchParams.page}>
+      <Link id="link-1" href="/search-params-navigation?page=1">
+        Page 1
+      </Link>
+      <Link id="link-2" href="/search-params-navigation?page=2">
+        Page 2
+      </Link>
+    </nav>
+  )
+}

--- a/test/e2e/app-dir/index.test.ts
+++ b/test/e2e/app-dir/index.test.ts
@@ -1593,6 +1593,45 @@ describe('app dir', () => {
       })
     })
 
+    describe('searchParams navigation', () => {
+      describe('client component', () => {
+        it('should update the search params on browser navigation ', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/search-params-navigation?page=1'
+          )
+          const getAttr = () =>
+            browser.elementByCss('nav').getAttribute('data-param-page')
+          expect(await getAttr()).toBe('1')
+          await browser.elementByCss('#link-2').click()
+          expect(await getAttr()).toBe('2')
+          await browser.back()
+          expect(await getAttr()).toBe('1')
+          await browser.forward()
+          expect(await getAttr()).toBe('2')
+          await browser.close()
+        })
+      })
+      describe('server component', () => {
+        it('should update the search params on browser navigation ', async () => {
+          const browser = await webdriver(
+            next.url,
+            '/search-params-navigation/server?page=1'
+          )
+          const getAttr = () =>
+            browser.elementByCss('nav').getAttribute('data-param-page')
+          expect(await getAttr()).toBe('1')
+          await browser.elementByCss('#link-2').click()
+          expect(await getAttr()).toBe('2')
+          await browser.back()
+          expect(await getAttr()).toBe('1')
+          await browser.forward()
+          expect(await getAttr()).toBe('2')
+          await browser.close()
+        })
+      })
+    })
+
     describe('sass support', () => {
       describe('server layouts', () => {
         it('should support global sass/scss inside server layouts', async () => {


### PR DESCRIPTION
Fixes #42451

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
