### PR TITLE
switching Dockerfile COPY order

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -17,8 +17,8 @@ RUN \
 # Rebuild the source code only when needed
 FROM node:16-alpine AS builder
 WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY --from=deps /app/node_modules ./node_modules
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry


### PR DESCRIPTION
If you run this docker build on with node_modules already populated (like on local machine), having `COPY . .` second basically overwrites the node_modules you just built in `deps` and COPYed to `builder`.

This change ensures the `node_modules` created in `deps` are the modules being built into the container

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Likely to be a minor irritation (step below a bug), and this change (swapping two lines) is too small to justify a lot of paperwork.