### PR TITLE
Remove useless async declaration and replace regexp to plain string in AMP postProcessor

### DIFF
--- a/packages/next/server/post-process.ts
+++ b/packages/next/server/post-process.ts
@@ -226,8 +226,8 @@ async function postProcessHTML(
         }
       : null,
     inAmpMode || hybridAmp
-      ? async (html: string) => {
-          return html.replace(/&amp;amp=1/g, '&amp=1')
+      ? (html: string) => {
+          return html.replace('&amp;amp=1', '&amp=1')
         }
       : null,
   ].filter(nonNullable)


### PR DESCRIPTION
## Bug

- Remove useless async declaration for a fully sync function
- Replace RegExp to plain string for better perfomance
