### PR TITLE
Fix undici warning in Node.js 18

### DIFF
--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -57,8 +57,12 @@ const experimentalWarning = execOnce(
   }
 )
 
-// TODO-APP: the type of this is wrong. In worker.ts it's called with only a fraction of the config, not the full config object.
-export function setHttpClientAndAgentOptions(config: NextConfig) {
+export function setHttpClientAndAgentOptions(config: {
+  httpAgentOptions?: NextConfig['httpAgentOptions']
+  experimental?: {
+    enableUndici?: boolean
+  }
+}) {
   if (isAboveNodejs16) {
     // Node.js 18 has undici built-in.
     if (config.experimental?.enableUndici && !isAboveNodejs18) {

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -57,6 +57,7 @@ const experimentalWarning = execOnce(
   }
 )
 
+// TODO-APP: the type of this is wrong. In worker.ts it's called with only a fraction of the config, not the full config object.
 export function setHttpClientAndAgentOptions(config: NextConfig) {
   if (isAboveNodejs16) {
     // Node.js 18 has undici built-in.

--- a/packages/next/server/config.ts
+++ b/packages/next/server/config.ts
@@ -59,15 +59,8 @@ const experimentalWarning = execOnce(
 
 export function setHttpClientAndAgentOptions(config: NextConfig) {
   if (isAboveNodejs16) {
-    if (
-      config.experimental?.enableUndici &&
-      !config.experimental?.appDir &&
-      isAboveNodejs18
-    ) {
-      Log.warn(
-        `\`enableUndici\` option is unnecessary in Node.js v${NODE_18_VERSION} or greater.`
-      )
-    } else {
+    // Node.js 18 has undici built-in.
+    if (config.experimental?.enableUndici && !isAboveNodejs18) {
       // When appDir is enabled undici is the default because of Response.clone() issues in node-fetch
       ;(global as any).__NEXT_USE_UNDICI = config.experimental?.enableUndici
     }


### PR DESCRIPTION
- Remove warn for undici in Node.js 18
- Add node about the type being wrong

Follow-up to #42444. The other day I noticed that the type is incorrect. This just removes the warning.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
