### PR TITLE
Restore find-pages-dir API compatibility

### DIFF
--- a/packages/next/lib/find-pages-dir.ts
+++ b/packages/next/lib/find-pages-dir.ts
@@ -57,6 +57,7 @@ export function findPagesDir(
   }
 
   return {
+    pages: pagesDir,
     pagesDir,
     appDir: isAppDirEnabled ? appDir : undefined,
   }


### PR DESCRIPTION
This change of API shape causes `nextra@beta` builds to spin forever when adopting `next@13`. Introduced in #41166, this was only ever released in the 12.3.2 canaries and 13.0.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
