### PR TITLE
fix typo in dynamic-api-routes.md

### DIFF
--- a/docs/api-routes/dynamic-api-routes.md
+++ b/docs/api-routes/dynamic-api-routes.md
@@ -18,7 +18,7 @@ For example, the API route `pages/api/post/[pid].js` has the following code:
 ```js
 export default function handler(req, res) {
   const { pid } = req.query
-  res.end(`Post: ${pid}`)
+  res.send(`Post: ${pid}`)
 }
 ```
 
@@ -67,7 +67,7 @@ An API route for `pages/api/post/[...slug].js` could look like this:
 ```js
 export default function handler(req, res) {
   const { slug } = req.query
-  res.end(`Post: ${slug.join(', ')}`)
+  res.send(`Post: ${slug.join(', ')}`)
 }
 ```
 


### PR DESCRIPTION
.end changed to .send in api request examples