### PR TITLE
react-version.md: Update minimum React version for Next.js 13

### DIFF
--- a/errors/react-version.md
+++ b/errors/react-version.md
@@ -5,7 +5,7 @@
 Your project is using an old version of `react` or `react-dom` that does not
 meet the suggested minimum version requirement.
 
-Next.js suggests using, at a minimum, `react@17.0.2` and `react-dom@17.0.2`.
+Next.js suggests using, at a minimum, `react@18.2.0` and `react-dom@18.2.0`.
 Older versions of `react` and `react-dom` do work with Next.js, however, they do
 not enable all of Next.js' features.
 
@@ -39,8 +39,8 @@ yarn add react@latest react-dom@latest
 ```json
 {
   "dependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }
 ```


### PR DESCRIPTION
Updated minimum React version to match information at https://nextjs.org/blog/next-13. This page is the first Google result for "next.js 13 react 17" and the info in it is out of data after Next.js 13 was released.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
