### PR TITLE
test(integration): update test fixture

### DIFF
--- a/test/integration/typescript-app-type-declarations/next-env.d.ts
+++ b/test/integration/typescript-app-type-declarations/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

**I'm not sure if this is legit to fix, shared context below**

This PR attempts to fix test fixtures to reflect test failures. On my working branch has unrelated changes to `next-env.d.ts` declaration. I started to seeing intermittent test failures on CI, as well as local. It was nearly 100% reproducible on local, while on CI it was nearly not reproducible but only appears intermittently.

Some code archaeology leads me to this PR https://github.com/vercel/next.js/pull/28316, specifically https://github.com/vercel/next.js/commit/77150dac791d63be87af9cbfae1b0c5b17da5267#diff-9495c8b2cd0a5f2c471a37c24eac56caba4bd5cf95e2d021f95c4718e3191b47L33 seems implying test fixture need to be updated. However, I can't figure out why this does not fail in CI since changes landed.

Please feel free to close out if this is not expected changes. It is entirely possible my setup have some weird side effect to cause test failures.

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see `contributing.md`

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see `contributing.md`

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
