### PR TITLE
Add more details to invalid-next-config doc

### DIFF
--- a/errors/invalid-next-config.md
+++ b/errors/invalid-next-config.md
@@ -2,7 +2,7 @@
 
 #### Why This Error Occurred
 
-In your `next.config.js` file you passed invalid options that either are the incorrect type or an unknown field.
+In your `next.config.js` file you passed invalid options that either are the incorrect type or an unknown field. This warning is shown to help catch typos that cause expected configs to not be applied.
 
 #### Possible Ways to Fix It
 
@@ -17,6 +17,12 @@ const nextConfig = {
 }
 
 module.exports = nextConfig
+```
+
+For example for the below warning, there is a typo and `rewritess` needs to be renamed to `rewrites` to resolve the issue.
+
+```sh
+The root value has an unexpected property, rewritess, which is not in the list of allowed properties
 ```
 
 ### Useful Links


### PR DESCRIPTION
This adds some more clarity to the error doc and we can also iterate on the warnings to show suggestions as well in follow-ups. 

x-ref: [slack thread](https://vercel.slack.com/archives/CHZGRCJSD/p1668430036939189?thread_ts=1668394104.483679&cid=CHZGRCJSD)

## Documentation / Examples

- [x] Make sure the linting passes by running `pnpm build && pnpm lint`
- [x] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
