### PR TITLE
Weight argument changed.

### DIFF
--- a/docs/api-reference/next/font.md
+++ b/docs/api-reference/next/font.md
@@ -23,7 +23,7 @@ For usage, review [Google Fonts](/docs/basic-features/font-optimization.md#googl
 
 | Key                                         | Example                            | Data type                                                 | Required                                         |
 | ------------------------------------------- | ---------------------------------- | --------------------------------------------------------- | ------------------------------------------------ |
-| [`weight`](#weight)                         | `weight: '600'`                    | String                                                    | Required if font is not variable                 |
+| [`weight`](#weight)                         | `weight: '600'`                    | String \| Array of Strings                                | Required if font is not variable                 |
 | [`style`](#style)                           | `style: 'italic'`                  | String                                                    | Optional                                         |
 | [`subsets`](#subsets)                       | `subsets: ['latin']`               | Array of Strings                                          | Optional                                         |
 | [`axes`](#axes)                             | `axes: ['slnt']`                   | Array of Strings based on the available axes for the font | Optional for variable fonts that have extra axes |


### PR DESCRIPTION
When importing a font with @next/font/google, it is possible to specify multiple weights as well as a single weight.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
