### PR TITLE
docs/next/link: Mention middleware + dynamic routes changes

### DIFF
--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -221,7 +221,7 @@ The default behavior of `Link` is to scroll to the top of the page. When there i
 
 ## With Next.js 13 Middleware
 
-It's common to use [Middleware](/docs/advanced-features/middleware) for authentication or other purposes that involve redirecting the user to a different page. In versions prior to Next.js 13 , the redirect is handled on the client instead of the server. So, in order for the `<Link />` component to properly [prefetch](#prefetch) links with redirects via Middleware, you need to tell Next.js both the URL to display and the URL to prefetch.
+It's common to use [Middleware](/docs/advanced-features/middleware) for authentication or other purposes that involve redirecting the user to a different page. In versions prior to Next.js 13, the redirect is handled on the client instead of the server. So, in order for the `<Link />` component to properly prefetch links with redirects via Middleware, you need to tell Next.js both the URL to display and the URL to prefetch.
 
 For example, if you have want to serve a `/dashboard` route that has authenticated and visitor views, you may add something similar to the following in your Middleware to redirect the user to the correct page:
 

--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -218,3 +218,37 @@ The default behavior of `Link` is to scroll to the top of the page. When there i
   Disables scrolling to the top
 </Link>
 ```
+
+## With Next.js 13 Middleware
+
+It's common to use [Middleware](/docs/advanced-features/middleware) for authentication or other purposes that involve redirecting the user to a different page. In versions prior to Next.js 13 , the redirect is handled on the client instead of the server. So, in order for the `<Link />` component to properly [prefetch](#prefetch) links with redirects via Middleware, you need to tell Next.js both the URL to display and the URL to prefetch.
+
+For example, if you have want to serve a `/dashboard` route that has authenticated and visitor views, you may add something similar to the following in your Middleware to redirect the user to the correct page:
+
+```js:middleware.js
+export function middleware(req) {
+  const nextUrl = req.nextUrl;
+  if (nextUrl.pathname === '/dashboard') {
+    if (req.cookies.authToken) {
+      return NextResponse.rewrite('/auth/dashboard');
+    } else {
+      return NextResponse.rewrite('/public/dashboard');
+    }
+  }
+}
+```
+
+In this case, you would want to use the following code in your `<Link />` component (inside `pages/`):
+
+```js:pages/index.js
+import Link from 'next/link';
+import useIsAuthed from './hooks/useIsAuthed';
+
+export default function Page() {
+  const isAuthed = useIsAuthed();
+  const path = isAuthed ? '/auth/dashboard' : '/dashboard';
+  return (<Link as="/dashboard" href={path}>Dashboard</Link>);
+}
+```
+
+> **Note:** If you're using [Dynamic Routes](/docs/routing/dynamic-routes), you'll need to adapt your `as` and `href` props. For example, if you have a Dynamic Route like `/dashboard/[user]` that you want to present differently via middleware, you would write: `<Link href={{ pathname: '/dashboard/authed/[user]', query: { user: username } }} as="/dashboard/[user]">Profile</Link>`.

--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -221,19 +221,19 @@ The default behavior of `Link` is to scroll to the top of the page. When there i
 
 ## With Next.js 13 Middleware
 
-It's common to use [Middleware](/docs/advanced-features/middleware) for authentication or other purposes that involve rewriting the user to a different page. In order for the `<Link />` component to properly prefetch links with rewrites via Middleware, you need to tell Next.js both the URL to display and the URL to prefetch. This is required to avoid un-necessary fetches to middleware to know the correct route to prefetch. 
+It's common to use [Middleware](/docs/advanced-features/middleware) for authentication or other purposes that involve rewriting the user to a different page. In order for the `<Link />` component to properly prefetch links with rewrites via Middleware, you need to tell Next.js both the URL to display and the URL to prefetch. This is required to avoid un-necessary fetches to middleware to know the correct route to prefetch.
 
 For example, if you have want to serve a `/dashboard` route that has authenticated and visitor views, you may add something similar to the following in your Middleware to redirect the user to the correct page:
 
 ```js
 // middleware.js
 export function middleware(req) {
-  const nextUrl = req.nextUrl;
+  const nextUrl = req.nextUrl
   if (nextUrl.pathname === '/dashboard') {
     if (req.cookies.authToken) {
-      return NextResponse.rewrite('/auth/dashboard');
+      return NextResponse.rewrite('/auth/dashboard')
     } else {
-      return NextResponse.rewrite('/public/dashboard');
+      return NextResponse.rewrite('/public/dashboard')
     }
   }
 }
@@ -243,13 +243,17 @@ In this case, you would want to use the following code in your `<Link />` compon
 
 ```js
 // pages/index.js
-import Link from 'next/link';
-import useIsAuthed from './hooks/useIsAuthed';
+import Link from 'next/link'
+import useIsAuthed from './hooks/useIsAuthed'
 
 export default function Page() {
-  const isAuthed = useIsAuthed();
-  const path = isAuthed ? '/auth/dashboard' : '/dashboard';
-  return (<Link as="/dashboard" href={path}>Dashboard</Link>);
+  const isAuthed = useIsAuthed()
+  const path = isAuthed ? '/auth/dashboard' : '/dashboard'
+  return (
+    <Link as="/dashboard" href={path}>
+      Dashboard
+    </Link>
+  )
 }
 ```
 

--- a/docs/api-reference/next/link.md
+++ b/docs/api-reference/next/link.md
@@ -221,11 +221,12 @@ The default behavior of `Link` is to scroll to the top of the page. When there i
 
 ## With Next.js 13 Middleware
 
-It's common to use [Middleware](/docs/advanced-features/middleware) for authentication or other purposes that involve redirecting the user to a different page. In versions prior to Next.js 13, the redirect is handled on the client instead of the server. So, in order for the `<Link />` component to properly prefetch links with redirects via Middleware, you need to tell Next.js both the URL to display and the URL to prefetch.
+It's common to use [Middleware](/docs/advanced-features/middleware) for authentication or other purposes that involve rewriting the user to a different page. In order for the `<Link />` component to properly prefetch links with rewrites via Middleware, you need to tell Next.js both the URL to display and the URL to prefetch. This is required to avoid un-necessary fetches to middleware to know the correct route to prefetch. 
 
 For example, if you have want to serve a `/dashboard` route that has authenticated and visitor views, you may add something similar to the following in your Middleware to redirect the user to the correct page:
 
-```js:middleware.js
+```js
+// middleware.js
 export function middleware(req) {
   const nextUrl = req.nextUrl;
   if (nextUrl.pathname === '/dashboard') {
@@ -240,7 +241,8 @@ export function middleware(req) {
 
 In this case, you would want to use the following code in your `<Link />` component (inside `pages/`):
 
-```js:pages/index.js
+```js
+// pages/index.js
 import Link from 'next/link';
 import useIsAuthed from './hooks/useIsAuthed';
 


### PR DESCRIPTION
Documents the next 13 changes requiring `as` and `href` using `next/link` with Dynamic Routes.

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
