### PR TITLE
Include @prisma/client in default external packages

### DIFF
--- a/packages/next/lib/server-external-packages.ts
+++ b/packages/next/lib/server-external-packages.ts
@@ -1,5 +1,6 @@
 // A list of popular packages that cannot be bundled on the server.
 export const EXTERNAL_PACKAGES = [
+  '@prisma/client',
   '@sentry/nextjs',
   '@sentry/node',
   'autoprefixer',


### PR DESCRIPTION
As per https://twitter.com/shadcn/status/1589667660505427968.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
