### PR TITLE
docs(edge-api-routes): fixes example

### DIFF
--- a/docs/api-routes/edge-api-routes.md
+++ b/docs/api-routes/edge-api-routes.md
@@ -95,7 +95,7 @@ export const config = {
 }
 
 export default async function handler(req: NextRequest) {
-  const authorization = req.cookies.get('authorization')
+  const authorization = req.cookies.get('authorization')?.value
   return fetch('https://backend-api.com/api/protected', {
     method: req.method,
     headers: {


### PR DESCRIPTION
## 📖 What's in there?

The last example on the documentation page for [Edge Api routes](https://nextjs.org/docs/api-routes/edge-api-routes) is wrong since next@13 breaking change on cookie handling.
While [middleware page](https://nextjs.org/docs/advanced-features/middleware#using-cookies) is updated, this one was left off.

