### PR TITLE
fix: prevent middleware fetches from mutating init param

### DIFF
--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -217,7 +217,7 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
         }
 
       const __fetch = context.fetch
-      context.fetch = async (input, init = {}) => {
+      context.fetch = async (input, { ...init } = {}) => {
         const assetResponse = await fetchInlineAsset({
           input,
           assets: options.edgeFunctionEntry.assets,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Summary

Middleware using `fetch` with a `RequestInit` parameter defined outside the scope of the middleware will have every request append the `x-middleware-subrequest` header to its value from the previous request. This eventually results in a `431` response from the upstream API. 

For example, given an app with the following middleware:
```js
// middleware.js
import { NextResponse } from 'next/server'

const reqInit = { headers: { foo: 'bar' } }

export default async function middleware (req) {
  await fetch('https://my-api.com/ping', reqInit)

  return NextResponse.next()
}
```
The 2nd request to the app will trigger a fetch to the upstream API containing an `x-middleware-subrequest` header equal to `'middleware:middleware'` and every subsequent request will append another `':middleware'` to that header.

This is due to the `init` parameter being mutated in `packages/next/server/web/sandbox/context.ts` and can be resolved by using a shallow clone of the parameter instead.


## Test Plan

Without this PR's changes to `context.ts`, the added test will fail with the following output:

![Screen Shot 2022-11-09 at 5 28 39 PM](https://user-images.githubusercontent.com/28017008/200978061-4be2f4e5-e928-41a0-83a1-5c6644ccc7f3.png)



## Bug

- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

