### PR TITLE
Fix relative TypeScript path in monorepos

### DIFF
--- a/packages/next/lib/typescript/writeVscodeConfigurations.ts
+++ b/packages/next/lib/typescript/writeVscodeConfigurations.ts
@@ -6,7 +6,8 @@ import * as CommentJson from 'next/dist/compiled/comment-json'
 
 // Write .vscode settings to enable Next.js typescript plugin.
 export async function writeVscodeConfigurations(
-  baseDir: string
+  baseDir: string,
+  tsPath: string
 ): Promise<void> {
   try {
     const vscodeSettings = path.join(baseDir, '.vscode', 'settings.json')
@@ -24,7 +25,7 @@ export async function writeVscodeConfigurations(
       }
     }
 
-    const libPath = './node_modules/typescript/lib'
+    const libPath = path.relative(baseDir, path.dirname(tsPath))
     if (
       settings['typescript.tsdk'] === libPath &&
       settings['typescript.enablePromptUseWorkspaceTsdk']

--- a/packages/next/lib/verifyTypeScriptSetup.ts
+++ b/packages/next/lib/verifyTypeScriptSetup.ts
@@ -103,8 +103,9 @@ export async function verifyTypeScriptSetup({
     }
 
     // Load TypeScript after we're sure it exists:
+    const tsPath = deps.resolved.get('typescript')!
     const ts = (await Promise.resolve(
-      require(deps.resolved.get('typescript')!)
+      require(tsPath)
     )) as typeof import('typescript')
 
     if (semver.lt(ts.version, '4.3.2')) {
@@ -125,7 +126,7 @@ export async function verifyTypeScriptSetup({
     await writeAppTypeDeclarations(dir, !disableStaticImages)
 
     if (isAppDirEnabled) {
-      await writeVscodeConfigurations(dir)
+      await writeVscodeConfigurations(dir, tsPath)
     }
 
     let result


### PR DESCRIPTION
When under a monorepo, it's possible that the installed TypeScript isn't under `./node_modules/typescript`, and hence the `tsdk` option for VS Code won't work correctly. This PR fixes that to ensure the path is correct.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
