### PR TITLE
Track page counts during builds

### DIFF
--- a/packages/next/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/build/webpack/plugins/middleware-plugin.ts
@@ -683,6 +683,7 @@ function getExtractMetadata(params: {
         wasmBindings: new Map(),
         assetBindings: new Map(),
       }
+      let ogImageGenerationCount = 0
 
       for (const module of modules) {
         const buildInfo = getModuleBuildInfo(module)
@@ -697,13 +698,10 @@ function getExtractMetadata(params: {
             /[\\/]node_modules[\\/]@vercel[\\/]og[\\/]dist[\\/]index.js$/.test(
               resource
             )
-          telemetry.record({
-            eventName: EVENT_BUILD_FEATURE_USAGE,
-            payload: {
-              featureName: 'vercelImageGeneration',
-              invocationCount: hasOGImageGeneration ? 1 : 0,
-            },
-          })
+
+          if (hasOGImageGeneration) {
+            ogImageGenerationCount++
+          }
         }
 
         /**
@@ -818,6 +816,13 @@ function getExtractMetadata(params: {
         }
       }
 
+      telemetry.record({
+        eventName: EVENT_BUILD_FEATURE_USAGE,
+        payload: {
+          featureName: 'vercelImageGeneration',
+          invocationCount: ogImageGenerationCount,
+        },
+      })
       metadataByEntry.set(entryName, entryMetadata)
     }
   }

--- a/packages/next/telemetry/events/build.ts
+++ b/packages/next/telemetry/events/build.ts
@@ -56,6 +56,7 @@ type EventBuildCompleted = {
   totalPageCount: number
   hasDunderPages: boolean
   hasTestPages: boolean
+  totalAppPagesCount?: number
 }
 
 export function eventBuildCompleted(
@@ -77,6 +78,7 @@ export function eventBuildCompleted(
         (path) =>
           REGEXP_DIRECTORY_TESTS.test(path) || REGEXP_FILE_TEST.test(path)
       ),
+      totalAppPagesCount: event.totalAppPagesCount,
     },
   }
 }
@@ -100,6 +102,11 @@ type EventBuildOptimized = {
   rewritesWithHasCount: number
   redirectsWithHasCount: number
   middlewareCount: number
+  totalAppPagesCount?: number
+  staticAppPagesCount?: number
+  serverAppPagesCount?: number
+  edgeRuntimeAppCount?: number
+  edgeRuntimePagesCount?: number
 }
 
 export function eventBuildOptimize(
@@ -121,6 +128,11 @@ export function eventBuildOptimize(
         (path) =>
           REGEXP_DIRECTORY_TESTS.test(path) || REGEXP_FILE_TEST.test(path)
       ),
+      totalAppPagesCount: event.totalAppPagesCount,
+      staticAppPagesCount: event.staticAppPagesCount,
+      serverAppPagesCount: event.serverAppPagesCount,
+      edgeRuntimeAppCount: event.edgeRuntimeAppCount,
+      edgeRuntimePagesCount: event.edgeRuntimePagesCount,
     },
   }
 }

--- a/test/integration/telemetry/pages/edge.js
+++ b/test/integration/telemetry/pages/edge.js
@@ -1,0 +1,23 @@
+import Image from 'next/image'
+import LegacyImage from 'next/legacy/image'
+import profilePic from '../public/small.jpg'
+
+export const config = {
+  runtime: 'experimental-edge',
+}
+
+function About() {
+  return (
+    <>
+      <h1>My Homepage</h1>
+      <Image src={profilePic} alt="Picture of the author" />
+      <p>Welcome to my homepage!</p>
+    </>
+  )
+}
+
+export default About
+
+export function AboutFutureImage() {
+  return <LegacyImage src={profilePic} alt="Picture of the author" />
+}

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -834,6 +834,7 @@ describe('Telemetry CLI', () => {
       stderr,
       'NEXT_BUILD_FEATURE_USAGE'
     )
+
     expect(featureUsageEvents).toEqual(
       expect.arrayContaining([
         {
@@ -842,7 +843,7 @@ describe('Telemetry CLI', () => {
         },
         {
           featureName: 'next/image',
-          invocationCount: 1,
+          invocationCount: 2,
         },
         {
           featureName: 'next/script',
@@ -871,8 +872,14 @@ describe('Telemetry CLI', () => {
       stderr: true,
       env: { NEXT_TELEMETRY_DEBUG: 1 },
     })
-    await fs.remove(path.join(appDir, 'next.config.js'))
-    await fs.remove(path.join(appDir, 'jsconfig.json'))
+    await fs.rename(
+      path.join(appDir, 'next.config.js'),
+      path.join(appDir, 'next.config.swc')
+    )
+    await fs.rename(
+      path.join(appDir, 'jsconfig.json'),
+      path.join(appDir, 'jsconfig.swc')
+    )
     const featureUsageEvents = findAllTelemetryEvents(
       stderr,
       'NEXT_BUILD_FEATURE_USAGE'
@@ -1047,11 +1054,11 @@ describe('Telemetry CLI', () => {
     )
     expect(featureUsageEvents).toContainEqual({
       featureName: 'next/legacy/image',
-      invocationCount: 1,
+      invocationCount: 2,
     })
     expect(featureUsageEvents).toContainEqual({
       featureName: 'next/image',
-      invocationCount: 1,
+      invocationCount: 2,
     })
   })
 


### PR DESCRIPTION
Ensures we keep track of page counts during builds. 

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
