### PR TITLE
Use window.location directly instead of parsing into URL

### DIFF
--- a/packages/next/client/components/app-router.tsx
+++ b/packages/next/client/components/app-router.tsx
@@ -136,7 +136,8 @@ function Router({
         // location.href is read as the initial value for canonicalUrl in the browser
         // This is safe to do as canonicalUrl can't be rendered, it's only used to control the history updates in the useEffect further down in this file.
         typeof window !== 'undefined'
-          ? createHrefFromUrl(new URL(window.location.href))
+          ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
+            createHrefFromUrl(window.location as unknown as URL)
           : initialCanonicalUrl,
     }
   }, [children, initialCanonicalUrl, initialTree])


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/pull/42735#discussion_r1019116319.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
